### PR TITLE
Remove redundant project.json reference

### DIFF
--- a/local-cli/generator-windows/templates/proj/MyApp.csproj
+++ b/local-cli/generator-windows/templates/proj/MyApp.csproj
@@ -178,10 +178,6 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
-    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
-    <None Include="project.json" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Issue #1329 was to remove project.json files. I think this is the last one.
Seems to work fine without this.
