### PR TITLE
fix(TextInput): Don't set component props to fields on ViewManager

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
@@ -19,8 +19,6 @@ namespace ReactNative.Views.TextInput
     {
         internal const int FocusTextInput = 1;
         internal const int BlurTextInput = 2;
-
-        private bool _onSelectionChange;
 
         internal static readonly Color DefaultTextBoxBorder = Color.FromArgb(255, 122, 122, 122);
         internal static readonly Color DefaultPlaceholderTextColor = Color.FromArgb(255, 0, 0, 0);
@@ -187,18 +185,9 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The view instance.</param>
         /// <param name="onSelectionChange">The indicator.</param>
         [ReactProp("onSelectionChange", DefaultBoolean = false)]
-        public void SetSelectionChange(ReactTextBox view, bool onSelectionChange)
+        public void SetOnSelectionChange(ReactTextBox view, bool onSelectionChange)
         {
-            if (onSelectionChange)
-            {
-                _onSelectionChange = true;
-                view.SelectionChanged += OnSelectionChanged;
-            }
-            else
-            {
-                _onSelectionChange = false;
-                view.SelectionChanged -= OnSelectionChanged;
-            }
+            view.OnSelectionChange = onSelectionChange;
         }
 
         /// <summary>
@@ -440,12 +429,13 @@ namespace ReactNative.Views.TextInput
                 {
                     return;
                 }
-                
+
                 view.TextChanged -= OnTextChanged;
 
-                if (_onSelectionChange)
+                var removeOnSelectionChange = view.OnSelectionChange;
+                if (removeOnSelectionChange)
                 {
-                    view.SelectionChanged -= OnSelectionChanged;
+                    view.OnSelectionChange = false;
                 }
 
                 var text = textUpdate.Item2;
@@ -458,9 +448,9 @@ namespace ReactNative.Views.TextInput
                 view.SelectionStart = Math.Min(selectionStart, textLength);
                 view.SelectionLength = Math.Min(selectionLength, maxLength < 0 ? 0 : maxLength);
 
-                if (_onSelectionChange)
+                if (removeOnSelectionChange)
                 {
-                    view.SelectionChanged += OnSelectionChanged;
+                    view.OnSelectionChange = true;
                 }
 
                 view.TextChanged += OnTextChanged;
@@ -558,7 +548,7 @@ namespace ReactNative.Views.TextInput
                       textBox.GetTag(),
                       textBox.Text));
         }
-        
+
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Enter)
@@ -576,21 +566,6 @@ namespace ReactNative.Views.TextInput
                                 textBox.Text));
                 }
             }
-        }
-
-        private void OnSelectionChanged(object sender, RoutedEventArgs e)
-        {
-            var textBox = (ReactTextBox)sender;
-            var start = textBox.SelectionStart;
-            var length = textBox.SelectionLength;
-            textBox.GetReactContext()
-                .GetNativeModule<UIManagerModule>()
-                .EventDispatcher
-                .DispatchEvent(
-                    new ReactTextInputSelectionEvent(
-                        textBox.GetTag(),
-                        start,
-                        start + length));
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextBox.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextBox.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.UIManager;
+using ReactNative.UIManager;
 using System.Threading;
 #if WINDOWS_UWP
 using Windows.UI.Xaml;
@@ -13,6 +13,7 @@ namespace ReactNative.Views.TextInput
     class ReactTextBox : TextBox
     {
         private int _eventCount;
+        private bool _selectionChangedSubscribed;
 
         public ReactTextBox()
         {
@@ -37,6 +38,29 @@ namespace ReactNative.Views.TextInput
         {
             get;
             set;
+        }
+
+        public bool OnSelectionChange
+        {
+            get
+            {
+                return _selectionChangedSubscribed;
+            }
+            set
+            {
+                if (value != _selectionChangedSubscribed)
+                {
+                    _selectionChangedSubscribed = value;
+                    if (_selectionChangedSubscribed)
+                    {
+                        this.SelectionChanged += OnSelectionChanged;
+                    }
+                    else
+                    {
+                        this.SelectionChanged -= OnSelectionChanged;
+                    }
+                }
+            }
         }
 
         public int IncrementEventCount()
@@ -71,6 +95,20 @@ namespace ReactNative.Views.TextInput
                         e.NewSize.Width,
                         e.NewSize.Height,
                         IncrementEventCount()));
+        }
+
+        private void OnSelectionChanged(object sender, RoutedEventArgs e)
+        {
+            var start = this.SelectionStart;
+            var length = this.SelectionLength;
+            this.GetReactContext()
+                .GetNativeModule<UIManagerModule>()
+                .EventDispatcher
+                .DispatchEvent(
+                    new ReactTextInputSelectionEvent(
+                        this.GetTag(),
+                        start,
+                        start + length));
         }
     }
 }

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -47,8 +47,6 @@ namespace ReactNative.Views.TextInput
         private const uint DefaultTextControlBorderBrushFocused = 0xFF298FCC;
         private const uint DefaultTextControlBorderBrushDisabled = 0x33000000;
 
