### PR TITLE
Fix a regression.

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/EventDispatcher.cs
@@ -296,13 +296,13 @@ namespace ReactNative.UIManager.Events
                 _reactContext.RunOnJavaScriptQueueThread(() =>
                 {
                     DispatchEvents(activity);
-                    activity.Dispose();
+                    activity?.Dispose();
                 });
 
                 return;
             }
 
-            activity.Dispose();
+            activity?.Dispose();
         }
 
         private void DispatchEvents(IDisposable activity)


### PR DESCRIPTION
https://github.com/Microsoft/react-native-windows/pull/1786 introduced a regression in the UWP flavor since "Trace" returns null if no session is active (compared to a dummy object the WPF flavor does).

I could've reused the "dummy" object, but an inline check for null seems better memory consumption wise.

@matthargett FYI.
I'll just fast track this one :)