### PR TITLE
Align TextInput keyboard events to the other platforms.

### DIFF
--- a/Libraries/Components/TextInput/TextInput.windows.js
+++ b/Libraries/Components/TextInput/TextInput.windows.js
@@ -625,18 +625,6 @@ const TextInput = createReactClass({
      *  @platform windows
      */
     tabIndex: PropTypes.number,
-    /**
-     * Called when key down while component has focus.
-     *
-     * @platform windows
-     */
-    onKeyDown: PropTypes.func,
-    /**
-     * Called when key up while component has focus.
-     *
-     * @platform windows
-     */
-    onKeyUp: PropTypes.func,
   },
   getDefaultProps(): Object {
     return {
@@ -925,9 +913,7 @@ const TextInput = createReactClass({
           text={this._getText()}
           isTabStop={windowsTabFocusable}
           tabIndex={tabIndex}
-          onKeyDown={this.props.onKeyDown}
-          onKeyUp={this.props.onKeyUp}
-          />;
+        />;
     } else {
       textContainer =
         <RCTTextBox
@@ -944,8 +930,6 @@ const TextInput = createReactClass({
           onScroll={this._onScroll}
           isTabStop={windowsTabFocusable}
           tabIndex={tabIndex}
-          onKeyDown={this.props.onKeyDown}
-          onKeyUp={this.props.onKeyUp}
         />;
     }
 

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -372,7 +372,6 @@ namespace ReactNative.Views.TextInput
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
             view.KeyDown += OnKeyDown;
-            view.KeyUp += OnKeyUp;
         }
 
         /// <summary>
@@ -386,7 +385,6 @@ namespace ReactNative.Views.TextInput
         {
             base.OnDropViewInstance(reactContext, view);
             view.KeyDown -= OnKeyDown;
-            view.KeyUp -= OnKeyUp;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
             view.PasswordChanged -= OnPasswordChanged;
@@ -465,24 +463,10 @@ namespace ReactNative.Views.TextInput
                     .EventDispatcher
                     .DispatchEvent(
                         new KeyEvent(
-                            KeyEvent.KeyDownEventString,
+                            KeyEvent.KeyPressEventString,
                             textBox.GetTag(),
                             e.Key));
             }
-        }
-
-        private void OnKeyUp(object sender, KeyEventArgs e)
-        {
-            var textBox = (PasswordBox)sender;
-            var keyCode = e.Key.GetKeyCode();
-            textBox.GetReactContext()
-                .GetNativeModule<UIManagerModule>()
-                .EventDispatcher
-                .DispatchEvent(
-                    new KeyEvent(
-                        KeyEvent.KeyUpEventString,
-                        textBox.GetTag(),
-                        e.Key));
         }
     }
 }

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -466,7 +466,6 @@ namespace ReactNative.Views.TextInput
         {
             base.OnDropViewInstance(reactContext, view);
             view.KeyDown -= OnKeyDown;
-            view.KeyUp -= OnKeyUp;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
             view.TextChanged -= OnTextChanged;
@@ -504,7 +503,6 @@ namespace ReactNative.Views.TextInput
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
             view.KeyDown += OnKeyDown;
-            view.KeyUp += OnKeyUp;
         }
 
         private void OnTextChanged(object sender, TextChangedEventArgs e)
@@ -571,24 +569,10 @@ namespace ReactNative.Views.TextInput
                     .EventDispatcher
                     .DispatchEvent(
                         new KeyEvent(
-                            KeyEvent.KeyDownEventString,
+                            KeyEvent.KeyPressEventString,
                             textBox.GetTag(),
                             e.Key));
             }
-        }
-
-        private void OnKeyUp(object sender, KeyEventArgs e)
-        {
-            var textBox = (ReactTextBox)sender;
-            var keyCode = e.Key.GetKeyCode();
-            textBox.GetReactContext()
-                .GetNativeModule<UIManagerModule>()
-                .EventDispatcher
-                .DispatchEvent(
-                    new KeyEvent(
-                        KeyEvent.KeyUpEventString,
-                        textBox.GetTag(),
-                        e.Key));
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/KeyEvent.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/KeyEvent.cs
@@ -19,6 +19,7 @@ namespace ReactNative.UIManager.Events
     {
         public const string KeyDownEventString = "topKeyDown";
         public const string KeyUpEventString = "topKeyUp";
+        public const string KeyPressEventString = "topKeyPress";
 
         private readonly string _key;
         private readonly int _keyCode;

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
@@ -301,6 +301,20 @@ namespace ReactNative.UIManager
                         }
                     }
                 },
