### PR TITLE
fix(ReactChoreographer): Unsubscribe when no callbacks necessary

### DIFF
--- a/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
@@ -61,6 +61,13 @@ namespace ReactNative.Bridge
             await CurrentDispatcher.InvokeAsync(action).Task.ConfigureAwait(false);
         }
 
+        public static async void RunOnDispatcher(DispatcherPriority priority, Action action)
+        {
+            AssertDispatcherSet();
+
+            await CurrentDispatcher.InvokeAsync(action, priority).Task.ConfigureAwait(false);
+        }
+
         public static Task<T> CallOnDispatcher<T>(Func<T> func)
         {
             var taskCompletionSource = new TaskCompletionSource<T>();

--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
@@ -122,6 +122,10 @@ namespace ReactNative.Animated
                     {
                         nodesManager.RunUpdates(args.RenderingTime);
                     }
+                    else
+                    {
+                        ReactChoreographer.Instance.DeactivateCallback(nameof(NativeAnimatedModule));
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -152,6 +156,8 @@ namespace ReactNative.Animated
                         _readyOperations.AddRange(operations);
                     }
                 }
+
+                ReactChoreographer.Instance.ActivateCallback(nameof(NativeAnimatedModule));
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -109,6 +109,8 @@ namespace ReactNative.Modules.Core
             {
                 _timers.Enqueue(timer);
             }
+
+            ReactChoreographer.Instance.ActivateCallback(nameof(Timing));
         }
 
         /// <summary>
@@ -121,6 +123,10 @@ namespace ReactNative.Modules.Core
             lock (_gate)
             {
                 _timers.Remove(new TimerData(timerId));
+                if (_timers.Count == 0)
+                {
+                    ReactChoreographer.Instance.DeactivateCallback(nameof(Timing));
+                }
             }
         }
 
@@ -158,6 +164,11 @@ namespace ReactNative.Modules.Core
                     {
                         _timers.Enqueue(nextInterval);
                     }
+                }
+
+                if (_timers.Count == 0)
+                {
+                    ReactChoreographer.Instance.DeactivateCallback(nameof(Timing));
                 }
             }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.Bridge;
+using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.Tracing;
 using System;
@@ -115,6 +115,8 @@ namespace ReactNative.UIManager.Events
             {
                 _eventStaging.Add(@event);
             }
+
+            ReactChoreographer.Instance.ActivateCallback(nameof(EventDispatcher));
         }
 
         /// <summary>
@@ -231,6 +233,7 @@ namespace ReactNative.UIManager.Events
                 }
 
                 _eventStaging.Clear();
+                ReactChoreographer.Instance.DeactivateCallback(nameof(EventDispatcher));
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using static System.FormattableString;
 
 namespace ReactNative.UIManager
@@ -916,13 +917,16 @@ namespace ReactNative.UIManager
 
                 if (frameDidChange && cssNode.ShouldNotifyOnLayout)
                 {
-                    _eventDispatcher.DispatchEvent(
-                        OnLayoutEvent.Obtain(
-                            tag,
-                            cssNode.ScreenX,
-                            cssNode.ScreenY,
-                            cssNode.ScreenWidth,
-                            cssNode.ScreenHeight));
+                    // Dispatch event from non-layout thread to avoid queueing
+                    // main dispatcher callbacks from the layout thread
+                    var task = Task.Run(() =>
+                        _eventDispatcher.DispatchEvent(
+                            OnLayoutEvent.Obtain(
+                                tag,
+                                cssNode.ScreenX,
+                                cssNode.ScreenY,
+                                cssNode.ScreenWidth,
+                                cssNode.ScreenHeight)));
                 }
             }
 

--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -54,9 +54,19 @@ namespace ReactNative.Bridge
         /// Invokes an action on the dispatcher.
         /// </summary>
         /// <param name="action">The action to invoke.</param>
-        public static async void RunOnDispatcher(DispatchedHandler action)
+        public static void RunOnDispatcher(DispatchedHandler action)
         {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action).AsTask().ConfigureAwait(false);
+            RunOnDispatcher(CoreDispatcherPriority.Normal, action);
+        }
+
+        /// <summary>
+        /// Invokes an action on the dispatcher.
+        /// </summary>
+        /// <param name="priority">The priority.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static async void RunOnDispatcher(CoreDispatcherPriority priority, DispatchedHandler action)
+        {
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(priority, action).AsTask().ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
We can track if any work is needed to be done by the ReactChoreographer. If we simply subscribe to the CompositionTarget.Rendering event all the time, we'll pay a battery life penalty for a small amount of CPU usage constantly. This PR adds a registration mechanism that notifies when callbacks are required.

Fixes #1343