### PR TITLE
feat(ViewManager): Lazy load view manager constants

### DIFF
--- a/Libraries/ReactNative/UIManager.windows.js
+++ b/Libraries/ReactNative/UIManager.windows.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule UIManager
+ * @flow
+ * @format
+ */
+'use strict';
+
+const NativeModules = require('NativeModules');
+const Platform = require('Platform');
+
+const defineLazyObjectProperty = require('defineLazyObjectProperty');
+const invariant = require('fbjs/lib/invariant');
+
+const {UIManager} = NativeModules;
+
+invariant(
+  UIManager,
+  'UIManager is undefined. The native module config is probably incorrect.',
+);
+
+// In past versions of ReactNative users called UIManager.takeSnapshot()
+// However takeSnapshot was moved to ReactNative in order to support flat
+// bundles and to avoid a cyclic dependency between UIManager and ReactNative.
+// UIManager.takeSnapshot still exists though. In order to avoid confusion or
+// accidental usage, mask the method with a deprecation warning.
+UIManager.__takeSnapshot = UIManager.takeSnapshot;
+UIManager.takeSnapshot = function() {
+  invariant(
+    false,
+    'UIManager.takeSnapshot should not be called directly. ' +
+      'Use ReactNative.takeSnapshot instead.',
+  );
+};
+
+/**
+ * Copies the ViewManager constants and commands into UIManager. This is
+ * only needed for iOS, which puts the constants in the ViewManager
+ * namespace instead of UIManager, unlike Android.
+ */
+if (Platform.OS === 'ios') {
+  Object.keys(UIManager).forEach(viewName => {
+    const viewConfig = UIManager[viewName];
+    if (viewConfig.Manager) {
+      defineLazyObjectProperty(viewConfig, 'Constants', {
+        get: () => {
+          const viewManager = NativeModules[viewConfig.Manager];
+          const constants = {};
+          viewManager &&
+            Object.keys(viewManager).forEach(key => {
+              const value = viewManager[key];
+              if (typeof value !== 'function') {
+                constants[key] = value;
+              }
+            });
+          return constants;
+        },
+      });
+      defineLazyObjectProperty(viewConfig, 'Commands', {
+        get: () => {
+          const viewManager = NativeModules[viewConfig.Manager];
+          const commands = {};
+          let index = 0;
+          viewManager &&
+            Object.keys(viewManager).forEach(key => {
+              const value = viewManager[key];
+              if (typeof value === 'function') {
+                commands[key] = index++;
+              }
+            });
+          return commands;
+        },
+      });
+    }
+  });
+} else if (UIManager.ViewManagerNames) {
+  UIManager.ViewManagerNames.forEach(viewManagerName => {
+    defineLazyObjectProperty(UIManager, viewManagerName, {
+      get: () => UIManager.getConstantsForViewManager(viewManagerName),
+    });
+  });
+}
+
+module.exports = UIManager;

--- a/Libraries/ReactNative/requireNativeComponent.windows.js
+++ b/Libraries/ReactNative/requireNativeComponent.windows.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * @providesModule requireNativeComponent
  * @flow
@@ -12,7 +10,6 @@
  */
 'use strict';
 
-const Platform = require('Platform');
 const ReactNativeBridgeEventPlugin = require('ReactNativeBridgeEventPlugin');
 const ReactNativeStyleAttributes = require('ReactNativeStyleAttributes');
 const UIManager = require('UIManager');
@@ -25,9 +22,6 @@ const processColor = require('processColor');
 const resolveAssetSource = require('resolveAssetSource');
 const sizesDiffer = require('sizesDiffer');
 const verifyPropTypes = require('verifyPropTypes');
-/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
- * found when Flow v0.54 was deployed. To see the error delete this comment and
- * run Flow. */
 const invariant = require('fbjs/lib/invariant');
 const warning = require('fbjs/lib/warning');
 
