### PR TITLE
chore(NPM): update to `react-native@0.53.*`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "peerDependencies": {
     "react": "16.2.0",
-    "react-native": "~0.52.0"
+    "react-native": "~0.53.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -40,15 +40,15 @@
     "eslint-plugin-flowtype": "^2.33.0",
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.2.1",
-    "flow-bin": "^0.61.0",
+    "flow-bin": "^0.63.0",
     "https-proxy-agent": "^1.0.0",
     "jasmine": "^2.6.0",
     "jasmine-reporters": "^2.2.1",
     "minimist": "^1.2.0",
-    "prettier": "^1.7.0",
+    "prettier": "^1.9.1",
     "react": "16.2.0",
     "react-devtools-core": "^3.0.0",
-    "react-native": "~0.52.0",
+    "react-native": "~0.53.0",
     "selenium-webdriver": "2.48.x"
   },
   "dependencies": {


### PR DESCRIPTION
Updating to `react-native@0.53.*`, as well as other related dependencies.