### PR TITLE
fix(Image): Update ImagePipeline to v0.1.1.

### DIFF
--- a/ReactWindows/ReactNative/Modules/Image/ImageLoaderModule.cs
+++ b/ReactWindows/ReactNative/Modules/Image/ImageLoaderModule.cs
@@ -126,7 +126,7 @@ namespace ReactNative.Modules.Image
             foreach (var url in urls)
             {
                 var uri = new Uri(url);
-                if (imagePipeline.IsInBitmapMemoryCache(uri))
+                if (imagePipeline.IsInEncodedMemoryCache(uri))
                 {
                     result.Add(url, "memory");
                 }

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -271,19 +271,7 @@ namespace ReactNative.Views.Image
             try
             {
                 var imagePipeline = ImagePipelineFactory.Instance.GetImagePipeline();
-                var image = default(BitmapSource);
-                var uri = new Uri(source);
-
-                // Remote images
-                if (source.StartsWith("http:") || source.StartsWith("https:"))
-                {
-                    image = await imagePipeline.FetchEncodedBitmapImageAsync(uri);                   
-                }
-                else // Base64 or local images
-                {
-                    image = await imagePipeline.FetchDecodedBitmapImageAsync(ImageRequest.FromUri(uri));
-                }
-
+                var image = await imagePipeline.FetchEncodedBitmapImageAsync(new Uri(source));
                 var metadata = new ImageMetadata(source, image.PixelWidth, image.PixelHeight);
                 OnImageStatusUpdate(view, ImageLoadStatus.OnLoad, metadata);
                 imageBrush.ImageSource = image;

--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Facebook.Yoga": "1.5.0-pre1",
-    "fresco.imagepipeline": "0.0.8",
+    "fresco.imagepipeline": "0.1.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.1",
     "Newtonsoft.Json": "9.0.1",
     "OpenCover": "4.6.519",


### PR DESCRIPTION
**Improvements**

- Local images are now fetched as [BitmapImage](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.imaging.bitmapimage) instead of [WriteableBitmap](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.imaging.writeablebitmap).
- Supporting fetching images from [FutureAccessList](https://docs.microsoft.com/en-us/uwp/api/windows.storage.accesscache.storageapplicationpermissions#Windows_Storage_AccessCache_StorageApplicationPermissions_FutureAccessList) (_urn:future-access-list:{GUID}_).

This fixes #1557 #1463 #1492 after landing.

cc @antonkh 
  