### PR TITLE
Optimize-away accessibility-related XAML elements

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
@@ -85,6 +85,10 @@ namespace ReactNative.UIManager
         public const string TextDecorationLine = "textDecorationLine";
         public const string AllowFontScaling = "allowFontScaling";
 
+        public const string AccessibilityTraits = "accessibilityTraits";
+        public const string AccessibilityLabel = "accessibilityLabel";
+        public const string ImportantForAccessibility = "importantForAccessibility";
+
         public const string BorderWidth = "borderWidth";
         public const string BorderLeftWidth = "borderLeftWidth";
         public const string BorderTopWidth = "borderTopWidth";
@@ -210,6 +214,27 @@ namespace ReactNative.UIManager
             {
                 var value = props.GetProperty(prop).Value<string>();
                 return value == "auto" || value == "box-none";
+            }
+
+            // These are more aggressive optimizations based on property values.
+            // In RN Android there is a runtime check here. We omitted it because
+            // the check didn't inspire confidence in the optimizations that must be
+            // either correct or not.
+            {
+                var value = props[prop];
+
+                switch (prop)
+                {
+                    case AccessibilityTraits:
+                        return value == null || value is JArray array && array.Count == 0;
+
+                    case AccessibilityLabel:
+                        return value == null || value.Type == JTokenType.String && value.Value<string>().Length == 0;
+
+                    case ImportantForAccessibility:
+                        return value == null || value.Type == JTokenType.String &&
+                            (value.Value<string>().Length == 0 || value.Value<string>() == "auto");
+                }
             }
 
             return false;


### PR DESCRIPTION
Accessibilty properties are sometimes set to trivial/do-nothing values, we try to keep those views as layout-only as much as we can.