+                {
+                    "topKeyPress",
+                    new Dictionary<string, object>()
+                    {
+                        {
+                            "phasedRegistrationNames",
+                            new Dictionary<string, string>()
+                            {
+                                { "bubbled" , "onKeyPress" },
+                                { "captured" , "onKeyPressCapture" }
+                            }
+                        }
+                    }
+                },
             };
         }
 

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -442,7 +442,6 @@ namespace ReactNative.Views.TextInput
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
             view.KeyDown += OnKeyDown;
-            view.KeyUp += OnKeyUp;
         }
 
         /// <summary>
@@ -456,7 +455,6 @@ namespace ReactNative.Views.TextInput
         {
             base.OnDropViewInstance(reactContext, view);
             view.KeyDown -= OnKeyDown;
-            view.KeyUp -= OnKeyUp;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
             view.PasswordChanged -= OnPasswordChanged;
@@ -535,23 +533,10 @@ namespace ReactNative.Views.TextInput
                     .EventDispatcher
                     .DispatchEvent(
                         new KeyEvent(
-                            KeyEvent.KeyDownEventString,
+                            KeyEvent.KeyPressEventString,
                             textBox.GetTag(),
                             e.Key));
             }
-        }
-
-        private void OnKeyUp(object sender, KeyRoutedEventArgs e)
-        {
-            var textBox = (PasswordBox)sender;
-            textBox.GetReactContext()
-                .GetNativeModule<UIManagerModule>()
-                .EventDispatcher
-                .DispatchEvent(
-                    new KeyEvent(
-                        KeyEvent.KeyUpEventString,
-                        textBox.GetTag(),
-                        e.Key));
         }
     }
 }

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -606,7 +606,6 @@ namespace ReactNative.Views.TextInput
         {
             base.OnDropViewInstance(reactContext, view);
             view.KeyDown -= OnKeyDown;
-            view.KeyUp -= OnKeyUp;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
             view.TextChanged -= OnTextChanged;
@@ -663,7 +662,6 @@ namespace ReactNative.Views.TextInput
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
             view.KeyDown += OnKeyDown;
-            view.KeyUp += OnKeyUp;
         }
 
         private void OnTextChanging(TextBox sender, TextBoxTextChangingEventArgs args)
@@ -736,23 +734,10 @@ namespace ReactNative.Views.TextInput
                     .EventDispatcher
                     .DispatchEvent(
                         new KeyEvent(
-                            KeyEvent.KeyDownEventString,
+                            KeyEvent.KeyPressEventString,
                             textBox.GetTag(),
                             e.Key));
             }
-        }
-
-        private void OnKeyUp(object sender, KeyRoutedEventArgs e)
-        {
-            var textBox = (ReactTextBox)sender;
-            textBox.GetReactContext()
-                .GetNativeModule<UIManagerModule>()
-                .EventDispatcher
-                .DispatchEvent(
-                    new KeyEvent(
-                        KeyEvent.KeyUpEventString,
-                        textBox.GetTag(),
-                        e.Key));
         }
     }
 }


### PR DESCRIPTION
I had added KeyDown/Up events to TextInput some time ago, but the correct way would've been to use the already defined onKeyPress.
Reverting the damage and moved to using this existing event.