### PR TITLE
Make RNW 0.46 compatible with RN 0.46.4

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.windows.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.windows.js
@@ -15,6 +15,7 @@ const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const React = require('React');
+const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
@@ -36,7 +37,8 @@ type DefaultProps = {
 /**
  * Displays a circular loading indicator.
  */
-const ActivityIndicator = React.createClass({
+const ActivityIndicator = createReactClass({
+  displayName: 'ActivityIndicator',
   mixins: [NativeMethodsMixin],
 
   propTypes: {
@@ -102,7 +104,7 @@ const ActivityIndicator = React.createClass({
         />
       </View>
     );
-  }
+  },
 });
 
 const styles = StyleSheet.create({

--- a/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
+++ b/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
@@ -6,14 +6,13 @@
  */
 'use strict';
 
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var UIManager = require('UIManager');
 var View = require('View');
 
 var requireNativeComponent = require('requireNativeComponent');
-
-var ReactPropTypes = React.PropTypes;
 
 var FLIPVIEW_REF = 'flipView';
 
@@ -66,12 +65,12 @@ var FlipViewWindows = React.createClass({
      * Index of initial page that should be selected. Use `setPage` method to
      * update the page, and `onSelectionChange` to monitor page changes
      */
-    initialPage: ReactPropTypes.number,
+    initialPage: PropTypes.number,
 
     /**
      * Indicates whether `setPage` calls should be animated.
      */
-    alwaysAnimate: ReactPropTypes.bool,
+    alwaysAnimate: PropTypes.bool,
     
     /**
      * This callback when FlipView selection is changed (when user swipes between
@@ -79,7 +78,7 @@ var FlipViewWindows = React.createClass({
      * following fields:
      *  - position - index of page that has been selected
      */
-    onSelectionChange: ReactPropTypes.func,
+    onSelectionChange: PropTypes.func,
   },
 
   componentDidMount: function() {

--- a/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
+++ b/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
@@ -10,7 +10,7 @@ var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var UIManager = require('UIManager');
-var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 
 var requireNativeComponent = require('requireNativeComponent');
 
@@ -60,7 +60,7 @@ type Event = Object;
 var FlipViewWindows = React.createClass({
 
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     /**
      * Index of initial page that should be selected. Use `setPage` method to
      * update the page, and `onSelectionChange` to monitor page changes

--- a/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
+++ b/Libraries/Components/FlipViewWindows/FlipViewWindows.windows.js
@@ -57,9 +57,14 @@ type Event = Object;
  * }
  * ```
  */
-var FlipViewWindows = React.createClass({
+class FlipViewWindows extends React.Component {
+  props: {
+    initialPage?: number,
+    alwaysAnimate?: boolean,
+    onSelectionChange?: Function,
+  };
 
-  propTypes: {
+  static propTypes = {
     ...ViewPropTypes,
     /**
      * Index of initial page that should be selected. Use `setPage` method to
@@ -79,19 +84,19 @@ var FlipViewWindows = React.createClass({
      *  - position - index of page that has been selected
      */
     onSelectionChange: PropTypes.func,
-  },
+  };
 
-  componentDidMount: function() {
+  componentDidMount() {
     if (this.props.initialPage) {
       this.setPage(this.props.initialPage);
     }
-  },
-  
-  getInnerViewNode: function(): ReactComponent<*,*,*> {
-    return this.refs[FLIPVIEW_REF].getInnerViewNode();
-  },
+  }
 
-  _childrenWithOverridenStyle: function(): Array<*> {
+  getInnerViewNode = (): ReactComponent<*,*,*> => {
+    return this.refs[FLIPVIEW_REF].getInnerViewNode();
+  };
+
+  _childrenWithOverridenStyle = (): Array<*> => {
     // Override styles so that each page will fill the parent. Native component
     // will handle positioning of elements, so it's not important to offset
     // them correctly.
@@ -120,26 +125,26 @@ var FlipViewWindows = React.createClass({
       }
       return React.createElement(child.type, newProps);
     });
-  },
+  };
 
-  _onSelectionChange: function(e: Event) {
+  _onSelectionChange = (e: Event) => {
     if (this.props.onSelectionChange) {
       this.props.onSelectionChange(e);
     }
-  },
+  };
 
   /**
    * A helper function to switch to a specific page in the FlipView.
    */
-  setPage: function(selectedPage: number) {
+  setPage = (selectedPage: number) => {
     UIManager.dispatchViewManagerCommand(
       ReactNative.findNodeHandle(this),
       UIManager.WindowsFlipView.Commands.setPage,
       [selectedPage],
     );
-  },
+  };
 
-  render: function() {
+  render() {
     return (
       <NativeWindowsFlipView
         ref={FLIPVIEW_REF}
@@ -150,8 +155,8 @@ var FlipViewWindows = React.createClass({
         children={this._childrenWithOverridenStyle()}
       />
     );
-  },
-});
+  }
+}
 
 var NativeWindowsFlipView = requireNativeComponent('WindowsFlipView', FlipViewWindows);
 

--- a/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
+++ b/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
@@ -16,6 +16,7 @@ var EventEmitter = require('EventEmitter');
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var Text = require('Text');
@@ -49,7 +50,9 @@ type Event = Object;
  *   />
  * ```
  */
-var PasswordBoxWindows = React.createClass({
+var PasswordBoxWindows = createReactClass({
+  displayName: 'PasswordBoxWindows',
+
   statics: {
     /* TODO(brentvatne) docs are needed for this */
     State: TextInputState,
@@ -387,7 +390,6 @@ var PasswordBoxWindows = React.createClass({
       </TouchableWithoutFeedback>
     );
   },
-
 
   _onFocus: function(event: Event) {
     if (this.props.onFocus) {

--- a/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
+++ b/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
@@ -23,7 +23,7 @@ var TextInputState = require('TextInputState');
 var TimerMixin = require('react-timer-mixin');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 
-var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 
 var requireNativeComponent = require('requireNativeComponent');
 
@@ -56,7 +56,7 @@ var PasswordBoxWindows = React.createClass({
   },
 
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     /**
      * If false, disables auto-correct. The default value is true.
      */

--- a/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
+++ b/Libraries/Components/PasswordBoxWindows/PasswordBoxWindows.windows.js
@@ -14,6 +14,7 @@
 var DocumentSelectionState = require('DocumentSelectionState');
 var EventEmitter = require('EventEmitter');
 var NativeMethodsMixin = require('NativeMethodsMixin');
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
@@ -21,11 +22,10 @@ var Text = require('Text');
 var TextInputState = require('TextInputState');
 var TimerMixin = require('react-timer-mixin');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
+
 var View = require('View');
 
 var requireNativeComponent = require('requireNativeComponent');
-
-var PropTypes = React.PropTypes;
 
 var NativePasswordBox = requireNativeComponent('PasswordBoxWindows', null);
 
@@ -293,8 +293,8 @@ var PasswordBoxWindows = React.createClass({
   },
 
   contextTypes: {
-    onFocusRequested: React.PropTypes.func,
-    focusEmitter: React.PropTypes.instanceOf(EventEmitter),
+    onFocusRequested: PropTypes.func,
+    focusEmitter: PropTypes.instanceOf(EventEmitter),
   },
 
   _focusSubscription: (undefined: ?Function),
@@ -335,7 +335,7 @@ var PasswordBoxWindows = React.createClass({
   },
 
   childContextTypes: {
-    isInAParentText: React.PropTypes.bool
+    isInAParentText: PropTypes.bool
   },
 
   /**

--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -13,16 +13,16 @@
 'use strict';
 
 var ColorPropType = require('ColorPropType');
+var PropTypes = require('prop-types');
 var React = require('React');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
 var View = require('View');
+
 var ViewStylePropTypes = require('ViewStylePropTypes');
-
 var processColor = require('processColor');
-var requireNativeComponent = require('requireNativeComponent');
 
-var ReactPropTypes = React.PropTypes;
+var requireNativeComponent = require('requireNativeComponent');
 
 var REF_PICKER = 'picker';
 
@@ -41,9 +41,9 @@ var PickerWindows = React.createClass({
   propTypes: {
     ...View.propTypes,
     style: pickerStyleType,
-    items: React.PropTypes.any,
-    selected: React.PropTypes.number,
-    selectedValue: React.PropTypes.any,
+    items: PropTypes.any,
+    selected: PropTypes.number,
+    selectedValue: PropTypes.any,
     enabled: ReactPropTypes.bool,
     onValueChange: ReactPropTypes.func,
     prompt: ReactPropTypes.string,

--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -44,10 +44,10 @@ var PickerWindows = React.createClass({
     items: PropTypes.any,
     selected: PropTypes.number,
     selectedValue: PropTypes.any,
-    enabled: ReactPropTypes.bool,
-    onValueChange: ReactPropTypes.func,
-    prompt: ReactPropTypes.string,
-    testID: ReactPropTypes.string,
+    enabled: PropTypes.bool,
+    onValueChange: PropTypes.func,
+    prompt: PropTypes.string,
+    testID: PropTypes.string,
   },
 
   getInitialState: function() {

--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -17,7 +17,7 @@ var PropTypes = require('prop-types');
 var React = require('React');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
-var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 
 var ViewStylePropTypes = require('ViewStylePropTypes');
 var processColor = require('processColor');
@@ -39,7 +39,7 @@ type Event = Object;
 var PickerWindows = React.createClass({
 
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     style: pickerStyleType,
     items: PropTypes.any,
     selected: PropTypes.number,

--- a/Libraries/Components/Picker/PickerWindows.js
+++ b/Libraries/Components/Picker/PickerWindows.js
@@ -36,9 +36,19 @@ type Event = Object;
 /**
  * Not exposed as a public API - use <Picker> instead.
  */
-var PickerWindows = React.createClass({
+class PickerWindows extends React.Component {
+  props: {
+    style?: $FlowFixMe,
+    items?: any,
+    selected?: number,
+    selectedValue?: any,
+    enabled?: boolean,
+    onValueChange?: Function,
+    prompt?: string,
+    testID?: string,
+  };
 
-  propTypes: {
+  static propTypes = {
     ...ViewPropTypes,
     style: pickerStyleType,
     items: PropTypes.any,
@@ -48,18 +58,14 @@ var PickerWindows = React.createClass({
     onValueChange: PropTypes.func,
     prompt: PropTypes.string,
     testID: PropTypes.string,
-  },
+  };
 
-  getInitialState: function() {
-    return this._stateFromProps(this.props);
-  },
-
-  componentWillReceiveProps: function(nextProps: Object) {
+  componentWillReceiveProps(nextProps: Object) {
     this.setState(this._stateFromProps(nextProps));
-  },
+  }
 
   // Translate prop and children into stuff that the native picker understands.
-  _stateFromProps: function(props) {
+  _stateFromProps = (props) => {
     var selectedIndex = 0;
     let items = React.Children.map(props.children, (child, index) => {
       if (child.props.value === props.selectedValue) {
@@ -78,9 +84,9 @@ var PickerWindows = React.createClass({
       return childProps;
     });
     return {selectedIndex, items};
-  },
-  
-  render: function() {
+  };
+
+  render() {
     var Picker = ComboBoxPicker;
 
     var nativeProps = {
@@ -94,9 +100,9 @@ var PickerWindows = React.createClass({
     };
 
     return <Picker ref={REF_PICKER} {...nativeProps} />;
-  },
+  }
 
-  _onChange: function(event: Object) {
+  _onChange = (event: Object) => {
     if (this.props.onValueChange) {
       var position = event.nativeEvent.position;
       if (position >= 0) {
@@ -116,8 +122,10 @@ var PickerWindows = React.createClass({
     if (this.refs[REF_PICKER] && this.state.selectedIndex !== event.nativeEvent.position) {
       this.refs[REF_PICKER].setNativeProps({selected: this.state.selectedIndex});
     }
-  },
-});
+  };
+
+  state = this._stateFromProps(this.props);
+}
 
 var cfg = {
   nativeOnly: {

--- a/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
+++ b/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
@@ -19,34 +19,38 @@ var requireNativeComponent = require('requireNativeComponent');
  * React component that wraps the Windows-only `ProgressBar`. This component is used to indicate
  * that the app is loading or there is some activity in the app.
  */
-var ProgressBarWindows = React.createClass({
-  propTypes: {
-    ...ViewPropTypes,
-    
-    /**
-     * If the progress bar will show indeterminate progress.
-     */
-    indeterminate: PropTypes.bool,
-    /**
-     * The progress value (between 0 and 100).
-     */
-    progress: PropTypes.number,
-    /**
-     * Color of the progress bar.
-     */
-    color: ColorPropType,
-  },
-  
-  getDefaultProps: function() {
-    return {
-      indeterminate: true
-    };
-  },
-  
-  render: function() {
-    return <WindowsProgressBar {...this.props}/> ;
-  },
-});
+class ProgressBarWindows extends React.Component {
+ props: {
+  indeterminate?: boolean,
+  progress?: number,
+  color?: $FlowFixMe,
+ };
+
+ static propTypes = {
+   ...ViewPropTypes,
+   
+   /**
+    * If the progress bar will show indeterminate progress.
+    */
+   indeterminate: PropTypes.bool,
+   /**
+    * The progress value (between 0 and 100).
+    */
+   progress: PropTypes.number,
+   /**
+    * Color of the progress bar.
+    */
+   color: ColorPropType,
+ };
+
+ static defaultProps = {
+   indeterminate: true
+ };
+
+ render() {
+   return <WindowsProgressBar {...this.props}/> ;
+ }
+}
 
 var WindowsProgressBar = requireNativeComponent('WindowsProgressBar', ProgressBarWindows);
 

--- a/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
+++ b/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
@@ -6,14 +6,14 @@
  */
 'use strict';
 
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var View = require('View');
+
 var ColorPropType = require('ColorPropType');
 
 var requireNativeComponent = require('requireNativeComponent');
-
-var ReactPropTypes = React.PropTypes;
 
 /**
  * React component that wraps the Windows-only `ProgressBar`. This component is used to indicate
@@ -26,11 +26,11 @@ var ProgressBarWindows = React.createClass({
     /**
      * If the progress bar will show indeterminate progress.
      */
-    indeterminate: ReactPropTypes.bool,
+    indeterminate: PropTypes.bool,
     /**
      * The progress value (between 0 and 100).
      */
-    progress: ReactPropTypes.number,
+    progress: PropTypes.number,
     /**
      * Color of the progress bar.
      */

--- a/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
+++ b/Libraries/Components/ProgressBarWindows/ProgressBarWindows.windows.js
@@ -9,7 +9,7 @@
 var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 
 var ColorPropType = require('ColorPropType');
 
@@ -21,7 +21,7 @@ var requireNativeComponent = require('requireNativeComponent');
  */
 var ProgressBarWindows = React.createClass({
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     
     /**
      * If the progress bar will show indeterminate progress.

--- a/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
+++ b/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
@@ -6,13 +6,13 @@
  */
 'use strict';
 
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var View = require('View');
 var requireNativeComponent = require('requireNativeComponent');
-var ColorPropType = require('ColorPropType');
 
-var ReactPropTypes = React.PropTypes;
+var ColorPropType = require('ColorPropType');
 
 var ProgressRingWindows = React.createClass({  
   propTypes: {

--- a/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
+++ b/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
@@ -9,14 +9,14 @@
 var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 var requireNativeComponent = require('requireNativeComponent');
 
 var ColorPropType = require('ColorPropType');
 
 var ProgressRingWindows = React.createClass({  
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     /**
      * Color of the progress bar.
      */

--- a/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
+++ b/Libraries/Components/ProgressRingWindows/ProgressRingWindows.windows.js
@@ -14,25 +14,25 @@ var requireNativeComponent = require('requireNativeComponent');
 
 var ColorPropType = require('ColorPropType');
 
-var ProgressRingWindows = React.createClass({  
-  propTypes: {
+class ProgressRingWindows extends React.Component {
+  props: {color?: $FlowFixMe};
+
+  static propTypes = {
     ...ViewPropTypes,
     /**
      * Color of the progress bar.
      */
     color: ColorPropType,
-  },
-  
-  getDefaultProps: function() {
-    return {
-      animating: true
-    };
-  },
-  
-  render: function() {
+  };
+
+  static defaultProps = {
+    animating: true
+  };
+
+  render() {
     return <WindowsProgressRing {...this.props}/> ;
-  },
-});
+  }
+}
 
 var WindowsProgressRing = requireNativeComponent(
     'WindowsProgressRing', 

--- a/Libraries/Components/ScrollView/ScrollView.windows.js
+++ b/Libraries/Components/ScrollView/ScrollView.windows.js
@@ -18,6 +18,7 @@ const Platform = require('Platform');
 const PointPropType = require('PointPropType');
 const PropTypes = require('prop-types');
 const React = require('React');
+const createReactClass = require('create-react-class');
 const ReactNative = require('ReactNative');
 const ScrollResponder = require('ScrollResponder');
 const ScrollViewStickyHeader = require('ScrollViewStickyHeader');
@@ -72,7 +73,9 @@ import type {NativeMethodsMixinType} from 'ReactNativeTypes';
  * supports out of the box.
  */
 // $FlowFixMe(>=0.41.0)
-const ScrollView = React.createClass({
+const ScrollView = createReactClass({
+  displayName: 'ScrollView',
+
   propTypes: {
     ...ViewPropTypes,
     /**
@@ -410,11 +413,11 @@ const ScrollView = React.createClass({
   },
 
   mixins: [ScrollResponder.Mixin],
-
   _scrollAnimatedValue: (new Animated.Value(0): Animated.Value),
   _scrollAnimatedValueAttachment: (null: ?{detach: () => void}),
   _stickyHeaderRefs: (new Map(): Map<number, ScrollViewStickyHeader>),
   _headerLayoutYs: (new Map(): Map<string, number>),
+
   getInitialState: function() {
     return this.scrollResponderMixinGetInitialState();
   },
@@ -598,11 +601,13 @@ const ScrollView = React.createClass({
   },
 
   _scrollViewRef: (null: ?ScrollView),
+
   _setScrollViewRef: function(ref: ?ScrollView) {
     this._scrollViewRef = ref;
   },
 
   _innerViewRef: (null: ?NativeMethodsMixinType),
+
   _setInnerViewRef: function(ref: ?NativeMethodsMixinType) {
     this._innerViewRef = ref;
   },
@@ -786,7 +791,7 @@ const ScrollView = React.createClass({
         {contentContainer}
       </ScrollViewClass>
     );
-  }
+  },
 });
 
 const styles = StyleSheet.create({

--- a/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
+++ b/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
@@ -18,6 +18,7 @@ var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
 
 var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 
 var SplitViewConsts = UIManager.WindowsSplitView.Constants;
 var dismissKeyboard = require('dismissKeyboard');
@@ -69,7 +70,7 @@ var SplitViewWindows = React.createClass({
   },
 
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     /**
      * Determines whether the keyboard gets dismissed in response to a drag.
      *   - 'none' (the default), drags do not dismiss the keyboard.

--- a/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
+++ b/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
@@ -11,18 +11,18 @@
 'use strict';
 
 var NativeMethodsMixin = require('NativeMethodsMixin');
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
+
 var View = require('View');
 
 var SplitViewConsts = UIManager.WindowsSplitView.Constants;
-
 var dismissKeyboard = require('dismissKeyboard');
-var requireNativeComponent = require('requireNativeComponent');
 
-var ReactPropTypes = React.PropTypes;
+var requireNativeComponent = require('requireNativeComponent');
 
 var RK_PANE_REF = 'paneView';
 var CONTENT_REF = 'contentView';
@@ -75,14 +75,14 @@ var SplitViewWindows = React.createClass({
      *   - 'none' (the default), drags do not dismiss the keyboard.
      *   - 'on-drag', the keyboard is dismissed when a drag begins.
      */
-    keyboardDismissMode: ReactPropTypes.oneOf([
+    keyboardDismissMode: PropTypes.oneOf([
       'none', // default
       'on-drag',
     ]),
     /**
      * Specifies the side of the screen from which the pane will slide in.
      */
-    panePosition: ReactPropTypes.oneOf([
+    panePosition: PropTypes.oneOf([
       SplitViewConsts.PanePositions.Left,
       SplitViewConsts.PanePositions.Right
     ]),
@@ -90,19 +90,19 @@ var SplitViewWindows = React.createClass({
      * Specifies the width of the pane, more precisely the width of the view that be pulled in
      * from the edge of the window.
      */
-    paneWidth: ReactPropTypes.number,
+    paneWidth: PropTypes.number,
     /**
      * Function called whenever the pane view has been opened.
      */
-    onPaneOpen: ReactPropTypes.func,
+    onPaneOpen: PropTypes.func,
     /**
      * Function called whenever the pane view has been closed.
      */
-    onPaneClose: ReactPropTypes.func,
+    onPaneClose: PropTypes.func,
     /**
      * The pane view that will be rendered to the side of the screen and can be pulled in.
      */
-    renderPaneView: ReactPropTypes.func.isRequired,
+    renderPaneView: PropTypes.func.isRequired,
   },
 
   mixins: [NativeMethodsMixin],

--- a/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
+++ b/Libraries/Components/SplitViewWindows/SplitViewWindows.windows.js
@@ -13,6 +13,7 @@
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
@@ -64,7 +65,9 @@ var SplitViewValidAttributes = {
  * },
  * ```
  */
-var SplitViewWindows = React.createClass({
+var SplitViewWindows = createReactClass({
+  displayName: 'SplitViewWindows',
+
   statics: {
     positions: SplitViewConsts.PanePositions,
   },

--- a/Libraries/Components/StatusBar/StatusBar.windows.js
+++ b/Libraries/Components/StatusBar/StatusBar.windows.js
@@ -109,91 +109,102 @@ function createStackEntry(props: any): any {
  * set by the static API will get overriden by the one set by the component in
  * the next render.
  */
-const StatusBar = React.createClass({
-  statics: {
-    _propsStack: [],
-    _defaultProps: createStackEntry({
-      animated: false,
-      showHideTransition: 'fade',
-      backgroundColor: 'black',
-      barStyle: 'default',
-      translucent: false,
-      hidden: false,
-      networkActivityIndicatorVisible: false,
-    }),
-    // Timer for updating the native module values at the end of the frame.
-    _updateImmediate: null,
-    // The current merged values from the props stack.
-    _currentValues: null,
+class StatusBar extends React.Component {
+  props: {
+    hidden?: boolean,
+    animated?: boolean,
+    backgroundColor?: $FlowFixMe,
+    translucent?: boolean,
+    barStyle?: 'default' | 'light-content',
+    networkActivityIndicatorVisible?: boolean,
+    showHideTransition?: 'fade' | 'slide',
+  };
 
-    // TODO(janic): Provide a real API to deal with status bar height. See the
-    // discussion in #6195.
-    /**
-     * The current height of the status bar on the device.
-     *
-     * @platform android
-     */
-    currentHeight: StatusBarManager.HEIGHT,
+  static _propsStack = [];
 
-    // Provide an imperative API as static functions of the component.
-    // See the corresponding prop for more detail.
-    setHidden(hidden: boolean, animation?: StatusBarAnimation) {
-      animation = animation || 'none';
-      StatusBar._defaultProps.hidden.value = hidden;
-      if (Platform.OS === 'ios') {
-        StatusBarManager.setHidden(hidden, animation);
-      } else if (Platform.OS === 'android') {
-        StatusBarManager.setHidden(hidden);
-      } else if (Platform.OS === 'windows') {
-        StatusBarManager.setHidden(hidden);
-      }
-    },
+  static _defaultProps = createStackEntry({
+    animated: false,
+    showHideTransition: 'fade',
+    backgroundColor: 'black',
+    barStyle: 'default',
+    translucent: false,
+    hidden: false,
+    networkActivityIndicatorVisible: false,
+  });
 
-    setBarStyle(style: StatusBarStyle, animated?: boolean) {
-      if (Platform.OS !== 'ios') {
-        console.warn('`setBarStyle` is only available on iOS');
-        return;
-      }
+  // Timer for updating the native module values at the end of the frame.
+  static _updateImmediate = null;
+
+  // The current merged values from the props stack.
+  static _currentValues = null;
+
+  // TODO(janic): Provide a real API to deal with status bar height. See the
+  // discussion in #6195.
+  /**
+   * The current height of the status bar on the device.
+   *
+   * @platform android
+   */
+  static currentHeight = StatusBarManager.HEIGHT;
+
+  // Provide an imperative API as static functions of the component.
+  // See the corresponding prop for more detail.
+  static setHidden(hidden: boolean, animation?: StatusBarAnimation) {
+    animation = animation || 'none';
+    StatusBar._defaultProps.hidden.value = hidden;
+    if (Platform.OS === 'ios') {
+      StatusBarManager.setHidden(hidden, animation);
+    } else if (Platform.OS === 'android') {
+      StatusBarManager.setHidden(hidden);
+    } else if (Platform.OS === 'windows') {
+      StatusBarManager.setHidden(hidden);
+    }
+  }
+
+  static setBarStyle(style: StatusBarStyle, animated?: boolean) {
+    if (Platform.OS !== 'ios') {
+      console.warn('`setBarStyle` is only available on iOS');
+      return;
+    }
+    animated = animated || false;
+    StatusBar._defaultProps.barStyle.value = style;
+    StatusBarManager.setStyle(style, animated);
+  }
+
+  static setNetworkActivityIndicatorVisible(visible: boolean) {
+    if (Platform.OS !== 'ios') {
+      console.warn('`setNetworkActivityIndicatorVisible` is only available on iOS');
+      return;
+    }
+    StatusBar._defaultProps.networkActivityIndicatorVisible = visible;
+    StatusBarManager.setNetworkActivityIndicatorVisible(visible);
+  }
+
+  static setBackgroundColor(color: string, animated?: boolean) {
+    if (Platform.OS === 'ios') {
+      console.warn('`setBackgroundColor` is only available on Android and Windows');
+    }
+    else if (Platform.OS === 'android') {
       animated = animated || false;
-      StatusBar._defaultProps.barStyle.value = style;
-      StatusBarManager.setStyle(style, animated);
-    },
+      StatusBar._defaultProps.backgroundColor.value = color;
+      StatusBarManager.setColor(processColor(color), animated);
+    }
+    else if (Platform.OS === 'windows') {
+      StatusBar._defaultProps.backgroundColor.value = color;
+      StatusBarManager.setColor(processColor(color));    
+    }
+  }
 
-    setNetworkActivityIndicatorVisible(visible: boolean) {
-      if (Platform.OS !== 'ios') {
-        console.warn('`setNetworkActivityIndicatorVisible` is only available on iOS');
-        return;
-      }
-      StatusBar._defaultProps.networkActivityIndicatorVisible = visible;
-      StatusBarManager.setNetworkActivityIndicatorVisible(visible);
-    },
+  static setTranslucent(translucent: boolean) {
+    if (Platform.OS === 'ios') {
+      console.warn('`setTranslucent` is not available on iOS');
+      return;
+    }
+    StatusBar._defaultProps.translucent = translucent;
+    StatusBarManager.setTranslucent(translucent);
+  }
 
-    setBackgroundColor(color: string, animated?: boolean) {
-      if (Platform.OS === 'ios') {
-        console.warn('`setBackgroundColor` is only available on Android and Windows');
-      }
-      else if (Platform.OS === 'android') {
-        animated = animated || false;
-        StatusBar._defaultProps.backgroundColor.value = color;
-        StatusBarManager.setColor(processColor(color), animated);
-      }
-      else if (Platform.OS === 'windows') {
-        StatusBar._defaultProps.backgroundColor.value = color;
-        StatusBarManager.setColor(processColor(color));    
-      }
-    },
-
-    setTranslucent(translucent: boolean) {
-      if (Platform.OS === 'ios') {
-        console.warn('`setTranslucent` is not available on iOS');
-        return;
-      }
-      StatusBar._defaultProps.translucent = translucent;
-      StatusBarManager.setTranslucent(translucent);
-    },
-  },
-
-  propTypes: {
+  static propTypes = {
     /**
      * If the status bar is hidden.
      */
@@ -241,16 +252,14 @@ const StatusBar = React.createClass({
       'fade',
       'slide',
     ]),
-  },
+  };
 
-  getDefaultProps(): DefaultProps {
-    return {
-      animated: false,
-      showHideTransition: 'fade',
-    };
-  },
+  static defaultProps = {
+    animated: false,
+    showHideTransition: 'fade',
+  };
 
-  _stackEntry: null,
+  _stackEntry = null;
 
   componentDidMount() {
     // Every time a StatusBar component is mounted, we push it's prop to a stack
@@ -260,7 +269,7 @@ const StatusBar = React.createClass({
     this._stackEntry = createStackEntry(this.props);
     StatusBar._propsStack.push(this._stackEntry);
     this._updatePropsStack();
-  },
+  }
 
   componentWillUnmount() {
     // When a StatusBar is unmounted, remove itself from the stack and update
@@ -269,7 +278,7 @@ const StatusBar = React.createClass({
     StatusBar._propsStack.splice(index, 1);
 
     this._updatePropsStack();
-  },
+  }
 
   componentDidUpdate() {
     const index = StatusBar._propsStack.indexOf(this._stackEntry);
@@ -277,12 +286,12 @@ const StatusBar = React.createClass({
     StatusBar._propsStack[index] = this._stackEntry;
 
     this._updatePropsStack();
-  },
+  }
 
   /**
    * Updates the native status bar with the props from the stack.
    */
-  _updatePropsStack() {
+  _updatePropsStack = () => {
     // Send the update to the native module only once at the end of the frame.
     clearImmediate(StatusBar._updateImmediate);
     StatusBar._updateImmediate = setImmediate(() => {
@@ -340,11 +349,11 @@ const StatusBar = React.createClass({
       // Update the current prop values.
       StatusBar._currentValues = mergedProps;
     });
-  },
+  };
 
   render(): ?ReactElement {
     return null;
-  },
-});
+  }
+}
 
 module.exports = StatusBar;

--- a/Libraries/Components/StatusBar/StatusBar.windows.js
+++ b/Libraries/Components/StatusBar/StatusBar.windows.js
@@ -11,6 +11,8 @@
  */
 'use strict';
 
+const PropTypes = require('prop-types');
+
 const React = require('React');
 const ColorPropType = require('ColorPropType');
 const Platform = require('Platform');
@@ -195,12 +197,12 @@ const StatusBar = React.createClass({
     /**
      * If the status bar is hidden.
      */
-    hidden: React.PropTypes.bool,
+    hidden: PropTypes.bool,
     /**
      * If the transition between status bar property changes should be animated.
      * Supported for backgroundColor, barStyle and hidden.
      */
-    animated: React.PropTypes.bool,
+    animated: PropTypes.bool,
     /**
      * The background color of the status bar.
      * @platform android
@@ -213,13 +215,13 @@ const StatusBar = React.createClass({
      *
      * @platform android
      */
-    translucent: React.PropTypes.bool,
+    translucent: PropTypes.bool,
     /**
      * Sets the color of the status bar text.
      *
      * @platform ios
      */
-    barStyle: React.PropTypes.oneOf([
+    barStyle: PropTypes.oneOf([
       'default',
       'light-content',
     ]),
@@ -228,14 +230,14 @@ const StatusBar = React.createClass({
      *
      * @platform ios
      */
-    networkActivityIndicatorVisible: React.PropTypes.bool,
+    networkActivityIndicatorVisible: PropTypes.bool,
     /**
      * The transition effect when showing and hiding the status bar using the `hidden`
      * prop. Defaults to 'fade'.
      *
      * @platform ios
      */
-    showHideTransition: React.PropTypes.oneOf([
+    showHideTransition: PropTypes.oneOf([
       'fade',
       'slide',
     ]),

--- a/Libraries/Components/TextInput/TextInput.windows.js
+++ b/Libraries/Components/TextInput/TextInput.windows.js
@@ -15,6 +15,7 @@ var DocumentSelectionState = require('DocumentSelectionState');
 var EventEmitter = require('EventEmitter');
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var Platform = require('Platform');
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
@@ -24,13 +25,12 @@ var TimerMixin = require('react-timer-mixin');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 var UIManager = require('UIManager');
 var View = require('View');
-var PasswordBoxWindows = require('react-native-windows').PasswordBoxWindows;
 
+var PasswordBoxWindows = require('react-native-windows').PasswordBoxWindows;
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var invariant = require('fbjs/lib/invariant');
-var requireNativeComponent = require('requireNativeComponent');
 
-var PropTypes = React.PropTypes;
+var requireNativeComponent = require('requireNativeComponent');
 
 var onlyMultiline = {
   onTextInput: true, // not supported in Open Source yet
@@ -369,8 +369,8 @@ var TextInput = React.createClass({
   },
 
   contextTypes: {
-    onFocusRequested: React.PropTypes.func,
-    focusEmitter: React.PropTypes.instanceOf(EventEmitter),
+    onFocusRequested: PropTypes.func,
+    focusEmitter: PropTypes.instanceOf(EventEmitter),
   },
 
   _focusSubscription: (undefined: ?Function),
@@ -411,7 +411,7 @@ var TextInput = React.createClass({
   },
 
   childContextTypes: {
-    isInAParentText: React.PropTypes.bool
+    isInAParentText: PropTypes.bool
   },
 
   /**

--- a/Libraries/Components/TextInput/TextInput.windows.js
+++ b/Libraries/Components/TextInput/TextInput.windows.js
@@ -24,7 +24,7 @@ var TextInputState = require('TextInputState');
 var TimerMixin = require('react-timer-mixin');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 var UIManager = require('UIManager');
-var View = require('View');
+var ViewPropTypes = require('ViewPropTypes');
 
 var PasswordBoxWindows = require('react-native-windows').PasswordBoxWindows;
 var emptyFunction = require('fbjs/lib/emptyFunction');
@@ -94,7 +94,7 @@ var TextInput = React.createClass({
   },
 
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     /**
      * Can tell TextInput to automatically capitalize certain characters.
      *

--- a/Libraries/Components/TextInput/TextInput.windows.js
+++ b/Libraries/Components/TextInput/TextInput.windows.js
@@ -17,6 +17,7 @@ var NativeMethodsMixin = require('NativeMethodsMixin');
 var Platform = require('Platform');
 var PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNative = require('ReactNative');
 var StyleSheet = require('StyleSheet');
 var Text = require('Text');
@@ -87,7 +88,9 @@ function notSupported(prop) {
  *  </View>
  * ```
  */
-var TextInput = React.createClass({
+var TextInput = createReactClass({
+  displayName: 'TextInput',
+
   statics: {
     /* TODO(brentvatne) docs are needed for this */
     State: TextInputState,
@@ -693,7 +696,6 @@ var TextInput = React.createClass({
       </TouchableWithoutFeedback>
     );
   },
-
 
   _onFocus: function(event: Event) {
     if (this.props.onFocus) {

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.windows.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.windows.js
@@ -16,15 +16,15 @@ var StyleSheet = require('StyleSheet');
 var Text = require('Text');
 var View = require('View');
 
-var DummyTouchableNativeFeedback = React.createClass({
-  render: function() {
+class DummyTouchableNativeFeedback extends React.Component {
+  render() {
     return (
       <View style={[styles.container, this.props.style]}>
         <Text style={styles.info}>TouchableNativeFeedback is not supported on this platform!</Text>
       </View>
     );
-  },
-});
+  }
+}
 
 var styles = StyleSheet.create({
   container: {

--- a/Libraries/Components/WebView/WebView.windows.js
+++ b/Libraries/Components/WebView/WebView.windows.js
@@ -18,6 +18,7 @@ var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
 
+var ViewPropTypes = require('ViewPropTypes');
 var View = require('View');
 var deprecatedPropType = require('deprecatedPropType');
 var keyMirror = require('fbjs/lib/keyMirror');
@@ -40,7 +41,7 @@ var WebViewState = keyMirror({
 var WebView = React.createClass({
 
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     renderError: PropTypes.func,
     renderLoading: PropTypes.func,
     onLoad: PropTypes.func,
@@ -51,7 +52,7 @@ var WebView = React.createClass({
     contentInset: EdgeInsetsPropType,
     onNavigationStateChange: PropTypes.func,
     startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
 
     html: deprecatedPropType(
       PropTypes.string,

--- a/Libraries/Components/WebView/WebView.windows.js
+++ b/Libraries/Components/WebView/WebView.windows.js
@@ -11,20 +11,20 @@
 'use strict';
 
 var EdgeInsetsPropType = require('EdgeInsetsPropType');
+var PropTypes = require('prop-types');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
-var View = require('View');
 
+var View = require('View');
 var deprecatedPropType = require('deprecatedPropType');
 var keyMirror = require('fbjs/lib/keyMirror');
 var merge = require('merge');
 var requireNativeComponent = require('requireNativeComponent');
-var resolveAssetSource = require('resolveAssetSource');
 
-var PropTypes = React.PropTypes;
+var resolveAssetSource = require('resolveAssetSource');
 
 var RCT_WEBVIEW_REF = 'webview';
 

--- a/Libraries/Components/WebView/WebView.windows.js
+++ b/Libraries/Components/WebView/WebView.windows.js
@@ -38,9 +38,8 @@ var WebViewState = keyMirror({
 /**
  * Renders a native WebView.
  */
-var WebView = React.createClass({
-
-  propTypes: {
+class WebView extends React.Component {
+  static propTypes = {
     ...ViewPropTypes,
     renderError: PropTypes.func,
     renderLoading: PropTypes.func,
@@ -134,29 +133,25 @@ var WebView = React.createClass({
      * start playing. The default value is `false`.
      */
     mediaPlaybackRequiresUserAction: PropTypes.bool,
-  },
+  };
 
-  getInitialState: function() {
-    return {
-      viewState: WebViewState.IDLE,
-      lastErrorEvent: null,
-      startInLoadingState: true,
-    };
-  },
+  static defaultProps = {
+    javaScriptEnabled : true,
+  };
 
-  getDefaultProps: function() {
-    return {
-      javaScriptEnabled : true,
-    };
-  },
+  state = {
+    viewState: WebViewState.IDLE,
+    lastErrorEvent: null,
+    startInLoadingState: true,
+  };
 
-  componentWillMount: function() {
+  componentWillMount() {
     if (this.props.startInLoadingState) {
       this.setState({viewState: WebViewState.LOADING});
     }
-  },
+  }
 
-  render: function() {
+  render() {
     var otherView = null;
 
     if (this.state.viewState === WebViewState.LOADING) {
@@ -208,53 +203,53 @@ var WebView = React.createClass({
         {otherView}
       </View>
     );
-  },
+  }
 
-  goForward: function() {
+  goForward = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       UIManager.RCTWebView.Commands.goForward,
       null
     );
-  },
+  };
 
-  goBack: function() {
+  goBack = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       UIManager.RCTWebView.Commands.goBack,
       null
     );
-  },
+  };
 
-  reload: function() {
+  reload = () => {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       UIManager.RCTWebView.Commands.reload,
       null
     );
-  },
+  };
 
   /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
    */
-  updateNavigationState: function(event) {
+  updateNavigationState = (event) => {
     if (this.props.onNavigationStateChange) {
       this.props.onNavigationStateChange(event.nativeEvent);
     }
-  },
+  };
 
-  getWebViewHandle: function() {
+  getWebViewHandle = () => {
     return ReactNative.findNodeHandle(this.refs[RCT_WEBVIEW_REF]);
-  },
+  };
 
-  onLoadingStart: function(event) {
+  onLoadingStart = (event) => {
     var onLoadStart = this.props.onLoadStart;
     onLoadStart && onLoadStart(event);
     this.updateNavigationState(event);
-  },
+  };
 
-  onLoadingError: function(event) {
+  onLoadingError = (event) => {
     event.persist(); // persist this event because we need to store it
     var {onError, onLoadEnd} = this.props;
     onError && onError(event);
@@ -265,9 +260,9 @@ var WebView = React.createClass({
       lastErrorEvent: event.nativeEvent,
       viewState: WebViewState.ERROR
     });
-  },
+  };
 
-  onLoadingFinish: function(event) {
+  onLoadingFinish = (event) => {
     var {onLoad, onLoadEnd} = this.props;
     onLoad && onLoad(event);
     onLoadEnd && onLoadEnd(event);
@@ -275,8 +270,8 @@ var WebView = React.createClass({
       viewState: WebViewState.IDLE,
     });
     this.updateNavigationState(event);
-  },
-});
+  };
+}
 
 var RCTWebView = requireNativeComponent('RCTWebView', WebView);
 

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.windows.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.windows.js
@@ -23,6 +23,8 @@
 */
 'use strict';
 
+const PropTypes = require('prop-types');
+
 const React = require('react');
 const ReactNative = require('react-native');
 
@@ -45,7 +47,7 @@ const NavigationHeaderBackButton = (props: Props) => (
 );
 
 NavigationHeaderBackButton.propTypes = {
-  onPress: React.PropTypes.func.isRequired
+  onPress: PropTypes.func.isRequired
 };
 
 const styles = StyleSheet.create({

--- a/Libraries/Image/Image.windows.js
+++ b/Libraries/Image/Image.windows.js
@@ -16,20 +16,20 @@ var NativeModules = require('NativeModules');
 var ImageResizeMode = require('ImageResizeMode');
 var ImageStylePropTypes = require('ImageStylePropTypes');
 var ViewStylePropTypes = require('ViewStylePropTypes');
+const PropTypes = require('prop-types');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
-var View = require('View');
 
+var View = require('View');
 var flattenStyle = require('flattenStyle');
 var merge = require('merge');
 var requireNativeComponent = require('requireNativeComponent');
 var resolveAssetSource = require('resolveAssetSource');
 var Set = require('Set');
-var filterObject = require('fbjs/lib/filterObject');
 
-var PropTypes = React.PropTypes;
+var filterObject = require('fbjs/lib/filterObject');
 var {
   ImageLoader,
 } = NativeModules;
@@ -244,7 +244,7 @@ var Image = React.createClass({
   },
 
   contextTypes: {
-    isInAParentText: React.PropTypes.bool
+    isInAParentText: PropTypes.bool
   },
 
   render: function() {

--- a/Libraries/Image/Image.windows.js
+++ b/Libraries/Image/Image.windows.js
@@ -22,6 +22,7 @@ var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
 
+var ViewPropTypes = require('ViewPropTypes');
 var View = require('View');
 var flattenStyle = require('flattenStyle');
 var merge = require('merge');
@@ -76,7 +77,7 @@ var ImageSpecificStyleKeys = new Set(Object.keys(ImageStylePropTypes).filter(x =
 
 var Image = React.createClass({
   propTypes: {
-    ...View.propTypes,
+    ...ViewPropTypes,
     style: StyleSheetPropType(ImageStylePropTypes),
    /**
      * `uri` is a string representing the resource identifier for the image, which

--- a/Libraries/Image/Image.windows.js
+++ b/Libraries/Image/Image.windows.js
@@ -18,6 +18,7 @@ var ImageStylePropTypes = require('ImageStylePropTypes');
 var ViewStylePropTypes = require('ViewStylePropTypes');
 const PropTypes = require('prop-types');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
@@ -75,7 +76,9 @@ var ImageViewAttributes = merge(ReactNativeViewAttributes.UIView, {
 var ViewStyleKeys = new Set(Object.keys(ViewStylePropTypes));
 var ImageSpecificStyleKeys = new Set(Object.keys(ImageStylePropTypes).filter(x => !ViewStyleKeys.has(x)));
 
-var Image = React.createClass({
+var Image = createReactClass({
+  displayName: 'Image',
+
   propTypes: {
     ...ViewPropTypes,
     style: StyleSheetPropType(ImageStylePropTypes),
@@ -303,7 +306,7 @@ var Image = React.createClass({
       }
     }
     return null;
-  }
+  },
 });
 
 var styles = StyleSheet.create({

--- a/Libraries/Text/Text.windows.js
+++ b/Libraries/Text/Text.windows.js
@@ -16,6 +16,7 @@ const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const PropTypes = require('prop-types');
 const React = require('React');
+const createReactClass = require('create-react-class');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheetPropType = require('StyleSheetPropType');
 const TextStylePropTypes = require('TextStylePropTypes');
@@ -70,7 +71,9 @@ const viewConfig = {
  * ```
  */
 
-const Text = React.createClass({
+const Text = createReactClass({
+  displayName: 'Text',
+
   propTypes: {
     /**
      * Line Break mode. Works only with numberOfLines.
@@ -129,6 +132,7 @@ const Text = React.createClass({
      */
     allowFontScaling: PropTypes.bool,
   },
+
   getDefaultProps(): Object {
     return {
       accessible: true,
@@ -136,38 +140,48 @@ const Text = React.createClass({
       lineBreakMode: 'tail',
     };
   },
+
   getInitialState: function(): Object {
     return merge(Touchable.Mixin.touchableGetInitialState(), {
       isHighlighted: false,
     });
   },
+
   mixins: [NativeMethodsMixin],
   viewConfig: viewConfig,
+
   getChildContext(): Object {
     return {isInAParentText: true};
   },
+
   childContextTypes: {
     isInAParentText: PropTypes.bool
   },
+
   contextTypes: {
     isInAParentText: PropTypes.bool
   },
+
   /**
    * Only assigned if touch is needed.
    */
   _handlers: (null: ?Object),
+
   _hasPressHandler(): boolean {
     return !!this.props.onPress || !!this.props.onLongPress;
   },
+
   /**
    * These are assigned lazily the first time the responder is set to make plain
    * text nodes as cheap as possible.
    */
   touchableHandleActivePressIn: (null: ?Function),
+
   touchableHandleActivePressOut: (null: ?Function),
   touchableHandlePress: (null: ?Function),
   touchableHandleLongPress: (null: ?Function),
   touchableGetPressRectOffset: (null: ?Function),
+
   render(): ReactElement<any> {
     let newProps = this.props;
     if (this.props.onStartShouldSetResponder || this._hasPressHandler()) {

--- a/Libraries/Text/Text.windows.js
+++ b/Libraries/Text/Text.windows.js
@@ -14,6 +14,7 @@
 const EdgeInsetsPropType = require('EdgeInsetsPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
+const PropTypes = require('prop-types');
 const React = require('React');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheetPropType = require('StyleSheetPropType');
@@ -75,27 +76,27 @@ const Text = React.createClass({
      * Line Break mode. Works only with numberOfLines.
      * clip is working only for iOS
      */
-    lineBreakMode: React.PropTypes.oneOf(['head', 'middle', 'tail', 'clip']),
+    lineBreakMode: PropTypes.oneOf(['head', 'middle', 'tail', 'clip']),
     /**
      * Used to truncate the text with an ellipsis after computing the text
      * layout, including line wrapping, such that the total number of lines
      * does not exceed this number.
      */
-    numberOfLines: React.PropTypes.number,
+    numberOfLines: PropTypes.number,
     /**
      * Invoked on mount and layout changes with
      *
      *   `{nativeEvent: {layout: {x, y, width, height}}}`
      */
-    onLayout: React.PropTypes.func,
+    onLayout: PropTypes.func,
     /**
      * This function is called on press.
      */
-    onPress: React.PropTypes.func,
+    onPress: PropTypes.func,
     /**
      * This function is called on long press.
      */
-    onLongPress: React.PropTypes.func,
+    onLongPress: PropTypes.func,
       /**
        * When the scroll view is disabled, this defines how far your touch may
        * move off of the button, before deactivating the button. Once deactivated,
@@ -110,23 +111,23 @@ const Text = React.createClass({
      * @platform android
      * @platform windows
      */
-    selectable: React.PropTypes.bool,
+    selectable: PropTypes.bool,
     /**
      * When true, no visual change is made when text is pressed down. By
      * default, a gray oval highlights the text on press down.
      * @platform ios
      */
-    suppressHighlighting: React.PropTypes.bool,
+    suppressHighlighting: PropTypes.bool,
     style: stylePropType,
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID: React.PropTypes.string,
+    testID: PropTypes.string,
     /**
      * Specifies should fonts scale to respect Text Size accessibility setting on iOS.
      * @platform ios
      */
-    allowFontScaling: React.PropTypes.bool,
+    allowFontScaling: PropTypes.bool,
   },
   getDefaultProps(): Object {
     return {
@@ -146,10 +147,10 @@ const Text = React.createClass({
     return {isInAParentText: true};
   },
   childContextTypes: {
-    isInAParentText: React.PropTypes.bool
+    isInAParentText: PropTypes.bool
   },
   contextTypes: {
-    isInAParentText: React.PropTypes.bool
+    isInAParentText: PropTypes.bool
   },
   /**
    * Only assigned if touch is needed.

--- a/docs/NativeComponentsWindows.md
+++ b/docs/NativeComponentsWindows.md
@@ -127,7 +127,7 @@ The very final step is to create the JavaScript module that defines the interfac
 // ImageView.js
 
 import { PropTypes } from 'react';
-import { requireNativeComponent, View } from 'react-native';
+import { requireNativeComponent, View, ViewPropTypes } from 'react-native';
 
 var iface = {
   name: 'ImageView',
@@ -135,7 +135,7 @@ var iface = {
     src: PropTypes.string,
     borderRadius: PropTypes.number,
     resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
-    ...View.propTypes // include the default view properties
+    ...ViewPropTypes // include the default view properties
   },
 };
 


### PR DESCRIPTION
RN 0.46.4 uses React 16.0.0-alpha.12 which is currently incompatible with RNW 0.46 because PropTypes (`React.PropTypes`) was moved out of the "react" library and into its own library called "prop-types".

This fixes the issue by cherry-picking the relevant RNW commits which update RNW to consume prop types from the appropriate location. Also cherry-picked a change to migrate away from `React.createClass`.