### PR TITLE
feat(unbundle): Adds unbundle support to react-native-windows

### DIFF
--- a/ReactWindows/ChakraBridge/ChakraBridge.vcxproj
+++ b/ReactWindows/ChakraBridge/ChakraBridge.vcxproj
@@ -208,6 +208,8 @@
   <ItemGroup>
     <ClInclude Include="asprintf.h" />
     <ClInclude Include="ChakraHost.h" />
+    <ClInclude Include="JsIndexedModulesUnbundle.h" />
+    <ClInclude Include="JsModulesUnbundle.h" />
     <ClInclude Include="JsStringify.h" />
     <ClInclude Include="NativeJavaScriptExecutor.h" />
     <ClInclude Include="ChakraStringResult.h" />
@@ -217,6 +219,8 @@
   <ItemGroup>
     <ClCompile Include="asprintf.cpp" />
     <ClCompile Include="ChakraHost.cpp" />
+    <ClCompile Include="JsIndexedModulesUnbundle.cpp" />
+    <ClCompile Include="JsModulesUnbundle.cpp" />
     <ClCompile Include="JsStringify.cpp" />
     <ClCompile Include="NativeJavaScriptExecutor.cpp" />
     <ClCompile Include="pch.cpp">

--- a/ReactWindows/ChakraBridge/ChakraBridge.vcxproj.filters
+++ b/ReactWindows/ChakraBridge/ChakraBridge.vcxproj.filters
@@ -12,6 +12,8 @@
     <ClCompile Include="NativeJavaScriptExecutor.cpp" />
     <ClCompile Include="asprintf.cpp" />
     <ClCompile Include="JsStringify.cpp" />
+    <ClCompile Include="JsModulesUnbundle.cpp" />
+    <ClCompile Include="JsIndexedModulesUnbundle.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -21,5 +23,7 @@
     <ClInclude Include="asprintf.h" />
     <ClInclude Include="JsStringify.h" />
     <ClInclude Include="SerializedSourceContext.h" />
+    <ClInclude Include="JsModulesUnbundle.h" />
+    <ClInclude Include="JsIndexedModulesUnbundle.h" />
   </ItemGroup>
 </Project>

--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -1,7 +1,11 @@
 ﻿#include "pch.h"
 #include "ChakraHost.h"
+#include "JsIndexedModulesUnbundle.h"
 #include "JsStringify.h"
 #include "SerializedSourceContext.h"
+#include <stdint.h>
+
+const unsigned int MagicFileHeader = 0xFB0BD1E5;
 
 void ThrowException(const wchar_t* szException)
 {
@@ -27,106 +31,109 @@ JsErrorCode DefineHostCallback(JsValueRef globalObject, const wchar_t *callbackN
 
 wchar_t* LogLevel(int logLevel)
 {
-	switch (logLevel)
-	{
-	case 0:
-		return L"Trace";
-	case 1:
-		return L"Info";
-	case 2:
-		return L"Warn";
-	case 3:
-		return L"Error";
-	default:
-		return L"Log";
-	}
+    switch (logLevel)
+    {
+    case 0:
+        return L"Trace";
+    case 1:
+        return L"Info";
+    case 2:
+        return L"Warn";
+    case 3:
+        return L"Error";
+    default:
+        return L"Log";
+    }
 }
 
 JsValueRef CALLBACK NativeLoggingCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState)
 {
 #ifdef _DEBUG
-	wchar_t buff[56];
-	double logLevelIndex;
-	JsNumberToDouble(arguments[2], &logLevelIndex);
-	swprintf(buff, 56, L"[JS %s] ", LogLevel((int)logLevelIndex));
-	OutputDebugStringW(buff);
-	StringifyJsString(arguments[1]);
-	OutputDebugStringW(L"\n");
+    wchar_t buff[56];
+    double logLevelIndex;
+    JsNumberToDouble(arguments[2], &logLevelIndex);
+    swprintf(buff, 56, L"[JS %s] ", LogLevel((int)logLevelIndex));
+    OutputDebugStringW(buff);
+    StringifyJsString(arguments[1]);
+    OutputDebugStringW(L"\n");
 #endif
-	return JS_INVALID_REFERENCE;
+    return JS_INVALID_REFERENCE;
 }
 
-JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE* hFile, HANDLE* hMap)
+JsErrorCode ChakraHost::LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE* hFile, HANDLE* hMap, bool bIsReadOnly)
 {
-    *pData = nullptr;
+	*pData = nullptr;
 
-    *hFile = CreateFile2(szPath, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, OPEN_EXISTING, nullptr);
-    if (*hFile == INVALID_HANDLE_VALUE)
-    {
-        return JsErrorFatal;
-    }
+	DWORD dwShareMode = bIsReadOnly ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE;
+	*hFile = CreateFile2(szPath, dwShareMode, FILE_SHARE_READ, OPEN_EXISTING, nullptr);
+	if (*hFile == INVALID_HANDLE_VALUE)
+	{
+		return JsErrorFatal;
+	}
 
-    *hMap = CreateFileMapping(*hFile, nullptr, PAGE_READWRITE | SEC_RESERVE, 0, 0, L"ReactNativeMapping");
-    if (*hMap == NULL)
-    {
-        CloseHandle(*hFile);
-        return JsErrorFatal;
-    }
+	DWORD flProtect = (bIsReadOnly ? PAGE_READONLY : PAGE_READWRITE) | SEC_RESERVE;
+	*hMap = CreateFileMapping(*hFile, nullptr, flProtect, 0, 0, L"ReactNativeMapping");
+	if (*hMap == NULL)
+	{
+		CloseHandle(*hFile);
+		return JsErrorFatal;
+	}
 
-    *pData = (BYTE*)MapViewOfFile(*hMap, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0);
-    if (*pData == NULL)
-    {
-        CloseHandle(*hMap);
-        CloseHandle(*hFile);
-        return JsErrorFatal;
-    }
+	DWORD dwDesiredAccess = bIsReadOnly ? FILE_MAP_READ : FILE_MAP_READ | FILE_MAP_WRITE;
+	*pData = (BYTE*)MapViewOfFile(*hMap, dwDesiredAccess, 0, 0, 0);
+	if (*pData == NULL)
+	{
+		CloseHandle(*hMap);
+		CloseHandle(*hFile);
+		return JsErrorFatal;
+	}
 
-    return JsNoError;
+	return JsNoError;
 }
 
-JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData)
+JsErrorCode ChakraHost::LoadFileContents(const wchar_t* szPath, wchar_t** pszData)
 {
-    FILE *file;
-    *pszData = nullptr;
+	FILE *file;
+	*pszData = nullptr;
 
-    if (_wfopen_s(&file, szPath, L"rb"))
-    {
-        return JsErrorInvalidArgument;
-    }
+	if (_wfopen_s(&file, szPath, L"rb"))
+	{
+		return JsErrorInvalidArgument;
+	}
 
-    unsigned int current = ftell(file);
-    fseek(file, 0, SEEK_END);
-    unsigned int end = ftell(file);
-    fseek(file, current, SEEK_SET);
-    unsigned int lengthBytes = end - current;
-    char *rawBytes = (char *)calloc(lengthBytes + 1, sizeof(char));
+	unsigned int current = ftell(file);
+	fseek(file, 0, SEEK_END);
+	unsigned int end = ftell(file);
+	fseek(file, current, SEEK_SET);
+	unsigned int lengthBytes = end - current;
+	char *rawBytes = (char *)calloc(lengthBytes + 1, sizeof(char));
 
-    if (rawBytes == nullptr)
-    {
-        return JsErrorFatal;
-    }
+	if (rawBytes == nullptr)
+	{
+		return JsErrorFatal;
+	}
 
-    fread(rawBytes, sizeof(char), lengthBytes, file);
-    if (fclose(file))
-    {
-        return JsErrorFatal;
-    }
+	fread(rawBytes, sizeof(char), lengthBytes, file);
+	if (fclose(file))
+	{
+		return JsErrorFatal;
+	}
 
-    *pszData = (wchar_t *)calloc(lengthBytes + 1, sizeof(wchar_t));
-    if (*pszData == nullptr)
-    {
-        free(rawBytes);
-        return JsErrorFatal;
-    }
+	*pszData = (wchar_t *)calloc(lengthBytes + 1, sizeof(wchar_t));
+	if (*pszData == nullptr)
+	{
+		free(rawBytes);
+		return JsErrorFatal;
+	}
 
-    if (MultiByteToWideChar(CP_UTF8, 0, rawBytes, lengthBytes + 1, *pszData, lengthBytes + 1) == 0)
-    {
-        free(*pszData);
-        free(rawBytes);
-        return JsErrorFatal;
-    }
+	if (MultiByteToWideChar(CP_UTF8, 0, rawBytes, lengthBytes + 1, *pszData, lengthBytes + 1) == 0)
+	{
+		free(*pszData);
+		free(rawBytes);
+		return JsErrorFatal;
+	}
 
-    return JsNoError;
+	return JsNoError;
 }
 
 bool CompareLastWrite(const wchar_t* szPath1, const wchar_t* szPath2)
@@ -164,6 +171,80 @@ void CALLBACK UnloadSourceCallback(JsSourceContext sourceContext)
     delete context;
 }
 
