### PR TITLE
Refactored AccessibilityHelper to do a top down processing of acc prop changes

### DIFF
--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -144,6 +144,7 @@ namespace ReactNative.UIManager
             view.MouseEnter -= OnPointerEntered;
             view.MouseLeave -= OnPointerExited;
             _transforms.Remove(view);
+            base.OnDropViewInstance(reactContext, view);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -400,7 +400,10 @@ namespace ReactNative.UIManager
             _rootTags.Remove(rootViewTag);
 
 #if WINDOWS_UWP
-            AccessibilityHelper.OnRootViewRemoved(rootView as UIElement);
+            if (rootView is UIElement element)
+            {
+                AccessibilityHelper.OnRootViewRemoved(element);
+            }
 #endif
 
             _deletedTagsBatchReporter.Send();

--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueueInstance.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueueInstance.cs
@@ -454,7 +454,7 @@ namespace ReactNative.UIManager
                             }
                         }
 
-                        _nativeViewHierarchyManager.ClearLayoutAnimation();
+                        _nativeViewHierarchyManager.OnBatchComplete();
                     }
                 });
             }

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
@@ -4,7 +4,6 @@
 // Licensed under the MIT License.
 
 #if WINDOWS_UWP
-using ReactNative.Accessibility;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #else
@@ -54,12 +53,5 @@ namespace ReactNative.UIManager
             view.Width = dimensions.Width;
             view.Height = dimensions.Height;
         }
-#if WINDOWS_UWP
-
-        internal override void OnViewInstanceCreated(ThemedReactContext reactContext, TFrameworkElement view)
-        {
-            AccessibilityHelper.OnViewInstanceCreated(view);
-        }
-#endif
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactRunManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactRunManager.cs
@@ -79,18 +79,5 @@ namespace ReactNative.Views.Text
         {
             return new Run();
         }
-
-        /// <summary>
-        /// Receive extra updates from the shadow node.
-        /// </summary>
-        /// <param name="root">The root view.</param>
-        /// <param name="extraData">The extra data.</param>
-        public override void UpdateExtraData(Run root, object extraData)
-        {
-            base.UpdateExtraData(root, extraData);
-#if WINDOWS_UWP
-            AccessibilityHelper.OnTextChanged(root);
-#endif
-        }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactSpanViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactSpanViewManager.cs
@@ -6,7 +6,6 @@ using ReactNative.UIManager.Annotations;
 using System;
 using System.Linq;
 #if WINDOWS_UWP
-using ReactNative.Accessibility;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
@@ -114,12 +113,6 @@ namespace ReactNative.Views.Text
 
 #if WINDOWS_UWP
             span.Inlines.Insert(index, inlineChild);
-
-            var parentUIElement = AccessibilityHelper.GetParentElementFromTextElement(span);
-            if (parentUIElement != null)
-            {
-                AccessibilityHelper.OnChildAdded(parentUIElement, dependencyObject);
-            }
 #else
             ((IList)span.Inlines).Insert(index, inlineChild);
 #endif
@@ -198,13 +191,6 @@ namespace ReactNative.Views.Text
         {
             var span = (Span)parent;
             span.Inlines.Clear();
-#if WINDOWS_UWP
-            var parentUIElement = AccessibilityHelper.GetParentElementFromTextElement(span);
-            if (parentUIElement != null)
-            {
-                AccessibilityHelper.OnChildRemoved(parentUIElement);
-            }
-#endif
         }
 
         /// <summary>
@@ -217,12 +203,6 @@ namespace ReactNative.Views.Text
             var span = (Span)parent;
 #if WINDOWS_UWP
             span.Inlines.RemoveAt(index);
-
-            var parentUIElement = AccessibilityHelper.GetParentElementFromTextElement(span);
-            if (parentUIElement != null)
-            {
-                AccessibilityHelper.OnChildRemoved(parentUIElement);
-            }
 #else
             ((IList)span.Inlines).RemoveAt(index);
 #endif

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactTextInlineViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactTextInlineViewManager.cs
@@ -24,7 +24,7 @@ namespace ReactNative.Views.Text
         /// </summary>
         /// <param name="root">The root view.</param>
         /// <param name="extraData">The extra data.</param>
-        public override void UpdateExtraData(TInline root, object extraData)
+        public sealed override void UpdateExtraData(TInline root, object extraData)
         {
             var inlineNode = extraData as ReactInlineShadowNode;
             if (inlineNode != null)

--- a/ReactWindows/ReactNative/Accessibility/AccessibilityHelper.cs
+++ b/ReactWindows/ReactNative/Accessibility/AccessibilityHelper.cs
@@ -5,10 +5,12 @@
 
 using Newtonsoft.Json.Linq;
 using ReactNative.Reflection;
-using ReactNative.Tracing;
 using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
+#if PERF_LOG
+using System.Diagnostics;
+#endif
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -106,7 +108,7 @@ namespace ReactNative.Accessibility
             return property;
         }
 
-        #region Property Accessors
+#region Property Accessors
 
         private static void SetAccessibilityLabelProp(UIElement element, string value)
         {
@@ -198,9 +200,9 @@ namespace ReactNative.Accessibility
             s_treeContext.Value.Dirty = true;
         }
 
-        #endregion
+#endregion
 
-        #region Public entry points
+#region Public entry points
 
         /// <summary>
         /// Marks accessibility data in UI tree for update after <paramref name="child"/> is added to <paramref name="parent"/>
@@ -313,9 +315,9 @@ namespace ReactNative.Accessibility
             view.AccessibilityTraits = result;
         }
 
-        #endregion
+#endregion
 
-        #region Internal entry points
+#region Internal entry points
 
         /// <summary>
         /// The framework calls this method on new view instance creation. The method is
@@ -409,16 +411,16 @@ namespace ReactNative.Accessibility
             s_treeContext.Value.Dirty = false;
 
 #if PERF_LOG
-            RnLog.Info("AccessibilityHelper", $"Stats: ElementCount: {s_treeContext.Value.ElementCount}, " +
-                                                     $"MarkedDirtyNodesCount: {s_treeContext.Value.MarkedDirtyNodesCount}, " +
-                                                     $"DirtyNodesCount(before): {savedDirtyNodesCount}, " +
-                                                     $"DirtyNodesCount(after): {s_treeContext.Value.DirtyNodesCount}, " +
-                                                     $"ProcessedNodesCount: {s_treeContext.Value.ProcessedNodesCount}");
+            Debug.WriteLine($"Stats: ElementCount: {s_treeContext.Value.ElementCount}, " +
+                                   $"MarkedDirtyNodesCount: {s_treeContext.Value.MarkedDirtyNodesCount}, " +
+                                   $"DirtyNodesCount(before): {savedDirtyNodesCount}, " +
+                                   $"DirtyNodesCount(after): {s_treeContext.Value.DirtyNodesCount}, " +
+                                   $"ProcessedNodesCount: {s_treeContext.Value.ProcessedNodesCount}");
             s_treeContext.Value.MarkedDirtyNodesCount = 0;
 #endif
         }
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Recursively updates all accessibility properties in the tree rooted by <paramref name="rootElement"/>.

