### PR TITLE
Reduce ReactRootView coupling and add support for InitialProps changes

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -149,6 +149,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ReactInstanceManagerBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactNativeHost.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactRootView.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReactRootViewBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\EnumHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ExpressionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ReflectionHelpers.cs" />

--- a/ReactWindows/ReactNative.Shared/ReactRootViewBase.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootViewBase.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json.Linq;
+using ReactNative.UIManager;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ReactNative
+{
+    /// <summary>
+    /// Base class for a panel that hosts React content.
+    /// Custom implementations may use their own logic for injecting the view
+    /// into <see cref="ReactInstanceManager"/>.
+    /// </summary>
+    public abstract class ReactRootViewBase : SizeMonitoringCanvas
+    {
+        /// <summary>
+        /// The name of the JS module this view loads
+        /// </summary>
+        public virtual string JavaScriptModuleName { get; set; }
+
+        /// <summary>
+        /// The props value passed to the React component
+        /// </summary>
+        public virtual JObject InitialProps { get; set; }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/RootViewHelper.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/RootViewHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 #if WINDOWS_UWP
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
@@ -19,7 +19,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view instance.</param>
         /// <returns>The root view instance.</returns>
-        public static ReactRootView GetRootView(DependencyObject view)
+        public static ReactRootViewBase GetRootView(DependencyObject view)
         {
             var current = view;
             while (true)
@@ -29,7 +29,7 @@ namespace ReactNative.UIManager
                     return null;
                 }
 
-                var rootView = current as ReactRootView;
+                var rootView = current as ReactRootViewBase;
                 if (rootView != null)
                 {
                     return rootView;
@@ -54,7 +54,7 @@ namespace ReactNative.UIManager
                     yield break;
                 }
 
-                if (current is ReactRootView)
+                if (current is ReactRootViewBase)
                 {
                     yield break;
                 }


### PR DESCRIPTION
-Introduce ReactRootViewBase to reduce coupling with ReactInstanceManager and permit custom implementations that control their own lifecycle and insertion into the manager.
-Add support for updating InitialProps. Changes will trigger componentWillReceiveProps on the React component.

Together these changes should help anyone attempting to integrate individual ReactNative components into a larger C# application.