### PR TITLE
fix(Generator): Use index.js entry point for RN v0.49 generator

### DIFF
--- a/local-cli/generator-windows/index.js
+++ b/local-cli/generator-windows/index.js
@@ -85,8 +85,8 @@ module.exports = yeoman.Base.extend({
     }
 
     this.fs.copyTpl(
-      this.templatePath('index.windows.js'),
-      this.destinationPath('index.windows.js'),
+      this.templatePath('App.windows.js'),
+      this.destinationPath('App.windows.js'),
       templateVars
     );
 

--- a/local-cli/generator-windows/templates/App.windows.js
+++ b/local-cli/generator-windows/templates/App.windows.js
@@ -6,13 +6,17 @@
 
 import React, { Component } from 'react';
 import {
-  AppRegistry,
+  Platform,
   StyleSheet,
   Text,
   View
 } from 'react-native';
 
-class <%= name %> extends Component {
+const instructions =
+  'Press Ctrl+R to reload,\n' +
+  'Shift+F10 or shake for dev menu';
+
+export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
@@ -20,11 +24,10 @@ class <%= name %> extends Component {
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
-          To get started, edit index.wpf.js
+          To get started, edit App.windows.js
         </Text>
         <Text style={styles.instructions}>
-          Press Ctrl+R to reload,{'\n'}
-          Ctrl+D or Ctrl+M for dev menu
+          {instructions}
         </Text>
       </View>
     );
@@ -49,5 +52,3 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
 });
-
-AppRegistry.registerComponent('<%= name %>', () => <%= name %>);

--- a/local-cli/generator-windows/templates/src/MainPage.cs
+++ b/local-cli/generator-windows/templates/src/MainPage.cs
@@ -15,6 +15,14 @@ namespace <%= ns %>
             }
         }
 
+        public override string JavaScriptMainModuleName
+        {
+            get
+            {
+                return "index";
+            }
+        }
+
 #if BUNDLE
         public override string JavaScriptBundleFile
         {

--- a/local-cli/generator-wpf/index.js
+++ b/local-cli/generator-wpf/index.js
@@ -47,8 +47,8 @@ module.exports = yeoman.Base.extend({
     const templateVars = { name: this.name, ns: this.options.ns, projectGuid, packageGuid };
 
     this.fs.copyTpl(
-      this.templatePath('index.wpf.js'),
-      this.destinationPath('index.wpf.js'),
+      this.templatePath('App.windows.js'),
+      this.destinationPath('App.windows.js'),
       templateVars
     );
 

--- a/local-cli/generator-wpf/templates/App.windows.js
+++ b/local-cli/generator-wpf/templates/App.windows.js
@@ -6,13 +6,17 @@
 
 import React, { Component } from 'react';
 import {
-  AppRegistry,
+  Platform,
   StyleSheet,
   Text,
   View
 } from 'react-native';
 
-class <%= name %> extends Component {
+const instructions =
+  'Press Ctrl+R to reload,\n' +
+  'Ctrl+D or Ctrl+M for dev menu';
+
+export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
@@ -20,11 +24,10 @@ class <%= name %> extends Component {
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
-          To get started, edit index.windows.js
+          To get started, edit App.windows.js
         </Text>
         <Text style={styles.instructions}>
-          Press Ctrl+R to reload,{'\n'}
-          Shift+F10 or shake for dev menu
+          {instructions}
         </Text>
       </View>
     );
@@ -49,5 +52,3 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
 });
-
-AppRegistry.registerComponent('<%= name %>', () => <%= name %>);

--- a/local-cli/generator-wpf/templates/src/AppReactPage.cs
+++ b/local-cli/generator-wpf/templates/src/AppReactPage.cs
@@ -10,7 +10,7 @@ namespace <%= ns %>
     {
         public override string MainComponentName => "<%= name %>";
 
-        public override string JavaScriptMainModuleName => "index.wpf";
+        public override string JavaScriptMainModuleName => "index";
 
 #if BUNDLE
         public override string JavaScriptBundleFile => AppDomain.CurrentDomain.BaseDirectory + "ReactAssets/index.wpf.bundle";


### PR DESCRIPTION
RN v0.49 switched to a single entry point template. This change leverages this single entry point and overrides the App.js template instead.

Fixes #1421