### PR TITLE
fix(Image): `SetDimensions` should not rely on tag

### DIFF
--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -25,8 +25,8 @@ namespace ReactNative.Views.Image
     /// </summary>
     public class ReactImageManager : SimpleViewManager<Border>
     {
-        private readonly ConcurrentDictionary<int, List<KeyValuePair<string, double>>> _imageSources =
-            new ConcurrentDictionary<int, List<KeyValuePair<string, double>>>();
+        private readonly ConcurrentDictionary<Border, List<KeyValuePair<string, double>>> _imageSources =
+            new ConcurrentDictionary<Border, List<KeyValuePair<string, double>>>();
 
         /// <summary>
         /// The view manager name.
@@ -130,16 +130,14 @@ namespace ReactNative.Views.Image
             }
             else
             {
-                var tag = view.GetTag();
-
-                if (_imageSources.TryGetValue(tag, out var viewSources))
+                if (_imageSources.TryGetValue(view, out var viewSources))
                 {
                     viewSources.Clear();
                 }
                 else
                 {
                     viewSources = new List<KeyValuePair<string, double>>(count);
-                    _imageSources.AddOrUpdate(tag, viewSources, (k, v) => viewSources);
+                    _imageSources.AddOrUpdate(view, viewSources, (k, v) => viewSources);
                 }
 
                 foreach (var source in sources)
@@ -215,7 +213,7 @@ namespace ReactNative.Views.Image
         {
             base.OnDropViewInstance(reactContext, view);
 
-            _imageSources.TryRemove(view.GetTag(), out _);
+            _imageSources.TryRemove(view, out _);
         }
 
         /// <summary>
@@ -324,7 +322,7 @@ namespace ReactNative.Views.Image
         /// <param name="view">The image view instance.</param>
         private void SetUriFromMultipleSources(Border view)
         {
-            if (_imageSources.TryGetValue(view.GetTag(), out var sources))
+            if (_imageSources.TryGetValue(view, out var sources))
             {
                 var targetImageSize = view.Width * view.Height;
                 var bestResult = sources.LocalMin((s) => Math.Abs(s.Value - targetImageSize));


### PR DESCRIPTION
A recent change (#1704) now calls `SetDimensions` before a tag has been set on the view. The image view manager uses the SetDimensions event to choose the correct image source when multiple URIs used. This change removes the dependency on `GetTag()`.