### PR TITLE
Specify correct pixel scale in window dimensions to support multi-res assets in high-res display.

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -2,7 +2,6 @@
 using ReactNative.Modules.Core;
 using System.Collections.Generic;
 using System.Windows;
-using System;
 
 namespace ReactNative.Modules.DeviceInfo
 {
@@ -85,8 +84,8 @@ namespace ReactNative.Modules.DeviceInfo
             var content = (FrameworkElement)_window.Content;
             double scale = 1.0;
 
-            IntPtr hwnd = new System.Windows.Interop.WindowInteropHelper(_window).Handle;
-            using (System.Drawing.Graphics g = System.Drawing.Graphics.FromHwnd(hwnd))
+            var hwnd = new System.Windows.Interop.WindowInteropHelper(_window).Handle;
+            using (var g = System.Drawing.Graphics.FromHwnd(hwnd))
             {
                 scale = g.DpiX / 96;
             }

--- a/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -2,6 +2,7 @@
 using ReactNative.Modules.Core;
 using System.Collections.Generic;
 using System.Windows;
+using System;
 
 namespace ReactNative.Modules.DeviceInfo
 {
@@ -83,6 +84,12 @@ namespace ReactNative.Modules.DeviceInfo
         {
             var content = (FrameworkElement)_window.Content;
             double scale = 1.0;
+
+            IntPtr hwnd = new System.Windows.Interop.WindowInteropHelper(_window).Handle;
+            using (System.Drawing.Graphics g = System.Drawing.Graphics.FromHwnd(hwnd))
+            {
+                scale = g.DpiX / 96;
+            }
 
             return new Dictionary<string, object>
             {


### PR DESCRIPTION
So that image asset loader can load best fit image asset for high resolution display.