### PR TITLE
Prevent the child of FocusableWindows from being optimized out

### DIFF
--- a/Libraries/Components/FocusableWindows/FocusableWindows.windows.js
+++ b/Libraries/Components/FocusableWindows/FocusableWindows.windows.js
@@ -215,7 +215,9 @@ function createFocusableComponent(Component: any) {
 
     _splitProps(props: Object) {
       this._focusableProps = {};
-      this._componentProps = {};
+      // Prevent the child (that is View in most of the cases) from being collapsed.
+      // Passed parameters can override this
+      this._componentProps = { collapsable: false };
 
       for (const key in props) {
         if (key in FocusableWindowsTemplate.focusablePropTypes) {


### PR DESCRIPTION
FocusableWindows supports one child only (since it mimics its layout).
Added a tweak to prevent the optimization of this child (by default) so FocusableWindow doesn't end up with its grandchildren as children.