### PR TITLE
Fix measureInWindow() to invoke the callback with correct arguments

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueue.cs
@@ -297,7 +297,7 @@ namespace ReactNative.UIManager
                 var y = _measureBuffer[1];
                 var width = _measureBuffer[2];
                 var height = _measureBuffer[3];
-                callback.Invoke(0, 0, width, height, x, y);
+                callback.Invoke(x, y, width, height);
             });
         }
 


### PR DESCRIPTION
Unlike measure(), measureInWindow() is supposed to return only x, y,
width, height. Technically a breaking change but fixes the API to
match the documentation.

https://facebook.github.io/react-native/docs/direct-manipulation.html#measureinwindowcallback