### PR TITLE
breaking(IReactContext): Adds minimal interface for React context

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockViewManager.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockViewManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
+using ReactNative.Bridge;
 using ReactNative.UIManager;
 using System;
 
@@ -70,7 +71,7 @@ namespace ReactNative.Tests
             throw new NotImplementedException();
         }
 
-        public virtual object CreateView(ThemedReactContext reactContext)
+        public virtual object CreateView(IReactContext reactContext)
         {
             throw new NotImplementedException();
         }
@@ -80,7 +81,7 @@ namespace ReactNative.Tests
             throw new NotImplementedException();
         }
 
-        public virtual void OnDropViewInstance(ThemedReactContext reactContext, object view)
+        public virtual void OnDropViewInstance(IReactContext reactContext, object view)
         {
             throw new NotImplementedException();
         }

--- a/ReactWindows/ReactNative.Shared/Bridge/IReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IReactContext.cs
@@ -3,27 +3,25 @@
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
 
-using ReactNative.Bridge;
 using System;
 
-namespace ReactNative.UIManager
+namespace ReactNative.Bridge
 {
+    /// <inheritdoc />
     /// <summary>
-    /// A wrapper <see cref="ReactContext"/> that delegates lifecycle events to
-    /// the original instance of <see cref="ReactContext"/>.
+    /// Abstract context wrapper for the React instance to manage
+    /// lifecycle events.
     /// </summary>
-    public class ThemedReactContext : IReactContext
+    public interface IReactContext
     {
-        private readonly IReactContext _reactContext;
-
         /// <summary>
-        /// Instantiates the <see cref="ThemedReactContext"/>.
+        /// Gets the instance of the <see cref="IJavaScriptModule"/> associated
+        /// with the <see cref="IReactInstance"/>.
         /// </summary>
-        /// <param name="reactContext">The inner context.</param>
-        public ThemedReactContext(ReactContext reactContext)
-        {
-            _reactContext = reactContext ?? throw new ArgumentNullException(nameof(reactContext));
-        }
+        /// <typeparam name="T">Type of JavaScript module.</typeparam>
+        /// <returns>The JavaScript module instance.</returns>
+        T GetJavaScriptModule<T>()
+            where T : IJavaScriptModule, new();
 
         /// <summary>
         /// Gets the instance of the <see cref="INativeModule"/> associated
@@ -31,59 +29,32 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <typeparam name="T">Type of native module.</typeparam>
         /// <returns>The native module instance.</returns>
-        public T GetNativeModule<T>()
-            where T : INativeModule
-        {
-            return _reactContext.GetNativeModule<T>();
-        }
-
-        /// <summary>
-        /// Gets the instance of the <see cref="IJavaScriptModule"/> associated
-        /// with the <see cref="IReactInstance"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of JavaScript module.</typeparam>
-        /// <returns>The JavaScript module instance.</returns>
-        public T GetJavaScriptModule<T>()
-            where T : IJavaScriptModule, new()
-        {
-            return _reactContext.GetJavaScriptModule<T>();
-        }
+        T GetNativeModule<T>()
+            where T : INativeModule;
 
         /// <summary>
         /// Adds a lifecycle event listener to the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public void AddLifecycleEventListener(ILifecycleEventListener listener)
-        {
-            _reactContext.AddLifecycleEventListener(listener);
-        }
+        void AddLifecycleEventListener(ILifecycleEventListener listener);
 
         /// <summary>
         /// Removes a lifecycle event listener from the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public void RemoveLifecycleEventListener(ILifecycleEventListener listener)
-        {
-            _reactContext.RemoveLifecycleEventListener(listener);
-        }
+        void RemoveLifecycleEventListener(ILifecycleEventListener listener);
 
         /// <summary>
         /// Adds a background event listener to the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public void AddBackgroundEventListener(IBackgroundEventListener listener)
-        {
-            _reactContext.AddBackgroundEventListener(listener);
-        }
+        void AddBackgroundEventListener(IBackgroundEventListener listener);
 
         /// <summary>
         /// Removes a background event listener from the context.
         /// </summary>
         /// <param name="listener">The listener.</param>
-        public void RemoveBackgroundEventListener(IBackgroundEventListener listener)
-        {
-            _reactContext.RemoveBackgroundEventListener(listener);
-        }
+        void RemoveBackgroundEventListener(IBackgroundEventListener listener);
 
         /// <summary>
         /// Checks if the current thread is on the React instance dispatcher
@@ -93,19 +64,13 @@ namespace ReactNative.UIManager
         /// <b>true</b> if the call is from the dispatcher queue thread,
         ///  <b>false</b> otherwise.
         /// </returns>
-        public bool IsOnDispatcherQueueThread()
-        {
-            return _reactContext.IsOnDispatcherQueueThread();
-        }
+        bool IsOnDispatcherQueueThread();
 
         /// <summary>
         /// Enqueues an action on the dispatcher queue thread.
         /// </summary>
         /// <param name="action">The action.</param>
-        public void RunOnDispatcherQueueThread(Action action)
-        {
-            _reactContext.RunOnDispatcherQueueThread(action);
-        }
+        void RunOnDispatcherQueueThread(Action action);
 
         /// <summary>
         /// Checks if the current thread is on the React instance
@@ -115,19 +80,13 @@ namespace ReactNative.UIManager
         /// <b>true</b> if the call is from the JavaScript queue thread,
         /// <b>false</b> otherwise.
         /// </returns>
-        public bool IsOnJavaScriptQueueThread()
-        {
-            return _reactContext.IsOnJavaScriptQueueThread();
-        }
+        bool IsOnJavaScriptQueueThread();
 
         /// <summary>
         /// Enqueues an action on the JavaScript queue thread.
         /// </summary>
         /// <param name="action">The action.</param>
-        public void RunOnJavaScriptQueueThread(Action action)
-        {
-            _reactContext.RunOnJavaScriptQueueThread(action);
-        }
+        void RunOnJavaScriptQueueThread(Action action);
 
         /// <summary>
         /// Checks if the current thread is on the React instance native 
@@ -137,28 +96,20 @@ namespace ReactNative.UIManager
         /// <b>true</b> if the call is from the native modules queue thread,
         /// <b>false</b> otherwise.
         /// </returns>
-        public bool IsOnNativeModulesQueueThread()
-        {
-            return _reactContext.IsOnNativeModulesQueueThread();
-        }
+        bool IsOnNativeModulesQueueThread();
 
         /// <summary>
         /// Enqueues an action on the native modules queue thread.
         /// </summary>
         /// <param name="action">The action.</param>
-        public void RunOnNativeModulesQueueThread(Action action)
-        {
-            _reactContext.RunOnNativeModulesQueueThread(action);
-        }
+        void RunOnNativeModulesQueueThread(Action action);
 
         /// <summary>
         /// Passes the exception to the default exception handler, if set, otherwise
         /// rethrows.
         /// </summary>
         /// <param name="exception">The exception.</param>
-        public void HandleException(Exception exception)
-        {
-            _reactContext.HandleException(exception);
-        }
+        void HandleException(Exception exception);
     }
 }
