### PR TITLE
fix(ReactDelegateFactoryBase): Remove checks for methods that return Task

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleBaseTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleBaseTests.cs
@@ -24,20 +24,13 @@ namespace ReactNative.Tests.Bridge
                 () => new CallbackNotSupportedNativeModule(),
                 () => new CallbackNotSupportedNativeModule2(),
                 () => new PromiseNotSupportedNativeModule(),
-                () => new AsyncCallbackNotSupportedNativeModule(),
-                () => new AsyncPromiseNotSupportedNativeModule(),
+                () => new AsyncNotSupportedNativeModule(),
             };
 
             foreach (var action in actions)
             {
                 AssertEx.Throws<NotSupportedException>(action);
             }
-        }
-
-        [Test]
-        public void NativeModuleBase_ReactMethod_Async_ThrowsNotImplemented()
-        {
-            AssertEx.Throws<NotImplementedException>(() => new AsyncNotImplementedNativeModule());
         }
 
         [Test]
@@ -384,41 +377,7 @@ namespace ReactNative.Tests.Bridge
             public void Foo(IPromise promise, int foo) { }
         }
 
-        class AsyncCallbackNotSupportedNativeModule : NativeModuleBase
-        {
-            public override string Name
-            {
-                get
-                {
-                    return "Test";
-                }
-            }
-
-            [ReactMethod]
-            public Task Foo(ICallback callback)
-            {
-                return Task.CompletedTask;
-            }
-        }
-
-        class AsyncPromiseNotSupportedNativeModule : NativeModuleBase
-        {
-            public override string Name
-            {
-                get
-                {
-                    return "Test";
-                }
-            }
-
-            [ReactMethod]
-            public Task Foo(IPromise promise)
-            {
-                return Task.CompletedTask;
-            }
-        }
-
-        class AsyncNotImplementedNativeModule : NativeModuleBase
+        class AsyncNotSupportedNativeModule : NativeModuleBase
         {
             public override string Name
             {

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactDelegateFactoryBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactDelegateFactoryBase.cs
@@ -56,11 +56,6 @@ namespace ReactNative
                 return SyncMethodType;
             }
 
-            if (method.ReturnType == typeof(Task))
-            {
-                throw new NotImplementedException("Async methods are not yet supported.");
-            }
-
             var parameters = method.GetParameters();
             if (parameters.Length > 0 && parameters.Last().ParameterType == typeof(IPromise))
             {
@@ -78,7 +73,7 @@ namespace ReactNative
         public void Validate(MethodInfo method, ReactMethodAttribute attribute)
         {
             var returnType = method.ReturnType;
-            if (!attribute.IsBlockingSynchronousMethod && returnType != typeof(Task) && returnType != typeof(void))
+            if (!attribute.IsBlockingSynchronousMethod && returnType != typeof(void))
             {
                 throw new NotSupportedException("Native module methods must either return void or Task.");
             }
@@ -98,10 +93,6 @@ namespace ReactNative
                     {
                         throw new NotSupportedException("Callbacks are only supported in the last two positions of a native module method.");
                     }
-                }
-                else if (returnType == typeof(Task) && (parameterType == typeof(ICallback) || parameterType == typeof(IPromise)))
-                {
-                    throw new NotSupportedException("Callbacks and promises are not supported in async native module methods.");
                 }
             }
         }


### PR DESCRIPTION
ReactDelegateFactoryBase had stub behavior for native methods that returned tasks. The idea was to automatically convert those native methods to promise method types. We chose not to pursue this because the threading model for native modules is complicated enough without having to worry about guarantees for asynchronous behavior.