### PR TITLE
prototype(View): add `isTabStop` prop to focus

### DIFF
--- a/Libraries/Components/Button.windows.js
+++ b/Libraries/Components/Button.windows.js
@@ -19,6 +19,7 @@ const StyleSheet = require('StyleSheet');
 const Text = require('Text');
 const TouchableNativeFeedback = require('TouchableNativeFeedback');
 const TouchableOpacity = require('TouchableOpacity');
+const TouchableButtonFeedback = require('TouchableButtonFeedback');
 const View = require('View');
 
 const invariant = require('fbjs/lib/invariant');
@@ -80,6 +81,7 @@ class Button extends React.Component {
      * Handler to be called when the user taps the button
      */
     onPress: PropTypes.func.isRequired,
+
     /**
      * Used to locate this view in end-to-end tests.
      */
@@ -115,7 +117,20 @@ class Button extends React.Component {
       'The title prop of a Button must be a string',
     );
     const formattedTitle = Platform.OS === 'android' ? title.toUpperCase() : title;
-    const Touchable = Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
+    const Touchable = Platform.OS === 'android' 
+      ? TouchableNativeFeedback 
+      : Platform.OS === 'windows'
+        ? TouchableButtonFeedback
+        : TouchableOpacity;
+
+    const touchableProps = Platform.select({
+      ios: {},
+      android: {},
+      windows: {
+        underlayColor: 'rgba(0, 0, 0, 0.3)',
+      }
+    });
+
     return (
       <Touchable
         accessibilityComponentType="button"
@@ -123,7 +138,8 @@ class Button extends React.Component {
         accessibilityTraits={accessibilityTraits}
         testID={testID}
         disabled={disabled}
-        onPress={onPress}>
+        onPress={onPress}
+        {...touchableProps}>
         <View style={buttonStyles}>
           <Text style={textStyles} disabled={disabled}>{formattedTitle}</Text>
         </View>

--- a/Libraries/Components/Touchable/TouchableButtonFeedback.js
+++ b/Libraries/Components/Touchable/TouchableButtonFeedback.js
@@ -1,0 +1,326 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule TouchableButtonFeedback
+ * @flow
+ */
+'use strict';
+
+const ColorPropType = require('ColorPropType');
+const NativeMethodsMixin = require('NativeMethodsMixin');
+const PropTypes = require('prop-types');
+const React = require('React');
+const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
+const StyleSheet = require('StyleSheet');
+const TimerMixin = require('react-timer-mixin');
+const Touchable = require('Touchable');
+const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
+const UIManager = require('UIManager');
+const View = require('View');
+const ViewPropTypes = require('ViewPropTypes');
+
+const createReactClass = require('create-react-class');
+const ensureComponentIsNative = require('ensureComponentIsNative');
+const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
+const keyOf = require('fbjs/lib/keyOf');
+const merge = require('merge');
+
+import type {Event} from 'TouchableWithoutFeedback';
+
+const DEFAULT_PROPS = {
+  activeOpacity: 0.85, // TODO: check this
+  activePadding: 2,
+  underlayColor: 'black',
+};
+
+const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
+
+const ENTER_KEY = UIManager.RCTView.Constants.Keys.Enter;
+const HANDLED_KEYS = [ENTER_KEY];
+
+/**
+ * A wrapper for making views respond properly to touches.
+ * On press down, the opacity of the wrapped view is decreased, which allows
+ * the underlay color to show through, darkening or tinting the view.
+ *
+ * The underlay comes from wrapping the child in a new View, which can affect
+ * layout, and sometimes cause unwanted visual artifacts if not used correctly,
+ * for example if the backgroundColor of the wrapped view isn't explicitly set
+ * to an opaque color.
+ *
+ * TouchableButtonWindows must have one child (not zero or more than one).
+ * If you wish to have several child components, wrap them in a View.
+ *
+ * Example:
+ *
+ * ```
+ * renderButton: function() {
+ *   return (
+ *     <TouchableButtonWindows onPress={this._onPressButton}>
+ *       <Image
+ *         style={styles.button}
+ *         source={require('./myButton.png')}
+ *       />
+ *     </TouchableButtonWindows>
+ *   );
+ * },
+ * ```
+ */
+
+var TouchableButtonWindows = createReactClass({
+  displayName: 'TouchableButtonWindows',
+  propTypes: {
+    ...TouchableWithoutFeedback.propTypes,
+    /**
+     * Determines what the opacity of the wrapped view should be when touch is
+     * active.
+     */
+    activeOpacity: PropTypes.number,
+    /**
+     * Determines what the padding of the wrapped view should be when touch is
+     * active.
+     */
+    activePadding: PropTypes.number,
+    /**
+     * The color of the underlay that will show through when the touch is
+     * active.
+     */
+    underlayColor: ColorPropType,
+    style: ViewPropTypes.style,
+    /**
+     * Called immediately after the underlay is shown
+     */
+    onShowUnderlay: PropTypes.func,
+    /**
+     * Called immediately after the underlay is hidden
+     */
+    onHideUnderlay: PropTypes.func,
+   },
+
+  mixins: [NativeMethodsMixin, TimerMixin, Touchable.Mixin],
+
+  getDefaultProps: () => DEFAULT_PROPS,
+
+  // Performance optimization to avoid constantly re-generating these objects.
+  _computeSyntheticState: function(props) {
+    return {
+      activeProps: {
+        style: {
+          opacity: props.activeOpacity,
+        }
+      },
+      activeUnderlayProps: {
+        style: {
+          backgroundColor: props.underlayColor,
+        }
+      },
+      focusedProps: {
+        style: {
+          borderWidth: 2,
+          margin: -2,
+        }
+      },
+      underlayStyle: [
+        INACTIVE_UNDERLAY_PROPS.style,
+        props.style,
+      ],
+    };
+  },
+
+  getInitialState: function() {
+    this._isMounted = false;
+    return merge(
+      this.touchableGetInitialState(), 
+      this._computeSyntheticState(this.props), 
+      { isFocused: false, isFocusedEnterKeyDown: false },
+    );
+  },
+
+  componentDidMount: function() {
+    this._isMounted = true;
+    ensurePositiveDelayProps(this.props);
+    ensureComponentIsNative(this.refs[CHILD_REF]);
+  },
+
+  componentWillUnmount: function() {
+    this._isMounted = false;
+  },
+
+  componentDidUpdate: function() {
+    ensureComponentIsNative(this.refs[CHILD_REF]);
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    ensurePositiveDelayProps(nextProps);
+    if (nextProps.activeOpacity !== this.props.activeOpacity ||
+        nextProps.underlayColor !== this.props.underlayColor ||
+        nextProps.style !== this.props.style) {
+      this.setState(this._computeSyntheticState(nextProps));
+    }
+  },
+
+  viewConfig: {
+    uiViewClassName: 'RCTView',
+    validAttributes: ReactNativeViewAttributes.RCTView
+  },
+
+  /**
+   * `Touchable.Mixin` self callbacks. The mixin will invoke these if they are
+   * defined on your component.
+   */
+  touchableHandleActivePressIn: function(e: Event) {
+    this.clearTimeout(this._hideTimeout);
+    this._hideTimeout = null;
+    this._showUnderlay();
+    this.props.onPressIn && this.props.onPressIn(e);
+  },
+
+  touchableHandleActivePressOut: function(e: Event) {
+    if (!this._hideTimeout) {
+      this._hideUnderlay();
+    }
+    this.props.onPressOut && this.props.onPressOut(e);
+  },
+
+  touchableHandlePress: function(e: Event) {
+    this.clearTimeout(this._hideTimeout);
+    this._showUnderlay();
+    this._hideTimeout = this.setTimeout(this._hideUnderlay,
+      this.props.delayPressOut || 100);
+    this.props.onPress && this.props.onPress(e);
+  },
+
+  touchableHandleLongPress: function(e: Event) {
+    this.props.onLongPress && this.props.onLongPress(e);
+  },
+
+  touchableGetPressRectOffset: function() {
+    return this.props.pressRetentionOffset || PRESS_RETENTION_OFFSET;
+  },
+
+  touchableGetHitSlop: function() {
+    return this.props.hitSlop;
+  },
+
+  touchableGetHighlightDelayMS: function() {
+    return this.props.delayPressIn;
+  },
+
+  touchableGetLongPressDelayMS: function() {
+    return this.props.delayLongPress;
+  },
+
+  touchableGetPressOutDelayMS: function() {
+    return this.props.delayPressOut;
+  },
+
+  _showUnderlay: function() {
+    if (!this._isMounted || !this._hasPressHandler()) {
+      return;
+    }
+
+    this.refs[UNDERLAY_REF].setNativeProps(this.state.activeUnderlayProps);
+    this.refs[CHILD_REF].setNativeProps(this.state.activeProps);
+    this.props.onShowUnderlay && this.props.onShowUnderlay();
+  },
+
+  _hideUnderlay: function() {
+    this.clearTimeout(this._hideTimeout);
+    this._hideTimeout = null;
+    if (this._hasPressHandler() && this.refs[UNDERLAY_REF]) {
+      this.refs[CHILD_REF].setNativeProps(INACTIVE_CHILD_PROPS);
+      this.refs[UNDERLAY_REF].setNativeProps({
+        ...INACTIVE_UNDERLAY_PROPS,
+        style: this.state.underlayStyle,
+      });
+      this.props.onHideUnderlay && this.props.onHideUnderlay();
+    }
+  },
+
+  _hasPressHandler: function() {
+    return !!(
+      this.props.onPress ||
+      this.props.onPressIn ||
+      this.props.onPressOut ||
+      this.props.onLongPress
+    );
+  },
+
+  _onFocus: function() {
+    this.setState({isFocused: true});
+  },
+
+  _onBlur: function() {
+    this.setState({isFocused: false});      
+  },
+
+  _onKeyDown: function(e: Event) {
+    if (e.nativeEvent.key === ENTER_KEY) {
+      this.touchableHandleActivePressIn(e);
+    }
+  },
+
+  _onKeyUp: function(e: Event) {
+    if (e.nativeEvent.key === ENTER_KEY) {
+      this.touchableHandleActivePressOut(e);        
+    }
+  },
+
+  render: function() {
+    let underlayStyle = this.state.underlayStyle;
+    if (this.state.isFocused) {
+      underlayStyle = [ this.state.focusedProps.style, underlayStyle ];
+    }
+
+    return (
+      <View
+        accessible={this.props.accessible !== false}
+        accessibilityLabel={this.props.accessibilityLabel}
+        accessibilityComponentType={this.props.accessibilityComponentType}
+        accessibilityTraits={this.props.accessibilityTraits}
+        ref={UNDERLAY_REF}
+        style={underlayStyle}
+        onLayout={this.props.onLayout}
+        hitSlop={this.props.hitSlop}
+        onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
+        onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
+        onResponderGrant={this.touchableHandleResponderGrant}
+        onResponderMove={this.touchableHandleResponderMove}
+        onResponderRelease={this.touchableHandleResponderRelease}
+        onResponderTerminate={this.touchableHandleResponderTerminate}
+        isTabStop={!this.props.disabled}
+        onFocus={this._onFocus}
+        onBlur={this._onBlur}
+        onKeyDown={this._onKeyDown}
+        onKeyUp={this._onKeyUp}
+        handledKeyDownKeys={HANDLED_KEYS}
+        handledKeyUpKeys={HANDLED_KEYS}
+        nativeID={this.props.nativeID}
+        testID={this.props.testID}>
+        {React.cloneElement(
+          React.Children.only(this.props.children),
+          {
+            ref: CHILD_REF,
+          }
+        )}
+        {Touchable.renderDebugView({color: 'green', hitSlop: this.props.hitSlop})}
+      </View>
+    );
+  }
+});
+
+var CHILD_REF = keyOf({childRef: null});
+var UNDERLAY_REF = keyOf({underlayRef: null});
+var INACTIVE_CHILD_PROPS = {
+  style: StyleSheet.create({x: {opacity: 1.0}}).x,
+};
+var INACTIVE_UNDERLAY_PROPS = {
+  style: StyleSheet.create({x: {backgroundColor: 'transparent'}}).x,
+};
+
+module.exports = TouchableButtonWindows;

--- a/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/Libraries/Components/View/ViewPropTypes.windows.js
@@ -519,4 +519,32 @@ module.exports = {
      * @platform windows
      */
     onBlur: PropTypes.func,
+
+    /**
+     * Set of keys that should be handled on key down by this component.
+     * 
+     * @platform windows
+     */
+    handledKeyDownKeys: PropTypes.arrayOf(PropTypes.number),
+
+    /**
+     * Set of keys that should be handled on key up by this component.
+     * 
+     * @platform windows
+     */
+    handledKeyUpKeys: PropTypes.arrayOf(PropTypes.number),
+
+    /**
+     * Called when key down while component has focus.
+     * 
+     * @platform windows
+     */
+    onKeyDown: PropTypes.func,
+
+    /**
+     * Called when key up while component has focus.
+     * 
+     * @platform windows
+     */
+    onKeyUp: PropTypes.func,
 };

--- a/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/Libraries/Components/View/ViewPropTypes.windows.js
@@ -497,4 +497,26 @@ module.exports = {
         'scale',
         'all',
     ])),
+
+    /**
+     * Controls whether the view is a tab stop. Useful for buttons and other
+     * controls that can be focused.
+     * 
+     * @platform windows
+     */
+    isTabStop: PropTypes.bool,
+
+    /**
+     * Called when the view receives focus.
+     * 
+     * @platform windows
+     */
+    onFocus: PropTypes.func,
+
+    /**
+     * Called when the view focus is lost.
+     * 
+     * @platform windows
+     */
+    onBlur: PropTypes.func,
 };

