### PR TITLE
Accounting for Facebook license and grant of patent rights

### DIFF
--- a/FacebookLicense/LICENSE
+++ b/FacebookLicense/LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For React Native software
+
+Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/FacebookLicense/PATENTS
+++ b/FacebookLicense/PATENTS
@@ -1,0 +1,33 @@
+Additional Grant of Patent Rights Version 2
+
+"Software" means the React Native software distributed by Facebook, Inc.
+
+Facebook, Inc. (“Facebook”) hereby grants to each recipient of the Software
+(“you”) a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook's rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/FacebookLicense/README.md
+++ b/FacebookLicense/README.md
@@ -1,0 +1,20 @@
+## Facebook License and Grant of Patent Rights
+
+A subset of the source code in React Native Windows is derived from React Native.  Files that are derived from React Native contain the following copyright headers:
+
+```
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+```
+
+In React Native Windows, the BSD-style license referred to above can be found in the [LICENSE](LICENSE) file in this folder. The grant of patent rights can be found in the [PATENTS](PATENTS) file in this folder.
+
+A non-exhaustive list of that source code can be found in the following directories:
+- [Libraries](/Libraries)
+- [RNTester](https://github.com/Microsoft/react-native-windows/tree/rntester)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Each pull request has the unit tests, code analysis, and a [Winium](https://gith
 
 ## License
 
-The React Native Windows plugin is provided under the [MIT License](LICENSE).
+Portions of the React Native Windows plugin are subject to certain Facebook provided license terms. More information can be found in the [FacebookLicense](FacebookLicense) directory.
+
+All modifications to the original Facebook source code, and all newly contributed code to the React Native Windows plugin are provided under the [MIT License](LICENSE).
 
 ## Code of Conduct
 


### PR DESCRIPTION
Some files in react-native-windows are copied over from react-native and modified. These files, except for their modifications that are specific to react-native-windows, are originally provided by Facebook under the BSD-style license and Facebook's grant of patent rights from Facebook's repo.

*Please note* - this is not a change in licensing terms. These terms were already in existence and documented through the file headers of copied source code. This change only serves to provide a specific link to the Facebook licensing terms referenced in certain files in this repository.
