### PR TITLE
Animation module doesn't activate callback from choreographer.

### DIFF
--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedModule.cs
@@ -174,6 +174,8 @@ namespace ReactNative.Animated
                     operation(nodesManager);
                 }
             }));
+
+            ReactChoreographer.Instance.ActivateCallback(nameof(NativeAnimatedModule));
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -1,6 +1,5 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
-using ReactNative.Modules.Core;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Events;
 using System;
@@ -108,7 +107,6 @@ namespace ReactNative.Animated
 
             _animatedNodes.Add(tag, node);
             _updatedNodes[tag] = node;
-            ReactChoreographer.Instance.ActivateCallback(nameof(NativeAnimatedModule));
         }
 
         public void DropAnimatedNode(int tag)
@@ -235,7 +233,6 @@ namespace ReactNative.Animated
             }
 
             _activeAnimations[animationId] = animation;
-            ReactChoreographer.Instance.ActivateCallback(nameof(NativeAnimatedModule));
         }
 
         public void StopAnimation(int animationId)

--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Modules.Core;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Events;
 using System;
@@ -107,6 +108,7 @@ namespace ReactNative.Animated
 
             _animatedNodes.Add(tag, node);
             _updatedNodes[tag] = node;
+            ReactChoreographer.Instance.ActivateCallback(nameof(NativeAnimatedModule));
         }
 
         public void DropAnimatedNode(int tag)
@@ -233,6 +235,7 @@ namespace ReactNative.Animated
             }
 
             _activeAnimations[animationId] = animation;
+            ReactChoreographer.Instance.ActivateCallback(nameof(NativeAnimatedModule));
         }
 
         public void StopAnimation(int animationId)


### PR DESCRIPTION
It does deactivate it when no animation is active anymore.
Added "ActivateCallback" call to the point where UIBlock objects are sent to operations queue.
Without this fix there are scenarios that are impacted if an active animation takes a
long time.