+

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -17,7 +17,7 @@ namespace ReactNative.Bridge
     /// Abstract context wrapper for the React instance to manage
     /// lifecycle events.
     /// </summary>
-    public class ReactContext : IAsyncDisposable
+    public class ReactContext : IReactContext
     {
         private readonly ReaderWriterLockSlim _lifecycleLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim _backgroundLock = new ReaderWriterLockSlim();
@@ -346,16 +346,6 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
-        /// Asserts that the current thread is on the React instance dispatcher
-        /// queue thread.
-        /// </summary>
-        public void AssertOnDispatcherQueueThread()
-        {
-            AssertReactInstance();
-            _reactInstance.QueueConfiguration.DispatcherQueue.AssertOnThread();
-        }
-
-        /// <summary>
         /// Enqueues an action on the dispatcher queue thread.
         /// </summary>
         /// <param name="action">The action.</param>
@@ -380,16 +370,6 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
-        /// Asserts that the current thread is on the React instance
-        /// JavaScript queue thread.
-        /// </summary>
-        public void AssertOnJavaScriptQueueThread()
-        {
-            AssertReactInstance();
-            _reactInstance.QueueConfiguration.JavaScriptQueue.AssertOnThread();
-        }
-
-        /// <summary>
         /// Enqueues an action on the JavaScript queue thread.
         /// </summary>
         /// <param name="action">The action.</param>
@@ -411,16 +391,6 @@ namespace ReactNative.Bridge
         {
             AssertReactInstance();
             return _reactInstance.QueueConfiguration.NativeModulesQueue.IsOnThread();
-        }
-
-        /// <summary>
-        /// Asserts that the current thread is on the React instance native
-        /// modules queue thread.
-        /// </summary>
-        public void AssertOnNativeModulesQueueThread()
-        {
-            AssertReactInstance();
-            _reactInstance.QueueConfiguration.NativeModulesQueue.AssertOnThread();
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContextExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContextExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+using System;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Extension methods for <see cref="IReactContext"/>.
+    /// </summary>
+    public static class ReactContextExtensions
+    {
+        /// <summary>
+        /// Asserts that the current thread is on the React instance native
+        /// modules queue thread.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        public static void AssertOnNativeModulesQueueThread(this IReactContext reactContext)
+        {
+            if (!reactContext.IsOnNativeModulesQueueThread())
+            {
+                throw new InvalidOperationException("Thread access assertion failed.");
+            }
+        }
+
+        /// <summary>
+        /// Asserts that the current thread is on the React instance JavaScript
+        /// queue thread.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        public static void AssertOnJavaScriptQueueThread(this IReactContext reactContext)
+        {
+            if (!reactContext.IsOnJavaScriptQueueThread())
+            {
+                throw new InvalidOperationException("Thread access assertion failed.");
+            }
+        }
+
+        /// <summary>
+        /// Asserts that the current thread is on the React instance dispatcher
+        /// queue thread.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        public static void AssertOnDispatcherQueueThread(this IReactContext reactContext)
+        {
+            if (!reactContext.IsOnDispatcherQueueThread())
+            {
+                throw new InvalidOperationException("Thread access assertion failed.");
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -45,6 +45,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IPromise.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactBridge.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactCallback.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactDelegateFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactInstance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\JavaScriptBundleLoader.cs" />
@@ -66,6 +67,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\Queue\ReactQueueConfigurationFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ReactBridge.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ReactContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\ReactContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ReactContextNativeModuleBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ReactDelegateFactoryBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\ReactInstance.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/IViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/IViewManager.cs
@@ -4,6 +4,7 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
+using ReactNative.Bridge;
 using System;
 
 namespace ReactNative.UIManager
@@ -70,7 +71,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="reactContext">The context.</param>
         /// <returns>The view.</returns>
-        object CreateView(ThemedReactContext reactContext);
+        object CreateView(IReactContext reactContext);
 
         /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
@@ -82,7 +83,7 @@ namespace ReactNative.UIManager
         /// <remarks>
         /// Derived classes do not need to call this base method.
         /// </remarks>
-        void OnDropViewInstance(ThemedReactContext reactContext, object view);
+        void OnDropViewInstance(IReactContext reactContext, object view);
 
         /// <summary>
         /// This method should return the subclass of <see cref="ReactShadowNode"/>

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManagerBase.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManagerBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
+using ReactNative.Bridge;
 using ReactNative.Json;
 using System;
 using System.Collections.Generic;
@@ -247,14 +248,14 @@ namespace ReactNative.UIManager
             OnAfterUpdateTransaction((TView)viewToUpdate);
         }
 
-        object IViewManager.CreateView(ThemedReactContext reactContext)
+        object IViewManager.CreateView(IReactContext reactContext)
         {
-            return CreateView(reactContext);
+            return CreateView((ThemedReactContext)reactContext);
         }
 
-        void IViewManager.OnDropViewInstance(ThemedReactContext reactContext, object view)
+        void IViewManager.OnDropViewInstance(IReactContext reactContext, object view)
         {
-            OnDropViewInstance(reactContext, (TView)view);
+            OnDropViewInstance((ThemedReactContext)reactContext, (TView)view);
         }
 
         ReactShadowNode IViewManager.CreateShadowNodeInstance()


### PR DESCRIPTION
Adding minimal interface for `IReactContext` so the `IViewManager` interface can be moved to an interfaces-only project.

This change avoids any breaking changes on base classes, such as `BaseViewManager` or `ReactContextNativeModuleBase`, however it is still a breaking change for view managers that implement `IViewManager` directly, which I suspect there are few.