### PR TITLE
clean(NativeModules): Remove deprecated naming convention

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
@@ -299,29 +299,13 @@ namespace ReactNative.Bridge
 
                 foreach (var module in _modules.Values)
                 {
-                    var name = NormalizeModuleName(module.Name);
+                    var name = module.Name;
                     var moduleDef = new ModuleDefinition(name, module);
                     moduleTable.Add(moduleDef);
                     moduleInstances.Add(module.GetType(), module);
                 }
 
                 return new NativeModuleRegistry(moduleTable, moduleInstances);
-            }
-
-            private static string NormalizeModuleName(string name)
-            {
-                if (name.StartsWith("RCT"))
-                {
-                    return name.Substring(3);
-                }
-                else if (name.StartsWith("RK"))
-                {
-                    return name.Substring(2);
-                }
-                else
-                {
-                    return name;
-                }
             }
         }
     }

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -48,7 +48,7 @@ namespace ReactNative.Modules.Core
         {
             get
             {
-                return "RCTTiming";
+                return "Timing";
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Modules/DevSupport/SourceCodeModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/DevSupport/SourceCodeModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using System.Collections.Generic;
 
@@ -31,7 +31,7 @@ namespace ReactNative.Modules.DevSupport
         {
             get
             {
-                return "RCTSourceCode";
+                return "SourceCode";
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Collections;
 using ReactNative.Modules.Core;
@@ -65,7 +65,7 @@ namespace ReactNative.Modules.Network
         {
             get
             {
-                return "RCTNetworking";
+                return "Networking";
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Bridge.Queue;
 using ReactNative.UIManager.Events;
@@ -57,7 +57,7 @@ namespace ReactNative.UIManager
         {
             get
             {
-                return "RKUIManager";
+                return "UIManager";
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.Reflection;
+using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 #if WINDOWS_UWP
@@ -43,7 +43,7 @@ namespace ReactNative.Views.View
         {
             get
             {
-                return "RCTView";
+                return ViewProps.ViewClassName;
             }
         }
 


### PR DESCRIPTION
Remove "RCT" and "RK" prefix from native modules.