### PR TITLE
fix(PasswordBox): Do not blur if PasswordBox not focused

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -424,8 +424,11 @@ namespace ReactNative.Views.TextInput
             }
             else if (commandId == ReactTextInputManager.BlurTextInput)
             {
-                var frame = Window.Current?.Content as Frame;
-                frame?.Focus(FocusState.Programmatic);
+                if (FocusManager.GetFocusedElement() == view)
+                {
+                    var frame = Window.Current?.Content as Frame;
+                    frame?.Focus(FocusState.Programmatic);
+                }
             }
         }
 


### PR DESCRIPTION
Ensure that the blur command, which works by focusing on the current window Frame, does not execute if the PasswordBox does not currently have focus.