### PR TITLE
fix(WebView): Minor bug introduced in WebView

### DIFF
--- a/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.UIManager;
@@ -392,7 +392,7 @@ namespace ReactNative.Views.Web
                     new WebViewLoadEvent(
                         webView.GetTag(),
                         WebViewLoadEvent.TopLoadingFinish,
-                        e.Uri.ToString(),
+                        e.Uri?.ToString(),
                         false,
                         webView.DocumentTitle,
                         webView.CanGoBack,


### PR DESCRIPTION
NavigationCompleted event args have a URI property that can be null (e.g., when you use the `NavigateToString` API). This changeset switches to a null propogating method call on the `Uri` property.