### PR TITLE
test(ReactChoreographer): fix broken tests from ReactChoreographer

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.Bridge;
+using ReactNative.Bridge;
 using ReactNative.Bridge.Queue;
 using ReactNative.Chakra.Executor;
 using ReactNative.Common;
@@ -154,7 +154,6 @@ namespace ReactNative
         /// </summary>
         public async void CreateReactContextInBackground()
         {
-            ReactChoreographer.Initialize();
             await CreateReactContextInBackgroundAsync().ConfigureAwait(false);
         }
 
@@ -178,6 +177,7 @@ namespace ReactNative
                     "a new file, explicitly, use the re-create method.");
             }
 
+            ReactChoreographer.Initialize();
             _hasStartedCreatingInitialContext = true;
             await RecreateReactContextInBackgroundInnerAsync().ConfigureAwait(false);
         }
@@ -287,7 +287,7 @@ namespace ReactNative
             var currentReactContext = _currentReactContext;
             if (currentReactContext != null)
             {
-                await currentReactContext.DisposeAsync().ConfigureAwait(false);
+                await currentReactContext.DisposeAsync();
                 _currentReactContext = null;
                 _hasStartedCreatingInitialContext = false;
             }

--- a/ReactWindows/ReactNative.Tests/Internal/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/DispatcherHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Windows.UI.Core;
 