+JsValueRef CALLBACK NativeRequire(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState)
+{
+	// cast the callback state to the ChakraHost instance
+	auto host = (ChakraHost*)callbackState;
+
+	// Assert the argument count.
+	if (argumentCount != 2)
+	{
+		ThrowException(L"Expected only one parameter to nativeRequire.");
+		return JS_INVALID_REFERENCE;
+	}
+
+	// Assert a valid module index
+	double index;
+	IfFailThrow(JsNumberToDouble(arguments[1], &index), L"Index parameter to nativeRequire must be a number.");
+	uint32_t convertedIndex = (uint32_t)index;
+	if (convertedIndex <= 0)
+	{
+		ThrowException(L"Index parameter to nativeRequire must be greater than zero.");
+		return JS_INVALID_REFERENCE;
+	}
+
+	// Retrieve the unbundle module
+	auto module = host->unbundle->GetModule(convertedIndex);
+	if (!module)
+	{
+		ThrowException(L"Unable to resolve unbundle module.");
+		return JS_INVALID_REFERENCE;
+	}
+
+	// Evaluate the unbundle module script
+	if (host->EvaluateScript(module->source, module->sourceUrl, nullptr) != JsNoError)
+	{
+		// Note, control flow continues below, exception set to JS runtime
+		ThrowException(L"Failure occurred while evaluating unbundle module.");
+	}
+
+	delete module;
+	return JS_INVALID_REFERENCE;
+}
+
+bool HasMagicFileHeader(const wchar_t* szPath)
+{
+	FILE *file;
+	if (_wfopen_s(&file, szPath, L"rb"))
+	{
+		return false;
+	}
+
+	uint32_t magicHeader;
+	size_t nRead = fread(&magicHeader, sizeof(uint32_t), 1, file);
+	if (fclose(file) || nRead != 1)
+	{
+		return false;
+	}
+
+	// The header is little-endian, this function assumes a little-endian host
+	return magicHeader == MagicFileHeader;
+}
+
+bool IsUnbundle(const wchar_t* szSourcePath)
+{
+	wchar_t buffer[_MAX_DIR] = L"";
+	auto filename = wcsrchr(szSourcePath, L'\\');
+	wcsncat_s(buffer, szSourcePath, wcslen(szSourcePath) - wcslen(filename) + 1);
+	wcscat_s(buffer, L"js-modules\\UNBUNDLE");
+	return HasMagicFileHeader(buffer);
+}
+
+bool IsIndexedUnbundle(const wchar_t* szSourcePath)
+{
+	return HasMagicFileHeader(szSourcePath);
+}
+
 JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t* szSerializedPath, const wchar_t* szSourceUri, JsValueRef* result)
 {
     HANDLE hFile = NULL;
@@ -187,7 +268,7 @@ JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t
     }
     else
     {
-        IfFailRet(LoadByteCode(szSerializedPath, &buffer, &hFile, &hMap));
+        IfFailRet(LoadByteCode(szSerializedPath, &buffer, &hFile, &hMap, false));
     }
 
     SerializedSourceContext* context = new SerializedSourceContext();
@@ -203,12 +284,42 @@ JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t
 JsErrorCode ChakraHost::RunScript(const wchar_t* szFileName, const wchar_t* szSourceUri, JsValueRef* result)
 {
     wchar_t* contents = nullptr;
-    IfFailRet(LoadFileContents(szFileName, &contents));
+    if (IsUnbundle(szFileName))
+    {
+        this->unbundle = new JsModulesUnbundle(szFileName);
+		IfFailRet(InitNativeRequire());
+        IfFailRet(unbundle->GetStartupCode(&contents));
+    }
+    else if (IsIndexedUnbundle(szFileName))
+    {
+        this->unbundle = new JsIndexedModulesUnbundle(szFileName);
+		IfFailRet(InitNativeRequire());
+		IfFailRet(unbundle->GetStartupCode(&contents));
+    }
+    else
+    {
+        IfFailRet(LoadFileContents(szFileName, &contents));
+    }
 
-    JsErrorCode status = JsRunScript(contents, currentSourceContext++, szSourceUri, result);
+    JsErrorCode status = EvaluateScript(contents, szSourceUri, result);
     free(contents);
 
     return status;
+}
+
+JsErrorCode ChakraHost::EvaluateScript(const wchar_t* szScript, const wchar_t* szSourceUri, JsValueRef* result)
+{
+	if (szScript == nullptr)
+	{
+		return JsErrorNullArgument;
+	}
+
+	if (szSourceUri == nullptr)
+	{
+		return JsErrorNullArgument;
+	}
+
+	return JsRunScript(szScript, currentSourceContext++, szSourceUri, result);
 }
 
 JsErrorCode ChakraHost::JsonStringify(JsValueRef argument, JsValueRef* result)
@@ -264,6 +375,13 @@ JsErrorCode ChakraHost::InitConsole()
     IfFailRet(DefineHostCallback(globalObject, L"nativeLoggingHook", NativeLoggingCallback, nullptr));
 
     return JsNoError;
+}
+
+JsErrorCode ChakraHost::InitNativeRequire()
+{
+	IfFailRet(DefineHostCallback(globalObject, L"nativeRequire", NativeRequire, this));
+
+	return JsNoError;
 }
 
 JsErrorCode ChakraHost::Init()

--- a/ReactWindows/ChakraBridge/ChakraHost.h
+++ b/ReactWindows/ChakraBridge/ChakraHost.h
@@ -1,11 +1,10 @@
 ﻿#pragma once
 
 #include "pch.h"
+#include "JsModulesUnbundle.h"
 #include <jsrt.h>
 
 bool CompareLastWrite(const wchar_t* szPath1, const wchar_t* szPath2);
-JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE* hFile, HANDLE* hMap);
-JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData);
 
 /// <summary>
 /// This class wraps the main functionality dealing with the JSRT.
@@ -14,24 +13,47 @@ class ChakraHost
 {
 public:
 	/// <summary>
-	/// Initializes a JSRT session with the context, globals, JSON, and console logging.
-	///</summary>
+	/// Loads a memory mapped file from the given path.
+	/// </summary>
+	/// <param name="szPath">The location of the file to load.</param>
+	/// <param name="pData">The location to write the mapped file data.</param>
+	/// <param name="hFile">The file handle.</param>
+	/// <param name="hFile">The mapped file handle.</param>
+	/// <param name="bIsReadOnly">Signals that the mapped file is only for reading.</param>
 	/// <returns>
 	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
 	/// </returns>
-	JsErrorCode Init();
+	static JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE* hFile, HANDLE* hMap, bool bIsReadOnly);
 
 	/// <summary>
-	/// Destorys the current JSRT session.
-	///</summary>
+	/// Loads the file contents from the given path.
+	/// </summary>
+	/// <param name="szPath">The location of the file to load.</param>
+	/// <param name="pszData">The location to write the file contents.</param>
 	/// <returns>
 	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
 	/// </returns>
