### PR TITLE
feat(Text): Measure Text on Dispatcher directly

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -185,39 +185,31 @@ namespace ReactNative.Views.Text
 
         private static YogaSize MeasureText(ReactTextShadowNode textNode, YogaNode node, float width, YogaMeasureMode widthMode, float height, YogaMeasureMode heightMode)
         {
-            // This is not a terribly efficient way of projecting the height of
-            // the text elements. It requires that we have access to the
-            // dispatcher in order to do measurement, which, for obvious
-            // reasons, can cause perceived performance issues as it will block
-            // the UI thread from handling other work.
-            //
-            // TODO: determine another way to measure text elements.
-            var task = DispatcherHelpers.CallOnDispatcher(() =>
+            // TODO: Measure text with DirectWrite or other API that does not
+            // require dispatcher access. Currently, we're instantiating a
+            // second CoreApplicationView (that is never activated) and using
+            // its Dispatcher thread to calculate layout.
+            var textBlock = new TextBlock
             {
-                var textBlock = new TextBlock
-                {
-                    TextAlignment = TextAlignment.Left,
-                    TextWrapping = TextWrapping.Wrap,
-                    TextTrimming = TextTrimming.CharacterEllipsis,
-                };
+                TextAlignment = TextAlignment.Left,
+                TextWrapping = TextWrapping.Wrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            };
 
-                textNode.UpdateTextBlockCore(textBlock, true);
+            textNode.UpdateTextBlockCore(textBlock, true);
 
-                for (var i = 0; i < textNode.ChildCount; ++i)
-                {
-                    var child = textNode.GetChildAt(i);
-                    textBlock.Inlines.Add(ReactInlineShadowNodeVisitor.Apply(child));
-                }
+            for (var i = 0; i < textNode.ChildCount; ++i)
+            {
+                var child = textNode.GetChildAt(i);
+                textBlock.Inlines.Add(ReactInlineShadowNodeVisitor.Apply(child));
+            }
 
-                var normalizedWidth = YogaConstants.IsUndefined(width) ? double.PositiveInfinity : width;
-                var normalizedHeight = YogaConstants.IsUndefined(height) ? double.PositiveInfinity : height;
-                textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
-                return MeasureOutput.Make(
-                    (float)Math.Ceiling(textBlock.DesiredSize.Width),
-                    (float)Math.Ceiling(textBlock.DesiredSize.Height));
-            });
-
-            return task.Result;
+            var normalizedWidth = YogaConstants.IsUndefined(width) ? double.PositiveInfinity : width;
+            var normalizedHeight = YogaConstants.IsUndefined(height) ? double.PositiveInfinity : height;
+            textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
+            return MeasureOutput.Make(
+                (float)Math.Ceiling(textBlock.DesiredSize.Width),
+                (float)Math.Ceiling(textBlock.DesiredSize.Height));
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/IReactQueueConfiguration.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/IReactQueueConfiguration.cs
@@ -16,6 +16,11 @@ namespace ReactNative.Bridge.Queue
         IMessageQueueThread DispatcherQueueThread { get; }
 
         /// <summary>
+        /// The layout thread.
+        /// </summary>
+        IMessageQueueThread LayoutQueueThread { get; }
+
+        /// <summary>
         /// The native modules thread.
         /// </summary>
         IMessageQueueThread NativeModulesQueueThread { get; }

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/MessageQueueThread.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/MessageQueueThread.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using static System.FormattableString;
 #if WINDOWS_UWP
-using Windows.UI.Core;
+using Windows.ApplicationModel.Core;
 #else
 using System.Windows.Threading;
 #endif
