### PR TITLE
Make choreographer StopWatch a per thread static

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -29,7 +29,7 @@ namespace ReactNative.Modules.Core
 #endif
         private const int InactiveFrameCount = 120;
 
-        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private static readonly ThreadLocal<Stopwatch> _stopwatch = new ThreadLocal<Stopwatch>(() => Stopwatch.StartNew());
         private static ReactChoreographer s_instance;
 
         private readonly object _gate = new object();
@@ -275,14 +275,14 @@ namespace ReactNative.Modules.Core
 
                     if (isSubscribed)
                     {
-                        OnRendering(null, _stopwatch.Elapsed);
+                        OnRendering(null, _stopwatch.Value.Elapsed);
                     }
                 });
         }
 
         private void OnRendering(object sender, TimeSpan e)
         {
-            var renderingTime = _stopwatch.Elapsed;
+            var renderingTime = _stopwatch.Value.Elapsed;
             if (_frameEventArgs == null)
             {
                 _mutableReference = _frameEventArgs = new FrameEventArgs(renderingTime);


### PR DESCRIPTION
We need to make sure the "elapsed" time grows monotonically across suspend/resume cycles.
(this is a regression from the multi-window support work since I missed this subtlety - https://github.com/Microsoft/react-native-windows/pull/1615)