### PR TITLE
fix(ActionQueue): Dispose bug and unit tests for ActionQueue

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/ActionQueueExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/ActionQueueExtensions.cs
@@ -36,11 +36,24 @@ namespace ReactNative.Bridge.Queue
 
             actionQueue.Dispatch(() =>
             {
-                var result = func();
+                try
+                {
+                    var result = func();
 
-                // TaskCompletionSource<T>.SetResult can call continuations
-                // on the awaiter of the task completion source.
-                Task.Run(() => taskCompletionSource.SetResult(result));
+                    // TaskCompletionSource<T>.SetResult can call continuations
+                    // on the awaiter of the task completion source. We want to
+                    // prevent the action queue thread from executing these
+                    // continuations.
+                    Task.Run(() => taskCompletionSource.SetResult(result));
+                }
+                catch (Exception ex)
+                {
+                    // TaskCompletionSource<T>.SetException can call continuations
+                    // on the awaiter of the task completion source. We want to
+                    // prevent the action queue thread from executing these
+                    // continuations.
+                    Task.Run(() => taskCompletionSource.SetException(ex));
+                }
             });
 
             return taskCompletionSource.Task;


### PR DESCRIPTION
Small bug fix to guarantee we don't return from `Dispose` until no more actions will be executed (including those currently executing). Also adds unit tests for other expected behaviors.