### PR TITLE
Avoid re-parsing JSON and unncessary object allocs during Bridge initialization

### DIFF
--- a/ReactWindows/ReactNative.Net46/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Net46/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -128,7 +128,7 @@ namespace ReactNative.DevSupport
         {
         }
 
-        public void SetGlobalVariable(string propertyName, string value)
+        public void SetGlobalVariable(string propertyName, JToken value)
         {
             _injectedObjects.Add(propertyName, value);
         }

--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockJavaScriptExecutor.cs
@@ -14,12 +14,12 @@ namespace ReactNative.Tests
         public Func<JToken> OnFlushQueue { get; set; } = EmptyFlushQueue;
 
         public Action<string, string> OnRunScript { get; set; } = EmptyRunScript;
-        public Action<string, string> OnSetGlobalVariable { get; set; } = EmptySetGlobalVariable;
+        public Action<string, JToken> OnSetGlobalVariable { get; set; } = EmptySetGlobalVariable;
         public Action OnDispose { get; set; } = EmptyAction;
 
         private static readonly Action EmptyAction = () => { };
         private static readonly Action<string, string> EmptyRunScript = (_, __) => { };
-        private static readonly Action<string, string> EmptySetGlobalVariable = (_, __) => { };
+        private static readonly Action<string, JToken> EmptySetGlobalVariable = (_, __) => { };
         private static readonly Func<string, string, JArray, JToken> EmptyCallFunctionReturnFlushedQueue = (_, __, ___) => { throw new NotImplementedException(); };
         private static readonly Func<int, JArray, JToken> EmptyInvokeCallbackAndReturnFlushedQueue = (_, __) => { throw new NotImplementedException(); };
         private static readonly Func<JToken> EmptyFlushQueue = () => { throw new NotImplementedException(); };
@@ -35,7 +35,7 @@ namespace ReactNative.Tests
         {
         }
 
-        public void SetGlobalVariable(string propertyName, string value)
+        public void SetGlobalVariable(string propertyName, JToken value)
         {
             OnSetGlobalVariable(propertyName, value);
         }

--- a/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IJavaScriptExecutor.cs
@@ -41,7 +41,7 @@ namespace ReactNative.Bridge
         /// </summary>
         /// <param name="propertyName">The global variable name.</param>
         /// <param name="value">The value.</param>
-        void SetGlobalVariable(string propertyName, string value);
+        void SetGlobalVariable(string propertyName, JToken value);
 
         /// <summary>
         /// Runs the JavaScript at the given path.

--- a/ReactWindows/ReactNative.Shared/Bridge/IReactBridge.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IReactBridge.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
@@ -31,8 +31,8 @@ namespace ReactNative.Bridge
         /// Sets a global JavaScript variable.
         /// </summary>
         /// <param name="propertyName">The property name.</param>
-        /// <param name="jsonEncodedArgument">The JSON-encoded value.</param>
-        void SetGlobalVariable(string propertyName, string jsonEncodedArgument);
+        /// <param name="value">The value.</param>
+        void SetGlobalVariable(string propertyName, JToken value);
 
         /// <summary>
         /// Evaluates JavaScript.

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
@@ -70,17 +70,13 @@ namespace ReactNative.Bridge
             ProcessResponse(response, true);
         }
 
-        /// <summary>
-        /// Sets a global JavaScript variable.
-        /// </summary>
-        /// <param name="propertyName">The property name.</param>
-        /// <param name="jsonEncodedArgument">The JSON-encoded value.</param>
-        public void SetGlobalVariable(string propertyName, string jsonEncodedArgument)
+        /// <inheritdoc cref="IReactBridge"/>
+        public void SetGlobalVariable(string propertyName, JToken value)
         {
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));
 
-            _jsExecutor.SetGlobalVariable(propertyName, jsonEncodedArgument);
+            _jsExecutor.SetGlobalVariable(propertyName, value);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
@@ -179,28 +179,18 @@ namespace ReactNative.Bridge
             QueueConfiguration.Dispose();
         }
 
-        private string BuildModulesConfig()
+        private JToken BuildModulesConfig()
         {
-            var stringWriter = new StringWriter(CultureInfo.InvariantCulture);
-            try
+            var writer = new JTokenWriter();
+            using (writer)
             {
-                using (var writer = new JsonTextWriter(stringWriter))
-                {
-                    writer.WriteStartObject();
-                    writer.WritePropertyName("remoteModuleConfig");
-                    _registry.WriteModuleDescriptions(writer);
-                    writer.WriteEndObject();
-                }
+                writer.WriteStartObject();
+                writer.WritePropertyName("remoteModuleConfig");
+                _registry.WriteModuleDescriptions(writer);
+                writer.WriteEndObject();
+            }
 
-                return stringWriter.ToString();
-            }
-            finally
-            {
-                if (stringWriter != null)
-                {
-                    stringWriter.Dispose();
-                }
-            }
+            return writer.Token;
         }
 
         public sealed class Builder

--- a/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -176,7 +176,7 @@ namespace ReactNative.Chakra.Executor
         /// </summary>
         /// <param name="propertyName">The global variable name.</param>
         /// <param name="value">The value.</param>
-        public void SetGlobalVariable(string propertyName, string value)
+        public void SetGlobalVariable(string propertyName, JToken value)
         {
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -195,7 +195,7 @@ namespace ReactNative.Chakra.Executor
         /// </summary>
         /// <param name="propertyName">The global variable name.</param>
         /// <param name="value">The value.</param>
-        public void SetGlobalVariable(string propertyName, string value)
+        public void SetGlobalVariable(string propertyName, JToken value)
         {
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));
@@ -203,7 +203,7 @@ namespace ReactNative.Chakra.Executor
                 throw new ArgumentNullException(nameof(value));
 
             Native.ThrowIfError(
-                (JavaScriptErrorCode)_executor.SetGlobalVariable(propertyName, value));
+                (JavaScriptErrorCode)_executor.SetGlobalVariable(propertyName, value.ToString(Formatting.None)));
         }
     }
 }

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -142,7 +142,7 @@ namespace ReactNative.DevSupport
         {
         }
 
-        public void SetGlobalVariable(string propertyName, string value)
+        public void SetGlobalVariable(string propertyName, JToken value)
         {
             _injectedObjects.Add(propertyName, value);
         }


### PR DESCRIPTION
An alternate take on the optimiztion in #1743. Pushes string conversion down, keeping things in native JSON objects. The next step would be for the native executor C++ to accept the JSON object and do any conversion in C++. At worst, avoid a few object allocations over the current approach.