### PR TITLE
fix(LayoutAnimation): Fix overflow: hidden with LayoutAnimation

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/BaseLayoutAnimation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/BaseLayoutAnimation.cs
@@ -36,9 +36,10 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// based on the animation configuration supplied at initialization
         /// time and the new view position and size.
         /// </summary>
+        /// <param name="viewManager">The view manager for the view.</param>
         /// <param name="view">The view to create the animation for.</param>
         /// <param name="dimensions">The view dimensions.</param>
-        protected override IObservable<Unit> CreateAnimationCore(FrameworkElement view, Dimensions dimensions)
+        protected override IObservable<Unit> CreateAnimationCore(IViewManager viewManager, FrameworkElement view, Dimensions dimensions)
         {
             var fromValue = IsReverse ? 1.0 : 0.0;
             var toValue = IsReverse ? 0.0 : 1.0;

--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutAnimation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutAnimation.cs
@@ -66,17 +66,18 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// based on the animation configuration supplied at initialization
         /// time and the new view position and size.
         /// </summary>
+        /// <param name="viewManager">The view manager for the view.</param>
         /// <param name="view">The view to create the animation for.</param>
         /// <param name="dimensions">The view dimensions.</param>
         /// <returns>The storyboard.</returns>
-        public IObservable<Unit> CreateAnimation(FrameworkElement view, Dimensions dimensions)
+        public IObservable<Unit> CreateAnimation(IViewManager viewManager, FrameworkElement view, Dimensions dimensions)
         {
             if (!IsValid)
             {
                 return null;
             }
 
-            return CreateAnimationCore(view, dimensions);
+            return CreateAnimationCore(viewManager, view, dimensions);
         }
 
         /// <summary>
@@ -123,9 +124,10 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// based on the animation configuration supplied at initialization
         /// time and the new view position and size.
         /// </summary>
+        /// <param name="viewManager">The view manager for the view.</param>
         /// <param name="view">The view to create the animation for.</param>
         /// <param name="dimensions">The view dimensions.</param>
         /// <returns>The storyboard.</returns>
-        protected abstract IObservable<Unit> CreateAnimationCore(FrameworkElement view, Dimensions dimensions);
+        protected abstract IObservable<Unit> CreateAnimationCore(IViewManager viewManager, FrameworkElement view, Dimensions dimensions);
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutAnimationController.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutAnimationController.cs
@@ -93,7 +93,7 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// </summary>
         /// <param name="view">The native view to animate.</param>
         /// <param name="dimensions">The new view dimensions to animate to.</param>
-        public void ApplyLayoutUpdate(FrameworkElement view, Dimensions dimensions)
+        public void ApplyLayoutUpdate(IViewManager viewManager, FrameworkElement view, Dimensions dimensions)
         {
             DispatcherHelpers.AssertOnDispatcher();
 
@@ -101,13 +101,10 @@ namespace ReactNative.UIManager.LayoutAnimation
                 ? _layoutCreateAnimation
                 : _layoutUpdateAnimation;
 
-            var animation = layoutAnimation.CreateAnimation(view, dimensions);
+            var animation = layoutAnimation.CreateAnimation(viewManager, view, dimensions);
             if (animation == null)
             {
-                Canvas.SetLeft(view, dimensions.X);
-                Canvas.SetTop(view, dimensions.Y);
-                view.Width = dimensions.Width;
-                view.Height = dimensions.Height;
+                viewManager.SetDimensions(view, dimensions);
             }
             else
             {
@@ -124,20 +121,13 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// Called once the animation is finished, should be used to completely
         /// remove the view.
         /// </param>
-        public void DeleteView(FrameworkElement view, Action @finally)
+        public void DeleteView(IViewManager viewManager, FrameworkElement view, Action @finally)
         {
             DispatcherHelpers.AssertOnDispatcher();
 
             var layoutAnimation = _layoutDeleteAnimation;
 
-            var animation = layoutAnimation.CreateAnimation(
-                view, new Dimensions
-                {
-                    X = Canvas.GetLeft(view),
-                    Y = Canvas.GetTop(view),
-                    Width = view.Width,
-                    Height = view.Height,
-                });
+            var animation = layoutAnimation.CreateAnimation(viewManager, view, viewManager.GetDimensions(view));
 
             if (animation != null)
             {

--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutCreateAnimation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutCreateAnimation.cs
@@ -26,12 +26,13 @@ namespace ReactNative.UIManager.LayoutAnimation
                 return false;
             }
         }
-        
+
         /// <summary>
         /// Create an observable animation to be used to animate the view, 
         /// based on the animation configuration supplied at initialization
         /// time and the new view position and size.
         /// </summary>
+        /// <param name="viewManager">The view manager for the view.</param>
         /// <param name="view">The view to create the animation for.</param>
         /// <param name="dimensions">The view dimensions</param>
         /// <returns>
@@ -39,14 +40,10 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// stops the animation when disposed, and that completes 
         /// simultaneously with the underlying animation.
         /// </returns>
-        protected override IObservable<Unit> CreateAnimationCore(FrameworkElement view, Dimensions dimensions)
+        protected override IObservable<Unit> CreateAnimationCore(IViewManager viewManager, FrameworkElement view, Dimensions dimensions)
         {
-            Canvas.SetLeft(view, dimensions.X);
-            Canvas.SetTop(view, dimensions.Y);
-            view.Width = dimensions.Width;
-            view.Height = dimensions.Height;
-
-            return base.CreateAnimationCore(view, dimensions);
+            viewManager.SetDimensions(view, dimensions);
+            return base.CreateAnimationCore(viewManager, view, dimensions);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutUpdateAnimation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutUpdateAnimation.cs
@@ -34,18 +34,16 @@ namespace ReactNative.UIManager.LayoutAnimation
         /// based on the animation configuration supplied at initialization
         /// time and the new view position and size.
         /// </summary>
+        /// <param name="viewManager">The view manager for the view.</param>
         /// <param name="view">The view to create the animation for.</param>
         /// <param name="dimensions">The view dimensions.</param>
         /// <returns>The storyboard.</returns>
-        protected override IObservable<Unit> CreateAnimationCore(FrameworkElement view, Dimensions dimensions)
+        protected override IObservable<Unit> CreateAnimationCore(IViewManager viewManager, FrameworkElement view, Dimensions dimensions)
         {
-            var currentX = Canvas.GetLeft(view);
-            var currentY = Canvas.GetTop(view);
-            var currentWidth = view.Width;
-            var currentHeight = view.Height;
+            var currentDimensions = viewManager.GetDimensions(view);
 
-            var animateLocation = dimensions.X != currentX || dimensions.Y != currentY;
-            var animateSize = dimensions.Width != currentWidth || dimensions.Height != currentHeight;
+            var animateLocation = dimensions.X != currentDimensions.X || dimensions.Y != currentDimensions.Y;
+            var animateSize = dimensions.Width != currentDimensions.Width || dimensions.Height != currentDimensions.Height;
 
             if (!animateLocation && !animateSize)
             {
@@ -53,30 +51,30 @@ namespace ReactNative.UIManager.LayoutAnimation
             }
 
             var storyboard = new Storyboard();
-            if (currentX != dimensions.X)
+            if (currentDimensions.X != dimensions.X)
             {
                 storyboard.Children.Add(
-                    CreateTimeline(view, "(Canvas.Left)", currentX, dimensions.X));
+                    CreateTimeline(view, "(Canvas.Left)", currentDimensions.X, dimensions.X));
             }
 
-            if (currentY != dimensions.Y)
+            if (currentDimensions.Y != dimensions.Y)
             {
                 storyboard.Children.Add(
-                    CreateTimeline(view, "(Canvas.Top)", currentY, dimensions.Y));
+                    CreateTimeline(view, "(Canvas.Top)", currentDimensions.Y, dimensions.Y));
             }
 
-            if (currentWidth != dimensions.Width)
+            if (currentDimensions.Width != dimensions.Width)
             {
-                var timeline = CreateTimeline(view, "Width", currentWidth, dimensions.Width);
+                var timeline = CreateTimeline(view, "Width", currentDimensions.Width, dimensions.Width);
 #if WINDOWS_UWP
                 timeline.EnableDependentAnimation = true;
 #endif
                 storyboard.Children.Add(timeline);
             }
 
-            if (currentHeight != dimensions.Height)
+            if (currentDimensions.Height != dimensions.Height)
             {
-                var timeline = CreateTimeline(view, "Height", currentHeight, dimensions.Height);
+                var timeline = CreateTimeline(view, "Height", currentDimensions.Height, dimensions.Height);
 #if WINDOWS_UWP
                 timeline.EnableDependentAnimation = true;
 #endif
@@ -85,10 +83,7 @@ namespace ReactNative.UIManager.LayoutAnimation
 
             return new StoryboardObservable(storyboard, () =>
             {
-                Canvas.SetLeft(view, dimensions.X);
-                Canvas.SetTop(view, dimensions.Y);
-                view.Width = dimensions.Width;
-                view.Height = dimensions.Height;
+                viewManager.SetDimensions(view, dimensions);
             });
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -286,7 +286,7 @@ namespace ReactNative.UIManager
                     if (elementToDestroy != null &&
                         _layoutAnimator.ShouldAnimateLayout(elementToDestroy))
                     {
-                        _layoutAnimator.DeleteView(elementToDestroy, () =>
+                        _layoutAnimator.DeleteView(viewManager, elementToDestroy, () =>
                         {
                             if (viewParentManager.TryRemoveView(viewToManage, viewToDestroy))
                             {
@@ -657,7 +657,7 @@ namespace ReactNative.UIManager
             var frameworkElement = viewToUpdate as FrameworkElement;
             if (frameworkElement != null && _layoutAnimator.ShouldAnimateLayout(frameworkElement))
             {
-                _layoutAnimator.ApplyLayoutUpdate(frameworkElement, dimensions);
+                _layoutAnimator.ApplyLayoutUpdate(viewManager, frameworkElement, dimensions);
             }
             else
             {;

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -83,9 +83,11 @@ namespace ReactNative.UIManager
                 dimensionBoundProperties.OverflowHidden = true;
                 var dimensions = GetDimensions(view);
                 SetOverflowHidden(view, dimensions);
+                view.SizeChanged += OnSizeChanged;
             }
             else
             {
+                view.SizeChanged -= OnSizeChanged;
                 var dimensionBoundProperties = GetDimensionBoundProperties(view);
                 if (dimensionBoundProperties != null && dimensionBoundProperties.OverflowHidden)
                 {
@@ -210,9 +212,15 @@ namespace ReactNative.UIManager
             if (overflowHidden)
             {
                 SetOverflowHidden(view, dimensions);
+                view.SizeChanged -= OnSizeChanged;
             }
 
             base.SetDimensions(view, dimensions);
+
+            if (overflowHidden)
+            {
+                view.SizeChanged += OnSizeChanged;
+            }
         }
 
         /// <summary>
@@ -232,6 +240,15 @@ namespace ReactNative.UIManager
         {
             view.PointerEntered += OnPointerEntered;
             view.PointerExited += OnPointerExited;
+        }
+
+        private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            var view = (TFrameworkElement)sender;
+            view.Clip = new RectangleGeometry
+            {
+                Rect = new Rect(0, 0, e.NewSize.Width, e.NewSize.Height),
+            };
         }
 
         private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
@@ -373,13 +390,7 @@ namespace ReactNative.UIManager
             {
                 element.Clip = new RectangleGeometry
                 {
-                    Rect = new Rect
-                    {
-                        X = 0,
-                        Y = 0,
-                        Width = dimensions.Width,
-                        Height = dimensions.Height,
-                    },
+                    Rect = new Rect(0, 0, dimensions.Width, dimensions.Height),
                 };
             }
         }


### PR DESCRIPTION
A previous change decoupled `overflow: hidden` from the `SizeChanged` event for views. We have to keep this to support clipping on dependent animations (affecting size and position) generated from LayoutAnimation.

Fixes #1236