### PR TITLE
fix(react-native-windows): Updated CI configuration.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,40 @@
 version: 1.0.{build}
 max_jobs: 2
-image: Visual Studio 2015
 
+# Reducing build load and CI time by specifying the exact test matrix.
 environment:
-  nodejs_version: "6"
+  nodejs_version: "LTS"
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PLATFORM_TOOLSET: v140
+      CONFIGURATION: Debug
+      PLATFORM: x64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PLATFORM_TOOLSET: v140
+      CONFIGURATION: Debug
+      PLATFORM: ARM
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PLATFORM_TOOLSET: v141
+      CONFIGURATION: ReleaseBundle
+      PLATFORM: x86
+
+# Uncomment to enable entire matrix of tests.
+#image:
+#  - Visual Studio 2015
+#  - Visual Studio 2017
+#configuration:
+#  - Debug
+#  - ReleaseBundle
+#  - DebugBundle
+#  - Release
+#platform:
+#  - x86
+#  - x64
+#  - ARM
+
+matrix:
+  # Fail everything immediately if one build fails.
+  fast_finish: true
 
 hosts:
   api.nuget.org: 93.184.221.200
@@ -18,46 +49,60 @@ install:
   - ps: '[IO.Compression.ZipFile]::ExtractToDirectory("C:\winium.zip", "C:\winium")'
 
 clone_script:
-- ps: git clone -q $("--branch=" + $Env:APPVEYOR_REPO_BRANCH) $("https://github.com/" + $Env:APPVEYOR_REPO_NAME + ".git") $Env:APPVEYOR_BUILD_FOLDER
-- ps: if (!$Env:APPVEYOR_PULL_REQUEST_NUMBER) {$("git checkout -qf " + $Env:APPVEYOR_REPO_COMMIT)}
-- ps: if ($Env:APPVEYOR_PULL_REQUEST_NUMBER) {git fetch -q origin +refs/pull/$($Env:APPVEYOR_PULL_REQUEST_NUMBER)/merge; git checkout -qf FETCH_HEAD}
+- ps: git clone -q $("--branch=" + $env:APPVEYOR_REPO_BRANCH) $("https://github.com/" + $env:APPVEYOR_REPO_NAME + ".git") $env:APPVEYOR_BUILD_FOLDER
+- ps: if (!$env:APPVEYOR_PULL_REQUEST_NUMBER) {$("git checkout -qf " + $env:APPVEYOR_REPO_COMMIT)}
+- ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {git fetch -q origin +refs/pull/$($env:APPVEYOR_PULL_REQUEST_NUMBER)/merge; git checkout -qf FETCH_HEAD}
 - ps: git submodule update -q --init --recursive
 
 before_build:
-- ps: $env:playgroundNet46_dir=$Env:APPVEYOR_BUILD_FOLDER + "\ReactWindows\Playground.Net46"
-- ps: $env:bundle_dir=$Env:APPVEYOR_BUILD_FOLDER + "\ReactWindows\Playground.Net46\ReactAssets"
+- ps: $env:playgroundNet46_dir=$env:APPVEYOR_BUILD_FOLDER + "\ReactWindows\Playground.Net46"
+- ps: $env:bundle_dir=$env:APPVEYOR_BUILD_FOLDER + "\ReactWindows\Playground.Net46\ReactAssets"
 - ps: nuget restore ReactWindows\ReactNative.sln
 - npm i -g react-native-cli
 
 build_script:
 - ps: mkdir $env:bundle_dir
 - ps: react-native bundle --platform windows --entry-file $($env:playgroundNet46_dir + "\index.windows.js") --bundle-output $($env:bundle_dir + "\index.windows.bundle") --assets-dest $env:bundle_dir --dev false; echo "Suppressing error"
-- cmd: >-
-    set DEVENV="%VS140COMNTOOLS%\..\IDE\devenv"
-
-    %DEVENV% /build "Debug|x86" ReactWindows\ReactNative.sln
-
-    %DEVENV% /build "ReleaseBundle|x64" ReactWindows\ReactNative.sln
-
-    %DEVENV% /build "Debug|ARM" ReactWindows\ReactNative.sln
+- ps: msbuild /p:Configuration=$env:CONFIGURATION /p:Platform=$env:PLATFORM /p:PlatformToolset=$env:PLATFORM_TOOLSET /nologo /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "ReactWindows\ReactNative.sln"
 
 # Start Winium in the background, give it a moment to start
 before_test:
   - ps: $winium = Start-Process -PassThru C:\winium\Winium.Desktop.Driver.exe
   - ps: Start-Sleep -s 5
 