@@ -56,10 +50,13 @@ function requireNativeComponent(
   extraConfig?: ?{nativeOnly?: Object},
 ): React$ComponentType<any> | string {
   function attachDefaultEventTypes(viewConfig: any) {
+    // This is supported on UIManager platforms (ex: Android),
+    // as lazy view managers are not implemented for all platforms.
+    // See [UIManager] for details on constants and implementation.
     if (UIManager.ViewManagerNames) {
       // Lazy view managers enabled.
       viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
-    } else if (Platform.OS === 'android') {
+    } else {
       viewConfig.bubblingEventTypes = merge(
         viewConfig.bubblingEventTypes,
         UIManager.genericBubblingEventTypes,

--- a/Libraries/ReactNative/requireNativeComponent.windows.js
+++ b/Libraries/ReactNative/requireNativeComponent.windows.js
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule requireNativeComponent
+ * @flow
+ * @format
+ */
+'use strict';
+
+const Platform = require('Platform');
+const ReactNativeBridgeEventPlugin = require('ReactNativeBridgeEventPlugin');
+const ReactNativeStyleAttributes = require('ReactNativeStyleAttributes');
+const UIManager = require('UIManager');
+
+const createReactNativeComponentClass = require('createReactNativeComponentClass');
+const insetsDiffer = require('insetsDiffer');
+const matricesDiffer = require('matricesDiffer');
+const pointsDiffer = require('pointsDiffer');
+const processColor = require('processColor');
+const resolveAssetSource = require('resolveAssetSource');
+const sizesDiffer = require('sizesDiffer');
+const verifyPropTypes = require('verifyPropTypes');
+/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
+ * found when Flow v0.54 was deployed. To see the error delete this comment and
+ * run Flow. */
+const invariant = require('fbjs/lib/invariant');
+const warning = require('fbjs/lib/warning');
+
+/**
+ * Used to create React components that directly wrap native component
+ * implementations.  Config information is extracted from data exported from the
+ * UIManager module.  You should also wrap the native component in a
+ * hand-written component with full propTypes definitions and other
+ * documentation - pass the hand-written component in as `componentInterface` to
+ * verify all the native props are documented via `propTypes`.
+ *
+ * If some native props shouldn't be exposed in the wrapper interface, you can
+ * pass null for `componentInterface` and call `verifyPropTypes` directly
+ * with `nativePropsToIgnore`;
+ *
+ * Common types are lined up with the appropriate prop differs with
+ * `TypeToDifferMap`.  Non-scalar types not in the map default to `deepDiffer`.
+ */
+import type {ComponentInterface} from 'verifyPropTypes';
+
+let hasAttachedDefaultEventTypes: boolean = false;
+
+function requireNativeComponent(
+  viewName: string,
+  componentInterface?: ?ComponentInterface,
+  extraConfig?: ?{nativeOnly?: Object},
+): React$ComponentType<any> | string {
+  function attachDefaultEventTypes(viewConfig: any) {
+    if (UIManager.ViewManagerNames) {
+      // Lazy view managers enabled.
+      viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
+    } else if (Platform.OS === 'android') {
+      viewConfig.bubblingEventTypes = merge(
+        viewConfig.bubblingEventTypes,
+        UIManager.genericBubblingEventTypes,
+      );
+      viewConfig.directEventTypes = merge(
+        viewConfig.directEventTypes,
+        UIManager.genericDirectEventTypes,
+      );
+    }
+  }
+
+  function merge(destination: ?Object, source: ?Object): ?Object {
+    if (!source) {
+      return destination;
+    }
+    if (!destination) {
+      return source;
+    }
+
+    for (const key in source) {
+      if (!source.hasOwnProperty(key)) {
+        continue;
+      }
+
+      var sourceValue = source[key];
+      if (destination.hasOwnProperty(key)) {
+        const destinationValue = destination[key];
+        if (
+          typeof sourceValue === 'object' &&
+          typeof destinationValue === 'object'
+        ) {
+          sourceValue = merge(destinationValue, sourceValue);
+        }
+      }
+      destination[key] = sourceValue;
+    }
+    return destination;
+  }
+
+  // Don't load the ViewConfig from UIManager until it's needed for rendering.
+  // Lazy-loading this can help avoid Prepack deopts.
+  function getViewConfig() {
+    const viewConfig = UIManager[viewName];
+
+    invariant(
+      viewConfig != null && !viewConfig.NativeProps != null,
+      'Native component for "%s" does not exist',
+      viewName,
+    );
+
+    viewConfig.uiViewClassName = viewName;
+    viewConfig.validAttributes = {};
+
+    // ReactNative `View.propTypes` have been deprecated in favor of
+    // `ViewPropTypes`. In their place a temporary getter has been added with a
+    // deprecated warning message. Avoid triggering that warning here by using
+    // temporary workaround, __propTypesSecretDontUseThesePlease.
+    // TODO (bvaughn) Revert this particular change any time after April 1
+    if (componentInterface) {
+      viewConfig.propTypes =
+        typeof componentInterface.__propTypesSecretDontUseThesePlease ===
+        'object'
+          ? componentInterface.__propTypesSecretDontUseThesePlease
+          : componentInterface.propTypes;
+    } else {
+      viewConfig.propTypes = null;
+    }
+
+    let baseModuleName = viewConfig.baseModuleName;
+    let bubblingEventTypes = viewConfig.bubblingEventTypes;
+    let directEventTypes = viewConfig.directEventTypes;
+    let nativeProps = viewConfig.NativeProps;
+    while (baseModuleName) {
+      const baseModule = UIManager[baseModuleName];
+      if (!baseModule) {
+        warning(false, 'Base module "%s" does not exist', baseModuleName);
+        baseModuleName = null;
+      } else {
+        bubblingEventTypes = {
+          ...baseModule.bubblingEventTypes,
+          ...bubblingEventTypes,
+        };
+        directEventTypes = {
+          ...baseModule.directEventTypes,
+          ...directEventTypes,
+        };
+        nativeProps = {
+          ...baseModule.NativeProps,
+          ...nativeProps,
+        };
+        baseModuleName = baseModule.baseModuleName;
+      }
+    }
+
+    viewConfig.bubblingEventTypes = bubblingEventTypes;
+    viewConfig.directEventTypes = directEventTypes;
+
+    for (const key in nativeProps) {
+      let useAttribute = false;
+      const attribute = {};
+
+      const differ = TypeToDifferMap[nativeProps[key]];
+      if (differ) {
+        attribute.diff = differ;
+        useAttribute = true;
+      }
+
+      const processor = TypeToProcessorMap[nativeProps[key]];
+      if (processor) {
+        attribute.process = processor;
+        useAttribute = true;
+      }
+
+      viewConfig.validAttributes[key] = useAttribute ? attribute : true;
+    }
+
+    // Unfortunately, the current set up puts the style properties on the top
+    // level props object. We also need to add the nested form for API
+    // compatibility. This allows these props on both the top level and the
+    // nested style level. TODO: Move these to nested declarations on the
+    // native side.
+    viewConfig.validAttributes.style = ReactNativeStyleAttributes;
+
+    if (__DEV__) {
+      componentInterface &&
+        verifyPropTypes(
+          componentInterface,
+          viewConfig,
+          extraConfig && extraConfig.nativeOnly,
+        );
+    }
+
+    if (!hasAttachedDefaultEventTypes) {
+      attachDefaultEventTypes(viewConfig);
+      hasAttachedDefaultEventTypes = true;
+    }
+
+    // Register this view's event types with the ReactNative renderer.
+    // This enables view managers to be initialized lazily, improving perf,
+    // While also enabling 3rd party components to define custom event types.
+    ReactNativeBridgeEventPlugin.processEventTypes(viewConfig);
+
+    return viewConfig;
+  }
+
+  return createReactNativeComponentClass(viewName, getViewConfig);
+}
+
+const TypeToDifferMap = {
+  // iOS Types
+  CATransform3D: matricesDiffer,
+  CGPoint: pointsDiffer,
+  CGSize: sizesDiffer,
+  UIEdgeInsets: insetsDiffer,
+  // Android Types
+  // (not yet implemented)
+};
+
+function processColorArray(colors: ?Array<any>): ?Array<?number> {
+  return colors && colors.map(processColor);
+}
+
+const TypeToProcessorMap = {
+  // iOS Types
+  CGColor: processColor,
+  CGColorArray: processColorArray,
+  UIColor: processColor,
+  UIColorArray: processColorArray,
+  CGImage: resolveAssetSource,
+  UIImage: resolveAssetSource,
+  RCTImageSource: resolveAssetSource,
+  // Android Types
+  Color: processColor,
+  ColorArray: processColorArray,
+};
+
+module.exports = requireNativeComponent;

--- a/ReactWindows/ReactNative.Net46.Tests/UIManager/UIManagerModuleTests.cs
+++ b/ReactWindows/ReactNative.Net46.Tests/UIManager/UIManagerModuleTests.cs
@@ -9,9 +9,9 @@ using ReactNative.Tests.Constants;
 using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Threading;
 
 namespace ReactNative.Tests.UIManager
@@ -30,15 +30,15 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 ArgumentNullException ex1 = Assert.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, null, uiImplementationProvider, actionQueue));
+                    () => new UIManagerModule(context, null, uiImplementationProvider, actionQueue, false));
                 Assert.AreEqual("viewManagers", ex1.ParamName);
 
                 ArgumentNullException ex2 = Assert.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, viewManagers, null, actionQueue));
