### PR TITLE
Documentation: Add how to hide Performance stats black boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ For information on parity status with Android and iOS, including details on impl
 - On UWP, press Shift+F10 to open the debug menu.
 - On WPF, press CTRL+D or CTRL+M to open the debug menu.
 
+### Hide Debug Performance Counters/Stats
+- Open App.xaml.cs and then jump into ReactApplication.cs (or open it directly from the ReactNative project)
+- Search for debug and set `this.DebugSettings.EnableFrameRateCounter = false`
+
 ## Extending React Native
 
 - Looking for a component? [JS.coach](https://js.coach/react-native)


### PR DESCRIPTION
It's just a small change to the Readme about how to hide the debug performance counters/stats but it wasn't mentioned anywhere yet.

At some point it may be better to move it to the UserProject in the solution so it's configurable by the user without having to open internals.
