### PR TITLE
fix(ReactChoreographer): Add guarantees for frame callback hook processing order

### DIFF
--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
@@ -68,11 +68,8 @@ namespace ReactNative.Animated
     {
         private readonly object _operationsGate = new object();
 
-#if WINDOWS_UWP
         private EventHandler<object> _animatedFrameCallback;
-#else
-        private EventHandler _animatedFrameCallback;
-#endif
+
         private List<Action<NativeAnimatedNodesManager>> _operations = 
             new List<Action<NativeAnimatedNodesManager>>();
         private List<Action<NativeAnimatedNodesManager>> _readyOperations;
@@ -181,7 +178,7 @@ namespace ReactNative.Animated
         /// </summary>
         public void OnResume()
         {
-            CompositionTarget.Rendering += _animatedFrameCallback;
+            ReactChoreographer.Instance.NativeAnimatedCallback += _animatedFrameCallback;
         }
 
         /// <summary>
@@ -189,7 +186,7 @@ namespace ReactNative.Animated
         /// </summary>
         public void OnSuspend()
         {
-            CompositionTarget.Rendering -= _animatedFrameCallback;
+            ReactChoreographer.Instance.NativeAnimatedCallback -= _animatedFrameCallback;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -1,0 +1,92 @@
+﻿using ReactNative.Bridge;
+using System;
+#if WINDOWS_UWP
+using Windows.UI.Xaml.Media;
+#else
+using System.Windows.Media;
+#endif
+
+namespace ReactNative.Modules.Core
+{
+    /// <summary>
+    /// A simple action queue that allows us to control the order certain
+    /// callbacks are executed within a given frame.
+    /// </summary>
+    public class ReactChoreographer : IDisposable
+    {
+        private static ReactChoreographer s_instance;
+
+        private ReactChoreographer()
+        {
+            CompositionTarget.Rendering += OnRendering;
+        }
+
+        /// <summary>
+        /// For use by <see cref="UIManager.UIManagerModule"/>. 
+        /// </summary>
+        public event EventHandler<object> DispatchUICallback;
+
+        /// <summary>
+        /// For use by <see cref="Animated.NativeAnimatedModule"/>. 
+        /// </summary>
+        public event EventHandler<object> NativeAnimatedCallback;
+
+        /// <summary>
+        /// For events that make JavaScript do things.
+        /// </summary>
+        public event EventHandler<object> JavaScriptEventsCallback;
+
+        /// <summary>
+        /// The choreographer instance.
+        /// </summary>
+        public static ReactChoreographer Instance
+        {
+            get
+            {
+                if (s_instance == null)
+                {
+                    throw new InvalidOperationException("ReactChoreographer needs to be initialized.");
+                }
+
+                return s_instance;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="ReactChoreographer"/> instance.
+        /// </summary>
+        public static void Initialize()
+        {
+            if (s_instance == null)
+            {
+                DispatcherHelpers.AssertOnDispatcher();
+                s_instance = new ReactChoreographer();
+            }
+        }
+
+        /// <summary>
+        /// Disposes the <see cref="ReactChoreographer"/> instance. 
+        /// </summary>
+        public static void Dispose()
+        {
+            if (s_instance != null)
+            {
+                DispatcherHelpers.AssertOnDispatcher();
+                ((IDisposable)s_instance).Dispose();
+                s_instance = null;
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            CompositionTarget.Rendering -= OnRendering;
+        }
+
+        private void OnRendering(object sender, object e)
+        {
+            DispatchUICallback?.Invoke(sender, e);
+            NativeAnimatedCallback?.Invoke(sender, e);
+            JavaScriptEventsCallback?.Invoke(sender, e);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -64,7 +64,7 @@ namespace ReactNative.Modules.Core
             _suspended = true;
             if (_renderingHandled)
             {
-                CompositionTarget.Rendering -= DoFrameSafe;
+                ReactChoreographer.Instance.JavaScriptEventsCallback -= DoFrameSafe;
                 _renderingHandled = false;
             }
         }
@@ -77,7 +77,7 @@ namespace ReactNative.Modules.Core
             _suspended = false;
             if (!_renderingHandled)
             {
-                CompositionTarget.Rendering += DoFrameSafe;
+                ReactChoreographer.Instance.JavaScriptEventsCallback += DoFrameSafe;
                 _renderingHandled = true;
             }
         }
@@ -89,7 +89,7 @@ namespace ReactNative.Modules.Core
         {
             if (_renderingHandled)
             {
-                CompositionTarget.Rendering -= DoFrameSafe;
+                ReactChoreographer.Instance.JavaScriptEventsCallback -= DoFrameSafe;
                 _renderingHandled = false;
             }
         }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -154,6 +154,7 @@ namespace ReactNative
         /// </summary>
         public async void CreateReactContextInBackground()
         {
+            ReactChoreographer.Initialize();
             await CreateReactContextInBackgroundAsync().ConfigureAwait(false);
         }
 
@@ -290,6 +291,8 @@ namespace ReactNative
                 _currentReactContext = null;
                 _hasStartedCreatingInitialContext = false;
             }
+
+            ReactChoreographer.Dispose();
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -120,6 +120,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\JSTimers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\RCTDeviceEventEmitter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\RCTNativeAppEventEmitter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\ReactChoreographer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\Timing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\DevSupport\IDeveloperSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\DevSupport\SourceCodeModule.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using ReactNative.Bridge;
+using ReactNative.Modules.Core;
 using ReactNative.Tracing;
 using System;
 using System.Collections.Generic;
@@ -144,14 +145,12 @@ namespace ReactNative.UIManager.Events
         /// </summary>
         public void OnResume()
         {
-            DispatcherHelpers.AssertOnDispatcher();
-
             if (_rctEventEmitter == null)
             {
                 _rctEventEmitter = _reactContext.GetJavaScriptModule<RCTEventEmitter>();
             }
 
-            CompositionTarget.Rendering += ScheduleDispatcherSafe;
+            ReactChoreographer.Instance.JavaScriptEventsCallback += ScheduleDispatcherSafe;
         }
 
         /// <summary>
@@ -180,8 +179,7 @@ namespace ReactNative.UIManager.Events
 
         private void ClearCallback()
         {
-            DispatcherHelpers.AssertOnDispatcher();
-            CompositionTarget.Rendering -= ScheduleDispatcherSafe;
+            ReactChoreographer.Instance.JavaScriptEventsCallback -= ScheduleDispatcherSafe;
         }
 
         private void MoveStagedEventsToDispatchQueue()

--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Modules.Core;
 using ReactNative.Tracing;
 using System;
 using System.Collections.Generic;
@@ -384,7 +385,7 @@ namespace ReactNative.UIManager
         /// </summary>
         public void OnSuspend()
         {
-            CompositionTarget.Rendering -= OnRenderingSafe;
+            ReactChoreographer.Instance.DispatchUICallback -= OnRenderingSafe;
         }
 
         /// <summary>
@@ -392,7 +393,7 @@ namespace ReactNative.UIManager
         /// </summary>
         public void OnResume()
         {
-            CompositionTarget.Rendering += OnRenderingSafe;
+            ReactChoreographer.Instance.DispatchUICallback += OnRenderingSafe;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -32,9 +32,6 @@ namespace ReactNative.Tests.UIManager.Events
             var context = new ReactContext();
             var dispatcher = new EventDispatcher(context);
 
-            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnResume());
-            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnSuspend());
-            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnSuspend());
             AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnReactInstanceDispose());
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);


### PR DESCRIPTION
ReactAndroid uses the ReactChoreographer to guarantee that frame callbacks throughout the native bridge are executed in a guaranteed order per frame. We had no such ordering guarantees previously, as each component subscribed individually to the CompositionTarget.Rendering event.

Fixes #1323