+                    () => new UIManagerModule(context, viewManagers, null, actionQueue, false));
                 Assert.AreEqual("uiImplementationProvider", ex2.ParamName);
 
                 ArgumentNullException ex3 = Assert.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, null));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, null, false));
                 Assert.AreEqual("layoutActionQueue", ex3.ParamName);
             }
         }
@@ -56,7 +56,7 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 var module = await DispatcherHelpers.CallOnDispatcherAsync(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, false));
 
                 var constants = module.Constants.GetMap("Test");
 
@@ -102,13 +102,39 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 var module = await DispatcherHelpers.CallOnDispatcherAsync(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, false));
 
                 var constants = module.Constants.GetMap("Test");
                 Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("otherSelectionChange"));
                 Assert.AreEqual(42, constants.GetMap("directEventTypes").GetMap("topSelectionChange").GetValue("registrationName"));
                 Assert.AreEqual(42, constants.GetMap("directEventTypes").GetMap("topLoadingStart").GetValue("foo"));
                 Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("topLoadingError"));
+            }
+
+            // Ideally we should dispose, but the original dispatcher is somehow lost/etc.
+            // await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
+        }
+
+        [Test]
+        public async Task UIManagerModule_Constants_ViewManager_CustomEvents()
+        {
+            var context = new ReactContext();
+            var viewManagers = new List<IViewManager> { new TestViewManager() };
+
+            ReactNative.Bridge.DispatcherHelpers.MainDispatcher = Dispatcher.CurrentDispatcher;
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
+            var uiImplementationProvider = new UIImplementationProvider();
+            using (var actionQueue = new ActionQueue(ex => { }))
+            {
+                var module = await DispatcherHelpers.CallOnDispatcherAsync(
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, true));
+
+                var obj = module.Constants.GetValue("ViewManagerNames");
+                var viewManagerNames = obj as IEnumerable<string>;
+                Assert.IsNotNull(viewManagerNames);
+                Assert.AreEqual(1, viewManagerNames.Count());
+                Assert.AreEqual("Test", viewManagerNames.Single());
             }
 
             // Ideally we should dispose, but the original dispatcher is somehow lost/etc.

