### PR TITLE
refactor(NativeModules): Remove ILifecycleEventListener

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PCLStorage;
 using ReactNative.Bridge;
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ReactNative.Modules.Storage
 {
-    class AsyncStorageModule : NativeModuleBase, ILifecycleEventListener
+    class AsyncStorageModule : NativeModuleBase
     {
         private readonly SemaphoreSlim _mutex = new SemaphoreSlim(1, 1);
 
@@ -267,15 +267,7 @@ namespace ReactNative.Modules.Storage
             callback.Invoke(null, keys);
         }
 
-        public void OnSuspend()
-        {
-        }
-
-        public void OnResume()
-        {
-        }
-
-        public void OnDestroy()
+        public override void OnReactInstanceDispose()
         {
             _mutex.Dispose();
         }

--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
@@ -1,14 +1,9 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
-#if WINDOWS_UWP
-using Windows.UI.Xaml.Media;
-#else
-using System.Windows.Media;
-#endif
 
 namespace ReactNative.Animated
 {
@@ -165,6 +160,7 @@ namespace ReactNative.Animated
         /// </summary>
         public void OnDestroy()
         {
+            ReactChoreographer.Instance.NativeAnimatedCallback -= _animatedFrameCallback;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -1,13 +1,8 @@
-﻿using ReactNative.Bridge;
+using ReactNative.Bridge;
 using ReactNative.Collections;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-#if WINDOWS_UWP
-using Windows.UI.Xaml.Media;
-#else
-using System.Windows.Media;
-#endif
 
 namespace ReactNative.Modules.Core
 {
@@ -22,7 +17,6 @@ namespace ReactNative.Modules.Core
 
         private JSTimers _jsTimersModule;
         private bool _suspended;
-        private bool _renderingHandled;
 
         /// <summary>
         /// Instantiates the <see cref="Timing"/> module.
@@ -62,11 +56,7 @@ namespace ReactNative.Modules.Core
         public void OnSuspend()
         {
             _suspended = true;
-            if (_renderingHandled)
-            {
-                ReactChoreographer.Instance.JavaScriptEventsCallback -= DoFrameSafe;
-                _renderingHandled = false;
-            }
+            ReactChoreographer.Instance.JavaScriptEventsCallback -= DoFrameSafe;
         }
 
         /// <summary>
@@ -75,11 +65,7 @@ namespace ReactNative.Modules.Core
         public void OnResume()
         {
             _suspended = false;
-            if (!_renderingHandled)
-            {
-                ReactChoreographer.Instance.JavaScriptEventsCallback += DoFrameSafe;
-                _renderingHandled = true;
-            }
+            ReactChoreographer.Instance.JavaScriptEventsCallback += DoFrameSafe;
         }
 
         /// <summary>
@@ -87,11 +73,7 @@ namespace ReactNative.Modules.Core
         /// </summary>
         public void OnDestroy()
         {
-            if (_renderingHandled)
-            {
-                ReactChoreographer.Instance.JavaScriptEventsCallback -= DoFrameSafe;
-                _renderingHandled = false;
-            }
+            ReactChoreographer.Instance.JavaScriptEventsCallback -= DoFrameSafe;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
@@ -4,11 +4,6 @@ using ReactNative.Tracing;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-#if WINDOWS_UWP
-using Windows.UI.Xaml.Media;
-#else
-using System.Windows.Media;
-#endif
 using static System.FormattableString;
 
 namespace ReactNative.UIManager.Events

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -1,4 +1,4 @@
-﻿using Facebook.Yoga;
+using Facebook.Yoga;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Modules.I18N;
@@ -664,9 +664,9 @@ namespace ReactNative.UIManager
         /// <summary>
         /// Called when the host is shutting down.
         /// </summary>
-        public void OnShutdown()
+        public void OnDestroy()
         {
-            _operationsQueue.OnShutdown();
+            _operationsQueue.OnDestroy();
         }
 
         private void UpdateViewHierarchy()

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
-using ReactNative.Tracing;
 using ReactNative.UIManager.Events;
 using System;
 using System.Collections.Generic;
@@ -452,7 +451,7 @@ namespace ReactNative.UIManager
 
         #endregion
 
-        #region ILifecycleEventListenere
+        #region ILifecycleEventListener
 
         /// <summary>
         /// Called when the host receives the suspend event.
@@ -476,8 +475,7 @@ namespace ReactNative.UIManager
         /// </summary>
         public void OnDestroy()
         {
-            _uiImplementation.OnShutdown();
-            _eventDispatcher.OnDestroy();
+            _uiImplementation.OnDestroy();
         }
 
         #endregion

--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
@@ -1,16 +1,10 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.Tracing;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-#if WINDOWS_UWP
-using Windows.UI.Xaml.Media;
-#else
-using System.Windows.Media;
-#endif
 
 namespace ReactNative.UIManager
 {
@@ -39,8 +33,6 @@ namespace ReactNative.UIManager
         private IList<Action> _operations = new List<Action>();
         private IList<Action> _batches = new List<Action>();
 
-        private long _lastRenderingTicks = -1;
-
         /// <summary>
         /// Instantiates the <see cref="UIViewOperationQueue"/>.
         /// </summary>
@@ -63,7 +55,7 @@ namespace ReactNative.UIManager
             {
                 return _nativeViewHierarchyManager;
             }
-        } 
+        }
 
         /// <summary>
         /// Checks if the operation queue is empty.
@@ -193,14 +185,6 @@ namespace ReactNative.UIManager
                    viewClassName,
                    initialProps));
             }
-        }
-
-        /// <summary>
-        /// Clears the animation layout updates.
-        /// </summary>
-        public void ClearAnimationLayout()
-        {
-            _nativeViewHierarchyManager.ClearLayoutAnimation();
         }
 
         /// <summary>