@@ -127,7 +127,9 @@ namespace ReactNative.Bridge.Queue
             switch (spec.Kind)
             {
                 case MessageQueueThreadKind.DispatcherThread:
-                    return new DispatcherMessageQueueThread(spec.Name, handler);
+                case MessageQueueThreadKind.LayoutThread:
+                    var isSecondary = spec.Kind == MessageQueueThreadKind.LayoutThread;
+                    return new DispatcherMessageQueueThread(spec.Name, handler, isSecondary);
                 case MessageQueueThreadKind.BackgroundSingleThread:
                     return new SingleBackgroundMessageQueueThread(spec.Name, handler);
                 case MessageQueueThreadKind.BackgroundAnyThread:
@@ -140,25 +142,78 @@ namespace ReactNative.Bridge.Queue
 
         class DispatcherMessageQueueThread : MessageQueueThread
         {
+#if WINDOWS_UWP && CREATE_LAYOUT_THREAD
+            private static readonly CoreApplicationView s_secondaryView = CoreApplication.CreateNewView();
+#endif
             private static readonly IObserver<Action> s_nop = Observer.Create<Action>(_ => { });
 
+            private readonly bool _isSecondary;
             private readonly Subject<Action> _actionSubject;
             private readonly IDisposable _subscription;
 
+#if WINDOWS_UWP
+            private readonly CoreApplicationView _currentApplicationView;
+#else
+            private readonly Thread _currentDispatcherThread;
+#endif
+
             private IObserver<Action> _actionObserver;
 
+#if !WINDOWS_UWP
+            private static readonly ManualResetEvent s_layoutDispatcherReady = new ManualResetEvent(false);
+            private static readonly Thread s_layoutDispatcherThread;
+            private static Dispatcher s_layoutDispatcher;
+
+            static DispatcherMessageQueueThread()
+            {
+                s_layoutDispatcherThread = new Thread(new ThreadStart(() => {
+                    s_layoutDispatcher = Dispatcher.CurrentDispatcher;
+                    s_layoutDispatcherReady.Set();
+                    Dispatcher.Run();
+                }));
+
+                s_layoutDispatcherThread.SetApartmentState(ApartmentState.STA);
+                s_layoutDispatcherThread.Start();
+            }
+#endif
+
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-            public DispatcherMessageQueueThread(string name, Action<Exception> handler)
+            public DispatcherMessageQueueThread(string name, Action<Exception> handler, bool isSecondary)
                 : base(name)
             {
+                _isSecondary = isSecondary;
                 _actionSubject = new Subject<Action>();
                 _actionObserver = _actionSubject;
-                _subscription = _actionSubject
+
 #if WINDOWS_UWP
-                    .ObserveOnDispatcher()
+#if CREATE_LAYOUT_THREAD
+                _currentApplicationView = isSecondary
+                    ? s_secondaryView
+                    : CoreApplication.GetCurrentView();
 #else
-                    .ObserveOn(Dispatcher.CurrentDispatcher)
+                // For DEBUG builds, we use the main UI dispatcher fors both
+                // layout and dispatcher queue threads because of a limitation
+                // with the native debugging capabilities.
+                _currentApplicationView = CoreApplication.GetCurrentView();
 #endif
+                var dispatcher = _currentApplicationView.Dispatcher;
+#else
+                var dispatcher = isSecondary
+                    ? s_layoutDispatcher
+                    : Dispatcher.CurrentDispatcher;
+
+                _currentDispatcherThread = isSecondary
+                    ? s_layoutDispatcherThread
+                    : Dispatcher.CurrentDispatcher.Thread;
+
+                if (isSecondary)
+                {
+                    s_layoutDispatcherReady.WaitOne();
+                }
+#endif
+
+                _subscription = _actionSubject
+                    .ObserveOn(dispatcher)
                     .Subscribe(action =>
                     {
                         try
@@ -180,9 +235,9 @@ namespace ReactNative.Bridge.Queue
             protected override bool IsOnThreadCore()
             {
 #if WINDOWS_UWP
-                return CoreWindow.GetForCurrentThread().Dispatcher != null;
+                return GetApplicationView() == _currentApplicationView;
 #else
-                return Thread.CurrentThread == Dispatcher.CurrentDispatcher.Thread;
+                return Thread.CurrentThread == _currentDispatcherThread;
 #endif
             }
 
@@ -193,6 +248,26 @@ namespace ReactNative.Bridge.Queue
                 _actionSubject.Dispose();
                 _subscription.Dispose();
             }
+
+#if WINDOWS_UWP
+            private CoreApplicationView GetApplicationView()
+            {
+#if CREATE_LAYOUT_THREAD
+                if (_isSecondary && s_secondaryView.Dispatcher.HasThreadAccess)
+                {
+                    return s_secondaryView;
+                }
+                else if (!_isSecondary)
+                {
+                    return CoreApplication.GetCurrentView();
+                }
+
+                return null;
+#else
+                return CoreApplication.GetCurrentView();
+#endif
+            }
+#endif
         }
 
         class SingleBackgroundMessageQueueThread : MessageQueueThread

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/MessageQueueThreadKind.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/MessageQueueThreadKind.cs
@@ -19,6 +19,11 @@
         /// Any background thread type.
         /// </summary>
         BackgroundAnyThread,
+
+        /// <summary>
+        /// Layout thread type.
+        /// </summary>
+        LayoutThread,
     }
 
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/MessageQueueThreadSpec.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/MessageQueueThreadSpec.cs
@@ -30,6 +30,11 @@ namespace ReactNative.Bridge.Queue
         public static MessageQueueThreadSpec DispatcherThreadSpec { get; } = new MessageQueueThreadSpec(MessageQueueThreadKind.DispatcherThread, "main_ui");
 
         /// <summary>
+        /// Singleton layout <see cref="IMessageQueueThread"/> specification. 
+        /// </summary>
+        public static MessageQueueThreadSpec LayoutThreadSpec { get; } = new MessageQueueThreadSpec(MessageQueueThreadKind.LayoutThread, "layout");
+
+        /// <summary>
         /// Factory for creating <see cref="MessageQueueThreadSpec"/>s.
         /// </summary>
         /// <param name="name">The name.</param>
@@ -40,6 +45,11 @@ namespace ReactNative.Bridge.Queue
             if (kind == MessageQueueThreadKind.DispatcherThread)
             {
                 throw new NotSupportedException(Invariant($"Use the singleton {nameof(DispatcherThreadSpec)} instance."));
+            }
+
+            if (kind == MessageQueueThreadKind.LayoutThread)
+            {
+                throw new NotSupportedException(Invariant($"Use the singleton {nameof(LayoutThreadSpec)} instance."));
             }
 
             return new MessageQueueThreadSpec(kind, name);

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/ReactQueueConfiguration.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/ReactQueueConfiguration.cs
@@ -11,15 +11,18 @@ namespace ReactNative.Bridge.Queue
     class ReactQueueConfiguration : IReactQueueConfiguration
     {
         private readonly MessageQueueThread _dispatcherQueueThread;
+        private readonly MessageQueueThread _layoutQueueThread;
         private readonly MessageQueueThread _nativeModulesQueueThread;
         private readonly MessageQueueThread _jsQueueThread;
 
         private ReactQueueConfiguration(
             MessageQueueThread dispatcherQueueThread,
+            MessageQueueThread layoutQueueThread,
             MessageQueueThread nativeModulesQueueThread,
             MessageQueueThread jsQueueThread)
         {
             _dispatcherQueueThread = dispatcherQueueThread;
+            _layoutQueueThread = layoutQueueThread;
             _nativeModulesQueueThread = nativeModulesQueueThread;
             _jsQueueThread = jsQueueThread;
         }
@@ -32,6 +35,17 @@ namespace ReactNative.Bridge.Queue
             get
             {
                 return _dispatcherQueueThread;
+            }
+        }
+
+        /// <summary>
+        /// The layout queue thread.
+        /// </summary>
+        public IMessageQueueThread LayoutQueueThread
+        {
+            get
+            {
+                return _layoutQueueThread;
             }
         }
 
@@ -67,6 +81,7 @@ namespace ReactNative.Bridge.Queue
         public void Dispose()
         {
             _dispatcherQueueThread.Dispose();
+            _layoutQueueThread.Dispose();
             _nativeModulesQueueThread.Dispose();
             _jsQueueThread.Dispose();
         }
@@ -85,6 +100,9 @@ namespace ReactNative.Bridge.Queue
             var dispatcherThreadSpec = MessageQueueThreadSpec.DispatcherThreadSpec;
             var dispatcherThread = MessageQueueThread.Create(dispatcherThreadSpec, exceptionHandler);
 
+            var layoutThreadSpec = MessageQueueThreadSpec.LayoutThreadSpec;
+            var layoutThread = MessageQueueThread.Create(layoutThreadSpec, exceptionHandler);
+
             var jsThread = spec.JSQueueThreadSpec != dispatcherThreadSpec
                 ? MessageQueueThread.Create(spec.JSQueueThreadSpec, exceptionHandler)
                 : dispatcherThread;
@@ -93,7 +111,11 @@ namespace ReactNative.Bridge.Queue
                 ? MessageQueueThread.Create(spec.NativeModulesQueueThreadSpec, exceptionHandler)
                 : dispatcherThread;
 
-            return new ReactQueueConfiguration(dispatcherThread, nativeModulesThread, jsThread);
+            return new ReactQueueConfiguration(
+                dispatcherThread,
+                layoutThread, 
+                nativeModulesThread, 
+                jsThread);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -230,6 +230,40 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
+        /// Checks if the current thread is on the React instance layout
+        /// queue thread.
+        /// </summary>
+        /// <returns>
+        /// <b>true</b> if the call is from the layout queue thread,
+        ///  <b>false</b> otherwise.
+        /// </returns>
+        public bool IsOnLayoutQueueThread()
+        {
+            AssertReactInstance();
+            return _reactInstance.QueueConfiguration.LayoutQueueThread.IsOnThread();
+        }
+
+        /// <summary>
+        /// Asserts that the current thread is on the React instance layout
+        /// queue thread.
+        /// </summary>
+        public void AssertOnLayoutQueueThread()
+        {
+            AssertReactInstance();
+            _reactInstance.QueueConfiguration.LayoutQueueThread.AssertOnThread();
+        }
+
+        /// <summary>
+        /// Enqueues an action on the layout queue thread.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        public void RunOnLayoutQueueThread(Action action)
+        {
+            AssertReactInstance();
+            _reactInstance.QueueConfiguration.LayoutQueueThread.RunOnQueue(action);
+        }
+
+        /// <summary>
         /// Checks if the current thread is on the React instance
         /// JavaScript queue thread.
         /// </summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -115,11 +115,11 @@ namespace ReactNative.UIManager
                 var newWidth = args.NewSize.Width;
                 var newHeight = args.NewSize.Height;
 
-                Context.RunOnNativeModulesQueueThread(() =>
+                Context.RunOnLayoutQueueThread(() =>
                 {
                     if (currentCount == resizeCount)
                     {
-                        Context.AssertOnNativeModulesQueueThread();
+                        Context.AssertOnLayoutQueueThread();
                         _uiImplementation.UpdateRootNodeSize(tag, newWidth, newHeight);
                     }
                 });
@@ -135,7 +135,8 @@ namespace ReactNative.UIManager
         /// <param name="block">The UI block.</param>
         public void AddUIBlock(IUIBlock block)
         {
-            _uiImplementation.AddUIBlock(block);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.AddUIBlock(block));
         }
 
         #region React Methods
@@ -147,7 +148,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void removeRootView(int rootViewTag)
         {
-            _uiImplementation.RemoveRootView(rootViewTag);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.RemoveRootView(rootViewTag));
         }
 
         /// <summary>
@@ -160,7 +162,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void createView(int tag, string className, int rootViewTag, JObject props)
         {
-            _uiImplementation.CreateView(tag, className, rootViewTag, props);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.CreateView(tag, className, rootViewTag, props));
         }
 
         /// <summary>
