### PR TITLE
fix(TextInput): Ensure cursor stays at end of TextInput

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -512,15 +512,22 @@ namespace ReactNative.Views.TextInput
                 }
 
                 var text = textUpdate.Item2;
+                var previousText = view.Text;
                 var selectionStart = view.SelectionStart;
                 var selectionLength = view.SelectionLength;
                 var textLength = text?.Length ?? 0;
                 var maxLength = textLength - selectionLength;
 
                 view.Text = text ?? "";
-
-                view.SelectionStart = Math.Min(selectionStart, textLength);
-                view.SelectionLength = Math.Min(selectionLength, maxLength < 0 ? 0 : maxLength);
+                if (selectionStart == previousText.Length)
+                {
+                    view.SelectionStart = textLength;
+                }
+                else
+                {
+                    view.SelectionStart = Math.Min(selectionStart, textLength);
+                    view.SelectionLength = Math.Min(selectionLength, maxLength < 0 ? 0 : maxLength);
+                }
 
                 if (removeOnSelectionChange)
                 {


### PR DESCRIPTION
When `value` or `defaultValue` is set on the TextInput, if the cursor started at the end, it should remain at the end after the text is updated.

Towards #1109