--- a/ReactWindows/ReactNative.Net46.Tests/UIManager/UIManagerModuleTests.cs
+++ b/ReactWindows/ReactNative.Net46.Tests/UIManager/UIManagerModuleTests.cs
@@ -30,15 +30,15 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 ArgumentNullException ex1 = Assert.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, null, uiImplementationProvider, actionQueue, false));
+                    () => new UIManagerModule(context, null, uiImplementationProvider, actionQueue, UIManagerModuleOptions.None));
                 Assert.AreEqual("viewManagers", ex1.ParamName);
 
                 ArgumentNullException ex2 = Assert.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, viewManagers, null, actionQueue, false));
+                    () => new UIManagerModule(context, viewManagers, null, actionQueue, UIManagerModuleOptions.None));
                 Assert.AreEqual("uiImplementationProvider", ex2.ParamName);
 
                 ArgumentNullException ex3 = Assert.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, null, false));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, null, UIManagerModuleOptions.None));
                 Assert.AreEqual("layoutActionQueue", ex3.ParamName);
             }
         }
@@ -56,7 +56,7 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 var module = await DispatcherHelpers.CallOnDispatcherAsync(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, false));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.None));
 
                 var constants = module.Constants.GetMap("Test");
 
@@ -102,7 +102,7 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 var module = await DispatcherHelpers.CallOnDispatcherAsync(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, false));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.None));
 
                 var constants = module.Constants.GetMap("Test");
                 Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("otherSelectionChange"));
