### PR TITLE
fix(DispatcherHelpers): Remove CoreWindow reference

### DIFF
--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -35,7 +35,7 @@ namespace ReactNative.Bridge
         {
             if (s_isOnDispatcherThread == null)
             {
-                if (CoreWindow.GetForCurrentThread()?.Dispatcher == CoreApplication.MainView.CoreWindow.Dispatcher)
+                if (CoreWindow.GetForCurrentThread()?.Dispatcher == CoreApplication.MainView.Dispatcher)
                 {
                     s_isOnDispatcherThread = new ThreadLocal<bool>();
                     s_isOnDispatcherThread.Value = true;
@@ -66,7 +66,7 @@ namespace ReactNative.Bridge
         /// <param name="action">The action to invoke.</param>
         public static async void RunOnDispatcher(CoreDispatcherPriority priority, DispatchedHandler action)
         {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(priority, action).AsTask().ConfigureAwait(false);
+            await CoreApplication.MainView.Dispatcher.RunAsync(priority, action).AsTask().ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Some scenarios, like background activation, only have a valid dispatcher on the `CoreApplicationView`, not necessarily on the CoreWindow.

Towards #1268