### PR TITLE
fix(ActionQueue): use TaskCreationOptions.RunContinuationsAsynchronously

### DIFF
--- a/ReactWindows/ReactNative.Net46.Tests/Internal/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Net46.Tests/Internal/DispatcherHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using NUnit.Framework;
@@ -31,13 +31,12 @@ namespace ReactNative.Tests
         [Apartment(ApartmentState.STA)]
         public static async Task<T> CallOnDispatcherAsync<T>(Func<T> func)
         {
-            var tcs = new TaskCompletionSource<T>();
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await RunOnDispatcherAsync(() =>
             {
                 var result = func();
-
-                Task.Run(() => tcs.SetResult(result));
+                tcs.SetResult(result);
             }).ConfigureAwait(false);
 
             return await tcs.Task.ConfigureAwait(false);
@@ -45,12 +44,12 @@ namespace ReactNative.Tests
 
         public static async Task CallOnDispatcherAsync(Func<Task> asyncFunc)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await RunOnDispatcherAsync(async () =>
             {
                 await asyncFunc();
-                await Task.Run(() => tcs.SetResult(true));
+                tcs.SetResult(true);
             }).ConfigureAwait(false);
 
             await tcs.Task.ConfigureAwait(false);

--- a/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
@@ -155,15 +155,12 @@ namespace ReactNative.Bridge
             }
             else
             {
-                var taskCompletionSource = new TaskCompletionSource<T>();
+                var taskCompletionSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 RunOnDispatcher(dispatcher, DispatcherPriority.Normal, () =>
                 {
                     var result = func();
-
-                    // TaskCompletionSource<T>.SetResult can call continuations
-                    // on the awaiter of the task completion source.
-                    Task.Run(() => taskCompletionSource.SetResult(result));
+                    taskCompletionSource.SetResult(result);
                 });
 
                 return taskCompletionSource.Task;

--- a/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
@@ -127,15 +127,10 @@ namespace ReactNative.Tests.Bridge
             };
 
             var exception = new Exception();
-            var tcs = new TaskCompletionSource<Exception>();
-            var handler = new Action<Exception>(ex =>
-            {
-                Task.Run(() => tcs.SetResult(ex));
-            });
-
+            var tcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
             var builder = new ReactInstance.Builder()
             {
-                QueueConfiguration = TestReactQueueConfiguration.Create(handler),
+                QueueConfiguration = TestReactQueueConfiguration.Create(tcs.SetResult),
                 Registry = registry,
                 JavaScriptExecutorFactory = () => executor,
                 BundleLoader = JavaScriptBundleLoader.CreateFileLoader("ms-appx:///Resources/test.js"),

--- a/ReactWindows/ReactNative.Tests/Internal/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/DispatcherHelpers.cs
@@ -16,18 +16,18 @@ namespace ReactNative.Tests
 
         public static async Task<T> CallOnDispatcherAsync<T>(Func<T> func)
         {
-            var tcs = new TaskCompletionSource<T>();
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await RunOnDispatcherAsync(async () =>
+            await RunOnDispatcherAsync(() =>
             {
                 try
                 {
                     var result = func();
-                    await Task.Run(() => tcs.SetResult(result));
+                    tcs.SetResult(result);
                 }
                 catch (Exception ex)
                 {
-                    await Task.Run(() => tcs.SetException(ex));
+                    tcs.SetException(ex);
                 }
             }).ConfigureAwait(false);
 
@@ -36,18 +36,18 @@ namespace ReactNative.Tests
 
         public static async Task CallOnDispatcherAsync(Func<Task> asyncFunc)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await RunOnDispatcherAsync(async () =>
             {
                 try
                 {
                     await asyncFunc();
-                    await Task.Run(() => tcs.SetResult(true));
+                    tcs.SetResult(true);
                 }
                 catch (Exception ex)
                 {
-                    await Task.Run(() => tcs.SetException(ex));
+                    tcs.SetException(ex);
                 }
             }).ConfigureAwait(false);
 
@@ -56,18 +56,18 @@ namespace ReactNative.Tests
 
         public static async Task<T> CallOnDispatcherAsync<T>(Func<Task<T>> asyncFunc)
         {
-            var tcs = new TaskCompletionSource<T>();
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await RunOnDispatcherAsync(async () =>
             {
                 try
                 {
                     var result = await asyncFunc();
-                    await Task.Run(() => tcs.SetResult(result));
+                    tcs.SetResult(result);
                 }
                 catch (Exception ex)
                 {
-                    await Task.Run(() => tcs.SetException(ex));
+                    tcs.SetException(ex);
                 }
             }).ConfigureAwait(false);
 

--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -233,15 +233,12 @@ namespace ReactNative.Bridge
             }
             else
             {
-                var taskCompletionSource = new TaskCompletionSource<T>();
+                var taskCompletionSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 RunOnDispatcher(dispatcher, () =>
                 {
                     var result = func();
-
-                    // TaskCompletionSource<T>.SetResult can call continuations
-                    // on the awaiter of the task completion source.
-                    Task.Run(() => taskCompletionSource.SetResult(result));
+                    taskCompletionSource.SetResult(result);
                 });
 
                 return taskCompletionSource.Task;


### PR DESCRIPTION
Previously, to avoid the possibility of continuations being run on the IActionQueue or Dispatcher threads, we did something like:
```
Task.Run(() => taskCompletionSource.SetResult(...))
```

This is unnecessary overhead, when we can simply configure the `TaskCompletionSource<T>` to never inline continuations by using the constructor parameter `TaskCreationOptions.RunContinuationsAsynchronously`.