### PR TITLE
Fix crash where TextInput Width or Height = NaN

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -619,8 +619,12 @@ namespace ReactNative.Views.TextInput
         /// <param name="dimensions">The dimensions.</param>
         public override void SetDimensions(ReactTextBox view, Dimensions dimensions)
         {
-            view.MinWidth = dimensions.Width;
-            view.MinHeight = dimensions.Height;
+            if (!Double.IsNaN(dimensions.Height) && !Double.IsInfinity(dimensions.Height)
+                && !Double.IsNaN(dimensions.Width) && !Double.IsInfinity(dimensions.Width))
+            {
+                view.MinWidth = dimensions.Width;
+                view.MinHeight = dimensions.Height;
+            }
 
             if (view.AutoGrow)
             {
@@ -632,7 +636,11 @@ namespace ReactNative.Views.TextInput
             }
             else
             {
-                base.SetDimensions(view, dimensions);
+                if (!Double.IsNaN(dimensions.Height) && !Double.IsInfinity(dimensions.Height)
+                && !Double.IsNaN(dimensions.Width) && !Double.IsInfinity(dimensions.Width))
+                {
+                    base.SetDimensions(view, dimensions);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes issue #1673 by preventing invalid dimensions being passed to MinWidth, or MinHeight, or base.SetDimensions