### PR TITLE
fix(DevSupportManager): UWP hanging on IStorageItem APIs

### DIFF
--- a/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
@@ -82,9 +82,9 @@ namespace ReactNative.DevSupport
             return Task.FromResult(default(ReactContext));
         }
 
-        public Task<bool> HasUpToDateBundleInCacheAsync(CancellationToken token)
+        public bool HasUpToDateBundleInCache()
         {
-            return Task.FromResult(false);
+            return false;
         }
 
         public void HideRedboxDialog()

--- a/ReactWindows/ReactNative.Shared/DevSupport/IDevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/IDevSupportManager.cs
@@ -70,9 +70,11 @@ namespace ReactNative.DevSupport
         /// <summary>
         /// Checks if an up-to-date JavaScript bundle is ready.
         /// </summary>
-        /// <param name="token">A token to cancel the check.</param>
-        /// <returns>A task to await the result.</returns>
-        Task<bool> HasUpToDateBundleInCacheAsync(CancellationToken token);
+        /// <returns>
+        /// <code>true</code> if the cached bundle is newer than the date the
+        /// application was installed, otherwise <code>false</code>.
+        /// </returns>
+        bool HasUpToDateBundleInCache();
 
         /// <summary>
         /// Dismisses the red box exception dialog.

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -416,7 +416,7 @@ namespace ReactNative
 
         private async Task<ReactContext> CreateReactContextFromDevManagerAsync(CancellationToken token)
         {
-            if (await _devSupportManager.HasUpToDateBundleInCacheAsync(token))
+            if (_devSupportManager.HasUpToDateBundleInCache())
             {
                 return await CreateReactContextFromCachedPackagerBundleAsync(token);
             }


### PR DESCRIPTION
Initial API calls to IStorageItem are hanging, but blocking System.IO calls are not. Changed to System.IO.File APIs (which are blocking, but it's only for debug/dev code); these have an added benefit of being compatible with WPF.