### PR TITLE
RN WPF Webview: onNavigationStateChange is not triggered for redirect URLs

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
@@ -168,7 +168,7 @@ namespace ReactNative.Views.Web
         {
             base.OnDropViewInstance(reactContext, view);
             view.LoadCompleted -= OnLoadCompleted;
-            view.Navigated -= OnNavigationStarting;
+            view.Navigating -= OnNavigationStarting;
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace ReactNative.Views.Web
         {
             base.AddEventEmitters(reactContext, view);
             view.LoadCompleted += OnLoadCompleted;
-            view.Navigated += OnNavigationStarting;
+            view.Navigating += OnNavigationStarting;
         }
 
         private void OnLoadCompleted(object sender, NavigationEventArgs e)
@@ -222,7 +222,7 @@ namespace ReactNative.Views.Web
             }
         }
 
-        private static void OnNavigationStarting(object sender, NavigationEventArgs e)
+        private static void OnNavigationStarting(object sender, NavigatingCancelEventArgs e)
         {
             var webView = (WebBrowser)sender;
 


### PR DESCRIPTION
**Issue description:**
Steps to reproduce the problem:
1. Load “http://google.com” in a Webview
**Example:**
<WebView
        onNavigationStateChange={this.onNavigationStateChange}
        source={{ uri: “http://google.com”}}
  />

2. Observe - **onNavigationStateChange** is not triggered for redirect URLs (only trigged for https://www.google.com with 204 response and not for any other intermediate redirects/(301,307) URLs)
 
Here is the chrome browser Network data:
![image](https://user-images.githubusercontent.com/38461920/38869556-b2e656e4-4268-11e8-86e6-0c1e60edddb6.png)

**Expected behaviour:**
I expect onNavigationStateChange trigged for all URL changes. It works this way in iOS and Android.
 
**Root cause:**
In RN WPF WebBrowser native class implements only **Navigated** and **LoadCompleted** interfaces. Navigated is fired for navigated events, that means it is not fired for redirect URLs.
 
**Proposed Solution:**
Replace the Navigated to Navigating in ReactWebViewManager.cs class and it correctly detects the redirects URLs too.

I have submitted the pull request with same proposal. Please review.