### PR TITLE
perf(Transform): Replace MatrixTransform with TranslateTransform

### DIFF
--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -315,11 +315,9 @@ namespace ReactNative.UIManager
                 ResetProjectionMatrix(view);
                 // We need to use a new instance of MatrixTransform because matrix
                 // updates to an existing MatrixTransform don't seem to take effect.
-                var transform = new MatrixTransform();
-                var matrix = transform.Matrix;
-                matrix.OffsetX = projectionMatrix.OffsetX;
-                matrix.OffsetY = projectionMatrix.OffsetY;
-                transform.Matrix = matrix;
+                var transform = new TranslateTransform();
+                transform.X = projectionMatrix.OffsetX;
+                transform.Y = projectionMatrix.OffsetY;
                 view.RenderTransform = transform;
             }
             else
@@ -353,7 +351,7 @@ namespace ReactNative.UIManager
         private static void ResetRenderTransform(TFrameworkElement view)
         {
             var transform = view.RenderTransform;
-            var matrixTransform = transform as MatrixTransform;
+            var matrixTransform = transform as TranslateTransform;
             if (transform != null && matrixTransform == null)
             {
                 throw new InvalidOperationException("Unknown transform set on framework element.");


### PR DESCRIPTION
In order to support scrolling inside of a "transformed" view, we added a hack to conditionally use a `MatrixTransform` instead of a `Matrix3DProjection`. We can simplify this even further to use `TranslateTransform`, as these are the only transforms we support in this case, which should improve performance.