### PR TITLE
Added the ability to override the root view background

### DIFF
--- a/ReactWindows/ReactNative/ReactPage.cs
+++ b/ReactWindows/ReactNative/ReactPage.cs
@@ -110,8 +110,6 @@ namespace ReactNative
         /// <param name="initialProps">The initialProps.</param>
         public void OnCreate(string arguments, JObject initialProps)
         {
-            RootView.Background = (Brush)Application.Current.Resources["ApplicationPageBackgroundThemeBrush"];
-
             ApplyArguments(arguments);
             RootView.StartReactApplication(_reactInstanceManager, MainComponentName, initialProps);
 
@@ -163,7 +161,9 @@ namespace ReactNative
         /// </remarks>
         protected virtual ReactRootView CreateRootView()
         {
-            return new ReactRootView();
+            ReactRootView rootView = new ReactRootView();
+            rootView.Background = (Brush)Application.Current.Resources["ApplicationPageBackgroundThemeBrush"];
+            return rootView;
         }
 
         /// <summary>


### PR DESCRIPTION
`ReactPage` was missing a `virtual` or `abstract` method that could be overridden to change `RootView.Background`.

It can be used like this, in your `MainPage.cs`:

```c#
using ReactNative.UIManager;
using Windows.UI.Xaml.Media;

        // ...

        protected override void SetRootViewBackground()
        {
            RootView.Background = new SolidColorBrush(ColorHelpers.Parse(0xFF123456));
        }
```
