### PR TITLE
perf(Event): Use pooled event objects

### DIFF
--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -44,10 +44,10 @@ var PickerWindows = React.createClass({
     items: PropTypes.any,
     selected: PropTypes.number,
     selectedValue: PropTypes.any,
-    enabled: ReactPropTypes.bool,
-    onValueChange: ReactPropTypes.func,
-    prompt: ReactPropTypes.string,
-    testID: ReactPropTypes.string,
+    enabled: PropTypes.bool,
+    onValueChange: PropTypes.func,
+    prompt: PropTypes.string,
+    testID: PropTypes.string,
   },
 
   getInitialState: function() {

--- a/ReactWindows/ReactNative.Net46/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative.Net46/Touch/TouchHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using ReactNative.Pooling;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Events;
 using System;
@@ -48,7 +49,7 @@ namespace ReactNative.Touch
                     .GetNativeModule<UIManagerModule>()
                     .EventDispatcher
                     .DispatchEvent(
-                        new PointerEnterExitEvent(TouchEventType.Entered, view.GetTag()));
+                        PointerEnterExitEvent.Obtain(view.GetTag(), TouchEventType.Entered));
             }
         }
 
@@ -60,7 +61,7 @@ namespace ReactNative.Touch
                     .GetNativeModule<UIManagerModule>()
                     .EventDispatcher
                     .DispatchEvent(
-                        new PointerEnterExitEvent(TouchEventType.Exited, view.GetTag()));
+                        PointerEnterExitEvent.Obtain(view.GetTag(), TouchEventType.Exited));
             }
         }
 
@@ -298,7 +299,7 @@ namespace ReactNative.Touch
             pointer.PageY = (float)positionInRoot.Y;
             pointer.LocationX = (float)positionInView.X;
             pointer.LocationY = (float)positionInView.Y;
-            pointer.Timestamp = (ulong) timestamp;
+            pointer.Timestamp = (ulong)timestamp;
         }
 
         private void DispatchTouchEvent(TouchEventType touchEventType, List<ReactPointer> activePointers, int pointerIndex)
@@ -314,7 +315,7 @@ namespace ReactNative.Touch
 
             var coalescingKey = activePointers[pointerIndex].PointerId;
 
-            var touchEvent = new TouchEvent(touchEventType, touches, changedIndices, coalescingKey);
+            var touchEvent = TouchEvent.Obtain(touchEventType, touches, changedIndices, coalescingKey);
 
             _view.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
