### PR TITLE
Allow custom shadow nodes to override removal of children

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
@@ -1104,7 +1104,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="index">The index.</param>
         /// <returns>The child removed.</returns>
-        public ReactShadowNode RemoveNativeChildAt(int index)
+        public virtual ReactShadowNode RemoveNativeChildAt(int index)
         {
             if (_nativeChildren == null)
             {
@@ -1120,7 +1120,7 @@ namespace ReactNative.UIManager
         /// <summary>
         /// Remove all native children.
         /// </summary>
-        public void RemoveAllNativeChildren()
+        public virtual void RemoveAllNativeChildren()
         {
             if (_nativeChildren != null)
             {


### PR DESCRIPTION
* When there are extra steps that need to be taken to unbind from unsafe/native resources, a ShadowNode has to override the Remove*Children*() methods. This allows users to do that without in-tree modifications.

Thanks to my colleague @shmax for identifying this improvement while developing custom controls.