### PR TITLE
fix(DeviceInfoModule): Support background transition to foreground

### DIFF
--- a/ReactWindows/Playground/App.xaml.cs
+++ b/ReactWindows/Playground/App.xaml.cs
@@ -29,6 +29,8 @@ namespace Playground
             this.InitializeComponent();
             this.Suspending += OnSuspending;
             this.Resuming += OnResuming;
+            this.EnteredBackground += OnEnteredBackground;
+            this.LeavingBackground += OnLeavingBackground;
         }
 
         /// <summary>
@@ -145,6 +147,26 @@ namespace Playground
         private void OnResuming(object sender, object e)
         {
             _host.OnResume(Exit);
+        }
+
+        /// <summary>
+        /// Invoked when application entered the background.
+        /// </summary>
+        /// <param name="sender">The source of the entered background request.</param>
+        /// <param name="e">Details about the entered background request.</param>
+        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
+        {
+            _host.OnEnteredBackground();
+        }
+
+        /// <summary>
+        /// Invoked when application leaving the background.
+        /// </summary>
+        /// <param name="sender">The source of the leaving background request.</param>
+        /// <param name="e">Details about the leaving background request.</param>
+        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
+        {
+            _host.OnLeavingBackground();
         }
     }
 }

--- a/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -18,14 +18,13 @@ namespace ReactNative.Modules.DeviceInfo
         /// Instantiates the <see cref="DeviceInfoModule"/>. 
         /// </summary>
         /// <param name="reactContext">The React context.</param>
-        /// <param name="initialDisplayMetrics">The initial display metrics.</param>
-        public DeviceInfoModule(ReactContext reactContext, DisplayMetrics initialDisplayMetrics)
+        public DeviceInfoModule(ReactContext reactContext)
             : base(reactContext)
         {
             _window = Application.Current.MainWindow;
             _constants = new Dictionary<string, object>
             {
-                { "Dimensions", GetDimensions(initialDisplayMetrics) },
+                { "Dimensions", GetDimensions() },
             };
         }
 

--- a/ReactWindows/ReactNative.Shared/Bridge/IBackgroundEventListener.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IBackgroundEventListener.cs
@@ -1,0 +1,18 @@
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Listener for application life cycle events.
+    /// </summary>
+    public interface IBackgroundEventListener
+    {
+        /// <summary>
+        /// Called when the host entered background mode.
+        /// </summary>
+        void OnEnteredBackground();
+
+        /// <summary>
+        /// Called when the host is leaving background mode.
+        /// </summary>
+        void OnLeavingBackground();
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Common/LifecycleState.cs
+++ b/ReactWindows/ReactNative.Shared/Common/LifecycleState.cs
@@ -1,4 +1,4 @@
-﻿namespace ReactNative.Common
+namespace ReactNative.Common
 {
     /// <summary>
     /// An enumeration to signify the current lifecycle state for a 
@@ -20,5 +20,10 @@
         /// Lifecycle state of a resumed application.
         /// </summary>
         Resumed,
+
+        /// <summary>
+        /// Lifecycle state when the application is in the background.
+        /// </summary>
+        Background,
     }
 }

--- a/ReactWindows/ReactNative.Shared/CoreModulesPackage.cs
+++ b/ReactWindows/ReactNative.Shared/CoreModulesPackage.cs
@@ -22,18 +22,15 @@ namespace ReactNative
         private readonly ReactInstanceManager _reactInstanceManager;
         private readonly Action _hardwareBackButtonHandler;
         private readonly UIImplementationProvider _uiImplementationProvider;
-        private readonly DisplayMetrics _initialDisplayMetrics;
 
         public CoreModulesPackage(
             ReactInstanceManager reactInstanceManager,
             Action hardwareBackButtonHandler,
-            UIImplementationProvider uiImplementationProvider,
-            DisplayMetrics initialDisplayMetrics)
+            UIImplementationProvider uiImplementationProvider)
         {
             _reactInstanceManager = reactInstanceManager;
             _hardwareBackButtonHandler = hardwareBackButtonHandler;
             _uiImplementationProvider = uiImplementationProvider;
-            _initialDisplayMetrics = initialDisplayMetrics;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller manages scope of returned list of disposables.")]
@@ -57,7 +54,7 @@ namespace ReactNative
                 //    reactContext,
                 //    _reactInstanceManager.DevSupportManager.DevSettings),
                 new DeviceEventManagerModule(reactContext, _hardwareBackButtonHandler),
-                new DeviceInfoModule(reactContext, _initialDisplayMetrics),
+                new DeviceInfoModule(reactContext),
                 new ExceptionsManagerModule(_reactInstanceManager.DevSupportManager),
                 new PlatformConstantsModule(),
                 new SourceCodeModule(

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -252,6 +252,24 @@ namespace ReactNative
         }
 
         /// <summary>
+        /// Called when the host entered background mode.
+        /// </summary>
+        public void OnEnteredBackground()
+        {
+            DispatcherHelpers.AssertOnDispatcher();
+            MoveToBackgroundLifecycleState();
+        }
+
+        /// <summary>
+        /// Called when the host is leaving background mode.
+        /// </summary>
+        public void OnLeavingBackground()
+        {
+            DispatcherHelpers.AssertOnDispatcher();
+            MoveToResumedLifecycleState(false);
+        }
+
+        /// <summary>
         /// Used when the application resumes to reset the back button handling
         /// in JavaScript.
         /// </summary>
@@ -574,8 +592,7 @@ namespace ReactNative
                 var coreModulesPackage = new CoreModulesPackage(
                     this,
                     InvokeDefaultOnBackPressed,
-                    _uiImplementationProvider,
-                    DisplayMetrics.GetForCurrentView());
+                    _uiImplementationProvider);
 
                 ProcessPackage(coreModulesPackage, reactContext, nativeRegistryBuilder);
             }
