### PR TITLE
fix(CI): resolve CI blockers using NPM LTS

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ hosts:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm install -g npm@latest
+  - npm install -g npm@lts
   - npm i
   - ps: curl -o C:\winium.zip https://github.com/2gis/Winium.Desktop/releases/download/v1.6.0/Winium.Desktop.Driver.zip
   - ps: mkdir C:\winium


### PR DESCRIPTION
There was an issue with npm@5.4.0 running some of the post-install scripts that was causing the CI to fail.

Fixes #1315