### PR TITLE
fix(View): Remove background brush when possible

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Scroll/ReactScrollViewManager.cs
@@ -92,11 +92,12 @@ namespace ReactNative.Views.Scroll
         /// <param name="color">The masked color value.</param>
         [ReactProp(
             ViewProps.BackgroundColor,
-            CustomType = "Color",
-            DefaultUInt32 = ColorHelpers.Transparent)]
-        public void SetBackgroundColor(ScrollView view, uint color)
+            CustomType = "Color")]
+        public void SetBackgroundColor(ScrollView view, uint? color)
         {
-            view.Background = new SolidColorBrush(ColorHelpers.Parse(color));
+            view.Background = color.HasValue
+                ? new SolidColorBrush(ColorHelpers.Parse(color.Value))
+                : null;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -164,11 +164,12 @@ namespace ReactNative.Views.View
         /// <param name="color">The masked color value.</param>
         [ReactProp(
             ViewProps.BackgroundColor,
-            CustomType = "Color",
-            DefaultUInt32 = ColorHelpers.Transparent)]
-        public void SetBackgroundColor(BorderedCanvas view, uint color)
+            CustomType = "Color")]
+        public void SetBackgroundColor(BorderedCanvas view, uint? color)
         {
-            view.Background = new SolidColorBrush(ColorHelpers.Parse(color));
+            view.Background = color.HasValue
+                ? new SolidColorBrush(ColorHelpers.Parse(color.Value))
+                : null;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -96,11 +96,12 @@ namespace ReactNative.Views.Scroll
         /// <param name="color">The masked color value.</param>
         [ReactProp(
             ViewProps.BackgroundColor,
-            CustomType = "Color", 
-            DefaultUInt32 = ColorHelpers.Transparent)]
-        public void SetBackgroundColor(ScrollViewer view, uint color)
+            CustomType = "Color")]
+        public void SetBackgroundColor(ScrollViewer view, uint? color)
         {
-            view.Background = new SolidColorBrush(ColorHelpers.Parse(color));
+            view.Background = color.HasValue
+                ? new SolidColorBrush(ColorHelpers.Parse(color.Value))
+                : null;
         }
 
         /// <summary>


### PR DESCRIPTION
When the `backgroundColor` is set to `null` or removed from the style props, we can also remove the `Background` property `Brush` object.

Currently, when `backgroundColor` is set to some value, then subsequently set to null, the `Background` property will be set to a transparent brush. This changeset fixes that behavior.