### PR TITLE
fix(DispatcherHelpers): Fix broken release builds

### DIFF
--- a/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
@@ -75,6 +75,11 @@ namespace ReactNative.Bridge
             });
 
             return taskCompletionSource.Task;
+        }
+
+        public static void Reset()
+        {
+            // No-op on WPF
         }
 
         private static void AssertDispatcherSet()

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -246,6 +246,8 @@ namespace ReactNative
             }
 
             MoveToBeforeResumeLifecycleState();
+
+            DispatcherHelpers.Reset();
         }
 
         /// <summary>


### PR DESCRIPTION
DispatcherHelpers was broken on release builds for UWP due to the use of a separate CoreWindow for layout. Instead of trying to compare the dispatchers, this change assumes at least the first call to Dispatcher helpers from a dispatcher thread will be from the main window. DispatcherHelpers is well overdue for a refactoring.

Fixes #1377