@@ -382,23 +383,31 @@ namespace ReactNative.Touch
 
         class TouchEvent : Event
         {
-            private readonly TouchEventType _touchEventType;
-            private readonly JArray _touches;
-            private readonly JArray _changedIndices;
-            private readonly uint _coalescingKey;
+            private static readonly ObjectPool<TouchEvent> s_eventsPool =
+                new ObjectPool<TouchEvent>(() => new TouchEvent(), 3);
 
-            public TouchEvent(TouchEventType touchEventType, JArray touches, JArray changedIndices, uint coalescingKey)
-                : base(-1, TimeSpan.FromTicks(Environment.TickCount))
+            private TouchEventType _touchEventType;
+            private JArray _touches;
+            private JArray _changedIndices;
+            private uint _coalescingKey;
+
+            private TouchEvent() { }
+
+            public override string EventName
             {
-                _touchEventType = touchEventType;
-                _touches = touches;
-                _changedIndices = changedIndices;
-                _coalescingKey = coalescingKey;
+                get
+                {
+                    return _touchEventType.GetJavaScriptEventName();
+                }
             }
 
-            public override string EventName => _touchEventType.GetJavaScriptEventName();
-
-            public override bool CanCoalesce => _touchEventType == TouchEventType.Move;
+            public override bool CanCoalesce
+            {
+                get
+                {
+                    return _touchEventType == TouchEventType.Move;
+                }
+            }
 
             public override short CoalescingKey
             {
@@ -415,21 +424,54 @@ namespace ReactNative.Touch
             {
                 eventEmitter.receiveTouches(EventName, _touches, _changedIndices);
             }
+
+            protected override void OnDispose()
+            {
+                base.OnDispose();
+                s_eventsPool.Free(this);
+            }
+
+            private void Init(TouchEventType touchEventType, JArray touches, JArray changedIndices, uint coalescingKey)
+            {
+                Init(-1);
+                _touchEventType = touchEventType;
+                _touches = touches;
+                _changedIndices = changedIndices;
+                _coalescingKey = coalescingKey;
+            }
+
+            public static TouchEvent Obtain(TouchEventType touchEventType, JArray touches, JArray changedIndices, uint coalescingKey)
+            {
+                var @event = s_eventsPool.Allocate();
+                @event.Init(touchEventType, touches, changedIndices, coalescingKey);
+                return @event;
+            }
         }
 
         class PointerEnterExitEvent : Event
         {
-            private readonly TouchEventType _touchEventType;
+            private static readonly ObjectPool<PointerEnterExitEvent> s_eventsPool =
+                new ObjectPool<PointerEnterExitEvent>(() => new PointerEnterExitEvent(), 3);
 
-            public PointerEnterExitEvent(TouchEventType touchEventType, int viewTag)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            private TouchEventType _touchEventType;
+
+            private PointerEnterExitEvent() { }
+
+            public override string EventName
             {
-                _touchEventType = touchEventType;
+                get
+                {
+                    return _touchEventType.GetJavaScriptEventName();
+                }
             }
 
-            public override string EventName => _touchEventType.GetJavaScriptEventName();
-
-            public override bool CanCoalesce => false;
+            public override bool CanCoalesce
+            {
+                get
+                {
+                    return false;
+                }
+            }
 
             public override void Dispatch(RCTEventEmitter eventEmitter)
             {
@@ -439,14 +481,13 @@ namespace ReactNative.Touch
                 };
 
                 var enterLeaveEventName = default(string);
-                switch (_touchEventType)
+                if (_touchEventType == TouchEventType.Entered)
                 {
-                    case TouchEventType.Entered:
-                        enterLeaveEventName = "topMouseEnter";
-                        break;
-                    case TouchEventType.Exited:
-                        enterLeaveEventName = "topMouseLeave";
-                        break;
+                    enterLeaveEventName = "topMouseEnter";
+                }
+                else if (_touchEventType == TouchEventType.Exited)
+                {
+                    enterLeaveEventName = "topMouseLeave";
                 }
 
                 if (enterLeaveEventName != null)
@@ -455,6 +496,25 @@ namespace ReactNative.Touch
                 }
 
                 eventEmitter.receiveEvent(ViewTag, EventName, eventData);
+            }
+
+            protected override void OnDispose()
+            {
+                base.OnDispose();
+                s_eventsPool.Free(this);
+            }
+
+            private void Init(int viewTag, TouchEventType touchEventType)
+            {
+                Init(viewTag);
+                _touchEventType = touchEventType;
+            }
+
+            public static PointerEnterExitEvent Obtain(int viewTag, TouchEventType touchEventType)
+            {
+                var @event = s_eventsPool.Allocate();
+                @event.Init(viewTag, touchEventType);
+                return @event;
             }
         }
 