@@ -172,7 +175,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void updateView(int tag, string className, JObject props)
         {
-            _uiImplementation.UpdateView(tag, className, props);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.UpdateView(tag, className, props));
         }
 
         /// <summary>
@@ -204,13 +208,14 @@ namespace ReactNative.UIManager
             int[] addAtIndexes,
             int[] removeFrom)
         {
-            _uiImplementation.ManageChildren(
-                viewTag,
-                moveFrom,
-                moveTo,
-                addChildTags,
-                addAtIndexes,
-                removeFrom);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ManageChildren(
+                    viewTag,
+                    moveFrom,
+                    moveTo,
+                    addChildTags,
+                    addAtIndexes,
+                    removeFrom));
         }
 
         /// <summary>
@@ -226,7 +231,8 @@ namespace ReactNative.UIManager
             int viewTag,
             int[] childrenTags)
         {
-            _uiImplementation.SetChildren(viewTag, childrenTags);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.SetChildren(viewTag, childrenTags));
         }
 
         /// <summary>
@@ -242,7 +248,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void replaceExistingNonRootView(int oldTag, int newTag)
         {
-            _uiImplementation.ReplaceExistingNonRootView(oldTag, newTag);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ReplaceExistingNonRootView(oldTag, newTag));
         }
 
         /// <summary>
