### PR TITLE
fix(DevSupport): Remove Debugger.Break

### DIFF
--- a/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
@@ -141,10 +141,6 @@ namespace ReactNative.DevSupport
 
         public void HandleException(Exception exception)
         {
-#if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached) System.Diagnostics.Debugger.Break();
-#endif
-
             if (IsEnabled)
             {
                 ShowNewNativeError(exception.Message, exception);


### PR DESCRIPTION
The DevSupportManager has a Debugger.Break() call. This is not particularly useful because by the time this is hit, we've lost the callstack of the exception (except the stacktrace inside the exception itself). It's not useful for debugging because we can't inspect variables on the stack. Good riddance.