### PR TITLE
Prevent crash on dev reload

### DIFF
--- a/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -283,7 +283,7 @@ namespace ReactNative.Chakra.Executor
 #else
         private JavaScriptValue ConvertJson(JToken token)
         {
-            var jsonString = token.ToString(Formatting.None);
+            var jsonString = token?.ToString(Formatting.None) ?? null;
             return ConvertJson(jsonString);
         }
 

--- a/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -283,7 +283,7 @@ namespace ReactNative.Chakra.Executor
 #else
         private JavaScriptValue ConvertJson(JToken token)
         {
-            var jsonString = token?.ToString(Formatting.None) ?? "";
+            var jsonString = token?.ToString(Formatting.None) ?? "null";
             return ConvertJson(jsonString);
         }
 

--- a/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -283,7 +283,7 @@ namespace ReactNative.Chakra.Executor
 #else
         private JavaScriptValue ConvertJson(JToken token)
         {
-            var jsonString = token?.ToString(Formatting.None) ?? null;
+            var jsonString = token?.ToString(Formatting.None) ?? "";
             return ConvertJson(jsonString);
         }
 

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -214,7 +214,7 @@ namespace ReactNative.Chakra.Executor
                 throw new ArgumentNullException(nameof(callSyncHook));
 
             _executor.SetCallSyncHook((moduleId, methodId, args) =>
-                callSyncHook(moduleId, methodId, JArray.Parse(args)).ToString(Formatting.None));
+                callSyncHook(moduleId, methodId, JArray.Parse(args))?.ToString(Formatting.None) ?? "");
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -214,7 +214,7 @@ namespace ReactNative.Chakra.Executor
                 throw new ArgumentNullException(nameof(callSyncHook));
 
             _executor.SetCallSyncHook((moduleId, methodId, args) =>
-                callSyncHook(moduleId, methodId, JArray.Parse(args))?.ToString(Formatting.None) ?? "");
+                callSyncHook(moduleId, methodId, JArray.Parse(args))?.ToString(Formatting.None) ?? "null");
         }
 
         /// <summary>


### PR DESCRIPTION
When bridge is disposed, any synchronous hook call returns a null that crashes a later piece of code that tries to dereference it.
We're fixing by treating this case. The return value may still be incorrect as far as the calling function expects, but we're disposing anyway.