### PR TITLE
feat(UIManager): Adds option to extend view managers

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/ReactNative.Shared.Tests.projitems
+++ b/ReactWindows/ReactNative.Shared.Tests/ReactNative.Shared.Tests.projitems
@@ -38,7 +38,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\RootViewHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ShadowNodeRegistryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewAtIndexTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagerExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagerRegistryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagersPropertyCacheTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagerWithExtensionsTests.cs" />
   </ItemGroup>
 </Project>

--- a/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerExtensionTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerExtensionTests.cs
@@ -44,9 +44,9 @@ namespace ReactNative.Tests.UIManager
             Assert.IsTrue(props.ContainsKey("foo"));
             Assert.IsTrue(props.ContainsKey("bar"));
             Assert.IsTrue(props.ContainsKey("qux"));
-            Assert.AreEqual("async", props["foo"]);
-            Assert.AreEqual("async", props["bar"]);
-            Assert.AreEqual("async", props["qux"]);
+            Assert.AreEqual("number", props["foo"]);
+            Assert.AreEqual("String", props["bar"]);
+            Assert.AreEqual("String", props["qux"]);
         }
 
         [Test]

--- a/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerExtensionTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerExtensionTests.cs
@@ -1,0 +1,189 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using ReactNative.UIManager;
+using ReactNative.UIManager.Annotations;
+using System;
+using System.Collections.Generic;
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#else
+using System.Windows;
+using System.Windows.Controls;
+#endif
+
+namespace ReactNative.Tests.UIManager
+{
+    [TestFixture]
+    class ViewManagerExtensionTests
+    {
+        [Test]
+        public void ViewManagerExtension_ArgumentChecks()
+        {
+            var vmx = new TestViewManagerExtension();
+            AssertEx.Throws<ArgumentNullException>(
+                () => vmx.UpdateProperties(null, null),
+                ex => Assert.AreEqual("props", ex.ParamName));
+        }
+
+        [Test]
+        public void ViewManagerExtension_AddEventEmitters()
+        {
+            var vmx = new TestViewManagerExtension();
+            var count = 0;
+            vmx.AddEventEmittersAction = () => count++;
+            vmx.OnCreateView(null, null);
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void ViewManagerExtension_NativeProperties()
+        {
+            var vmx = new TestViewManagerExtension();
+            var props = vmx.NativeProperties;
+            Assert.IsTrue(props.ContainsKey("foo"));
+            Assert.IsTrue(props.ContainsKey("bar"));
+            Assert.IsTrue(props.ContainsKey("qux"));
+            Assert.AreEqual("async", props["foo"]);
+            Assert.AreEqual("async", props["bar"]);
+            Assert.AreEqual("async", props["qux"]);
+        }
+
+        [Test]
+        public void ViewManagerExtension_UpdateProperties()
+        {
+            var vmx = new TestViewManagerExtension();
+            var foo = 42;
+            var diffMap = new ReactStylesDiffMap(new JObject
+            {
+                { "foo", foo },
+            });
+
+            var count = 0;
+            vmx.SetFooAction = x =>
+            {
+                Assert.AreEqual(foo, x);
+                count++;
+            };
+
+            vmx.UpdateProperties(null, diffMap);
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void ViewManagerExtension_UpdateProperties_Group()
+        {
+            var vmx = new TestViewManagerExtension();
+            var v1 = "hello";
+            var v2 = "world";
+            var diffMap = new ReactStylesDiffMap(new JObject
+            {
+                { "bar", v1 },
+                { "qux", v2 },
+            });
+
+            var count = 0;
+            vmx.SetOtherAction = (index, x) =>
+            {
+                Assert.IsTrue(index == 0 || index == 1);
+                Assert.AreEqual(index == 0 ? v1 : v2, x);
+                count++;
+            };
+
+            vmx.UpdateProperties(null, diffMap);
+            Assert.AreEqual(2, count);
+        }
+
+        [Test]
+        public void ViewManagerExtension_OnAfterUpdateTransaction()
+        {
+            var vmx = new TestViewManagerExtension();
+            var count = 0;
+            vmx.OnAfterUpdateTransactionAction = () => count++;
+            vmx.UpdateProperties(null, new ReactStylesDiffMap(new JObject()));
+            Assert.AreEqual(1, count);
+        }
+
+        #region Test Classes
+
+        class DummyViewManager : IViewManager
+        {
+            public string Name => throw new NotImplementedException();
+
+            public Type ShadowNodeType => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, object> CommandsMap => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, object> ExportedViewConstants => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, string> NativeProperties => throw new NotImplementedException();
+
+            public ReactShadowNode CreateShadowNodeInstance()
+            {
+                throw new NotImplementedException();
+            }
+
+            public DependencyObject CreateView(ThemedReactContext reactContext)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Dimensions GetDimensions(DependencyObject view)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ReceiveCommand(DependencyObject view, int commandId, JArray args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetDimensions(DependencyObject view, Dimensions dimensions)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UpdateExtraData(DependencyObject root, object extraData)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class TestViewManagerExtension : ViewManagerExtension<Canvas, DummyViewManager>
+        {
+            public Action AddEventEmittersAction { get; set; }
+
+            protected override void AddEventEmitters(ThemedReactContext reactContext, Canvas view) => AddEventEmittersAction?.Invoke();
+
+            public Action OnAfterUpdateTransactionAction { get; set; }
+
+            protected override void OnAfterUpdateTransaction(Canvas view) => OnAfterUpdateTransactionAction?.Invoke();
+
+            public Action<int> SetFooAction { get; set; }
+
+            [ReactProp("foo")]
+            public void SetFoo(Canvas view, int foo) => SetFooAction?.Invoke(foo);
+
+            public Action<int, string> SetOtherAction { get; set; }
+
+            [ReactPropGroup("bar", "qux")]
+            public void SetOther(Canvas view, int id, string value) => SetOtherAction?.Invoke(id, value);
+        }
+
+        #endregion
+    }
+}

--- a/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerWithExtensionsTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerWithExtensionsTests.cs
@@ -85,7 +85,7 @@ namespace ReactNative.Tests.UIManager
             vmx.UpdatePropertiesAction = x =>
             {
                 Assert.AreSame(diffMap, x);
-                count++;
+                xcount++;
             };
 
             vmplusx.UpdateProperties(null, diffMap);
@@ -108,7 +108,6 @@ namespace ReactNative.Tests.UIManager
             };
 
             var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
-
 
             var args = new JArray();
             var count = 0;
@@ -234,7 +233,7 @@ namespace ReactNative.Tests.UIManager
 
             foreach (var pair in TestMapDifferent)
             {
-                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+                Assert.AreEqual(TestMapDifferent[pair.Key], result[pair.Key]);
             }
         }
 
@@ -262,7 +261,7 @@ namespace ReactNative.Tests.UIManager
 
             foreach (var pair in TestMapDifferent)
             {
-                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+                Assert.AreEqual(TestMapDifferent[pair.Key], result[pair.Key]);
             }
         }
 
@@ -290,7 +289,7 @@ namespace ReactNative.Tests.UIManager
 
             foreach (var pair in TestMapDifferent)
             {
-                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+                Assert.AreEqual(TestMapDifferent[pair.Key], result[pair.Key]);
             }
         }
 
