### PR TITLE
perf(EventDispatcher): Reduce load on JavaScript queue thread

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
@@ -283,7 +283,13 @@ namespace ReactNative.UIManager.Events
 
             MoveStagedEventsToDispatchQueue();
 
-            if (!Volatile.Read(ref _hasDispatchScheduled))
+            bool shouldDispatch;
+            lock (_eventsToDispatchLock)
+            {
+                shouldDispatch = _eventsToDispatchSize > 0;
+            }
+
+            if (shouldDispatch && !Volatile.Read(ref _hasDispatchScheduled))
             {
                 _hasDispatchScheduled = true;
                 _reactContext.RunOnJavaScriptQueueThread(() => DispatchEvents(activity));


### PR DESCRIPTION
Only schedule work on the JavaScript queue thread if there are events to process.

Fixes #1356