### PR TITLE
Correct check for tag presence during synchronous animations

### DIFF
--- a/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
@@ -492,6 +492,11 @@ namespace ReactNative.UIManager
             if (queue == MainUIViewOperationQueue)
             {
                 // Main queue case. Just forward.
+                if (!MainUIViewOperationQueue.NativeViewHierarchyManager.ViewExists(tag))
+                {
+                    return false;
+                }
+
                 MainUIViewOperationQueue.NativeViewHierarchyManager.UpdateProperties(tag, props);
             }
             else


### PR DESCRIPTION
This is a small regression from multi window work.

There is an expected race condition for this animation related code path when tags may have been deleted already. Previous code used to check the presence of the view before calling UpdateProperties.
Multi window added the "tag to queue" lookup, so we piggy backed on that one for the check.
Problem is, that lookup checks a different data store, with different item lifetimes. In fact that store is cleanup more lazily, so the window for the tag to exist in the lookup table but not in NativeViewHierarchyManager is wider..

Added back the missing check to prevent app crashing.