### PR TITLE
fix(WebView): Seal WinRT component type

### DIFF
--- a/ReactWindows/ReactNativeWebViewBridge/MessagePostedEventArgs.cs
+++ b/ReactWindows/ReactNativeWebViewBridge/MessagePostedEventArgs.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Arguments for <see cref="WebViewBridge.MessagePosted"/> event.
     /// </summary>
-    public class MessagePostedEventArgs
+    public sealed class MessagePostedEventArgs
     {
         internal MessagePostedEventArgs(int tag, string message)
         {


### PR DESCRIPTION
MessagePostedEventArgs from WinRT component was not sealed and causing issues for Win App Cert Kit.

Towards #1401