### PR TITLE
fix(ReactChoreographer): Use `RenderingEventArgs.RenderingTime`

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -285,14 +285,13 @@ namespace ReactNative.Modules.Core
 
         private void OnRendering(object sender, TimeSpan e)
         {
-            var renderingTime = _stopwatch.Elapsed;
             if (_frameEventArgs == null)
             {
-                _mutableReference = _frameEventArgs = new FrameEventArgs(renderingTime);
+                _mutableReference = _frameEventArgs = new FrameEventArgs(e);
             }
             else
             {
-                _mutableReference.Update(renderingTime);
+                _mutableReference.Update(e);
             }
 
             DispatchUICallback?.Invoke(this, _frameEventArgs);


### PR DESCRIPTION
When the `Stopwatch` approach for `ReactChoreographer` was introduced when React Native is in the background, it introduced a bug that stopped using the `RenderingEventArgs.RenderingTime` property.