### PR TITLE
Fix crash ("ReactChoreographer needs to be initialized.") on suspend

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -29,7 +29,7 @@ namespace ReactNative.Modules.Core
 #endif
         private const int InactiveFrameCount = 120;
 
-        private static readonly ThreadLocal<Stopwatch> _stopwatch = new ThreadLocal<Stopwatch>(() => Stopwatch.StartNew());
+        private static readonly Stopwatch _stopwatch = Stopwatch.StartNew();
         private static ReactChoreographer s_instance;
 
         private readonly object _gate = new object();
@@ -275,14 +275,14 @@ namespace ReactNative.Modules.Core
 
                     if (isSubscribed)
                     {
-                        OnRendering(null, _stopwatch.Value.Elapsed);
+                        OnRendering(null, _stopwatch.Elapsed);
                     }
                 });
         }
 
         private void OnRendering(object sender, TimeSpan e)
         {
-            var renderingTime = _stopwatch.Value.Elapsed;
+            var renderingTime = _stopwatch.Elapsed;
             if (_frameEventArgs == null)
             {
                 _mutableReference = _frameEventArgs = new FrameEventArgs(renderingTime);

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -151,6 +151,7 @@ namespace ReactNative
         /// <returns>A task to await the result.</returns>
         public async Task<ReactContext> CreateReactContextAsync(CancellationToken token)
         {
+            DispatcherHelpers.AssertOnDispatcher();
             using (await _lock.LockAsync())
             {
                 if (_hasStartedCreatingInitialContext)
@@ -161,7 +162,7 @@ namespace ReactNative
                             "a new file, explicitly, use the re-create method.");
                 }
                 _hasStartedCreatingInitialContext = true;
- 
+
                 ReactChoreographer.Initialize();
                 return await CreateReactContextCoreAsync(token);
             }
@@ -277,9 +278,6 @@ namespace ReactNative
             }
 
             _lifecycleStateMachine.OnSuspend();
-
-            ReactChoreographer.Dispose();
-            DispatcherHelpers.Reset();
         }
 
         /// <summary>
@@ -350,6 +348,7 @@ namespace ReactNative
                 }
 
                 ReactChoreographer.Dispose();
+                DispatcherHelpers.Reset();
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -163,7 +163,6 @@ namespace ReactNative
                 }
                 _hasStartedCreatingInitialContext = true;
 
-                ReactChoreographer.Initialize();
                 return await CreateReactContextCoreAsync(token);
             }
         }
@@ -212,7 +211,6 @@ namespace ReactNative
                 {
                     _hasStartedCreatingInitialContext = true;
 
-                    ReactChoreographer.Initialize();
                     return await CreateReactContextCoreAsync(token);
                 }
             }

--- a/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
@@ -232,6 +232,9 @@ namespace ReactNative.Tests
 
             await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
 
+            // The manager.DisposeAsync resets DispatherHelpers as well 
+            ReactNative.Bridge.DispatcherHelpers.Initialize();
+
             reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
                 () => manager.CreateReactContextAsync(CancellationToken.None));
 
@@ -564,6 +567,8 @@ namespace ReactNative.Tests
 
         private static ReactInstanceManager CreateReactInstanceManager(string jsBundleFile, LifecycleState initialLifecycleState = LifecycleState.Foreground)
         {
+            ReactNative.Bridge.DispatcherHelpers.Initialize();
+
             return new ReactInstanceManagerBuilder
             {
                 InitialLifecycleState = initialLifecycleState,

--- a/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
@@ -97,7 +97,8 @@ namespace ReactNative.Tests
         [TestMethod]
         public async Task ReactInstanceManager_ArgumentChecks()
         {
-            var manager = CreateReactInstanceManager();
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager());
 
             await AssertEx.ThrowsAsync<ArgumentNullException>(
                 async () => await DispatcherHelpers.CallOnDispatcherAsync(() =>
@@ -114,28 +115,30 @@ namespace ReactNative.Tests
                     manager.DetachRootViewAsync(null)),
                 ex => Assert.AreEqual("rootView", ex.ParamName));
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_CreateReactContextAsync()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
                 () => manager.CreateReactContextAsync(CancellationToken.None));
 
             Assert.AreEqual(jsBundleFile, manager.SourceUrl);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_CreateReactContextAsync_EnsuresOneCall()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var caught = false;
             await DispatcherHelpers.CallOnDispatcherAsync(async () =>
@@ -154,14 +157,15 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(caught);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_RecreateReactContextAsync()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var task = default(Task<ReactContext>);
             var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
@@ -175,14 +179,15 @@ namespace ReactNative.Tests
             Assert.AreEqual(jsBundleFile, manager.SourceUrl);
             Assert.AreNotEqual(initialReactContext, reactContext);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_RecreateReactContextAsync_EnsuresCalledOnce()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var caught = false;
             await DispatcherHelpers.CallOnDispatcherAsync(async () =>
@@ -199,14 +204,16 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(caught);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_OnBackPressed_NoContext()
         {
             var waitHandle = new AutoResetEvent(false);
-            var manager = CreateReactInstanceManager();
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager());
+
             await DispatcherHelpers.RunOnDispatcherAsync(() =>
             {
                 manager.OnResume(() => waitHandle.Set());
@@ -215,38 +222,15 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(waitHandle.WaitOne());
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
-        }
-
-        [TestMethod]
-        public async Task ReactInstanceManager_OnDestroy_CreateReactContextAsync()
-        {
-            var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
-
-            var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
-                () => manager.CreateReactContextAsync(CancellationToken.None));
-
-            Assert.IsNotNull(reactContext);
-            Assert.AreEqual(jsBundleFile, manager.SourceUrl);
-
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
-
-            // The manager.DisposeAsync resets DispatherHelpers as well 
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
-
-            reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
-                () => manager.CreateReactContextAsync(CancellationToken.None));
-
-            Assert.IsNotNull(reactContext);
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_DisposeAsync_WhileBusy()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
                 () => manager.CreateReactContextAsync(CancellationToken.None));
@@ -264,7 +248,8 @@ namespace ReactNative.Tests
             var task = DispatcherHelpers.CallOnDispatcherAsync(async () =>
             {
                 e.Set();
-                await manager.DisposeAsync();
+                await DisposeInstanceManager(manager);
+                ;
             });
 
             var completedTask = await Task.WhenAny(
@@ -278,7 +263,8 @@ namespace ReactNative.Tests
         public async Task ReactInstanceManager_CreateReactContextAsync_Canceled()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.Cancel();
@@ -287,14 +273,15 @@ namespace ReactNative.Tests
                     manager.CreateReactContextAsync(cancellationTokenSource.Token)),
                 ex => Assert.AreEqual(cancellationTokenSource.Token, ex.CancellationToken));
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_GetReactContextAsync_Unfinished()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var initialContextTask = DispatcherHelpers.CallOnDispatcherAsync(async () =>
                 await manager.CreateReactContextAsync(CancellationToken.None));
@@ -304,7 +291,7 @@ namespace ReactNative.Tests
 
             Assert.AreSame(initialContext, context);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
 
@@ -312,7 +299,8 @@ namespace ReactNative.Tests
         public async Task ReactInstanceManager_GetReactContextAsync_Finished()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var initialContext = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
                 await manager.CreateReactContextAsync(CancellationToken.None));