-	JsErrorCode Destroy();
+	static JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData);
+
+    /// <summary>
+    /// Initializes a JSRT session with the context, globals, JSON, and console logging.
+    /// </summary>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode Init();
+
+    /// <summary>
+    /// Destorys the current JSRT session.
+    /// </summary>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode Destroy();
 
     /// <summary>
     /// Runs the script from the file location with the source URI and returns the <see cref="JsValueRef" /> result.
-    ///</summary>
+    /// </summary>
     /// <param name="szPath">The location of the script to run.</param>
     /// <param name="szSourceUri">The source URI of the script.</param>
     /// <param name="result">[Out] The result from running the script.</param>
@@ -52,57 +74,74 @@ public:
     /// </returns>
     JsErrorCode RunSerializedScript(const wchar_t* szPath, const wchar_t* szSerializedPath, const wchar_t* szSourceUri, JsValueRef* result);
 
-	/// <summary>
-	/// Calls JSON stringify on the given <see cref="JsValueRef" /> and returns the <see cref="JsValueRef" /> result.
-	///</summary>
-	/// <param name="argument">The argument to stringify.</param>
-	/// <param name="result">[Out] The result from running JSON.stringify.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
-	JsErrorCode JsonStringify(JsValueRef argument, JsValueRef* result);
+    /// <summary>
+    /// Calls JSON stringify on the given <see cref="JsValueRef" /> and returns the <see cref="JsValueRef" /> result.
+    /// </summary>
+    /// <param name="argument">The argument to stringify.</param>
+    /// <param name="result">[Out] The result from running JSON.stringify.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode JsonStringify(JsValueRef argument, JsValueRef* result);
+
+    /// <summary>
+    /// Calls JSON parse on the given <see cref="JsValueRef" /> and returns the <see cref="JsValueRef" /> result.
+    /// </summary>
+    /// <param name="argument">The argument to parse.</param>
+    /// <param name="result">[Out] The result from running JSON.parse.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode JsonParse(JsValueRef argument, JsValueRef* result);
+
+    /// <summary>
+    /// Gets a global variable and returns the <see cref="JsValueRef" /> result.
+    /// </summary>
+    /// <param name="szPropertyName">The property name from global to get.</param>
+    /// <param name="result">[Out] The global property value.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode GetGlobalVariable(const wchar_t* szPropertyName, JsValueRef* result);
+
+    /// <summary>
+    /// Sets a global variable with the <see cref="JsValueRef" />.
+    /// </summary>
+    /// <param name="szPropertyName">The property name from global to get.</param>
+    /// <param name="value">The global property value to set.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode SetGlobalVariable(const wchar_t* szPropertyName, JsValueRef value);
 
 	/// <summary>
-	/// Calls JSON parse on the given <see cref="JsValueRef" /> and returns the <see cref="JsValueRef" /> result.
-	///</summary>
-	/// <param name="argument">The argument to parse.</param>
-	/// <param name="result">[Out] The result from running JSON.parse.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
-	JsErrorCode JsonParse(JsValueRef argument, JsValueRef* result);
-
-	/// <summary>
-	/// Gets a global variable and returns the <see cref="JsValueRef" /> result.
-	///</summary>
-	/// <param name="szPropertyName">The property name from global to get.</param>
-	/// <param name="result">[Out] The global property value.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
-	JsErrorCode GetGlobalVariable(const wchar_t* szPropertyName, JsValueRef* result);
-
-	/// <summary>
-	/// Sets a global variable with the <see cref="JsValueRef" />.
-	///</summary>
-	/// <param name="szPropertyName">The property name from global to get.</param>
-	/// <param name="value">The global property value to set.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
-	JsErrorCode SetGlobalVariable(const wchar_t* szPropertyName, JsValueRef value);
-
-	/// <summary>
-	/// The JSRT global object for the session.
+	/// Evaluates the given script.
 	/// </summary>
-	JsValueRef globalObject;
-private:
-	JsErrorCode InitJson();
-	JsErrorCode InitConsole();
+	/// <param name="szScript">The script.</param>
+	/// <param name="szSourceUri">The source URI.</param>
+	/// <param name="result">The return value.</param>
+	/// <returns>
+	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
+	/// </returns>
+	JsErrorCode EvaluateScript(const wchar_t* szScript, const wchar_t* szSourceUri, JsValueRef* result);
 
-	unsigned currentSourceContext;
-	JsRuntimeHandle runtime;
-	JsContextRef context;
-	JsValueRef jsonParseObject;
-	JsValueRef jsonStringifyObject;
+    /// <summary>
+    /// The JSRT global object for the session.
+    /// </summary>
+    JsValueRef globalObject;
+
+	/// <summary>
+	/// The reference to the unbundle manager.
+	/// </summary>
+	JsModulesUnbundle* unbundle;
+private:
+    JsErrorCode InitJson();
+    JsErrorCode InitConsole();
+	JsErrorCode InitNativeRequire();
+
+    unsigned currentSourceContext;
+    JsRuntimeHandle runtime;
+    JsContextRef context;
+    JsValueRef jsonParseObject;
+    JsValueRef jsonStringifyObject;
 };

