### PR TITLE
Add simple text tooltips to views.

### DIFF
--- a/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/Libraries/Components/View/ViewPropTypes.windows.js
@@ -82,6 +82,7 @@ export type ViewProps = {
   shouldRasterizeIOS?: bool,
   collapsable?: bool,
   needsOffscreenAlphaCompositing?: bool,
+  tooltip?: string,
 } & TVViewProps;
 
 module.exports = {
@@ -497,4 +498,12 @@ module.exports = {
         'scale',
         'all',
     ])),
+
+    /**
+     * A short string description that will appear in a tooltip if the user
+     * hovers their pointer over the View for a short duration.
+     *
+     * @platform windows
+     */
+    tooltip: PropTypes.string,
 };

--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -113,6 +113,17 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
+        /// Sets a tooltip for the view.
+        /// </summary>
+        /// <param name="view">The view instance.</param>
+        /// <param name="tooltip">String to display in the tooltip.</param>
+        [ReactProp("tooltip")]
+        public void SetTooltip(TFrameworkElement view, string tooltip)
+        {
+            ToolTipService.SetToolTip(view, tooltip);
+        }
+
+        /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
         /// additional cleanup by the <see cref="IViewManager"/> subclass.
         /// </summary>

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -178,6 +178,17 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
+        /// Sets a tooltip for the view.
+        /// </summary>
+        /// <param name="view">The view instance.</param>
+        /// <param name="tooltip">String to display in the tooltip.</param>
+        [ReactProp("tooltip")]
+        public void SetTooltip(TFrameworkElement view, string tooltip)
+        {
+            ToolTipService.SetToolTip(view, tooltip);
+        }
+
+        /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
         /// additional cleanup by the <see cref="IViewManager"/> subclass.
         /// </summary>


### PR DESCRIPTION
This seems to cover all the functionality we require right now, but I was
hoping someone might point me in the right direction of a more general
solution where the tooltip could be composed out of components.

In particular, I'm not sure how to allow a React component to define the
tooltip and pass it to the native side without actually rendering it as part
of the regular RN component tree first. Doing off-screen rendering could
perhaps work, but it puts an unnatural burden on users where they have to
give it a `position: 'absolute'` style etc. It also seems like it would lead
to re-parenting complexities on the native side.

In any case, I'll probably leave such work for the future unless someone
objects.