### PR TITLE
fix(DevSupport): set `needFileInfo` param to false

### DIFF
--- a/ReactWindows/ReactNative.Shared/DevSupport/StackTraceHelper.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/StackTraceHelper.cs
@@ -42,7 +42,7 @@ namespace ReactNative.DevSupport
 
         public static IStackFrame[] ConvertNativeStackTrace(Exception exception)
         {
-            var stackTrace = new StackTrace(exception, true);
+            var stackTrace = new StackTrace(exception, false);
             var frames = stackTrace.GetFrames();
             var n = frames.Length;
             var results = new IStackFrame[n];

--- a/ReactWindows/ReactNative.Shared/DevSupport/StackTraceHelper.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/StackTraceHelper.cs
@@ -204,7 +204,15 @@ namespace ReactNative.DevSupport
             {
                 get
                 {
-                    return _stackFrame.GetMethod()?.Name ?? "<unknown method>";
+                    var method = _stackFrame.GetMethod();
+                    if (method != null)
+                    {
+                        var typeName = method.DeclaringType?.FullName;
+                        typeName = typeName != null ? typeName + "." : "";
+                        return typeName + method.Name;
+                    }
+
+                    return "<unknown method>";
                 }
             }
         }

--- a/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml
+++ b/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml
@@ -1,8 +1,7 @@
-﻿<ContentDialog
+<ContentDialog
     x:Class="ReactNative.DevSupport.RedBoxDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:ReactNative.DevSupport"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:devsupport="using:ReactNative.DevSupport"
@@ -11,21 +10,28 @@
     PrimaryButtonText="Reload JavaScript"
     PrimaryButtonClick="ContentDialog_PrimaryButtonClick">
     <ContentDialog.Resources>
+        <devsupport:SourceInfoVisibilityConverter x:Key="SourceInfoVisibilityConverter" />
         <DataTemplate x:Key="StackFrameTemplate"
                       x:DataType="devsupport:IStackFrame">
             <StackPanel>
                 <TextBlock FontFamily="Monospace"
                            FontSize="12"
                            Foreground="White"
+                           TextWrapping="Wrap"
                            Text="{x:Bind Path=Method}" />
                 <TextBlock FontSize="10"
                            Foreground="LightGray"
+                           Visibility="{x:Bind Path=FileName, Converter={StaticResource SourceInfoVisibilityConverter}}"
                            Text="{x:Bind Path=SourceInfo}" 
                            Grid.Row="1" />
             </StackPanel>
         </DataTemplate>
     </ContentDialog.Resources>
-    <StackPanel>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
         <TextBlock FontFamily="Monospace"
                    FontSize="14"
                    FontWeight="SemiBold"
@@ -35,7 +41,8 @@
                    TextWrapping="Wrap" />
         <ListView ItemsSource="{x:Bind Path=StackTrace, Mode=OneWay}"
                   ItemTemplate="{StaticResource StackFrameTemplate}"
-                  SelectionMode="None">
+                  SelectionMode="None"
+                  Grid.Row="1">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
                     <Setter Property="BorderBrush"
@@ -45,5 +52,5 @@
                 </Style>
             </ListView.ItemContainerStyle>
         </ListView>
-    </StackPanel>
+    </Grid>
 </ContentDialog>

--- a/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml.cs
+++ b/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -89,11 +89,7 @@ namespace ReactNative.DevSupport
 
         private void OnNotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-            {
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/ReactWindows/ReactNative/DevSupport/SourceInfoVisibilityConverter.cs
+++ b/ReactWindows/ReactNative/DevSupport/SourceInfoVisibilityConverter.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace ReactNative.DevSupport
+{
+    class SourceInfoVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return value == null ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -112,6 +112,7 @@
       <DependentUpon>RedBoxDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="DevSupport\ShakeAccelerometer.cs" />
+    <Compile Include="DevSupport\SourceInfoVisibilityConverter.cs" />
     <Compile Include="DevSupport\WebSocketJavaScriptExecutor.cs" />
     <Compile Include="Modules\AccessibilityInfo\AccessibilityInfoModule.cs" />
     <Compile Include="Modules\Clipboard\ClipboardInstance.cs" />


### PR DESCRIPTION
Setting `needFileInfo` seems to cause a `FileNotFoundException` and hides the original native exception. Disabling for now until this can be resolved.