@@ -397,8 +381,9 @@ namespace ReactNative.UIManager
         /// <summary>
         /// Called when the host is shutting down.
         /// </summary>
-        public void OnShutdown()
+        public void OnDestroy()
         {
+            ReactChoreographer.Instance.DispatchUICallback -= OnRenderingSafe;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using System.Collections.Generic;
@@ -70,8 +70,6 @@ namespace ReactNative.Modules.DeviceInfo
         /// </summary>
         public void OnDestroy()
         {
-            ApplicationView.GetForCurrentView().VisibleBoundsChanged -= OnBoundsChanged;
-            DisplayInformation.GetForCurrentView().OrientationChanged -= OnOrientationChanged;
         }
 
         private void OnBoundsChanged(ApplicationView sender, object args)

--- a/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
+++ b/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using System;
@@ -157,7 +157,6 @@ namespace ReactNative.Modules.Launch
         /// </summary>
         public void OnDestroy()
         {
-            _subscription.Dispose();
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Modules/Location/LocationModule.cs
+++ b/ReactWindows/ReactNative/Modules/Location/LocationModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Collections;
 using ReactNative.Modules.Core;
@@ -12,7 +12,7 @@ using static System.FormattableString;
 
 namespace ReactNative.Modules.Location
 {
-    class LocationModule : ReactContextNativeModuleBase, ILifecycleEventListener
+    class LocationModule : ReactContextNativeModuleBase
     {
         private readonly SerialDisposable _currentSubscription = new SerialDisposable();
 
@@ -138,15 +138,7 @@ namespace ReactNative.Modules.Location
             _currentSubscription.Disposable = Disposable.Empty;
         }
 
-        public void OnSuspend()
-        {        
-        }
-
-        public void OnResume()
-        {
-        }
-
-        public void OnDestroy()
+        public override void OnReactInstanceDispose()
         {
             _currentSubscription.Dispose();
         }

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using System;
@@ -8,7 +8,7 @@ using Windows.Storage;
 
 namespace ReactNative.Modules.Storage
 {
-    class AsyncStorageModule : NativeModuleBase, ILifecycleEventListener
+    class AsyncStorageModule : NativeModuleBase
     {
         private readonly SemaphoreSlim _mutex = new SemaphoreSlim(1, 1);
 
@@ -271,15 +271,7 @@ namespace ReactNative.Modules.Storage
             callback.Invoke(null, keys);
         }
 
-        public void OnSuspend()
-        {
-        }
-
-        public void OnResume()
-        {
-        }
-
-        public void OnDestroy()
+        public override void OnReactInstanceDispose()
         {
             _mutex.Dispose();
         }


### PR DESCRIPTION
Many modules used lifecycle event listener to subscribe / unsubscribe from the CompositionTarget.Rendering event. Since the event does not fire when the app is suspended, unsubscribing is not worth the additional code to maintain.

Fixes #1373