### PR TITLE
fix(ReactChoreographer): add self-adjustment to `FrameTime`

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/FrameEventArgs.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/FrameEventArgs.cs
@@ -7,8 +7,10 @@ namespace ReactNative.Modules.Core
     /// </summary>
     public class FrameEventArgs : IMutableFrameEventArgs
     {
+        private static readonly TimeSpan s_frameDuration = TimeSpan.FromTicks(166666);
+
         private readonly TimeSpan _initialRenderingTime;
-        private readonly DateTimeOffset _initialAbsoluteTime;
+        private DateTimeOffset _initialAbsoluteTime;
 
         internal FrameEventArgs(TimeSpan renderingTime)
         {
@@ -38,6 +40,9 @@ namespace ReactNative.Modules.Core
         {
             RenderingTime = renderingTime;
             FrameTime = _initialAbsoluteTime + renderingTime - _initialRenderingTime;
+
+            // Self-adjust initial absolute time to better approximate CompositionTarget frame boundary
+            _initialAbsoluteTime -= FrameTime - DateTimeOffset.UtcNow - s_frameDuration;
         }
     }
 }


### PR DESCRIPTION
This change helps make minor adjustments to the initial absolute time to better align the absolute frame time with the CompositionTarget relative clock.