@@ -253,7 +260,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void removeSubviewsFromContainerWithID(int containerTag)
         {
-            _uiImplementation.RemoveSubViewsFromContainerWithId(containerTag);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.RemoveSubViewsFromContainerWithId(containerTag));
         }
 
         /// <summary>
@@ -265,7 +273,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void measure(int reactTag, ICallback callback)
         {
-            _uiImplementation.Measure(reactTag, callback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.Measure(reactTag, callback));
         }
 
         /// <summary>
@@ -277,7 +286,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void measureInWindow(int reactTag, ICallback callback)
         {
-            _uiImplementation.MeasureInWindow(reactTag, callback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.MeasureInWindow(reactTag, callback));
         }
 
         /// <summary>
@@ -302,7 +312,8 @@ namespace ReactNative.UIManager
             ICallback errorCallback,
             ICallback successCallback)
         {
-            _uiImplementation.MeasureLayout(tag, ancestorTag, errorCallback, successCallback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.MeasureLayout(tag, ancestorTag, errorCallback, successCallback));
         }
 
         /// <summary>
@@ -325,7 +336,8 @@ namespace ReactNative.UIManager
             ICallback errorCallback,
             ICallback successCallback)
         {
-            _uiImplementation.MeasureLayoutRelativeToParent(tag, errorCallback, successCallback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.MeasureLayoutRelativeToParent(tag, errorCallback, successCallback));
         }
 
         /// <summary>
