### PR TITLE
fix(Image): Update ImagePipeline to v0.0.6 to fix Windows App Certification Kit error.

### DIFF
--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Facebook.Yoga": "1.5.0-pre1",
-    "fresco.imagepipeline": "0.0.4",
+    "fresco.imagepipeline": "0.0.6",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
     "OpenCover": "4.6.519",


### PR DESCRIPTION
Fix #1401.

More info about the issue [here](https://github.com/phongcao/image-pipeline-windows/issues/5).