### PR TITLE
refactor(RootView): change how root view instances are sanitized

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -315,7 +315,8 @@ namespace ReactNative
                 throw new ArgumentNullException(nameof(rootView));
 
             DispatcherHelpers.AssertOnDispatcher();
-
+            rootView.Children.Clear();
+            rootView.ClearData();
             _attachedRootViews.Add(rootView);
 
             // If the React context is being created in the background, the
@@ -513,15 +514,8 @@ namespace ReactNative
         {
             DispatcherHelpers.AssertOnDispatcher();
 
-            // Reset view content as it's going to be populated by the
-            // application content from JavaScript
-            rootView.TouchHandler?.Dispose();
-            rootView.Children.Clear();
-            rootView.Tag = null;
-
             var uiManagerModule = reactInstance.GetNativeModule<UIManagerModule>();
             var rootTag = uiManagerModule.AddMeasuredRootView(rootView);
-            rootView.TouchHandler = new TouchHandler(rootView);
 
             var jsAppModuleName = rootView.JavaScriptModuleName;
             var appParameters = new Dictionary<string, object>
@@ -550,7 +544,8 @@ namespace ReactNative
 
             foreach (var rootView in _attachedRootViews)
             {
-                DetachViewFromInstance(rootView, reactContext.ReactInstance);
+                rootView.Children.Clear();
+                rootView.ClearData();
             }
 
             await reactContext.DisposeAsync();

--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -29,6 +29,14 @@ namespace ReactNative
         private bool _attachScheduled;
 
         /// <summary>
+        /// Instantiates the <see cref="ReactRootView"/>.
+        /// </summary>
+        public ReactRootView()
+        {
+            TouchHandler = new TouchHandler(this);
+        }
+
+        /// <summary>
         /// Gets the JavaScript module name.
         /// </summary>
         internal string JavaScriptModuleName
@@ -45,7 +53,6 @@ namespace ReactNative
         internal TouchHandler TouchHandler
         {
             get;
-            set;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/DependencyObjectExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/DependencyObjectExtensions.cs
@@ -159,12 +159,17 @@ namespace ReactNative.UIManager
                 throw new ArgumentNullException(nameof(view));
 
             var elementData = default(DependencyObjectData);
-            if (!s_properties.TryGetValue(view, out elementData) || !elementData.Tag.HasValue)
+            if (!s_properties.TryGetValue(view, out elementData))
             {
-                throw new InvalidOperationException("Could not get tag for view.");
+                throw new InvalidOperationException("Could not get React context for view.");
             }
 
             return elementData.Context;
+        }
+
+        internal static void ClearData(this DependencyObject view)
+        {
+            s_properties.Remove(view);
         }
 
         internal static T As<T>(this DependencyObject view)


### PR DESCRIPTION
Before being used by React Native, the root view children have to be removed and the associated data (tag and context) have to be cleaned as well. Making sure this is done as the React context is torn down.