### PR TITLE
Fix Dimensions calculation bug due to race condition (Fixes #844)

### DIFF
--- a/ReactWindows/ReactNative.Net46/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIManagerModule.cs
@@ -134,6 +134,9 @@ namespace ReactNative.UIManager
                 });
             });
 
+            // Must recalculate dimensions after adding root view
+            UpdateDimensions();
+
             return tag;
         }
 
@@ -511,6 +514,11 @@ namespace ReactNative.UIManager
 
 #region Dimensions
         private void OnBoundsChanged(object sender, SizeChangedEventArgs args)
+        {
+            UpdateDimensions();
+        }
+
+        private void UpdateDimensions()
         {
             Context.GetJavaScriptModule<RCTDeviceEventEmitter>()
                 .emit("didUpdateDimensions", GetDimensions());

--- a/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
@@ -129,6 +129,9 @@ namespace ReactNative.UIManager
                 });
             });
 
+            // Must recalculate dimensions after adding root view
+            UpdateDimensions();
+
             return tag;
         }
 
@@ -510,6 +513,11 @@ namespace ReactNative.UIManager
 
 #region Dimensions
         private void OnBoundsChanged(ApplicationView sender, object args)
+        {
+            UpdateDimensions();
+        }
+
+        private void UpdateDimensions()
         {
             Context.GetJavaScriptModule<RCTDeviceEventEmitter>()
                 .emit("didUpdateDimensions", GetDimensions());


### PR DESCRIPTION
See: #844

There is a race condition in the Dimensions calculation, where it is not returning the correct width and height for debug builds when they use cached JS, or for builds with bundled JS.

When my app started, `GetDimensions()` would initially return:

```
bounds	{0,0,1280,800}	Windows.Foundation.Rect
```

When I triggered a resize event (or reloaded JS), it would be updated to:

```
bounds	{202,108,903.3333,588}	Windows.Foundation.Rect
```


This change recalculates the dimensions after adding the root view, which fixes the problem.

`GetDimensions` will still initially return a wrong value, but it is quickly updated once the root view is present, so the app will always be using the correct dimensions.

P.S. I guess this is sort of an ugly workaround, but also I think it makes sense. And it's literally the last thing on my todo list before I can launch my app.