### PR TITLE
Adding RunOnDispatcherThread

### DIFF
--- a/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
@@ -98,11 +98,11 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Enqueues the action to execute on MainDispatcher.
+        /// Invokes action on MainDispatcher.
         /// </summary>
         /// <param name="tag">The react tag which specifies view. Not used here, runs on main dispatcher.</param>
         /// <param name="action">The action to invoke.</param>
-        public void EnqueueAction(int tag, Action action)
+        public void InvokeAction(int tag, Action action)
         {
             DispatcherHelpers.RunOnDispatcher(action);
         }

--- a/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
@@ -100,8 +100,11 @@ namespace ReactNative.UIManager
         /// <summary>
         /// Invokes action on MainDispatcher.
         /// </summary>
-        /// <param name="tag">The react tag which specifies view. Not used here, runs on main dispatcher.</param>
+        /// <param name="tag">The react tag which specifies view.</param>
         /// <param name="action">The action to invoke.</param>
+        /// <remarks>
+        /// <paramref name="tag"/> is not used, always runs on main dispatcher.
+        /// </remarks>
         public void InvokeAction(int tag, Action action)
         {
             DispatcherHelpers.RunOnDispatcher(action);

--- a/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
@@ -96,5 +96,15 @@ namespace ReactNative.UIManager
                 return false;
             }
         }
+
+        /// <summary>
+        /// Enqueues the action to execute on MainDispatcher.
+        /// </summary>
+        /// <param name="tag">The react tag which specifies view. Not used here, runs on main dispatcher.</param>
+        /// <param name="action">The action to invoke.</param>
+        public void EnqueueAction(int tag, Action action)
+        {
+            DispatcherHelpers.RunOnDispatcher(action);
+        }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -643,12 +643,14 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Runs action on dispatcher thread associated with view specified by reactTag.
+        /// Runs action on dispatcher thread associated with view specified by <paramref name="reactTag" />.
         /// Action is not queued on operation queue, but it goes to dispatcher directly.
-        /// Always on main dispatcher for WPF.
         /// </summary>
-        /// <param name="reactTag">The react tag which specifies view. Only valid for UWP.</param>
+        /// <param name="reactTag">The react tag which specifies view.</param>
         /// <param name="action">The action to invoke.</param>
+        /// <remarks>
+        /// <paramref name="reactTag"/> is only valid for UWP. For WPF it always runs on main dispatcher.
+        /// </remarks>
         public void RunOnDispatcherThread(int reactTag, Action action)
         {
             //runs on dispather thread

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -646,7 +646,7 @@ namespace ReactNative.UIManager
         /// Runs action on dispatcher thread associated with view specified by reactTag.
         /// Always on main dispatcher for WPF.
         /// </summary>
-        /// <param name="tag">The react tag which specifies view. Only valid for UWP.</param>
+        /// <param name="reactTag">The react tag which specifies view. Only valid for UWP.</param>
         /// <param name="action">The action to invoke.</param>
         public void RunOnDispatcherThread(int reactTag, Action action)
         {

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -642,6 +642,17 @@ namespace ReactNative.UIManager
             _operationsQueue.OnDestroy();
         }
 
+        /// <summary>
+        /// Runs action on dispatcher thread associated with view specified by reactTag.
+        /// Always on main dispatcher for WPF.
+        /// </summary>
+        /// <param name="tag">The react tag which specifies view. Only valid for UWP.</param>
+        /// <param name="action">The action to invoke.</param>
+        public void RunOnDispatcherThread(int reactTag, Action action)
+        {
+            _operationsQueue.EnqueueAction(reactTag, action);
+        }
+
         private void UpdateViewHierarchy()
         {
             foreach (var tag in _shadowNodeRegistry.RootNodeTags)

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -644,13 +644,15 @@ namespace ReactNative.UIManager
 
         /// <summary>
         /// Runs action on dispatcher thread associated with view specified by reactTag.
+        /// Action is not queued on operation queue, but it goes to dispatcher directly.
         /// Always on main dispatcher for WPF.
         /// </summary>
         /// <param name="reactTag">The react tag which specifies view. Only valid for UWP.</param>
         /// <param name="action">The action to invoke.</param>
         public void RunOnDispatcherThread(int reactTag, Action action)
         {
-            _operationsQueue.EnqueueAction(reactTag, action);
+            //runs on dispather thread
+            _operationsQueue.InvokeAction(reactTag, action);
         }
 
         private void UpdateViewHierarchy()

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -653,7 +653,7 @@ namespace ReactNative.UIManager
         /// </remarks>
         public void RunOnDispatcherThread(int reactTag, Action action)
         {
-            //runs on dispatcher thread
+            //runs on any thread
             _operationsQueue.InvokeAction(reactTag, action);
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -653,7 +653,7 @@ namespace ReactNative.UIManager
         /// </remarks>
         public void RunOnDispatcherThread(int reactTag, Action action)
         {
-            //runs on dispather thread
+            //runs on dispatcher thread
             _operationsQueue.InvokeAction(reactTag, action);
         }
 

--- a/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
@@ -532,12 +532,13 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Enqueues the action to execute on dispatcher thread associated with view specified by reactTag.
+        /// Invokes the action to execute on dispatcher thread associated with view specified by reactTag.
+        /// Action is not queued on operation queue, but it goes to dispatcher directly.
         /// Always on main dispatcher for WPF.
         /// </summary>
         /// <param name="tag">The react tag which specifies view. Only valid for UWP.</param>
         /// <param name="action">The action to invoke.</param>
-        public void EnqueueAction(int tag, Action action)
+        public void InvokeAction(int tag, Action action)
         {
             DispatcherHelpers.RunOnDispatcher(GetQueueByTag(tag).Dispatcher,() => action());
         }

--- a/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
@@ -532,6 +532,17 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
+        /// Enqueues the action to execute on dispatcher thread associated with view specified by reactTag.
+        /// Always on main dispatcher for WPF.
+        /// </summary>
+        /// <param name="tag">The react tag which specifies view. Only valid for UWP.</param>
+        /// <param name="action">The action to invoke.</param>
+        public void EnqueueAction(int tag, Action action)
+        {
+            DispatcherHelpers.RunOnDispatcher(GetQueueByTag(tag).Dispatcher,() => action());
+        }
+
+        /// <summary>
         /// Dispatches the view updates.
         /// </summary>
         /// <param name="batchId">The batch identifier.</param>

--- a/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
@@ -532,11 +532,10 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Invokes the action to execute on dispatcher thread associated with view specified by reactTag.
+        /// Invokes the action to execute on dispatcher thread associated with view specified by <paramref name="tag" />.
         /// Action is not queued on operation queue, but it goes to dispatcher directly.
-        /// Always on main dispatcher for WPF.
         /// </summary>
-        /// <param name="tag">The react tag which specifies view. Only valid for UWP.</param>
+        /// <param name="tag">The react tag which specifies view.</param>
         /// <param name="action">The action to invoke.</param>
         public void InvokeAction(int tag, Action action)
         {


### PR DESCRIPTION
In some scenarios, like multi window scenario, we need to have ability to run on Dispatcher which is associated with view specified by react tag. RunOnDispatcherThread takes action and react tag, tries to find view dispatcher based on reactTag and invokes action there.