### PR TITLE
References `_settings` for `JavaScriptProxyHost`

### DIFF
--- a/ReactWindows/ReactNative.Shared/DevSupport/DevServerHelper.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevServerHelper.cs
@@ -106,7 +106,7 @@ namespace ReactNative.DevSupport
         {
             get
             {
-                return DeviceLocalhost;
+                return _settings.DebugServerHost ?? DeviceLocalhost;
             }
         }
 


### PR DESCRIPTION
Addresses my concern in #358 that the remote debugger (`JavaScriptProxyHost`) is not utilizing the same url as `DebugServerHost`.