### PR TITLE
feat(BackgroundSerialization): Generate bytecode in a background thread

### DIFF
--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -271,22 +271,13 @@ JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t
 {
     HANDLE hFile = NULL;
     HANDLE hMap = NULL;
-    JsErrorCode status = JsNoError;
-    ULONG bufferSize = 0L;
     BYTE* buffer = nullptr;
     wchar_t* szScriptBuffer = nullptr;
     IfFailRet(LoadFileContents(szPath, &szScriptBuffer));
 
     if (!CompareLastWrite(szSerializedPath, szPath))
     {
-        IfFailRet(JsSerializeScript(szScriptBuffer, buffer, &bufferSize));
-        buffer = new BYTE[bufferSize];
-        IfFailRet(JsSerializeScript(szScriptBuffer, buffer, &bufferSize));
-
-        FILE* file;
-        _wfopen_s(&file, szSerializedPath, L"wb");
-        fwrite(buffer, sizeof(BYTE), bufferSize, file);
-        fclose(file);
+        return JsErrorBadSerializedScript;
     }
     else
     {
@@ -300,7 +291,7 @@ JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t
     context->mapHandle = hMap;
 
     IfFailRet(JsRunSerializedScriptWithCallback(&LoadSourceCallback, &UnloadSourceCallback, buffer, (JsSourceContext)context, szSourceUri, result));
-    return status;
+    return JsNoError;
 }
 
 JsErrorCode ChakraHost::RunScript(const wchar_t* szFileName, const wchar_t* szSourceUri, JsValueRef* result)

--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "ChakraHost.h"
 #include "JsIndexedModulesUnbundle.h"
 #include "JsStringify.h"
@@ -243,6 +243,28 @@ bool IsUnbundle(const wchar_t* szSourcePath)
 bool IsIndexedUnbundle(const wchar_t* szSourcePath)
 {
 	return HasMagicFileHeader(szSourcePath);
+}
+
+JsErrorCode ChakraHost::SerializeScript(const wchar_t* szPath, const wchar_t* szSerializedPath)
+{
+    ULONG bufferSize = 0L;
+    BYTE* buffer = nullptr;
+    wchar_t* szScriptBuffer = nullptr;
+    IfFailRet(LoadFileContents(szPath, &szScriptBuffer));
+
+    if (!CompareLastWrite(szSerializedPath, szPath))
+    {
+        IfFailRet(JsSerializeScript(szScriptBuffer, buffer, &bufferSize));
+        buffer = new BYTE[bufferSize];
+        IfFailRet(JsSerializeScript(szScriptBuffer, buffer, &bufferSize));
+
+        FILE* file;
+        _wfopen_s(&file, szSerializedPath, L"wb");
+        fwrite(buffer, sizeof(BYTE), bufferSize, file);
+        fclose(file);
+    }
+
+    return JsNoError;
 }
 
 JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t* szSerializedPath, const wchar_t* szSourceUri, JsValueRef* result)

--- a/ReactWindows/ChakraBridge/ChakraHost.h
+++ b/ReactWindows/ChakraBridge/ChakraHost.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "pch.h"
 #include "JsModulesUnbundle.h"
@@ -61,6 +61,11 @@ public:
     /// JsNoError is no error, else a JsErrorCode with the appropriate error.
     /// </returns>
     JsErrorCode RunScript(const wchar_t* szPath, const wchar_t* szSourceUri, JsValueRef* result);
+
+    /// <summary>
+    /// Serializes the script and writes the bytecode to the specified file.
+    /// </summary>
+    JsErrorCode SerializeScript(const wchar_t* szPath, const wchar_t* szSerializedPath);
 
     /// <summary>
     /// Runs the serialized script from the serialized file location with source file path, source URI and returns the <see cref="JsValueRef" /> result.

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
@@ -50,6 +50,12 @@ int NativeJavaScriptExecutor::RunScript(String^ source, String^ sourceUri)
     return JsNoError;
 }
 
