### PR TITLE
Revert "implement WPF TextInput blurOnSubmit (#1444)"

### DIFF
--- a/Libraries/Components/TextInput/TextInput.windows.js
+++ b/Libraries/Components/TextInput/TextInput.windows.js
@@ -681,7 +681,6 @@ var TextInput = createReactClass({
           selectionColor={this.props.selectionColor}
           text={this._getText()}
           editable={this.props.editable}
-          blurOnSubmit={this.props.blurOnSubmit}
         />;
     }
 

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -21,7 +21,6 @@ namespace ReactNative.Views.TextInput
         internal const int BlurTextInput = 2;
 
         private bool _onSelectionChange;
-        private bool? _blurOnSubmit;
 
         internal static readonly Color DefaultTextBoxBorder = Color.FromArgb(255, 122, 122, 122);
         internal static readonly Color DefaultPlaceholderTextColor = Color.FromArgb(255, 0, 0, 0);
@@ -332,10 +331,6 @@ namespace ReactNative.Views.TextInput
         {
             view.AcceptsReturn = multiline;
             view.TextWrapping = multiline ? TextWrapping.Wrap : TextWrapping.NoWrap;
-            if (_blurOnSubmit == null)
-            {
-                _blurOnSubmit = !multiline;
-            }
         }
 
         /// <summary>
@@ -389,12 +384,6 @@ namespace ReactNative.Views.TextInput
         public void SetSelectTextOnFocus(ReactTextBox view, bool selectTextOnFocus)
         {
             view.SelectTextOnFocus = selectTextOnFocus;
-        }
-
-        [ReactProp("blurOnSubmit")]
-        public void SetBlurOnSubmit(ReactTextBox view, bool blurOnSubmit)
-        {
-            _blurOnSubmit = blurOnSubmit;
         }
 
         /// <summary>
@@ -488,7 +477,7 @@ namespace ReactNative.Views.TextInput
         public override void OnDropViewInstance(ThemedReactContext reactContext, ReactTextBox view)
         {
             base.OnDropViewInstance(reactContext, view);
-            view.PreviewKeyDown -= OnKeyDown;
+            view.KeyDown -= OnKeyDown;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
             view.TextChanged -= OnTextChanged;
@@ -526,7 +515,7 @@ namespace ReactNative.Views.TextInput
             view.TextChanged += OnTextChanged;
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
-            view.PreviewKeyDown += OnKeyDown;
+            view.KeyDown += OnKeyDown;
         }
 
         private void OnTextChanged(object sender, TextChangedEventArgs e)
@@ -572,20 +561,12 @@ namespace ReactNative.Views.TextInput
         
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
-            var shiftModifier = (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift;
-            var controlModifier = (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control;
-            var blurOnSubmit = (_blurOnSubmit.HasValue && _blurOnSubmit.Value);
-
-            if (e.Key == Key.Enter && !shiftModifier)
+            if (e.Key == Key.Enter)
             {
                 var textBox = (ReactTextBox)sender;
-                if (!textBox.AcceptsReturn || blurOnSubmit || controlModifier)
+                if (!textBox.AcceptsReturn)
                 {
                     e.Handled = true;
-                    if (blurOnSubmit)
-                    {
-                        Keyboard.ClearFocus();
-                    }
                     textBox.GetReactContext()
                         .GetNativeModule<UIManagerModule>()
                         .EventDispatcher


### PR DESCRIPTION
Reverts Microsoft/react-native-windows#1444

This isn't implemented properly. There's a boolean at the root level of a view manager when view managers are responsible for many text inputs. By setting `blurOnSubmit` on one TextInput, you're effectively doing it for all of them with this PR.