-        private bool _onSelectionChange;
-
         /// <summary>
         /// The name of the view manager.
         /// </summary>
@@ -223,18 +221,9 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The view instance.</param>
         /// <param name="onSelectionChange">The indicator.</param>
         [ReactProp("onSelectionChange", DefaultBoolean = false)]
-        public void SetSelectionChange(ReactTextBox view, bool onSelectionChange)
+        public void SetOnSelectionChange(ReactTextBox view, bool onSelectionChange)
         {
-            if (onSelectionChange)
-            {
-                _onSelectionChange = true;
-                view.SelectionChanged += OnSelectionChanged;
-            }
-            else
-            {
-                _onSelectionChange = false;
-                view.SelectionChanged -= OnSelectionChanged;
-            }
+            view.OnSelectionChange = onSelectionChange;
         }
 
         /// <summary>
@@ -513,9 +502,10 @@ namespace ReactNative.Views.TextInput
                 view.TextChanging -= OnTextChanging;
                 view.TextChanged -= OnTextChanged;
 
-                if (_onSelectionChange)
+                var removeOnSelectionChange = view.OnSelectionChange;
+                if (removeOnSelectionChange)
                 {
-                    view.SelectionChanged -= OnSelectionChanged;
+                    view.OnSelectionChange = false;
                 }
 
                 var text = textUpdate.Item2;
@@ -528,9 +518,9 @@ namespace ReactNative.Views.TextInput
                 view.SelectionStart = Math.Min(selectionStart, textLength);
                 view.SelectionLength = Math.Min(selectionLength, maxLength < 0 ? 0 : maxLength);
 
-                if (_onSelectionChange)
+                if (removeOnSelectionChange)
                 {
-                    view.SelectionChanged += OnSelectionChanged;
+                    view.OnSelectionChange = true;
                 }
 
                 view.TextChanged += OnTextChanged;
@@ -659,21 +649,6 @@ namespace ReactNative.Views.TextInput
                                 textBox.Text));
                 }
             }
-        }
-
-        private void OnSelectionChanged(object sender, RoutedEventArgs e)
-        {
-            var textBox = (ReactTextBox)sender;
-            var start = textBox.SelectionStart;
-            var length = textBox.SelectionLength;
-            textBox.GetReactContext()
-                .GetNativeModule<UIManagerModule>()
-                .EventDispatcher
-                .DispatchEvent(
-                    new ReactTextInputSelectionEvent(
-                        textBox.GetTag(),
-                        start,
-                        start + length));
         }
     }
 }


### PR DESCRIPTION
A setting on a single TextInput has the potential to affect all other TextInput's `onSelectionChange` behavior. This makes the setting local to a single <TextInput/> component.