### PR TITLE
fix(Background): Workaround for missing SynchronizationContext

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -501,7 +501,7 @@ namespace ReactNative
             try
             {
                 var reactContext = await CreateReactContextCoreAsync(jsExecutorFactory, jsBundleLoader, token);
-                SetupReactContext(reactContext);
+                RunOrInlineOnDispatcher(() => SetupReactContext(reactContext));
                 return reactContext;
             }
             catch (OperationCanceledException)
@@ -762,6 +762,18 @@ namespace ReactNative
                         _lifecycleState = LifecycleState.Background;
                     }
                 }
+            }
+        }
+
+        private static void RunOrInlineOnDispatcher(Action action)
+        {
+            if (DispatcherHelpers.IsOnDispatcher())
+            {
+                action();
+            }
+            else
+            {
+                DispatcherHelpers.RunOnDispatcher(() => action());
             }
         }
 


### PR DESCRIPTION
When using UWP 10.0.14393, there is no SynchronizationContext set on the CoreApplication dispatcher thread when running in the background. To work around this, this change set re-enqueues a continuation on the Dispatcher to finish the ReactContext set up. It also does a check to see if the thread is already on the background thread and executes inline in possible (as would be the case in foreground and RS3+).

Fixes #1548