### PR TITLE
fix(AccessibilityInfo): Do not subscribe to accessibility events in background

### DIFF
--- a/ReactWindows/ReactNative/Modules/AccessibilityInfo/AccessibilityInfoModule.cs
+++ b/ReactWindows/ReactNative/Modules/AccessibilityInfo/AccessibilityInfoModule.cs
@@ -1,14 +1,17 @@
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using System.Collections.Generic;
+using Windows.ApplicationModel.Core;
 using Windows.UI.ViewManagement;
 
 namespace ReactNative.Modules.Accessibilityinfo
 {
-    class AccessibilityInfoModule : ReactContextNativeModuleBase
+    class AccessibilityInfoModule : ReactContextNativeModuleBase, ILifecycleEventListener, IBackgroundEventListener
     {
         private readonly AccessibilitySettings _accessibility = new AccessibilitySettings();
         private readonly UISettings _settings = new UISettings();
+
+        private bool _isSubscribed;
 
         private string GetRgbaString(UIElementType type)
         {
@@ -53,20 +56,72 @@ namespace ReactNative.Modules.Accessibilityinfo
             }
         }
 
+        private static bool HasCoreWindow => CoreApplication.MainView.CoreWindow != null;
+
+        /// <summary>
+        /// Called after the creation of a <see cref="IReactInstance"/>,
+        /// </summary>
         public override void Initialize()
         {
-            DispatcherHelpers.RunOnDispatcher(() =>
-            {
-                _accessibility.HighContrastChanged += OnHighContrastChanged;
-            });
+            Context.AddLifecycleEventListener(this);
+            Context.AddBackgroundEventListener(this);
         }
 
-        public override void OnReactInstanceDispose()
+        /// <summary>
+        /// Called when the application is suspended.
+        /// </summary>
+        public void OnSuspend()
         {
-            DispatcherHelpers.RunOnDispatcher(() =>
+            Unsubscribe();
+        }
+
+        /// <summary>
+        /// Called when the application is resumed.
+        /// </summary>
+        public void OnResume()
+        {
+            Subscribe();
+        }
+
+        /// <summary>
+        /// Called when the host entered background mode.
+        /// </summary>
+        public void OnEnteredBackground()
+        {
+            Unsubscribe();
+        }
+
+        /// <summary>
+        /// Called when the host is leaving background mode.
+        /// </summary>
+        public void OnLeavingBackground()
+        {
+            Subscribe();
+        }
+
+        private void Subscribe()
+        {
+            if (!_isSubscribed && HasCoreWindow)
+            {
+                _isSubscribed = true;
+                _accessibility.HighContrastChanged += OnHighContrastChanged;
+            }
+        }
+
+        private void Unsubscribe()
+        {
+            if (_isSubscribed && HasCoreWindow)
             {
                 _accessibility.HighContrastChanged -= OnHighContrastChanged;
-            });
+                _isSubscribed = false;
+            }
+        }
+
+        /// <summary>
+        /// Called when the application is terminated.
+        /// </summary>
+        public void OnDestroy()
+        {
         }
 
         private void OnHighContrastChanged(AccessibilitySettings sender, object args)


### PR DESCRIPTION
…ackground

Uses the same pattern as DeviceInfoModule to subscribe/unsubscribe from the high contrast event only when the app is running in the foreground.