### PR TITLE
fix(TextInput): workaround for Yoga bug

### DIFF
--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextBox.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextBox.cs
@@ -88,6 +88,12 @@ namespace ReactNative.Views.TextInput
             set;
         }
 
+        public bool DimensionsUpdated
+        {
+            get;
+            set;
+        }
+
         public int IncrementEventCount()
         {
             return Interlocked.Increment(ref _eventCount);
@@ -111,6 +117,12 @@ namespace ReactNative.Views.TextInput
 
         private void OnSizeChanged(object sender, SizeChangedEventArgs e)
         {
+            if (DimensionsUpdated)
+            {
+                DimensionsUpdated = false;
+                return;
+            }
+
             this.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -621,17 +621,13 @@ namespace ReactNative.Views.TextInput
         /// <param name="dimensions">The dimensions.</param>
         public override void SetDimensions(ReactTextBox view, Dimensions dimensions)
         {
-            var removeContentSizeChange = view.OnContentSizeChange;
-            if (removeContentSizeChange)
-            {
-                view.OnContentSizeChange = false;
-            }
-
             view.MinWidth = dimensions.Width;
             view.MinHeight = dimensions.Height;
 
             if (view.AutoGrow)
             {
+                // TODO: investigate Yoga bug that rounds up height 1px
+                view.DimensionsUpdated = true;
                 Canvas.SetLeft(view, dimensions.X);
                 Canvas.SetTop(view, dimensions.Y);
                 view.Width = dimensions.Width;
@@ -639,11 +635,6 @@ namespace ReactNative.Views.TextInput
             else
             {
                 base.SetDimensions(view, dimensions);
-            }
-
-            if (removeContentSizeChange)
-            {
-                view.OnContentSizeChange = true;
             }
         }
 


### PR DESCRIPTION
There seems to be a bug with Yoga that increments the height of an auto-growing TextInput and creates an endless feedback loop. This adds a small hack to ensure that the next `SizeChanged` event is not fired after a `SetDimensions` call.