### PR TITLE
Fixed link to React Native documentation in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please use these community resources for getting help. We use the GitHub issues 
 
 ## Documentation
 
-[React Native already has great documentation](http://facebook.github.io/react-native/docs), and we're working to ensure the React Native Windows plugin is part of that documentation story. Check out the [React documentation](http://facebook.github.io/react/) for further details about the React API in general.
+[React Native already has great documentation](https://facebook.github.io/react-native/docs/getting-started.html), and we're working to ensure the React Native Windows plugin is part of that documentation story. Check out the [React documentation](http://facebook.github.io/react/) for further details about the React API in general.
 
 For information on parity status with Android and iOS, including details on implemented and missing components and modules, along with related issues for missing features from partial implementations, go [here](docs/CoreParityStatus.md).
 


### PR DESCRIPTION
Clicking on the link to the React Native documentation resulted in a 404.