@@ -318,7 +317,7 @@ namespace ReactNative.Tests.UIManager
 
             foreach (var pair in TestMapDifferent)
             {
-                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+                Assert.AreEqual(TestMapDifferent[pair.Key], result[pair.Key]);
             }
         }
 
@@ -337,16 +336,16 @@ namespace ReactNative.Tests.UIManager
 
             var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
 
-            var result = vmplusx.ExportedViewConstants;
+            var result = vmplusx.NativeProperties;
 
-            foreach (var pair in TestMap)
+            foreach (var pair in TestMapString)
             {
-                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+                Assert.AreEqual(TestMapString[pair.Key], result[pair.Key]);
             }
 
-            foreach (var pair in TestMapDifferent)
+            foreach (var pair in TestMapDifferentString)
             {
-                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+                Assert.AreEqual(TestMapDifferentString[pair.Key], result[pair.Key]);
             }
         }
 
@@ -444,7 +443,7 @@ namespace ReactNative.Tests.UIManager
 
             var vmx = new TestViewManagerExtension
             {
-                NativeProperties = TestMapDifferentString,
+                NativeProperties = TestMapSameKeyString,
             };
 
             var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });

--- a/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerWithExtensionsTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/UIManager/ViewManagerWithExtensionsTests.cs
@@ -1,0 +1,598 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using ReactNative.UIManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+#else
+using System.Windows;
+#endif
+
+namespace ReactNative.Tests.UIManager
+{
+    [TestFixture]
+    class ViewManagerWithExtensionsTests
+    {
+        [Test]
+        public void ViewManagerWithExtensions_ArgumentChecks()
+        {
+            AssertEx.Throws<ArgumentNullException>(
+                () => new ViewManagerWithExtensions(null, null),
+                ex => Assert.AreEqual("viewManager", ex.ParamName));
+
+            AssertEx.Throws<ArgumentNullException>(
+                () => new ViewManagerWithExtensions(new TestViewManager(), null),
+                ex => Assert.AreEqual("extensions", ex.ParamName));
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_CreateView()
+        {
+            var vm = new TestViewManager();
+            var vmx = new TestViewManagerExtension();
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var count = 0;
+            var xcount = 0;
+            vm.CreateViewFunc = () =>
+            {
+                count++;
+                return null;
+            };
+
+            vmx.OnCreateViewAction = () => xcount++;
+
+            vmplusx.CreateView(null);
+            Assert.AreEqual(1, count);
+            Assert.AreEqual(1, xcount);
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_DropView()
+        {
+            var vm = new TestViewManager();
+            var vmx = new TestViewManagerExtension();
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var count = 0;
+            var xcount = 0;
+            vm.OnDropViewInstanceAction = () => count++;
+            vmx.OnDropViewInstanceAction = () => xcount++;
+            vmplusx.OnDropViewInstance(null, null);
+            Assert.AreEqual(1, count);
+            Assert.AreEqual(1, xcount);
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_UpdateProperties()
+        {
+            var vm = new TestViewManager();
+            var vmx = new TestViewManagerExtension();
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var count = 0;
+            var xcount = 0;
+            var diffMap = new ReactStylesDiffMap(new JObject());
+
+            vm.UpdatePropertiesAction = x =>
+            {
+                Assert.AreSame(diffMap, x);
+                count++;
+            };
+
+            vmx.UpdatePropertiesAction = x =>
+            {
+                Assert.AreSame(diffMap, x);
+                count++;
+            };
+
+            vmplusx.UpdateProperties(null, diffMap);
+
+            Assert.AreEqual(1, count);
+            Assert.AreEqual(1, xcount);
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_ReceiveCommand()
+        {
+            var vm = new TestViewManager
+            {
+                CommandsMap = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                CommandsMap = TestMapDifferent,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+
+            var args = new JArray();
+            var count = 0;
+            var xcount = 0;
+
+            var id = TestMap.Values.OfType<int>().First();
+            var xid = TestMapDifferent.Values.OfType<int>().First();
+
+            vm.ReceiveCommandAction = (i, a) =>
+            {
+                Assert.AreSame(args, a);
+                Assert.AreEqual(id, i);
+                count++;
+            };
+
+            vmx.ReceiveCommandAction = (i, a) =>
+            {
+                Assert.AreSame(args, a);
+                Assert.AreEqual(xid, i);
+                xcount++;
+            };
+
+            vmplusx.ReceiveCommand(null, id, args);
+            vmplusx.ReceiveCommand(null, xid, args);
+
+            Assert.AreEqual(1, count);
+            Assert.AreEqual(1, xcount);
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_ViewManagerPassThrough()
+        {
+            var vm = new TestViewManager();
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension>(0));
+
+            // Name
+
+            Assert.AreEqual(vm.Name, vmplusx.Name);
+
+            // ShadowNodeType
+
+            Assert.AreEqual(vm.ShadowNodeType, vmplusx.ShadowNodeType);
+
+            // CreateShadowNodeInstance
+
+            var count = 0;
+            var shadowNode = new ReactShadowNode();
+            vm.CreateShadowNodeInstanceFunc = () =>
+            {
+                count++;
+                return shadowNode;
+            };
+
+            object result = vmplusx.CreateShadowNodeInstance();
+            Assert.AreSame(shadowNode, result);
+            Assert.AreEqual(1, count);
+
+            // GetDimensions
+
+            var dimensions = new Dimensions
+            {
+                X = 42,
+            };
+
+            count = 0;
+            vm.GetDimensionsFunc = () =>
+            {
+                count++;
+                return dimensions;
+            };
+
+            result = vmplusx.GetDimensions(null);
+            Assert.AreEqual(dimensions, result);
+            Assert.AreEqual(1, count);
+
+            // SetDimensions
+
+            count = 0;
+            vm.SetDimensionsAction = d =>
+            {
+                Assert.AreEqual(dimensions, d);
+                count++;
+            };
+
+            vmplusx.SetDimensions(null, dimensions);
+            Assert.AreEqual(1, count);
+
+            // UpdateExtraData
+
+            var data = new object();
+            count = 0;
+            vm.UpdateExtraDataAction = x =>
+            {
+                Assert.AreSame(data, x);
+                count++;
+            };
+
+            vmplusx.UpdateExtraData(null, data);
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeDirectEvents()
+        {
+            var vm = new TestViewManager
+            {
+                ExportedCustomDirectEventTypeConstants = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                ExportedCustomDirectEventTypeConstants = TestMapDifferent,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var result = vmplusx.ExportedCustomDirectEventTypeConstants;
+
+            foreach (var pair in TestMap)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+
+            foreach (var pair in TestMapDifferent)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeBubblingEvents()
+        {
+            var vm = new TestViewManager
+            {
+                ExportedCustomBubblingEventTypeConstants = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                ExportedCustomBubblingEventTypeConstants = TestMapDifferent,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var result = vmplusx.ExportedCustomBubblingEventTypeConstants;
+
+            foreach (var pair in TestMap)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+
+            foreach (var pair in TestMapDifferent)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeConstants()
+        {
+            var vm = new TestViewManager
+            {
+                ExportedViewConstants = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                ExportedViewConstants = TestMapDifferent,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var result = vmplusx.ExportedViewConstants;
+
+            foreach (var pair in TestMap)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+
+            foreach (var pair in TestMapDifferent)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeCommands()
+        {
+            var vm = new TestViewManager
+            {
+                CommandsMap = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                CommandsMap = TestMapDifferent,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var result = vmplusx.CommandsMap;
+
+            foreach (var pair in TestMap)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+
+            foreach (var pair in TestMapDifferent)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeProps()
+        {
+            var vm = new TestViewManager
+            {
+                NativeProperties = TestMapString,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                NativeProperties = TestMapDifferentString,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            var result = vmplusx.ExportedViewConstants;
+
+            foreach (var pair in TestMap)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+
+            foreach (var pair in TestMapDifferent)
+            {
+                Assert.AreEqual(TestMap[pair.Key], result[pair.Key]);
+            }
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeDirectEvents_NoOverride()
+        {
+            var vm = new TestViewManager
+            {
+                ExportedCustomDirectEventTypeConstants = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                ExportedCustomDirectEventTypeConstants = TestMapSameKey,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var x = vmplusx.ExportedCustomDirectEventTypeConstants;
+            });
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeBubblingEvents_NoOverride()
+        {
+            var vm = new TestViewManager
+            {
+                ExportedCustomBubblingEventTypeConstants = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                ExportedCustomBubblingEventTypeConstants = TestMapSameKey,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var x = vmplusx.ExportedCustomBubblingEventTypeConstants;
+            });
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeCommands_NoOveride()
+        {
+            var vm = new TestViewManager
+            {
+                CommandsMap = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                CommandsMap = TestMapSameKey,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var x = vmplusx.CommandsMap;
+            });
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeConstants_NoOveride()
+        {
+            var vm = new TestViewManager
+            {
+                ExportedViewConstants = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                ExportedViewConstants = TestMapSameKey,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var x = vmplusx.ExportedViewConstants;
+            });
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeProps_NoOverride()
+        {
+            var vm = new TestViewManager
+            {
+                NativeProperties = TestMapString,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                NativeProperties = TestMapDifferentString,
+            };
+
+            var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var x = vmplusx.NativeProperties;
+            });
+        }
+
+        [Test]
+        public void ViewManagerWithExtensions_MergeCommands_UniqueValues()
+        {
+            var vm = new TestViewManager
+            {
+                CommandsMap = TestMap,
+            };
+
+            var vmx = new TestViewManagerExtension
+            {
+                CommandsMap = TestMapSameValue,
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var vmplusx = new ViewManagerWithExtensions(vm, new List<IViewManagerExtension> { vmx });
+            });
+        }
+
+        #region Test Classes
+
+        class TestViewManager : IViewManager
+        {
+            public string Name => "Test";
+
+            public Type ShadowNodeType => typeof(ReactShadowNode);
+
+            public IReadOnlyDictionary<string, object> CommandsMap { get; set; }
+
+            public IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants { get; set; }
+
+            public IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants { get; set; }
+
+            public IReadOnlyDictionary<string, object> ExportedViewConstants { get; set; }
+
+            public IReadOnlyDictionary<string, string> NativeProperties { get; set; }
+
+            public Func<ReactShadowNode> CreateShadowNodeInstanceFunc { get; set; }
+
+            public ReactShadowNode CreateShadowNodeInstance() => CreateShadowNodeInstanceFunc?.Invoke();
+
+            public Func<DependencyObject> CreateViewFunc { get; set; }
+
+            public DependencyObject CreateView(ThemedReactContext reactContext) => CreateViewFunc?.Invoke();
+
+            public Action OnDropViewInstanceAction { get; set; }
+
+            public void OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view) => OnDropViewInstanceAction?.Invoke();
+
+            public Action<int, JArray> ReceiveCommandAction { get; set; }
+
+            public void ReceiveCommand(DependencyObject view, int commandId, JArray args) => ReceiveCommandAction?.Invoke(commandId, args);
+
+            public Action<ReactStylesDiffMap> UpdatePropertiesAction { get; set; }
+
+            public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props) => UpdatePropertiesAction?.Invoke(props);
+
+            public Action<object> UpdateExtraDataAction { get; set; }
+
+            public void UpdateExtraData(DependencyObject root, object extraData) => UpdateExtraDataAction?.Invoke(extraData);
+
+            public Func<Dimensions> GetDimensionsFunc { get; set; }
+
+            public Dimensions GetDimensions(DependencyObject view) => GetDimensionsFunc?.Invoke() ?? default(Dimensions);
+
+            public Action<Dimensions> SetDimensionsAction { get; set; }
+
+            public void SetDimensions(DependencyObject view, Dimensions dimensions) => SetDimensionsAction?.Invoke(dimensions);
+        }
+
+        class TestViewManagerExtension : IViewManagerExtension
+        {
+            public Type ViewManagerType => typeof(TestViewManager);
+
+            public IReadOnlyDictionary<string, object> CommandsMap { get; set; }
+
+            public IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants { get; set; }
+
+            public IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants { get; set; }
+
+            public IReadOnlyDictionary<string, object> ExportedViewConstants { get; set; }
+
+            public IReadOnlyDictionary<string, string> NativeProperties { get; set; }
+
+            public Action OnCreateViewAction { get; set; }
+
+            public void OnCreateView(ThemedReactContext reactContext, DependencyObject view) => OnCreateViewAction?.Invoke();
+
+            public Action OnDropViewInstanceAction { get; set; }
+
+            public void OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view) => OnDropViewInstanceAction?.Invoke();
+
+            public Action<int, JArray> ReceiveCommandAction { get; set; }
+
+            public void ReceiveCommand(DependencyObject view, int commandId, JArray args) => ReceiveCommandAction?.Invoke(commandId, args);
+
+            public Action<ReactStylesDiffMap> UpdatePropertiesAction { get; set; }
+
+            public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props) => UpdatePropertiesAction?.Invoke(props);
+        }
+
+        #endregion
+
+        #region Test Constants
+
+        private static readonly Dictionary<string, object> TestMap =
+            new Dictionary<string, object>
+            {
+                { "foo", 42 },
+            };
+
+        private static readonly Dictionary<string, string> TestMapString =
+            TestMap.ToDictionary(p => p.Key, p => p.Value.ToString());
+
+        private static readonly Dictionary<string, object> TestMapSameKey =
+            new Dictionary<string, object>
+            {
+                { "foo", 43 },
+            };
+
+        private static readonly Dictionary<string, string> TestMapSameKeyString =
+            TestMapSameKey.ToDictionary(p => p.Key, p => p.Value.ToString());
+
+        private static readonly Dictionary<string, object> TestMapSameValue =
+            new Dictionary<string, object>
+            {
+                { "bar", 42 },
+            };
+
+        private static readonly Dictionary<string, object> TestMapDifferent =
+            new Dictionary<string, object>
+            {
+                { "bar", 43 },
+            };
+
+        private static readonly Dictionary<string, string> TestMapDifferentString =
+            TestMapDifferent.ToDictionary(p => p.Key, p => p.Value.ToString());
+
+        #endregion
+    }
+}

--- a/ReactWindows/ReactNative.Shared/IReactPackage.cs
+++ b/ReactWindows/ReactNative.Shared/IReactPackage.cs
@@ -1,6 +1,5 @@
-﻿using ReactNative.Bridge;
+using ReactNative.Bridge;
 using ReactNative.UIManager;
-using System;
 using System.Collections.Generic;
 
 namespace ReactNative.Modules.Core

--- a/ReactWindows/ReactNative.Shared/IViewManagerExtensionProvider.cs
+++ b/ReactWindows/ReactNative.Shared/IViewManagerExtensionProvider.cs
@@ -1,0 +1,37 @@
+using ReactNative.Bridge;
+using ReactNative.UIManager;
+using System.Collections.Generic;
+
+namespace ReactNative
+{
+    /// <summary>
+    /// Interface for exposing native view manager extensions.
+    /// </summary>
+    /// <remarks>
+    /// To add <see cref="IViewManagerExtension"/> instances to your application,
+    /// extend your <see cref="IReactPackage" /> implementation with this
+    /// interface, e.g.:
+    /// <code>
+    /// class ReactPackage : IReactPackage, IViewManagerExtensionProvider
+    /// {
+    ///     /* ... IReactPackage implementation ... */
+    ///
+    ///     public IReadOnlyList&lt;IViewManagerExtension&gt; CreateViewManagerExtensions(ReactContext reactContext) =>
+    ///         new List&lt;IViewManagerExtension&gt;
+    ///         {
+    ///             new MyViewManagerExtension(),
+    ///         };
+    /// }
+    /// </code>
+    /// </remarks>
+    public interface IViewManagerExtensionProvider
+    {
+        /// <summary>
+        /// Creates the list of view manager extensions that should be
+        ///  registered with the <see cref="UIManagerModule"/>.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <returns>The list of view managers.</returns>
+        IReadOnlyList<IViewManagerExtension> CreateViewManagerExtensions(ReactContext reactContext);
+    }
+}

--- a/ReactWindows/ReactNative.Shared/IViewManagerExtensionProvider.cs
+++ b/ReactWindows/ReactNative.Shared/IViewManagerExtensionProvider.cs
@@ -9,7 +9,7 @@ namespace ReactNative
     /// </summary>
     /// <remarks>
     /// To add <see cref="IViewManagerExtension"/> instances to your application,
-    /// extend your <see cref="IReactPackage" /> implementation with this
+    /// extend your <see cref="Modules.Core.IReactPackage" /> implementation with this
     /// interface, e.g.:
     /// <code>
     /// class ReactPackage : IReactPackage, IViewManagerExtensionProvider
@@ -28,7 +28,7 @@ namespace ReactNative
     {
         /// <summary>
         /// Creates the list of view manager extensions that should be
-        ///  registered with the <see cref="UIManagerModule"/>.
+        /// registered with the <see cref="UIManagerModule"/>.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         /// <returns>The list of view managers.</returns>

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -389,11 +389,45 @@ namespace ReactNative
 
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "createAllViewManagers").Start())
             {
+                var allViewManagerExtensions = new Dictionary<Type, List<IViewManagerExtension>>();
+                foreach (var package in _packages)
+                {
+                    if (package is IViewManagerExtensionProvider provider)
+                    {
+                        foreach (var extension in provider.CreateViewManagerExtensions(reactContext))
+                        {
+                            List<IViewManagerExtension> extensions;
+                            if (!allViewManagerExtensions.TryGetValue(extension.ViewManagerType, out extensions))
+                            {
+                                extensions = new List<IViewManagerExtension>();
+                                allViewManagerExtensions.Add(extension.ViewManagerType, extensions);
+                            }
+
+                            extensions.Add(extension);
+                        }
+                    }
+                }
+
                 var allViewManagers = new List<IViewManager>();
                 foreach (var package in _packages)
                 {
-                    allViewManagers.AddRange(
-                        package.CreateViewManagers(reactContext));
+                    foreach (var viewManager in package.CreateViewManagers(reactContext))
+                    {
+                        var modifiedViewManager = viewManager;
+                        if (allViewManagerExtensions.TryGetValue(viewManager.GetType(), out List<IViewManagerExtension> extensions))
+                        {
+                            if (viewManager is IViewParentManager viewParentManager)
+                            {
+                                modifiedViewManager = new ViewParentManagerWithExtensions(viewParentManager, extensions);
+                            }
+                            else
+                            {
+                                modifiedViewManager = new ViewManagerWithExtensions(viewManager, extensions);
+                            }
+                        }
+
+                        allViewManagers.Add(modifiedViewManager);
+                    }
                 }
 
                 return allViewManagers;

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -114,6 +114,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DevSupport\StackFrameExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevSupport\StackTraceHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IReactPackage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IViewManagerExtensionProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\AppState\AppStateModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\DeviceEventManagerModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\ExceptionsManagerModule.cs" />
@@ -163,6 +164,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\FocusEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\KeyEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\IUIBlock.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\IViewManagerExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ReactShadowNodeVisitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\DependencyObjectExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\DependencyObjectViewManager.cs" />
@@ -215,9 +217,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\UIViewOperationQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewAtIndex.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagerExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagerRegistry.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManagerWithExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewParentManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewParentManagerExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewParentManagerWithExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewProps.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\YogaNodePool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\KeyHelpers.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/IPropertySetter.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/IPropertySetter.cs
@@ -1,4 +1,4 @@
-﻿#if WINDOWS_UWP
+#if WINDOWS_UWP
 using Windows.UI.Xaml;
 #else
 using System.Windows;
@@ -15,5 +15,7 @@ namespace ReactNative.UIManager
         void UpdateShadowNodeProperty(ReactShadowNode shadowNode, ReactStylesDiffMap value);
 
         void UpdateViewManagerProperty(IViewManager viewManager, DependencyObject view, ReactStylesDiffMap value);
+
+        void UpdateViewManagerExtensionProperty(IViewManagerExtension extension, DependencyObject view, ReactStylesDiffMap value);
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/IViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/IViewManager.cs
@@ -113,7 +113,7 @@ namespace ReactNative.UIManager
         /// <param name="view">
         /// The view instance that should receive the command.
         /// </param>
-        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="commandId">Identifier for the command.</param>
         /// <param name="args">Optional arguments for the command.</param>
         void ReceiveCommand(DependencyObject view, int commandId, JArray args);
 

--- a/ReactWindows/ReactNative.Shared/UIManager/IViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/IViewManager.cs
@@ -28,7 +28,7 @@ namespace ReactNative.UIManager
         /// node that this manager will return from
         /// <see cref="CreateShadowNodeInstance"/>.
         /// 
-        /// This method will be used in the bridge initialization phase to
+        /// This property will be used in the bridge initialization phase to
         /// collect properties exposed using the <see cref="Annotations.ReactPropAttribute"/>
         /// annotation from the <see cref="ReactShadowNode"/> subclass.
         /// </summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/IViewManagerExtension.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/IViewManagerExtension.cs
@@ -1,0 +1,84 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+#else
+using System.Windows;
+#endif
+
+namespace ReactNative.UIManager
+{
+    /// <summary>
+    /// An interface for extending view managers with additional props.
+    /// </summary>
+    public interface IViewManagerExtension
+    {
+        /// <summary>
+        /// The type of view manager type being extended.
+        /// </summary>
+        Type ViewManagerType { get; }
+
+        /// <summary>
+        /// The commands map for the view manager.
+        /// </summary>
+        IReadOnlyDictionary<string, object> CommandsMap { get; }
+
+        /// <summary>
+        /// The exported custom bubbling event types.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants { get; }
+
+        /// <summary>
+        /// The exported custom direct event types.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants { get; }
+
+        /// <summary>
+        /// The exported view constants.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ExportedViewConstants { get; }
+
+        /// <summary>
+        /// The native props for the view manager.
+        /// </summary>
+        IReadOnlyDictionary<string, string> NativeProperties { get; }
+
+        /// <summary>
+        /// Called when the view is created.
+        /// </summary>
+        /// <param name="reactContext">The context.</param>
+        /// <param name="view">The view.</param>
+        void OnCreateView(ThemedReactContext reactContext, DependencyObject view);
+
+        /// <summary>
+        /// Called when view is detached from view hierarchy and allows for 
+        /// additional cleanup by the <see cref="IViewManager"/>
+        /// subclass.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view.</param>
+        /// <remarks>
+        /// Derived classes do not need to call this base method.
+        /// </remarks>
+        void OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view);
+
+        /// <summary>
+        /// Implement this method to receive events/commands directly from
+        /// JavaScript through the <see cref="UIManager"/>.
+        /// </summary>
+        /// <param name="view">
+        /// The view instance that should receive the command.
+        /// </param>
+        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="args">Optional arguments for the command.</param>
+        void ReceiveCommand(DependencyObject view, int commandId, JArray args);
+
+        /// <summary>
+        /// Update the properties of the given view.
+        /// </summary>
+        /// <param name="viewToUpdate">The view to update.</param>
+        /// <param name="props">The properties.</param>
+        void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props);
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/IViewManagerExtension.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/IViewManagerExtension.cs
@@ -20,7 +20,7 @@ namespace ReactNative.UIManager
         Type ViewManagerType { get; }
 
         /// <summary>
-        /// The commands map for the view manager.
+        /// The commands map for the view manager extension.
         /// </summary>
         IReadOnlyDictionary<string, object> CommandsMap { get; }
 
@@ -40,7 +40,7 @@ namespace ReactNative.UIManager
         IReadOnlyDictionary<string, object> ExportedViewConstants { get; }
 
         /// <summary>
-        /// The native props for the view manager.
+        /// The native props for the view manager extension.
         /// </summary>
         IReadOnlyDictionary<string, string> NativeProperties { get; }
 
@@ -53,14 +53,11 @@ namespace ReactNative.UIManager
 
         /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
-        /// additional cleanup by the <see cref="IViewManager"/>
+        /// additional cleanup by the <see cref="IViewManagerExtension"/>
         /// subclass.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         /// <param name="view">The view.</param>
-        /// <remarks>
-        /// Derived classes do not need to call this base method.
-        /// </remarks>
         void OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view);
 
         /// <summary>
@@ -70,7 +67,7 @@ namespace ReactNative.UIManager
         /// <param name="view">
         /// The view instance that should receive the command.
         /// </param>
-        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="commandId">Identifier for the command.</param>
         /// <param name="args">Optional arguments for the command.</param>
         void ReceiveCommand(DependencyObject view, int commandId, JArray args);
 

--- a/ReactWindows/ReactNative.Shared/UIManager/PropertySetter.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/PropertySetter.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.UIManager.Annotations;
+using ReactNative.UIManager.Annotations;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -93,6 +93,16 @@ namespace ReactNative.UIManager
                 throw new ArgumentNullException(nameof(props));
 
             Invoke(viewManager, GetViewManagerArgs(view, props));
+        }
+
+        public void UpdateViewManagerExtensionProperty(IViewManagerExtension extension, DependencyObject view, ReactStylesDiffMap props)
+        {
+            if (extension == null)
+                throw new ArgumentNullException(nameof(extension));
+            if (props == null)
+                throw new ArgumentNullException(nameof(props));
+
+            Invoke(extension, GetViewManagerArgs(view, props));
         }
 
         protected virtual object[] GetShadowNodeArgs(ReactStylesDiffMap props)

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
@@ -82,6 +82,9 @@ namespace ReactNative.UIManager
         /// <param name="props">The properties.</param>
         public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
         {
+             if (props == null)
+                throw new ArgumentNullException(nameof(props));
+
             var propertySetters =
                 ViewManagersPropertyCache.GetNativePropertySettersForViewManagerType(GetType());
 

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
@@ -149,7 +149,7 @@ namespace ReactNative.UIManager
         /// <param name="view">
         /// The view instance that should receive the command.
         /// </param>
-        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="commandId">Identifier for the command.</param>
         /// <param name="args">Optional arguments for the command.</param>
         public virtual void ReceiveCommand(TFrameworkElement view, int commandId, JArray args)
         {

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
@@ -65,9 +65,8 @@ namespace ReactNative.UIManager
         public virtual IReadOnlyDictionary<string, object> ExportedViewConstants { get; }
 
         /// <summary>
-        /// Creates a shadow node for the view manager.
+        /// The native props for the view manager.
         /// </summary>
-        /// <returns>The shadow node instance.</returns>
         public IReadOnlyDictionary<string, string> NativeProperties
         {
             get
@@ -81,7 +80,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="viewToUpdate">The view to update.</param>
         /// <param name="props">The properties.</param>
-        public void UpdateProperties(TFrameworkElement viewToUpdate, ReactStylesDiffMap props)
+        public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
         {
             var propertySetters =
                 ViewManagersPropertyCache.GetNativePropertySettersForViewManagerType(GetType());
@@ -96,7 +95,7 @@ namespace ReactNative.UIManager
                 }
             }
 
-            OnAfterUpdateTransaction(viewToUpdate);
+            OnAfterUpdateTransaction((TFrameworkElement)viewToUpdate);
         }
 
         /// <summary>
@@ -216,12 +215,7 @@ namespace ReactNative.UIManager
         {
         }
 
-#region IViewManager
-
-        void IViewManager.UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
-        {
-            UpdateProperties((TFrameworkElement)viewToUpdate, props);
-        }
+        #region IViewManager
 
         DependencyObject IViewManager.CreateView(ThemedReactContext reactContext)
         {
@@ -258,6 +252,6 @@ namespace ReactNative.UIManager
             SetDimensions((TFrameworkElement)view, dimensions);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerExtension.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerExtension.cs
@@ -24,7 +24,7 @@ namespace ReactNative.UIManager
         public Type ViewManagerType => typeof(TViewManager);
 
         /// <summary>
-        /// The commands map for the view manager.
+        /// The commands map for the view manager extension.
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> CommandsMap { get; }
 
@@ -65,7 +65,7 @@ namespace ReactNative.UIManager
 
         /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
-        /// additional cleanup by the <see cref="IViewManager"/>
+        /// additional cleanup by the <see cref="IViewManagerExtension"/>
         /// subclass.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
@@ -84,7 +84,7 @@ namespace ReactNative.UIManager
         /// <param name="view">
         /// The view instance that should receive the command.
         /// </param>
-        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="commandId">Identifier for the command.</param>
         /// <param name="args">Optional arguments for the command.</param>
         public virtual void ReceiveCommand(TDependencyObject view, int commandId, JArray args)
         {

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerExtension.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerExtension.cs
@@ -1,0 +1,159 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+#else
+using System.Windows;
+#endif
+
+namespace ReactNative.UIManager
+{
+    /// <summary>
+    /// Base class for view manager extensions.
+    /// </summary>
+    /// <typeparam name="TDependencyObject">Type of dependency object.</typeparam>
+    /// <typeparam name="TViewManager">Type of view manager.</typeparam>
+    public class ViewManagerExtension<TDependencyObject, TViewManager> : IViewManagerExtension
+        where TDependencyObject : DependencyObject
+        where TViewManager : IViewManager
+    {
+        /// <summary>
+        /// The type of view manager type being extended.
+        /// </summary>
+        public Type ViewManagerType => typeof(TViewManager);
+
+        /// <summary>
+        /// The commands map for the view manager.
+        /// </summary>
+        public virtual IReadOnlyDictionary<string, object> CommandsMap { get; }
+
+        /// <summary>
+        /// The exported custom bubbling event types.
+        /// </summary>
+        public virtual IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants { get; }
+
+        /// <summary>
+        /// The exported custom direct event types.
+        /// </summary>
+        public virtual IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants { get; }
+
+        /// <summary>
+        /// The exported view constants.
+        /// </summary>
+        public virtual IReadOnlyDictionary<string, object> ExportedViewConstants { get; }
+
+        /// <summary>
+        /// The native props for the view manager extension.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> NativeProperties
+        {
+            get
+            {
+                return ViewManagersPropertyCache.GetNativePropertiesForView(GetType(), typeof(ReactShadowNode));
+            }
+        }
+
+        /// <summary>
+        /// Called when the view is created.
+        /// </summary>
+        /// <param name="reactContext">The context.</param>
+        /// <param name="view">The view.</param>
+        public virtual void OnCreateView(ThemedReactContext reactContext, TDependencyObject view)
+        {
+        }
+
+        /// <summary>
+        /// Called when view is detached from view hierarchy and allows for 
+        /// additional cleanup by the <see cref="IViewManager"/>
+        /// subclass.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view.</param>
+        /// <remarks>
+        /// Derived classes do not need to call this base method.
+        /// </remarks>
+        public virtual void OnDropViewInstance(ThemedReactContext reactContext, TDependencyObject view)
+        {
+        }
+
+        /// <summary>
+        /// Implement this method to receive events/commands directly from
+        /// JavaScript through the <see cref="UIManager"/>.
+        /// </summary>
+        /// <param name="view">
+        /// The view instance that should receive the command.
+        /// </param>
+        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="args">Optional arguments for the command.</param>
+        public virtual void ReceiveCommand(TDependencyObject view, int commandId, JArray args)
+        {
+        }
+
+        /// <summary>
+        /// Update the properties of the given view.
+        /// </summary>
+        /// <param name="viewToUpdate">The view to update.</param>
+        /// <param name="props">The properties.</param>
+        public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
+        {
+            var propertySetters =
+                ViewManagersPropertyCache.GetNativePropertySettersForViewManagerType(GetType());
+
+            var keys = props.Keys;
+            foreach (var key in keys)
+            {
+                var setter = default(IPropertySetter);
+                if (propertySetters.TryGetValue(key, out setter))
+                {
+                    setter.UpdateViewManagerExtensionProperty(this, viewToUpdate, props);
+                }
+            }
+
+            OnAfterUpdateTransaction((TDependencyObject)viewToUpdate);
+        }
+
+        /// <summary>
+        /// Subclasses can override this method to install custom event 
+        /// emitters on the given view.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view instance.</param>
+        /// <remarks>
+        /// Consider overriding this method if your view needs to emit events
+        /// besides basic touch events to JavaScript (e.g., scroll events).
+        /// </remarks>
+        protected virtual void AddEventEmitters(ThemedReactContext reactContext, TDependencyObject view)
+        {
+        }
+
+        /// <summary>
+        /// Callback that will be triggered after all properties are updated in
+        /// the current update transation (all <see cref="Annotations.ReactPropAttribute"/> handlers
+        /// for properties updated in the current transaction have been called).
+        /// </summary>
+        /// <param name="view">The view.</param>
+        protected virtual void OnAfterUpdateTransaction(TDependencyObject view)
+        {
+        }
+
+        #region IViewManagerExtension
+
+        void IViewManagerExtension.OnCreateView(ThemedReactContext reactContext, DependencyObject view)
+        {
+            OnCreateView(reactContext, (TDependencyObject)view);
+        }
+
+        void IViewManagerExtension.OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view)
+        {
+            OnDropViewInstance(reactContext, (TDependencyObject)view);
+        }
+
+        void IViewManagerExtension.ReceiveCommand(DependencyObject view, int commandId, JArray args)
+        {
+            ReceiveCommand((TDependencyObject)view, commandId, args);
+        }
+
+        #endregion
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerExtension.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerExtension.cs
@@ -61,6 +61,7 @@ namespace ReactNative.UIManager
         /// <param name="view">The view.</param>
         public virtual void OnCreateView(ThemedReactContext reactContext, TDependencyObject view)
         {
+            AddEventEmitters(reactContext, view);
         }
 
         /// <summary>
@@ -97,6 +98,9 @@ namespace ReactNative.UIManager
         /// <param name="props">The properties.</param>
         public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
         {
+            if (props == null)
+                throw new ArgumentNullException(nameof(props));
+
             var propertySetters =
                 ViewManagersPropertyCache.GetNativePropertySettersForViewManagerType(GetType());
 

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
@@ -171,7 +171,7 @@ namespace ReactNative.UIManager
                 var extensionCommands = extension.CommandsMap;
                 if (extensionCommands != null)
                 {
-                    foreach (var command in extensionCommands)
+                    foreach (var command in extensionCommands.Values)
                     {
                         if (reverseMap.ContainsKey(command))
                         {

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
@@ -168,7 +168,7 @@ namespace ReactNative.UIManager
                 {
                     foreach (var command in extensionCommands)
                     {
-                        if (reverseMap.TryGetValue(command, out IViewManagerExtension unused) || /* registered by view manager */ unused == null)
+                        if (reverseMap.ContainsKey(command))
                         {
                             throw new InvalidOperationException("View manager extensions must use unique command identifiers.");
                         }

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
@@ -18,6 +18,11 @@ namespace ReactNative.UIManager
 
         public ViewManagerWithExtensions(IViewManager viewManager, IReadOnlyList<IViewManagerExtension> extensions)
         {
+            if (viewManager == null)
+                throw new ArgumentNullException(nameof(viewManager));
+            if (extensions == null)
+                throw new ArgumentNullException(nameof(extensions));
+
             _viewManager = viewManager;
             _extensions = extensions;
             _reverseCommandsMap = CreateReverseCommandsMap(viewManager, extensions);

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerWithExtensions.cs
@@ -1,0 +1,184 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+#else
+using System.Windows;
+#endif
+
+namespace ReactNative.UIManager
+{
+    class ViewManagerWithExtensions : IViewManager
+    {
+        private readonly IViewManager _viewManager;
+        private readonly IReadOnlyList<IViewManagerExtension> _extensions;
+        private readonly IReadOnlyDictionary<object, IViewManagerExtension> _reverseCommandsMap;
+
+        public ViewManagerWithExtensions(IViewManager viewManager, IReadOnlyList<IViewManagerExtension> extensions)
+        {
+            _viewManager = viewManager;
+            _extensions = extensions;
+            _reverseCommandsMap = CreateReverseCommandsMap(viewManager, extensions);
+        }
+
+        public string Name => _viewManager.Name;
+   
+        public Type ShadowNodeType => _viewManager.ShadowNodeType;
+
+        public IReadOnlyDictionary<string, object> CommandsMap =>
+            Merge(vm => vm.CommandsMap, vmx => vmx.CommandsMap);
+
+        public IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants =>
+            Merge(vm => vm.ExportedCustomBubblingEventTypeConstants, vmx => vmx.ExportedCustomBubblingEventTypeConstants);
+
+        public IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants =>
+            Merge(vm => vm.ExportedCustomDirectEventTypeConstants, vmx => vmx.ExportedCustomDirectEventTypeConstants);
+
+        public IReadOnlyDictionary<string, object> ExportedViewConstants =>
+            Merge(vm => vm.ExportedViewConstants, vmx => vmx.ExportedViewConstants);
+
+        public IReadOnlyDictionary<string, string> NativeProperties =>
+            Merge(vm => vm.NativeProperties, vmx => vmx.NativeProperties);
+
+        public ReactShadowNode CreateShadowNodeInstance() => _viewManager.CreateShadowNodeInstance();
+
+        public DependencyObject CreateView(ThemedReactContext reactContext)
+        {
+            var view = _viewManager.CreateView(reactContext);
+            foreach (var extension in _extensions)
+            {
+                extension.OnCreateView(reactContext, view);
+            }
+
+            return view;
+        }
+
+        public Dimensions GetDimensions(DependencyObject view) => _viewManager.GetDimensions(view);
+
+        public void OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view)
+        {
+            foreach (var extension in _extensions)
+            {
+                extension.OnDropViewInstance(reactContext, view);
+            }
+
+            _viewManager.OnDropViewInstance(reactContext, view);
+        }
+
+        public void ReceiveCommand(DependencyObject view, int commandId, JArray args)
+        {
+            if (_reverseCommandsMap.TryGetValue(commandId, out IViewManagerExtension extension) && extension != null)
+            {
+                extension.ReceiveCommand(view, commandId, args);
+            }
+            else
+            {
+                _viewManager.ReceiveCommand(view, commandId, args);
+            }
+        }
+
+        public void SetDimensions(DependencyObject view, Dimensions dimensions)
+        {
+            _viewManager.SetDimensions(view, dimensions);
+        }
+
+        public void UpdateExtraData(DependencyObject root, object extraData)
+        {
+            _viewManager.UpdateExtraData(root, extraData);
+        }
+
+        public void UpdateProperties(DependencyObject viewToUpdate, ReactStylesDiffMap props)
+        {
+            // TODO: should we split up the ReactStylesDiffMap?
+            _viewManager.UpdateProperties(viewToUpdate, props);
+            foreach (var extension in _extensions)
+            {
+                extension.UpdateProperties(viewToUpdate, props);
+            }
+        }
+
+        private IReadOnlyDictionary<string, TValue> Merge<TValue>(
+            Func<IViewManager, IReadOnlyDictionary<string, TValue>> viewManagerSelector,
+            Func<IViewManagerExtension, IReadOnlyDictionary<string, TValue>> viewManagerExtensionSelector)
+        {
+            var result = new Dictionary<string, TValue>();
+
+            var viewManagerData = viewManagerSelector(_viewManager);
+            if (viewManagerData != null)
+            {
+                foreach (var pair in viewManagerData)
+                {
+                    result.Add(pair.Key, pair.Value);
+                }
+            }
+
+            foreach (var extension in _extensions)
+            {
+                var extensionData = viewManagerExtensionSelector(extension);
+                Merge(result, extensionData);
+            }
+
+            return result.Count > 0 ? result : null;
+        }
+
+        private static void Merge<TValue>(IDictionary<string, TValue> sink, IReadOnlyDictionary<string, TValue> source)
+        {
+            if (sink == null || source == null || source.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var pair in source)
+            {
+                if (sink.ContainsKey(pair.Key))
+                {
+                    throw new InvalidOperationException("View manager extension cannot override behaviors.");
+                }
+                else
+                {
+                    sink.Add(pair.Key, pair.Value);
+                }
+            }
+        }
+
+
+        private static IReadOnlyDictionary<object, IViewManagerExtension> CreateReverseCommandsMap(
+            IViewManager viewManager,
+            IReadOnlyList<IViewManagerExtension> extensions)
+        {
+            var commands = viewManager.CommandsMap;
+            var reverseMap = new Dictionary<object, IViewManagerExtension>();
+
+            if (commands != null)
+            {
+                // Create a null entry for each view manager command index
+                foreach (var command in commands.Values)
+                {
+                    // Don't use `Add` here, IViewManager puts no restriction on command identifiers.
+                    reverseMap[command] = null;
+                }
+            }
+
+            foreach (var extension in extensions)
+            {
+                var extensionCommands = extension.CommandsMap;
+                if (extensionCommands != null)
+                {
+                    foreach (var command in extensionCommands)
+                    {
+                        if (reverseMap.TryGetValue(command, out IViewManagerExtension unused) || /* registered by view manager */ unused == null)
+                        {
+                            throw new InvalidOperationException("View manager extensions must use unique command identifiers.");
+                        }
+
+                        reverseMap.Add(command, extension);
+                    }
+                }
+            }
+
+            return reverseMap;
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerWithExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerWithExtensions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+#if WINDOWS_UWP
+using Windows.UI.Xaml;
+#else
+using System.Windows;
+#endif
+
+namespace ReactNative.UIManager
+{
+    class ViewParentManagerWithExtensions : ViewManagerWithExtensions, IViewParentManager
+    {
+        private readonly IViewParentManager _viewManager;
+
+        public ViewParentManagerWithExtensions(IViewParentManager viewManager, IReadOnlyList<IViewManagerExtension> extensions)
+            : base(viewManager, extensions)
+        {
+            _viewManager = viewManager;
+        }
+
+        public bool NeedsCustomLayoutForChildren => _viewManager.NeedsCustomLayoutForChildren;
+
+        public void AddView(DependencyObject parent, DependencyObject child, int index)
+        {
+            _viewManager.AddView(parent, child, index);
+        }
+
+        public DependencyObject GetChildAt(DependencyObject parent, int index)
+        {
+            return _viewManager.GetChildAt(parent, index);
+        }
+
+        public int GetChildCount(DependencyObject parent)
+        {
+            return _viewManager.GetChildCount(parent);
+        }
+
+        public void RemoveAllChildren(DependencyObject parent)
+        {
+            _viewManager.RemoveAllChildren(parent);
+        }
+
+        public void RemoveChildAt(DependencyObject parent, int index)
+        {
+            _viewManager.RemoveChildAt(parent, index);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerWithExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerWithExtensions.cs
@@ -19,29 +19,19 @@ namespace ReactNative.UIManager
 
         public bool NeedsCustomLayoutForChildren => _viewManager.NeedsCustomLayoutForChildren;
 
-        public void AddView(DependencyObject parent, DependencyObject child, int index)
-        {
+        public void AddView(DependencyObject parent, DependencyObject child, int index) =>
             _viewManager.AddView(parent, child, index);
-        }
 
-        public DependencyObject GetChildAt(DependencyObject parent, int index)
-        {
-            return _viewManager.GetChildAt(parent, index);
-        }
+        public DependencyObject GetChildAt(DependencyObject parent, int index) =>
+            _viewManager.GetChildAt(parent, index);
 
-        public int GetChildCount(DependencyObject parent)
-        {
-            return _viewManager.GetChildCount(parent);
-        }
+        public int GetChildCount(DependencyObject parent) =>
+            _viewManager.GetChildCount(parent);
 
-        public void RemoveAllChildren(DependencyObject parent)
-        {
+        public void RemoveAllChildren(DependencyObject parent) =>
             _viewManager.RemoveAllChildren(parent);
-        }
 
-        public void RemoveChildAt(DependencyObject parent, int index)
-        {
+        public void RemoveChildAt(DependencyObject parent, int index) =>
             _viewManager.RemoveChildAt(parent, index);
-        }
     }
 }


### PR DESCRIPTION
Native plugins may need the ability to extend the prop types available for a native component. For example, if we want to keep a lean core, but add features the extend functionality for some of the [Windows 10 Fluent APIs](), we'd like to do so without modifying the core ReactViewManager implementation.

This changeset adds the `IViewManagerExtension`, which you can expose on your `IReactPackage` with the `IViewManagerExtensionProvider` interface. The `IViewManagerExtension` is linked to a `ViewManagerType`, and all props added to the `IViewManagerExtension` will be exposed to the React.js component. The developer experience for adding props to the `IViewManagerExtension` is identical to the `IViewManager` experience. There are also some useful lifecycle event hooks like `OnCreateView` and `OnDropViewInstance` that can be used to attach event handlers.