### PR TITLE
fix(PasswordBox): Override platform defaults for `MinWidth` and `MinHeight`

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -399,10 +399,9 @@ namespace ReactNative.Views.TextInput
         /// <param name="dimensions">The output buffer.</param>
         public override void SetDimensions(PasswordBox view, Dimensions dimensions)
         {
-            Canvas.SetLeft(view, dimensions.X);
-            Canvas.SetTop(view, dimensions.Y);
-            view.Width = dimensions.Width;
-            view.Height = dimensions.Height;
+            base.SetDimensions(view, dimensions);
+            view.MinWidth = dimensions.Width;
+            view.MinHeight = dimensions.Height;
         }
 
         private void OnPasswordChanged(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The default `MinWidth` and `MinHeight` for PasswordBox is 64 x 32. Overriding these values in the `SetDimensions` method to ensure the `PasswordBox` abides by the layout specified by Yoga. This is reasonably safe because Yoga has it's own implementation of `minWidth` and `minHeight`.

Fixes #1369