### PR TITLE
fix(Text): text inline shadow node visitor recurses too far

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNodeVisitor.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNodeVisitor.cs
@@ -12,6 +12,11 @@ namespace ReactNative.UIManager
                 throw new ArgumentNullException(nameof(node));
             }
 
+            return VisitCore(node);
+        }
+
+        protected virtual T VisitCore(ReactShadowNode node)
+        {
             var n = node.ChildCount;
             if (n == 0)
             {

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactInlineShadowNodeVisitor.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactInlineShadowNodeVisitor.cs
@@ -21,6 +21,17 @@ namespace ReactNative.Views.Text
             return s_instance.Visit(node);
         }
 
+        protected override Inline VisitCore(ReactShadowNode node)
+        {
+            var textNode = node as ReactInlineShadowNode;
+            if (textNode != null)
+            {
+                return base.VisitCore(node);
+            }
+
+            return Make(node, Array.Empty<Inline>());
+        }
+
         protected sealed override Inline Make(ReactShadowNode node, IList<Inline> children)
         {
             var textNode = node as ReactInlineShadowNode;


### PR DESCRIPTION
The shadow node visitor for measuring text recurses into nested views, when it should bail out at the root embedded view. This change adds a hook to ensure only root nested views in text are used in measurement.

Fixes #1216