### PR TITLE
Use _window to get content height and width

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -81,7 +81,6 @@ namespace ReactNative.Modules.DeviceInfo
 
         private IDictionary<string, object> GetDimensions()
         {
-            var content = (FrameworkElement)_window.Content;
             double scale = 1.0;
 
             return new Dictionary<string, object>
@@ -90,8 +89,8 @@ namespace ReactNative.Modules.DeviceInfo
                     "window",
                     new Dictionary<string, object>
                     {
-                        { "width", content?.ActualWidth ?? 0.0 },
-                        { "height", content?.ActualHeight ?? 0.0 },
+                        { "width", _window?.ActualWidth ?? 0.0 },
+                        { "height", _window?.ActualHeight ?? 0.0 },
                         { "scale", scale },
                         /* TODO: density and DPI needed? */
                     }

--- a/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
@@ -127,7 +127,6 @@ namespace ReactNative.Views.Scroll
         [ReactProp("horizontal")]
         public void SetHorizontal(ScrollViewer view, bool horizontal)
         {
-            throw new NotImplementedException();
             var horizontalScrollMode = horizontal
                 ? ScrollBarVisibility.Auto
                 : ScrollBarVisibility.Disabled;


### PR DESCRIPTION
It will get null reference content when run on release bundle mode, so I use _window to get ActualHight and ActualWidth, and it works fine