### PR TITLE
fix(NativeAnimated): Dispatch native handled events to JS

### DIFF
--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -327,12 +327,12 @@ namespace ReactNative.Animated
             }
         }
 
-        public bool OnEventDispatch(Event @event)
+        public void OnEventDispatch(Event @event)
         {
             // Only support events dispatched from the dispatcher thread.
             if (!DispatcherHelpers.IsOnDispatcher())
             {
-                return false;
+                return;
             }
 
             if (_eventDrivers.Count > 0)
@@ -355,11 +355,8 @@ namespace ReactNative.Animated
 
                     UpdateNodes(_runUpdateNodeList);
                     _runUpdateNodeList.Clear();
-                    return true;
                 }
             }
-
-            return false;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
@@ -116,21 +116,11 @@ namespace ReactNative.UIManager.Events
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var eventHandled = false;
             foreach (var listener in _listeners)
             {
-                if (listener.OnEventDispatch(@event))
-                {
-                    eventHandled = true;
-                }
+                listener.OnEventDispatch(@event);
             }
             
-            // If the event was handled by one of the event listeners, don't send it to JavaScript.
-            if (eventHandled)
-            {
-                return;
-            }
-
             lock (_eventsStagingLock)
             {
                 _eventStaging.Add(@event);

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/IEventDispatcherListener.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/IEventDispatcherListener.cs
@@ -11,10 +11,6 @@
         /// dispatched from.
         /// </summary>
         /// <param name="event">Event that was dispatched.</param>
-        /// <returns>
-        /// If the event was handled. If true the event won't be sent to 
-        /// JavaScript.
-        /// </returns>
-        bool OnEventDispatch(Event @event);
+        void OnEventDispatch(Event @event);
     }
 }


### PR DESCRIPTION
Native handled events still need to be dispatched to JS in case multiple listeners are attached to the event (e.g., in the case of a ListView with sticky headers).