@@ -128,13 +128,39 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 var module = await DispatcherHelpers.CallOnDispatcherAsync(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, true));
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.LazyViewManagers));
 
                 var obj = module.Constants.GetValue("ViewManagerNames");
                 var viewManagerNames = obj as IEnumerable<string>;
                 Assert.IsNotNull(viewManagerNames);
                 Assert.AreEqual(1, viewManagerNames.Count());
                 Assert.AreEqual("Test", viewManagerNames.Single());
+            }
+
+            // Ideally we should dispose, but the original dispatcher is somehow lost/etc.
+            // await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
+        }
+
+        [Test]
+        public async Task UIManagerModule_getConstantsForViewManager()
+        {
+            var context = new ReactContext();
+            var viewManagers = new List<IViewManager> { new TestViewManager() };
+
+            ReactNative.Bridge.DispatcherHelpers.MainDispatcher = Dispatcher.CurrentDispatcher;
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+
+            var uiImplementationProvider = new UIImplementationProvider();
+            using (var actionQueue = new ActionQueue(ex => { }))
+            {
+                var module = await DispatcherHelpers.CallOnDispatcherAsync(
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.LazyViewManagers));
+
+                var constants = module.getConstantsForViewManager("Test");
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("otherSelectionChange"));
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetMap("topSelectionChange").GetValue("registrationName"));
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetMap("topLoadingStart").GetValue("foo"));
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("topLoadingError"));
             }
 
             // Ideally we should dispose, but the original dispatcher is somehow lost/etc.

--- a/ReactWindows/ReactNative.Shared/CoreModulesPackage.cs
+++ b/ReactWindows/ReactNative.Shared/CoreModulesPackage.cs
@@ -48,12 +48,13 @@ namespace ReactNative
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "createUIManagerModule").Start())
             {
                 var layoutActionQueue = new LayoutActionQueue(reactContext.HandleException);
+                var options = _lazyViewManagersEnabled ? UIManagerModuleOptions.LazyViewManagers : UIManagerModuleOptions.None;
                 uiManagerModule = new UIManagerModule(
                     reactContext,
                     _reactInstanceManager.CreateAllViewManagers(reactContext),
                     _uiImplementationProvider,
                     layoutActionQueue,
-                    _lazyViewManagersEnabled);
+                    options);
             }
 
             return new List<INativeModule>

--- a/ReactWindows/ReactNative.Shared/CoreModulesPackage.cs
+++ b/ReactWindows/ReactNative.Shared/CoreModulesPackage.cs
@@ -27,15 +27,18 @@ namespace ReactNative
         private readonly ReactInstanceManager _reactInstanceManager;
         private readonly Action _hardwareBackButtonHandler;
         private readonly UIImplementationProvider _uiImplementationProvider;
