### PR TITLE
Fix a crash on start in i18NUtil id allowRTL is set to true (the UWP flavor)

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/I18N/I18NUtil.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/I18N/I18NUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -88,7 +88,10 @@ namespace ReactNative.Modules.I18N
             get
             {
 #if WINDOWS_UWP
-                return ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"] == "RTL";
+                // We use GetForViewIndependentUse because the customary GetForCurrentView throws exception when
+                // an associated CoreWindow is not present, condition that happens during background activation scenarios.
+                // GetForViewIndependentUse is good enough for the LayoutDirection resource (it's not view or display dependent)
+                return ResourceContext.GetForViewIndependentUse().QualifierValues["LayoutDirection"] == "RTL";
 #else
                 return CultureInfo.CurrentCulture.TextInfo.IsRightToLeft;
 #endif


### PR DESCRIPTION
A ResourceContext.GetForCurrentView used in i18NUtil fails miserably when the view has no CoreWindow.
We use now a GetForViewIndependentUse that seems to fare better.