### PR TITLE
Generate self signed Certificate on Initialization

### DIFF
--- a/local-cli/generator-windows/index.js
+++ b/local-cli/generator-windows/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const chalk = require('chalk');
+const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const uuid = require('uuid');
 const yeoman = require('yeoman-generator');
 
-const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
+const REACT_NATIVE_PACKAGE_JSON_PATH = function () {
   return path.resolve(
     process.cwd(),
     'node_modules',
@@ -27,7 +28,7 @@ module.exports = yeoman.Base.extend({
     });
   },
 
-  configuring: function() {
+  configuring: function () {
     this.fs.copy(
       this.templatePath('_gitignore'),
       this.destinationPath(path.join('windows', '.gitignore'))
@@ -42,7 +43,30 @@ module.exports = yeoman.Base.extend({
   writing: function () {
     const projectGuid = uuid.v4();
     const packageGuid = uuid.v4();
-    const templateVars = { name: this.name, ns: this.options.ns, projectGuid, packageGuid };
+    const currentUser = childProcess.execSync('powershell $env:username')
+    const templateVars = { name: this.name, ns: this.options.ns, certificateThumbprint : null, projectGuid, packageGuid, currentUser };
+
+    const certGenCommand = [
+      `$cert = New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject "CN=${currentUser}" -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}Subject Type:End Entity") -CertStoreLocation "Cert:\\CurrentUser\\My"`,
+      `$pwd = ConvertTo-SecureString -String password -Force -AsPlainText`,
+      `Export-PfxCertificate -Cert "cert:\\CurrentUser\\My\\$($cert.Thumbprint)" -FilePath ${path.join('windows', this.name, this.name)}_TemporaryKey.pfx -Password $pwd`,
+      `$cert.Thumbprint`
+    ];
+
+    console.log(`Generating self-signed certificate...`);
+    const certGenProcess = childProcess.spawnSync('powershell', ['-command', certGenCommand.join(';')]);
+
+    if (certGenProcess.status === 0) {
+      const certGenProcessOutput = certGenProcess.stdout.toString().trim().split('\n');
+      templateVars.certificateThumbprint = certGenProcessOutput[certGenProcessOutput.length - 1];
+      console.log(chalk.green("Self-signed certificate generated successfully."));
+    } else {
+      console.log(chalk.yellow('Failed to generate Self-signed certificate. Using Default Certificate. Use Visual Studio to renew it.'));
+      this.fs.copy(
+        this.templatePath(path.join('keys', 'MyApp_TemporaryKey.pfx')),
+        this.destinationPath(path.join('windows', this.name, this.name + '_TemporaryKey.pfx'))
+      );
+    }
 
     this.fs.copyTpl(
       this.templatePath('index.windows.js'),
@@ -65,25 +89,21 @@ module.exports = yeoman.Base.extend({
     this.fs.copyTpl(
       this.templatePath(path.join('proj', 'MyApp.csproj')),
       this.destinationPath(path.join('windows', this.name, this.name + '.csproj'))
-    , templateVars);
+      , templateVars);
 
     this.fs.copyTpl(
       this.templatePath(path.join('proj', 'MyApp.sln')),
       this.destinationPath(path.join('windows', this.name + '.sln'))
-    , templateVars);
+      , templateVars);
 
     this.fs.copy(
       this.templatePath(path.join('assets', '**')),
       this.destinationPath(path.join('windows', this.name, 'Assets'))
     );
 
-    this.fs.copy(
-      this.templatePath(path.join('keys', 'MyApp_TemporaryKey.pfx')),
-      this.destinationPath(path.join('windows', this.name, this.name + '_TemporaryKey.pfx'))
-    );
   },
 
-  install: function() {
+  install: function () {
     const reactNativeWindowsPackageJson = require('../../package.json');
     const peerDependencies = reactNativeWindowsPackageJson.peerDependencies;
     if (!peerDependencies) {
@@ -111,7 +131,7 @@ module.exports = yeoman.Base.extend({
     this.npmInstall(`react@${reactVersion}`, { '--save': true });
   },
 
-  end: function() {
+  end: function () {
     const projectPath = path.resolve(this.destinationRoot(), 'windows', this.name);
     this.log(chalk.white.bold('To run your app on UWP:'));
     this.log(chalk.white('   react-native run-windows'));

--- a/local-cli/generator-windows/templates/proj/MyApp.csproj
+++ b/local-cli/generator-windows/templates/proj/MyApp.csproj
@@ -17,6 +17,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile><%=name%>_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <% if (certificateThumbprint) { %><PackageCertificateThumbprint><%=certificateThumbprint%></PackageCertificateThumbprint><% } %>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/local-cli/generator-windows/templates/src/Package.appxmanifest
+++ b/local-cli/generator-windows/templates/src/Package.appxmanifest
@@ -8,7 +8,7 @@
 
   <Identity
     Name="<%= packageGuid %>"
-    Publisher="CN=publisher"
+    Publisher="CN=<%=currentUser%>"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="<%= packageGuid %>" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>


### PR DESCRIPTION
This PR does the following changes while running `react-native windows` command.
* A new certificate for app signing using `New-SelfSignedCertificate` command will be Generated. 
* If the `New-SelfSignedCertificate` command failed on executing, it will fallback to the pre-existing certificate .
* The `Publisher` property in `Package.appxmanifest` will be Updated to `CN=<current user name>`.