--- a/ReactWindows/ChakraBridge/ChakraStringResult.h
+++ b/ReactWindows/ChakraBridge/ChakraStringResult.h
@@ -9,9 +9,9 @@ namespace ChakraBridge {
 /// </summary>
 public value struct ChakraStringResult
 {
-	/// <summary>The <see cref="JsErrorCode" /> for the operation, JsNoError if no error has occurred.</summary>
+    /// <summary>The <see cref="JsErrorCode" /> for the operation, JsNoError if no error has occurred.</summary>
     int ErrorCode;
-	/// <summary>The string result for the operation.</summary>
+    /// <summary>The string result for the operation.</summary>
     String^ Result;
 };
 

--- a/ReactWindows/ChakraBridge/JsIndexedModulesUnbundle.cpp
+++ b/ReactWindows/ChakraBridge/JsIndexedModulesUnbundle.cpp
@@ -1,0 +1,110 @@
+#include "pch.h"
+#include "ChakraHost.h"
+#include "JsIndexedModulesUnbundle.h"
+
+JsIndexedModulesUnbundle::JsIndexedModulesUnbundle(const wchar_t* szSourcePath)
+{
+	// Clone the source path in case it is garbage collected
+	sourcePath = new wchar_t[_MAX_DIR];
+	sourcePath[0] = L'\0';
+	wcscat_s(sourcePath, _MAX_DIR, szSourcePath);
+}
+
+JsIndexedModulesUnbundle::~JsIndexedModulesUnbundle()
+{
+	delete[] sourcePath;
+
+	if (fileHandle != NULL)
+	{
+		UnmapViewOfFile(byteBuffer);
+		CloseHandle(mapHandle);
+		CloseHandle(fileHandle);
+	}
+	else
+	{
+		delete[] byteBuffer;
+	}
+}
+
+JsModulesUnbundleModule* JsIndexedModulesUnbundle::GetModule(uint32_t index)
+{
+	// The module data is little-endian, this function assumes a little-endian host
+	ModuleData moduleData = moduleTable.modules[index];
+
+	auto module = new JsModulesUnbundleModule();
+	auto filename = new wchar_t[_MAX_FNAME];
+	auto script = new char[moduleData.length];
+	auto wcScript = new wchar_t[moduleData.length];
+
+	// Create the source URL
+	IfErrnoCleanup(_itow_s(index, filename, _MAX_FNAME, 10));
+	IfErrnoCleanup(wcscat_s(filename, _MAX_FNAME, L".js"));
+
+	// Copy the script
+	size_t numConverted;
+	IfErrnoCleanup(memcpy_s(script, moduleData.length, byteBuffer + baseOffset + moduleData.offset, moduleData.length));
+	IfErrnoCleanup(mbstowcs_s(&numConverted, wcScript, moduleData.length, script, moduleData.length));
+	delete[] script;
+
+	// Return the module
+	module->source = wcScript;
+	module->sourceUrl = filename;
+	return module;
+
+cleanup:
+	delete module;
+	delete[] filename;
+	delete[] script;
+	delete[] wcScript;
+	return nullptr;
+}
+
+JsErrorCode JsIndexedModulesUnbundle::GetStartupCode(wchar_t** pszScript)
+{
+	// Open the memory mapped file
+	IfFailRet(ChakraHost::LoadByteCode(sourcePath, &byteBuffer, &fileHandle, &mapHandle, true));
+
+	// Copy the header data
+	uint32_t header[3];
+	if (memcpy_s(header, sizeof(header), byteBuffer, sizeof(header)))
+	{
+		return JsErrorFatal;
+	}
+
+	// Create the module table
+	uint32_t numberOfTableEntries = header[1];
+	moduleTable = ModuleTable(numberOfTableEntries);
+	uint32_t moduleTableSize = moduleTable.byteLength();
+	if (memcpy_s(moduleTable.modules, moduleTableSize, byteBuffer + sizeof(header), moduleTableSize))
+	{
+		return JsErrorFatal;
+	}
+
+	// Store the base offset
+	baseOffset = sizeof(header) + moduleTableSize;
+
+	// Copy the startup code
+	uint32_t startupCodeSize = header[2];
+	auto startupCode = new char[startupCodeSize];
+	auto wcStartupCode = new wchar_t[startupCodeSize];
+	if (memcpy_s(startupCode, startupCodeSize, byteBuffer + baseOffset, startupCodeSize))
+	{
+		delete[] startupCode;
+		delete[] wcStartupCode;
+		return JsErrorFatal;
+	}
+
+	// Convert startup code to wide char
+	size_t ignored;
+	if (mbstowcs_s(&ignored, wcStartupCode, startupCodeSize, startupCode, startupCodeSize))
+	{
+		delete[] startupCode;
+		delete[] wcStartupCode;
+		return JsErrorFatal;
+	}
+
+	delete[] startupCode;
+	*pszScript = wcStartupCode;
+
+	return JsNoError;
+}

--- a/ReactWindows/ChakraBridge/JsIndexedModulesUnbundle.h
+++ b/ReactWindows/ChakraBridge/JsIndexedModulesUnbundle.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdint.h>
+#include "JsModulesUnbundle.h"
+
+class JsIndexedModulesUnbundle : public JsModulesUnbundle
+{
+public:
+    JsIndexedModulesUnbundle(const wchar_t* szSourcePath);
+	~JsIndexedModulesUnbundle();
+	virtual JsModulesUnbundleModule* GetModule(uint32_t index) override;
+	virtual JsErrorCode GetStartupCode(wchar_t** pszScript) override;
+private:
+    wchar_t* sourcePath;
+	HANDLE fileHandle;
+	HANDLE mapHandle;
+	BYTE* byteBuffer;
+
+	struct ModuleData {
+		uint32_t offset;
+		uint32_t length;
+	};
+
+	static_assert(
+		sizeof(ModuleData) == 8,
+		"ModuleData must not have any padding and use sizes matching input files");
+
+	struct ModuleTable {
+		size_t numEntries;
+		ModuleData* modules;
+		ModuleTable() : numEntries(0) {};
+		ModuleTable(size_t entries) :
+			numEntries(entries),
+			modules(new ModuleData[numEntries]) {};
+		size_t byteLength() const {
+			return numEntries * sizeof(ModuleData);
+		}
+	};
+
+	ModuleTable moduleTable;
+	uint32_t baseOffset;
+};
+

--- a/ReactWindows/ChakraBridge/JsModulesUnbundle.cpp
+++ b/ReactWindows/ChakraBridge/JsModulesUnbundle.cpp
@@ -1,0 +1,64 @@
+#include "pch.h"
+#include "ChakraHost.h"
+#include "JsModulesUnbundle.h"
+
+const unsigned int MagicFileHeader = 0xFB0BD1E5;
+
+wchar_t* GetJavaScriptModuleDirectory(const wchar_t* sourcePath)
+{
+	auto buffer = new wchar_t[_MAX_DIR];
+	buffer[0] = '\0';
+	auto filename = wcsrchr(sourcePath, L'\\');
+	wcsncat_s(buffer, _MAX_DIR, sourcePath, wcslen(sourcePath) - wcslen(filename) + 1);
+	wcscat_s(buffer, _MAX_DIR, L"js-modules\\");
+	return buffer;
+}
+
+JsModulesUnbundle::JsModulesUnbundle()
+{
+}
+
+JsModulesUnbundle::JsModulesUnbundle(const wchar_t* szSourcePath)
+{
+	// Clone the source path in case it is garbage collected
+	sourcePath = new wchar_t[_MAX_DIR];
+    sourcePath[0] = L'\0';
+	wcscat_s(sourcePath, _MAX_DIR, szSourcePath);
+	modulesPath = GetJavaScriptModuleDirectory(sourcePath);
+}
+
+JsModulesUnbundle::~JsModulesUnbundle()
+{
+	delete[] sourcePath;
+	delete[] modulesPath;
+}
+
+JsModulesUnbundleModule* JsModulesUnbundle::GetModule(uint32_t index)
+{
+    auto module = new JsModulesUnbundleModule();
+    auto filename = new wchar_t[_MAX_FNAME];
+	wchar_t path[_MAX_DIR] = L"";
+	
+	IfErrnoCleanup(_itow_s(index, filename, _MAX_FNAME, 10));
+	IfErrnoCleanup(wcscat_s(filename, _MAX_FNAME, L".js"));
+	IfErrnoCleanup(wcscat_s(path, modulesPath));
+	IfErrnoCleanup(wcscat_s(path, filename));
+
+    module->sourceUrl = filename;
+	if (ChakraHost::LoadFileContents(path, &module->source) != JsNoError)
+	{
+		goto cleanup;
+	}
+
+    return module;
+
+cleanup:
+	delete filename;
+	delete module;
+	return nullptr;
+}
+
+JsErrorCode JsModulesUnbundle::GetStartupCode(wchar_t** pszScript)
+{
+	return ChakraHost::LoadFileContents(sourcePath, pszScript);
+}

--- a/ReactWindows/ChakraBridge/JsModulesUnbundle.h
+++ b/ReactWindows/ChakraBridge/JsModulesUnbundle.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <jsrt.h>
+#include <stdint.h>
+
+struct JsModulesUnbundleModule sealed
+{
+public:
+	wchar_t* source;
+	wchar_t* sourceUrl;
+	~JsModulesUnbundleModule()
+	{
+		delete[] source;
+		delete[] sourceUrl;
+	}
+};
+
+class JsModulesUnbundle
+{
+public:
+    JsModulesUnbundle(const wchar_t* szSourcePath);
+	~JsModulesUnbundle();
+	virtual JsModulesUnbundleModule* GetModule(uint32_t index);
+	virtual JsErrorCode GetStartupCode(wchar_t** pszScript);
+protected:
+    JsModulesUnbundle();
+private:
+	wchar_t* sourcePath;
+	wchar_t* modulesPath;
+};

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
@@ -14,49 +14,49 @@ namespace ChakraBridge {
 public ref class NativeJavaScriptExecutor sealed
 {
 public:
-	/// <summary>
-	/// Initializes the JSRT session.
-	/// </summary>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
+    /// <summary>
+    /// Initializes the JSRT session.
+    /// </summary>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
     int InitializeHost();
 
-	/// <summary>
-	/// Disposes the current JSRT session.
-	/// </summary>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
+    /// <summary>
+    /// Disposes the current JSRT session.
+    /// </summary>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
     int DisposeHost();
 
-	/// <summary>
-	/// Gets the global variable value.
-	/// </summary>
-	/// <param name="variableName">The global variable to get.</param>
-	/// <returns>
-	/// A compount result with the JSON stringified value and an error code if any occurred.
-	/// </returns>
+    /// <summary>
+    /// Gets the global variable value.
+    /// </summary>
+    /// <param name="variableName">The global variable to get.</param>
+    /// <returns>
+    /// A compount result with the JSON stringified value and an error code if any occurred.
+    /// </returns>
     ChakraStringResult GetGlobalVariable(String^ variableName);
 
-	/// <summary>
-	/// Sets the global variable
-	/// </summary>
-	/// <param name="variableName">The variable name to set.</param>
-	/// <param name="value">The value to set on the global variable.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
+    /// <summary>
+    /// Sets the global variable
+    /// </summary>
+    /// <param name="variableName">The variable name to set.</param>
+    /// <param name="value">The value to set on the global variable.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
     int SetGlobalVariable(String^ variableName, String^ value);
 
-	/// <summary>
-	/// Runs the given script with the source URI and returns the result.
-	/// </summary>
-	/// <param name="source">The source of the script to run.</param>
-	/// <param name="sourceUri">The source URI of the script to run.</param>
-	/// <returns>
-	/// A compount result with the JSON stringified value and an error code if any occurred.
-	/// </returns>
+    /// <summary>
+    /// Runs the given script with the source URI and returns the result.
+    /// </summary>
+    /// <param name="source">The source of the script to run.</param>
+    /// <param name="sourceUri">The source URI of the script to run.</param>
+    /// <returns>
+    /// A compount result with the JSON stringified value and an error code if any occurred.
+    /// </returns>
     int RunScript(String^ source, String^ sourceUri);
 
     /// <summary>
@@ -70,34 +70,34 @@ public:
     /// </returns>
     int RunSerializedScript(String^ source, String^ serialized, String^ sourceUri);
 
-	/// <summary>
-	/// Calls the underlying function with the given module and method name and JSON stringified arguments.
-	/// </summary>
-	/// <param name="moduleName">The module name to call.</param>
-	/// <param name="methodName">The method name on the module to call.</param>
-	/// <param name="args">JSON stringified arguments to call on the module.</param>
-	/// <returns>
-	/// A compount result with the JSON stringified value and an error code if any occurred.
-	/// </returns>
+    /// <summary>
+    /// Calls the underlying function with the given module and method name and JSON stringified arguments.
+    /// </summary>
+    /// <param name="moduleName">The module name to call.</param>
+    /// <param name="methodName">The method name on the module to call.</param>
+    /// <param name="args">JSON stringified arguments to call on the module.</param>
+    /// <returns>
+    /// A compount result with the JSON stringified value and an error code if any occurred.
+    /// </returns>
     ChakraStringResult CallFunctionAndReturnFlushedQueue(String^ moduleName, String^ methodName, String^ args);
 
-	/// <summary>
-	/// Calls the underlying function with the callback ID and JSON stringified arguments.
-	/// </summary>
-	/// <param name="callbackId">The callback ID.</param>
-	/// <param name="args">JSON stringified arguments to call on the module.</param>
-	/// <returns>
-	/// A compount result with the JSON stringified value and an error code if any occurred.
-	/// </returns>
-	ChakraStringResult InvokeCallbackAndReturnFlushedQueue(int callbackId, String^ args);
+    /// <summary>
+    /// Calls the underlying function with the callback ID and JSON stringified arguments.
+    /// </summary>
+    /// <param name="callbackId">The callback ID.</param>
+    /// <param name="args">JSON stringified arguments to call on the module.</param>
+    /// <returns>
+    /// A compount result with the JSON stringified value and an error code if any occurred.
+    /// </returns>
+    ChakraStringResult InvokeCallbackAndReturnFlushedQueue(int callbackId, String^ args);
 
-	/// <summary>
-	/// Calls the flush queue function.
-	/// </summary>
-	/// <returns>
-	/// A compount result with the JSON stringified value and an error code if any occurred.
-	/// </returns>
-	ChakraStringResult FlushedQueue();
+    /// <summary>
+    /// Calls the flush queue function.
+    /// </summary>
+    /// <returns>
+    /// A compount result with the JSON stringified value and an error code if any occurred.
+    /// </returns>
+    ChakraStringResult FlushedQueue();
 private:
     ChakraHost host;
 };

--- a/ReactWindows/ChakraBridge/pch.h
+++ b/ReactWindows/ChakraBridge/pch.h
@@ -19,8 +19,8 @@
         if (status != JsNoError) \
         { \
             ChakraStringResult stringResult; \
-			stringResult.ErrorCode = status; \
-			return stringResult; \
+            stringResult.ErrorCode = status; \
+            return stringResult; \
         } \
     }
 
@@ -50,4 +50,12 @@
         { \
             goto cleanup; \
         } \
+    }
+
+#define IfErrnoCleanup(v) \
+    { \
+        if (v) \
+		{ \
+            goto cleanup; \
+		} \
     }

