### PR TITLE
feat(nativePerformanceNow): adding nativePerformanceNow callback to Chakra

### DIFF
--- a/ReactWindows/ChakraBridge/ChakraHost.h
+++ b/ReactWindows/ChakraBridge/ChakraHost.h
@@ -125,6 +125,14 @@ public:
 	/// </returns>
 	JsErrorCode EvaluateScript(const wchar_t* szScript, const wchar_t* szSourceUri, JsValueRef* result);
 
+	/// <summary>
+	/// Gets the current value of `performanceNow` callback.
+	/// </summary>
+	/// <returns>
+	/// The performance clock time.
+	/// </returns>
+	LARGE_INTEGER PerformanceNow();
+
     /// <summary>
     /// The JSRT global object for the session.
     /// </summary>
@@ -138,10 +146,12 @@ private:
     JsErrorCode InitJson();
     JsErrorCode InitConsole();
 	JsErrorCode InitNativeRequire();
+	JsErrorCode InitPerformanceNow();
 
     unsigned currentSourceContext;
     JsRuntimeHandle runtime;
     JsContextRef context;
     JsValueRef jsonParseObject;
     JsValueRef jsonStringifyObject;
+	bool isHighResolution;
 };

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
@@ -162,3 +162,8 @@ ChakraStringResult NativeJavaScriptExecutor::FlushedQueue()
     ChakraStringResult finalResult = { JsNoError, ref new String(szBuf, bufLen) };
     return finalResult;
 }
+
+LONGLONG NativeJavaScriptExecutor::PerformanceNow()
+{
+	return host.PerformanceNow().QuadPart;
+}

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
@@ -98,6 +98,14 @@ public:
     /// A compount result with the JSON stringified value and an error code if any occurred.
     /// </returns>
     ChakraStringResult FlushedQueue();
+
+	/// <summary>
+	/// Gets the current value of `performanceNow` callback.
+	/// </summary>
+	/// <returns>
+	/// The performance clock time.
+	/// </returns>
+	LONGLONG PerformanceNow();
 private:
     ChakraHost host;
 };

--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
@@ -12,6 +12,7 @@ namespace ReactNative.Tests
 
         public Action<string, string> OnRunScript { get; set; } = EmptyRunScript;
         public Action<string, JToken> OnSetGlobalVariable { get; set; } = EmptySetGlobalVariable;
+        public Func<long> OnPerformanceNow { get; set; } = EmptyPerformanceNow;
         public Action OnDispose { get; set; } = EmptyAction;
 
         private static readonly Action EmptyAction = () => { };
@@ -20,6 +21,7 @@ namespace ReactNative.Tests
         private static readonly Func<string, string, JArray, JToken> EmptyCallFunctionReturnFlushedQueue = (_, __, ___) => { throw new NotImplementedException(); };
         private static readonly Func<int, JArray, JToken> EmptyInvokeCallbackAndReturnFlushedQueue = (_, __) => { throw new NotImplementedException(); };
         private static readonly Func<JToken> EmptyFlushQueue = () => { throw new NotImplementedException(); };
+        private static readonly Func<long> EmptyPerformanceNow = () => { throw new NotImplementedException(); };
 
         public void Initialize() { }
 
@@ -51,6 +53,11 @@ namespace ReactNative.Tests
         public JToken FlushedQueue()
         {
             return OnFlushQueue();
+        }
+
+        public long PerformanceNow()
+        {
+            return OnPerformanceNow();
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
@@ -6,7 +6,7 @@ namespace ReactNative.Bridge
     /// <summary>
     /// Interface for making JavaScript calls from native code.
     /// </summary>
-    public interface IJavaScriptExecutor : IDisposable
+    public interface IJavaScriptExecutor : IPerformanceNow, IDisposable
     {
         /// <summary>
         /// Call the JavaScript method from the given module.

--- a/ReactWindows/ReactNative.Shared/Bridge/IPerformanceNow.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IPerformanceNow.cs
@@ -1,0 +1,14 @@
+﻿namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Interface for performance counter.
+    /// </summary>
+    public interface IPerformanceNow
+    {
+        /// <summary>
+        /// Returns performance counter.
+        /// </summary>
+        /// <returns>The current performance counter value.</returns>
+        long PerformanceNow();
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\INativeMethod.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\INativeModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IOnBatchCompleteListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\IPerformanceNow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IPromise.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactBridge.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactCallback.cs" />

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -139,5 +139,14 @@ namespace ReactNative.Chakra.Executor
             Native.ThrowIfError(
                 (JavaScriptErrorCode)_executor.SetGlobalVariable(propertyName, value.ToString(Formatting.None)));
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public long PerformanceNow()
+        {
+            return _executor.PerformanceNow();
+        }
     }
 }

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -132,6 +132,11 @@ namespace ReactNative.DevSupport
             _injectedObjects.Add(propertyName, value.ToString(Formatting.None));
         }
 
+        public long PerformanceNow()
+        {
+            return DateTimeOffset.UtcNow.Ticks;
+        }
+
         public void Dispose()
         {
             _isDisposed = true;


### PR DESCRIPTION
This demonstrates how we would add the `nativePerformanceNow` callback to Chakra. Once the Timing module included `setIdleCallback` functionality, it would have to use the IPerformanceNow clock for the frameTime callbacks for everything to work appropriately.

Unfortunately, due to the P/Invoke boundary to chakra.dll, the `performanceNow` callback is 2x slower than Date.now() in Chakra, and I've already confirmed that Date.now() matches DateTimeOffset.Now.ToUnixTimeMilliseconds(). Likewise, the C++/CX bridge will not result in any significant speedup because the `performanceNow` clock value would have to be marshalled for the timing module (unless we implement timing in C++, in which case we might see a small speedup).

Fixes #1341