### PR TITLE
fix(local-cli): Missing toString() and trim() calls.

### DIFF
--- a/local-cli/rnpm/windows/src/common.js
+++ b/local-cli/rnpm/windows/src/common.js
@@ -16,7 +16,7 @@ const Registry = require('npm-registry')
 const child_process = require('child_process');
 const validUrl = require('valid-url');
 
-let npmConfReg = child_process.execSync('npm config get registry').toString();
+let npmConfReg = child_process.execSync('npm config get registry').toString().trim();
 let NPM_REGISTRY_URL = validUrl.is_uri(npmConfReg) ? npmConfReg: 'http://registry.npmjs.org';
 
 const REACT_NATIVE_PACKAGE_JSON_PATH = function() {

--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -96,7 +96,7 @@ function deployToDesktop(options) {
     console.log(chalk.green('Installing new version of the app'));
     execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Install-App "${script}"`, execOptions);
 
-    const appFamilyName = execSync(`powershell -c $(Get-AppxPackage -Name ${appName}).PackageFamilyName`);
+    const appFamilyName = execSync(`powershell -c $(Get-AppxPackage -Name ${appName}).PackageFamilyName`).toString().trim();
     execSync(`CheckNetIsolation LoopbackExempt -a -n=${appFamilyName}`, execOptions);
 
     console.log(chalk.green('Starting the app'));

--- a/local-cli/runWpf/utils/deploy.js
+++ b/local-cli/runWpf/utils/deploy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const child_process = require('child_process');
-const spawn = child_process.spawn, execSync = child_process.execSync;
+const spawn = child_process.spawn;
 const fs = require('fs');
 const http = require('http');
 const path = require('path');


### PR DESCRIPTION
fix(local-cli): Missing `toString()` and `trim()` calls for specific `execSync()` calls.

Removed unnecessary require.