### PR TITLE
Implementation of the PopUp Menu in UIManagerModule

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -600,7 +600,7 @@ namespace ReactNative.UIManager
                 };
                 item.Click += (sender, e) =>
                 {
-                    success.Invoke((sender as Windows.UI.Xaml.Controls.MenuFlyoutItem).Tag);
+                    success.Invoke(UIManagerModule.ACTION_ITEM_SELECTED, (sender as Windows.UI.Xaml.Controls.MenuFlyoutItem).Tag);
                     dismissed = false;
                 };
                 menu.Items.Add(item);
@@ -609,7 +609,7 @@ namespace ReactNative.UIManager
             {
                 if (dismissed)
                 {
-                    success.Invoke();
+                    success.Invoke(UIManagerModule.ACTION_DISMISSED);
                 }
             };
             menu.ShowAt(view as FrameworkElement);

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using ReactNative.Accessibility;
 using Windows.Foundation;
 using Windows.UI.Core;
-using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #else
@@ -570,15 +569,25 @@ namespace ReactNative.UIManager
         /// view (shadow views cannot be anchors).
         /// </param>
         /// <param name="items">The menu items as an array of strings.</param>
+        /// <param name="error">Called if the popup menu failed to be shown.</param>
         /// <param name="success">
         /// A callback used with the position of the selected item as the first
         /// argument, or no arguments if the menu is dismissed.
         /// </param>
-        public void ShowPopupMenu(int tag, string[] items, ICallback success)
+        public void ShowPopupMenu(int tag, string[] items, ICallback error, ICallback success)
         {
 #if WINDOWS_UWP
             AssertOnCorrectDispatcher();
-            var view = ResolveView(tag);
+            object view;
+            try
+            {
+                view = ResolveView(tag);
+            }
+            catch (InvalidOperationException e)
+            {
+                error.Invoke(e.Message);
+                return;
+            }
 
             var menu = new Windows.UI.Xaml.Controls.MenuFlyout();
             bool dismissed = true;

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -55,7 +55,6 @@ namespace ReactNative.UIManager
     /// 
     /// TODO: 
     /// 1) AnimationRegistry
-    /// 2) ShowPopupMenu
     /// </remarks>
     public class NativeViewHierarchyManager
     {
@@ -581,22 +580,33 @@ namespace ReactNative.UIManager
             AssertOnCorrectDispatcher();
             var view = ResolveView(tag);
 
-            var menu = new PopupMenu();
-            for (var i = 0; i < items.Length; ++i)
+            var menu = new Windows.UI.Xaml.Controls.MenuFlyout();
+            bool dismissed = true;
+            for (int i = 0; i < items.Length; ++i)
             {
-                menu.Commands.Add(new UICommand(
-                    items[i],
-                    cmd =>
-                    {
-                        success.Invoke(cmd.Id);
-                    },
-                    i));
+                var item = new Windows.UI.Xaml.Controls.MenuFlyoutItem
+                {
+                    Text = items[i],
+                    Tag = i
+                };
+                item.Click += (sender, e) =>
+                {
+                    success.Invoke((sender as Windows.UI.Xaml.Controls.MenuFlyoutItem).Tag);
+                    dismissed = false;
+                };
+                menu.Items.Add(item);
             }
-#endif
-
-            // TODO: figure out where to popup the menu
-            // TODO: add continuation that calls the callback with empty args
+            menu.Closed += (sender, e) =>
+            {
+                if (dismissed)
+                {
+                    success.Invoke();
+                }
+            };
+            menu.ShowAt(view as FrameworkElement);
+#else
             throw new NotImplementedException();
+#endif
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
@@ -19,8 +19,8 @@ namespace ReactNative.UIManager
         private const string BUBBLING_EVENTS_KEY = "bubblingEventTypes";
         private const string DIRECT_EVENTS_KEY = "directEventTypes";
 
-        private const string ACTION_DISMISSED = "dismissed";
-        private const string ACTION_ITEM_SELECTED = "itemSelected";
+        public const string ACTION_DISMISSED = "dismissed";
+        public const string ACTION_ITEM_SELECTED = "itemSelected";
 
         private static JObject CreateConstants(
             IReadOnlyList<IViewManager> viewManagers,

--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueueInstance.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueueInstance.cs
@@ -150,7 +150,7 @@ namespace ReactNative.UIManager
         /// <param name="success">Called on success.</param>
         public void EnqueueShowPopupMenu(int tag, string[] items, ICallback error, ICallback success)
         {
-            EnqueueOperation(() => _nativeViewHierarchyManager.ShowPopupMenu(tag, items, success));
+            EnqueueOperation(() => _nativeViewHierarchyManager.ShowPopupMenu(tag, items, error, success));
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request implements PopUp menus for Windows (UWP) (See #212). It internally uses UWP's MenuFlyout, being able to anchor on a definable view.
The implementation has been done by keeping the one of Android in mind. On Android, success callbacks retrieve one or two arguments:

1) The event type
  -> "dismissed" if the popup has been dismissed
  -> "itemSelected" if an item has been selected
2) (Optional) The index of the selected item

For this reason, the ACTION_DISMISSED and ACTION_ITEM_SELECTED constants from the UIManagerModule had to be made public.
Furthermore, the method signature of the ShowPopupMenu function in NativeViewHierarchyManager had to be modified to include the error callback.
This error callback is present in the ShowPopupMenu function of the UIManagerModule, but it has not been passed to the previously mentioned function.
This callback is needed for the same reason than in the Android implementation: to forward errors about unknown anchor views to the JavaScript code.