### PR TITLE
perf(TouchHandler): Improve the performance of touch

### DIFF
--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -4,6 +4,7 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
+using ReactNative.Reflection;
 using ReactNative.Touch;
 using ReactNative.UIManager.Annotations;
 using System;
@@ -141,6 +142,18 @@ namespace ReactNative.UIManager
         public void SetTooltip(TFrameworkElement view, string tooltip)
         {
             ToolTipService.SetToolTip(view, tooltip);
+        }
+
+        /// <summary>
+        /// Set the pointer events handling mode for the view.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="pointerEventsValue">The pointerEvents mode.</param>
+        [ReactProp("pointerEvents")]
+        public void SetPointerEvents(TFrameworkElement view, string pointerEventsValue)
+        {
+            var pointerEvents = EnumHelpers.ParseNullable<PointerEvents>(pointerEventsValue) ?? PointerEvents.Auto;
+            view.SetPointerEvents(pointerEvents);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -3,13 +3,12 @@
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
 
-using ReactNative.Reflection;
+using Newtonsoft.Json.Linq;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
-using Newtonsoft.Json.Linq;
 #if WINDOWS_UWP
 using ReactNative.Accessibility;
-using Windows.UI;
+using ReactNative.Reflection;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -67,18 +66,6 @@ namespace ReactNative.Views.View
             // We need to have this stub for this prop so that Views which
             // specify the accessible prop aren't considered to be layout-only.
             // The proper implementation is still to be determined.
-        }
-
-        /// <summary>
-        /// Set the pointer events handling mode for the view.
-        /// </summary>
-        /// <param name="view">The view.</param>
-        /// <param name="pointerEventsValue">The pointerEvents mode.</param>
-        [ReactProp("pointerEvents")]
-        public void SetPointerEvents(BorderedCanvas view, string pointerEventsValue)
-        {
-            var pointerEvents = EnumHelpers.ParseNullable<PointerEvents>(pointerEventsValue) ?? PointerEvents.Auto;
-            view.SetPointerEvents(pointerEvents);
         }
 
 #if WINDOWS_UWP

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -6,11 +6,12 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Accessibility;
 using ReactNative.Reflection;
-using ReactNative.Touch;
 using ReactNative.UIManager.Annotations;
+using ReactNative.UIManager.Events;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Linq;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
@@ -208,6 +209,35 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
+        /// Set the pointer events handling mode for the view.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="pointerEventsValue">The pointerEvents mode.</param>
+        [ReactProp("pointerEvents")]
+        public void SetPointerEvents(TFrameworkElement view, string pointerEventsValue)
+        {
+            var pointerEvents = EnumHelpers.ParseNullable<PointerEvents>(pointerEventsValue) ?? PointerEvents.Auto;
+            view.SetPointerEvents(pointerEvents);
+
+            // When `pointerEvents: none`, set `IsHitTestVisible` to `false`.
+            view.IsHitTestVisible = pointerEvents != PointerEvents.None;
+
+            // When `pointerEvents: none|box-none`, unsubscribe the enter/leave events.
+            if (pointerEvents == PointerEvents.None || pointerEvents == PointerEvents.BoxNone)
+            {
+                view.PointerExited -= OnPointerExited;
+                view.PointerEntered -= OnPointerEntered;
+            }
+            else
+            {
+                view.PointerExited -= OnPointerExited;
+                view.PointerEntered -= OnPointerEntered;
+                view.PointerEntered += OnPointerEntered;
+                view.PointerExited += OnPointerExited;
+            }
+        }
+
+        /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
         /// additional cleanup by the <see cref="IViewManager"/> subclass.
         /// </summary>
@@ -284,13 +314,35 @@ namespace ReactNative.UIManager
         private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
         {
             var view = (TFrameworkElement)sender;
-            TouchHandler.OnPointerEntered(view, e);
+            var hasBoxOnlyParent = RootViewHelper.GetReactViewHierarchy(view)
+                .Skip(1) // Skip the current view
+                .Any(v => v.GetPointerEvents() == PointerEvents.BoxOnly);
+
+            if (!hasBoxOnlyParent)
+            {
+                view.GetReactContext()
+                    .GetNativeModule<UIManagerModule>()
+                    .EventDispatcher
+                    .DispatchEvent(
+                        new PointerEnterExitEvent(TouchEventType.Entered, view.GetTag()));
+            }
         }
 
         private void OnPointerExited(object sender, PointerRoutedEventArgs e)
         {
             var view = (TFrameworkElement)sender;
-            TouchHandler.OnPointerExited(view, e);
+            var hasBoxOnlyParent = RootViewHelper.GetReactViewHierarchy(view)
+                .Skip(1) // Skip the current view
+                .Any(v => v.GetPointerEvents() == PointerEvents.BoxOnly);
+
+            if (!hasBoxOnlyParent)
+            {
+                view.GetReactContext()
+                    .GetNativeModule<UIManagerModule>()
+                    .EventDispatcher
+                    .DispatchEvent(
+                        new PointerEnterExitEvent(TouchEventType.Exited, view.GetTag()));
+            }
         }
 
         private DimensionBoundProperties GetDimensionBoundProperties(TFrameworkElement view)
@@ -433,6 +485,58 @@ namespace ReactNative.UIManager
             public bool OverflowHidden { get; set; }
 
             public JArray MatrixTransform { get; set; }
+        }
+
+        class PointerEnterExitEvent : Event
+        {
+            private readonly TouchEventType _touchEventType;
+
+            public PointerEnterExitEvent(TouchEventType touchEventType, int viewTag)
+                : base(viewTag)
+            {
+                _touchEventType = touchEventType;
+            }
+
+            public override string EventName
+            {
+                get
+                {
+                    return _touchEventType.GetJavaScriptEventName();
+                }
+            }
+
+            public override bool CanCoalesce
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public override void Dispatch(RCTEventEmitter eventEmitter)
+            {
+                var eventData = new JObject
+                {
+                    { "target", ViewTag },
+                };
+
+                var enterLeaveEventName = default(string);
+                if (_touchEventType == TouchEventType.Entered)
+                {
+                    enterLeaveEventName = "topMouseEnter";
+                }
+                else if (_touchEventType == TouchEventType.Exited)
+                {
+                    enterLeaveEventName = "topMouseLeave";
+                }
+
+                if (enterLeaveEventName != null)
+                {
+                    eventEmitter.receiveEvent(ViewTag, enterLeaveEventName, eventData);
+                }
+
+                eventEmitter.receiveEvent(ViewTag, EventName, eventData);
+            }
         }
     }
 }


### PR DESCRIPTION
Using `IsHitTestVisible`, we can limit the conditions where we need to use `VisualTreeHelper` to only those instances where the first React view in the hit test uses `pointerEvents: box-none`. This should be a reasonably rare case, and can be avoided altogether if you never use a border brush on a view with `pointerEvents: box-none`. Given that any view in a subtree with `pointerEvents: none` at the root will no longer register as the `OriginalSource` for the `PointerRoutedEvent`, we now only need to check whether any parent of the `OriginalSource` applies the `pointerEvents: box-only` to take over as the pointer target.

cc @rigdern 