### PR TITLE
ReactNativeHost - Add & Implement Initial Props

### DIFF
--- a/ReactWindows/Playground/MainReactNativeHost.cs
+++ b/ReactWindows/Playground/MainReactNativeHost.cs
@@ -15,13 +15,6 @@ namespace Playground
 
 #if !BUNDLE || DEBUG
         public override bool UseDeveloperSupport => true;
-
-        public override JObject InitialProperties => JObject.FromObject(new Dictionary<string, object>
-        {
-            {
-                "date", System.DateTime.Now.ToString("M/d/yyyy")
-            }
-        });
 #else
         public override bool UseDeveloperSupport => false;
 #endif
@@ -31,6 +24,13 @@ namespace Playground
 #if BUNDLE
         protected override string JavaScriptBundleFile => "ms-appx:///ReactAssets/index.windows.bundle";
 #endif
+
+        public override JObject InitialProperties => JObject.FromObject(new Dictionary<string, object>
+        {
+            {
+                "date", System.DateTime.Now.ToString("M/d/yyyy")
+            }
+        });
 
         protected override List<IReactPackage> Packages => new List<IReactPackage>
         {

--- a/ReactWindows/Playground/MainReactNativeHost.cs
+++ b/ReactWindows/Playground/MainReactNativeHost.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json.Linq;
 using ReactNative;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
@@ -14,6 +15,13 @@ namespace Playground
 
 #if !BUNDLE || DEBUG
         public override bool UseDeveloperSupport => true;
+
+        public override JObject InitialProperties => JObject.FromObject(new Dictionary<string, object>
+        {
+            {
+                "date", System.DateTime.Now.ToString("M/d/yyyy")
+            }
+        });
 #else
         public override bool UseDeveloperSupport => false;
 #endif

--- a/ReactWindows/Playground/index.windows.js
+++ b/ReactWindows/Playground/index.windows.js
@@ -19,6 +19,9 @@ class Playground extends Component {
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
+          Today is {this.props.date}
+        </Text>
+        <Text style={styles.instructions}>
           To get started, edit index.windows.js
         </Text>
         <Text style={styles.instructions}>

--- a/ReactWindows/ReactNative.Shared/ReactNativeHost.cs
+++ b/ReactWindows/ReactNative.Shared/ReactNativeHost.cs
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Common;
 using ReactNative.Modules.Core;
@@ -55,6 +56,11 @@ namespace ReactNative
         /// Signals whether developer mode should be enabled.
         /// </summary>
         public abstract bool UseDeveloperSupport { get; }
+
+        /// <summary>
+        /// The set of initial properties to give to <see cref="ReactRootView"/>
+        /// </summary>
+        public abstract JObject InitialProperties { get; }
 
         /// <summary>
         /// Instantiates the JavaScript executor.

--- a/ReactWindows/ReactNative/ReactApplication.cs
+++ b/ReactWindows/ReactNative/ReactApplication.cs
@@ -116,7 +116,7 @@ namespace ReactNative
                 // parameter
                 rootFrame.Content = new Page
                 {
-                    Content = Host.OnCreate(),
+                    Content = Host.OnCreate(Host.InitialProperties),
                 };
             }
 

--- a/local-cli/generator-windows/templates/src/MainReactNativeHost.cs
+++ b/local-cli/generator-windows/templates/src/MainReactNativeHost.cs
@@ -1,4 +1,5 @@
-﻿using ReactNative;
+﻿using Newtonsoft.Json.Linq;
+using ReactNative;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
 using System.Collections.Generic;
@@ -14,6 +15,8 @@ namespace <%= ns %>
 #else
         public override bool UseDeveloperSupport => false;
 #endif
+
+        public override JObject InitialProperties => null;
 
         protected override string JavaScriptMainModuleName => "index";
 


### PR DESCRIPTION
### Overview
This adds an abstract method to the `ReactNativeHost` to implement Initial Properties that get passed to the root React Component.

### Motivation
Initial Props can be passed via the `ReactRootView` but currently extending `ReactApplication` doesn't allow an easy way to specify these properties.

See: #1774 

##### Note: RNTester needs updated as well, but I wasn't quite sure how to do that yet

### Alternative
Another approach, would be for `ReactApplication` to have an abstract method -> InitialProps, that can be implemented in the `App.xaml.cs` -- The more I think about it, that approach might be more preferred and open to suggestions