### PR TITLE
perf(Bridge): Do not re-parse `__fbBatchedBridgeConfig`

### DIFF
--- a/ReactWindows/ReactNative.Net46/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Net46/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -124,9 +124,9 @@ namespace ReactNative.DevSupport
             }
         }
 
-        public void SetGlobalVariable(string propertyName, JToken value)
+        public void SetGlobalVariable(string propertyName, string value)
         {
-            _injectedObjects.Add(propertyName, value.ToString(Formatting.None));
+            _injectedObjects.Add(propertyName, value);
         }
 
         public void SetCallSyncHook(Func<int, int, JArray, JToken> nativeCallSyncHook)

--- a/ReactWindows/ReactNative.Shared.Tests/Chakra/Executor/ChakraJavaScriptExecutorTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Chakra/Executor/ChakraJavaScriptExecutorTests.cs
@@ -46,7 +46,7 @@ namespace ReactNative.Tests.Chakra.Executor
                 );
 
                 Assert.That(
-                    () => executor.SetGlobalVariable(null, new JArray()),
+                    () => executor.SetGlobalVariable(null, "[]"),
                     Throws.ArgumentNullException.With.Property("ParamName").EqualTo("propertyName")
                 );
 

--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
@@ -14,12 +14,12 @@ namespace ReactNative.Tests
         public Func<JToken> OnFlushQueue { get; set; } = EmptyFlushQueue;
 
         public Action<string, string> OnRunScript { get; set; } = EmptyRunScript;
-        public Action<string, JToken> OnSetGlobalVariable { get; set; } = EmptySetGlobalVariable;
+        public Action<string, string> OnSetGlobalVariable { get; set; } = EmptySetGlobalVariable;
         public Action OnDispose { get; set; } = EmptyAction;
 
         private static readonly Action EmptyAction = () => { };
         private static readonly Action<string, string> EmptyRunScript = (_, __) => { };
-        private static readonly Action<string, JToken> EmptySetGlobalVariable = (_, __) => { };
+        private static readonly Action<string, string> EmptySetGlobalVariable = (_, __) => { };
         private static readonly Func<string, string, JArray, JToken> EmptyCallFunctionReturnFlushedQueue = (_, __, ___) => { throw new NotImplementedException(); };
         private static readonly Func<int, JArray, JToken> EmptyInvokeCallbackAndReturnFlushedQueue = (_, __) => { throw new NotImplementedException(); };
         private static readonly Func<JToken> EmptyFlushQueue = () => { throw new NotImplementedException(); };
@@ -31,7 +31,7 @@ namespace ReactNative.Tests
             OnRunScript(sourcePath, sourceUrl);
         }
 
-        public void SetGlobalVariable(string propertyName, JToken value)
+        public void SetGlobalVariable(string propertyName, string value)
         {
             OnSetGlobalVariable(propertyName, value);
         }

--- a/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
@@ -41,7 +41,7 @@ namespace ReactNative.Bridge
         /// </summary>
         /// <param name="propertyName">The global variable name.</param>
         /// <param name="value">The value.</param>
-        void SetGlobalVariable(string propertyName, JToken value);
+        void SetGlobalVariable(string propertyName, string value);
 
         /// <summary>
         /// Runs the JavaScript at the given path.

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
@@ -78,7 +78,7 @@ namespace ReactNative.Bridge
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));
 
-            _jsExecutor.SetGlobalVariable(propertyName, JToken.Parse(jsonEncodedArgument));
+            _jsExecutor.SetGlobalVariable(propertyName, jsonEncodedArgument);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -174,7 +174,7 @@ namespace ReactNative.Chakra.Executor
         /// </summary>
         /// <param name="propertyName">The global variable name.</param>
         /// <param name="value">The value.</param>
-        public void SetGlobalVariable(string propertyName, JToken value)
+        public void SetGlobalVariable(string propertyName, string value)
         {
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));
@@ -267,6 +267,11 @@ namespace ReactNative.Chakra.Executor
         private JavaScriptValue ConvertJson(JToken token)
         {
             var jsonString = token.ToString(Formatting.None);
+            return ConvertJson(jsonString);
+        }
+
+        private JavaScriptValue ConvertJson(string jsonString)
+        {
             var jsonStringValue = JavaScriptValue.FromString(jsonString);
             jsonStringValue.AddRef();
             var parseFunction = EnsureParseFunction();

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -182,7 +182,7 @@ namespace ReactNative.Chakra.Executor
         /// </summary>
         /// <param name="propertyName">The global variable name.</param>
         /// <param name="value">The value.</param>
-        public void SetGlobalVariable(string propertyName, JToken value)
+        public void SetGlobalVariable(string propertyName, string value)
         {
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));
@@ -190,7 +190,7 @@ namespace ReactNative.Chakra.Executor
                 throw new ArgumentNullException(nameof(value));
 
             Native.ThrowIfError(
-                (JavaScriptErrorCode)_executor.SetGlobalVariable(propertyName, value.ToString(Formatting.None)));
+                (JavaScriptErrorCode)_executor.SetGlobalVariable(propertyName, value));
         }
     }
 }

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -138,9 +138,9 @@ namespace ReactNative.DevSupport
             }
         }
 
-        public void SetGlobalVariable(string propertyName, JToken value)
+        public void SetGlobalVariable(string propertyName, string value)
         {
-            _injectedObjects.Add(propertyName, value.ToString(Formatting.None));
+            _injectedObjects.Add(propertyName, value);
         }
 
         public void SetCallSyncHook(Func<int, int, JArray, JToken> callSyncHook)


### PR DESCRIPTION
The ReactBridge writes the RN config to a string, but then because of the interface for `IJavaScriptExecutor`, parses it to a JSON data model object, only to immediately re-serialize it. This change removes the parse and re-serialize steps.