### PR TITLE
make WPF NetInfo more reliably return internet availability

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/NetInfo/DefaultNetworkInformation.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/NetInfo/DefaultNetworkInformation.cs
@@ -1,29 +1,31 @@
-﻿using System.Net.NetworkInformation;
+﻿using System;
+using System.Net.NetworkInformation;
 
 namespace ReactNative.Modules.NetInfo
 {
     class DefaultNetworkInformation : INetworkInformation
     {
-        public event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged;
+        public event NetworkAddressChangedEventHandler NetworkAddressChanged;
 
         public void Start()
         {
-            NetworkChange.NetworkAvailabilityChanged += OnNetworkAvailabilityChanged;
+            NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
         }
 
         public void Stop()
         {
-            NetworkChange.NetworkAvailabilityChanged -= OnNetworkAvailabilityChanged;
+            NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
         }
 
         public string GetInternetStatus()
         {
-            return NetworkInterface.GetIsNetworkAvailable() ? "InternetAccess" : "None";
+            int result;
+            return NetInfoModuleNativeMethods.InternetGetConnectedState(out result, 0) ? "InternetAccess" : "None";
         }
 
-        private void OnNetworkAvailabilityChanged(object sender, NetworkAvailabilityEventArgs e)
+        private void OnNetworkAddressChanged(object sender, EventArgs e)
         {
-            NetworkAvailabilityChanged?.Invoke(sender, e);
+            NetworkAddressChanged?.Invoke(sender, e);
         }
     }
 }

--- a/ReactWindows/ReactNative.Net46/Modules/NetInfo/INetworkInformation.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/NetInfo/INetworkInformation.cs
@@ -11,7 +11,7 @@ namespace ReactNative.Modules.NetInfo
         /// An event that occurs whenever the network status changes.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly", Justification = "API matches Windows.Networking.Connectivity.NetworkingInformation.")]
-        event NetworkAvailabilityChangedEventHandler NetworkAvailabilityChanged;
+        event NetworkAddressChangedEventHandler NetworkAddressChanged;
 
         /// <summary>
         /// Gets the internet status

--- a/ReactWindows/ReactNative.Net46/Modules/NetInfo/NetInfoModuleNativeMethods.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/NetInfo/NetInfoModuleNativeMethods.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReactNative.Modules.NetInfo
+{
+    internal static class NetInfoModuleNativeMethods
+    {
+        /// <summary>
+        /// Retrieves the connected state of the local system.
+        /// </summary>
+        /// <param name="lpdwFlags">Pointer to a variable that receives the connection description. This parameter may return a valid flag even when the function returns FALSE. This parameter can be one or more of the following values.</param>
+        /// <param name="dwReserved"></param>
+        /// <returns></returns>
+        [DllImport("wininet.dll", SetLastError = true)]
+        public static extern bool InternetGetConnectedState(out int lpdwFlags, int dwReserved);
+
+        [Flags]
+        enum ConnectionStates
+        {
+            INTERNET_CONNECTION_MODEM = 0x1, // Local system uses a modem to connect to the Internet.
+            INTERNET_CONNECTION_LAN = 0x2, // Local system uses a local area network to connect to the Internet.
+            INTERNET_CONNECTION_PROXY = 0x4, // Local system uses a proxy server to connect to the Internet.
+            INTERNET_RAS_INSTALLED = 0x10, // Local system has RAS installed.
+            INTERNET_CONNECTION_OFFLINE = 0x20, // Local system is in offline mode.
+            INTERNET_CONNECTION_CONFIGURED = 0x40, // Local system has a valid connection to the Internet, but it might or might not be currently connected.
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Modules\Dialog\DialogModule.cs" />
     <Compile Include="Modules\Image\BitmapImageHelpers.cs" />
     <Compile Include="Modules\Image\ImageLoaderModule.cs" />
+    <Compile Include="Modules\NetInfo\NetInfoModuleNativeMethods.cs" />
     <Compile Include="Modules\Storage\AsyncStorageModule.cs" />
     <Compile Include="Modules\Clipboard\ClipboardModule.cs" />
     <Compile Include="Modules\Clipboard\ClipboardInstance.cs" />


### PR DESCRIPTION
The weakness of this approach is if the internet connection issue is upstream we will not receive a disconnected event or a connected event when the problem is resolved unless the user makes a network related change.