@@ -15,11 +15,17 @@ namespace ReactNative.Tests
         {
             var tcs = new TaskCompletionSource<T>();
 
-            await RunOnDispatcherAsync(() =>
+            await RunOnDispatcherAsync(async () =>
             {
-                var result = func();
-
-                Task.Run(() => tcs.SetResult(result));
+                try
+                {
+                    var result = func();
+                    await Task.Run(() => tcs.SetResult(result));
+                }
+                catch (Exception ex)
+                {
+                    await Task.Run(() => tcs.SetException(ex));
+                }
             }).ConfigureAwait(false);
 
             return await tcs.Task.ConfigureAwait(false);
@@ -31,8 +37,15 @@ namespace ReactNative.Tests
 
             await RunOnDispatcherAsync(async () =>
             {
-                await asyncFunc();
-                await Task.Run(() => tcs.SetResult(true));
+                try
+                {
+                    await asyncFunc();
+                    await Task.Run(() => tcs.SetResult(true));
+                }
+                catch (Exception ex)
+                {
+                    await Task.Run(() => tcs.SetException(ex));
+                }
             }).ConfigureAwait(false);
 
             await tcs.Task.ConfigureAwait(false);

--- a/ReactWindows/ReactNative.Tests/Modules/Core/TimingTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Core/TimingTests.cs
@@ -16,6 +16,8 @@ namespace ReactNative.Tests.Modules.Core
         [TestMethod]
         public async Task Timing_Create()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var waitHandle = new AutoResetEvent(false);
             var context = CreateReactContext(new MockInvocationHandler((name, args) =>
@@ -35,11 +37,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(new[] { 42 }.SequenceEqual(ids));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_ManyTimers()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var count = 1000;
             var ids = new List<int>(count);
             var countdown = new CountdownEvent(count);
@@ -67,11 +73,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(countdown.Wait(count * 2));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_Create_Delete()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var waitHandle = new AutoResetEvent(false);
             var context = CreateReactContext(new MockInvocationHandler((name, args) =>
@@ -92,11 +102,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsFalse(waitHandle.WaitOne(1000));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_Suspend_Resume()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var waitHandle = new AutoResetEvent(false);
             var context = CreateReactContext(new MockInvocationHandler((name, args) =>
@@ -118,11 +132,15 @@ namespace ReactNative.Tests.Modules.Core
             await DispatcherHelpers.RunOnDispatcherAsync(context.OnResume);
             Assert.IsTrue(waitHandle.WaitOne(1000));
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_Repeat()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var repeat = 10;
             var interval = 200;
@@ -153,11 +171,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(ids.Count >= repeat);
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_ManOrBoy()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var r = new Random();
             var batchCount = 15;
             var maxDuration = 500;
@@ -196,11 +218,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(countdown.Wait(batchCount * maxDuration / 4 * 2));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_AnimationBehavior()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var id = 0;
 
             var seconds = 3;
@@ -246,11 +272,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(waitHandle.WaitOne());
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_Zero_NoRepeat()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var waitHandle = new AutoResetEvent(false);
             var context = CreateReactContext(new MockInvocationHandler((name, args) =>
@@ -270,11 +300,15 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(new[] { 42 }.SequenceEqual(ids));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_Zero_Repeat()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var countdown = new CountdownEvent(60);
             var context = CreateReactContext(new MockInvocationHandler((name, args) =>
@@ -294,11 +328,15 @@ namespace ReactNative.Tests.Modules.Core
             timing.deleteTimer(42);
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task Timing_Correct_Order()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var ids = new List<int>();
             var countdown = new CountdownEvent(1);
             var context = CreateReactContext(new MockInvocationHandler((name, args) =>
@@ -321,6 +359,8 @@ namespace ReactNative.Tests.Modules.Core
             timing.deleteTimer(1);
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         private static ReactContext CreateReactContext(IInvocationHandler handler)

--- a/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using ReactNative.Common;
 using System;
 using System.Threading;
@@ -205,19 +205,17 @@ namespace ReactNative.Tests
                 }).Result;
             });
 
-            var tcs = new TaskCompletionSource<bool>();
-            await DispatcherHelpers.RunOnDispatcherAsync(async () =>
+            var task = DispatcherHelpers.CallOnDispatcherAsync(async () =>
             {
                 e.Set();
                 await manager.DisposeAsync();
-                await Task.Run(() => tcs.SetResult(true));
             });
 
             var completedTask = await Task.WhenAny(
                 Task.Delay(5000),
-                tcs.Task);
+                task);
 
-            Assert.IsTrue(tcs.Task.IsCompleted);
+            Assert.IsTrue(task.IsCompleted);
         }
 
         private static ReactInstanceManager CreateReactInstanceManager()

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Bridge.Queue;
+using ReactNative.Modules.Core;
 using ReactNative.UIManager.Events;
 using System;
 using System.Reactive.Disposables;
@@ -40,6 +41,8 @@ namespace ReactNative.Tests.UIManager.Events
         [TestMethod]
         public async Task EventDispatcher_EventDispatches()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             // TODO: (#288) Check for non-determinism.
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
@@ -63,11 +66,15 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsTrue(waitDispatched.WaitOne());
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_NonCoalesced()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -97,11 +104,15 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsTrue(waitDispatched.WaitOne());
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_MultipleDispatches()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -127,11 +138,15 @@ namespace ReactNative.Tests.UIManager.Events
             }
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_EventsCoalesced1()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -172,11 +187,15 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsTrue(disposed.WaitOne());
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_EventsNotCoalesced()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -224,11 +243,15 @@ namespace ReactNative.Tests.UIManager.Events
             }
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_OnSuspend_EventDoesNotDispatch()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -256,11 +279,15 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsFalse(waitDispatched.WaitOne(500));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_OnReactInstanceDispose_EventDoesNotDispatch()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -288,11 +315,15 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsFalse(waitDispatched.WaitOne(500));
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         [TestMethod]
         public async Task EventDispatcher_DispatchedAfterSuspend_ThenResume()
         {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
             var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor
             {
@@ -320,6 +351,8 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsTrue(waitDispatched.WaitOne());
 
             await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
         }
 
         private static async Task<ReactContext> CreateContextAsync(IJavaScriptExecutor executor)


### PR DESCRIPTION
Various tests relying on CompositionTarget.Rendering behavior have broken since the ReactChoreographer refactoring. This patches those tests.

Fixes #1375