-test:
-  assemblies:
-  - ReactWindows\ReactNative.Net46.Tests\bin\x64\**\*.Tests.dll
-
 test_script:
-#  - npm run flow-check
-  - npm test
+  # Run Nunit 3.x test engine and output to AppVeyor's UI.
+  - ps: >-
+      $platform = Get-ChildItem Env:PLATFORM
+
+      $platform = $platform.value
+
+      $config = Get-ChildItem Env:CONFIGURATION
+
+      if($config.value -eq "ReleaseBundle") { $config = "Release" } elseif ($config -eq "DebugBundle") { $config = "Debug" } else { $config = $config.value }
+
+      if($platform -ne "ARM") { nunit3-console "ReactWindows\ReactNative.Net46.Tests\bin\$platform\$config\ReactNative.Net46.Tests.dll" --result=myresults.xml }
+
+      if ($platform -eq "ReleaseBundle" -Or $platform -eq "DebugBundle") { npm test }
+
+  # Disabling for now
+  #- npm run flow-check
+  # Spec test only works when there is a bundle
+
   - npm run lint
 
 after_test:
-  - ps: Stop-Process -Id $winium.Id
-  - ReactWindows\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"ReactWindows\packages\NUnit.ConsoleRunner.3.5.0\tools\nunit3-console.exe" -targetargs:"ReactWindows\ReactNative.Net46.Tests\bin\x86\Debug\ReactNative.Net46.Tests.dll" -output:ReactWindows_coverage.xml
+  - ps: >-
+      Stop-Process -Id $winium.Id
+
+      $platform = Get-ChildItem Env:PLATFORM
+
+      $config = Get-ChildItem Env:CONFIGURATION
+
+      if($config.value -eq "ReleaseBundle") { $config = "Release" } elseif ($config -eq "DebugBundle") { $config = "Debug" } else { $config = $config.value }
+
+      if ($platform.value -ne "ARM") { ReactWindows\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"ReactWindows\packages\NUnit.ConsoleRunner.3.5.0\tools\nunit3-console.exe" -targetargs:"ReactWindows\ReactNative.Net46.Tests\bin\$env:PLATFORM\$config\ReactNative.Net46.Tests.dll" -output:ReactWindows_coverage.xml }
+
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
   - codecov -f "ReactWindows_coverage.xml"

--- a/spec/PlaygroundNet46TestSpec.js
+++ b/spec/PlaygroundNet46TestSpec.js
@@ -1,4 +1,5 @@
 var selenium = require('selenium-webdriver');
+var path = require('path');
 var By = selenium.By;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
@@ -8,7 +9,8 @@ describe('In PlaygroundNet46 Test', () => {
         this.driver = new selenium.Builder()
           .usingServer('http://localhost:9999')
           .withCapabilities({
-              'app': __dirname + '\\..\\ReactWindows\\Playground.Net46\\bin\\x64\\ReleaseBundle\\Playground.Net46.exe',
+              'app': path.join(__dirname, '\\..\\ReactWindows\\Playground.Net46\\bin\\', process.env["PLATFORM"] || "x86",
+                process.env["CONFIGURATION"] || "ReleaseBundle", "Playground.Net46.exe"),
               'launchDelay': '1000'
           })
           .forBrowser('desktop')


### PR DESCRIPTION
Updated appveyor.yml to test with both VS2015 & VS2017 (along with their
respective platform toolsets), all configurations (Debug, DebugBundle,
Release, ReleaseBundle) and all platforms (x86, x64, ARM). However for
CI speed, only three configurations are hardcoded into the matrix. (SEE
COMMENTS).

FIXED: Tests weren't actually running except through OpenCover to record
coverage. Nunit3-console is now running and output tests results in an
AppVeyor-friendly format

Added missing run flow-check (fixes #1204, #1203).