--- a/ReactWindows/ReactNative/Accessibility/AccessibilityHelper.cs
+++ b/ReactWindows/ReactNative/Accessibility/AccessibilityHelper.cs
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// #define PERF_LOG
+
 using Newtonsoft.Json.Linq;
 using ReactNative.Reflection;
+using ReactNative.Tracing;
+using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
-using Windows.UI.Xaml.Documents;
+using Windows.UI.Xaml.Controls;
 
 namespace ReactNative.Accessibility
 {
@@ -20,46 +25,185 @@ namespace ReactNative.Accessibility
     public static class AccessibilityHelper
     {
         /// <summary>
-        /// Finds the <see cref="UIElement"/> that owns the TextElement.
+        /// A per UIElement context containing accessibility props (as sent from JS), and some additional state
         /// </summary>
-        /// <param name="textElement"></param>
-        /// <returns><see cref="UIElement"/> parent of <paramref name="textElement"/>, null otherwise.</returns>
-        public static UIElement GetParentElementFromTextElement(TextElement textElement)
+        private class ElementAccessibilityContext
         {
-            // If the TextElement has not been added to an UIElement yet, accessing ElementStart
-            // will throw NotSupportedException.
-            DependencyObject parent;
-            try
+            public enum HidingChildren
             {
-                parent = textElement.ElementStart?.Parent;
-            }
-            catch (NotSupportedException)
-            {
-                return null;
+                NotSure = 0,
+                Yes,
+                No
             }
 
-            while (parent is TextElement textElementParent)
-            {
-                try
-                {
-                    parent = textElementParent.ElementStart?.Parent;
-                }
-                catch (NotSupportedException)
-                {
-                    return null;
-                }
-            }
+            public ImportantForAccessibility ImportantForAccessibilityProp { get; set; }
 
-            if (parent is UIElement parentUIElement)
-            {
-                return parentUIElement;
-            }
+            public string AccessibilityLabelProp { get; set; }
 
-            return null;
+            public HidingChildren CurrentlyHidingChildren { get; set; }
+
+            public bool Dirty { get; set; }
         }
 
         /// <summary>
-        /// Updates accessibility data in UI tree after <paramref name="child"/> is added to <paramref name="parent"/>
+        /// Per dispatcher thread context
+        /// </summary>
+        private class TreeContext
+        {
+            /// <summary>
+            /// Set of root views
+            /// </summary>
+            public HashSet<UIElement> RootViews { get; set; }
+
+            /// <summary>
+            /// Dictionary replacement of AttachedProperty objects associated with UIElement (it seems attached properties are >10x slower)
+            /// A null value is interpreted as {ImportantForAccessibility.Auto, null, HidingChildren.NotSure, false}.
+            /// </summary>
+            public Dictionary<UIElement, ElementAccessibilityContext> ElementAccessibilityContextMap { get; set; }
+
+            /// <summary>
+            /// Set to true if any accessibility processing is needed for the next batch
+            /// </summary>
+            public bool Dirty { get; set; }
+
+#if PERF_LOG
+            public int ElementCount;
+            public int ProcessedNodesCount;
+            public int DirtyNodesCount;
+            public int MarkedDirtyNodesCount;
+#endif
+        }
+
+        /// <summary>
+        /// State for all dispatcher threads
+        /// </summary>
+        private static ThreadLocal<TreeContext> s_treeContext =
+            new ThreadLocal<TreeContext>(() => new TreeContext()
+            {
+                RootViews = new HashSet<UIElement>(),
+                ElementAccessibilityContextMap = new Dictionary<UIElement, ElementAccessibilityContext>()
+            });
+
+        private static ElementAccessibilityContext EnsureElementAccessibilityContext(UIElement element)
+        {
+            if (!s_treeContext.Value.ElementAccessibilityContextMap.TryGetValue(element, out ElementAccessibilityContext property))
+            {
+                if (!element.HasTag())
+                {
+                    throw new InvalidOperationException("Can't create an ElementAccessibilityContext for a non-React view");
+                }
+
+                property = new ElementAccessibilityContext()
+                {
+                    ImportantForAccessibilityProp = ImportantForAccessibility.Auto,
+                    AccessibilityLabelProp = null,
+                    CurrentlyHidingChildren = ElementAccessibilityContext.HidingChildren.NotSure,
+                    Dirty = false
+                };
+                s_treeContext.Value.ElementAccessibilityContextMap.Add(element, property);
+            }
+
+            return property;
+        }
+
+        #region Property Accessors
+
+        private static void SetAccessibilityLabelProp(UIElement element, string value)
+        {
+            EnsureElementAccessibilityContext(element).AccessibilityLabelProp = value;
+        }
+
+        private static string GetAccessibilityLabelProp(UIElement element)
+        {
+            return EnsureElementAccessibilityContext(element).AccessibilityLabelProp;
+        }
+
+        private static void SetImportantForAccessibilityProp(UIElement element, ImportantForAccessibility value)
+        {
+            EnsureElementAccessibilityContext(element).ImportantForAccessibilityProp = value;
+        }
+
+        private static ImportantForAccessibility GetImportantForAccessibilityProp(UIElement element)
+        {
+            return EnsureElementAccessibilityContext(element).ImportantForAccessibilityProp;
+        }
+
+        private static void SetCurrentlyHidingChildren(UIElement element, ElementAccessibilityContext.HidingChildren value)
+        {
+            EnsureElementAccessibilityContext(element).CurrentlyHidingChildren = value;
+        }
+
+        private static ElementAccessibilityContext.HidingChildren GetCurrentlyHidingChildren(UIElement element)
+        {
+            return EnsureElementAccessibilityContext(element).CurrentlyHidingChildren;
+        }
+
+        private static void SetDirty(UIElement element, bool value)
+        {
+#if PERF_LOG
+            if (GetDirty(element) != value)
+            {
+                s_treeContext.Value.DirtyNodesCount += (value ? 1 : -1);
+            }
+#endif
+            EnsureElementAccessibilityContext(element).Dirty = value;
+        }
+
+        private static bool GetDirty(UIElement element)
+        {
+            return EnsureElementAccessibilityContext(element).Dirty;
+        }
+
+        private static void MarkElementDirty(UIElement element)
+        {
+#if PERF_LOG
+            if (!GetDirty(element))
+            {
+                s_treeContext.Value.MarkedDirtyNodesCount++;
+            }
+#endif
+            // Mark element itself
+            SetDirty(element, true);
+
+            // Retrieve automation peer
+            var peer = FrameworkElementAutomationPeer.FromElement(element);
+
+            if (peer == null)
+            {
+                throw new InvalidOperationException("Element has no automation peer");
+            }
+
+            // Go up the parent chain
+            peer = peer.Navigate(AutomationNavigationDirection.Parent) as AutomationPeer;
+
+            while (peer != null)
+            {
+                element = GetUIElementFromAutomationPeer(peer);
+                // Skip elements not created directly by React
+                if (element != null && element.HasTag())
+                {
+                    if (GetDirty(element))
+                    {
+                        // Found dirty element, no need to continue.
+                        break;
+                    }
+
+                    SetDirty(element, true);
+                }
+
+                // Go up the parent chain
+                peer = peer.Navigate(AutomationNavigationDirection.Parent) as AutomationPeer;
+            }
+
+            s_treeContext.Value.Dirty = true;
+        }
+
+        #endregion
+
+        #region Public entry points
+
+        /// <summary>
+        /// Marks accessibility data in UI tree for update after <paramref name="child"/> is added to <paramref name="parent"/>
         /// Must be called when a child is added to <paramref name="parent"/>.
         /// </summary>
         /// <param name="parent">The element to which <paramref name="child"/> is added.</param>
@@ -68,12 +212,16 @@ namespace ReactNative.Accessibility
         {
             // Call UpdateLayout() on parent to make sure parent/child relationship is updated.
             parent.UpdateLayout();
-            UpdateImportantForAccessibilityForAddedChild(parent, child);
-            UpdateGeneratedNameHereAndUp(parent);
+
+            // No guarantee all children are hidden anymore due to additional child, reset the flag
+            SetCurrentlyHidingChildren(parent, ElementAccessibilityContext.HidingChildren.NotSure);
+
+            // Mark the parent dirty
+            MarkElementDirty(parent);
         }
 
         /// <summary>
-        /// Updates accessibility data in UI tree after a child is removed from <paramref name="parent"/>
+        /// Marks accessibility data in UI tree for update after a child is removed from <paramref name="parent"/>
         /// Must be called when a child is removed from <paramref name="parent"/>.
         /// </summary>
         /// <param name="parent">The element from which a child is removed.</param>
@@ -81,66 +229,61 @@ namespace ReactNative.Accessibility
         {
             // Call UpdateLayout() on parent to make sure parent/child relationship is updated.
             parent.UpdateLayout();
-            UpdateGeneratedNameHereAndUp(parent);
+
+            // Mark the parent dirty
+            MarkElementDirty(parent);
         }
 
         /// <summary>
-        /// Updates accessibility data in UI tree after text is changed on a <see cref="TextElement"/>
-        /// Must be called after text is changed on a <see cref="TextElement"/>
+        /// Marks accessibility data in UI tree for update after a relevant (to accessibility) property of that element changed.
+        /// For example, it is used by <see cref="RichTextBlock"/> to notify when text or structure is changed inside the text block.
         /// </summary>
-        /// <param name="textElement">The <see cref="TextElement"/>.</param>
-        public static void OnTextChanged(TextElement textElement)
+        /// <param name="uiElement">The <see cref="UIElement"/>.</param>
+        public static void OnElementChanged(UIElement uiElement)
         {
-            var parentUIElement = GetParentElementFromTextElement(textElement);
-            if (parentUIElement != null)
+            // Mark the element dirty
+            MarkElementDirty(uiElement);
+        }
+
+        /// <summary>
+        /// Sets the ImportantForAccessibility property for <paramref name="uiElement"/>.
+        /// It uses AutomationProperties.AccessibilityView to expose the element and its children
+        /// to narrator. ImportantForAccessibility value is stored as an attached-like property.
+        /// </summary>
+        /// <param name="uiElement">Element which ImportantForAccessibility property is set.</param>
+        /// <param name="importantForAccessibility">The new value of ImportantForAccessibility property.</param>
+        public static void SetImportantForAccessibility(UIElement uiElement, ImportantForAccessibility importantForAccessibility)
+        {
+            // Check if property is already set to requested value.
+            if (GetImportantForAccessibilityProp(uiElement) == importantForAccessibility)
             {
-                // Call UpdateLayout() on parent to make sure parent/child relationship is updated.
-                parentUIElement.UpdateLayout();
-                UpdateGeneratedNameHereAndUp(parentUIElement);
+                return;
             }
+            SetImportantForAccessibilityProp(uiElement, importantForAccessibility);
+
+            // Mark element as dirty
+            MarkElementDirty(uiElement);
         }
 
         /// <summary>
-        /// The framework calls this method on new view instance creation. The method is
-        /// intended for performing necessary accessibility setup (if any) for the newly created views.
+        /// Sets the AccessibilityLabel property for <paramref name="element"/>.
+        /// It uses <see cref="AutomationProperties.NameProperty"/> to expose the element and its children
+        /// to narrator. AccessibilityLabel value is stored as an attached-like property.
         /// </summary>
-        /// <param name="view"></param>
-        public static void OnViewInstanceCreated(UIElement view)
+        /// <param name="element"></param>
+        /// <param name="accessibilityLabel"></param>
+        public static void SetAccessibilityLabel(UIElement element, string accessibilityLabel)
         {
-            // Not all the UIElements will create AutomationPeer immediately after being created (e.g. Border, Canvas).
-            // We need to make sure AutomationPeer is always created since the impementation relies on
-            // traversing automation tree. Setting AutomationProperties.Name to some string and then clearing it will guarantee that
-            // AutomationPeer is always created.
-            AutomationProperties.SetName(view, " ");
-            view.ClearValue(AutomationProperties.NameProperty);
-        }
-
-        /// <summary>
-        /// If an UIElement owning the <paramref name="peer"/> can be determined, it is returned,
-        /// otherwise returns null.
-        /// </summary>
-        /// <param name="peer"></param>
-        /// <returns></returns>
-        private static UIElement GetUIElementFromAutomationPeer(AutomationPeer peer)
-        {
-            UIElement ret = null;
-
-            switch (peer)
+            // Check if property is already set to requested value.
+            if (GetAccessibilityLabelProp(element) == accessibilityLabel)
             {
-                case FrameworkElementAutomationPeer feAutomationPeer:
-                    ret = feAutomationPeer.Owner;
-                    break;
-                case ItemAutomationPeer itemAutomationPeer:
-                    ret = itemAutomationPeer.Item as UIElement;
-                    break;
-                default:
-                    break;
+                return;
             }
+            SetAccessibilityLabelProp(element, accessibilityLabel);
 
-            return ret;
+            // Mark element as dirty
+            MarkElementDirty(element);
         }
-
-        #region AccessibilityTraits
 
         /// <summary>
         /// Parses <paramref name="accessibilityTraitsValue"/> and sets AccessibilityTraits property for <paramref name="view"/>.
@@ -170,207 +313,229 @@ namespace ReactNative.Accessibility
             view.AccessibilityTraits = result;
         }
 
+        #endregion
+
+        #region Internal entry points
+
         /// <summary>
-        /// Helper parses the <paramref name="trait"/> into AccessibilityTrait enum.
+        /// The framework calls this method on new view instance creation. The method is
+        /// intended for performing necessary accessibility setup (if any) for the newly created views.
         /// </summary>
-        /// <param name="trait"></param>
-        /// <returns>AccessibilityTrait enum</returns>
-        private static AccessibilityTrait? ParseTrait(string trait)
+        /// <param name="view"></param>
+        internal static void OnViewInstanceCreated(UIElement view)
         {
-            if (EnumHelpers.TryParse<AccessibilityTrait>(trait, out var result))
+            var elementPeer = FrameworkElementAutomationPeer.FromElement(view);
+            if (elementPeer == null)
             {
-                return result;
+                // Not all the UIElements will create AutomationPeer immediately after being created (e.g. Border, Canvas).
+                // We need to make sure AutomationPeer is always created since the impementation relies on
+                // traversing automation tree. Setting AutomationProperties.Name to some string and then clearing it will guarantee that
+                // AutomationPeer is always created.
+                AutomationProperties.SetName(view, " ");
+                view.ClearValue(AutomationProperties.NameProperty);
             }
 
-            return null;
+            // Create context proactively, there is no room for allocation optimization due to CurrentlyHidingChildren property.
+            EnsureElementAccessibilityContext(view);
+
+#if PERF_LOG
+            s_treeContext.Value.ElementCount++;
+#endif
         }
 
-        #endregion AccessibilityTraits
+        /// <summary>
+        /// The framework calls this method on view instance destruction. We use it to clean up associated context
+        /// </summary>
+        /// <param name="view"></param>
+        internal static void OnDropViewInstance(UIElement view)
+        {
+#if PERF_LOG
+            if (GetDirty(view))
+            {
+                s_treeContext.Value.DirtyNodesCount--;
+            }
 
-        #region ImportantForAccessibility
+            s_treeContext.Value.ElementCount--;
+#endif
+            s_treeContext.Value.ElementAccessibilityContextMap.Remove(view);
+        }
 
         /// <summary>
-        /// Sets the ImportantForAccessibility property for <paramref name="uiElement"/>.
-        /// It uses AutomationProperties.AccessibilityView to expose the element and its children
-        /// to narrator. ImportantForAccessibility value is stored as an attached property.
+        /// Called on root view creation.
+        /// Has to be run on the dispatcher thread corresponding to this root view.
         /// </summary>
-        /// <param name="uiElement">Element which ImportantForAccessibility property is set.</param>
-        /// <param name="importantForAccessibility">The new value of ImportantForAccessibility property.</param>
-        public static void SetImportantForAccessibility(UIElement uiElement, ImportantForAccessibility importantForAccessibility)
+        /// <param name="rootView">The root view to be added.</param>
+        internal static void OnRootViewAdded(UIElement rootView)
         {
-            // Check if property is already set to requested value.
-            if (GetImportantForAccessibilityAttached(uiElement) == importantForAccessibility)
+            s_treeContext.Value.RootViews.Add(rootView);
+
+            OnViewInstanceCreated(rootView);
+        }
+
+        /// <summary>
+        /// Called on root view removal.
+        /// Has to be run on the dispatcher thread corresponding to this root view.
+        /// </summary>
+        /// <param name="rootView">The root view to be removed.</param>
+        internal static void OnRootViewRemoved(UIElement rootView)
+        {
+            s_treeContext.Value.RootViews.Remove(rootView);
+        }
+
+        /// <summary>
+        /// Called at the end of each batch.
+        /// Has to be run on the dispatcher thread corresponding to the <see cref="UIManager.NativeViewHierarchyManager"/> processing the batch.
+        /// </summary>
+        internal static void OnBatchComplete()
+        {
+            // Exit fast if no dirty node exists at all
+            if (!s_treeContext.Value.Dirty)
             {
                 return;
             }
-            SetImportantForAccessibilityAttached(uiElement, importantForAccessibility);
-            UpdateName(uiElement);
-            UpdateAccessibilityViewIfNeeded(uiElement);
+
+#if PERF_LOG
+            s_treeContext.Value.ProcessedNodesCount = 0;
+            var savedDirtyNodesCount = s_treeContext.Value.DirtyNodesCount;
+#endif
+
+            // Recurse through all known roots
+            foreach (var root in s_treeContext.Value.RootViews)
+            {
+                UpdateAccessibilityPropertiesForTree(root);
+            }
+
+            // Not dirty anymore
+            s_treeContext.Value.Dirty = false;
+
+#if PERF_LOG
+            RnLog.Info("AccessibilityHelper", $"Stats: ElementCount: {s_treeContext.Value.ElementCount}, " +
+                                                     $"MarkedDirtyNodesCount: {s_treeContext.Value.MarkedDirtyNodesCount}, " +
+                                                     $"DirtyNodesCount(before): {savedDirtyNodesCount}, " +
+                                                     $"DirtyNodesCount(after): {s_treeContext.Value.DirtyNodesCount}, " +
+                                                     $"ProcessedNodesCount: {s_treeContext.Value.ProcessedNodesCount}");
+            s_treeContext.Value.MarkedDirtyNodesCount = 0;
+#endif
         }
 
-        private static void UpdateImportantForAccessibilityForAddedChild(UIElement parent, DependencyObject child)
+        #endregion
+
+        /// <summary>
+        /// Recursively updates all accessibility properties in the tree rooted by <paramref name="rootElement"/>.
+        /// </summary>
+        /// <param name="rootElement"></param>
+        private static void UpdateAccessibilityPropertiesForTree(UIElement rootElement)
         {
-            var parentPeer = FrameworkElementAutomationPeer.FromElement(parent);
-            if (DoesHideDescendants(parent)
-                || IsHiddenByAncestor(parentPeer))
+            // Bootstrap the recursion
+            var elementPeer = FrameworkElementAutomationPeer.FromElement(rootElement);
+ 
+            UpdateAccessibilityViewAndNameForUIElement(rootElement, elementPeer, false);
+
+            SetDirty(rootElement, false);
+        }
+
+        /// <summary>
+        /// Sets AccessibilityView and Name property for <paramref name="element"/> and its children according to
+        /// the element's "importantForAccessibility" property  (if <paramref name="hideNodes"/>  is false) / "Raw" (if <paramref name="hideNodes"/>  is true) ,
+        /// and "accessibilityLabel".
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="elementPeer"></param>
+        /// <param name="hideNodes"></param>
+         private static void UpdateAccessibilityViewAndNameForUIElement(UIElement element, AutomationPeer elementPeer, bool hideNodes)
+        {
+            var importantForAccessibilityProp = GetImportantForAccessibilityProp(element);
+            var accessibilityLabelProp = GetAccessibilityLabelProp(element);
+            var hasLabelSet = !string.IsNullOrEmpty(accessibilityLabelProp);
+
+#if PERF_LOG
+            s_treeContext.Value.ProcessedNodesCount++;
+#endif
+
+            //
+            // Phase 1: set correct AV for the current node
+            if (hideNodes)
             {
-                if (child is UIElement childElement)
+                AutomationProperties.SetAccessibilityView(element, AccessibilityView.Raw);
+            }
+            else
+            {
+                switch (importantForAccessibilityProp)
                 {
-                    // If an ancestor is "hiding" the element, set AccessibilityView to Raw.
-                    AutomationPeer childPeer = FrameworkElementAutomationPeer.FromElement(childElement);
-                    AutomationProperties.SetAccessibilityView(childElement, AccessibilityView.Raw);
-                    // Clear the generated label if any.
-                    if (IsInGenerativeStateAndHidden(childElement))
-                    {
-                        childElement.ClearValue(AutomationProperties.NameProperty);
-                    }
-                    SetChildrenAccessibilityView(childPeer, AccessibilityView.Raw);
+                    case ImportantForAccessibility.Auto when !hasLabelSet:
+                        element.ClearValue(AutomationProperties.AccessibilityViewProperty);
+                        break;
+
+                    case ImportantForAccessibility.Auto when hasLabelSet:
+                    case ImportantForAccessibility.Yes:
+                        AutomationProperties.SetAccessibilityView(element, AccessibilityView.Content);
+                        break;
+
+                    case ImportantForAccessibility.No:
+                    case ImportantForAccessibility.NoHideDescendants:
+                        AutomationProperties.SetAccessibilityView(element, AccessibilityView.Raw);
+                        break;
+
+                    default:
+                        throw new NotImplementedException("Can't reach here");
+                }
+            }
+
+            //
+            // Phase 2: go down the tree after deciding how
+            // We can follow dirty nodes (may be none) or traverse all
+            // We can switch to "hiding nodes", to "unhiding nodes", or not switch at all.
+
+            bool willHideChildren = hideNodes ||
+                                    importantForAccessibilityProp == ImportantForAccessibility.Yes ||
+                                    importantForAccessibilityProp == ImportantForAccessibility.NoHideDescendants ||
+                                    importantForAccessibilityProp == ImportantForAccessibility.Auto && hasLabelSet;
+
+            bool traverseAllChildren;
+            if (willHideChildren)
+            {
+                // Will be hiding children
+                // Force a full traversal of children if current node hasn't been hiding them (or not sure),
+                // else just follow the "dirty" nodes, if any
+                traverseAllChildren = GetCurrentlyHidingChildren(element) != ElementAccessibilityContext.HidingChildren.Yes;
+                SetChildrenAccessibilityViewAndNameForPeer(elementPeer, true, traverseAllChildren);
+            }
+            else
+            {
+                // Will be unhiding children
+                // Force a full traversal of children if current node has been hiding them (or not sure),
+                // else just follow the "dirty" nodes, if any
+                traverseAllChildren = GetCurrentlyHidingChildren(element) != ElementAccessibilityContext.HidingChildren.No;
+                SetChildrenAccessibilityViewAndNameForPeer(elementPeer, true, traverseAllChildren);
+            }
+               
+            SetCurrentlyHidingChildren(element, willHideChildren ? ElementAccessibilityContext.HidingChildren.Yes : ElementAccessibilityContext.HidingChildren.No);
+
+            //
+            // Phase 3: set name if needed (all children nodes have been updated by this point)
+            if (traverseAllChildren || GetDirty(element))
+            {
+                if (importantForAccessibilityProp == ImportantForAccessibility.Yes && !hasLabelSet)
+                {
+                    // Set generated name
+                    SetName(element, GenerateNameFromPeer(elementPeer));
                 }
                 else
                 {
-                    // If the parent or an ancestor is "hiding" the children, set AccessibilityView to Raw.
-                    SetChildrenAccessibilityView(parentPeer, AccessibilityView.Raw);
+                    // Set name as the specified label (includes null as a special case)
+                    SetName(element, accessibilityLabelProp);
                 }
             }
         }
 
         /// <summary>
-        /// If needed sets AccessibilityView property for <paramref name="element"/> and its children
-        /// according to the element's <see cref="ImportantForAccessibilityAttachedProperty"/> and
-        /// <see cref="AccessibilityLabelAttachedProperty"/> values.
-        /// </summary>
-        /// <param name="element"></param>
-        private static void UpdateAccessibilityViewIfNeeded(UIElement element)
-        {
-            // Check if uiElement has an ancestor that "hides" children. If so, AccessibilityView is
-            // already set to "Raw" for all children and no updates are required.
-            var elementPeer = FrameworkElementAutomationPeer.FromElement(element);
-            if (IsHiddenByAncestor(elementPeer))
-            {
-                return;
-            }
-
-            // Update AccessibilityView property accordingly.
-            UpdateAccessibilityViewForUIElement(element, elementPeer, GetImportantForAccessibilityAttached(element));
-        }
-
-        /// <summary>
-        /// Attached property used to store ImportantForAccessibility value in native controls.
-        /// </summary>
-        private static readonly DependencyProperty ImportantForAccessibilityAttachedProperty =
-            DependencyProperty.RegisterAttached(
-                "ImportantForAccessibilityAttached",
-                typeof(ImportantForAccessibility),
-                typeof(UIElement),
-                new PropertyMetadata(ImportantForAccessibility.Auto));
-
-        /// <summary>
-        /// ImportantForAccessibilityAttached property setter.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <param name="value"></param>
-        private static void SetImportantForAccessibilityAttached(UIElement element, ImportantForAccessibility value)
-        {
-            element.SetValue(ImportantForAccessibilityAttachedProperty, value);
-        }
-
-        /// <summary>
-        /// ImportantForAccessibilityAttached property getter.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <returns></returns>
-        private static ImportantForAccessibility GetImportantForAccessibilityAttached(UIElement element)
-        {
-            return (ImportantForAccessibility)element.GetValue(ImportantForAccessibilityAttachedProperty);
-        }
-
-        /// <summary>
-        /// Recursively sets AccessibilityView to <paramref name="accessibilityView"/> for <paramref name="parentPeer"/> children.
-        /// </summary>
-        /// <param name="parentPeer"></param>
-        /// <param name="accessibilityView"></param>
-        private static void SetChildrenAccessibilityView(AutomationPeer parentPeer, AccessibilityView accessibilityView)
-        {
-            if (parentPeer?.GetChildren() == null)
-            {
-                return;
-            }
-
-            foreach (AutomationPeer childPeer in parentPeer.GetChildren())
-            {
-                UIElement child = GetUIElementFromAutomationPeer(childPeer);
-                if (child != null)
-                {
-                    AutomationProperties.SetAccessibilityView(child, accessibilityView);
-                    // If element is hidden clear the generated label if any.
-                    if (IsInGenerativeStateAndHidden(child))
-                    {
-                        child.ClearValue(AutomationProperties.NameProperty);
-                    }
-                }
-                SetChildrenAccessibilityView(childPeer, accessibilityView);
-            }
-        }
-
-        /// <summary>
-        /// Returns true if in <paramref name="elementPeer"/> parents chain there is an UIElement with
-        /// ImportantForAccessibility value of Yes or NoHideDescendants or (Auto and AccessibilityLabelAttached attached property is set).
-        /// 'Yes' or (Auto and AccessibilityLabelAttached attached property is set) denotes that the element is visible
-        /// to the narrator as a container i.e. its children are 'hidden'. 'NoHideDescendants' denotes that both
-        /// the element and its children are 'hidden'. 'Hidden' children have AccessibilityView set to 'Raw'.
+        /// Recursively sets the value of AccessibilityView and Name for children of <paramref name="elementPeer"/>
+        /// based on ImportantForAccessibility and AccesibilityLabel
         /// </summary>
         /// <param name="elementPeer"></param>
-        /// <returns></returns>
-        private static bool IsHiddenByAncestor(AutomationPeer elementPeer)
-        {
-            if (elementPeer == null)
-            {
-                return false;
-            }
-
-            bool result;
-            switch (elementPeer.Navigate(AutomationNavigationDirection.Parent))
-            {
-                case FrameworkElementAutomationPeer parentFEAutomationPeer:
-                    if (parentFEAutomationPeer.Owner != null)
-                    {
-                        if (DoesHideDescendants(parentFEAutomationPeer.Owner))
-                        {
-                            return true;
-                        }
-                    }
-                    result = IsHiddenByAncestor(parentFEAutomationPeer);
-                    break;
-                case ItemAutomationPeer parentIAutomationPeer:
-                    if (parentIAutomationPeer.Item is UIElement parentUIElement)
-                    {
-                        if (DoesHideDescendants(parentUIElement))
-                        {
-                            return true;
-                        }
-                    }
-                    result = IsHiddenByAncestor(parentIAutomationPeer);
-                    break;
-                case AutomationPeer parentAutomationPeer:
-                    result = IsHiddenByAncestor(parentAutomationPeer);
-                    break;
-                case null:
-                    result = false;
-                    break;
-                default:
-                    result = false;
-                    break;
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Recursively sets the value of AccessibilityView according ImportantForAccessibility setting
-        /// for children of <paramref name="elementPeer"/>
-        /// </summary>
-        /// <param name="elementPeer"></param>
-        private static void SetChildrenAccessibilityViewFromImportantForAccessibility(AutomationPeer elementPeer)
+        /// <param name="hideNodes"></param>
+        /// <param name="traverseAllChildren"></param>
+        private static void SetChildrenAccessibilityViewAndNameForPeer(AutomationPeer elementPeer, bool hideNodes, bool traverseAllChildren)
         {
             if (elementPeer?.GetChildren() == null)
             {
@@ -380,221 +545,58 @@ namespace ReactNative.Accessibility
             foreach (AutomationPeer childPeer in elementPeer.GetChildren())
             {
                 UIElement child = GetUIElementFromAutomationPeer(childPeer);
-                if (child == null)
+                // Take into account just views created by React
+                if (child == null || !child.HasTag())
                 {
-                    SetChildrenAccessibilityViewFromImportantForAccessibility(childPeer);
+                    SetChildrenAccessibilityViewAndNameForPeer(childPeer, hideNodes, traverseAllChildren);
                 }
                 else
                 {
-                    var importantForAccessibilityAttached = GetImportantForAccessibilityAttached(child);
-                    UpdateAccessibilityViewForUIElement(child, childPeer, importantForAccessibilityAttached);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Sets AccessibilityView property for <paramref name="element"/> and its children according to
-        /// the element's <paramref name="importantForAccessibility"/> property and
-        /// <see cref="AccessibilityLabelAttachedProperty"/> values.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <param name="elementPeer"></param>
-        /// <param name="importantForAccessibility"></param>
-        private static void UpdateAccessibilityViewForUIElement(UIElement element, AutomationPeer elementPeer, ImportantForAccessibility importantForAccessibility)
-        {
-            switch (importantForAccessibility)
-            {
-                case ImportantForAccessibility.Auto when GetAccessibilityLabelAttached(element) == null:
-                    element.ClearValue(AutomationProperties.AccessibilityViewProperty);
-                    SetChildrenAccessibilityViewFromImportantForAccessibility(elementPeer);
-                    break;
-                case ImportantForAccessibility.Auto when GetAccessibilityLabelAttached(element) != null:
-                case ImportantForAccessibility.Yes:
-                    var currentAccessibilityView = AutomationProperties.GetAccessibilityView(element);
-                    AutomationProperties.SetAccessibilityView(element, AccessibilityView.Content);
-                    // Generate the label in case the element was hidden.
-                    if (currentAccessibilityView == AccessibilityView.Raw)
+                    if (traverseAllChildren || GetDirty(child))
                     {
-                        UpdateName(element);
+                        UpdateAccessibilityViewAndNameForUIElement(child, childPeer, hideNodes);
                     }
-                    SetChildrenAccessibilityView(elementPeer, AccessibilityView.Raw);
-                    break;
-                case ImportantForAccessibility.No:
-                    AutomationProperties.SetAccessibilityView(element, AccessibilityView.Raw);
-                    SetChildrenAccessibilityViewFromImportantForAccessibility(elementPeer);
-                    break;
-                case ImportantForAccessibility.NoHideDescendants:
-                    AutomationProperties.SetAccessibilityView(element, AccessibilityView.Raw);
-                    SetChildrenAccessibilityView(elementPeer, AccessibilityView.Raw);
-                    break;
-                default:
-                    break;
-            }
-        }
 
-        private static bool DoesHideDescendants(UIElement element)
-        {
-            ImportantForAccessibility importantForAccessibility = GetImportantForAccessibilityAttached(element);
-            bool isAccessibilityLabelSet = GetAccessibilityLabelAttached(element) != null;
-
-            return importantForAccessibility == ImportantForAccessibility.Yes
-                || importantForAccessibility == ImportantForAccessibility.NoHideDescendants
-                || (importantForAccessibility == ImportantForAccessibility.Auto && isAccessibilityLabelSet == true);
-        }
-
-        #endregion ImportantForAccessibility
-
-        #region AccessibilityLabel
-
-        /// <summary>
-        /// Sets the AccessibilityLabel property for <paramref name="element"/>.
-        /// It uses <see cref="AutomationProperties.NameProperty"/> to expose the element and its children
-        /// to narrator. AccessibilityLabel value is stored as an attached property.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <param name="accessibilityLabel"></param>
-        public static void SetAccessibilityLabel(UIElement element, string accessibilityLabel)
-        {
-            // Check if property is already set to requested value.
-            if (GetAccessibilityLabelAttached(element) == accessibilityLabel)
-            {
-                return;
-            }
-            SetAccessibilityLabelAttached(element, accessibilityLabel);
-            UpdateName(element);
-            UpdateAccessibilityViewIfNeeded(element);
-        }
-
-        /// <summary>
-        /// Updates name on <paramref name="element"/> from <see cref="AccessibilityLabelAttachedProperty"/>
-        /// or from generation, and then updates all parents' generated names where update is due.
-        /// </summary>
-        /// <param name="element"></param>
-        private static void UpdateName(UIElement element)
-        {
-            // Update name on the element itself from AccessibilityLabel or name generation.
-            var peer = FrameworkElementAutomationPeer.FromElement(element);
-            if (IsInGenerativeState(element))
-            {
-                if (AutomationProperties.GetAccessibilityView(element) != AccessibilityView.Raw)
-                {
-                    var generatedName = GenerateNameFromUpdated(peer);
-                    AutomationProperties.SetName(element, generatedName);
+                    SetDirty(child, false);
                 }
+            }
+        }
+
+        private static void SetName(UIElement element, string name)
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                AutomationProperties.SetName(element, name);
             }
             else
             {
-                var accessibilityLabel = GetAccessibilityLabelAttached(element);
-                if (string.IsNullOrEmpty(accessibilityLabel))
-                {
-                    element.ClearValue(AutomationProperties.NameProperty);
-                }
-                else
-                {
-                    AutomationProperties.SetName(element, accessibilityLabel);
-                }
-            }
-
-            // Update generated names only starting from parent and up.
-            var parentPeer = peer.Navigate(AutomationNavigationDirection.Parent) as AutomationPeer;
-            if (parentPeer != null)
-            {
-                UpdateGeneratedNameHereAndUp(parentPeer);
+                element.ClearValue(AutomationProperties.NameProperty);
             }
         }
 
         /// <summary>
-        /// Update <see cref="AutomationProperties.NameProperty"/> on <paramref name="element"/>
-        /// and all its parents as far up as needed and only when the name is generated. This must be called
-        /// when anything influencing generated names has changed in <paramref name="element"/> or somewhere in its subtree.
-        /// </summary>
-        /// <param name="element"></param>
-        private static void UpdateGeneratedNameHereAndUp(UIElement element)
-        {
-            var peer = FrameworkElementAutomationPeer.FromElement(element);
-            UpdateGeneratedNameHereAndUp(peer);
-        }
-
-        /// <summary>
-        /// Update <see cref="AutomationProperties.NameProperty"/> on <paramref name="peer"/>'s owner
-        /// and all its parents as far up as needed and only when the name is generated. This must be called
-        /// when anything influencing generated names has changed in <paramref name="peer"/>'s owner or somewhere in its subtree.
+        /// Generates name from peer and list of children.
+        /// Warning! It has clearing the Name AP as a side effect!
         /// </summary>
         /// <param name="peer"></param>
-        private static void UpdateGeneratedNameHereAndUp(AutomationPeer peer)
+        /// <returns>Generated name.</returns>
+        private static string GenerateNameFromPeer(AutomationPeer peer)
         {
-            var current = peer;
-            while (current != null)
-            {
-                UIElement element = GetUIElementFromAutomationPeer(current);
-                if (IsElementIgnoresChildrenForName(element))
-                {
-                    break;
-                }
-                if (IsInGenerativeState(element) &&
-                    (AutomationProperties.GetAccessibilityView(element) != AccessibilityView.Raw))
-                {
-                    var generatedName = GenerateNameFromUpdated(current);
-                    AutomationProperties.SetName(element, generatedName);
-                }
-                current = current.Navigate(AutomationNavigationDirection.Parent) as AutomationPeer;
-            }
-        }
-
-        /// <summary>
-        /// Checks if <paramref name="element"/> decides its name must be generated.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <returns>True if name should be generated. False otherwise.</returns>
-        private static bool IsInGenerativeState(UIElement element)
-        {
-            var i4a = GetImportantForAccessibilityAttached(element);
-            var label = GetAccessibilityLabelAttached(element);
-            return i4a == ImportantForAccessibility.Yes && string.IsNullOrEmpty(label);
-        }
-
-        /// <summary>
-        /// True if the <paramref name="element"/> generates name, but it is not visible to narrator.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <returns></returns>
-        private static bool IsInGenerativeStateAndHidden(UIElement element) => AutomationProperties.GetAccessibilityView(element) == AccessibilityView.Raw && IsInGenerativeState(element);
-
-        /// <summary>
-        /// Checks if <paramref name="element"/> decides that its children are not needed
-        /// for determining either its own name directly or its part it contributes to generation
-        /// of a parent's name. 
-        /// </summary>
-        /// <param name="element"></param>
-        /// <returns>True if element decides to ignore children. False otherwise.</returns>
-        private static bool IsElementIgnoresChildrenForName(UIElement element)
-        {
-            var i4a = GetImportantForAccessibilityAttached(element);
-            var label = GetAccessibilityLabelAttached(element);
-            return i4a == ImportantForAccessibility.NoHideDescendants
-                || (i4a == ImportantForAccessibility.Yes && !string.IsNullOrEmpty(label))
-                || (i4a == ImportantForAccessibility.Auto && !string.IsNullOrEmpty(label));
-        }
-
-        /// <summary>
-        /// Generates name for <paramref name="peer"/>.
-        /// Takes into account <see cref="AccessibilityLabelAttachedProperty"/>.
-        /// Does not take into account <see cref="ImportantForAccessibilityAttachedProperty"/>
-        /// on <paramref name="peer"/> itself but does take it into account on children transitively.
-        /// This assumes that the caller knows that the <see cref="AccessibilityLabelAttachedProperty"/> on
-        /// <paramref name="peer"/> must be taken into account no matter what is the value of
-        /// <see cref="ImportantForAccessibilityAttachedProperty"/> on it.
-        /// </summary>
-        /// <param name="peer">Peer to generate name for.</param>
-        /// <returns>The generated name.</returns>
-        private static string GenerateNameFromUpdated(AutomationPeer peer)
-        {
+            // Clear Name attached property to unhide any name generated by peer
             var element = GetUIElementFromAutomationPeer(peer);
-            var label = GetAccessibilityLabelAttached(element);
-            if (!string.IsNullOrEmpty(label))
+            if (element != null)
             {
-                return label;
+                element.ClearValue(AutomationProperties.NameProperty);
             }
+
+            var ownName = peer.GetName();
+            if (!string.IsNullOrEmpty(ownName))
+            {
+                // Own name present, we can use
+                return ownName;
+            }
+
+            // Defer to children
             return GenerateNameFromChildren(peer.GetChildren());
         }
 
@@ -614,8 +616,10 @@ namespace ReactNative.Accessibility
             foreach (var child in children)
             {
                 var childElement = GetUIElementFromAutomationPeer(child);
-                var i4a = GetImportantForAccessibilityAttached(childElement);
+                var isReactChild = childElement.HasTag();
+                var i4a = isReactChild ? GetImportantForAccessibilityProp(childElement) : ImportantForAccessibility.Auto;
                 var childResult = default(string);
+                string label;
                 switch (i4a)
                 {
                     case ImportantForAccessibility.NoHideDescendants:
@@ -626,28 +630,17 @@ namespace ReactNative.Accessibility
                         childResult = GenerateNameFromChildren(child.GetChildren());
                         break;
                     case ImportantForAccessibility.Yes:
-                        // AutomationProperties.Name should have been already set as
-                        // either generated from subtree, if AccessibilityLabel is not set,
-                        // or as value of AccessiblityLabel, if it's set.
-                        // If the element is hidden, the generated name is cleared. In such case do a full generation.
-                        if (IsInGenerativeStateAndHidden(childElement))
-                        {
-                            childResult = GenerateNameFromChildren(child.GetChildren());
-                        }
-                        else
-                        {
-                            childResult = AutomationProperties.GetName(childElement);
-                        }
-                        break;
                     case ImportantForAccessibility.Auto:
-                        // Priority order is: AccessiblityLabel, control-provided name, children.
-                        var label = GetAccessibilityLabelAttached(childElement);
+                        // Priority order is: AccessiblityLabel (if React element), control-provided name, children.
+                        label = isReactChild ? GetAccessibilityLabelProp(childElement) : null;
                         if (!string.IsNullOrEmpty(label))
                         {
                             childResult = label;
                         }
                         else
                         {
+                            // We don't use GenerateNameFromPeer because it affects the Name AP.
+                            // We actually use the peer name here since it may already by updated by prior steps of the recursive traversal
                             var ownName = child.GetName();
                             if (!string.IsNullOrEmpty(ownName))
                             {
@@ -675,35 +668,43 @@ namespace ReactNative.Accessibility
         }
 
         /// <summary>
-        /// Attached property used to store AccessibilityLabel value in native controls.
+        /// If an UIElement owning the <paramref name="peer"/> can be determined, it is returned,
+        /// otherwise returns null.
         /// </summary>
-        private static readonly DependencyProperty AccessibilityLabelAttachedProperty =
-            DependencyProperty.RegisterAttached(
-                "AccessibilityLabelAttached",
-                typeof(string),
-                typeof(UIElement),
-                new PropertyMetadata(null));
-
-        /// <summary>
-        /// AccessibilityLabelAttached property setter.
-        /// </summary>
-        /// <param name="element"></param>
-        /// <param name="value"></param>
-        private static void SetAccessibilityLabelAttached(UIElement element, string value)
-        {
-            element.SetValue(AccessibilityLabelAttachedProperty, value);
-        }
-
-        /// <summary>
-        /// AccessibilityLabelAttached property getter.
-        /// </summary>
-        /// <param name="element"></param>
+        /// <param name="peer"></param>
         /// <returns></returns>
-        private static string GetAccessibilityLabelAttached(UIElement element)
+        private static UIElement GetUIElementFromAutomationPeer(AutomationPeer peer)
         {
-            return (string)element.GetValue(AccessibilityLabelAttachedProperty);
+            UIElement ret = null;
+
+            switch (peer)
+            {
+                case FrameworkElementAutomationPeer feAutomationPeer:
+                    ret = feAutomationPeer.Owner;
+                    break;
+                case ItemAutomationPeer itemAutomationPeer:
+                    ret = itemAutomationPeer.Item as UIElement;
+                    break;
+                default:
+                    break;
+            }
+
+            return ret;
         }
 
-        #endregion AccessibilityLabel
+        /// <summary>
+        /// Helper parses the <paramref name="trait"/> into AccessibilityTrait enum.
+        /// </summary>
+        /// <param name="trait"></param>
+        /// <returns>AccessibilityTrait enum</returns>
+        private static AccessibilityTrait? ParseTrait(string trait)
+        {
+            if (EnumHelpers.TryParse<AccessibilityTrait>(trait, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
     }
 }

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -210,6 +210,7 @@ namespace ReactNative.UIManager
             view.PointerEntered -= OnPointerEntered;
             view.PointerExited -= OnPointerExited;
             _dimensionBoundProperties.TryRemove(view, out _);
+            base.OnDropViewInstance(reactContext, view);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -210,7 +210,6 @@ namespace ReactNative.UIManager
             view.PointerEntered -= OnPointerEntered;
             view.PointerExited -= OnPointerExited;
             _dimensionBoundProperties.TryRemove(view, out _);
-            base.OnDropViewInstance(reactContext, view);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -161,6 +161,8 @@ namespace ReactNative.Views.Text
             {
                 textNode.UpdateTextBlock(root);
             }
+
+            AccessibilityHelper.OnElementChanged(root);
         }
 
         /// <summary>


### PR DESCRIPTION
New code does a per batch processing of "dirty nodes" (as far as accessibility properties and tree structure are concerned) starting from roots.
This avoids work done on subtrees that are not added to main tree yet.
We avoid now that NotsupportedException case.

The inputs that "dirty" a node and its ancestors up to root are:
- any change of "importantForAccessibility" and "AccessibilityLabel"
- adding/removing a child
- "element changed" calls from controls that need accessibility re-assessed when some of their properties change (Text control is one of these in the current code)
The output consists of the "AccessibleView" and "Name" automation properties for each control.