@@ -676,6 +693,10 @@ namespace ReactNative
                     {
                         _currentReactContext.OnResume();
                     }
+                    else if (_lifecycleState == LifecycleState.Background)
+                    {
+                        _currentReactContext.OnLeavingBackground();
+                    }
                 }
 
                 _lifecycleState = LifecycleState.Resumed;
@@ -696,6 +717,21 @@ namespace ReactNative
                     if (_lifecycleState == LifecycleState.BeforeResume)
                     {
                         _currentReactContext.OnDestroy();
+                    }
+                }
+            }
+        }
+
+        private void MoveToBackgroundLifecycleState()
+        {
+            lock (_lifecycleStateLock)
+            {
+                if (_currentReactContext != null)
+                {
+                    if (_lifecycleState == LifecycleState.Resumed)
+                    {
+                        _currentReactContext.OnEnteredBackground();
+                        _lifecycleState = LifecycleState.Background;
                     }
                 }
             }

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\CompiledReactDelegateFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IAsyncCancelable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IAsyncDisposable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\IBackgroundEventListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ICallback.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IInvocationHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IJavaScriptExecutor.cs" />

--- a/ReactWindows/ReactNative.Shared/ReactNativeHostExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/ReactNativeHostExtensions.cs
@@ -58,6 +58,32 @@ namespace ReactNative
         }
 
         /// <summary>
+        /// Informs the React instance manager that the application entered
+        /// background mode.
+        /// </summary>
+        /// <param name="host">The React Native host.</param>
+        public static void OnEnteredBackground(this ReactNativeHost host)
+        {
+            if (host.HasInstance)
+            {
+                host.ReactInstanceManager.OnEnteredBackground();
+            }
+        }
+
+        /// <summary>
+        /// Informs the React instance manager that the application is leaving
+        /// background mode.
+        /// </summary>
+        /// <param name="host">The React Native host.</param>
+        public static void OnLeavingBackground(this ReactNativeHost host)
+        {
+            if (host.HasInstance)
+            {
+                host.ReactInstanceManager.OnLeavingBackground();
+            }
+        }
+
+        /// <summary>
         /// Applies the activation arguments.
         /// </summary>
         /// <param name="host">The React Native host.</param>

--- a/ReactWindows/ReactNative/UIManager/DisplayMetrics.cs
+++ b/ReactWindows/ReactNative/UIManager/DisplayMetrics.cs
@@ -18,6 +18,8 @@ namespace ReactNative.UIManager
 
         public double Scale { get; }
 
+        public static DisplayMetrics Empty { get; } = new DisplayMetrics(0, 0, 0);
+
         public static DisplayMetrics GetForCurrentView()
         {
             var bounds = ApplicationView.GetForCurrentView().VisibleBounds;

--- a/local-cli/generator-windows/templates/src/App.xaml.cs
+++ b/local-cli/generator-windows/templates/src/App.xaml.cs
@@ -26,6 +26,8 @@ namespace <%= ns %>
             this.InitializeComponent();
             this.Suspending += OnSuspending;
             this.Resuming += OnResuming;
+            this.EnteredBackground += OnEnteredBackground;
+            this.LeavingBackground += OnLeavingBackground;
         }
 
         /// <summary>
@@ -142,6 +144,26 @@ namespace <%= ns %>
         private void OnResuming(object sender, object e)
         {
             _host.OnResume(Exit);
+        }
+
+        /// <summary>
+        /// Invoked when application entered the background.
+        /// </summary>
+        /// <param name="sender">The source of the entered background request.</param>
+        /// <param name="e">Details about the entered background request.</param>
+        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
+        {
+            _host.OnEnteredBackground();
+        }
+
+        /// <summary>
+        /// Invoked when application leaving the background.
+        /// </summary>
+        /// <param name="sender">The source of the leaving background request.</param>
+        /// <param name="e">Details about the leaving background request.</param>
+        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
+        {
+            _host.OnLeavingBackground();
         }
     }
 }


### PR DESCRIPTION
We need to enable DeviceInfoModule initialization in the background by zeroing out the main window dimensions and not subscribing to application view events (which are not available in the background). In order to ensure the app receives the events when the app transitions from background to foreground, this changeset adds an `IBackgroundEventListener` that is used by the DeviceInfoModule to subscribe to and unsubscribe from the application view events (and send the latest dimensions when the foreground is entered).

Towards #1268