### PR TITLE
Fixed a cancellation issue

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -195,12 +195,12 @@ namespace ReactNative
         /// <returns>
         /// A task to await the React context.
         /// </returns>
-        public async Task<ReactContext> GetReactContextAsync(CancellationToken token, bool noThrow = false)
+        public async Task<ReactContext> GetReactContextAsync(CancellationToken token)
         {
             DispatcherHelpers.AssertOnDispatcher();
             using (await _lock.LockAsync())
             {
-                if (!_hasStartedCreatingInitialContext && !noThrow)
+                if (!_hasStartedCreatingInitialContext)
                 {
                     throw new InvalidOperationException(
                         "Use the create method to start initializing the React context.");

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -192,7 +192,6 @@ namespace ReactNative
         /// Awaits the currently initializing React context.
         /// </summary>
         /// <param name="token">A token to cancel the request.</param>
-        /// <param name="noThrow">If true, method returns null instead of throwing if no context exists.</param>
         /// <returns>
         /// A task to await the React context.
         /// </returns>
@@ -207,6 +206,23 @@ namespace ReactNative
                         "Use the create method to start initializing the React context.");
                 }
 
+                // By this point context has already been created due to the serialized aspect of context initialization.
+                return _currentReactContext;
+            }
+        }
+
+        /// <summary>
+        /// Awaits the currently initializing React context, or returns null if context fails to initialize.
+        /// </summary>
+        /// <param name="token">A token to cancel the request.</param>
+        /// <returns>
+        /// A task to await the React context.
+        /// </returns>
+        public async Task<ReactContext> TryGetReactContextAsync(CancellationToken token)
+        {
+            DispatcherHelpers.AssertOnDispatcher();
+            using (await _lock.LockAsync())
+            {
                 // By this point context has already been created due to the serialized aspect of context initialization.
                 return _currentReactContext;
             }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -171,7 +171,20 @@ namespace ReactNative
                 }
                 _hasStartedCreatingInitialContext = true;
 
-                return await CreateReactContextCoreAsync(token);
+                ReactContext context = null;
+                try
+                {
+                    context = await CreateReactContextCoreAsync(token);
+                }
+                finally
+                {
+                    if (context == null)
+                    {
+                        _hasStartedCreatingInitialContext = false;
+                    }
+                }
+
+                return context;
             }
         }
 
@@ -179,15 +192,16 @@ namespace ReactNative
         /// Awaits the currently initializing React context.
         /// </summary>
         /// <param name="token">A token to cancel the request.</param>
+        /// <param name="noThrow">If true, method returns null instead of throwing if no context exists.</param>
         /// <returns>
         /// A task to await the React context.
         /// </returns>
-        public async Task<ReactContext> GetReactContextAsync(CancellationToken token)
+        public async Task<ReactContext> GetReactContextAsync(CancellationToken token, bool noThrow = false)
         {
             DispatcherHelpers.AssertOnDispatcher();
             using (await _lock.LockAsync())
             {
-                if (!_hasStartedCreatingInitialContext)
+                if (!_hasStartedCreatingInitialContext && !noThrow)
                 {
                     throw new InvalidOperationException(
                         "Use the create method to start initializing the React context.");
@@ -219,7 +233,20 @@ namespace ReactNative
                 {
                     _hasStartedCreatingInitialContext = true;
 
-                    return await CreateReactContextCoreAsync(token);
+                    ReactContext context = null;
+                    try
+                    {
+                        context = await CreateReactContextCoreAsync(token);
+                    }
+                    finally
+                    {
+                        if (context == null)
+                        {
+                            _hasStartedCreatingInitialContext = false;
+                        }
+                    }
+
+                    return context;
                 }
             }
         }

--- a/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
@@ -341,6 +341,55 @@ namespace ReactNative.Tests
         }
 
         [TestMethod]
+        public async Task ReactInstanceManager_TryGetReactContextAsync_Unfinished()
+        {
+            var jsBundleFile = "ms-appx:///Resources/test.js";
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
+
+            var initialContextTask = DispatcherHelpers.CallOnDispatcherAsync(async () =>
+                await manager.CreateReactContextAsync(CancellationToken.None));
+            var context = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
+                await manager.TryGetReactContextAsync(CancellationToken.None));
+            var initialContext = await initialContextTask;
+
+            Assert.AreSame(initialContext, context);
+
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
+        }
+
+        [TestMethod]
+        public async Task ReactInstanceManager_TryGetReactContextAsync_Finished()
+        {
+            var jsBundleFile = "ms-appx:///Resources/test.js";
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
+
+            var initialContext = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
+                await manager.CreateReactContextAsync(CancellationToken.None));
+            var context = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
+                await manager.TryGetReactContextAsync(CancellationToken.None));
+
+            Assert.AreSame(initialContext, context);
+
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
+        }
+
+        [TestMethod]
+        public async Task ReactInstanceManager_TryGetReactContextAsync_Fail()
+        {
+            var jsBundleFile = "ms-appx:///Resources/test.js";
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
+            var context = await DispatcherHelpers.CallOnDispatcherAsync(async () =>
+                await manager.TryGetReactContextAsync(CancellationToken.None));
+
+            Assert.IsNull(context);
+
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
+        }
+
+        [TestMethod]
         public async Task ReactInstanceManager_GetOrCreateReactContextAsync_Create()
         {
             var jsBundleFile = "ms-appx:///Resources/test.js";


### PR DESCRIPTION
ReactInstanceManager.OnSuspend does a cancel of any pending context initialization operations, said operations ending up with a null context.
We need to reset a flag in that case, otherwise further attempts to create the context will always return null.