### PR TITLE
fix(resolveAssetSource): Remove logic that prepends `file://`

### DIFF
--- a/Libraries/Image/resolveAssetSource.windows.js
+++ b/Libraries/Image/resolveAssetSource.windows.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule resolveAssetSource
+ * @flow
+ *
+ * Resolves an asset into a `source` for `Image`.
+ */
+'use strict';
+
+const AssetRegistry = require('AssetRegistry');
+const AssetSourceResolver = require('AssetSourceResolver');
+const NativeModules = require('NativeModules');
+
+import type { ResolvedAssetSource } from 'AssetSourceResolver';
+
+let _customSourceTransformer, _serverURL, _scriptURL, _embeddedBundleURL;
+
+function getDevServerURL(): ?string {
+  if (_serverURL === undefined) {
+    var scriptURL = NativeModules.SourceCode.scriptURL;
+    var match = scriptURL && scriptURL.match(/^https?:\/\/.*?\//);
+    if (match) {
+      // jsBundle was loaded from network
+      _serverURL = match[0];
+    } else {
+      // jsBundle was loaded from file
+      _serverURL = null;
+    }
+  }
+  return _serverURL;
+}
+
+function getScriptURL(): ?string {
+  if (_scriptURL === undefined) {
+    const scriptURL = NativeModules.SourceCode.scriptURL;
+    _scriptURL = scriptURL;
+  }
+  return _scriptURL;
+}
+
+function getEmbeddedBundledURL(): ?string {
+  if (_embeddedBundleURL === undefined) {
+    const scriptURL = NativeModules.SourceCode.embeddedBundleURL;
+    _embeddedBundleURL = scriptURL;
+  }
+  return _embeddedBundleURL;
+}
+
+function setCustomSourceTransformer(
+  transformer: (resolver: AssetSourceResolver) => ResolvedAssetSource,
+): void {
+  _customSourceTransformer = transformer;
+}
+
+/**
+ * `source` is either a number (opaque type returned by require('./foo.png'))
+ * or an `ImageSource` like { uri: '<http location || file path>' }
+ */
+function resolveAssetSource(source: any): ?ResolvedAssetSource {
+  if (typeof source === 'object') {
+    return source;
+  }
+
+  var asset = AssetRegistry.getAssetByID(source);
+  if (!asset) {
+    return null;
+  }
+
+  const resolver = new AssetSourceResolver(
+    getDevServerURL(),
+    getScriptURL(),
+    getEmbeddedBundledURL(),
+    asset,
+  );
+  if (_customSourceTransformer) {
+    return _customSourceTransformer(resolver);
+  }
+  return resolver.defaultAsset();
+}
+
+module.exports = resolveAssetSource;
+module.exports.pickScale = AssetSourceResolver.pickScale;
+module.exports.setCustomSourceTransformer = setCustomSourceTransformer;


### PR DESCRIPTION
In React Native 0.50.*, a recent commit was added to always prepend `file://` to the JS bundle path (https://github.com/facebook/react-native/commit/b89d6c8e046b2166b28f351202be1ac56aa2f55d#diff-942c9db30202b4ea126651c2d0584255). This is incorrect behavior for react-native-windows, so overriding the `resolveAssetSource` module to ensure it doesn't happen.