### PR TITLE
feat(DependencyInjection): Adds singleton and interface for DI

### DIFF
--- a/ReactWindows/ReactNative.Net46/PlatformServices/CurrentPlatformServiceProvider.cs
+++ b/ReactWindows/ReactNative.Net46/PlatformServices/CurrentPlatformServiceProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 namespace ReactNative.PlatformServices
 {
     /// <summary>

--- a/ReactWindows/ReactNative.Net46/PlatformServices/CurrentPlatformServiceProvider.cs
+++ b/ReactWindows/ReactNative.Net46/PlatformServices/CurrentPlatformServiceProvider.cs
@@ -1,0 +1,18 @@
+namespace ReactNative.PlatformServices
+{
+    /// <summary>
+    /// Service provider implementation for WPF.
+    /// </summary>
+    public class CurrentPlatformServiceProvider : IServiceProvider
+    {
+        /// <summary>
+        /// Gets the platform-specific service instance.
+        /// </summary>
+        /// <typeparam name="T">Type of service.</typeparam>
+        /// <returns>The platform-specific instance.</returns>
+        public T GetService<T>() where T : class
+        {
+            return null;
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Modules\NetInfo\INetworkInformation.cs" />
     <Compile Include="Modules\NetInfo\NetInfoModule.cs" />
     <Compile Include="Modules\WebSocket\WebSocketModule.cs" />
+    <Compile Include="PlatformServices\CurrentPlatformServiceProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactPage.cs" />
     <Compile Include="ReactRootViewExtensions.cs" />

--- a/ReactWindows/ReactNative.Shared/PlatformServices/IServiceProvider.cs
+++ b/ReactWindows/ReactNative.Shared/PlatformServices/IServiceProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 namespace ReactNative.PlatformServices
 {
     /// <summary>

--- a/ReactWindows/ReactNative.Shared/PlatformServices/IServiceProvider.cs
+++ b/ReactWindows/ReactNative.Shared/PlatformServices/IServiceProvider.cs
@@ -1,0 +1,15 @@
+namespace ReactNative.PlatformServices
+{
+    /// <summary>
+    /// Interface for resolving platform-specific services.
+    /// </summary>
+    public interface IServiceProvider
+    {
+        /// <summary>
+        /// Gets the platform-specific service instance.
+        /// </summary>
+        /// <typeparam name="T">Type of service.</typeparam>
+        /// <returns>The platform-specific instance.</returns>
+        T GetService<T>() where T : class;
+    }
+}

--- a/ReactWindows/ReactNative.Shared/PlatformServices/ServiceResolver.cs
+++ b/ReactWindows/ReactNative.Shared/PlatformServices/ServiceResolver.cs
@@ -1,3 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
 namespace ReactNative.PlatformServices
 {
     /// <summary>
@@ -5,9 +10,34 @@ namespace ReactNative.PlatformServices
     /// </summary>
     public static class ServiceResolver
     {
+        private static IServiceProvider s_current = new CurrentPlatformServiceProvider();
+
         /// <summary>
         /// The current platform service provider.
         /// </summary>
-        public static IServiceProvider Instance { get; } = new CurrentPlatformServiceProvider();
+        public static IServiceProvider Current
+        {
+            get
+            {
+                return s_current;
+            }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                s_current = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the platform-specific service instance.
+        /// </summary>
+        /// <typeparam name="T">Type of service.</typeparam>
+        /// <returns>The platform-specific instance.</returns>
+        public static T GetService<T>() where T : class
+        {
+            return s_current.GetService<T>();
+        }
     }
 }

--- a/ReactWindows/ReactNative.Shared/PlatformServices/ServiceResolver.cs
+++ b/ReactWindows/ReactNative.Shared/PlatformServices/ServiceResolver.cs
@@ -1,0 +1,13 @@
+namespace ReactNative.PlatformServices
+{
+    /// <summary>
+    /// Singleton for platform-specific service provider.
+    /// </summary>
+    public static class ServiceResolver
+    {
+        /// <summary>
+        /// The current platform service provider.
+        /// </summary>
+        public static IServiceProvider Instance { get; } = new CurrentPlatformServiceProvider();
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -147,6 +147,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Modules\Storage\AsyncStorageHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\SystemInfo\PlatformConstantsModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\SystemInfo\ReactNativeVersion.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PlatformServices\IServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PlatformServices\ServiceResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pooling\ObjectPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactNativeHostExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactInstanceManager.cs" />

--- a/ReactWindows/ReactNative/PlatformServices/CurrentPlatformServiceProvider.cs
+++ b/ReactWindows/ReactNative/PlatformServices/CurrentPlatformServiceProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 namespace ReactNative.PlatformServices
 {
     /// <summary>

--- a/ReactWindows/ReactNative/PlatformServices/CurrentPlatformServiceProvider.cs
+++ b/ReactWindows/ReactNative/PlatformServices/CurrentPlatformServiceProvider.cs
@@ -1,0 +1,18 @@
+namespace ReactNative.PlatformServices
+{
+    /// <summary>
+    /// Service provider implementation for UWP.
+    /// </summary>
+    public class CurrentPlatformServiceProvider : IServiceProvider
+    {
+        /// <summary>
+        /// Gets the platform-specific service instance.
+        /// </summary>
+        /// <typeparam name="T">Type of service.</typeparam>
+        /// <returns>The platform-specific instance.</returns>
+        public T GetService<T>() where T : class
+        {
+            return null;
+        }
+    }
+}

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Modules\StatusBar\StatusBarModule.cs" />
     <Compile Include="Modules\Storage\AsyncStorageModule.cs" />
     <Compile Include="Modules\Vibration\VibrationModule.cs" />
+    <Compile Include="PlatformServices\CurrentPlatformServiceProvider.cs" />
     <Compile Include="ReactPage.cs" />
     <Compile Include="ReactRootViewExtensions.cs" />
     <Compile Include="Touch\PointerDeviceTypeExtensions.cs" />
@@ -230,6 +231,7 @@
       <Version>4.0.0-preview00001</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -231,7 +231,6 @@
       <Version>4.0.0-preview00001</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
In order to move some of the core React Native bridge to a .NET Standard library, we'll need a mechanism for dependency injection. This provides a singleton and interface for that.