### PR TITLE
fix(rnpm-plugin-windows): use registry uri set in npm config instead of defaulting to npm uri

### DIFF
--- a/local-cli/rnpm/windows/package.json
+++ b/local-cli/rnpm/windows/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "npm-registry": "^0.1.13",
-    "semver": "^5.0.3"
+    "semver": "^5.0.3",
+    "valid-url": "^1.0.9"
   }
 }

--- a/local-cli/rnpm/windows/src/common.js
+++ b/local-cli/rnpm/windows/src/common.js
@@ -13,8 +13,11 @@ const fs = require('fs')
 const path = require('path')
 const semver = require('semver')
 const Registry = require('npm-registry')
+const child_process = require('child_process');
+const validUrl = require('valid-url');
 
-const NPM_REGISTRY_URL = 'http://registry.npmjs.org'
+let npmConfReg = child_process.execSync('npm config get registry').toString();
+let NPM_REGISTRY_URL = validUrl.is_uri(npmConfReg) ? npmConfReg: 'http://registry.npmjs.org';
 
 const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
   return path.resolve(


### PR DESCRIPTION
Use the registry uri set in npm config instead of defaulting to the npmjs.org uri in case users are running a private npm registry.