--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
@@ -23,9 +23,9 @@ namespace ReactNative.Tests
 
         public void Initialize() { }
 
-        public void RunScript(string script, string sourceUrl)
+        public void RunScript(string sourcePath, string sourceUrl)
         {
-            OnRunScript(script, sourceUrl);
+            OnRunScript(sourcePath, sourceUrl);
         }
 
         public void SetGlobalVariable(string propertyName, JToken value)

--- a/ReactWindows/ReactNative.Shared.Tests/ReactNative.Shared.Tests.projitems
+++ b/ReactWindows/ReactNative.Shared.Tests/ReactNative.Shared.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>eea8b852-4d07-48e1-8294-a21ab5909fe6</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ReactNative.Shared.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ReactNative.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\JavaScriptModuleRegistrySharedTests.cs" />

--- a/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
@@ -39,10 +39,10 @@ namespace ReactNative.Bridge
         void SetGlobalVariable(string propertyName, JToken value);
 
         /// <summary>
-        /// Runs the given script.
+        /// Runs the JavaScript at the given path.
         /// </summary>
-        /// <param name="script">The script.</param>
+        /// <param name="sourcePath">The source path.</param>
         /// <param name="sourceUrl">The source URL.</param>
-        void RunScript(string script, string sourceUrl);
+        void RunScript(string sourcePath, string sourceUrl);
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge.Queue;
-using ReactNative.Common;
-using ReactNative.Tracing;
 using System;
