### PR TITLE
fix(NativeModuleRegistry): Run initialize and dispose on correct queue

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleRegistryTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleRegistryTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
@@ -14,7 +14,11 @@ namespace ReactNative.Tests.Bridge
         [Test]
         public void NativeModuleRegistry_ArgumentChecks()
         {
-            var builder = new NativeModuleRegistry.Builder();
+            AssertEx.Throws<ArgumentNullException>(
+                () => new NativeModuleRegistry.Builder(null),
+                ex => Assert.AreEqual("reactContext", ex.ParamName));
+
+            var builder = new NativeModuleRegistry.Builder(new ReactContext());
             AssertEx.Throws<ArgumentNullException>(
                 () => builder.Add(null),
                 ex => Assert.AreEqual("module", ex.ParamName));
@@ -23,7 +27,7 @@ namespace ReactNative.Tests.Bridge
         [Test]
         public void NativeModuleRegistry_Override_Disallowed()
         {
-            var builder = new NativeModuleRegistry.Builder();
+            var builder = new NativeModuleRegistry.Builder(new ReactContext());
             builder.Add(new OverrideDisallowedModule());
             AssertEx.Throws<InvalidOperationException>(() => builder.Add(new OverrideDisallowedModule()));
         }
@@ -31,7 +35,7 @@ namespace ReactNative.Tests.Bridge
         [Test]
         public void NativeModuleRegistry_Override_Allowed()
         {
-            var registry = new NativeModuleRegistry.Builder()
+            var registry = new NativeModuleRegistry.Builder(new ReactContext())
                 .Add(new OverrideAllowedModule())
                 .Add(new OverrideAllowedModule())
                 .Build();
@@ -42,7 +46,7 @@ namespace ReactNative.Tests.Bridge
         [Test]
         public void NativeModuleRegistry_ModuleWithNullName_Throws()
         {
-            var builder = new NativeModuleRegistry.Builder();
+            var builder = new NativeModuleRegistry.Builder(new ReactContext());
             AssertEx.Throws<ArgumentException>(
                 () => builder.Add(new NullNameModule()),
                 ex => Assert.AreEqual("module", ex.ParamName));
@@ -51,7 +55,7 @@ namespace ReactNative.Tests.Bridge
         [Test]
         public void NativeModuleRegistry_WriteModuleDefinitions()
         {
-            var registry = new NativeModuleRegistry.Builder()
+            var registry = new NativeModuleRegistry.Builder(new ReactContext())
                 .Add(new TestNativeModule())
                 .Build();
 

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Tracing;
 using System;
@@ -14,14 +14,17 @@ namespace ReactNative.Bridge
     /// </summary>
     public sealed class NativeModuleRegistry
     {
+        private readonly ReactContext _reactContext;
         private readonly IReadOnlyList<ModuleDefinition> _moduleTable;
         private readonly IReadOnlyDictionary<Type, INativeModule> _moduleInstances;
         private readonly IList<IOnBatchCompleteListener> _batchCompleteListenerModules;
 
         private NativeModuleRegistry(
+            ReactContext reactContext,
             IReadOnlyList<ModuleDefinition> moduleTable,
             IReadOnlyDictionary<Type, INativeModule> moduleInstances)
         {
+            _reactContext = reactContext;
             _moduleTable = moduleTable;
             _moduleInstances = moduleInstances;
             _batchCompleteListenerModules = _moduleTable
@@ -64,7 +67,7 @@ namespace ReactNative.Bridge
         {
             foreach (var module in _batchCompleteListenerModules)
             {
-                module.OnBatchComplete();
+                Dispatch((INativeModule)module, module.OnBatchComplete);
             }
         }
 
@@ -120,12 +123,12 @@ namespace ReactNative.Bridge
         /// </summary>
         internal void NotifyReactInstanceInitialize()
         {
-            DispatcherHelpers.AssertOnDispatcher();
+            _reactContext.AssertOnNativeModulesQueueThread();
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "NativeModuleRegistry_NotifyReactInstanceInitialize").Start())
             {
                 foreach (var module in _moduleInstances.Values)
                 {
-                    module.Initialize();
+                    Dispatch(module, module.Initialize);
                 }
             }
         }
@@ -136,13 +139,28 @@ namespace ReactNative.Bridge
         /// </summary>
         internal void NotifyReactInstanceDispose()
         {
-            DispatcherHelpers.AssertOnDispatcher();
+            _reactContext.AssertOnNativeModulesQueueThread();
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "NativeModuleRegistry_NotifyReactInstanceDestroy").Start())
             {
                 foreach (var module in _moduleInstances.Values)
                 {
-                    module.OnReactInstanceDispose();
+                    Dispatch(module, module.OnReactInstanceDispose);
+                    module.ActionQueue?.Dispose();
                 }
+            }
+        }
+
+        private static void Dispatch(INativeModule module, Action action)
+        {
+            // If the module has an action queue, dispatch there;
+            // otherwise execute inline.
+            if (module.ActionQueue != null)
+            {
+                module.ActionQueue.Dispatch(action);
+            }
+            else
+            {
+                action();
             }
         }
 
@@ -255,6 +273,20 @@ namespace ReactNative.Bridge
             private readonly IDictionary<string, INativeModule> _modules = 
                 new Dictionary<string, INativeModule>();
 
+            private readonly ReactContext _reactContext;
+
+            /// <summary>
+            /// Instantiates the <see cref="Builder"/>.
+            /// </summary>
+            /// <param name="reactContext">The React context.</param>
+            public Builder(ReactContext reactContext)
+            {
+                if (reactContext == null)
+                    throw new ArgumentNullException(nameof(reactContext));
+
+                _reactContext = reactContext;
+            }
+
             /// <summary>
             /// Add a native module to the builder.
             /// </summary>
@@ -305,7 +337,7 @@ namespace ReactNative.Bridge
                     moduleInstances.Add(module.GetType(), module);
                 }
 
-                return new NativeModuleRegistry(moduleTable, moduleInstances);
+                return new NativeModuleRegistry(_reactContext, moduleTable, moduleInstances);
             }
         }
     }

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
@@ -78,7 +78,7 @@ namespace ReactNative.Bridge
             }
 
             _initialized = true;
