### PR TITLE
Process and add native module package off the main thread to reduce stalls

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Tracing;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -302,7 +303,7 @@ namespace ReactNative.Bridge
         public sealed class Builder
         {
             private readonly IDictionary<string, INativeModule> _modules = 
-                new Dictionary<string, INativeModule>();
+                new ConcurrentDictionary<string, INativeModule>();
 
             private readonly ReactContext _reactContext;
 


### PR DESCRIPTION
Fixes #1781.

Attempt to minimize stalls on main thread as mentioned in #1781. May need to adjust existing tracing calls to be more relevant, given the time they were measuring now happens async outside of their existing scope.