### PR TITLE
Fix for NativeJavaScriptExecutor crashing after OS upgrade.

### DIFF
--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -373,7 +373,13 @@ JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t
     context->fileHandle = hFile;
     context->mapHandle = hMap;
 
-    IfFailRet(JsRunSerializedScriptWithCallback(&LoadSourceCallback, &UnloadSourceCallback, buffer, (JsSourceContext)context, szSourceUri, result));
+    JsErrorCode error = JsRunSerializedScriptWithCallback(&LoadSourceCallback, &UnloadSourceCallback, buffer, (JsSourceContext)context, szSourceUri, result);
+    if (error != JsNoError)
+    {
+        // UnloadSourceCallback is called even in error case (though LoadSourceCallback never is), so we can't fully delete the context
+        context->Dispose();
+        return error;
+    }
     return JsNoError;
 }
 

--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -364,7 +364,7 @@ JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t
     }
     else
     {
-        IfFailRet(LoadByteCode(szSerializedPath, &buffer, &hFile, &hMap, false));
+        IfFailRet(LoadByteCode(szSerializedPath, &buffer, &hFile, &hMap, true));
     }
 
     SerializedSourceContext* context = new SerializedSourceContext();

--- a/ReactWindows/ChakraBridge/SerializedSourceContext.h
+++ b/ReactWindows/ChakraBridge/SerializedSourceContext.h
@@ -7,27 +7,27 @@
 
 struct SerializedSourceContext
 {
-	HANDLE fileHandle;
-	HANDLE mapHandle;
-	BYTE* byteBuffer;
-	wchar_t* scriptBuffer;
+    HANDLE fileHandle;
+    HANDLE mapHandle;
+    BYTE* byteBuffer;
+    wchar_t* scriptBuffer;
 
-	void Dispose()
-	{
-		if (fileHandle != NULL)
-		{
-			UnmapViewOfFile(byteBuffer);
-			CloseHandle(mapHandle);
-			CloseHandle(fileHandle);
-			fileHandle = NULL;
-		}
+    void Dispose()
+    {
+        if (fileHandle != NULL)
+        {
+            UnmapViewOfFile(byteBuffer);
+            CloseHandle(mapHandle);
+            CloseHandle(fileHandle);
+            fileHandle = NULL;
+        }
 
-		delete[] scriptBuffer;
-		scriptBuffer = NULL;
-	}
+        delete[] scriptBuffer;
+        scriptBuffer = NULL;
+    }
 
-	~SerializedSourceContext()
-	{
-		Dispose();
-	}
+    ~SerializedSourceContext()
+    {
+        Dispose();
+    }
 };

--- a/ReactWindows/ChakraBridge/SerializedSourceContext.h
+++ b/ReactWindows/ChakraBridge/SerializedSourceContext.h
@@ -7,23 +7,27 @@
 
 struct SerializedSourceContext
 {
-    HANDLE fileHandle;
-    HANDLE mapHandle;
-    BYTE* byteBuffer;
-    wchar_t* scriptBuffer;
+	HANDLE fileHandle;
+	HANDLE mapHandle;
+	BYTE* byteBuffer;
+	wchar_t* scriptBuffer;
 
-    ~SerializedSourceContext()
-    {
-        if (fileHandle != NULL)
-        {
-            UnmapViewOfFile(byteBuffer);
-            CloseHandle(mapHandle);
-            CloseHandle(fileHandle);
-        }
-        else
-        {
-            delete[] byteBuffer;
-        }
-        delete[] scriptBuffer;
-    }
+	void Dispose()
+	{
+		if (fileHandle != NULL)
+		{
+			UnmapViewOfFile(byteBuffer);
+			CloseHandle(mapHandle);
+			CloseHandle(fileHandle);
+			fileHandle = NULL;
+		}
+
+		delete[] scriptBuffer;
+		scriptBuffer = NULL;
+	}
+
+	~SerializedSourceContext()
+	{
+		Dispose();
+	}
 };

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -119,14 +120,39 @@ namespace ReactNative.Chakra.Executor
                     var srcFileInfo = new FileInfo(sourcePath);
                     var binFileInfo = new FileInfo(binPath);
 
+                    bool ranSuccessfully = false;
                     // The idea is to run the JS bundle and generate bytecode for it on a background thread.
                     // This eliminates the need to delay the first start when the app doesn't have bytecode.
                     // Next time the app starts, it checks if bytecode is still good and  runs it directly.
                     if (binFileInfo.Exists && binFileInfo.LastWriteTime > srcFileInfo.LastWriteTime)
                     {
-                        Native.ThrowIfError((JavaScriptErrorCode)_executor.RunSerializedScript(sourcePath, binPath, sourceUrl));
+                        try
+                        {
+                            Native.ThrowIfError((JavaScriptErrorCode)_executor.RunSerializedScript(sourcePath, binPath, sourceUrl));
+                            ranSuccessfully = true;
+                        }
+                        catch (JavaScriptUsageException exc)
+                        {
+                            if (exc.ErrorCode == JavaScriptErrorCode.BadSerializedScript)
+                            {
+                                // Bytecode format is dependent on Chakra engine version, so an OS upgrade may require a recompilation
+                                Debug.WriteLine("Serialized bytecode script is corrupted or wrong format, will generate new one");
+                            }
+                            else
+                            {
+                                // Some more severe error. We still have a chance (recompiling), so we keep continuing.
+                                Debug.WriteLine($"Failed to run serialized bytecode script ({exc.ToString()}), will generate new one");
+                            }
+
+                            File.Delete(binPath);
+                        }
                     }
                     else
+                    {
+                        Debug.WriteLine("Serialized bytecode script doesn't exist or is obsolete, will generate one");
+                    }
+
+                    if (!ranSuccessfully)
                     {
                         Task.Run(() =>
                         {
@@ -141,8 +167,9 @@ namespace ReactNative.Chakra.Executor
                                 Native.ThrowIfError((JavaScriptErrorCode)rt.SerializeScript(sourcePath, binPath));
                                 Native.ThrowIfError((JavaScriptErrorCode)rt.DisposeHost());
                             }
-                            catch (Exception)
+                            catch (Exception ex)
                             {
+                                Debug.WriteLine($"Failed to generate serialized bytecode script ({ex.ToString()}).");
                                 // It's fine if the bytecode couldn't be generated: RN can still use the JS bundle.
                             }
                         });


### PR DESCRIPTION
NativeJavaScriptExecutor in "serialized bytes" mode keeps a cache (a file with bin extension) with the precompiled JS bundle.
The format is OS version dependent though, so a failure to run the serialized script should be followed by a second chance attempt to run the original bundle.