### PR TITLE
fix(LayoutAnimation): Fix minor bug in LayoutAnimation

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutAnimationController.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutAnimation/LayoutAnimationController.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using System;
 using System.Reactive;
@@ -98,7 +98,8 @@ namespace ReactNative.UIManager.LayoutAnimation
         {
             DispatcherHelpers.AssertOnDispatcher();
 
-            var layoutAnimation = view.ActualWidth == 0 || view.ActualHeight == 0
+            var currentDimensions = viewManager.GetDimensions(view);
+            var layoutAnimation = IsZeroOrNaN(currentDimensions.Width) || IsZeroOrNaN(currentDimensions.Height)
                 ? _layoutCreateAnimation
                 : _layoutUpdateAnimation;
 
@@ -162,6 +163,11 @@ namespace ReactNative.UIManager.LayoutAnimation
 
             // Start the next animation
             serialDisposable.Disposable = animation.Subscribe();
+        }
+
+        private static bool IsZeroOrNaN(double value)
+        {
+            return value == 0 || double.IsNaN(value);
         }
     }
 }


### PR DESCRIPTION
Previously, the layout animation controller chose whether to animate using "create" or "update" logic based on the ActualWidth and ActualHeight of the framework element. This is not valid, as some views may have an ActualWidth or ActualHeight before ReactNative sets any dimensions. Instead, we use the view managers GetDimensions API to check if ReactNative has set anything yet.