+        private readonly bool _lazyViewManagersEnabled;
 
         public CoreModulesPackage(
             ReactInstanceManager reactInstanceManager,
             Action hardwareBackButtonHandler,
-            UIImplementationProvider uiImplementationProvider)
+            UIImplementationProvider uiImplementationProvider,
+            bool lazyViewManagersEnabled)
         {
             _reactInstanceManager = reactInstanceManager;
             _hardwareBackButtonHandler = hardwareBackButtonHandler;
             _uiImplementationProvider = uiImplementationProvider;
+            _lazyViewManagersEnabled = lazyViewManagersEnabled;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller manages scope of returned list of disposables.")]
@@ -44,13 +47,13 @@ namespace ReactNative
             var uiManagerModule = default(INativeModule);
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "createUIManagerModule").Start())
             {
-                var viewManagerList = _reactInstanceManager.CreateAllViewManagers(reactContext);
                 var layoutActionQueue = new LayoutActionQueue(reactContext.HandleException);
                 uiManagerModule = new UIManagerModule(
-                    reactContext, 
-                    viewManagerList,
+                    reactContext,
+                    _reactInstanceManager.CreateAllViewManagers(reactContext),
                     _uiImplementationProvider,
-                    layoutActionQueue);
+                    layoutActionQueue,
+                    _lazyViewManagersEnabled);
             }
 
             return new List<INativeModule>

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -69,6 +69,7 @@ namespace ReactNative
         private readonly UIImplementationProvider _uiImplementationProvider;
         private readonly Func<IJavaScriptExecutor> _javaScriptExecutorFactory;
         private readonly Action<Exception> _nativeModuleCallExceptionHandler;
+        private readonly bool _lazyViewManagersEnabled;
 
         private LifecycleStateMachine _lifecycleStateMachine;
         private CancellationDisposable _suspendCancellation;
@@ -83,7 +84,8 @@ namespace ReactNative
             LifecycleState initialLifecycleState,
             UIImplementationProvider uiImplementationProvider,
             Func<IJavaScriptExecutor> javaScriptExecutorFactory,
-            Action<Exception> nativeModuleCallExceptionHandler)
+            Action<Exception> nativeModuleCallExceptionHandler,
+            bool lazyViewManagersEnabled)
         {
             if (packages == null)
                 throw new ArgumentNullException(nameof(packages));
@@ -658,7 +660,7 @@ namespace ReactNative
                     this,
                     InvokeDefaultOnBackPressed,
                     _uiImplementationProvider,
-                    true);
+                    _lazyViewManagersEnabled);
 
                 ProcessPackage(coreModulesPackage, reactContext, nativeRegistryBuilder);
             }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -109,7 +109,7 @@ namespace ReactNative
             _javaScriptExecutorFactory = javaScriptExecutorFactory;
             _nativeModuleCallExceptionHandler = nativeModuleCallExceptionHandler;
         }
-
+        
         /// <summary>
         /// The developer support manager for the instance.
         /// </summary>
@@ -657,7 +657,8 @@ namespace ReactNative
                 var coreModulesPackage = new CoreModulesPackage(
                     this,
                     InvokeDefaultOnBackPressed,
-                    _uiImplementationProvider);
+                    _uiImplementationProvider,
+                    true);
 
                 ProcessPackage(coreModulesPackage, reactContext, nativeRegistryBuilder);
             }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManagerBuilder.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManagerBuilder.cs
@@ -26,6 +26,7 @@ namespace ReactNative
         private UIImplementationProvider _uiImplementationProvider;
         private Action<Exception> _nativeModuleCallExceptionHandler;
         private Func<IJavaScriptExecutor> _jsExecutorFactory;
+        private bool _lazyViewManagersEnabled;
 
         /// <summary>
         /// Sets a provider of <see cref="UIImplementation"/>.
@@ -119,6 +120,19 @@ namespace ReactNative
         }
 
         /// <summary>
+        /// When <code>true</code>, view manager constants, including custom
+        /// events and native props configuration are loaded
+        /// on-demand rather than at startup.
+        /// </summary>
+        public bool LazyViewManagersEnabled
+        {
+            set
+            {
+                _lazyViewManagersEnabled = value;
+            }
+        }
+
+        /// <summary>
         /// Sets the JavaScript executor factory.
         /// </summary>
         public Func<IJavaScriptExecutor> JavaScriptExecutorFactory
@@ -169,7 +183,8 @@ namespace ReactNative
                 _initialLifecycleState.Value,
                 _uiImplementationProvider,
                 _jsExecutorFactory,