--- a/Libraries/react-native-windows/react-native-windows.js
+++ b/Libraries/react-native-windows/react-native-windows.js
@@ -17,6 +17,7 @@ var ReactWindows = {
   get ProgressBarWindows() {return require('ProgressBarWindows');},
   get ProgressRingWindows() {return require('ProgressRingWindows');},
   get SplitViewWindows() { return require('SplitViewWindows'); },
+  get TouchableButtonFeedback() { return require('TouchableButtonFeedback'); },
 };
 
 module.exports = ReactWindows;

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -151,7 +151,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Annotations\ReactPropBaseAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Annotations\ReactPropGroupAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\AppRegistry.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UIManager\BorderedCanvas.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\BorderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ColorHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\IUIBlock.cs" />
@@ -238,6 +237,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Views\TextInput\ReactTextInputSubmitEditingEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\Text\TextDecorationLine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\ViewManagersPropertyCache.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Views\View\ReactViewControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\View\ReactViewManager.cs" />
   </ItemGroup>
 </Project>

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -239,5 +239,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Views\ViewManagersPropertyCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\View\ReactViewControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\View\ReactViewManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Views\View\KeyHelpers.cs" />
   </ItemGroup>
 </Project>

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 
 namespace ReactNative.UIManager
@@ -59,7 +59,8 @@ namespace ReactNative.UIManager
         public const string AspectRatio = "aspectRatio";
 
         // Props that sometimes may prevent us from collapsing views
