### PR TITLE
fix(NativeModuleBase): use reflection for UWP

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
@@ -44,7 +44,11 @@ namespace ReactNative.Bridge
         /// Instantiates a <see cref="NativeModuleBase"/>.
         /// </summary>
         protected NativeModuleBase()
+#if WINDOWS_UWP
+            : this(ReflectionReactDelegateFactory.Instance)
+#else
             : this(CompiledReactDelegateFactory.Instance)
+#endif
         {
         }
 

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -29,11 +29,7 @@ namespace ReactNative.Modules.Core
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         public Timing(ReactContext reactContext)
-#if WINDOWS_UWP
             : base(reactContext)
-#else
-            : base(reactContext, CompiledReactDelegateFactory.Instance)
-#endif
         {
             _timers = new HeapBasedPriorityQueue<TimerData>(
                 Comparer<TimerData>.Create((x, y) => 


### PR DESCRIPTION
This change was previously overlooked. On UWP, expressions are interpreted rather than compiled, so it's actually faster to just use direct reflection.