-using static System.FormattableString;
 
 namespace ReactNative.Bridge
 {
@@ -81,16 +78,16 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Evaluates JavaScript.
         /// </summary>
-        /// <param name="script">The script.</param>
+        /// <param name="sourcePath">The source path.</param>
         /// <param name="sourceUrl">The source URL.</param>
-        public void RunScript(string script, string sourceUrl)
+        public void RunScript(string sourcePath, string sourceUrl)
         {
-            if (script == null)
-                throw new ArgumentNullException(nameof(script));
+            if (sourcePath == null)
+                throw new ArgumentNullException(nameof(sourcePath));
             if (sourceUrl == null)
                 throw new ArgumentNullException(nameof(sourceUrl));
 
-            _jsExecutor.RunScript(script, sourceUrl);
+            _jsExecutor.RunScript(sourcePath, sourceUrl);
             var response = _jsExecutor.FlushedQueue();
             ProcessResponse(response);
         }

--- a/ReactWindows/ReactNative.Shared/Common/InetHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Common/InetHelpers.cs
@@ -2,7 +2,7 @@
 
 namespace ReactNative.Common
 {
-    static class IntegerHelpers
+    static class InetHelpers
     {
         public static uint LittleEndianToHost(uint value)
         {

--- a/ReactWindows/ReactNative.Shared/Common/IntegerHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Common/IntegerHelpers.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace ReactNative.Common
+{
+    static class IntegerHelpers
+    {
+        public static uint LittleEndianToHost(uint value)
+        {
+            if (!BitConverter.IsLittleEndian)
+            {
+                // TODO: if you need big-endianess, please implement
+                throw new NotSupportedException("Only little-endian hosts are currently supported.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -96,7 +96,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Collections\HeapBasedPriorityQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\JObjectExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\ListExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Common\IntegerHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\InetHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ReactConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\WindowsPlatformHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CoreModulesPackage.cs" />

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>eea8b852-4d07-48e1-8294-a21ab5909fe5</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ReactNative.Shared</Import_RootNamespace>
+    <Import_RootNamespace>ReactNative</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Animated\AdditionAnimatedNode.cs" />
@@ -96,6 +96,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Collections\HeapBasedPriorityQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\JObjectExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\ListExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\IntegerHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ReactConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\WindowsPlatformHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CoreModulesPackage.cs" />

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -18,9 +18,9 @@ namespace ReactNative.Chakra.Executor
         /// <summary>
         /// Instantiates the <see cref="NativeJavaScriptExecutor"/>.
         /// </summary>
-        public NativeJavaScriptExecutor() : this(false)
+        public NativeJavaScriptExecutor()
+            : this(false)
         {
-
         }
 
         /// <summary>
@@ -92,27 +92,27 @@ namespace ReactNative.Chakra.Executor
         }
 
         /// <summary>
-        /// Runs the given script.
+        /// Runs the JavaScript at the given path.
         /// </summary>
-        /// <param name="script">The script.</param>
+        /// <param name="sourcePath">The source path.</param>
         /// <param name="sourceUrl">The source URL.</param>
-        public void RunScript(string script, string sourceUrl)
+        public void RunScript(string sourcePath, string sourceUrl)
         {
-            if (script == null)
-                throw new ArgumentNullException(nameof(script));
+            if (sourcePath == null)
+                throw new ArgumentNullException(nameof(sourcePath));
             if (sourceUrl == null)
                 throw new ArgumentNullException(nameof(sourceUrl));
 
             try
             {
-                if(_useSerialization)
+                if (_useSerialization)
                 {
                     var binPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "ReactNativeBundle.bin");
-                    Native.ThrowIfError((JavaScriptErrorCode)_executor.RunSerializedScript(script, binPath, sourceUrl));
+                    Native.ThrowIfError((JavaScriptErrorCode)_executor.RunSerializedScript(sourcePath, binPath, sourceUrl));
                 }
                 else
                 {
-                    Native.ThrowIfError((JavaScriptErrorCode)_executor.RunScript(script, sourceUrl));
+                    Native.ThrowIfError((JavaScriptErrorCode)_executor.RunScript(sourcePath, sourceUrl));
                 }
             }
             catch (JavaScriptScriptException ex)


### PR DESCRIPTION
Adds unbundle support by adding a check in ChakraJavaScriptExecutor for the UNBUNDLE magic file, and by adding a `nativeRequire` hook to the Chakra runtime to dynamically load files when needed. The intent is that this should reduce app start times by reducing the amount of JavaScript that needs to be initially processed, but it doesn't seem to have much effect on the simple Playground and UIExplorer apps I've tested it on.

Remaining TODO: add unbundle support to NativeJavaScriptExecutor

Depends on facebook/react-native#12423

Fixes #952