-        public static string PointerEvents = "pointerEvents";
+        public const string PointerEvents = "pointerEvents";
+        public const string IsTabStop = "isTabStop";
 
         // Properties that affect more than just layout
         public const string Disabled = "disabled";
@@ -204,6 +205,11 @@ namespace ReactNative.UIManager
             {
                 var value = props.GetProperty(prop).Value<string>();
                 return value == "auto" || value == "box-none";
+            }
+            else if (IsTabStop == prop)
+            {
+                var value = props.GetProperty(prop).Value<bool>();
+                return !value;
             }
 
             return false;

--- a/ReactWindows/ReactNative.Shared/Views/View/KeyHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/KeyHelpers.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+#if WINDOWS_UWP
+using Windows.System;
+#else
+using System.Windows.Input;
+#endif
+
+namespace ReactNative.Views.View
+{
+#if WINDOWS_UWP
+    using Key = VirtualKey;
+#endif
+
+    static class KeyHelpers
+    {
+        public static int GetKeyCode(this Key key)
+        {
+            return (int)key;
+        }
+
+        public static IReadOnlyDictionary<string, int> GetKeyConstants()
+        {
+            return Enum.GetValues(typeof(Key))
+                .OfType<Key>()
+                .Distinct() // Distinct() required*
+                .ToDictionary(
+                    key => key.ToString(),
+                    key => GetKeyCode(key));
+
+            // *The following keys are duplicated in Enum.GetValues(Type):
+            // `Hangul`, `Kanji`
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewControl.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewControl.cs
@@ -64,5 +64,23 @@ namespace ReactNative.Views.View
                 return _canvas.Children;
             }
         }
+
+        /// <summary>
+        /// Keys that should be handled during <see cref="UIElement.KeyDownEvent"/>. 
+        /// </summary>
+        public int[] HandledKeyDownKeys
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Keys that should be handled during <see cref="UIElement.KeyUpEvent"/>. 
+        /// </summary>
+        public int[] HandledKeyUpKeys
+        {
+            get;
+            set;
+        }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewControl.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewControl.cs
@@ -1,22 +1,35 @@
-﻿using System;
+using System;
 
 #if WINDOWS_UWP
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
 #else
 using System.Windows;
 using System.Windows.Controls;
 #endif
 
-namespace ReactNative.UIManager
+namespace ReactNative.Views.View
 {
     /// <summary>
-    /// Represents a Canvas with an optional Border inside.
+    /// Native control for React view.
     /// </summary>
-    public class BorderedCanvas : Canvas
+    public class ReactViewControl : UserControl
     {
+        private readonly Canvas _canvas;
+
         private Border _border = null;
+
+        /// <summary>
+        /// Instantiates the <see cref="ReactViewControl"/>. 
+        /// </summary>
+        public ReactViewControl()
+        {
+            Content = _canvas = new Canvas
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+            };
+        }
 
         /// <summary>
         /// The Border associated with this Canvas or null if it doesn't have a border.
@@ -38,6 +51,17 @@ namespace ReactNative.UIManager
                 _border = value;
 
                 Children.Insert(0, _border);
+            }
+        }
+
+        /// <summary>
+        /// The view children.
+        /// </summary>
+        public UIElementCollection Children
+        {
+            get
+            {
+                return _canvas.Children;
             }
         }
     }


### PR DESCRIPTION
Allow, e.g., View buttons to be focusable. This is the first step, the next step is to add a JS native event listener that tracks the currently focused element to re-route keyboard input.

Towards #886