### PR TITLE
Add null check to deal with the issue occurred by `{ stdio: 'inherit' }`.

### DIFF
--- a/local-cli/runWpf/utils/msbuildtools.js
+++ b/local-cli/runWpf/utils/msbuildtools.js
@@ -57,8 +57,11 @@ class MSBuildTools {
 
     const cmd = `"${path.join(this.path, 'msbuild.exe')}" ` + ['"' + slnFile + '"'].concat(args).join(' ');
     const execOptions = verbose ? { stdio: 'inherit' } : {};
-    const results = child_process.execSync(cmd, execOptions).toString().split(EOL);
-    results.forEach(result => console.log(chalk.white(result)));
+    const result = child_process.execSync(cmd, execOptions);
+    // result is null when enabling verbose option
+    if (result != null) {
+      result.toString().split(EOL).forEach(result => console.log(chalk.white(result)));
+    }
   }
 }
 


### PR DESCRIPTION
Close #1823

`execSync` returns `null` when passing `{ stdio: 'inherit' }` (c.f. https://github.com/nodejs/node-v0.x-archive/issues/9265#issuecomment-75768943).
So, this PR adds null check to avoid referring to null.
