### PR TITLE
fix(Text): Prevent crashing from touch/click

### DIFF
--- a/ReactWindows/ReactNative/Views/Text/ReactTextCompoundView.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextCompoundView.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.UIManager;
+using ReactNative.UIManager;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -11,7 +11,14 @@ namespace ReactNative.Views.Text
         {
             var richTextBlock = reactView.As<RichTextBlock>();
             var textPointer = richTextBlock.GetPositionFromPoint(point);
-            return textPointer.Parent.GetTag();
+            var textPointerParent = textPointer.Parent;
+
+            // We may encounter a case where the parent item is the
+            // `Paragraph` inline attached to the `RichTextBlock`.
+            // In this case, simply return the tag of the `RichTextBlock`.
+            return textPointerParent.HasTag()
+                ? textPointerParent.GetTag()
+                : richTextBlock.GetTag();
         }
     }
 }

--- a/ReactWindows/ReactNative/Views/Text/ReactTextCompoundView.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextCompoundView.cs
@@ -13,10 +13,12 @@ namespace ReactNative.Views.Text
             var textPointer = richTextBlock.GetPositionFromPoint(point);
             var textPointerParent = textPointer.Parent;
 
-            // We may encounter a case where the parent item is the
-            // `Paragraph` inline attached to the `RichTextBlock`.
+            // We may encounter a case where the parent object is the
+            // `Paragraph` inline attached to the `RichTextBlock`. This is a
+            // native implementation detail of the `Text` component, and as 
+            // such the `Paragraph` would not have a React tag associated.
             // In this case, simply return the tag of the `RichTextBlock`.
-            return textPointerParent.HasTag()
+            return textPointerParent != null && textPointerParent.HasTag()
                 ? textPointerParent.GetTag()
                 : richTextBlock.GetTag();
         }


### PR DESCRIPTION
Occasionally, if you click the root Span inline of the RichTextBlock rendered for the React Native <Text/> component, the app will not find the "tag" that was targeted, and will crash.

Fixes #1622