### PR TITLE
fix(View): Fix for style prop `display: none`

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
@@ -233,7 +233,9 @@ namespace ReactNative.UIManager
 
         DependencyObject IViewManager.CreateView(ThemedReactContext reactContext)
         {
-            return CreateView(reactContext);
+            var view = CreateView(reactContext);
+            SetDimensions(view, default(Dimensions));
+            return view;
         }
 
         void IViewManager.OnDropViewInstance(ThemedReactContext reactContext, DependencyObject view)


### PR DESCRIPTION
The `display` prop is considered layout only. When set, it sets the dimensions of all elements in the subtree to zero. If the view is first created with `display: none`, its props aren't updated, because Yoga assumes the initial dimensions are (0, 0, 0, 0). UWP does not have this assumption for some views (like RichTextBlock), so the <Text/> inside a <View/> initially created with `display: none` will be displayed.

There were two options for getting around this:
1. Set the initial dimensions of all views to (0, 0, 0, 0) for consistency with Yoga.
2. Set all FrameworkElements to `view.Visibility = Visibility.Collapsed`

This changeset uses the former option as it may be easier to generalize to any view manager type. Using the latter case might be more performant as it will take the view out of the Measure/Arrange layout passes, but it will also display tab stop behavior, which may not be desirable.

Fixes #1602