--- a/ReactWindows/ReactNative.Net46/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative.Net46/Touch/TouchHandler.cs
@@ -383,8 +383,8 @@ namespace ReactNative.Touch
 
         class TouchEvent : Event
         {
-            private static readonly ObjectPool<TouchEvent> s_eventsPool =
-                new ObjectPool<TouchEvent>(() => new TouchEvent(), 3);
+            private static readonly ConcurrentObjectPool<TouchEvent> s_eventsPool =
+                new ConcurrentObjectPool<TouchEvent>(() => new TouchEvent(), 3);
 
             private TouchEventType _touchEventType;
             private JArray _touches;
@@ -450,8 +450,8 @@ namespace ReactNative.Touch
 
         class PointerEnterExitEvent : Event
         {
-            private static readonly ObjectPool<PointerEnterExitEvent> s_eventsPool =
-                new ObjectPool<PointerEnterExitEvent>(() => new PointerEnterExitEvent(), 3);
+            private static readonly ConcurrentObjectPool<PointerEnterExitEvent> s_eventsPool =
+                new ConcurrentObjectPool<PointerEnterExitEvent>(() => new PointerEnterExitEvent(), 3);
 
             private TouchEventType _touchEventType;
 

--- a/ReactWindows/ReactNative.Net46/Views/Picker/ReactPickerManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Picker/ReactPickerManager.cs
@@ -186,7 +186,7 @@ namespace ReactNative.Views.Picker
             private readonly int _selectedIndex;
 
             public ReactPickerEvent(int viewTag, int selectedIndex)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+                : base(viewTag)
             {
                 _selectedIndex = selectedIndex;
             }

--- a/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
@@ -497,8 +497,8 @@ namespace ReactNative.Views.Scroll
 
         class ScrollEvent : Event
         {
-            private static readonly ObjectPool<ScrollEvent> s_eventsPool =
-                new ObjectPool<ScrollEvent>(() => new ScrollEvent(), 3);
+            private static readonly ConcurrentObjectPool<ScrollEvent> s_eventsPool =
+                new ConcurrentObjectPool<ScrollEvent>(() => new ScrollEvent(), 3);
 
             private ScrollEventType _type;
             private JObject _data;

--- a/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
+using ReactNative.Pooling;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using ReactNative.UIManager.Events;
@@ -456,7 +457,7 @@ namespace ReactNative.Views.Scroll
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher
                 .DispatchEvent(
-                    new ScrollEvent(
+                    ScrollEvent.Obtain(
                         reactTag,
                         eventType,
                         new JObject
@@ -496,15 +497,13 @@ namespace ReactNative.Views.Scroll
 
         class ScrollEvent : Event
         {
-            private readonly ScrollEventType _type;
-            private readonly JObject _data;
+            private static readonly ObjectPool<ScrollEvent> s_eventsPool =
+                new ObjectPool<ScrollEvent>(() => new ScrollEvent(), 3);
 
-            public ScrollEvent(int viewTag, ScrollEventType type, JObject data)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
-            {
-                _type = type;
-                _data = data;
-            }
+            private ScrollEventType _type;
+            private JObject _data;
+
+            private ScrollEvent() { }
 
             public override string EventName
             {
@@ -514,9 +513,37 @@ namespace ReactNative.Views.Scroll
                 }
             }
 
+            public override bool CanCoalesce
+            {
+                get
+                {
+                    return _type == ScrollEventType.Scroll;
+                }
+            }
+
             public override void Dispatch(RCTEventEmitter eventEmitter)
             {
                 eventEmitter.receiveEvent(ViewTag, EventName, _data);
+            }
+
+            protected override void OnDispose()
+            {
+                base.OnDispose();
+                s_eventsPool.Free(this);
+            }
+
+            private void Init(int viewTag, ScrollEventType type, JObject data)
+            {
+                Init(viewTag);
+                _type = type;
+                _data = data;
+            }
+
+            public static ScrollEvent Obtain(int viewTag, ScrollEventType type, JObject data)
+            {
+                var @event = s_eventsPool.Allocate();
+                @event.Init(viewTag, type, data);
+                return @event;
             }
         }
 

--- a/ReactWindows/ReactNative.Net46/Views/Web/Events/WebViewLoadingErrorEvent.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Web/Events/WebViewLoadingErrorEvent.cs
@@ -10,7 +10,7 @@ namespace ReactNative.Views.Web.Events
         private readonly string _description;
 
         public WebViewLoadingErrorEvent(int viewTag, string error, string description)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             if (description == null)
             {

--- a/ReactWindows/ReactNative.Net46/Views/Web/Events/WebViewLoadingEvent.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Web/Events/WebViewLoadingEvent.cs
@@ -22,7 +22,7 @@ namespace ReactNative.Views.Web.Events
             string title, 
             bool canGoBack, 
             bool canGoForward)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _type = type;
             _url = url;

--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockEvent.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockEvent.cs
@@ -10,6 +10,24 @@ namespace ReactNative.Tests
         private readonly JObject _eventArgs;
         private readonly Action _onDispose;
 
+        public MockEvent(int viewTag, string eventName)
+            : this(viewTag, eventName, new JObject())
+        {
+        }
+
+        public MockEvent(int viewTag, string eventName, JObject eventArgs)
+            : this(viewTag, eventName, eventArgs, () => { })
+        {
+        }
+
+        public MockEvent(int viewTag, string eventName, JObject eventArgs, Action onDispose)
+            : base(viewTag)
+        {
+            _eventName = eventName;
+            _eventArgs = eventArgs;
+            _onDispose = onDispose;
+        }
+
         public MockEvent(int viewTag, TimeSpan timestamp, string eventName)
             : this(viewTag, timestamp, eventName, new JObject())
         {

--- a/ReactWindows/ReactNative.Shared/Pooling/ConcurrentObjectPool.cs
+++ b/ReactWindows/ReactNative.Shared/Pooling/ConcurrentObjectPool.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ReactNative.Pooling
+{
+    /// <summary>
+    /// Simple object pool with lock synchronization to support multi-threaded scenarios.
+    /// </summary>
+    /// <typeparam name="T">Type of objects being pooled.</typeparam>
+    class ConcurrentObjectPool<T> where T : class
+    {
+        private readonly object _gate = new object();
+
+        private readonly T[] _pool;
+        private int _size;
+
+        private readonly Func<T> _factory;
+
+        /// <summary>
+        /// Instantiates the <see cref="ObjectPool{T}"/>.
+        /// </summary>
+        /// <param name="factory">The instance factory.</param>
+        /// <param name="size">The maximum size.</param>
+        public ConcurrentObjectPool(Func<T> factory, int size)
+        {
+            Debug.Assert(size >= 1);
+            _factory = factory;
+            _pool = new T[size];
+        }
+
+        /// <summary>
+        /// Get a new instance from the pool. Create one using the factory if not available.
+        /// </summary>
+        /// <returns>The instance.</returns>
+        public T Allocate()
+        {
+            lock (_gate)
+            {
+                if (_size == 0)
+                {
+                    return CreateInstance();
+                }
+
+                _size--;
+                var lastIndex = _size;
+                var toReturn = _pool[lastIndex];
+                _pool[lastIndex] = null;
+                return toReturn;
+            }
+        }
+
+        /// <summary>
+        /// Return an instance to the pool. No-op if pool is full.
+        /// </summary>
+        /// <param name="obj">The instance to return to the pool.</param>
+        public void Free(T obj)
+        {
+            lock (_gate)
+            {
+                if (_size == _pool.Length)
+                {
+                    return;
+                }
+
+                _pool[_size] = obj;
+                _size++;
+            }
+        }
+
+        private T CreateInstance()
+        {
+            var inst = _factory();
+            return inst;
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -136,6 +136,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Network\NetworkingModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Network\TaskCancellationManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Storage\AsyncStorageHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Pooling\ConcurrentObjectPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pooling\ObjectPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactContextInitializedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactInstanceManager.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/Event.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/Event.cs
@@ -18,10 +18,24 @@ namespace ReactNative.UIManager.Events
         private TimeSpan _timestamp;
 
         /// <summary>
+        /// Base constructor for <see cref="Event"/> to support pooling.
+        /// </summary>
+        protected Event() { }
+
+        /// <summary>
         /// Base constructor for <see cref="Event"/>.
         /// </summary>
         /// <param name="viewTag">The view tag.</param>
-        /// <param name="timestamp">The event timestamp.</param>
+        protected Event(int viewTag)
+        {
+            Init(viewTag);
+        }
+
+        /// <summary>
+        /// Base constructor for <see cref="Event"/>.
+        /// </summary>
+        /// <param name="viewTag">The view tag.</param>
+        /// <param name="timestamp">The timestamp.</param>
         protected Event(int viewTag, TimeSpan timestamp)
         {
             Init(viewTag, timestamp);
@@ -122,6 +136,19 @@ namespace ReactNative.UIManager.Events
         {
             _initialized = false;
             OnDispose();
+        }
+
+        /// <summary>
+        /// Initializes the event.
+        /// </summary>
+        /// <param name="viewTag">The view tag.</param>
+        /// <remarks>
+        /// This method must be called before the event is sent to the event
+        /// dispatcher.
+        /// </remarks>
+        protected void Init(int viewTag)
+        {
+            Init(viewTag, TimeSpan.FromTicks(Environment.TickCount));
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/OnLayoutEvent.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/OnLayoutEvent.cs
@@ -6,8 +6,8 @@ namespace ReactNative.UIManager
 {
     class OnLayoutEvent : Event
     {
-        private static readonly ObjectPool<OnLayoutEvent> s_eventsPool =
-            new ObjectPool<OnLayoutEvent>(() => new OnLayoutEvent(), 20);
+        private static readonly ConcurrentObjectPool<OnLayoutEvent> s_eventsPool =
+            new ConcurrentObjectPool<OnLayoutEvent>(() => new OnLayoutEvent(), 20);
 
         private double _x;
         private double _y;
@@ -61,6 +61,7 @@ namespace ReactNative.UIManager
 
         public static OnLayoutEvent Obtain(int viewTag, double x, double y, double width, double height)
         {
+            //var @event = new OnLayoutEvent();
             var @event = s_eventsPool.Allocate();
             @event.Init(viewTag, x, y, width, height);
             return @event;

--- a/ReactWindows/ReactNative.Shared/UIManager/OnLayoutEvent.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/OnLayoutEvent.cs
@@ -1,24 +1,20 @@
 ﻿using Newtonsoft.Json.Linq;
+using ReactNative.Pooling;
 using ReactNative.UIManager.Events;
-using System;
 
 namespace ReactNative.UIManager
 {
     class OnLayoutEvent : Event
     {
+        private static readonly ObjectPool<OnLayoutEvent> s_eventsPool =
+            new ObjectPool<OnLayoutEvent>(() => new OnLayoutEvent(), 20);
+
         private double _x;
         private double _y;
         private double _width;
         private double _height;
 
-        private OnLayoutEvent(int viewTag, double x, double y, double width, double height)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
-        {
-            _x = x;
-            _y = y;
-            _width = width;
-            _height = height;
-        }
+        private OnLayoutEvent() { }
 
         public override string EventName
         {
@@ -48,10 +44,26 @@ namespace ReactNative.UIManager
             eventEmitter.receiveEvent(ViewTag, EventName, eventArgs);
         }
 
+        private void Init(int viewTag, double x, double y, double width, double height)
+        {
+            Init(viewTag);
+            _x = x;
+            _y = y;
+            _width = width;
+            _height = height;
+        }
+
+        protected override void OnDispose()
+        {
+            base.OnDispose();
+            s_eventsPool.Free(this);
+        }
+
         public static OnLayoutEvent Obtain(int viewTag, double x, double y, double width, double height)
         {
-            // TODO: Introduce pooling mechanism
-            return new OnLayoutEvent(viewTag, x, y, width, height);
+            var @event = s_eventsPool.Allocate();
+            @event.Init(viewTag, x, y, width, height);
+            return @event;
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/Image/ReactImageLoadEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Image/ReactImageLoadEvent.cs
@@ -49,7 +49,7 @@ namespace ReactNative.Views.Image
         /// <param name="width">The image width.</param>
         /// <param name="height">The image height.</param>
         public ReactImageLoadEvent(int viewId, int eventType, string imageUri, int width, int height) 
-            : base(viewId, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewId)
         {
             _eventType = eventType;
             _imageUri = imageUri;

--- a/ReactWindows/ReactNative.Shared/Views/Slider/ReactSliderChangeEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Slider/ReactSliderChangeEvent.cs
@@ -18,7 +18,7 @@ namespace ReactNative.Views.Slider
         /// <param name="viewTag">The view tag.</param>
         /// <param name="value">Slider value.</param>
         public ReactSliderChangeEvent(int viewTag, double value)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _value = value;
         }

--- a/ReactWindows/ReactNative.Shared/Views/Slider/ReactSliderCompleteEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Slider/ReactSliderCompleteEvent.cs
@@ -18,7 +18,7 @@ namespace ReactNative.Views.Slider
         /// <param name="viewTag">The view tag.</param>
         /// <param name="value">Slider value.</param>
         public ReactSliderCompleteEvent(int viewTag, double value)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _value = value;
         }

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextChangedEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextChangedEvent.cs
@@ -24,7 +24,7 @@ namespace ReactNative.Views.TextInput
         /// <param name="contentHeight">The content height.</param>
         /// <param name="eventCount">The event count.</param>
         public ReactTextChangedEvent(int viewTag, string text, double contentWidth, double contentHeight, int eventCount) 
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _text = text;
             _contextWidth = contentWidth;

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputBlurEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputBlurEvent.cs
@@ -15,7 +15,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="viewTag">The view tag.</param>
         public ReactTextInputBlurEvent(int viewTag) 
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
         }
 

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputEndEditingEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputEndEditingEvent.cs
@@ -9,7 +9,7 @@ namespace ReactNative.Views.TextInput
         private readonly string _text;
 
         public ReactTextInputEndEditingEvent(int viewTag, string text)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _text = text;
         }

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputFocusEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputFocusEvent.cs
@@ -15,7 +15,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="viewTag">The view tag.</param>
         public ReactTextInputFocusEvent(int viewTag) 
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
         }
 

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputSelectionEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputSelectionEvent.cs
@@ -10,7 +10,7 @@ namespace ReactNative.Views.TextInput
         private readonly int _start;
 
         public ReactTextInputSelectionEvent(int viewTag, int start, int end)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _start = start;
             _end = end;

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputSubmitEditingEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputSubmitEditingEvent.cs
@@ -9,7 +9,7 @@ namespace ReactNative.Views.TextInput
         private readonly string _text;
 
         public ReactTextInputSubmitEditingEvent(int viewTag, string text)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _text = text;
         }

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -319,8 +319,8 @@ namespace ReactNative.Touch
 
         class TouchEvent : Event
         {
-            private static readonly ObjectPool<TouchEvent> s_eventsPool =
-                new ObjectPool<TouchEvent>(() => new TouchEvent(), 3);
+            private static readonly ConcurrentObjectPool<TouchEvent> s_eventsPool =
+                new ConcurrentObjectPool<TouchEvent>(() => new TouchEvent(), 3);
 
             private TouchEventType _touchEventType;
             private JArray _touches;
@@ -386,8 +386,8 @@ namespace ReactNative.Touch
 
         class PointerEnterExitEvent : Event
         {
-            private static readonly ObjectPool<PointerEnterExitEvent> s_eventsPool =
-                new ObjectPool<PointerEnterExitEvent>(() => new PointerEnterExitEvent(), 3);
+            private static readonly ConcurrentObjectPool<PointerEnterExitEvent> s_eventsPool =
+                new ConcurrentObjectPool<PointerEnterExitEvent>(() => new PointerEnterExitEvent(), 3);
 
             private TouchEventType _touchEventType;
 

--- a/ReactWindows/ReactNative/Views/Flip/ReactFlipViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Flip/ReactFlipViewManager.cs
@@ -138,7 +138,7 @@ namespace ReactNative.Views.Flip
             private readonly int _position;
 
             public SelectionChangedEvent(int viewTag, int position)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+                : base(viewTag)
             {
                 _position = position;
             }

--- a/ReactWindows/ReactNative/Views/Picker/ReactPickerManager.cs
+++ b/ReactWindows/ReactNative/Views/Picker/ReactPickerManager.cs
@@ -186,7 +186,7 @@ namespace ReactNative.Views.Picker
             private readonly int _selectedIndex;
 
             public ReactPickerEvent(int viewTag, int selectedIndex)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+                : base(viewTag)
             {
                 _selectedIndex = selectedIndex;
             }

--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -502,8 +502,8 @@ namespace ReactNative.Views.Scroll
 
         class ScrollEvent : Event
         {
-            private static readonly ObjectPool<ScrollEvent> s_eventsPool =
-                new ObjectPool<ScrollEvent>(() => new ScrollEvent(), 3);
+            private static readonly ConcurrentObjectPool<ScrollEvent> s_eventsPool =
+                new ConcurrentObjectPool<ScrollEvent>(() => new ScrollEvent(), 3);
 
             private ScrollEventType _type;
             private JObject _data;

--- a/ReactWindows/ReactNative/Views/Split/Events/SplitViewClosedEvent.cs
+++ b/ReactWindows/ReactNative/Views/Split/Events/SplitViewClosedEvent.cs
@@ -9,7 +9,7 @@ namespace ReactNative.Views.Split.Events
         public const string EventNameValue = "topSplitViewClosed";
 
         public SplitViewClosedEvent(int viewTag)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
         }
 

--- a/ReactWindows/ReactNative/Views/Split/Events/SplitViewOpenedEvent.cs
+++ b/ReactWindows/ReactNative/Views/Split/Events/SplitViewOpenedEvent.cs
@@ -9,7 +9,7 @@ namespace ReactNative.Views.Split.Events
         public const string EventNameValue = "topSplitViewOpened";
 
         public SplitViewOpenedEvent(int viewTag)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
         }
 

--- a/ReactWindows/ReactNative/Views/Switch/ReactSwitchManager.cs
+++ b/ReactWindows/ReactNative/Views/Switch/ReactSwitchManager.cs
@@ -134,7 +134,7 @@ namespace ReactNative.Views.Switch
             private readonly bool _isChecked;
 
             public ReactSwitchEvent(int viewTag, bool isChecked)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+                : base(viewTag)
             {
                 _isChecked = isChecked;
             }

--- a/ReactWindows/ReactNative/Views/Web/Events/WebViewLoadingErrorEvent.cs
+++ b/ReactWindows/ReactNative/Views/Web/Events/WebViewLoadingErrorEvent.cs
@@ -11,7 +11,7 @@ namespace ReactNative.Views.Web.Events
         private readonly string _description;
 
         public WebViewLoadingErrorEvent(int viewTag, WebErrorStatus error, string description)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _code = (double)error;
             if (description == null)

--- a/ReactWindows/ReactNative/Views/Web/Events/WebViewLoadingEvent.cs
+++ b/ReactWindows/ReactNative/Views/Web/Events/WebViewLoadingEvent.cs
@@ -22,7 +22,7 @@ namespace ReactNative.Views.Web.Events
             string title, 
             bool canGoBack, 
             bool canGoForward)
-            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag)
         {
             _type = type;
             _url = url;


### PR DESCRIPTION
ReactAndroid uses pooling on scroll, touch, and layout events. Adding the same behavior here.

Fixes #1212