### PR TITLE
fix(AppStateModule): Addressing race condition for AppState.currentState

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/AppState/AppStateModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/AppState/AppStateModule.cs
@@ -75,7 +75,15 @@ namespace ReactNative.Modules.AppState
         [ReactMethod]
         public void getCurrentAppState(ICallback success, ICallback error)
         {
-            success.Invoke(CreateAppStateEventMap());
+            // Accessing the `_appState` field from the dispatcher thread.
+            // This ensures that any calls to `getCurrentAppState` are queued
+            // behind any pending calls to `OnResume`. This is especially
+            // important at app start, where there is a race condition where
+            // the `AppState` JavaScript module makes an initial call to
+            // `getCurrentAppState`, which could return an `uninitialized`
+            // value after the `OnResume` call delivers the `active` state.
+            DispatcherHelpers.RunOnDispatcher(() =>
+                success.Invoke(CreateAppStateEventMap()));
         }
 
         private JObject CreateAppStateEventMap()


### PR DESCRIPTION
The way the JavaScript variable AppState.currentState gets initialized is problematic. It makes an initial asynchronous call to `getCurrentAppState`. The call ends up on the native module queue thread, where it could grab the current app state only to be interrupted by the UI thread running the `OnResume` lifecycle event. At this point, the `OnResume` event can queue a JavaScript call to send the `appStateDidChange` event, which will update `AppState.currentState` in JavaScript. After this, the native module can execute the JavaScript callback with the app state variable it originally captured (`uninitialized`), which will also set the `AppState.currentState` variable. Now the `AppState.currentState` incorrectly reports `uninitialized`.

To work around this, we can queue the call to `getCurrentAppState` onto the dispatcher thread, which will place it behind any pending `OnResume` calls.

Fixes #1300