### PR TITLE
fix(FocusableWindows): disable tab stop when `display: none`

### DIFF
--- a/Libraries/Components/FocusableWindows/FocusableWindows.windows.js
+++ b/Libraries/Components/FocusableWindows/FocusableWindows.windows.js
@@ -242,7 +242,7 @@ function createFocusableComponent(Component: any) {
             let componentStyle = {};
             const flattenedStyles = flattenStyle(styles);
             for (const styleName in flattenedStyles) {
-              if (styleName === 'transform') {
+              if (styleName === 'transform' || styleName === 'display') {
                 focusableStyle[styleName] = flattenedStyles[styleName];
               } else {
                 componentStyle[styleName] = flattenedStyles[styleName];
@@ -330,7 +330,7 @@ function createFocusableComponent(Component: any) {
               let focusableStyle = {};
               let childStyle = {};
               for (const styleName in styles) {
-                if (styleName === 'transform') {
+                if (styleName === 'transform' || styleName === 'display') {
                   focusableStyle[styleName] = styles[styleName];
                   atLeastOneFocusableProp = true;
                 } else {

--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -91,6 +91,17 @@ namespace ReactNative.UIManager
         public void SetZIndex(TFrameworkElement view, int zIndex)
         {
             Canvas.SetZIndex(view, zIndex);
+        }
+
+        /// <summary>
+        /// Sets the display mode of the element.
+        /// </summary>
+        /// <param name="view">The view instance.</param>
+        /// <param name="display">The display mode.</param>
+        [ReactProp(ViewProps.Display)]
+        public void SetDisplay(TFrameworkElement view, string display)
+        {
+            view.Visibility = display == "none" ? Visibility.Collapsed : Visibility.Visible;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -115,6 +115,17 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
+        /// Sets the display mode of the element.
+        /// </summary>
+        /// <param name="view">The view instance.</param>
+        /// <param name="display">The display mode.</param>
+        [ReactProp(ViewProps.Display)]
+        public void SetDisplay(TFrameworkElement view, string display)
+        {
+            view.Visibility = display == "none" ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        /// <summary>
         /// Sets the manipulation mode for the view.
         /// </summary>
         /// <param name="view">The view instance.</param>


### PR DESCRIPTION
To match behavior on Web, the control should not participate in tab stop when `display: none` is set.

Towards #1705