### PR TITLE
Add Reject impl where all arguments are explicit

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockPromise.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockPromise.cs
@@ -1,4 +1,5 @@
-﻿using ReactNative.Bridge;
+using Newtonsoft.Json.Linq;
+using ReactNative.Bridge;
 using System;
 
 namespace ReactNative.Tests
@@ -8,14 +9,14 @@ namespace ReactNative.Tests
         private const string DefaultError = "EUNSPECIFIED";
 
         private readonly Action<object> _resolve;
-        private readonly Action<string, string, Exception> _reject;
+        private readonly Action<string, string, string, JToken> _reject;
         
         public MockPromise(Action<object> resolve)
-            : this(resolve, (_, __, ___)=> { })
+            : this(resolve, (_, __, ___, ____)=> { })
         {
         }
 
-        public MockPromise(Action<object> resolve, Action<string, string, Exception> reject)
+        public MockPromise(Action<object> resolve, Action<string, string, string, JToken> reject)
         {
             _resolve = resolve;
             _reject = reject;
@@ -43,7 +44,16 @@ namespace ReactNative.Tests
 
         public void Reject(string code, string message, Exception e)
         {
-            _reject.Invoke(code, message, e);
+            var errorData = e?.Data;
+            var userInfo = errorData != null
+                ? JToken.FromObject(errorData)
+                : null;
+            Reject(code, message, e?.StackTrace, userInfo);
+        }
+
+        public void Reject(string code, string message, string stack, JToken userInfo)
+        {
+            _reject.Invoke(code, message, stack, userInfo);
         }
 
         public void Resolve(object value)

--- a/ReactWindows/ReactNative.Shared/Bridge/IPromise.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IPromise.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Newtonsoft.Json.Linq;
+using System;
 
 namespace ReactNative.Bridge
 {
@@ -56,5 +57,14 @@ namespace ReactNative.Bridge
         /// </summary>
         /// <param name="exception">The exception.</param>
         void Reject(Exception exception);
+
+        /// <summary>
+        /// Report an error by explicitly specifying all of the fields of the error.
+        /// </summary>
+        /// <param name="code">The error code.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="stack">A string representing the frames on the call stack. Usually you get this off of an Exception object.</param>
+        /// <param name="userInfo">User-defined information about the error. This is usually a collection of key-value pairs that provides additional error details.</param>
+        void Reject(string code, string message, string stack, JToken userInfo);
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/Promise.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Promise.cs
@@ -1,5 +1,6 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections;
 
 namespace ReactNative.Bridge
 {
@@ -49,17 +50,22 @@ namespace ReactNative.Bridge
 
         public void Reject(string code, string message, Exception e)
         {
+            var errorData = e?.Data;
+            var userInfo = errorData != null
+                ? JToken.FromObject(errorData) 
+                : null;
+            Reject(code, message, e?.StackTrace, userInfo);
+        }
+
+        public void Reject(string code, string message, string stack, JToken userInfo)
+        {
             if (_reject != null)
             {
-                var errorData = e?.Data;
-                var userInfo = errorData != null
-                    ? JToken.FromObject(errorData) 
-                    : null;
                 _reject.Invoke(new JObject
                 {
                     { "code", code ?? DefaultError },
                     { "message", message },
-                    { "stack", e?.StackTrace },
+                    { "stack", stack },
                     { "userInfo", userInfo },
                 });
             }

--- a/ReactWindows/ReactNative.Tests/Modules/Clipboard/ClipboardModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Clipboard/ClipboardModuleTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using ReactNative.Modules.Clipboard;
 using System;
 using System.Threading;
@@ -30,7 +30,7 @@ namespace ReactNative.Tests.Modules.Clipboard
             var waitHandle = new AutoResetEvent(false);
 
             var promise = new MockPromise(resolve => { result = resolve.ToString(); waitHandle.Set(); },
-                                          (code, message, e) => { result = message; waitHandle.Set(); });
+                                          (code, message, stack, userInfo) => { result = message; waitHandle.Set(); });
 
             module.setString(str);
             module.getString(promise);
@@ -49,7 +49,7 @@ namespace ReactNative.Tests.Modules.Clipboard
             var waitHandle = new AutoResetEvent(false);
 
             var promise = new MockPromise(resolve => { result = resolve.ToString(); waitHandle.Set(); },
-                                          (code, message, e) => { result = message; waitHandle.Set(); });
+                                          (code, message, stack, userInfo) => { result = message; waitHandle.Set(); });
 
             module.setString(null);
             module.getString(promise);

--- a/ReactWindows/ReactNative.Tests/Modules/Image/ImageLoaderModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Image/ImageLoaderModuleTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using ReactNative.Modules.Image;
 using System.Threading;
 
@@ -21,7 +21,7 @@ namespace ReactNative.Tests.Modules.Image
             var waitHandle = new AutoResetEvent(false);
 
             var promise = new MockPromise(resolve => { result = resolve.ToString(); waitHandle.Set(); },
-                                          (code, message, e) => { result = message; waitHandle.Set(); });
+                                          (code, message, stack, userInfo) => { result = message; waitHandle.Set(); });
 
             module.getSize(Base64Uri, promise);
 
@@ -39,7 +39,7 @@ namespace ReactNative.Tests.Modules.Image
             var waitHandle = new AutoResetEvent(false);
 
             var promise = new MockPromise(resolve => { result = resolve.ToString(); waitHandle.Set(); },
-                                          (code, message, e) => { result = message; waitHandle.Set(); });
+                                          (code, message, stack, userInfo) => { result = message; waitHandle.Set(); });
 
             module.getSize(LocalUri, promise);
 
@@ -57,7 +57,7 @@ namespace ReactNative.Tests.Modules.Image
             var waitHandle = new AutoResetEvent(false);
 
             var promise = new MockPromise(resolve => { result = resolve.ToString(); waitHandle.Set(); },
-                                          (code, message, e) => Assert.Inconclusive("Network request failed."));
+                                          (code, message, stack, userInfo) => Assert.Inconclusive("Network request failed."));
 
             module.getSize(NetworkUri, promise);
 


### PR DESCRIPTION
With the current Reject implementations, it's challenging to control the `stack` and `userInfo` parameters. To control them, you have to construct an Exception object which is awkward if the error didn't originate as an Exception.

To solve this, a new Reject is exposed which enables the caller to explicitly specify the `stack` and `userInfo` arguments.

An especially useful use case for this Reject variant is when a ReactMethod calls into another process (e.g. a background task) and the other process returns an error. The new version of Reject makes it easy to forward this other process's error to JavaScript while keeping the `stack` and `userInfo` parameters intact.