-            _registry.NotifyReactInstanceInitialize();
+            QueueConfiguration.NativeModulesQueue.Dispatch(_registry.NotifyReactInstanceInitialize);
         }
 
         public async Task InitializeBridgeAsync()
@@ -87,34 +87,26 @@ namespace ReactNative.Bridge
 
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "initializeBridge").Start())
             {
-                _bridge = await QueueConfiguration.JavaScriptQueue.RunAsync(() =>
+                await QueueConfiguration.JavaScriptQueue.RunAsync(() =>
                 {
                     QueueConfiguration.JavaScriptQueue.AssertOnThread();
 
                     var jsExecutor = _jsExecutorFactory();
 
-                    var bridge = default(ReactBridge);
                     using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "ReactBridgeCtor").Start())
                     {
-                        bridge = new ReactBridge(
+                        _bridge = new ReactBridge(
                             jsExecutor,
                             new NativeModulesReactCallback(this),
                             QueueConfiguration.NativeModulesQueue);
                     }
 
-                    return bridge;
-                }).ConfigureAwait(false);
-
-                await QueueConfiguration.JavaScriptQueue.RunAsync(() =>
-                {
                     using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "setBatchedBridgeConfig").Start())
                     {
                         _bridge.SetGlobalVariable("__fbBatchedBridgeConfig", BuildModulesConfig());
                     }
 
                     _bundleLoader.LoadScript(_bridge);
-
-                    return default(object);
                 }).ConfigureAwait(false);
             }
         }
@@ -175,14 +167,9 @@ namespace ReactNative.Bridge
             }
 
             IsDisposed = true;
-            _registry.NotifyReactInstanceDispose();
 
-            await QueueConfiguration.JavaScriptQueue.RunAsync(() =>
-            {
-                using (_bridge) { }
-                return true;
-            }).ConfigureAwait(false);
-
+            await QueueConfiguration.NativeModulesQueue.RunAsync(_registry.NotifyReactInstanceDispose).ConfigureAwait(false);
+            await QueueConfiguration.JavaScriptQueue.RunAsync(() => _bridge?.Dispose()).ConfigureAwait(false);
             QueueConfiguration.Dispose();
         }
 

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -566,8 +566,6 @@ namespace ReactNative
 
             _sourceUrl = jsBundleLoader.SourceUrl;
 
