### PR TITLE
RN WPF Webview: File scheme (file://) URIs are not loaded.

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
@@ -115,13 +115,19 @@ namespace ReactNative.Views.Web
                 {
                     using (var request = new HttpRequestMessage())
                     {
-                        request.RequestUri = new Uri(uri);
+                        var sourceUri = new Uri(uri);
 
+                        //If the source URI has a file URL scheme, do not form the RequestUri.
+                        if (!sourceUri.IsFile)
+                        {
+                            request.RequestUri = sourceUri;
+                        }
+                      
                         var method = source.Value<string>("method");
                         var headers = (string)source.GetValue("headers", StringComparison.Ordinal);
                         var body = source.Value<Byte[]>("body");
 
-                        view.Navigate(uri, view.Name, body, headers);
+                        view.Navigate(sourceUri, view.Name, body, headers);
                         return;
                     }
                 }


### PR DESCRIPTION
**Issue description:**
Steps to reproduce the problem:
1.      Load “file:///C:/test.html” in a Webview
 
**Example:**
<WebView
        source={{ uri: "file:///C:/test.html”}}
  />
 
2.  Observe - It throws exception "only http and https schema are allowed". (only worked for http or https URIs)
 
**Expected behaviour:**
I expect it should load the file scheme URI also (to support loading local files). It works this way in native WPF application as well as in iOS and Android (Also, works in UWP by using these URL scheme: ms-appdata/ms-appx-web).
 
**Root cause:**
In RN WPF WebBrowser native class: **SetSource** method, **HttpRequestMessage.RequestUri** Property only allows HTTP(s) request and throws exception for file URL schemes.
Whereas, native WPF WebBrowser class perform a File scheme URIs check using the ReadyNavigateToUrl method, which allows both File and Http(s) schemes.
 
**Proposed Solution:**
If the specified URI is a File scheme then do not form the **HttpRequestMessage.RequestUri** and use the original passed URI as input to the Navigate method. This approach allows to load both File and Http/Https schemes.
 
I have submitted the pull request with same proposal. Please review.
 