### PR TITLE
fix(Image): Update ImagePipeline to v0.0.8 which handles ms-appdata and file URIs properly.

### DIFF
--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Facebook.Yoga": "1.5.0-pre1",
-    "fresco.imagepipeline": "0.0.6",
+    "fresco.imagepipeline": "0.0.8",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
     "OpenCover": "4.6.519",


### PR DESCRIPTION
Prior to react-native-windows v0.43.4, **ms-appdata** and file URIs are handled internally by [BitmapImage](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.imaging.bitmapimage)

```
	var image = new BitmapImage();
	disposable.Disposable = image.GetUriLoadObservable().Subscribe(
		status => OnImageStatusUpdate(view, status.LoadStatus, status.Metadata),
		_ => OnImageFailed(view));
	image.UriSource = new Uri(source);
	imageBrush.ImageSource = image;
```

ImagePipeline v0.0.8 can now handle both of them properly.

- Unit tests for ms-appdata URI [here](https://github.com/phongcao/image-pipeline-windows/commit/a6855b1c7b88e01337a93e30e53dbc007ed3e23f)
- Unit tests for file URI [here](https://github.com/phongcao/image-pipeline-windows/commit/97d97d8b3226bbd1adf8082b751e6dd1b5e40fb3#diff-4c33d5bcba4a1af57f69c65e9734143dR616)

This will fix #1427 after landing.