### PR TITLE
Expose application time.

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -207,6 +207,11 @@ namespace ReactNative.Modules.Core
             }
         }
 
+        /// <summary>
+        /// Returns the time elapsed since application start.
+        /// </summary>
+        public TimeSpan GetApplicationTime => _stopwatch.Elapsed;
+
         void IDisposable.Dispose()
         {
             _isDisposed = true;


### PR DESCRIPTION
Application time is passed in Choreographer::OnRendering() but to initialize animation it may be needed to get the current value. This change exposes the application time.