### PR TITLE
fix(NetworkingModule): fix bug for requests without body

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Modules/Network/NetworkingModuleTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/Network/NetworkingModuleTests.cs
@@ -65,6 +65,46 @@ namespace ReactNative.Tests.Modules.Network
         }
 
         [Test]
+        public void NetworkingModule_Request_NoContent_Null()
+        {
+            var method = "GET";
+
+            var passed = false;
+            var waitHandle = new AutoResetEvent(false);
+            var httpClient = new MockHttpClient(request =>
+            {
+                passed = request.Method.ToString() == method;
+                waitHandle.Set();
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            });
+
+            var module = CreateNetworkingModule(httpClient, new MockInvocationHandler());
+            module.sendRequest(method, new Uri("http://example.com"), 1, null, null, "text", false, 1000);
+            waitHandle.WaitOne();
+            Assert.IsTrue(passed);
+        }
+
+        [Test]
+        public void NetworkingModule_Request_NoContent_NonNull()
+        {
+            var method = "GET";
+
+            var passed = false;
+            var waitHandle = new AutoResetEvent(false);
+            var httpClient = new MockHttpClient(request =>
+            {
+                passed = request.Method.ToString() == method;
+                waitHandle.Set();
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            });
+
+            var module = CreateNetworkingModule(httpClient, new MockInvocationHandler());
+            module.sendRequest(method, new Uri("http://example.com"), 1, null, new JObject(), "text", false, 1000);
+            waitHandle.WaitOne();
+            Assert.IsTrue(passed);
+        }
+
+        [Test]
         public void NetworkingModule_Request_Headers()
         {
             var headers = new[]

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -124,14 +124,9 @@ namespace ReactNative.Modules.Network
                 var stringBody = data.Value<string>("string");
                 var base64Body = default(string);
                 var uri = default(string);
-                var formData = (JArray)data.GetValue("formData", StringComparison.Ordinal);
+                var formData = default(JArray);
 
-                if (formData != null && headerData.ContentType == null)
-                {
-                    headerData.ContentType = "multipart/form-data";
-                }
-
-                if (headerData.ContentType == null)
+                if (HasRequestContent(data) && headerData.ContentType == null)
                 {
                     OnRequestError(requestId, "Payload is set but no 'content-type' header specified.", false);
                     return;
@@ -158,8 +153,13 @@ namespace ReactNative.Modules.Network
 
                     return;
                 }
-                else if (formData != null)
+                else if ((formData = (JArray)data.GetValue("formData", StringComparison.Ordinal)) != null)
                 {
+                    if (headerData.ContentType == null)
+                    {
+                        headerData.ContentType = "multipart/form-data";
+                    }
+
                     var formDataContent = new HttpMultipartFormDataContent();
                     foreach (var content in formData)
                     {
@@ -445,6 +445,13 @@ namespace ReactNative.Modules.Network
                 requestId,
                 null,
             });
+        }
+
+        private static bool HasRequestContent(JObject data)
+        {
+            return data.ContainsKey("string")
+                || data.ContainsKey("base64")
+                || data.ContainsKey("uri");
         }
 
         private static void ApplyHeaders(HttpRequestMessage request, string[][] headers)


### PR DESCRIPTION
Requests without body were erroring because an assertion that the request required a content-type. This change fixes that assertion.

Fixes #1412