### PR TITLE
fix(PickerWindows): Fix overlooked change from recent refactoring

### DIFF
--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -44,10 +44,10 @@ var PickerWindows = React.createClass({
     items: PropTypes.any,
     selected: PropTypes.number,
     selectedValue: PropTypes.any,
-    enabled: ReactPropTypes.bool,
-    onValueChange: ReactPropTypes.func,
-    prompt: ReactPropTypes.string,
-    testID: ReactPropTypes.string,
+    enabled: PropTypes.bool,
+    onValueChange: PropTypes.func,
+    prompt: PropTypes.string,
+    testID: PropTypes.string,
   },
 
   getInitialState: function() {


### PR DESCRIPTION
Recent refactoring eliminated deprecated `React.PropTypes` in favor of `prop-types` module. This change was overlooked during the refactoring (cc @jmcginty).

Fixes #1220