### PR TITLE
Fix fontStyle exception on WPF

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -89,14 +89,9 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            FontStyle fontStyle;
-            if (fontStyleValue == "italic") {
-                fontStyle = FontStyles.Italic;
-            } else {
-                fontStyle = FontStyles.Normal;
-            }
-
-            if (_fontStyle != fontStyle) {
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
+            if (_fontStyle != fontStyle)
+            {
                 _fontStyle = fontStyle;
                 MarkUpdated();
             }

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -89,9 +89,14 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
-            if (_fontStyle != fontStyle)
-            {
+            FontStyle fontStyle;
+            if (fontStyleValue == "italic") {
+                fontStyle = FontStyles.Italic;
+            } else {
+                fontStyle = FontStyles.Normal;
+            }
+
+            if (_fontStyle != fontStyle) {
                 _fontStyle = fontStyle;
                 MarkUpdated();
             }

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -179,7 +179,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(PasswordBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? new FontStyle();
         }
 

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -177,7 +177,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(ReactTextBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? new FontStyle();
         }
 

--- a/ReactWindows/ReactNative.Shared/Views/Text/FontStyleHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/FontStyleHelpers.cs
@@ -1,4 +1,5 @@
 ﻿#if WINDOWS_UWP
+using ReactNative.Reflection;
 using Windows.UI.Text;
 #else
 using System.Windows;
@@ -8,6 +9,23 @@ namespace ReactNative.Views.Text
 {
     static class FontStyleHelpers
     {
+        public static FontStyle? ParseFontStyle(string fontStyleString)
+        {
+#if WINDOWS_UWP
+            return EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+#else
+            if (fontStyleString == "normal")
+            {
+                return FontStyles.Normal;
+            }
+            else if (fontStyleString == "italic")
+            {
+                return FontStyles.Italic;
+            }
+            return null;
+#endif
+        }
+
         public static FontWeight? ParseFontWeight(string fontWeightString)
         {
             var fontWeightNumeric = fontWeightString != null

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactSpanShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactSpanShadowNode.cs
@@ -83,7 +83,7 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactPasswordBoxShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactPasswordBoxShadowNode.cs
@@ -125,7 +125,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleSValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleSValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleSValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
@@ -138,7 +138,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
@@ -93,7 +93,7 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -180,7 +180,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(PasswordBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? FontStyle.Normal;
         }
 

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -179,7 +179,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(ReactTextBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? FontStyle.Normal;
         }
 


### PR DESCRIPTION
WPF's System.Windows.FontStyle is not enum type and make EnumHelpers to throw exception.
The solution is to parse the fontStyleValue handy like what React Native Android did.