### PR TITLE
fix(Dispatcher): Store reference to dispatcher for background

### DIFF
--- a/ReactWindows/ReactNative.Net46.Tests/Modules/NetInfo/NetInfoModuleTests.cs
+++ b/ReactWindows/ReactNative.Net46.Tests/Modules/NetInfo/NetInfoModuleTests.cs
@@ -112,7 +112,7 @@ namespace ReactNative.Tests.Modules.NetInfo
 
         private static void SetDispatcherForTest()
         {
-            ReactNative.Bridge.DispatcherHelpers.CurrentDispatcher = Dispatcher.CurrentDispatcher;
+            ReactNative.Bridge.DispatcherHelpers.MainDispatcher = Dispatcher.CurrentDispatcher;
         }
 
         class TestReactInstance : MockReactInstance

--- a/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
@@ -7,18 +7,18 @@ namespace ReactNative.Bridge
 {
     public static class DispatcherHelpers
     {
-        private static Dispatcher _dispatcher;
+        private static Dispatcher s_mainDispatcher;
 
-        internal static Dispatcher CurrentDispatcher
+        public static Dispatcher MainDispatcher
         {
             get
             {
                 AssertDispatcherSet();
 
-                return _dispatcher;
+                return s_mainDispatcher;
             }
 
-            set
+            internal set
             {
                 if (value == null)
                 {
@@ -30,13 +30,21 @@ namespace ReactNative.Bridge
                     throw new ArgumentException("Dispatcher must be an STA thread");
                 }
 
-                _dispatcher = value;
+                s_mainDispatcher = value;
             }
+        }
+
+        /// <summary>
+        /// Sets the main dispatcher.
+        /// </summary>
+        public static void Initialize()
+        {
+            s_mainDispatcher = Dispatcher.CurrentDispatcher;
         }
 
         public static bool IsDispatcherSet()
         {
-            return _dispatcher != null;
+            return s_mainDispatcher != null;
         }
 
         public static void AssertOnDispatcher()
@@ -51,21 +59,21 @@ namespace ReactNative.Bridge
         {
             AssertDispatcherSet();
 
-            return CurrentDispatcher.CheckAccess();
+            return MainDispatcher.CheckAccess();
         }
 
         public static async void RunOnDispatcher(Action action)
         {
             AssertDispatcherSet();
 
-            await CurrentDispatcher.InvokeAsync(action).Task.ConfigureAwait(false);
+            await MainDispatcher.InvokeAsync(action).Task.ConfigureAwait(false);
         }
 
         public static async void RunOnDispatcher(DispatcherPriority priority, Action action)
         {
             AssertDispatcherSet();
 
-            await CurrentDispatcher.InvokeAsync(action, priority).Task.ConfigureAwait(false);
+            await MainDispatcher.InvokeAsync(action, priority).Task.ConfigureAwait(false);
         }
 
         public static Task<T> CallOnDispatcher<T>(Func<T> func)
@@ -91,7 +99,7 @@ namespace ReactNative.Bridge
 
         private static void AssertDispatcherSet()
         {
-            if (_dispatcher == null)
+            if (s_mainDispatcher == null)
             {
                 throw new InvalidOperationException("Dispatcher has not been set");
             }

--- a/ReactWindows/ReactNative.Net46/ReactPage.cs
+++ b/ReactWindows/ReactNative.Net46/ReactPage.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Common;
 using ReactNative.Modules.Core;
@@ -26,8 +26,6 @@ namespace ReactNative
         {
             _reactInstanceManager = new Lazy<ReactInstanceManager>(() =>
             {
-                DispatcherHelpers.CurrentDispatcher = base.Dispatcher;
-
                 var reactInstanceManager = CreateReactInstanceManager();
 
                 return reactInstanceManager;

--- a/ReactWindows/ReactNative.Shared.Tests/Modules/AppState/AppStateModuleTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/AppState/AppStateModuleTests.cs
@@ -35,7 +35,7 @@ namespace ReactNative.Tests.Modules.AppState
             Assert.AreEqual(uninitializedState.ToString(), args[0].ToString());
 
 #if !WINDOWS_UWP
-            ReactNative.Bridge.DispatcherHelpers.CurrentDispatcher = Dispatcher.CurrentDispatcher;
+            ReactNative.Bridge.DispatcherHelpers.MainDispatcher = Dispatcher.CurrentDispatcher;
 #endif
 
             await DispatcherHelpers.RunOnDispatcherAsync(context.OnResume);
@@ -67,7 +67,7 @@ namespace ReactNative.Tests.Modules.AppState
             }));
 
 #if !WINDOWS_UWP
-            ReactNative.Bridge.DispatcherHelpers.CurrentDispatcher = Dispatcher.CurrentDispatcher;
+            ReactNative.Bridge.DispatcherHelpers.MainDispatcher = Dispatcher.CurrentDispatcher;
 #endif
 
             await DispatcherHelpers.RunOnDispatcherAsync(context.OnResume);

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/ReactQueueConfigurationFactory.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/ReactQueueConfigurationFactory.cs
@@ -43,29 +43,11 @@ namespace ReactNative.Bridge.Queue
             get
             {
                 return new ReactQueueConfigurationFactory(
-                    new ActionQueueFactory(onError => new DispatcherActionQueue(onError, Dispatcher)),
+                    new ActionQueueFactory(onError => new DispatcherActionQueue(onError, DispatcherHelpers.MainDispatcher)),
                     new ActionQueueFactory(onError => new ActionQueue(onError, NewThreadScheduler.Default)),
                     new ActionQueueFactory(onError => new ActionQueue(onError)));
             }
         }
-
-#if WINDOWS_UWP
-        private static CoreDispatcher Dispatcher
-        {
-            get
-            {
-                return CoreApplication.MainView.Dispatcher;
-            }
-        }
-#else
-        private static Dispatcher Dispatcher
-        {
-            get
-            {
-                return Application.Current.MainWindow.Dispatcher;
-            }
-        }
-#endif
 
         /// <summary>
         /// Creates the React queue configuration.

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -260,6 +260,7 @@ namespace ReactNative
         /// </param>
         public void OnResume(Action onBackPressed)
         {
+            DispatcherHelpers.Initialize();
             DispatcherHelpers.AssertOnDispatcher();
 
             _defaultBackButtonHandler = onBackPressed;

--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -12,6 +12,40 @@ namespace ReactNative.Bridge
     public static class DispatcherHelpers
     {
         private static ThreadLocal<bool> s_isOnDispatcherThread;
+        private static CoreDispatcher s_mainDispatcher;
+
+        /// <summary>
+        /// Gets the main dispatcher for the app.
+        /// </summary>
+        public static CoreDispatcher MainDispatcher
+        {
+            get
+            {
+                if (s_mainDispatcher == null)
+                {
+                    throw new InvalidOperationException("Main dispatcher has not been set, please run Initialize.");
+                }
+
+                return s_mainDispatcher;
+            }
+            private set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                s_mainDispatcher = value;
+            }
+        }
+
+        /// <summary>
+        /// Sets the main dispatcher.
+        /// </summary>
+        public static void Initialize()
+        {
+            s_mainDispatcher = CoreApplication.MainView.Dispatcher;
+        }
 
         /// <summary>
         /// Asserts that the current thread has dispatcher access.
@@ -35,7 +69,7 @@ namespace ReactNative.Bridge
         {
             if (s_isOnDispatcherThread == null)
             {
-                if (CoreWindow.GetForCurrentThread()?.Dispatcher == CoreApplication.MainView.Dispatcher)
+                if (MainDispatcher.HasThreadAccess)
                 {
                     s_isOnDispatcherThread = new ThreadLocal<bool>();
                     s_isOnDispatcherThread.Value = true;
@@ -66,7 +100,7 @@ namespace ReactNative.Bridge
         /// <param name="action">The action to invoke.</param>
         public static async void RunOnDispatcher(CoreDispatcherPriority priority, DispatchedHandler action)
         {
-            await CoreApplication.MainView.Dispatcher.RunAsync(priority, action).AsTask().ConfigureAwait(false);
+            await MainDispatcher.RunAsync(priority, action).AsTask().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,6 +133,7 @@ namespace ReactNative.Bridge
         {
             s_isOnDispatcherThread.Dispose();
             s_isOnDispatcherThread = null;
+            s_mainDispatcher = null;
         }
     }
 }

--- a/ReactWindows/ReactNative/Bridge/Queue/LayoutActionQueue.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/LayoutActionQueue.cs
@@ -1,5 +1,7 @@
 using System;
+#if CREATE_LAYOUT_THREAD
 using Windows.ApplicationModel.Core;
+#endif
 
 namespace ReactNative.Bridge.Queue
 {
@@ -13,7 +15,7 @@ namespace ReactNative.Bridge.Queue
 #if CREATE_LAYOUT_THREAD
             : base(onError, s_layoutApplicationView.Dispatcher)
 #else
-            : base(onError, CoreApplication.MainView.Dispatcher)
+            : base(onError, DispatcherHelpers.MainDispatcher)
 #endif
         {
         }


### PR DESCRIPTION
There seems to be a bug in the single process background model for UWP where the CoreApplication.MainView.Dispatcher is no longer accessible after running an async operation. However, if we store the dispatcher in the `OnResume` lifecycle event, we can still have access to it. This change enables the capture of the main view dispatcher and replaces references to the captured instance.

Towards #1268