### PR TITLE
chore(WebViewBridge): remove project.json from .csproj

### DIFF
--- a/ReactWindows/ReactNativeWebViewBridge/ReactNativeWebViewBridge.csproj
+++ b/ReactWindows/ReactNativeWebViewBridge/ReactNativeWebViewBridge.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -87,10 +87,6 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
-  <ItemGroup>
-    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
-    <None Include="project.json" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="MessagePostedEventArgs.cs" />
     <Compile Include="WebViewBridge.cs" />


### PR DESCRIPTION
The project was converted to package references in the .csproj, but the project.json reference was not removed.