### PR TITLE
Fixed padding issue in TextInput

### DIFF
--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactPasswordBoxShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactPasswordBoxShadowNode.cs
@@ -32,8 +32,6 @@ namespace ReactNative.Views.TextInput
 
         private static string s_passwordChar;
 
-        private float[] _computedPadding;
-
         private int _letterSpacing;
 
         private double _fontSize = Unset;
@@ -173,10 +171,11 @@ namespace ReactNative.Views.TextInput
         {
             base.OnCollectExtraUpdates(uiViewOperationQueue);
 
-            if (_computedPadding != null)
+            var computedPadding = GetComputedPadding();
+
+            if (computedPadding != null)
             {
-                uiViewOperationQueue.EnqueueUpdateExtraData(ReactTag, _computedPadding);
-                _computedPadding = null;
+                uiViewOperationQueue.EnqueueUpdateExtraData(ReactTag, computedPadding);
             }
         }
 
@@ -214,8 +213,6 @@ namespace ReactNative.Views.TextInput
 
         private static YogaSize MeasurePasswordBox(ReactPasswordBoxShadowNode textInputNode, YogaNode node, float width, YogaMeasureMode widthMode, float height, YogaMeasureMode heightMode)
         {
-            textInputNode._computedPadding = textInputNode.GetComputedPadding();
-
             var normalizedWidth = Math.Max(0,
                 (YogaConstants.IsUndefined(width) ? double.PositiveInfinity : width));
 

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
@@ -38,8 +38,6 @@ namespace ReactNative.Views.TextInput
             5f,
         };
 
-        private float[] _computedPadding;
-
         private bool _multiline;
         private bool _autoGrow;
         private int _letterSpacing;
@@ -281,10 +279,11 @@ namespace ReactNative.Views.TextInput
         {
             base.OnCollectExtraUpdates(uiViewOperationQueue);
 
-            if (_computedPadding != null)
+            var computedPadding = GetComputedPadding();
+
+            if (computedPadding != null)
             {
-                uiViewOperationQueue.EnqueueUpdateExtraData(ReactTag, _computedPadding);
-                _computedPadding = null;
+                uiViewOperationQueue.EnqueueUpdateExtraData(ReactTag, computedPadding);
             }
 
             if (_jsEventCount != Unset)
@@ -326,8 +325,6 @@ namespace ReactNative.Views.TextInput
 
         private static YogaSize MeasureTextInput(ReactTextInputShadowNode textInputNode, YogaNode node, float width, YogaMeasureMode widthMode, float height, YogaMeasureMode heightMode)
         {
-            textInputNode._computedPadding = textInputNode.GetComputedPadding();
-
             var normalizedWidth = Math.Max(0,
                 (YogaConstants.IsUndefined(width) ? double.PositiveInfinity : width));
 


### PR DESCRIPTION
ReactTextInputShadow uses a measure function to compute text size. We also used to piggyback on that callback to retrieve the computed padding (that we do push to the TextBox controls).

The problem is that Yoga refrains from calling the measuring function when it already knows the sizes (usually due to a parent enforcing a particular size irrespective of text content).

I moved the retrieval of computed padding to the "collection of extra data" point.