### PR TITLE
fix(NetworkingModule): support incremental progress events

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Network/DefaultHttpClient.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/DefaultHttpClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 #if WINDOWS_UWP
@@ -27,7 +27,7 @@ namespace ReactNative.Modules.Network
         public async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
         {
 #if WINDOWS_UWP
-            var asyncInfo = _client.SendRequestAsync(request);
+            var asyncInfo = _client.SendRequestAsync(request, HttpCompletionOption.ResponseHeadersRead);
             using (token.Register(asyncInfo.Cancel))
             {
                 try


### PR DESCRIPTION
Although the NetworkingModule was coded to support incremental progress events, the HttpClient being used does not return from `SendRequestAsync` until the request is fully completed. Instead, we use `HttpCompletionOption.ResponseHeadersRead`.

Fixes #1380