### PR TITLE
feat(ReactApplication): Adds Application base class

### DIFF
--- a/ReactWindows/Playground/App.xaml
+++ b/ReactWindows/Playground/App.xaml
@@ -1,8 +1,8 @@
-﻿<Application
+<rn:ReactApplication
     x:Class="Playground.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Playground"
+    xmlns:rn="using:ReactNative"
     RequestedTheme="Light">
 
-</Application>
+</rn:ReactApplication>

--- a/ReactWindows/Playground/App.xaml.cs
+++ b/ReactWindows/Playground/App.xaml.cs
@@ -24,6 +24,6 @@ namespace Playground
         /// <summary>
         /// The React Native host.
         /// </summary>
-        protected override ReactNativeHost Host => _host;
+        public override ReactNativeHost Host => _host;
     }
 }

--- a/ReactWindows/Playground/App.xaml.cs
+++ b/ReactWindows/Playground/App.xaml.cs
@@ -2,21 +2,13 @@
 // Licensed under the MIT License.
 
 using ReactNative;
-using ReactNative.Modules.Launch;
-using System;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.UI.Core;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 namespace Playground
 {
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    sealed partial class App : Application
+    sealed partial class App : ReactApplication
     {
         private readonly ReactNativeHost _host = new MainReactNativeHost();
 
@@ -27,146 +19,11 @@ namespace Playground
         public App()
         {
             this.InitializeComponent();
-            this.Suspending += OnSuspending;
-            this.Resuming += OnResuming;
-            this.EnteredBackground += OnEnteredBackground;
-            this.LeavingBackground += OnLeavingBackground;
         }
 
         /// <summary>
-        /// Invoked when the application is launched normally by the end user.  Other entry points
-        /// will be used such as when the application is launched to open a specific file.
+        /// The React Native host.
         /// </summary>
-        /// <param name="e">Details about the launch request and process.</param>
-        protected override void OnLaunched(LaunchActivatedEventArgs e)
-        {
-            base.OnLaunched(e);
-            OnCreate(e.Arguments);
-        }
-
-        /// <summary>
-        /// Invoked when the application is activated.
-        /// </summary>
-        /// <param name="args">The activated event arguments.</param>
-        protected override void OnActivated(IActivatedEventArgs args)
-        {
-            base.OnActivated(args);
-
-            switch (args.Kind)
-            {
-                case ActivationKind.Protocol:
-                case ActivationKind.ProtocolForResults:
-                    var protocolArgs = (IProtocolActivatedEventArgs)args;
-                    LauncherModule.SetActivatedUrl(protocolArgs.Uri.AbsoluteUri);
-                    break;
-            }
-
-            if (args.PreviousExecutionState != ApplicationExecutionState.Running &&
-                args.PreviousExecutionState != ApplicationExecutionState.Suspended)
-            {
-                OnCreate(null);
-            }
-        }
-
-        /// <summary>
-        /// Called whenever the app is opened to initia
-        /// </summary>
-        /// <param name="arguments"></param>
-        private void OnCreate(string arguments)
-        {
-            _host.OnResume(Exit);
-            _host.ApplyArguments(arguments);
-
-#if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                this.DebugSettings.EnableFrameRateCounter = true;
-            }
-
-            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
-                AppViewBackButtonVisibility.Visible;
-#endif
-
-            Frame rootFrame = Window.Current.Content as Frame;
-
-            // Do not repeat app initialization when the Window already has content,
-            // just ensure that the window is active
-            if (rootFrame == null)
-            {
-                // Create a Frame to act as the navigation context and navigate to the first page
-                rootFrame = new Frame();
-
-                rootFrame.NavigationFailed += OnNavigationFailed;
-
-                // Place the frame in the current Window
-                Window.Current.Content = rootFrame;
-            }
-
-            if (rootFrame.Content == null)
-            {
-                // When the navigation stack isn't restored navigate to the first page,
-                // configuring the new page by passing required information as a navigation
-                // parameter
-                rootFrame.Content = new Page
-                {
-                    Content = _host.OnCreate(),
-                };
-            }
-
-            // Ensure the current window is active
-            Window.Current.Activate();
-        }
-
-        /// <summary>
-        /// Invoked when Navigation to a certain page fails
-        /// </summary>
-        /// <param name="sender">The Frame which failed navigation</param>
-        /// <param name="e">Details about the navigation failure</param>
-        private void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-        {
-            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being suspended.  Application state is saved
-        /// without knowing whether the application will be terminated or resumed with the contents
-        /// of memory still intact.
-        /// </summary>
-        /// <param name="sender">The source of the suspend request.</param>
-        /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
-        {
-            _host.OnSuspend();
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being resumed.
-        /// </summary>
-        /// <param name="sender">The source of the resume request.</param>
-        /// <param name="e">Details about the resume request.</param>
-        private void OnResuming(object sender, object e)
-        {
-            _host.OnResume(Exit);
-        }
-
-        /// <summary>
-        /// Invoked when application entered the background.
-        /// </summary>
-        /// <param name="sender">The source of the entered background request.</param>
-        /// <param name="e">Details about the entered background request.</param>
-        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
-        {
-            _host.OnEnteredBackground();
-        }
-
-        /// <summary>
-        /// Invoked when application leaving the background.
-        /// </summary>
-        /// <param name="sender">The source of the leaving background request.</param>
-        /// <param name="e">Details about the leaving background request.</param>
-        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
-        {
-            _host.OnLeavingBackground();
-        }
+        protected override ReactNativeHost Host => _host;
     }
 }

--- a/ReactWindows/ReactNative/IReactApplication.cs
+++ b/ReactWindows/ReactNative/IReactApplication.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+namespace ReactNative
+{
+    /// <summary>
+    /// An interface that holds the <see cref="ReactNativeHost"/>.
+    /// </summary>
+    public interface IReactApplication
+    {
+        /// <summary>
+        /// The default <see cref="ReactNativeHost"/> for the app.
+        /// </summary>
+        ReactNativeHost Host { get; }
+    }
+}

--- a/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
+++ b/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
@@ -16,8 +16,9 @@ namespace ReactNative.Modules.Launch
     /// </summary>
     public class LauncherModule : ReactContextNativeModuleBase, ILifecycleEventListener
     {
-        private static readonly Subject<string> s_urlSubject = new Subject<string>();
         private static string s_activatedUrl;
+
+        private readonly Subject<string> _urlSubject = new Subject<string>();
 
         private bool _initialized;
         private IDisposable _subscription;
@@ -161,17 +162,26 @@ namespace ReactNative.Modules.Launch
         }
 
         /// <summary>
+        /// Called whenever a protocol activation occurs.
+        /// </summary>
+        /// <param name="url">The URL.</param>
+        public void OnActivated(string url)
+        {
+            _urlSubject.OnNext(url);
+        }
+
+        /// <summary>
         /// The initial URL used to activate the application.
         /// </summary>
+        /// <param name="url">The URL.</param>
         public static void SetActivatedUrl(string url)
         {
             s_activatedUrl = url;
-            s_urlSubject.OnNext(url);
         }
 
         private IDisposable CreateUrlSubscription()
         {
-            return s_urlSubject.Subscribe(url =>
+            return _urlSubject.Subscribe(url =>
                 Context.GetJavaScriptModule<RCTDeviceEventEmitter>()
                     .emit("url", new JObject
                     {

--- a/ReactWindows/ReactNative/ReactApplication.cs
+++ b/ReactWindows/ReactNative/ReactApplication.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+using ReactNative.Modules.Launch;
+using System;
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace ReactNative
+{
+    /// <summary>
+    /// Base <see cref="Application"/> class to manage subscription to app
+    /// lifecycle events and initialize the window with the React root view.
+    /// </summary>
+    public abstract class ReactApplication : Application
+    {
+        /// <summary>
+        /// Initializes the singleton application object.  This is the first line of authored code
+        /// executed, and as such is the logical equivalent of main() or WinMain().
+        /// </summary>
+        public ReactApplication()
+        {
+            this.Suspending += OnSuspending;
+            this.Resuming += OnResuming;
+            this.EnteredBackground += OnEnteredBackground;
+            this.LeavingBackground += OnLeavingBackground;
+        }
+
+        /// <summary>
+        /// The React Native host.
+        /// </summary>
+        protected abstract ReactNativeHost Host
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Invoked when the application is launched normally by the end user.  Other entry points
+        /// will be used such as when the application is launched to open a specific file.
+        /// </summary>
+        /// <param name="e">Details about the launch request and process.</param>
+        protected override void OnLaunched(LaunchActivatedEventArgs e)
+        {
+            base.OnLaunched(e);
+            OnCreate(e.Arguments);
+        }
+
+        /// <summary>
+        /// Invoked when the application is activated.
+        /// </summary>
+        /// <param name="args">The activated event arguments.</param>
+        protected override void OnActivated(IActivatedEventArgs args)
+        {
+            base.OnActivated(args);
+
+            switch (args.Kind)
+            {
+                case ActivationKind.Protocol:
+                case ActivationKind.ProtocolForResults:
+                    var protocolArgs = (IProtocolActivatedEventArgs)args;
+                    LauncherModule.SetActivatedUrl(protocolArgs.Uri.AbsoluteUri);
+                    break;
+            }
+
+            if (args.PreviousExecutionState != ApplicationExecutionState.Running &&
+                args.PreviousExecutionState != ApplicationExecutionState.Suspended)
+            {
+                var arguments = (args as ILaunchActivatedEventArgs)?.Arguments;
+                OnCreate(arguments);
+            }
+        }
+
+        /// <summary>
+        /// Called whenever the app is opened to initia
+        /// </summary>
+        /// <param name="arguments"></param>
+        private void OnCreate(string arguments)
+        {
+            Host.OnResume(Exit);
+            Host.ApplyArguments(arguments);
+
+#if DEBUG
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                this.DebugSettings.EnableFrameRateCounter = true;
+            }
+
+            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
+                AppViewBackButtonVisibility.Visible;
+#endif
+
+            Frame rootFrame = Window.Current.Content as Frame;
+
+            // Do not repeat app initialization when the Window already has content,
+            // just ensure that the window is active
+            if (rootFrame == null)
+            {
+                // Create a Frame to act as the navigation context and navigate to the first page
+                rootFrame = new Frame();
+
+                rootFrame.NavigationFailed += OnNavigationFailed;
+
+                // Place the frame in the current Window
+                Window.Current.Content = rootFrame;
+            }
+
+            if (rootFrame.Content == null)
+            {
+                // When the navigation stack isn't restored navigate to the first page,
+                // configuring the new page by passing required information as a navigation
+                // parameter
+                rootFrame.Content = new Page
+                {
+                    Content = Host.OnCreate(),
+                };
+            }
+
+            // Ensure the current window is active
+            Window.Current.Activate();
+        }
+
+        /// <summary>
+        /// Invoked when Navigation to a certain page fails
+        /// </summary>
+        /// <param name="sender">The Frame which failed navigation</param>
+        /// <param name="e">Details about the navigation failure</param>
+        private void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+        {
+            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+        }
+
+        /// <summary>
+        /// Invoked when application execution is being suspended.  Application state is saved
+        /// without knowing whether the application will be terminated or resumed with the contents
+        /// of memory still intact.
+        /// </summary>
+        /// <param name="sender">The source of the suspend request.</param>
+        /// <param name="e">Details about the suspend request.</param>
+        private void OnSuspending(object sender, SuspendingEventArgs e)
+        {
+            Host.OnSuspend();
+        }
+
+        /// <summary>
+        /// Invoked when application execution is being resumed.
+        /// </summary>
+        /// <param name="sender">The source of the resume request.</param>
+        /// <param name="e">Details about the resume request.</param>
+        private void OnResuming(object sender, object e)
+        {
+            Host.OnResume(Exit);
+        }
+
+        /// <summary>
+        /// Invoked when application entered the background.
+        /// </summary>
+        /// <param name="sender">The source of the entered background request.</param>
+        /// <param name="e">Details about the entered background request.</param>
+        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
+        {
+            Host.OnEnteredBackground();
+        }
+
+        /// <summary>
+        /// Invoked when application leaving the background.
+        /// </summary>
+        /// <param name="sender">The source of the leaving background request.</param>
+        /// <param name="e">Details about the leaving background request.</param>
+        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
+        {
+            Host.OnLeavingBackground();
+        }
+    }
+}

--- a/ReactWindows/ReactNative/ReactApplication.cs
+++ b/ReactWindows/ReactNative/ReactApplication.cs
@@ -5,7 +5,6 @@
 
 using ReactNative.Modules.Launch;
 using System;
-using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -18,26 +17,34 @@ namespace ReactNative
     /// Base <see cref="Application"/> class to manage subscription to app
     /// lifecycle events and initialize the window with the React root view.
     /// </summary>
-    public abstract class ReactApplication : Application
+    public abstract class ReactApplication : Application, IReactApplication
     {
+        private readonly ReactApplicationDelegate _delegate;
+
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().
         /// </summary>
         public ReactApplication()
         {
-            this.Suspending += OnSuspending;
-            this.Resuming += OnResuming;
-            this.EnteredBackground += OnEnteredBackground;
-            this.LeavingBackground += OnLeavingBackground;
+            _delegate = CreateReactApplicationDelegate();
         }
 
         /// <summary>
         /// The React Native host.
         /// </summary>
-        protected abstract ReactNativeHost Host
+        public abstract ReactNativeHost Host
         {
             get;
+        }
+
+        /// <summary>
+        /// Creates the <see cref="ReactApplicationDelegate"/> for the application.
+        /// </summary>
+        /// <returns>The delegate instance.</returns>
+        protected virtual ReactApplicationDelegate CreateReactApplicationDelegate()
+        {
+            return new ReactApplicationDelegate(this);
         }
 
         /// <summary>
@@ -133,48 +140,6 @@ namespace ReactNative
         private void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
         {
             throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being suspended.  Application state is saved
-        /// without knowing whether the application will be terminated or resumed with the contents
-        /// of memory still intact.
-        /// </summary>
-        /// <param name="sender">The source of the suspend request.</param>
-        /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
-        {
-            Host.OnSuspend();
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being resumed.
-        /// </summary>
-        /// <param name="sender">The source of the resume request.</param>
-        /// <param name="e">Details about the resume request.</param>
-        private void OnResuming(object sender, object e)
-        {
-            Host.OnResume(Exit);
-        }
-
-        /// <summary>
-        /// Invoked when application entered the background.
-        /// </summary>
-        /// <param name="sender">The source of the entered background request.</param>
-        /// <param name="e">Details about the entered background request.</param>
-        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
-        {
-            Host.OnEnteredBackground();
-        }
-
-        /// <summary>
-        /// Invoked when application leaving the background.
-        /// </summary>
-        /// <param name="sender">The source of the leaving background request.</param>
-        /// <param name="e">Details about the leaving background request.</param>
-        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
-        {
-            Host.OnLeavingBackground();
         }
     }
 }

--- a/ReactWindows/ReactNative/ReactApplication.cs
+++ b/ReactWindows/ReactNative/ReactApplication.cs
@@ -3,7 +3,6 @@
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
 
-using ReactNative.Modules.Launch;
 using System;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Core;
@@ -66,14 +65,7 @@ namespace ReactNative
         {
             base.OnActivated(args);
 
-            switch (args.Kind)
-            {
-                case ActivationKind.Protocol:
-                case ActivationKind.ProtocolForResults:
-                    var protocolArgs = (IProtocolActivatedEventArgs)args;
-                    LauncherModule.SetActivatedUrl(protocolArgs.Uri.AbsoluteUri);
-                    break;
-            }
+            _delegate.OnActivated(args);
 
             if (args.PreviousExecutionState != ApplicationExecutionState.Running &&
                 args.PreviousExecutionState != ApplicationExecutionState.Suspended)

--- a/ReactWindows/ReactNative/ReactApplicationDelegate.cs
+++ b/ReactWindows/ReactNative/ReactApplicationDelegate.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+using System;
+using Windows.ApplicationModel;
+using Windows.UI.Xaml;
+
+namespace ReactNative
+{
+    /// <summary>
+    /// Class to manage subscription to application lifecycle events and handle
+    /// application activations.
+    /// </summary>
+    public class ReactApplicationDelegate
+    {
+        private readonly Application _application;
+        private readonly IReactApplication _reactApplication;
+
+        /// <summary>
+        /// Instantiates the <see cref="ReactApplicationDelegate"/>.
+        /// </summary>
+        /// <param name="application">The application instance.</param>
+        public ReactApplicationDelegate(
+            Application application)
+        {
+            if (application == null)
+                throw new ArgumentNullException(nameof(application));
+
+            _reactApplication = application as IReactApplication;
+            if (_reactApplication == null)
+            {
+                throw new ArgumentException("Expected argument to implement 'IReactApplication' interface", nameof(application));
+            }
+
+            _application = application;
+            _application.Resuming += OnResuming;
+            _application.Suspending += OnSuspending; ;
+            _application.LeavingBackground += OnLeavingBackground;
+            _application.EnteredBackground += OnEnteredBackground;
+        }
+
+        private void OnResuming(object sender, object e)
+        {
+            _reactApplication.Host.OnResume(_application.Exit);
+        }
+
+        private void OnSuspending(object sender, SuspendingEventArgs e)
+        {
+            _reactApplication.Host.OnSuspend();
+        }
+
+        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
+        {
+            _reactApplication.Host.OnLeavingBackground();
+        }
+
+        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
+        {
+            _reactApplication.Host.OnEnteredBackground();
+        }
+    }
+}

--- a/ReactWindows/ReactNative/ReactApplicationDelegate.cs
+++ b/ReactWindows/ReactNative/ReactApplicationDelegate.cs
@@ -3,8 +3,10 @@
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
 
+using ReactNative.Modules.Launch;
 using System;
 using Windows.ApplicationModel;
+using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 
 namespace ReactNative
@@ -39,6 +41,34 @@ namespace ReactNative
             _application.Suspending += OnSuspending; ;
             _application.LeavingBackground += OnLeavingBackground;
             _application.EnteredBackground += OnEnteredBackground;
+        }
+
+        /// <summary>
+        /// Apply activation arguments to the React instance.
+        /// </summary>
+        /// <param name="args">The activation arguments.</param>
+        public void OnActivated(IActivatedEventArgs args)
+        {
+            switch (args.Kind)
+            {
+                case ActivationKind.Protocol:
+                    var protocolArgs = (IProtocolActivatedEventArgs)args;
+                    var uri = protocolArgs.Uri.AbsoluteUri;
+                    if (args.PreviousExecutionState != ApplicationExecutionState.Running)
+                    {
+                        LauncherModule.SetActivatedUrl(uri);
+                    }
+                    else
+                    {
+                        _reactApplication.Host
+                            .ReactInstanceManager
+                            .CurrentReactContext?
+                            .GetNativeModule<LauncherModule>()
+                            .OnActivated(uri);
+                    }
+
+                    break;
+            }
         }
 
         private void OnResuming(object sender, object e)

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -113,6 +113,7 @@
     </Compile>
     <Compile Include="DevSupport\ShakeAccelerometer.cs" />
     <Compile Include="DevSupport\WebSocketJavaScriptExecutor.cs" />
+    <Compile Include="IReactApplication.cs" />
     <Compile Include="Modules\AccessibilityInfo\AccessibilityInfoModule.cs" />
     <Compile Include="Modules\Clipboard\ClipboardInstance.cs" />
     <Compile Include="Modules\Clipboard\ClipboardModule.cs" />
@@ -133,6 +134,7 @@
     <Compile Include="Modules\Storage\AsyncStorageModule.cs" />
     <Compile Include="Modules\Vibration\VibrationModule.cs" />
     <Compile Include="ReactApplication.cs" />
+    <Compile Include="ReactApplicationDelegate.cs" />
     <Compile Include="ReactPage.cs" />
     <Compile Include="ReactRootViewExtensions.cs" />
     <Compile Include="Touch\PointerDeviceTypeExtensions.cs" />

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Modules\StatusBar\StatusBarModule.cs" />
     <Compile Include="Modules\Storage\AsyncStorageModule.cs" />
     <Compile Include="Modules\Vibration\VibrationModule.cs" />
+    <Compile Include="ReactApplication.cs" />
     <Compile Include="ReactPage.cs" />
     <Compile Include="ReactRootViewExtensions.cs" />
     <Compile Include="Touch\PointerDeviceTypeExtensions.cs" />

--- a/local-cli/generator-windows/templates/src/App.xaml
+++ b/local-cli/generator-windows/templates/src/App.xaml
@@ -1,8 +1,8 @@
-﻿<Application
+﻿<rn:ReactApplication
     x:Class="<%= ns %>.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:<%= ns %>"
+    xmlns:rn="using:ReactNative"
     RequestedTheme="Light">
 
-</Application>
+</rn:ReactApplication>

--- a/local-cli/generator-windows/templates/src/App.xaml.cs
+++ b/local-cli/generator-windows/templates/src/App.xaml.cs
@@ -21,6 +21,6 @@ namespace <%= ns %>
         /// <summary>
         /// The React Native host.
         /// </summary>
-        protected override ReactNativeHost Host => _host;
+        public override ReactNativeHost Host => _host;
     }
 }

--- a/local-cli/generator-windows/templates/src/App.xaml.cs
+++ b/local-cli/generator-windows/templates/src/App.xaml.cs
@@ -1,19 +1,11 @@
 ﻿using ReactNative;
-using ReactNative.Modules.Launch;
-using System;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.UI.Core;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 namespace <%= ns %>
 {
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    sealed partial class App : Application
+    sealed partial class App : ReactApplication
     {
         private readonly ReactNativeHost _host = new MainReactNativeHost();
 
@@ -24,146 +16,11 @@ namespace <%= ns %>
         public App()
         {
             this.InitializeComponent();
-            this.Suspending += OnSuspending;
-            this.Resuming += OnResuming;
-            this.EnteredBackground += OnEnteredBackground;
-            this.LeavingBackground += OnLeavingBackground;
         }
 
         /// <summary>
-        /// Invoked when the application is launched normally by the end user.  Other entry points
-        /// will be used such as when the application is launched to open a specific file.
+        /// The React Native host.
         /// </summary>
-        /// <param name="e">Details about the launch request and process.</param>
-        protected override void OnLaunched(LaunchActivatedEventArgs e)
-        {
-            base.OnLaunched(e);
-            OnCreate(e.Arguments);
-        }
-
-        /// <summary>
-        /// Invoked when the application is activated.
-        /// </summary>
-        /// <param name="args">The activated event arguments.</param>
-        protected override void OnActivated(IActivatedEventArgs args)
-        {
-            base.OnActivated(args);
-
-            switch (args.Kind)
-            {
-                case ActivationKind.Protocol:
-                case ActivationKind.ProtocolForResults:
-                    var protocolArgs = (IProtocolActivatedEventArgs)args;
-                    LauncherModule.SetActivatedUrl(protocolArgs.Uri.AbsoluteUri);
-                    break;
-            }
-
-            if (args.PreviousExecutionState != ApplicationExecutionState.Running &&
-                args.PreviousExecutionState != ApplicationExecutionState.Suspended)
-            {
-                OnCreate(null);
-            }
-        }
-
-        /// <summary>
-        /// Called whenever the app is opened to initia
-        /// </summary>
-        /// <param name="arguments"></param>
-        private void OnCreate(string arguments)
-        {
-            _host.OnResume(Exit);
-            _host.ApplyArguments(arguments);
-
-#if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                this.DebugSettings.EnableFrameRateCounter = true;
-            }
-
-            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
-                AppViewBackButtonVisibility.Visible;
-#endif
-
-            Frame rootFrame = Window.Current.Content as Frame;
-
-            // Do not repeat app initialization when the Window already has content,
-            // just ensure that the window is active
-            if (rootFrame == null)
-            {
-                // Create a Frame to act as the navigation context and navigate to the first page
-                rootFrame = new Frame();
-
-                rootFrame.NavigationFailed += OnNavigationFailed;
-
-                // Place the frame in the current Window
-                Window.Current.Content = rootFrame;
-            }
-
-            if (rootFrame.Content == null)
-            {
-                // When the navigation stack isn't restored navigate to the first page,
-                // configuring the new page by passing required information as a navigation
-                // parameter
-                rootFrame.Content = new Page
-                {
-                    Content = _host.OnCreate(),
-                };
-            }
-
-            // Ensure the current window is active
-            Window.Current.Activate();
-        }
-
-        /// <summary>
-        /// Invoked when Navigation to a certain page fails
-        /// </summary>
-        /// <param name="sender">The Frame which failed navigation</param>
-        /// <param name="e">Details about the navigation failure</param>
-        private void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-        {
-            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being suspended.  Application state is saved
-        /// without knowing whether the application will be terminated or resumed with the contents
-        /// of memory still intact.
-        /// </summary>
-        /// <param name="sender">The source of the suspend request.</param>
-        /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
-        {
-            _host.OnSuspend();
-        }
-
-        /// <summary>
-        /// Invoked when application execution is being resumed.
-        /// </summary>
-        /// <param name="sender">The source of the resume request.</param>
-        /// <param name="e">Details about the resume request.</param>
-        private void OnResuming(object sender, object e)
-        {
-            _host.OnResume(Exit);
-        }
-
-        /// <summary>
-        /// Invoked when application entered the background.
-        /// </summary>
-        /// <param name="sender">The source of the entered background request.</param>
-        /// <param name="e">Details about the entered background request.</param>
-        private void OnEnteredBackground(object sender, EnteredBackgroundEventArgs e)
-        {
-            _host.OnEnteredBackground();
-        }
-
-        /// <summary>
-        /// Invoked when application leaving the background.
-        /// </summary>
-        /// <param name="sender">The source of the leaving background request.</param>
-        /// <param name="e">Details about the leaving background request.</param>
-        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
-        {
-            _host.OnLeavingBackground();
-        }
+        protected override ReactNativeHost Host => _host;
     }
 }


### PR DESCRIPTION
There are two goals of this base class:
1. Reduce boiler plate in the generated solutions for react-native-windows
2. Manage things like URL activations, lifecycle state subscriptions, etc. from within react-native-windows.

This is only the first step, we will likely also need to create something like a ReactApplicationDelegate, similar to the ReactActivityDelegate to separate these initialization behaviors from a concrete base class as all apps will not be able to use the ReactApplication base class.