### PR TITLE
fix(ThemedReactContext): add missing generic constraint

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ThemedReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ThemedReactContext.cs
@@ -44,7 +44,7 @@ namespace ReactNative.UIManager
         /// <typeparam name="T">Type of JavaScript module.</typeparam>
         /// <returns>The JavaScript module instance.</returns>
         public T GetJavaScriptModule<T>()
-            where T : IJavaScriptModule
+            where T : IJavaScriptModule, new()
         {
             return _reactContext.GetJavaScriptModule<T>();
         }


### PR DESCRIPTION
Recent API change to ThemedReactContext is missing a generic type constraint.