-                _nativeModuleCallExceptionHandler);
+                _nativeModuleCallExceptionHandler,
+                _lazyViewManagersEnabled);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -216,6 +216,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\UIImplementationProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\UIManagerModule.Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\UIManagerModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\UIManagerModuleOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\UIViewOperationQueueInstance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewAtIndex.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\ViewManager.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -698,7 +698,7 @@ namespace ReactNative.UIManager
             return _shadowNodeRegistry.GetNode(reactTag);
         }
 
-        private IViewManager ResolveViewManager(string className)
+        internal IViewManager ResolveViewManager(string className)
         {
             return _viewManagers.Get(className);
         }

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementationProvider.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementationProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -21,9 +21,9 @@ namespace ReactNative.UIManager
         /// <param name="reactContext">The React context.</param>
         /// <param name="viewManagers">The view managers.</param>
         /// <param name="eventDispatcher">The event dispatcher.</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="UIImplementation"/> instance.</returns>
         public UIImplementation Create(
-            ReactContext reactContext, 
+            ReactContext reactContext,
             IReadOnlyList<IViewManager> viewManagers,
             EventDispatcher eventDispatcher)
         {

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
@@ -6,6 +6,7 @@
 using ReactNative.Tracing;
 using ReactNative.UIManager.Events;
 using System.Collections.Generic;
+using System.Linq;
 using Map = System.Collections.Generic.Dictionary<string, object>;
 
 namespace ReactNative.UIManager
@@ -24,9 +25,16 @@ namespace ReactNative.UIManager
         private static Dictionary<string, object> CreateConstants(
             IReadOnlyList<IViewManager> viewManagers,
             IDictionary<string, object> allBubblingEventTypes,
-            IDictionary<string, object> allDirectEventTypes)
+            IDictionary<string, object> allDirectEventTypes,
+            bool lazyViewManagersEnabled)
         {
             var constants = GetConstants();
+
+            if (lazyViewManagersEnabled)
+            {
+                constants.Add("ViewManagerNames", viewManagers.Select(viewManager => viewManager.Name));
+                return constants;
+            }
 
             // Generic/default event types:
             // All view managers are capable of dispatching these events.
@@ -74,6 +82,15 @@ namespace ReactNative.UIManager
             }
 
             return constants;