-            var nativeRegistryBuilder = new NativeModuleRegistry.Builder();
-
             var reactContext = new ReactContext();
             if (_useDeveloperSupport)
             {
@@ -575,6 +573,7 @@ namespace ReactNative
                     _nativeModuleCallExceptionHandler ?? _devSupportManager.HandleException;
             }
 
+            var nativeRegistryBuilder = new NativeModuleRegistry.Builder(reactContext);
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "createAndProcessCoreModulesPackage").Start())
             {
                 var coreModulesPackage = new CoreModulesPackage(

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -480,11 +480,7 @@ namespace ReactNative.UIManager
         public void OnBatchComplete()
         {
             var batchId = _batchId++;
-
-            _layoutActionQueue.Dispatch(() =>
-            {
-                _uiImplementation.DispatchViewUpdates(batchId);
-            });
+            _uiImplementation.DispatchViewUpdates(batchId);
         }
 
         #endregion
@@ -497,7 +493,6 @@ namespace ReactNative.UIManager
         public override void OnReactInstanceDispose()
         {
             _eventDispatcher.OnReactInstanceDispose();
-            _layoutActionQueue.Dispose();
         }
 
         #endregion

--- a/ReactWindows/ReactNative.Tests/Bridge/Queue/ActionQueueTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/Queue/ActionQueueTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using ReactNative.Bridge.Queue;
 using System;
 using System.Reactive.Concurrency;
@@ -176,6 +176,29 @@ namespace ReactNative.Tests.Bridge.Queue
                     Assert.IsFalse(waitHandle.WaitOne(500));
                 }
             }
+        }
+
+        [TestMethod]
+        public async Task ActionQueue_DisposeSelf()
+        {
+            var aq = new ActionQueue(_ => { });
+
+            var disposeTask = aq.RunAsync(() =>
+            {
+                aq.Dispose();
+                return true;
+            });
+
+            var task = await Task.WhenAny(disposeTask, Task.Delay(5000));
+            Assert.AreSame(disposeTask, task);
+
+            var wontRunTask = aq.RunAsync(() =>
+            {
+                return true;
+            });
+
+            task = await Task.WhenAny(wontRunTask, Task.Delay(500));
+            Assert.AreNotSame(wontRunTask, task);
         }
     }
 }

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Bridge.Queue;
@@ -357,16 +357,23 @@ namespace ReactNative.Tests.UIManager.Events
 
         private static async Task<ReactContext> CreateContextAsync(IJavaScriptExecutor executor)
         {
-            var reactInstance = await DispatcherHelpers.CallOnDispatcherAsync(() => CreateReactInstance(executor));
-            await InitializeReactInstanceAsync(reactInstance);
             var context = new ReactContext();
-            context.InitializeWithInstance(reactInstance);
+
+            var reactInstance = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
+            {
+                var instance = CreateReactInstance(context, executor);
+                context.InitializeWithInstance(instance);
+                instance.Initialize();
+                await instance.InitializeBridgeAsync();
+                return instance;
+            });
+
             return context;
         }
 
-        private static ReactInstance CreateReactInstance(IJavaScriptExecutor executor)
+        private static ReactInstance CreateReactInstance(ReactContext reactContext, IJavaScriptExecutor executor)
         {
-            var registry = new NativeModuleRegistry.Builder().Build();
+            var registry = new NativeModuleRegistry.Builder(reactContext).Build();
 
             var instance = new ReactInstance.Builder
             {
@@ -376,14 +383,7 @@ namespace ReactNative.Tests.UIManager.Events
                 JavaScriptExecutorFactory = () => executor,
             }.Build();
 
-            instance.Initialize();
-
             return instance;
-        }
-
-        private static Task InitializeReactInstanceAsync(ReactInstance reactInstance)
-        {
-            return reactInstance.InitializeBridgeAsync();
         }
 
         private static IDisposable BlockJavaScriptThread(ReactContext reactContext)


### PR DESCRIPTION
The ReactInstance notifications for initialization and disposal should be run on the action queue for the native module rather than the dispatcher thread.

Fixes #1433