### PR TITLE
DO NOT MERGE: Update `ActionQueue` contract so it never returns null

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/IHasActionQueue.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IHasActionQueue.cs
@@ -5,5 +5,7 @@ namespace ReactNative.Bridge
     interface IHasActionQueue
     {
         IActionQueue ActionQueue { get; }
+
+        void DisposeActionQueue();
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/IHasActionQueue.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IHasActionQueue.cs
@@ -1,0 +1,9 @@
+using ReactNative.Bridge.Queue;
+
+namespace ReactNative.Bridge
+{
+    interface IHasActionQueue
+    {
+        IActionQueue ActionQueue { get; }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Bridge/INativeModule.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/INativeModule.cs
@@ -15,15 +15,6 @@ namespace ReactNative.Bridge
     public interface INativeModule
     {
         /// <summary>
-        /// The action queue used by the native module.
-        /// </summary>
-        /// <remarks>
-        /// Can be <code>null</code>, in which case, the call is evaluated
-        /// inline on the native modules action queue.
-        /// </remarks>
-        IActionQueue ActionQueue { get; }
-
-        /// <summary>
         /// Return true if you intend to override some other native module that
         /// was registered, e.g., as part of a different package (such as the
         /// core one). Trying to override without returning true from this 

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
@@ -46,7 +46,6 @@ namespace ReactNative.Bridge
 
         private readonly IReadOnlyDictionary<string, INativeMethod> _methods;
         private readonly IReactDelegateFactory _delegateFactory;
-        private readonly IActionQueue _actionQueue;
 
         /// <summary>
         /// Instantiates a <see cref="NativeModuleBase"/>.
@@ -63,35 +62,9 @@ namespace ReactNative.Bridge
         /// Factory responsible for creating delegates for method invocations.
         /// </param>
         protected NativeModuleBase(IReactDelegateFactory delegateFactory)
-            : this(delegateFactory, null)
-        {
-        }
-
-        /// <summary>
-        /// Instantiates a <see cref="NativeModuleBase"/>.
-        /// </summary>
-        /// <param name="actionQueue">
-        /// The action queue that native modules should execute on.
-        /// </param>
-        protected NativeModuleBase(IActionQueue actionQueue)
-            : this(s_defaultDelegateFactory, actionQueue)
-        {
-        }
-
-        /// <summary>
-        /// Instantiates a <see cref="NativeModuleBase"/>.
-        /// </summary>
-        /// <param name="delegateFactory">
-        /// Factory responsible for creating delegates for method invocations.
-        /// </param>
-        /// <param name="actionQueue">
-        /// The action queue that native modules should execute on.
-        /// </param>
-        protected NativeModuleBase(IReactDelegateFactory delegateFactory, IActionQueue actionQueue)
         {
             _delegateFactory = delegateFactory;
             _methods = InitializeMethods();
-            _actionQueue = actionQueue;
         }
 
         /// <summary>
@@ -106,17 +79,6 @@ namespace ReactNative.Bridge
             get
             {
                 return false;
-            }
-        }
-
-        /// <summary>
-        /// The action queue used by the native module.
-        /// </summary>
-        public IActionQueue ActionQueue
-        {
-            get
-            {
-                return _actionQueue;
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
@@ -106,6 +106,9 @@ namespace ReactNative.Bridge
             if (_moduleTable.Count < moduleId)
                 throw new ArgumentOutOfRangeException(nameof(moduleId), "Call to unknown module: " + moduleId);
 
+            // We don't use the `NativeModuleRegistry.Dispatch` helper here
+            // because it would require creating an an extra `Action` in the
+            // case that `Invoke` is called inline.
             var module = _moduleTable[moduleId].Target;
             if (module is IHasActionQueue moduleWithActionQueue)
             {
@@ -153,6 +156,10 @@ namespace ReactNative.Bridge
                 foreach (var module in _moduleInstances.Values)
                 {
                     Dispatch(module, module.OnReactInstanceDispose);
+                    if (module is IHasActionQueue moduleWithActionQueue)
+                    {
+                        moduleWithActionQueue.DisposeActionQueue();
+                    }
                 }
             }
         }

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
@@ -113,6 +113,9 @@ namespace ReactNative.Bridge
             if (module is IHasActionQueue moduleWithActionQueue)
             {
                 var actionQueue = moduleWithActionQueue.ActionQueue;
+                if (actionQueue == null)
+                    throw new InvalidOperationException("ActionQueue cannot be null.");
+
                 if (actionQueue.IsOnThread())
                 {
                     _moduleTable[moduleId].Invoke(reactInstance, methodId, parameters);
@@ -171,6 +174,9 @@ namespace ReactNative.Bridge
             if (module is IHasActionQueue moduleWithActionQueue)
             {
                 var actionQueue = moduleWithActionQueue.ActionQueue;
+                if (actionQueue == null)
+                    throw new InvalidOperationException("ActionQueue cannot be null.");
+
                 if (actionQueue.IsOnThread())
                 {
                     action();

--- a/ReactWindows/ReactNative.Shared/Bridge/Queue/IndisposableActionQueue.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/Queue/IndisposableActionQueue.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace ReactNative.Bridge.Queue
+{
+    /// <summary>
+    /// An action queue that cannot be disposed.
+    /// </summary>
+    /// <remarks>
+    /// Use this to wrap an <see cref="IActionQueue" /> that you want to pass to
+    /// somebody but you want to ensure they don't dispose it.
+    /// </remarks>
+    public class IndisposableActionQueue : IActionQueue
+    {
+        private readonly IActionQueue _actionQueue;
+
+        /// <summary>
+        /// Creates an action queue which behaves like the action queue that is
+        /// passed in except it isn't disposable.
+        /// </summary>
+        /// <param name="actionQueue">The action queue to wrap.</param>
+        public IndisposableActionQueue(IActionQueue actionQueue)
+        {
+            if (actionQueue == null)
+                throw new ArgumentNullException(nameof(actionQueue));
+
+            _actionQueue = actionQueue;
+        }
+
+        /// <summary>
+        /// Dispatch an action to the queue.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <remarks>
+        /// Returns immediately.
+        /// </remarks>
+        public void Dispatch(Action action)
+        {
+            _actionQueue.Dispatch(action);
+        }
+
+        /// <summary>
+        /// Checks if the current thread is running in the context of this
+        /// action queue.
+        /// </summary>
+        /// <returns>
+        /// <code>true</code> if the current thread is running an action
+        /// dispatched by this action queue, otherwise <code>false</code>.
+        /// </returns>
+        public bool IsOnThread()
+        {
+            return _actionQueue.IsOnThread();
+        }
+
+        /// <summary>
+        /// Disposes the action queue.
+        /// </summary>
+        public void Dispose()
+        {
+            throw new InvalidOperationException("You shouldn't call Dispose on this ActionQueue. Somebody else is responsible for disposing it.");
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -22,6 +22,7 @@ namespace ReactNative.Bridge
             new List<IBackgroundEventListener>();
 
         private IReactInstance _reactInstance;
+        private IndisposableActionQueue _indisposableNativeModulesQueue;
 
         /// <summary>
         /// The React instance associated with the context.
@@ -397,7 +398,7 @@ namespace ReactNative.Bridge
         /// <summary>
         /// The native modules queue.
         /// </summary>
-        internal IActionQueue NativeModulesQueue => _reactInstance.QueueConfiguration.NativeModulesQueue;
+        internal IActionQueue IndisposableNativeModulesQueue => _indisposableNativeModulesQueue;
 
         /// <summary>
         /// Checks if the current thread is on the React instance native 
@@ -410,7 +411,7 @@ namespace ReactNative.Bridge
         public bool IsOnNativeModulesQueueThread()
         {
             AssertReactInstance();
-            return NativeModulesQueue.IsOnThread();
+            return _reactInstance.QueueConfiguration.NativeModulesQueue.IsOnThread();
         }
 
         /// <summary>
@@ -420,7 +421,7 @@ namespace ReactNative.Bridge
         public void AssertOnNativeModulesQueueThread()
         {
             AssertReactInstance();
-            NativeModulesQueue.AssertOnThread();
+            _reactInstance.QueueConfiguration.NativeModulesQueue.AssertOnThread();
         }
 
         /// <summary>
@@ -430,7 +431,7 @@ namespace ReactNative.Bridge
         public void RunOnNativeModulesQueueThread(Action action)
         {
             AssertReactInstance();
-            NativeModulesQueue.Dispatch(action);
+            _reactInstance.QueueConfiguration.NativeModulesQueue.Dispatch(action);
         }
 
         /// <summary>
@@ -473,6 +474,7 @@ namespace ReactNative.Bridge
             }
 
             _reactInstance = instance;
+            _indisposableNativeModulesQueue = new IndisposableActionQueue(_reactInstance.QueueConfiguration.NativeModulesQueue);
         }
 
         private void AssertReactInstance()

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -397,7 +397,7 @@ namespace ReactNative.Bridge
         /// <summary>
         /// The native modules queue.
         /// </summary>
-        public IActionQueue NativeModulesQueue => _reactInstance.QueueConfiguration.NativeModulesQueue;
+        internal IActionQueue NativeModulesQueue => _reactInstance.QueueConfiguration.NativeModulesQueue;
 
         /// <summary>
         /// Checks if the current thread is on the React instance native 

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -395,6 +395,11 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
+        /// The native modules queue.
+        /// </summary>
+        public IActionQueue NativeModulesQueue => _reactInstance.QueueConfiguration.NativeModulesQueue;
+
+        /// <summary>
         /// Checks if the current thread is on the React instance native 
         /// modules queue thread.
         /// </summary>
@@ -405,7 +410,7 @@ namespace ReactNative.Bridge
         public bool IsOnNativeModulesQueueThread()
         {
             AssertReactInstance();
-            return _reactInstance.QueueConfiguration.NativeModulesQueue.IsOnThread();
+            return NativeModulesQueue.IsOnThread();
         }
 
         /// <summary>
@@ -415,7 +420,7 @@ namespace ReactNative.Bridge
         public void AssertOnNativeModulesQueueThread()
         {
             AssertReactInstance();
-            _reactInstance.QueueConfiguration.NativeModulesQueue.AssertOnThread();
+            NativeModulesQueue.AssertOnThread();
         }
 
         /// <summary>
@@ -425,7 +430,7 @@ namespace ReactNative.Bridge
         public void RunOnNativeModulesQueueThread(Action action)
         {
             AssertReactInstance();
-            _reactInstance.QueueConfiguration.NativeModulesQueue.Dispatch(action);
+            NativeModulesQueue.Dispatch(action);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContextNativeModuleBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContextNativeModuleBase.cs
@@ -47,8 +47,26 @@ namespace ReactNative.Bridge
         {
             get
             {
-                return Context.NativeModulesQueue;
+                return Context.IndisposableNativeModulesQueue;
             }
+        }
+
+        /// <summary>
+        /// Disposes the ActionQueue.
+        /// </summary>
+        /// <remarks>
+        /// If you override <see cref="ActionQueue" /> to return a custom action
+        /// queue, you should also override this method to ensure your action
+        /// queue is disposed properly. This method runs on the native modules
+        /// queue.
+        /// 
+        /// Note that <see cref="INativeModule.OnReactInstanceDispose" />
+        /// isn't the appropriate place to dispose your action queue because
+        /// that means you'll dispose your action queue while running on
+        /// your action queue.
+        /// </remarks>
+        public virtual void DisposeActionQueue()
+        {
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContextNativeModuleBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContextNativeModuleBase.cs
@@ -1,4 +1,4 @@
-﻿using ReactNative.Bridge.Queue;
+using ReactNative.Bridge.Queue;
 using System;
 
 namespace ReactNative.Bridge
@@ -7,27 +7,13 @@ namespace ReactNative.Bridge
     /// Base class for React Native modules that require access to the 
     /// <see cref="ReactContext"/>.
     /// </summary>
-    public abstract class ReactContextNativeModuleBase : NativeModuleBase
+    public abstract class ReactContextNativeModuleBase : NativeModuleBase, IHasActionQueue
     {
         /// <summary>
         /// Instantiates the <see cref="ReactContextNativeModuleBase"/>.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         protected ReactContextNativeModuleBase(ReactContext reactContext)
-        {
-            if (reactContext == null)
-                throw new ArgumentNullException(nameof(reactContext));
-
-            Context = reactContext;
-        }
-
-        /// <summary>
-        /// Instantiates the <see cref="ReactContextNativeModuleBase"/>.
-        /// </summary>
-        /// <param name="reactContext">The React context.</param>
-        /// <param name="actionQueue">The action queue.</param>
-        protected ReactContextNativeModuleBase(ReactContext reactContext, IActionQueue actionQueue)
-            : base(actionQueue)
         {
             if (reactContext == null)
                 throw new ArgumentNullException(nameof(reactContext));
@@ -50,18 +36,19 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
-        /// Instantiates the <see cref="ReactContextNativeModuleBase"/>.
+        /// The action queue used by the native module.
         /// </summary>
-        /// <param name="reactContext">The React context.</param>
-        /// <param name="delegateFactory">The React method delegate factory.</param>
-        /// <param name="actionQueue">The action queue.</param>
-        protected ReactContextNativeModuleBase(ReactContext reactContext, IReactDelegateFactory delegateFactory, IActionQueue actionQueue)
-            : base(delegateFactory, actionQueue)
+        /// <remarks>
+        /// Defaults to the native modules action queue. If you override this getter,
+        /// be sure to return the same IActionQueue instance each time this getter is
+        /// accessed for a given module instance.
+        /// </remarks>
+        public virtual IActionQueue ActionQueue
         {
-            if (reactContext == null)
-                throw new ArgumentNullException(nameof(reactContext));
-
-            Context = reactContext;
+            get
+            {
+                return Context.NativeModulesQueue;
+            }
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IBackgroundEventListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ICallback.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IGenericDelegate.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\IHasActionQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IInvocationHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IJavaScriptExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IJavaScriptModule.cs" />

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -59,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\ActionQueueFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\IActionQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\IActionQueueFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\IndisposableActionQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\IReactQueueConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\ActionQueueExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\LimitedConcurrencyActionQueue.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -570,6 +570,7 @@ namespace ReactNative.UIManager
         public override void OnReactInstanceDispose()
         {
             _eventDispatcher.OnReactInstanceDispose();
+            _layoutActionQueue.Dispose();
         }
 
         #endregion

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -80,6 +80,25 @@ namespace ReactNative.UIManager
         public override IActionQueue ActionQueue => _layoutActionQueue;
 
         /// <summary>
+        /// Disposes the ActionQueue.
+        /// </summary>
+        /// <remarks>
+        /// If you override <see cref="ActionQueue" /> to return a custom action
+        /// queue, you should also override this method to ensure your action
+        /// queue is disposed properly. This method runs on the native modules
+        /// queue.
+        /// 
+        /// Note that <see cref="INativeModule.OnReactInstanceDispose" />
+        /// isn't the appropriate place to dispose your action queue because
+        /// that means you'll dispose your action queue while running on
+        /// your action queue.
+        /// </remarks>
+        public override void DisposeActionQueue()
+        {
+            _layoutActionQueue.Dispose();
+        }
+
+        /// <summary>
         /// The constants exported by this module.
         /// </summary>
         public override IReadOnlyDictionary<string, object> Constants
@@ -570,7 +589,6 @@ namespace ReactNative.UIManager
         public override void OnReactInstanceDispose()
         {
             _eventDispatcher.OnReactInstanceDispose();
-            _layoutActionQueue.Dispose();
         }
 
         #endregion

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -35,7 +35,7 @@ namespace ReactNative.UIManager
             IReadOnlyList<IViewManager> viewManagers,
             UIImplementationProvider uiImplementationProvider,
             IActionQueue layoutActionQueue)
-            : base(reactContext, layoutActionQueue)
+            : base(reactContext)
         {
             if (viewManagers == null)
                 throw new ArgumentNullException(nameof(viewManagers));
@@ -68,6 +68,16 @@ namespace ReactNative.UIManager
                 return "UIManager";
             }
         }
+
+        /// <summary>
+        /// The action queue used by the native module.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to the native modules action queue. If you override this getter,
+        /// be sure to return the same IActionQueue instance each time this getter is
+        /// accessed for a given module instance.
+        /// </remarks>
+        public override IActionQueue ActionQueue => _layoutActionQueue;
 
         /// <summary>
         /// The constants exported by this module.


### PR DESCRIPTION
Prior to this change, ActionQueue defaults to null (which means NativeModulesQueue). This is inconvenient because you can only do ActionQueue.Dispatch(...) in your module if you've overriden the default ActionQueue. This change makes it so ActionQueue is always initialized to a non-null value.

Here's an example of typical usage:

```
public MyModule(ReactContext reactContext) : base(reactContext)
{
  _actionQueue = new LimitedConcurrencyActionQueue(
    (ex) => LogException("Unhandled exception on ActionQueue", ex));
}

private readonly IActionQueue _actionQueue;
public override IActionQueue ActionQueue => _actionQueue;

// Note above how we're careful to create the ActionQueue once, store it, and always
// return the same one when `ActionQueue` is accessed. The following would
// be bad because it'd return a different `ActionQueue` each time it was accessed:
// DON'T DO THIS
public override IActionQueue ActionQueue => new LimitedConcurrencyActionQueue(...);
```

Why isn't `ActionQueue` a module constructor parameter anymore? I tried keeping the ActionQueue as a module constructor parameter. However, when constructing a LimitedConcurrencyActionQueue you cannot reference `this` in the `onError` handler you pass to LimitedConcurrencyActionQueue's constructor.

There is an outstanding issue:

Disposing ActionQueues

Currently, when destroying a module we always call Dispose on its ActionQueue. This is problematic for ActionQueues that multiple modules share (e.g. NativeModulesQueue). Prior to this change, NativeModulesQueue is the default ActionQueue and is represented as `null` so we never call Dispose on it. One solution would be to start referencing counting the ActionQueues.