@@ -348,11 +360,12 @@ namespace ReactNative.UIManager
             JArray point,
             ICallback callback)
         {
-            _uiImplementation.FindSubViewIn(
-                reactTag,
-                point[0].Value<double>(),
-                point[1].Value<double>(),
-                callback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.FindSubViewIn(
+                    reactTag,
+                    point[0].Value<double>(),
+                    point[1].Value<double>(),
+                    callback));
         }
 
         /// <summary>
@@ -365,7 +378,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void setJSResponder(int reactTag, bool blockNativeResponder)
         {
-            _uiImplementation.SetJavaScriptResponder(reactTag, blockNativeResponder);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.SetJavaScriptResponder(reactTag, blockNativeResponder));
         }
 
         /// <summary>
@@ -374,7 +388,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void clearJSResponder()
         {
-            _uiImplementation.ClearJavaScriptResponder();
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ClearJavaScriptResponder());
         }
 
         /// <summary>
@@ -386,7 +401,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void dispatchViewManagerCommand(int reactTag, int commandId, JArray commandArgs)
         {
-            _uiImplementation.DispatchViewManagerCommand(reactTag, commandId, commandArgs);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.DispatchViewManagerCommand(reactTag, commandId, commandArgs));
         }
 
         /// <summary>
@@ -408,7 +424,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void showPopupMenu(int reactTag, string[] items, ICallback error, ICallback success)
         {
-            _uiImplementation.ShowPopupMenu(reactTag, items, error, success);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ShowPopupMenu(reactTag, items, error, success));
         }
 
         /// <summary>
