### PR TITLE
feat(ReactApplication): Adds `LaunchOptions` property to `ReactApplicationDelegate`

### DIFF
--- a/ReactWindows/ReactNative/ReactApplication.cs
+++ b/ReactWindows/ReactNative/ReactApplication.cs
@@ -81,9 +81,6 @@ namespace ReactNative
         /// <param name="arguments"></param>
         private void OnCreate(string arguments)
         {
-            Host.OnResume(Exit);
-            Host.ApplyArguments(arguments);
-
 #if DEBUG
             if (System.Diagnostics.Debugger.IsAttached)
             {
@@ -116,7 +113,7 @@ namespace ReactNative
                 // parameter
                 rootFrame.Content = new Page
                 {
-                    Content = Host.OnCreate(),
+                    Content = _delegate.OnCreate(arguments),
                 };
             }
 

--- a/ReactWindows/ReactNative/ReactApplicationDelegate.cs
+++ b/ReactWindows/ReactNative/ReactApplicationDelegate.cs
@@ -3,6 +3,7 @@
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json.Linq;
 using ReactNative.Modules.Launch;
 using System;
 using Windows.ApplicationModel;
@@ -44,6 +45,14 @@ namespace ReactNative
         }
 
         /// <summary>
+        /// The initial props for the React app.
+        /// </summary>
+        public virtual JObject LaunchOptions
+        {
+            get;
+        }
+
+        /// <summary>
         /// Apply activation arguments to the React instance.
         /// </summary>
         /// <param name="args">The activation arguments.</param>
@@ -69,6 +78,19 @@ namespace ReactNative
 
                     break;
             }
+        }
+
+        /// <summary>
+        /// Creates the root view for the React app.
+        /// </summary>
+        /// <param name="arguments">The native app launch arguments.</param>
+        /// <returns>The root view.</returns>
+        public ReactRootView OnCreate(string arguments)
+        {
+            var host = _reactApplication.Host;
+            host.OnResume(_application.Exit);
+            host.ApplyArguments(arguments);
+            return host.OnCreate(LaunchOptions);
         }
 
         private void OnResuming(object sender, object e)


### PR DESCRIPTION
Similar to the `getLaunchOptions` in React Native for Android on the `ReactActivityDelegate`, this adds a property that apps can override to send initial props to the React app.

Fixes #1774