### PR TITLE
feat(JSTimers): Add setIdleCallback support

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Modules/Core/JSTimersTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/Core/JSTimersTests.cs
@@ -6,7 +6,7 @@ namespace ReactNative.Tests.Modules.Core
     [TestFixture]
     public class JSTimersTests
     {
-        public void JSTimers_Invoke()
+        public void JSTimers_callTimers_Invoke()
         {
             var module = new JSTimers();
 
@@ -23,6 +23,25 @@ namespace ReactNative.Tests.Modules.Core
             Assert.AreEqual(nameof(JSTimers.callTimers), name);
             Assert.AreEqual(1, args.Length);
             Assert.AreSame(ids, args[0]);
+        }
+
+        public void JSTimers_callIdleCallbacks_Invoke()
+        {
+            var module = new JSTimers();
+
+            var name = default(string);
+            var args = default(object[]);
+            module.InvocationHandler = new MockInvocationHandler((n, a) =>
+            {
+                name = n;
+                args = a;
+            });
+
+            var frameTime = 42L;
+            module.callIdleCallbacks(frameTime);
+            Assert.AreEqual(nameof(JSTimers.callIdleCallbacks), name);
+            Assert.AreEqual(1, args.Length);
+            Assert.AreSame(frameTime, args[0]);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Modules/Core/JSTimers.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/JSTimers.cs
@@ -16,5 +16,14 @@ namespace ReactNative.Modules.Core
         {
             Invoke(timerIds);
         }
+        
+        /// <summary>
+        /// Calls the idle callbacks with the current frame time.
+        /// </summary>
+        /// <param name="frameTime">The frame time.</param>
+        public void callIdleCallbacks(long frameTime)
+        {
+            Invoke(frameTime);
+        }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -54,6 +54,12 @@ namespace ReactNative.Modules.Core
         public event EventHandler<FrameEventArgs> JavaScriptEventsCallback;
 
         /// <summary>
+        /// Event used to trigger the idle callback. Called after all UI work has been
+        /// dispatched to JavaScript.
+        /// </summary>
+        public event EventHandler<FrameEventArgs> IdleCallback;
+
+        /// <summary>
         /// The choreographer instance.
         /// </summary>
         public static ReactChoreographer Instance
@@ -166,6 +172,7 @@ namespace ReactNative.Modules.Core
             DispatchUICallback?.Invoke(sender, _frameEventArgs);
             NativeAnimatedCallback?.Invoke(sender, _frameEventArgs);
             JavaScriptEventsCallback?.Invoke(sender, _frameEventArgs);
+            IdleCallback?.Invoke(sender, _frameEventArgs);
 
             lock (_gate)
             {

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -2,7 +2,6 @@ using ReactNative.Bridge;
 using ReactNative.Collections;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reactive.Disposables;
 using System.Threading;
 
@@ -20,7 +19,6 @@ namespace ReactNative.Modules.Core
 
         private readonly object _gate = new object();
         private readonly object _idleGate = new object();
-        private readonly object _idleCallbackGate = new object();
 
         private readonly HeapBasedPriorityQueue<TimerData> _timers;
 


### PR DESCRIPTION
This changeset adds `setIdleCallback` support, now that we have a choreographer that can track frame deadlines.

There still seems to be an issue with getting idle callbacks on a regular basis for release builds. E.g., the "background" example in RNTester doesn't seem to fire very often (it only fires if there is at least 5ms of frame time remaining) in release builds (but does okay during Debug).

Fixes #917