@@ -429,10 +446,11 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void configureNextLayoutAnimation(JObject config, ICallback success, ICallback error)
         {
-            _uiImplementation.ConfigureNextLayoutAnimation(config, success, error);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ConfigureNextLayoutAnimation(config, success, error));
         }
 
-#endregion
+        #endregion
 
         #region ILifecycleEventListenere
 
@@ -475,12 +493,10 @@ namespace ReactNative.UIManager
         {
             var batchId = _batchId++;
 
-            using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "onBatchCompleteUI")
-                .With("BatchId", batchId)
-                .Start())
+            Context.RunOnLayoutQueueThread(() =>
             {
                 _uiImplementation.DispatchViewUpdates(batchId);
-            }
+            });
         }
 
         #endregion

--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
@@ -408,12 +408,6 @@ namespace ReactNative.UIManager
         /// <param name="batchId">The batch identifier.</param>
         internal void DispatchViewUpdates(int batchId)
         {
-            var operations = _operations.Count == 0 ? null : _operations;
-            if (operations != null)
-            {
-                _operations = new List<Action>();
-            }
-
             var nonBatchedOperations = default(Action[]);
             lock (_nonBatchedGate)
             {
@@ -430,6 +424,12 @@ namespace ReactNative.UIManager
 
             lock (_gate)
             {
+                var operations = _operations.Count == 0 ? null : _operations;
+                if (operations != null)
+                {
+                    _operations = new List<Action>();
+                }
+
                 _batches.Add(() =>
                 {
                     using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "DispatchUI")

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
@@ -1,6 +1,5 @@
 ﻿using Facebook.Yoga;
 using Newtonsoft.Json.Linq;
-using ReactNative.Bridge;
 using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
@@ -289,43 +288,31 @@ namespace ReactNative.Views.TextInput
                 - (YogaConstants.IsUndefined(borderRightWidth) ? 0 : borderRightWidth));
             var normalizedHeight = Math.Max(0, YogaConstants.IsUndefined(height) ? double.PositiveInfinity : height);
 
-            // This is not a terribly efficient way of projecting the height of
-            // the text elements. It requires that we have access to the
-            // dispatcher in order to do measurement, which, for obvious
-            // reasons, can cause perceived performance issues as it will block
-            // the UI thread from handling other work.
-            //
-            // TODO: determine another way to measure text elements.
-            var task = DispatcherHelpers.CallOnDispatcher(() =>
+            var textBlock = new TextBlock
             {
-                var textBlock = new TextBlock
-                {
-                    TextWrapping = TextWrapping.Wrap,
-                };
+                TextWrapping = TextWrapping.Wrap,
+            };
 
-                var normalizedText = string.IsNullOrEmpty(textInputNode._text) ? " " : textInputNode._text;
-                var inline = new Run { Text = normalizedText };
-                FormatInline(textInputNode, inline);
+            var normalizedText = string.IsNullOrEmpty(textInputNode._text) ? " " : textInputNode._text;
+            var inline = new Run { Text = normalizedText };
+            FormatInline(textInputNode, inline);
 
-                textBlock.Inlines.Add(inline);
+            textBlock.Inlines.Add(inline);
 
-                textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
+            textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
 
-                var borderTopWidth = textInputNode.GetBorder(YogaEdge.Top);
-                var borderBottomWidth = textInputNode.GetBorder(YogaEdge.Bottom);
+            var borderTopWidth = textInputNode.GetBorder(YogaEdge.Top);
+            var borderBottomWidth = textInputNode.GetBorder(YogaEdge.Bottom);
 
-                var finalizedHeight = textBlock.DesiredSize.Height;
-                finalizedHeight += textInputNode._computedPadding[1];
-                finalizedHeight += textInputNode._computedPadding[3];
-                finalizedHeight += YogaConstants.IsUndefined(borderTopWidth) ? 0 : borderTopWidth;
-                finalizedHeight += YogaConstants.IsUndefined(borderBottomWidth) ? 0 : borderBottomWidth;
+            var finalizedHeight = (float)textBlock.DesiredSize.Height;
+            finalizedHeight += textInputNode._computedPadding[1];
+            finalizedHeight += textInputNode._computedPadding[3];
+            finalizedHeight += YogaConstants.IsUndefined(borderTopWidth) ? 0 : borderTopWidth;
+            finalizedHeight += YogaConstants.IsUndefined(borderBottomWidth) ? 0 : borderBottomWidth;
 
-                return MeasureOutput.Make(
-                    (float)Math.Ceiling(width), 
-                    (float)Math.Ceiling(finalizedHeight));
-            });
-
-            return task.Result;
+            return MeasureOutput.Make(
+                (float)Math.Ceiling(width),
+                (float)Math.Ceiling(finalizedHeight));
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Tests/Bridge/Queue/MessageQueueThreadTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/Queue/MessageQueueThreadTests.cs
@@ -26,6 +26,7 @@ namespace ReactNative.Tests.Bridge.Queue
         public void MessageQueueThread_CreateUiThread_ThrowsNotSupported()
         {
             AssertEx.Throws<NotSupportedException>(() => MessageQueueThreadSpec.Create("ui", MessageQueueThreadKind.DispatcherThread));
+            AssertEx.Throws<NotSupportedException>(() => MessageQueueThreadSpec.Create("layout", MessageQueueThreadKind.LayoutThread));
         }
 
         [TestMethod]
@@ -33,12 +34,14 @@ namespace ReactNative.Tests.Bridge.Queue
         {
             var thrown = 0;
             var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => thrown++));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, ex => thrown++));
             var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => thrown++);
             var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => thrown++);
 
             var queueThreads = new[]
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };
@@ -69,12 +72,14 @@ namespace ReactNative.Tests.Bridge.Queue
             });
 
             var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, handler));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, handler));
             var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), handler);
             var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), handler);
 
             var queueThreads = new[]
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };
@@ -92,9 +97,10 @@ namespace ReactNative.Tests.Bridge.Queue
         [TestMethod]
         public async Task MessageQueueThread_OneAtATime()
         {
-            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => { Assert.Fail(); }));
-            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => { Assert.Fail(); });
-            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => { Assert.Fail(); });
+            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => Assert.Fail()));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, ex => Assert.Fail()));
+            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => Assert.Fail());
+            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => Assert.Fail());
 
             var enter = new AutoResetEvent(false);
             var exit = new AutoResetEvent(false);
