### PR TITLE
Fix DependencyObjectData leak

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Collections;
 using ReactNative.Modules.Image;
 using ReactNative.UIManager;
@@ -246,6 +246,12 @@ namespace ReactNative.Views.Image
 
         private void OnImageFailed(Border view)
         {
+            if (!view.HasTag())
+            {
+                // View may have been unmounted, ignore.
+                return;
+            }
+
             view.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher
@@ -257,6 +263,12 @@ namespace ReactNative.Views.Image
 
         private void OnImageStatusUpdate(Border view, ImageStatusEventData status)
         {
+            if (!view.HasTag())
+            {
+                // View may have been unmounted, ignore.
+                return;
+            }
+
             var eventDispatcher = view.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher;

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -627,6 +627,7 @@ namespace ReactNative.UIManager
 
             _tagsToViews.Remove(tag);
             _tagsToViewManagers.Remove(tag);
+            view.ClearData();
         }
 
         private void UpdateLayout(DependencyObject viewToUpdate, IViewManager viewManager, Dimensions dimensions)

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -1,4 +1,4 @@
-﻿using ImagePipeline.Core;
+using ImagePipeline.Core;
 using ImagePipeline.Request;
 using Newtonsoft.Json.Linq;
 using ReactNative.Collections;
@@ -235,6 +235,12 @@ namespace ReactNative.Views.Image
 
         private void OnImageFailed(Border view)
         {
+            if (!view.HasTag())
+            {
+                // View may have been unmounted, ignore.
+                return;
+            }
+
             view.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher
@@ -246,6 +252,12 @@ namespace ReactNative.Views.Image
 
         private void OnImageStatusUpdate(Border view, ImageLoadStatus status, ImageMetadata metadata)
         {
+            if (!view.HasTag())
+            {
+                // View may have been unmounted, ignore.
+                return;
+            }
+
             var eventDispatcher = view.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher;


### PR DESCRIPTION
DependencyObjectExtensions maintains DependencyObjectData objects attached to each native view. 
There is a ClearData cleanup method that's supposed to be called when a view is destroyed, but the current code doesn't do that.
As a result memory usage increases during the life time of an application.
The fix is to call ClearData from NativeViewHierarchyManager.DropView.

This exposes some cases where some asynchronous completion of an operation initiated by a view happens after the view is unmounted. Added some checks to prevent exceptions in one of these cases.
There may be other cases as well!

A more ideal solution would do the cleanup when the view reaches a reference count of 0, but that would require some major changes of the view lifetime, etc.