### PR TITLE
fix(BaseViewManager): Remove dependency on WinRTXamlToolkit

### DIFF
--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -7,7 +7,6 @@
     "OpenCover": "4.6.519",
     "PCLStorage": "1.0.2",
     "System.Reactive": "3.1.1",
-    "WinRTXamlToolkit": "2.2.0"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
The `SetClipToBounds` property from `WinRTXamlToolkit` is too simple to implement to justify the dependency. Also, the approach that uses dimensions seems to be a bit less complex that relying on both a XAML dependency property and the SizeChanged event.

Fixes #1214