@@ -321,14 +309,15 @@ namespace ReactNative.Tests
 
             Assert.AreSame(initialContext, context);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_GetReactContextAsync_Fail()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var caught = false;
             await DispatcherHelpers.CallOnDispatcherAsync(async () =>
@@ -345,26 +334,28 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(caught);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_GetOrCreateReactContextAsync_Create()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(() => manager.GetOrCreateReactContextAsync(CancellationToken.None));
             Assert.IsNotNull(reactContext);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_GetOrCreateReactContextAsync_Get()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
 
             var initialContext = default(ReactContext);
             var context = default(ReactContext);
@@ -377,14 +368,15 @@ namespace ReactNative.Tests
 
             Assert.AreSame(initialContext, context);
 
-            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_Lifecycle_Simple()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.BeforeCreate);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.BeforeCreate));
 
             var listener = new LifecycleEventsListener(new LifecycleEventsListener.Step[]
             {
@@ -421,14 +413,15 @@ namespace ReactNative.Tests
             });
 
             listener.Dispose();
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_Lifecycle_Dispose_From_Foreground()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.Foreground);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.Foreground));
 
             var listener = new LifecycleEventsListener(new LifecycleEventsListener.Step[]
             {
@@ -443,18 +436,19 @@ namespace ReactNative.Tests
                 context.AddBackgroundEventListener(listener);
                 context.AddLifecycleEventListener(listener);
 
-                await manager.DisposeAsync();
+                await DisposeInstanceManager(manager);
             });
 
             listener.Dispose();
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            // manager has been disposed already
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_Lifecycle_NoForeground()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.BeforeCreate);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.BeforeCreate));
 
             var listener = new LifecycleEventsListener(new LifecycleEventsListener.Step[]
             {
@@ -476,14 +470,15 @@ namespace ReactNative.Tests
             });
 
             listener.Dispose();
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_Lifecycle_StartSuspended()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.BeforeCreate);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.BeforeCreate));
 
             var listener = new LifecycleEventsListener(new LifecycleEventsListener.Step[]
             {
@@ -504,14 +499,15 @@ namespace ReactNative.Tests
             });
 
             listener.Dispose();
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_Lifecycle_Missing_Background()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.Foreground);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.Foreground));
 
             var listener = new LifecycleEventsListener(new LifecycleEventsListener.Step[]
             {
@@ -532,14 +528,15 @@ namespace ReactNative.Tests
             });
 
             listener.Dispose();
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         [TestMethod]
         public async Task ReactInstanceManager_Lifecycle_Cleanup_Old_Context()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";
-            var manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.Foreground);
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile, LifecycleState.Foreground));
 
             var listener = new LifecycleEventsListener(new LifecycleEventsListener.Step[]
             {
@@ -557,7 +554,7 @@ namespace ReactNative.Tests
             });
                 
             listener.Dispose();
-            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
         private static ReactInstanceManager CreateReactInstanceManager()
@@ -568,12 +565,21 @@ namespace ReactNative.Tests
         private static ReactInstanceManager CreateReactInstanceManager(string jsBundleFile, LifecycleState initialLifecycleState = LifecycleState.Foreground)
         {
             ReactNative.Bridge.DispatcherHelpers.Initialize();
+            ReactChoreographer.Initialize();
 
             return new ReactInstanceManagerBuilder
             {
                 InitialLifecycleState = initialLifecycleState,
                 JavaScriptBundleFile = jsBundleFile,
             }.Build();
+        }
+
+        private static async Task DisposeInstanceManager(ReactInstanceManager manager)
+        {
+            await manager.DisposeAsync();
+
+            // Go back to the initial state as set by the host test app
+            ReactNative.Bridge.DispatcherHelpers.Initialize();
         }
     }
 }


### PR DESCRIPTION
Extended the life of main ReactChoreographer and DispatcherHelpers across the suspend/resume hiatus.

OnSuspend is not something called after all other activity in the process ceased. Various activities continue for a while and nuking and later renewing instances or ReactChoreographer asserts when suspending, affects timers on resuming, etc.... with lots of bad side effects.

I had to tweak tests a little since they are not really independent of each other.