### PR TITLE
WPF Alert must remain on top of application main window until it is confirmed by the user.

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/Dialog/DialogModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Dialog/DialogModule.cs
@@ -53,33 +53,47 @@ namespace ReactNative.Modules.Dialog
 
             if (containsPositive && containsNegative)
             {
-                var result = MessageBox.Show(message, title, MessageBoxButton.OKCancel);
-                if (result == MessageBoxResult.OK)
+                DispatcherHelpers.RunOnDispatcher(() =>
                 {
-                    actionCallback.Invoke(DialogModuleHelper.ActionButtonClicked, DialogModuleHelper.KeyButtonPositiveValue);
-                }
-                else
-                {
-                    actionCallback.Invoke(DialogModuleHelper.ActionButtonClicked, DialogModuleHelper.KeyButtonNegativeValue);
-                }
+                    var result = MessageBox.Show(message, title, MessageBoxButton.OKCancel);
+                    if (result == MessageBoxResult.OK)
+                    {
+                        actionCallback.Invoke(DialogModuleHelper.ActionButtonClicked, DialogModuleHelper.KeyButtonPositiveValue);
+                    }
+                    else
+                    {
+                        actionCallback.Invoke(DialogModuleHelper.ActionButtonClicked, DialogModuleHelper.KeyButtonNegativeValue);
+                    }
+                });
+
             }
             else if (containsPositive)
             {
-                var result = MessageBox.Show(message, title, MessageBoxButton.OK);
-                if (result == MessageBoxResult.OK)
+                DispatcherHelpers.RunOnDispatcher(() =>
                 {
-                    actionCallback.Invoke(DialogModuleHelper.ActionButtonClicked, DialogModuleHelper.KeyButtonPositiveValue);
-                }
+                    var result = MessageBox.Show(message, title, MessageBoxButton.OK);
+                    if (result == MessageBoxResult.OK)
+                    {
+                        actionCallback.Invoke(DialogModuleHelper.ActionButtonClicked, DialogModuleHelper.KeyButtonPositiveValue);
+                    }
+                });
             }
             else if (containsTitle)
             {
-                MessageBox.Show(message, title);
+                DispatcherHelpers.RunOnDispatcher(() =>
+                {
+                    MessageBox.Show(message, title);
+                });
+
             }
             else
             {
-                MessageBox.Show(message);
+                DispatcherHelpers.RunOnDispatcher(() =>
+                {
+                    MessageBox.Show(message);
+                });
             }
-            
+
         }
 
     }


### PR DESCRIPTION
**Issue description:** Steps to reproduce the problem:
	1.	 Display an alert on any RN WPF application.

Example: Alert.alert(“Test Alert”)

	2.	Observe – Alert appeared on top of application main window but clicking on main window hides the Alert behind the main window. 
Also, UI interaction is not blocked on TextInput (typing is enabled).

**Expected behaviour**: I expect Alert must remain on top of application main window until it is confirmed by the user. It works this way in native WPF application as well as in UWP, iOS and Android.

**Root cause**: In RN WPF DialogModule native class: showAlert method, MessageBox.Show calls on non-UI main thread display native alert box on the main screen. 
But calling this on non UI main thread seems to be incorrect.  

**Proposed Solution**: Execute MessageBox.Show on Main UI thread so that it displays on top of application main window and blocks any other user interaction on main window until it is confirmed by the user. This way it behaves like natively.

I tested the proposed fix on RN WPF application and it work as expected now. 

I have submitted a PR with a proposed solution. Please review.
