### PR TITLE
Apply `borderColor` (if set) on Border creation.

### DIFF
--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -119,7 +119,9 @@ namespace ReactNative.Views.View
         {
             if (view.Border == null)
             {
-                view.Border = new Border { BorderBrush = DefaultBorderBrush };
+                var borderProps = GetBorderProps(view);
+                var borderBrush = (borderProps?.Color.HasValue ?? false) ? new SolidColorBrush(ColorHelpers.Parse(borderProps.Color.Value)) : DefaultBorderBrush;
+                view.Border = new Border { BorderBrush = borderBrush };
 
                 // Layout animations bypass SetDimensions, hence using XAML bindings.
 

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -48,6 +48,16 @@ namespace ReactNative.Views.View
         /// </summary>
         private BorderProps GetBorderProps(BorderedCanvas view)
         {
+            if (_borderProps.TryGetValue(view, out var props))
+            {
+                return props;
+            }
+
+            return null;
+        }
+
+        private BorderProps GetOrCreateBorderProps(BorderedCanvas view)
+        {
             BorderProps props;
 
             if (!_borderProps.TryGetValue(view, out props))
@@ -271,7 +281,7 @@ namespace ReactNative.Views.View
         {
             if (view.Border == null)
             {
-                GetBorderProps(view).Color = color;
+                GetOrCreateBorderProps(view).Color = color;
             }
             else
             {
@@ -302,7 +312,7 @@ namespace ReactNative.Views.View
 
             if (border.BorderBrush == null)
             {
-                var color = GetBorderProps(view).Color;
+                var color = GetOrCreateBorderProps(view).Color;
                 SetBorderColor(view, color);
             }
 


### PR DESCRIPTION
Previously, setting `borderColor` before `borderWidth` would always
result in a black border, since `GetOrCreateBorder` did not check
if a color had already been set. This meant that views defined, eg,
like this:

```
<View style={{borderColor: 'blue', borderWidth 2}}>
    ...
</View>
```
Always had a black (default colored) border, instead of the one assigned
by the user.

Verified in RNTester.