### PR TITLE
Persist JavaScript debugging flag across launches

### DIFF
--- a/ReactWindows/ReactNative.Shared/DevSupport/DevInternalSettings.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevInternalSettings.cs
@@ -24,6 +24,7 @@ namespace ReactNative.DevSupport
         private const string JsMinifyDebugKey = "js_minify_debug";
         private const string ReloadOnJSChangeKey = "reload_on_js_change";
         private const string HotModuleReplacementKey = "hot_module_replacement";
+        private const string RemoteDebuggingEnabledKey = "remote_debugging_enabled";
 
         private static readonly HashSet<string> s_triggerReload = new HashSet<string>
         {
@@ -134,6 +135,17 @@ namespace ReactNative.DevSupport
             }
         }
 
+        public bool IsRemoteDebuggingEnabled
+        {
+            get
+            {
+                return GetSetting(RemoteDebuggingEnabledKey, false);
+            }
+            set
+            {
+                SetSetting(RemoteDebuggingEnabledKey, value);
+            }
+        }
 
         //TODO: Git Issue #878
         private T GetSetting<T>(string key, T defaultValue)

--- a/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
@@ -162,7 +162,7 @@ namespace ReactNative.DevSupport
 
         public bool HasUpToDateBundleInCache()
         {
-            if (_isDevSupportEnabled)
+            if (_isDevSupportEnabled && !IsRemoteDebuggingEnabled)
             {
 #if WINDOWS_UWP
                 var lastNativeUpdateTime = Windows.ApplicationModel.Package.Current.InstalledDate.UtcDateTime;

--- a/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
@@ -585,7 +585,7 @@ namespace ReactNative.DevSupport
                     async progressToken =>
                     {
                         await _devServerHelper.LaunchDevToolsAsync(progressToken).ConfigureAwait(false);
-                webSocketExecutor = new WebSocketJavaScriptExecutor();
+                        webSocketExecutor = new WebSocketJavaScriptExecutor();
                         await webSocketExecutor.ConnectAsync(_devServerHelper.WebsocketProxyUrl, progressToken).ConfigureAwait(false);
                     },
                     progressDialog,

--- a/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
@@ -98,8 +98,14 @@ namespace ReactNative.DevSupport
 
         public bool IsRemoteDebuggingEnabled
         {
-            get;
-            set;
+            get
+            {
+                return _devSettings.IsRemoteDebuggingEnabled;
+            }
+            set
+            {
+                _devSettings.IsRemoteDebuggingEnabled = value;
+            }
         }
 
         public bool IsProgressDialogEnabled
@@ -579,7 +585,7 @@ namespace ReactNative.DevSupport
                     async progressToken =>
                     {
                         await _devServerHelper.LaunchDevToolsAsync(progressToken).ConfigureAwait(false);
-                        webSocketExecutor = new WebSocketJavaScriptExecutor();
+                webSocketExecutor = new WebSocketJavaScriptExecutor();
                         await webSocketExecutor.ConnectAsync(_devServerHelper.WebsocketProxyUrl, progressToken).ConfigureAwait(false);
                     },
                     progressDialog,

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -500,7 +500,7 @@ namespace ReactNative
 
         private Task<ReactContext> CreateReactContextFromDevManagerAsync(CancellationToken token)
         {
-            if (_devSupportManager.HasUpToDateBundleInCache())
+            if (!_devSupportManager.IsRemoteDebuggingEnabled && _devSupportManager.HasUpToDateBundleInCache())
             {
                 return CreateReactContextFromCachedPackagerBundleAsync(token);
             }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -500,7 +500,7 @@ namespace ReactNative
 
         private Task<ReactContext> CreateReactContextFromDevManagerAsync(CancellationToken token)
         {
-            if (!_devSupportManager.IsRemoteDebuggingEnabled && _devSupportManager.HasUpToDateBundleInCache())
+            if (_devSupportManager.HasUpToDateBundleInCache())
             {
                 return CreateReactContextFromCachedPackagerBundleAsync(token);
             }


### PR DESCRIPTION
Now RNW remembers what value you were using for the "Start/Stop JS Remote Debugging" flag in the debug menu (shift+f10) across launches of the app. This is useful for debugging JavaScript during app activation scenarios (e.g. receiving a push notification).

Note that this doesn't fully solve the problem. `ReloadJavaScriptInProxyModeAsync` shows a progress dialog when loading the JS but you can't do this during a background activation scenario because there's no UI. The result is the attempt to show the progress dialog throws and RNW fails to boot.