### PR TITLE
fix(Image): Update ImagePipeline to v0.0.7 which handles ms-appdata URI properly.

### DIFF
--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Facebook.Yoga": "1.5.0-pre1",
-    "fresco.imagepipeline": "0.0.6",
+    "fresco.imagepipeline": "0.0.7",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
     "OpenCover": "4.6.519",


### PR DESCRIPTION
Fix #1427 

Unit tests have been added [here](https://github.com/phongcao/image-pipeline-windows/commit/a6855b1c7b88e01337a93e30e53dbc007ed3e23f).