### PR TITLE
fix(TextInput): Override platform defaults for `MinWidth` and `MinHeight`

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -486,12 +486,16 @@ namespace ReactNative.Views.TextInput
             view.TextChanging -= OnTextChanging;
         }
 
+        /// <summary>
+        /// Sets the dimensions of the view.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="dimensions">The dimensions.</param>
         public override void SetDimensions(ReactTextBox view, Dimensions dimensions)
         {
-            Canvas.SetLeft(view, dimensions.X);
-            Canvas.SetTop(view, dimensions.Y);
-            view.Width = dimensions.Width;
-            view.Height = dimensions.Height;
+            base.SetDimensions(view, dimensions);
+            view.MinWidth = dimensions.Width;
+            view.MinHeight = dimensions.Height;
         }
 
         /// <summary>
@@ -521,7 +525,7 @@ namespace ReactNative.Views.TextInput
             view.LostFocus += OnLostFocus;
             view.KeyDown += OnKeyDown;
         }
-        
+
         private void OnTextChanging(TextBox sender, TextBoxTextChangingEventArgs args)
         {
             var textBox = (ReactTextBox)sender;


### PR DESCRIPTION
The default `MinWidth` and `MinHeight` for TextBox is 64 x 32. Overriding these values in the `SetDimensions` method to ensure the `TextBox` abides by the layout specified by Yoga. This is reasonably safe because Yoga has it's own implementation of `minWidth` and `minHeight`.

Fixes #1369