### PR TITLE
fix(BaseViewManager): ensure translation transforms are reset

### DIFF
--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -35,6 +35,7 @@ namespace ReactNative.UIManager
             if (transforms == null)
             {
                 ResetProjectionMatrix(view);
+                ResetRenderTransform(view);
             }
             else
             {
@@ -209,6 +210,7 @@ namespace ReactNative.UIManager
             }
             else
             {
+                ResetRenderTransform(view);
                 view.RenderTransform = new MatrixTransform();
                 var projection = EnsureProjection(view);
                 projection.ProjectionMatrix = projectionMatrix;
@@ -233,6 +235,18 @@ namespace ReactNative.UIManager
             }
 
             view.Projection = null;
+        }
+
+        private static void ResetRenderTransform(TFrameworkElement view)
+        {
+            var transform = view.RenderTransform;
+            var matrixTransform = transform as MatrixTransform;
+            if (transform != null && matrixTransform == null)
+            {
+                throw new InvalidOperationException("Unknown transform set on framework element.");
+            }
+
+            view.RenderTransform = null;
         }
 
         private static Matrix3DProjection EnsureProjection(FrameworkElement view)

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -211,7 +211,6 @@ namespace ReactNative.UIManager
             else
             {
                 ResetRenderTransform(view);
-                view.RenderTransform = new MatrixTransform();
                 var projection = EnsureProjection(view);
                 projection.ProjectionMatrix = projectionMatrix;
             }


### PR DESCRIPTION
The reset logic for the `transform` prop neglected to reset the workaround case of simple translations.