### PR TITLE
Do nothing if a previous transform is not be removed.

### DIFF
--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -42,9 +42,12 @@ namespace ReactNative.UIManager
         [ReactProp("transform")]
         public void SetTransform(TFrameworkElement view, JArray transforms)
         {
-            if (transforms == null && _transforms.Remove(view))
+            if (transforms == null)
             {
-                ResetProjectionMatrix(view);
+                if (_transforms.Remove(view))
+                {
+                    ResetProjectionMatrix(view);
+                }
             }
             else
             {


### PR DESCRIPTION
Close #1821 

When a WPF app uses `react-navigation`, the conditions `transforms == null` and `_transforms.Length == 0` can hold in the `SetTransform` method.
In this case, `SetProjectionMatrix` method is invoked even though `transforms` is `null`, then `NullPointerException` occurs.
So, this PR changes `SetTransform` method to not invoke `SetProjectionMatrix` method if `_transforms.Remove(view) == false`.