### PR TITLE
implement cursor module

### DIFF
--- a/Libraries/Cursor/Cursor.windows.js
+++ b/Libraries/Cursor/Cursor.windows.js
@@ -15,7 +15,7 @@ const NativeModules = require('NativeModules');
 
 var Cursor = {
   setCursor: function(
-    cursor: ?string
+    cursor: string | number
   ): void {
     NativeModules.Cursor.setCursor(cursor)
   }

--- a/Libraries/Cursor/Cursor.windows.js
+++ b/Libraries/Cursor/Cursor.windows.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Cursor
+ * @flow
+ */
+'use strict';
+
+const NativeModules = require('NativeModules');
+
+var Cursor = {
+  setCursor: function(
+    cursor: ?string
+  ): void {
+    NativeModules.Cursor.setCursor(cursor)
+  }
+}
+
+module.exports = Cursor;

--- a/ReactWindows/ReactNative.Net46/Modules/Cursor/CursorModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Cursor/CursorModule.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Windows.Input;
+using ReactNative.Bridge;
+
+namespace ReactNative.Modules.Cursor
+{
+    class CursorModule : NativeModuleBase
+    {
+        public override string Name
+        {
+            get
+            {
+                return "Cursor";
+            }
+        }
+
+        /// <summary>
+        /// Set a mouse cursor
+        /// </summary>
+        /// <param name="cursor">The name of a system cursor (listed here: https://msdn.microsoft.com/en-us/library/system.windows.input.cursors(v=vs.110).aspx
+        ///   ) or a file path to a custom cursor.</param>
+        [ReactMethod]
+        public void setCursor(string cursor)
+        {
+            var convertedCursor = Cursors.Arrow;
+            switch (cursor.ToLowerInvariant())
+            {
+                case "appstarting":
+                    convertedCursor = Cursors.AppStarting;
+                    break;
+                case "arrow":
+                    convertedCursor = Cursors.Arrow;
+                    break;
+                case "arrowcd":
+                    convertedCursor = Cursors.ArrowCD;
+                    break;
+                case "cross":
+                    convertedCursor = Cursors.Cross;
+                    break;
+                case "hand":
+                    convertedCursor = Cursors.Hand;
+                    break;
+                case "help":
+                    convertedCursor = Cursors.Help;
+                    break;
+                case "ibeam":
+                    convertedCursor = Cursors.IBeam;
+                    break;
+                case "no":
+                    convertedCursor = Cursors.No;
+                    break;
+                case "none":
+                    convertedCursor = Cursors.None;
+                    break;
+                case "pen":
+                    convertedCursor = Cursors.Pen;
+                    break;
+                case "scrollall":
+                    convertedCursor = Cursors.ScrollAll;
+                    break;
+                case "scrolle":
+                    convertedCursor = Cursors.ScrollE;
+                    break;
+                case "scrolln":
+                    convertedCursor = Cursors.ScrollN;
+                    break;
+                case "scrollne":
+                    convertedCursor = Cursors.ScrollNE;
+                    break;
+                case "scrollns":
+                    convertedCursor = Cursors.ScrollNS;
+                    break;
+                case "scrollnw":
+                    convertedCursor = Cursors.ScrollNW;
+                    break;
+                case "scrolls":
+                    convertedCursor = Cursors.ScrollS;
+                    break;
+                case "scrollse":
+                    convertedCursor = Cursors.ScrollSE;
+                    break;
+                case "scrollsw":
+                    convertedCursor = Cursors.ScrollSW;
+                    break;
+                case "scrollw":
+                    convertedCursor = Cursors.ScrollW;
+                    break;
+                case "scrollwe":
+                    convertedCursor = Cursors.ScrollWE;
+                    break;
+                case "sizeall":
+                    convertedCursor = Cursors.SizeAll;
+                    break;
+                case "sizenesw":
+                    convertedCursor = Cursors.SizeNESW;
+                    break;
+                case "sizens":
+                    convertedCursor = Cursors.SizeNS;
+                    break;
+                case "sizenwse":
+                    convertedCursor = Cursors.SizeNWSE;
+                    break;
+                case "sizewe":
+                    convertedCursor = Cursors.SizeWE;
+                    break;
+                case "uparrow":
+                    convertedCursor = Cursors.UpArrow;
+                    break;
+                case "wait":
+                    convertedCursor = Cursors.Wait;
+                    break;
+                default:
+                    convertedCursor = null;
+                    break;
+            }
+            DispatcherHelpers.RunOnDispatcher(() =>
+            {
+                if (convertedCursor != null)
+                {
+                    Mouse.OverrideCursor = convertedCursor;
+                }
+                else
+                {
+                    Mouse.OverrideCursor = new System.Windows.Input.Cursor(cursor, true);
+                }
+            });
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Net46/Modules/Cursor/CursorModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Cursor/CursorModule.cs
@@ -18,7 +18,7 @@ namespace ReactNative.Modules.Cursor
         /// Set a mouse cursor
         /// </summary>
         /// <param name="cursor">The name of a system cursor (listed here: https://msdn.microsoft.com/en-us/library/system.windows.input.cursors(v=vs.110).aspx
-        ///   ) or a file path to a custom cursor.</param>
+        ///   ) or an absolute file path to a custom cursor.</param>
         [ReactMethod]
         public void setCursor(string cursor)
         {

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -141,6 +141,7 @@
       <DependentUpon>RedBoxDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="DevSupport\WebSocketJavaScriptExecutor.cs" />
+    <Compile Include="Modules\Cursor\CursorModule.cs" />
     <Compile Include="Modules\DeviceInfo\DeviceInfoModule.cs" />
     <Compile Include="Modules\Dialog\DialogModule.cs" />
     <Compile Include="Modules\Image\BitmapImageHelpers.cs" />

--- a/ReactWindows/ReactNative.Net46/Shell/MainReactPackage.cs
+++ b/ReactWindows/ReactNative.Net46/Shell/MainReactPackage.cs
@@ -3,6 +3,7 @@ using ReactNative.Bridge;
 using ReactNative.Modules.AppState;
 using ReactNative.Modules.Clipboard;
 using ReactNative.Modules.Core;
+using ReactNative.Modules.Cursor;
 using ReactNative.Modules.Dialog;
 using ReactNative.Modules.Image;
 using ReactNative.Modules.I18N;
@@ -44,6 +45,7 @@ namespace ReactNative.Shell
                 new AsyncStorageModule(),
                 //new CameraRollManager(reactContext),
                 new ClipboardModule(),
+                new CursorModule(),
                 new DialogModule(reactContext),
                 new ImageLoaderModule(),
                 new I18NModule(),

--- a/ReactWindows/ReactNative/Modules/Cursor/CursorModule.cs
+++ b/ReactWindows/ReactNative/Modules/Cursor/CursorModule.cs
@@ -1,0 +1,42 @@
+﻿using ReactNative.Bridge;
+using ReactNative.Reflection;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+
+namespace ReactNative.Modules.Cursor
+{
+    class CursorModule : NativeModuleBase
+    {
+        public override string Name
+        {
+            get
+            {
+                return "Cursor";
+            }
+        }
+
+        /// <summary>
+        /// Set a mouse cursor
+        /// </summary>
+        /// <param name="cursor">The name of a system cursor (listed here: https://docs.microsoft.com/en-us/uwp/api/windows.ui.core.corecursortype ).</param>
+        [ReactMethod]
+        public void setCursor(string cursor)
+        {
+            var convertedCursor = EnumHelpers.Parse<CoreCursorType>(cursor);
+            DispatcherHelpers.RunOnDispatcher(() =>
+            {
+                Window.Current.CoreWindow.PointerCursor = new CoreCursor(convertedCursor, 0);
+            });
+        }
+
+        /// <summary>
+        /// Set a mouse cursor
+        /// </summary>
+        /// <param name="cursor">The resource ID of the custom cursor</param>
+        [ReactMethod]
+        public void setCursor(uint cursor)
+        {
+            Window.Current.CoreWindow.PointerCursor = new CoreCursor(CoreCursorType.Custom, cursor);
+        }
+    }
+}

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Modules\Clipboard\ClipboardInstance.cs" />
     <Compile Include="Modules\Clipboard\ClipboardModule.cs" />
     <Compile Include="Modules\Clipboard\IClipboardInstance.cs" />
+    <Compile Include="Modules\Cursor\CursorModule.cs" />
     <Compile Include="Modules\DeviceInfo\DeviceInfoModule.cs" />
     <Compile Include="Modules\Dialog\DialogModule.cs" />
     <Compile Include="Modules\Image\ImageLoaderModule.cs" />


### PR DESCRIPTION
Totally up for suggestions on how to replace the super ugly case statement. I tried to get CursorConverter to work but it refused to work with Cursor. ☹️ 

Usage: `Cursor.setCursor('Hand');` or `Cursor.setCursor('C:\\Windows\\arrow_r.cur')`

https://msdn.microsoft.com/en-us/library/system.windows.input.cursorconverter(v=vs.110).aspx