@@ -102,6 +108,7 @@ namespace ReactNative.Tests.Bridge.Queue
             var queueThreads = new[] 
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };
@@ -126,13 +133,15 @@ namespace ReactNative.Tests.Bridge.Queue
         [TestMethod]
         public async Task MessageQueueThread_Dispose()
         {
-            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => { Assert.Fail(); }));
-            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => { Assert.Fail(); });
-            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => { Assert.Fail(); });
+            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => Assert.Fail()));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, ex => Assert.Fail()));
+            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => Assert.Fail());
+            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => Assert.Fail());
 
             var queueThreads = new[]
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -32,7 +32,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;NO_REFLECTION</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CREATE_LAYOUT_THREAD</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -56,7 +56,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
     <OutputPath>bin\ARM\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;NO_REFLECTION</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CREATE_LAYOUT_THREAD</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -80,7 +80,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;NO_REFLECTION</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CREATE_LAYOUT_THREAD</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Prior to this change, layout was performed on any background thread. Because of this, we had to perform text measurement on the UI thread, which incurred many blocking calls to the UI. This change adds a secondary CoreApplicationView + Dispatcher in UWP and a secondary STA thread in WPF. This thread is characterized as the layout thread, which is only used from the UIManager. All text measurement calls can now be made directly without having to context switch to the main UI thread.

Fixes #106 