+        }
+
+        private static IDictionary<string, object> GetDefaultExportableEventTypes()
+        {
+            return new Map
+            {
+                { BUBBLING_EVENTS_KEY, GetBubblingEventTypeConstants() },
+                { DIRECT_EVENTS_KEY, GetDirectEventTypeConstants() },
+            };
         }
 
         private static IDictionary<string, object> CreateConstantsForViewManager(

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModuleOptions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModuleOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace ReactNative.UIManager
+{
+    /// <summary>
+    /// Options for the <see cref="UIManagerModule"/>.
+    /// </summary>
+    [Flags]
+    public enum UIManagerModuleOptions
+    {
+        /// <summary>
+        /// None.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Load view manager constants on-demand.
+        /// </summary>
+        LazyViewManagers,
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerRegistry.cs
@@ -15,7 +15,15 @@ namespace ReactNative.UIManager
     /// </summary>
     public class ViewManagerRegistry
     {
-        private readonly IDictionary<string, IViewManager> _registry;
+        /// <summary>
+        /// Map of view manager name to instance.
+        /// </summary>
+        /// <remarks>
+        /// This dictionary is accessed from both the main UI thread and the
+        /// JavaScript thread. We don't need to make it thread-safe because
+        /// only the UI thread writes to the dictionary.
+        /// </remarks>
+        private readonly IReadOnlyDictionary<string, IViewManager> _registry;
 
         /// <summary>
         /// Instantiates the <see cref="ViewManagerRegistry"/>.
@@ -28,11 +36,12 @@ namespace ReactNative.UIManager
             if (viewManagers == null)
                 throw new ArgumentNullException(nameof(viewManagers));
 
-            _registry = new Dictionary<string, IViewManager>(viewManagers.Count);
+            var registry = new Dictionary<string, IViewManager>(viewManagers.Count);
+            _registry = registry;
 
             foreach (var viewManager in viewManagers)
             {
-                _registry.Add(viewManager.Name, viewManager);
+                registry.Add(viewManager.Name, viewManager);
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerRegistry.cs
@@ -28,7 +28,7 @@ namespace ReactNative.UIManager
             if (viewManagers == null)
                 throw new ArgumentNullException(nameof(viewManagers));
 
-            _registry = new Dictionary<string, IViewManager>();
+            _registry = new Dictionary<string, IViewManager>(viewManagers.Count);
 
             foreach (var viewManager in viewManagers)
             {

--- a/ReactWindows/ReactNative.Tests/UIManager/UIManagerModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/UIManagerModuleTests.cs
@@ -27,15 +27,15 @@ namespace ReactNative.Tests.UIManager
             using (var actionQueue = new ActionQueue(ex => { }))
             {
                 AssertEx.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, null, uiImplementationProvider, actionQueue, false),
+                    () => new UIManagerModule(context, null, uiImplementationProvider, actionQueue, UIManagerModuleOptions.None),
                     ex => Assert.AreEqual("viewManagers", ex.ParamName));
 
                 AssertEx.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, viewManagers, null, actionQueue, false),
+                    () => new UIManagerModule(context, viewManagers, null, actionQueue, UIManagerModuleOptions.None),
                     ex => Assert.AreEqual("uiImplementationProvider", ex.ParamName));
 
                 AssertEx.Throws<ArgumentNullException>(
-                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, null, false),
+                    () => new UIManagerModule(context, viewManagers, uiImplementationProvider, null, UIManagerModuleOptions.None),
                     ex => Assert.AreEqual("layoutActionQueue", ex.ParamName));
             }
         }
@@ -51,7 +51,7 @@ namespace ReactNative.Tests.UIManager
 
             using (var actionQueue = new ActionQueue(ex => { }))
             {
-                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, false));
+                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.None));
  
                 var constants = module.Constants.GetMap("Test");
 
@@ -93,7 +93,7 @@ namespace ReactNative.Tests.UIManager
 
             using (var actionQueue = new ActionQueue(ex => { }))
             {
-                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, false));
+                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.None));
  
                 var constants = module.Constants.GetMap("Test");
 
@@ -116,13 +116,34 @@ namespace ReactNative.Tests.UIManager
 
             using (var actionQueue = new ActionQueue(ex => { }))
             {
-                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, true));
+                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.LazyViewManagers));
 
                 var obj = module.Constants.GetValue("ViewManagerNames");
                 var viewManagerNames = obj as IEnumerable<string>;
                 Assert.IsNotNull(viewManagerNames);
                 Assert.AreEqual(1, viewManagerNames.Count());
                 Assert.AreEqual("Test", viewManagerNames.Single());
+            }
+
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);
+        }
+
+        [TestMethod]
+        public async Task UIManagerModule_getConstantsForViewManager()
+        {
+            await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Initialize);
+            var context = new ReactContext();
+            var viewManagers = new List<IViewManager> { new TestViewManager() };
+            var uiImplementationProvider = new UIImplementationProvider();
+
+            using (var actionQueue = new ActionQueue(ex => { }))
+            {
+                var module = await DispatcherHelpers.CallOnDispatcherAsync(() => new UIManagerModule(context, viewManagers, uiImplementationProvider, actionQueue, UIManagerModuleOptions.LazyViewManagers));
+                var constants = module.getConstantsForViewManager("Test");
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("otherSelectionChange"));
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetMap("topSelectionChange").GetValue("registrationName"));
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetMap("topLoadingStart").GetValue("foo"));
+                Assert.AreEqual(42, constants.GetMap("directEventTypes").GetValue("topLoadingError"));
             }
 
             await DispatcherHelpers.RunOnDispatcherAsync(ReactChoreographer.Dispose);


### PR DESCRIPTION
A significant chunk of app initialization is spent loading constants for view managers, many of which won't be used in the initial screen. This allows React to request view manager config on demand.
