### PR TITLE
Migrate from React.createClass

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.windows.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.windows.js
@@ -15,6 +15,7 @@ const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const React = require('React');
+const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
@@ -36,7 +37,8 @@ type DefaultProps = {
 /**
  * Displays a circular loading indicator.
  */
-const ActivityIndicator = React.createClass({
+const ActivityIndicator = createReactClass({
+  displayName: 'ActivityIndicator',
   mixins: [NativeMethodsMixin],
 
   propTypes: {
@@ -102,7 +104,7 @@ const ActivityIndicator = React.createClass({
         />
       </View>
     );
-  }
+  },
 });
 
 const styles = StyleSheet.create({

--- a/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
+++ b/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
@@ -57,9 +57,14 @@ type Event = Object;
  * }
  * ```
  */
-var FlipViewWindows = React.createClass({
+class FlipViewWindows extends React.Component {
+  props: {
+    initialPage?: number,
+    alwaysAnimate?: boolean,
+    onSelectionChange?: Function,
+  };
 
-  propTypes: {
+  static propTypes = {
     ...ViewPropTypes,
     /**
      * Index of initial page that should be selected. Use `setPage` method to
@@ -79,19 +84,19 @@ var FlipViewWindows = React.createClass({
      *  - position - index of page that has been selected
      */
     onSelectionChange: PropTypes.func,
-  },
+  };
 
-  componentDidMount: function() {
+  componentDidMount() {
     if (this.props.initialPage) {
       this.setPage(this.props.initialPage);
     }
-  },
-  
-  getInnerViewNode: function(): ReactComponent<*,*,*> {
-    return this.refs[FLIPVIEW_REF].getInnerViewNode();
-  },
+  }
 
-  _childrenWithOverridenStyle: function(): Array<*> {
+  getInnerViewNode = (): ReactComponent<*,*,*> => {
+    return this.refs[FLIPVIEW_REF].getInnerViewNode();
+  };
+
+  _childrenWithOverridenStyle = (): Array<*> => {
     // Override styles so that each page will fill the parent. Native component
     // will handle positioning of elements, so it's not important to offset
     // them correctly.
@@ -120,26 +125,26 @@ var FlipViewWindows = React.createClass({
       }
       return React.createElement(child.type, newProps);
     });
-  },
+  };
 
-  _onSelectionChange: function(e: Event) {
+  _onSelectionChange = (e: Event) => {
     if (this.props.onSelectionChange) {
       this.props.onSelectionChange(e);
     }
-  },
+  };
 
   /**
    * A helper function to switch to a specific page in the FlipView.
    */
-  setPage: function(selectedPage: number) {
+  setPage = (selectedPage: number) => {
     UIManager.dispatchViewManagerCommand(
       ReactNative.findNodeHandle(this),
       UIManager.WindowsFlipView.Commands.setPage,
       [selectedPage],
     );
-  },
+  };
 
-  render: function() {
+  render() {
     return (
       <NativeWindowsFlipView
         ref={FLIPVIEW_REF}
@@ -150,8 +155,8 @@ var FlipViewWindows = React.createClass({
         children={this._childrenWithOverridenStyle()}
       />
     );
-  },
-});
+  }
+}
 
 var NativeWindowsFlipView = requireNativeComponent('WindowsFlipView', FlipViewWindows);
 

--- a/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
+++ b/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
@@ -16,6 +16,7 @@ var EventEmitter = require('EventEmitter');
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var Text = require('Text');
@@ -49,7 +50,9 @@ type Event = Object;
  *   />
  * ```
  */
-var PasswordBoxWindows = React.createClass({
+var PasswordBoxWindows = createReactClass({
+  displayName: 'PasswordBoxWindows',
+
   statics: {
     /* TODO(brentvatne) docs are needed for this */
     State: TextInputState,
@@ -387,7 +390,6 @@ var PasswordBoxWindows = React.createClass({
       </TouchableWithoutFeedback>
     );
   },
-
 
   _onFocus: function(event: Event) {
     if (this.props.onFocus) {

--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -36,9 +36,19 @@ type Event = Object;
 /**
  * Not exposed as a public API - use <Picker> instead.
  */
-var PickerWindows = React.createClass({
+class PickerWindows extends React.Component {
+  props: {
+    style?: $FlowFixMe,
+    items?: any,
+    selected?: number,
+    selectedValue?: any,
+    enabled?: boolean,
+    onValueChange?: Function,
+    prompt?: string,
+    testID?: string,
+  };
 
-  propTypes: {
+  static propTypes = {
     ...ViewPropTypes,
     style: pickerStyleType,
     items: PropTypes.any,
@@ -48,18 +58,14 @@ var PickerWindows = React.createClass({
     onValueChange: PropTypes.func,
     prompt: PropTypes.string,
     testID: PropTypes.string,
-  },
+  };
 
-  getInitialState: function() {
-    return this._stateFromProps(this.props);
-  },
-
-  componentWillReceiveProps: function(nextProps: Object) {
+  componentWillReceiveProps(nextProps: Object) {
     this.setState(this._stateFromProps(nextProps));
-  },
+  }
 
   // Translate prop and children into stuff that the native picker understands.
-  _stateFromProps: function(props) {
+  _stateFromProps = (props) => {
     var selectedIndex = 0;
     let items = React.Children.map(props.children, (child, index) => {
       if (child.props.value === props.selectedValue) {
@@ -78,9 +84,9 @@ var PickerWindows = React.createClass({
       return childProps;
     });
     return {selectedIndex, items};
-  },
-  
-  render: function() {
+  };
+
+  render() {
     var Picker = ComboBoxPicker;
 
     var nativeProps = {
@@ -94,9 +100,9 @@ var PickerWindows = React.createClass({
     };
 
     return <Picker ref={REF_PICKER} {...nativeProps} />;
-  },
+  }
 
-  _onChange: function(event: Object) {
+  _onChange = (event: Object) => {
     if (this.props.onValueChange) {
       var position = event.nativeEvent.position;
       if (position >= 0) {
@@ -116,8 +122,10 @@ var PickerWindows = React.createClass({
     if (this.refs[REF_PICKER] && this.state.selectedIndex !== event.nativeEvent.position) {
       this.refs[REF_PICKER].setNativeProps({selected: this.state.selectedIndex});
     }
-  },
-});
+  };
+
+  state = this._stateFromProps(this.props);
+}
 
 var cfg = {
   nativeOnly: {

--- a/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
+++ b/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
@@ -19,34 +19,38 @@ var requireNativeComponent = require('requireNativeComponent');
  * React component that wraps the Windows-only `ProgressBar`. This component is used to indicate
  * that the app is loading or there is some activity in the app.
  */
-var ProgressBarWindows = React.createClass({
-  propTypes: {
-    ...ViewPropTypes,
-    
-    /**
-     * If the progress bar will show indeterminate progress.
-     */
-    indeterminate: PropTypes.bool,
-    /**
-     * The progress value (between 0 and 100).
-     */
-    progress: PropTypes.number,
-    /**
-     * Color of the progress bar.
-     */
-    color: ColorPropType,
-  },
-  
-  getDefaultProps: function() {
-    return {
-      indeterminate: true
-    };
-  },
-  
-  render: function() {
-    return <WindowsProgressBar {...this.props}/> ;
-  },
-});
+class ProgressBarWindows extends React.Component {
+ props: {
+  indeterminate?: boolean,
+  progress?: number,
+  color?: $FlowFixMe,
+ };
+
+ static propTypes = {
+   ...ViewPropTypes,
+   
+   /**
+    * If the progress bar will show indeterminate progress.
+    */
+   indeterminate: PropTypes.bool,
+   /**
+    * The progress value (between 0 and 100).
+    */
+   progress: PropTypes.number,
+   /**
+    * Color of the progress bar.
+    */
+   color: ColorPropType,
+ };
+
+ static defaultProps = {
+   indeterminate: true
+ };
+
+ render() {
+   return <WindowsProgressBar {...this.props}/> ;
+ }
+}
 
 var WindowsProgressBar = requireNativeComponent('WindowsProgressBar', ProgressBarWindows);
 

--- a/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
+++ b/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
@@ -14,25 +14,25 @@ var requireNativeComponent = require('requireNativeComponent');
 
 var ColorPropType = require('ColorPropType');
 
-var ProgressRingWindows = React.createClass({  
-  propTypes: {
+class ProgressRingWindows extends React.Component {
+  props: {color?: $FlowFixMe};
+
+  static propTypes = {
     ...ViewPropTypes,
     /**
      * Color of the progress bar.
      */
     color: ColorPropType,
-  },
-  
-  getDefaultProps: function() {
-    return {
-      animating: true
-    };
-  },
-  
-  render: function() {
+  };
+
+  static defaultProps = {
+    animating: true
+  };
+
+  render() {
     return <WindowsProgressRing {...this.props}/> ;
-  },
-});
+  }
+}
 
 var WindowsProgressRing = requireNativeComponent(
     'WindowsProgressRing', 

--- a/Libraries/Components/ScrollView/ScrollView.windows.js
+++ b/Libraries/Components/ScrollView/ScrollView.windows.js
@@ -18,6 +18,7 @@ const Platform = require('Platform');
 const PointPropType = require('PointPropType');
 const PropTypes = require('prop-types');
 const React = require('React');
+const createReactClass = require('create-react-class');
 const ReactNative = require('ReactNative');
 const ScrollResponder = require('ScrollResponder');
 const ScrollViewStickyHeader = require('ScrollViewStickyHeader');
@@ -72,7 +73,9 @@ import type {NativeMethodsMixinType} from 'ReactNativeTypes';
  * supports out of the box.
  */
 // $FlowFixMe(>=0.41.0)
-const ScrollView = React.createClass({
+const ScrollView = createReactClass({
+  displayName: 'ScrollView',
+
   propTypes: {
     ...ViewPropTypes,
     /**
@@ -410,11 +413,11 @@ const ScrollView = React.createClass({
   },
 
   mixins: [ScrollResponder.Mixin],
-
   _scrollAnimatedValue: (new Animated.Value(0): Animated.Value),
   _scrollAnimatedValueAttachment: (null: ?{detach: () => void}),
   _stickyHeaderRefs: (new Map(): Map<number, ScrollViewStickyHeader>),
   _headerLayoutYs: (new Map(): Map<string, number>),
+
   getInitialState: function() {
     return this.scrollResponderMixinGetInitialState();
   },
@@ -598,11 +601,13 @@ const ScrollView = React.createClass({
   },
 
   _scrollViewRef: (null: ?ScrollView),
+
   _setScrollViewRef: function(ref: ?ScrollView) {
     this._scrollViewRef = ref;
   },
 
   _innerViewRef: (null: ?NativeMethodsMixinType),
+
   _setInnerViewRef: function(ref: ?NativeMethodsMixinType) {
     this._innerViewRef = ref;
   },
@@ -786,7 +791,7 @@ const ScrollView = React.createClass({
         {contentContainer}
       </ScrollViewClass>
     );
-  }
+  },
 });
 
 const styles = StyleSheet.create({

--- a/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
+++ b/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
@@ -13,6 +13,7 @@
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
@@ -64,7 +65,9 @@ var SplitViewValidAttributes = {
  * },
  * ```
  */
-var SplitViewWindows = React.createClass({
+var SplitViewWindows = createReactClass({
+  displayName: 'SplitViewWindows',
+
   statics: {
     positions: SplitViewConsts.PanePositions,
   },

--- a/Libraries/Components/StatusBar/StatusBar.windows.js
+++ b/Libraries/Components/StatusBar/StatusBar.windows.js
@@ -109,91 +109,102 @@ function createStackEntry(props: any): any {
  * set by the static API will get overriden by the one set by the component in
  * the next render.
  */
-const StatusBar = React.createClass({
-  statics: {
-    _propsStack: [],
-    _defaultProps: createStackEntry({
-      animated: false,
-      showHideTransition: 'fade',
-      backgroundColor: 'black',
-      barStyle: 'default',
-      translucent: false,
-      hidden: false,
-      networkActivityIndicatorVisible: false,
-    }),
-    // Timer for updating the native module values at the end of the frame.
-    _updateImmediate: null,
-    // The current merged values from the props stack.
-    _currentValues: null,
+class StatusBar extends React.Component {
+  props: {
+    hidden?: boolean,
+    animated?: boolean,
+    backgroundColor?: $FlowFixMe,
+    translucent?: boolean,
+    barStyle?: 'default' | 'light-content',
+    networkActivityIndicatorVisible?: boolean,
+    showHideTransition?: 'fade' | 'slide',
+  };
 
-    // TODO(janic): Provide a real API to deal with status bar height. See the
-    // discussion in #6195.
-    /**
-     * The current height of the status bar on the device.
-     *
-     * @platform android
-     */
-    currentHeight: StatusBarManager.HEIGHT,
+  static _propsStack = [];
 
-    // Provide an imperative API as static functions of the component.
-    // See the corresponding prop for more detail.
-    setHidden(hidden: boolean, animation?: StatusBarAnimation) {
-      animation = animation || 'none';
-      StatusBar._defaultProps.hidden.value = hidden;
-      if (Platform.OS === 'ios') {
-        StatusBarManager.setHidden(hidden, animation);
-      } else if (Platform.OS === 'android') {
-        StatusBarManager.setHidden(hidden);
-      } else if (Platform.OS === 'windows') {
-        StatusBarManager.setHidden(hidden);
-      }
-    },
+  static _defaultProps = createStackEntry({
+    animated: false,
+    showHideTransition: 'fade',
+    backgroundColor: 'black',
+    barStyle: 'default',
+    translucent: false,
+    hidden: false,
+    networkActivityIndicatorVisible: false,
+  });
 
-    setBarStyle(style: StatusBarStyle, animated?: boolean) {
-      if (Platform.OS !== 'ios') {
-        console.warn('`setBarStyle` is only available on iOS');
-        return;
-      }
+  // Timer for updating the native module values at the end of the frame.
+  static _updateImmediate = null;
+
+  // The current merged values from the props stack.
+  static _currentValues = null;
+
+  // TODO(janic): Provide a real API to deal with status bar height. See the
+  // discussion in #6195.
+  /**
+   * The current height of the status bar on the device.
+   *
+   * @platform android
+   */
+  static currentHeight = StatusBarManager.HEIGHT;
+
+  // Provide an imperative API as static functions of the component.
+  // See the corresponding prop for more detail.
+  static setHidden(hidden: boolean, animation?: StatusBarAnimation) {
+    animation = animation || 'none';
+    StatusBar._defaultProps.hidden.value = hidden;
+    if (Platform.OS === 'ios') {
+      StatusBarManager.setHidden(hidden, animation);
+    } else if (Platform.OS === 'android') {
+      StatusBarManager.setHidden(hidden);
+    } else if (Platform.OS === 'windows') {
+      StatusBarManager.setHidden(hidden);
+    }
+  }
+
+  static setBarStyle(style: StatusBarStyle, animated?: boolean) {
+    if (Platform.OS !== 'ios') {
+      console.warn('`setBarStyle` is only available on iOS');
+      return;
+    }
+    animated = animated || false;
+    StatusBar._defaultProps.barStyle.value = style;
+    StatusBarManager.setStyle(style, animated);
+  }
+
+  static setNetworkActivityIndicatorVisible(visible: boolean) {
+    if (Platform.OS !== 'ios') {
+      console.warn('`setNetworkActivityIndicatorVisible` is only available on iOS');
+      return;
+    }
+    StatusBar._defaultProps.networkActivityIndicatorVisible = visible;
+    StatusBarManager.setNetworkActivityIndicatorVisible(visible);
+  }
+
+  static setBackgroundColor(color: string, animated?: boolean) {
+    if (Platform.OS === 'ios') {
+      console.warn('`setBackgroundColor` is only available on Android and Windows');
+    }
+    else if (Platform.OS === 'android') {
       animated = animated || false;
-      StatusBar._defaultProps.barStyle.value = style;
-      StatusBarManager.setStyle(style, animated);
-    },
+      StatusBar._defaultProps.backgroundColor.value = color;
+      StatusBarManager.setColor(processColor(color), animated);
+    }
+    else if (Platform.OS === 'windows') {
+      StatusBar._defaultProps.backgroundColor.value = color;
+      StatusBarManager.setColor(processColor(color));    
+    }
+  }
 
-    setNetworkActivityIndicatorVisible(visible: boolean) {
-      if (Platform.OS !== 'ios') {
-        console.warn('`setNetworkActivityIndicatorVisible` is only available on iOS');
-        return;
-      }
-      StatusBar._defaultProps.networkActivityIndicatorVisible = visible;
-      StatusBarManager.setNetworkActivityIndicatorVisible(visible);
-    },
+  static setTranslucent(translucent: boolean) {
+    if (Platform.OS === 'ios') {
+      console.warn('`setTranslucent` is not available on iOS');
+      return;
+    }
+    StatusBar._defaultProps.translucent = translucent;
+    StatusBarManager.setTranslucent(translucent);
+  }
 
-    setBackgroundColor(color: string, animated?: boolean) {
-      if (Platform.OS === 'ios') {
-        console.warn('`setBackgroundColor` is only available on Android and Windows');
-      }
-      else if (Platform.OS === 'android') {
-        animated = animated || false;
-        StatusBar._defaultProps.backgroundColor.value = color;
-        StatusBarManager.setColor(processColor(color), animated);
-      }
-      else if (Platform.OS === 'windows') {
-        StatusBar._defaultProps.backgroundColor.value = color;
-        StatusBarManager.setColor(processColor(color));    
-      }
-    },
-
-    setTranslucent(translucent: boolean) {
-      if (Platform.OS === 'ios') {
-        console.warn('`setTranslucent` is not available on iOS');
-        return;
-      }
-      StatusBar._defaultProps.translucent = translucent;
-      StatusBarManager.setTranslucent(translucent);
-    },
-  },
-
-  propTypes: {
+  static propTypes = {
     /**
      * If the status bar is hidden.
      */
@@ -241,16 +252,14 @@ const StatusBar = React.createClass({
       'fade',
       'slide',
     ]),
-  },
+  };
 
-  getDefaultProps(): DefaultProps {
-    return {
-      animated: false,
-      showHideTransition: 'fade',
-    };
-  },
+  static defaultProps = {
+    animated: false,
+    showHideTransition: 'fade',
+  };
 
-  _stackEntry: null,
+  _stackEntry = null;
 
   componentDidMount() {
     // Every time a StatusBar component is mounted, we push it's prop to a stack
@@ -260,7 +269,7 @@ const StatusBar = React.createClass({
     this._stackEntry = createStackEntry(this.props);
     StatusBar._propsStack.push(this._stackEntry);
     this._updatePropsStack();
-  },
+  }
 
   componentWillUnmount() {
     // When a StatusBar is unmounted, remove itself from the stack and update
@@ -269,7 +278,7 @@ const StatusBar = React.createClass({
     StatusBar._propsStack.splice(index, 1);
 
     this._updatePropsStack();
-  },
+  }
 
   componentDidUpdate() {
     const index = StatusBar._propsStack.indexOf(this._stackEntry);
@@ -277,12 +286,12 @@ const StatusBar = React.createClass({
     StatusBar._propsStack[index] = this._stackEntry;
 
     this._updatePropsStack();
-  },
+  }
 
   /**
    * Updates the native status bar with the props from the stack.
    */
-  _updatePropsStack() {
+  _updatePropsStack = () => {
     // Send the update to the native module only once at the end of the frame.
     clearImmediate(StatusBar._updateImmediate);
     StatusBar._updateImmediate = setImmediate(() => {
@@ -340,11 +349,11 @@ const StatusBar = React.createClass({
       // Update the current prop values.
       StatusBar._currentValues = mergedProps;
     });
-  },
+  };
 
   render(): ?ReactElement {
     return null;
-  },
-});
+  }
+}
 
 module.exports = StatusBar;

--- a/Libraries/Components/TextInput/TextInput.windows.js
+++ b/Libraries/Components/TextInput/TextInput.windows.js
@@ -17,6 +17,7 @@ var NativeMethodsMixin = require('NativeMethodsMixin');
 var Platform = require('Platform');
 var PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var Text = require('Text');
@@ -87,7 +88,9 @@ function notSupported(prop) {
  *  </View>
  * ```
  */
-var TextInput = React.createClass({
+var TextInput = createReactClass({
+  displayName: 'TextInput',
+
   statics: {
     /* TODO(brentvatne) docs are needed for this */
     State: TextInputState,
@@ -693,7 +696,6 @@ var TextInput = React.createClass({
       </TouchableWithoutFeedback>
     );
   },
-
 
   _onFocus: function(event: Event) {
     if (this.props.onFocus) {

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.windows.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.windows.js
@@ -16,15 +16,15 @@ var StyleSheet = require('StyleSheet');
 var Text = require('Text');
 var View = require('View');
 
-var DummyTouchableNativeFeedback = React.createClass({
-  render: function() {
+class DummyTouchableNativeFeedback extends React.Component {
+  render() {
     return (
       <View style={[styles.container, this.props.style]}>
         <Text style={styles.info}>TouchableNativeFeedback is not supported on this platform!</Text>
       </View>
     );
-  },
-});
+  }
+}
 
 var styles = StyleSheet.create({
   container: {

--- a/Libraries/Components/WebView/WebView.windows.js
+++ b/Libraries/Components/WebView/WebView.windows.js
@@ -38,9 +38,8 @@ var WebViewState = keyMirror({
 /**
  * Renders a native WebView.
  */
-var WebView = React.createClass({
-
-  propTypes: {
+class WebView extends React.Component {
+  static propTypes = {
     ...ViewPropTypes,
     renderError: PropTypes.func,
     renderLoading: PropTypes.func,
@@ -134,29 +133,25 @@ var WebView = React.createClass({
      * start playing. The default value is `false`.
      */
     mediaPlaybackRequiresUserAction: PropTypes.bool,
-  },
+  };
 
-  getInitialState: function() {
-    return {
-      viewState: WebViewState.IDLE,
-      lastErrorEvent: null,
-      startInLoadingState: true,
-    };
-  },
+  static defaultProps = {
+    javaScriptEnabled : true,
+  };
 
-  getDefaultProps: function() {
-    return {
-      javaScriptEnabled : true,
-    };
-  },
+  state = {
+    viewState: WebViewState.IDLE,
+    lastErrorEvent: null,
+    startInLoadingState: true,
+  };
 
-  componentWillMount: function() {
+  componentWillMount() {
     if (this.props.startInLoadingState) {
       this.setState({viewState: WebViewState.LOADING});
     }
-  },
+  }
 
-  render: function() {
+  render() {
     var otherView = null;
 
     if (this.state.viewState === WebViewState.LOADING) {
@@ -208,53 +203,53 @@ var WebView = React.createClass({
         {otherView}
       </View>
     );
-  },
+  }
 
-  goForward: function() {
+  goForward = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       UIManager.RCTWebView.Commands.goForward,
       null
     );
-  },
+  };
 
-  goBack: function() {
+  goBack = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       UIManager.RCTWebView.Commands.goBack,
       null
     );
-  },
+  };
 
-  reload: function() {
+  reload = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       UIManager.RCTWebView.Commands.reload,
       null
     );
-  },
+  };
 
   /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
    */
-  updateNavigationState: function(event) {
+  updateNavigationState = (event) => {
     if (this.props.onNavigationStateChange) {
       this.props.onNavigationStateChange(event.nativeEvent);
     }
-  },
+  };
 
-  getWebViewHandle: function() {
+  getWebViewHandle = () => {
     return ReactNative.findNodeHandle(this.refs[RCT_WEBVIEW_REF]);
-  },
+  };
 
-  onLoadingStart: function(event) {
+  onLoadingStart = (event) => {
     var onLoadStart = this.props.onLoadStart;
     onLoadStart && onLoadStart(event);
     this.updateNavigationState(event);
-  },
+  };
 
-  onLoadingError: function(event) {
+  onLoadingError = (event) => {
     event.persist(); // persist this event because we need to store it
     var {onError, onLoadEnd} = this.props;
     onError && onError(event);
@@ -265,9 +260,9 @@ var WebView = React.createClass({
       lastErrorEvent: event.nativeEvent,
       viewState: WebViewState.ERROR
     });
-  },
+  };
 
-  onLoadingFinish: function(event) {
+  onLoadingFinish = (event) => {
     var {onLoad, onLoadEnd} = this.props;
     onLoad && onLoad(event);
     onLoadEnd && onLoadEnd(event);
@@ -275,8 +270,8 @@ var WebView = React.createClass({
       viewState: WebViewState.IDLE,
     });
     this.updateNavigationState(event);
-  },
-});
+  };
+}
 
 var RCTWebView = requireNativeComponent('RCTWebView', WebView);
 

--- a/Libraries/Image/Image.windows.js
+++ b/Libraries/Image/Image.windows.js
@@ -18,6 +18,7 @@ var ImageStylePropTypes = require('ImageStylePropTypes');
 var ViewStylePropTypes = require('ViewStylePropTypes');
 const PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
@@ -75,7 +76,9 @@ var ImageViewAttributes = merge(ReactNativeViewAttributes.UIView, {
 var ViewStyleKeys = new Set(Object.keys(ViewStylePropTypes));
 var ImageSpecificStyleKeys = new Set(Object.keys(ImageStylePropTypes).filter(x => !ViewStyleKeys.has(x)));
 
-var Image = React.createClass({
+var Image = createReactClass({
+  displayName: 'Image',
+
   propTypes: {
     ...ViewPropTypes,
     style: StyleSheetPropType(ImageStylePropTypes),
@@ -303,7 +306,7 @@ var Image = React.createClass({
       }
     }
     return null;
-  }
+  },
 });
 
 var styles = StyleSheet.create({

--- a/Libraries/Text/Text.windows.js
+++ b/Libraries/Text/Text.windows.js
@@ -16,6 +16,7 @@ const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const PropTypes = require('prop-types');
 const React = require('React');
+const createReactClass = require('create-react-class');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheetPropType = require('StyleSheetPropType');
 const TextStylePropTypes = require('TextStylePropTypes');
@@ -70,7 +71,9 @@ const viewConfig = {
  * ```
  */
 
-const Text = React.createClass({
+const Text = createReactClass({
+  displayName: 'Text',
+
   propTypes: {
     /**
      * Line Break mode. Works only with numberOfLines.
@@ -129,6 +132,7 @@ const Text = React.createClass({
      */
     allowFontScaling: PropTypes.bool,
   },
+
   getDefaultProps(): Object {
     return {
       accessible: true,
@@ -136,38 +140,48 @@ const Text = React.createClass({
       lineBreakMode: 'tail',
     };
   },
+
   getInitialState: function(): Object {
     return merge(Touchable.Mixin.touchableGetInitialState(), {
       isHighlighted: false,
     });
   },
+
   mixins: [NativeMethodsMixin],
   viewConfig: viewConfig,
+
   getChildContext(): Object {
     return {isInAParentText: true};
   },
+
   childContextTypes: {
     isInAParentText: PropTypes.bool
   },
+
   contextTypes: {
     isInAParentText: PropTypes.bool
   },
+
   /**
    * Only assigned if touch is needed.
    */
   _handlers: (null: ?Object),
+
   _hasPressHandler(): boolean {
     return !!this.props.onPress || !!this.props.onLongPress;
   },
+
   /**
    * These are assigned lazily the first time the responder is set to make plain
    * text nodes as cheap as possible.
    */
   touchableHandleActivePressIn: (null: ?Function),
+
   touchableHandleActivePressOut: (null: ?Function),
   touchableHandlePress: (null: ?Function),
   touchableHandleLongPress: (null: ?Function),
   touchableGetPressRectOffset: (null: ?Function),
+
   render(): ReactElement<any> {
     let newProps = this.props;
     if (this.props.onStartShouldSetResponder || this._hasPressHandler()) {


### PR DESCRIPTION
This pull request should account for the changes needed in the Libraries. The RNTester project is not fixed as part of this. I can't clone the submodule - I just don't get how. 
I have forked the react-native-windows project.
I then clone my fork locally and edit. I can't push back my edits for the RNTester though, because it is trying to push to react-native-windows, not my branch. 
Any ideas?