### PR TITLE
feat(Borders): Do not create invisible borders and use Canvas.Background

### DIFF
--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -80,8 +80,13 @@ namespace ReactNative.Views.View
         /// In WPF in order to be clickable (hit-test visible) the element needs to have background brush.
         /// This is why when the background and border brushes are set on the inner Border, the Canvas gets
         /// a transparent background brush.
-        /// </summary>
-        protected readonly Brush _defaultBackgroundBrush = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0));
+        /// </summary>                
+        protected readonly Brush _defaultBackgroundBrush
+#if WINDOWS_UWP
+            = null;
+#else
+            = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0));
+#endif
 
         /// <summary>
         /// The name of this view manager. This will be the name used to 

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -31,6 +31,40 @@ namespace ReactNative.Views.View
             BottomRight,
         }
 
+        private class BorderProps
+        {
+            public uint? Color;
+            public double[] Width = new double[4] { 0, 0, 0, 0 };
+        }
+
+        private readonly Dictionary<BorderedCanvas, BorderProps> _borderProps =
+            new Dictionary<BorderedCanvas, BorderProps>();
+
+        private BorderProps GetBorderProps(BorderedCanvas view)
+        {
+            BorderProps props;
+
+            if (!_borderProps.TryGetValue(view, out props))
+            {
+                props = new BorderProps();
+                _borderProps[view] = props;
+            }
+
+            return props;
+        }
+
+        /// Canvas.Background supports flat backgrounds. Border.Background supports
+        /// backgrounds with customizations, such as rounded corners. If the background
+        /// is flat, it's set on Canvas. If it has cutomizations, it's transferred to Border.
+        private void TransferBackgroundBrush(BorderedCanvas view)
+        {
+            if (view.Background != null && view.Border != null)
+            {
+                view.Border.Background = view.Background;
+                view.Background = null;
+            }
+        }
+
         /// <summary>
         /// Default brush for the view borders.
         /// </summary>
@@ -137,39 +171,6 @@ namespace ReactNative.Views.View
         #endregion
 
         #region borders and background
-
-        private class BorderProps
-        {
-            public uint? Color;
-            public double[] Width = new double[4] { 0, 0, 0, 0 };
-        }
-
-        private Dictionary<BorderedCanvas, BorderProps> _borderProps = new Dictionary<BorderedCanvas, BorderProps>();
-
-        private BorderProps GetBorderProps(BorderedCanvas view)
-        {
-            BorderProps props;
-
-            if (!_borderProps.TryGetValue(view, out props))
-            {
-                props = new BorderProps();
-                _borderProps[view] = props;
-            }
-
-            return props;
-        }
-
-        /// Canvas.Background supports flat backgrounds. Border.Background supports
-        /// backgrounds with customizations, such as rounded corners. If the background
-        /// is flat, it's set on Canvas. If it has cutomizations, it's transferred to Border.
-        private void TransferBackgroundBrush(BorderedCanvas view)
-        {
-            if (view.Background != null && view.Border != null)
-            {
-                view.Border.Background = view.Background;
-                view.Background = null;
-            }
-        }
 
         /// <summary>
         /// Sets the border radius of the view.

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -34,7 +34,6 @@ namespace ReactNative.Views.View
         private class BorderProps
         {
             public uint? Color;
-            public double[] Width = new double[4] { 0, 0, 0, 0 };
         }
 
         private readonly Dictionary<BorderedCanvas, BorderProps> _borderProps =

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -246,6 +246,7 @@ namespace ReactNative.Views.View
             {
                 var border = GetOrCreateBorder(view);
                 border.Background = brush;
+                view.Background = view.Background ?? _defaultBackgroundBrush;
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -61,7 +61,7 @@ namespace ReactNative.Views.View
         /// Canvas.Background supports flat backgrounds. Border.Background supports
         /// backgrounds with customizations, such as rounded corners. If the background
         /// is flat, it's set on Canvas. If it has cutomizations, it's transferred to Border.
-        /// /// </summary>
+        /// </summary>
         private void TransferBackgroundBrush(BorderedCanvas view)
         {
             if (view.Background != null && view.Background != _defaultBackgroundBrush && view.Border != null)
@@ -77,7 +77,7 @@ namespace ReactNative.Views.View
         protected readonly Brush _defaultBorderBrush = new SolidColorBrush(Colors.Black);
 
         /// <summary>
-        /// In WPF in order ot be clickable (hit-test visible) the element needs to have background brush.
+        /// In WPF in order to be clickable (hit-test visible) the element needs to have background brush.
         /// This is why when the background and border brushes are set on the inner Border, the Canvas gets
         /// a transparent background brush.
         /// </summary>


### PR DESCRIPTION
There are a few properties that are currently set on `Border`:

- background color
- border color
- border width
- border radius

Since `Canvas` also has the `Background` property, the background
color can be set directly on `Canvas`, thus avoiding the need to create
an extra `Border` element. In cases when this is not possible, i.e. when
there is a non-zero border radius, the background color is transferred
to the inner `Border`.

This change also partially addresses the hit-test problem in WPF: if the
`Canvas` element doesn't have background color, it's not visible in the
hit-test tree. The issue is addressed only partially because once
the background is transferred back to `Border`, the `Canvas` becomes
invisible in the hit-test tree again.
