### PR TITLE
fix(Background): Upgrade to Microsoft.NETCore.UWP 6.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,8 @@ WiniumDriver/
 #NuGet
 packages/
 *.nupkg
+*.nuget.props
+*.nuget.targets
 
 #ncrunch
 *ncrunch*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ You can use it to test your changes to React Native Windows by making sure your 
 #### But How?
 Before starting make sure you have run `npm install` in the react-native-windows directory. Additionally, make sure the RNTester submodule is up to date by running `git pull --recursive-submodules` from the react-native-windows directory.
 
-Use Visual Studio 2015 or higher, with the Windows 10 SDK 10.0.14393 or higher.
+Use Visual Studio 2017 or higher, with the Windows 10 SDK 10.0.14393 or higher.
 
 1. Open the RNTester solution file (react-native-windows/RNTester/RNTester.sln) in Visual Studio
 2. Set RNTesterApp as the StartUp project

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See the official [React Native website](https://facebook.github.io/react-native/
 - You can build and deploy React Native Windows apps on the Pro or Enterprise versions of Windows 7 SP1, Windows 8.1, or Windows 10
 	- You cannot run the emulators and some other developer tooling on the "Starter" or "Home" versions of these operating systems
 	- You can run React Native Windows UWP apps only on Windows 10 devices, but React Native Windows WPF apps will run on Windows 7-10 so long as .NET 4.6 is installed on the end user's machine
-- Download [Visual Studio 2017 Community or Greater](https://www.visualstudio.com/downloads/). (Visual Studio 2015 support is being deprecated.)
+- Download [Visual Studio 2017 Community or Greater](https://www.visualstudio.com/downloads/). (Visual Studio 2015 support has been deprecated.)
 	- You will need to start Visual Studio after it is installed to do some final setup before it can be used to build or run your React Native Windows application
 - [Windows 10 SDK Build 14393](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive)
 

--- a/ReactWindows/ChakraBridge/ChakraBridge.vcxproj
+++ b/ReactWindows/ChakraBridge/ChakraBridge.vcxproj
@@ -42,35 +42,35 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ReactWindows/Playground/project.json
+++ b/ReactWindows/Playground/project.json
@@ -4,10 +4,10 @@
     "Microsoft.ApplicationInsights": "2.2.0",
     "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
     "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/ReactWindows/ReactNative.Tests/project.json
+++ b/ReactWindows/ReactNative.Tests/project.json
@@ -1,14 +1,14 @@
 ﻿{
   "dependencies": {
     "Facebook.Yoga": "1.5.0-pre1",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1",
     "NUnit": "3.5.0",
     "NUnit.ConsoleRunner": "3.5.0",
     "NUnit3TestAdapter": "3.5.0",
     "System.Reactive": "3.1.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,14 +1,14 @@
-{
+﻿{
   "dependencies": {
     "Facebook.Yoga": "1.5.0-pre1",
     "fresco.imagepipeline": "0.0.8",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1",
     "Newtonsoft.Json": "9.0.1",
     "OpenCover": "4.6.519",
     "System.Reactive": "3.1.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/ReactWindows/ReactNativeWebViewBridge/project.json
+++ b/ReactWindows/ReactNativeWebViewBridge/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,13 @@ max_jobs: 2
 environment:
   nodejs_version: "LTS"
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PLATFORM_TOOLSET: v140
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CONFIGURATION: Debug
       PLATFORM: x64
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PLATFORM_TOOLSET: v140
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CONFIGURATION: Debug
       PLATFORM: ARM
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PLATFORM_TOOLSET: v141
       CONFIGURATION: ReleaseBundle
       PLATFORM: x86
 
@@ -63,7 +60,7 @@ before_build:
 build_script:
 - ps: mkdir $env:bundle_dir
 - ps: react-native bundle --platform windows --entry-file $($env:playgroundNet46_dir + "\index.windows.js") --bundle-output $($env:bundle_dir + "\index.windows.bundle") --assets-dest $env:bundle_dir --dev false; echo "Suppressing error"
-- ps: msbuild /p:Configuration=$env:CONFIGURATION /p:Platform=$env:PLATFORM /p:PlatformToolset=$env:PLATFORM_TOOLSET /nologo /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "ReactWindows\ReactNative.sln"
+- ps: msbuild /p:Configuration=$env:CONFIGURATION /p:Platform=$env:PLATFORM /nologo /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "ReactWindows\ReactNative.sln"
 
 # Start Winium in the background, give it a moment to start
 before_test:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -77,7 +77,7 @@ React Native Windows is not currently supported by Expo. If you have a React Nat
     - If there is not a retarget option:
         - Select "Reload", and the Visual Studio installer will open.
         - Make sure to close Visual Studio before installing
-        - Make sure the 10.0.10586.0 Windows 10 SDK is selected along with any other preselected components, and click "Modify" in the installer to install the components
+        - Make sure the 10.0.14393.0 Windows 10 SDK is selected along with any other preselected components, and click "Modify" in the installer to install the components
         - Retargeting the ChakraBridge project should be possible, so proceed to the next instructions regarding if there is a retarget option
     - If there is a retarget option:
         - Retarget by right clicking on the ChakraBridge project in the Solution Explorer and selecting "Retarget Projects" and pressing okay on the popup dialog (Platform Toolset should say "Upgrade to v141" in the dialog).

--- a/local-cli/generator-windows/templates/src/project.json
+++ b/local-cli/generator-windows/templates/src/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/local-cli/generator-windows/templates/src/project.json
+++ b/local-cli/generator-windows/templates/src/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
Updating the NuGet package fixes some issues with the dispatcher execution context in the background. In Microsoft.NETCore.UWP 5.x.x, the Dispatcher for the MainView had no execution context, so asynchronous methods would not return on the dispatcher thread.