### PR TITLE
Adding invariant culture qualifier to all decimal based parsing methods to prevent FormatException

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutShadowNode.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using ReactNative.Reflection;
 using ReactNative.UIManager.Annotations;
 using System;
+using System.Globalization;
 using static System.FormattableString;
 
 namespace ReactNative.UIManager
@@ -460,7 +461,7 @@ namespace ReactNative.UIManager
 
                 if (s.EndsWith("%"))
                 {
-                    return YogaValue.Percent(float.Parse(s.Substring(0, s.Length - 1)));
+                    return YogaValue.Percent(float.Parse(s.Substring(0, s.Length - 1), CultureInfo.InvariantCulture));
                 }
 
                 throw new InvalidOperationException(

--- a/ReactWindows/ReactNative.Shared/UIManager/TransformHelper.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/TransformHelper.cs
@@ -5,6 +5,7 @@
 
 using Newtonsoft.Json.Linq;
 using System;
+using System.Globalization;
 using System.Linq;
 #if WINDOWS_UWP
 using Windows.UI.Xaml.Media.Media3D;
@@ -119,7 +120,7 @@ namespace ReactNative.UIManager
                     stringValue = stringValue.Substring(0, stringValue.Length - 3);
                 }
 
-                value = double.Parse(stringValue);
+                value = double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
             else
             {


### PR DESCRIPTION
Using percent style with a decimal value (e.g. '7.8%') throws 'FormatException" in some locales

https://github.com/Microsoft/react-native-windows/issues/1849