+int NativeJavaScriptExecutor::SerializeScript(String^ source, String^ serialized)
+{
+    IfFailRet(this->host.SerializeScript(source->Data(), serialized->Data()));
+    return JsNoError;
+}
+
 int NativeJavaScriptExecutor::RunSerializedScript(String^ source, String^ serialized, String^ sourceUri)
 {
     JsValueRef result;

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
@@ -59,6 +59,8 @@ public:
     /// </returns>
     int RunScript(String^ source, String^ sourceUri);
 
+    int SerializeScript(String^ source, String^ serialized);
+
     /// <summary>
     /// Runs the given serialized script with the source URI and returns the result.
     /// </summary>

--- a/ReactWindows/Playground/MainReactNativeHost.cs
+++ b/ReactWindows/Playground/MainReactNativeHost.cs
@@ -1,6 +1,9 @@
 using ReactNative;
+using ReactNative.Bridge;
+using ReactNative.Chakra.Executor;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
+using System;
 using System.Collections.Generic;
 
 namespace Playground
@@ -8,6 +11,9 @@ namespace Playground
     class MainReactNativeHost : ReactNativeHost
     {
         public override string MainComponentName => "Playground";
+
+        protected override Func<IJavaScriptExecutor> JavaScriptExecutorFactory =>
+            () => new NativeJavaScriptExecutor(SerializationMode.Background);
 
 #if !BUNDLE || DEBUG
         public override bool UseDeveloperSupport => true;

--- a/ReactWindows/Playground/MainReactNativeHost.cs
+++ b/ReactWindows/Playground/MainReactNativeHost.cs
@@ -1,9 +1,6 @@
 using ReactNative;
-using ReactNative.Bridge;
-using ReactNative.Chakra.Executor;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
-using System;
 using System.Collections.Generic;
 
 namespace Playground
@@ -11,9 +8,6 @@ namespace Playground
     class MainReactNativeHost : ReactNativeHost
     {
         public override string MainComponentName => "Playground";
-
-        protected override Func<IJavaScriptExecutor> JavaScriptExecutorFactory =>
-            () => new NativeJavaScriptExecutor(SerializationMode.Background);
 
 #if !BUNDLE || DEBUG
         public override bool UseDeveloperSupport => true;

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -113,18 +113,18 @@ namespace ReactNative.Chakra.Executor
 
                 if (_useSerialization)
                 {
+                    var srcFileInfo = new FileInfo(sourcePath);
                     var binFileInfo = new FileInfo(binPath);
 
-                    if (binFileInfo.Exists)
+                    // The idea is to run the JS bundle and generate bytecode for it on a background thread.
+                    // This eliminates the need to delay the first start when the app doesn't have bytecode.
+                    // Next time the app starts, it checks if bytecode is still good and  runs it directly.
+                    if (binFileInfo.Exists && binFileInfo.LastWriteTime > srcFileInfo.LastWriteTime)
                     {
-                        // This function checks if the bytecode file matches the JS bundle and makes
-                        // a new bytecode file if necessary, but it does this on the same thread.
                         Native.ThrowIfError((JavaScriptErrorCode)_executor.RunSerializedScript(sourcePath, binPath, sourceUrl));
                     }
                     else
                     {
-                        // If the bytecode file doesn't exist yet, create it on a background thread,
-                        // while loading the JS bundle on the current thread.
                         Task.Run(() =>
                         {
                             try


### PR DESCRIPTION
Before this change RNW did serialization on the same thread: first it generated
bytecode and saved it to a file, then it loaded the bytecode. Now RNW creates
a background thread where it creates the 2nd JSRT execution context and uses
it to generate the bytecode, while the primary JS thread is loading the raw JS.
The 2nd execution context is necessary because JSRT allows an execution context
to run on one thread at a time (it can jump between threads, but cannot run on
two threads simultaneously).