### PR TITLE
perf(NativeAnimated): Eliminate exceptions for missing views

### DIFF
--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
-using ReactNative.Common;
-using ReactNative.Tracing;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Events;
 using System;
@@ -574,20 +572,7 @@ namespace ReactNative.Animated
                 var valueNode = default(ValueAnimatedNode);
                 if (propsNode != null)
                 {
-                    try
-                    {
-                        propsNode.UpdateView(_uiImplementation);
-                    }
-                    catch (InvalidOperationException e)
-                    {
-                        // An exception is thrown if the view hasn't been created yet. This can happen because views are
-                        // created in batches. If this particular view didn't make it into a batch yet, the view won't
-                        // exist and an exception will be thrown when attempting to start an animation on it.
-                        //
-                        // Eat the exception rather than crashing. The impact is that we may drop one or more frames of the
-                        // animation.
-                        Tracer.Error(ReactConstants.Tag, "Native animation workaround, frame lost as result of race condition", e);
-                    }
+                    propsNode.UpdateView(_uiImplementation);
                 }
                 else if ((valueNode = nextNode as ValueAnimatedNode) != null)
                 {

--- a/ReactWindows/ReactNative.Shared/Animated/PropsAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/PropsAnimatedNode.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
+using ReactNative.Common;
+using ReactNative.Tracing;
 using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
@@ -64,9 +66,14 @@ namespace ReactNative.Animated
             // values). We can take advantage on that and optimize the way we
             // allocate property maps (we also know that updating view props
             // doesn't retain a reference to the styles object).
-            uiImplementation.SynchronouslyUpdateViewOnDispatcherThread(
+            var updated = uiImplementation.SynchronouslyUpdateViewOnDispatcherThread(
                 ConnectedViewTag,
                 new ReactStylesDiffMap(propsMap));
+
+            if (!updated)
+            {
+                Tracer.Error(ReactConstants.Tag, "Native animation workaround, frame lost as result of race condition.", null);
+            }
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -577,6 +577,18 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
+        /// Checks whether a view exists.
+        /// </summary>
+        /// <param name="tag">The tag of the view.</param>
+        /// <returns>
+        /// <code>true</code> if the view still exists, otherwise <code>false</code>.
+        /// </returns>
+        public bool ViewExists(int tag)
+        {
+            return _tagsToViews.ContainsKey(tag);
+        }
+
+        /// <summary>
         /// Resolves a view.
         /// </summary>
         /// <param name="tag">The tag of the view.</param>

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -219,10 +219,23 @@ namespace ReactNative.UIManager
         /// <remarks>
         /// Make sure you know what you're doing before calling this method :)
         /// </remarks>
-        public void SynchronouslyUpdateViewOnDispatcherThread(int tag, ReactStylesDiffMap props)
+        public bool SynchronouslyUpdateViewOnDispatcherThread(int tag, ReactStylesDiffMap props)
         {
             DispatcherHelpers.AssertOnDispatcher();
-            _operationsQueue.NativeViewHierarchyManager.UpdateProperties(tag, props);
+
+            // First check if the view exists, as the views are created in
+            // batches, and native modules attempting to synchronously interact
+            // with views may attempt to update properties before the batch has
+            // been processed.
+            if (_operationsQueue.NativeViewHierarchyManager.ViewExists(tag))
+            {
+                _operationsQueue.NativeViewHierarchyManager.UpdateProperties(tag, props);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Because of the batching mechanism built into the UIImplementation, views that are updated by the native animated module may not exist yet by the time the animation frames are processed. Previously, a try/catch block was wrapped around the view update, and exceptions have a considerable overhead. Instead, we first check if the view exists before attempting to update, and return a boolean value signaling whether or not the view was updated.

Breaking Change: UIImplementation API has changed.