### PR TITLE
fix(DispatcherHelpers): Ensure correct dispatcher check

### DIFF
--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -30,7 +30,7 @@ namespace ReactNative.Bridge
         /// </returns>
         public static bool IsOnDispatcher()
         {
-            return CoreWindow.GetForCurrentThread()?.Dispatcher != null;
+            return CoreWindow.GetForCurrentThread()?.Dispatcher == CoreApplication.MainView.CoreWindow.Dispatcher;
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, the `IsOnDispatcher` check was for any dispatcher. Now, the dispatcher check is associated with the main window.

Fixes #1371