### PR TITLE
refactor(INativeModule): remove IReactInstance coupling

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleBaseTests.Generated.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleBaseTests.Generated.cs
@@ -18,61 +18,61 @@ namespace ReactNative.Tests.Bridge
         public void NativeModuleBase_ReactMethod_ArgumentCountChecks()
         {
             var module = new ArgumentCountTestNativeModule();
-            var reactInstance = new MockReactInstance();
+            var nopCallback = new InvokeCallback((_, __) => { });
             var args = Enumerable.Range(0, 17);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test0)].Invoke(reactInstance, JArray.FromObject(args.Take(0).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test0)].Invoke(nopCallback, JArray.FromObject(args.Take(0).ToArray()));
             Assert.AreEqual(1, module.test0Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test1)].Invoke(reactInstance, JArray.FromObject(args.Take(1).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test1)].Invoke(nopCallback, JArray.FromObject(args.Take(1).ToArray()));
             Assert.AreEqual(1, module.test1Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test2)].Invoke(reactInstance, JArray.FromObject(args.Take(2).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test2)].Invoke(nopCallback, JArray.FromObject(args.Take(2).ToArray()));
             Assert.AreEqual(1, module.test2Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test3)].Invoke(reactInstance, JArray.FromObject(args.Take(3).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test3)].Invoke(nopCallback, JArray.FromObject(args.Take(3).ToArray()));
             Assert.AreEqual(1, module.test3Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test4)].Invoke(reactInstance, JArray.FromObject(args.Take(4).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test4)].Invoke(nopCallback, JArray.FromObject(args.Take(4).ToArray()));
             Assert.AreEqual(1, module.test4Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test5)].Invoke(reactInstance, JArray.FromObject(args.Take(5).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test5)].Invoke(nopCallback, JArray.FromObject(args.Take(5).ToArray()));
             Assert.AreEqual(1, module.test5Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test6)].Invoke(reactInstance, JArray.FromObject(args.Take(6).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test6)].Invoke(nopCallback, JArray.FromObject(args.Take(6).ToArray()));
             Assert.AreEqual(1, module.test6Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test7)].Invoke(reactInstance, JArray.FromObject(args.Take(7).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test7)].Invoke(nopCallback, JArray.FromObject(args.Take(7).ToArray()));
             Assert.AreEqual(1, module.test7Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test8)].Invoke(reactInstance, JArray.FromObject(args.Take(8).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test8)].Invoke(nopCallback, JArray.FromObject(args.Take(8).ToArray()));
             Assert.AreEqual(1, module.test8Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test9)].Invoke(reactInstance, JArray.FromObject(args.Take(9).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test9)].Invoke(nopCallback, JArray.FromObject(args.Take(9).ToArray()));
             Assert.AreEqual(1, module.test9Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test10)].Invoke(reactInstance, JArray.FromObject(args.Take(10).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test10)].Invoke(nopCallback, JArray.FromObject(args.Take(10).ToArray()));
             Assert.AreEqual(1, module.test10Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test11)].Invoke(reactInstance, JArray.FromObject(args.Take(11).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test11)].Invoke(nopCallback, JArray.FromObject(args.Take(11).ToArray()));
             Assert.AreEqual(1, module.test11Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test12)].Invoke(reactInstance, JArray.FromObject(args.Take(12).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test12)].Invoke(nopCallback, JArray.FromObject(args.Take(12).ToArray()));
             Assert.AreEqual(1, module.test12Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test13)].Invoke(reactInstance, JArray.FromObject(args.Take(13).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test13)].Invoke(nopCallback, JArray.FromObject(args.Take(13).ToArray()));
             Assert.AreEqual(1, module.test13Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test14)].Invoke(reactInstance, JArray.FromObject(args.Take(14).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test14)].Invoke(nopCallback, JArray.FromObject(args.Take(14).ToArray()));
             Assert.AreEqual(1, module.test14Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test15)].Invoke(reactInstance, JArray.FromObject(args.Take(15).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test15)].Invoke(nopCallback, JArray.FromObject(args.Take(15).ToArray()));
             Assert.AreEqual(1, module.test15Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test16)].Invoke(reactInstance, JArray.FromObject(args.Take(16).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test16)].Invoke(nopCallback, JArray.FromObject(args.Take(16).ToArray()));
             Assert.AreEqual(1, module.test16Calls);
 
-            module.Methods[nameof(ArgumentCountTestNativeModule.test17)].Invoke(reactInstance, JArray.FromObject(args.Take(17).ToArray()));
+            module.Methods[nameof(ArgumentCountTestNativeModule.test17)].Invoke(nopCallback, JArray.FromObject(args.Take(17).ToArray()));
             Assert.AreEqual(1, module.test17Calls);
 
         }

--- a/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleWrapperBaseTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleWrapperBaseTests.cs
@@ -19,7 +19,7 @@ namespace ReactNative.Tests.Bridge
 
             var wrapper = new TestWrapper(new TestModule());
             AssertEx.Throws<ArgumentNullException>(() => wrapper.TestNullAction(), ex => Assert.AreEqual("action", ex.ParamName));
-            AssertEx.Throws<ArgumentNullException>(() => wrapper.TestNullCallbackInstance(), ex => Assert.AreEqual("instance", ex.ParamName));
+            AssertEx.Throws<ArgumentNullException>(() => wrapper.TestNullCallback(), ex => Assert.AreEqual("invokeCallback", ex.ParamName));
             AssertEx.Throws<ArgumentNullException>(() => wrapper.TestNullFunc(), ex => Assert.AreEqual("func", ex.ParamName));
             AssertEx.Throws<ArgumentNullException>(() => wrapper.TestNullTypeAction(), ex => Assert.AreEqual("type", ex.ParamName));
             AssertEx.Throws<ArgumentNullException>(() => wrapper.TestNullTypeFunc(), ex => Assert.AreEqual("type", ex.ParamName));
@@ -72,15 +72,15 @@ namespace ReactNative.Tests.Bridge
 
             public void TestNullAction()
             {
-                var method = new NativeMethod("foo", default(Action<IReactInstance, JArray>));
+                var method = new NativeMethod("foo", default(Action<InvokeCallback, JArray>));
             }
 
             public void TestNullFunc()
             {
-                var method = new NativeMethod("foo", default(Func<IReactInstance, JArray, JToken>));
+                var method = new NativeMethod("foo", default(Func<InvokeCallback, JArray, JToken>));
             }
 
-            public void TestNullCallbackInstance()
+            public void TestNullCallback()
             {
                 var callback = new Callback(0, null);
             }

--- a/ReactWindows/ReactNative.Shared/Bridge/INativeMethod.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/INativeMethod.cs
@@ -20,9 +20,9 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Invoke the native method.
         /// </summary>
-        /// <param name="reactInstance">The React instance.</param>
+        /// <param name="invokeCallback">The invoke callback delegate.</param>
         /// <param name="arguments">The arguments.</param>
         /// <returns>The native method result.</returns>
-        JToken Invoke(IReactInstance reactInstance, JArray arguments);
+        JToken Invoke(InvokeCallback invokeCallback, JArray arguments);
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/IReactDelegateFactory.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IReactDelegateFactory.cs
@@ -26,7 +26,7 @@ namespace ReactNative.Bridge
         /// <param name="nativeModule">The native module instance.</param>
         /// <param name="method">The method.</param>
         /// <returns>The invocation delegate.</returns>
-        Func<IReactInstance, JArray, JToken> Create(INativeModule nativeModule, MethodInfo method);
+        Func<InvokeCallback, JArray, JToken> Create(INativeModule nativeModule, MethodInfo method);
 
         /// <summary>
         /// Check that the method is valid for <see cref="ReactMethodAttribute"/>.

--- a/ReactWindows/ReactNative.Shared/Bridge/InvokeCallback.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/InvokeCallback.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Delegate used to invoke JavaScript callbacks.
+    /// </summary>
+    /// <param name="callbackId">The callback identifier.</param>
+    /// <param name="arguments">The callback arguments.</param>
+    public delegate void InvokeCallback(int callbackId, JArray arguments);
+}

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
@@ -236,13 +236,13 @@ namespace ReactNative.Bridge
 
         class NativeMethod : INativeMethod
         {
-            private readonly Lazy<Func<IReactInstance, JArray, JToken>> _invokeDelegate;
+            private readonly Lazy<Func<InvokeCallback, JArray, JToken>> _invokeDelegate;
 
             public NativeMethod(NativeModuleBase instance, MethodInfo method, ReactMethodAttribute attribute)
             {
                 var delegateFactory = instance._delegateFactory;
                 delegateFactory.Validate(method, attribute);
-                _invokeDelegate = new Lazy<Func<IReactInstance, JArray, JToken>>(() => delegateFactory.Create(instance, method));
+                _invokeDelegate = new Lazy<Func<InvokeCallback, JArray, JToken>>(() => delegateFactory.Create(instance, method));
                 Type = delegateFactory.GetMethodType(method, attribute);
             }
 
@@ -251,11 +251,11 @@ namespace ReactNative.Bridge
                 get;
             }
 
-            public JToken Invoke(IReactInstance reactInstance, JArray jsArguments)
+            public JToken Invoke(InvokeCallback invokeCallback, JArray jsArguments)
             {
                 using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "callNativeModuleMethod").Start())
                 {
-                    return _invokeDelegate.Value(reactInstance, jsArguments);
+                    return _invokeDelegate.Value(invokeCallback, jsArguments);
                 }
             }
         }

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleRegistry.cs
@@ -99,12 +99,12 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Invoke a method on a native module.
         /// </summary>
-        /// <param name="reactInstance">The React instance.</param>
+        /// <param name="invokeCallback">The invoke callback delegate.</param>
         /// <param name="moduleId">The module ID.</param>
         /// <param name="methodId">The method ID.</param>
         /// <param name="parameters">The parameters.</param>
         internal void Invoke(
-            IReactInstance reactInstance,
+            InvokeCallback invokeCallback,
             int moduleId,
             int methodId,
             JArray parameters)
@@ -117,24 +117,24 @@ namespace ReactNative.Bridge
             var actionQueue = _moduleTable[moduleId].Target.ActionQueue;
             if (actionQueue != null)
             {
-                actionQueue.Dispatch(() => _moduleTable[moduleId].Invoke(reactInstance, methodId, parameters));
+                actionQueue.Dispatch(() => _moduleTable[moduleId].Invoke(invokeCallback, methodId, parameters));
             }
             else
             {
-                _moduleTable[moduleId].Invoke(reactInstance, methodId, parameters);
+                _moduleTable[moduleId].Invoke(invokeCallback, methodId, parameters);
             }
         }
 
         /// <summary>
         /// Invoke the native method synchronously.
         /// </summary>
-        /// <param name="reactInstance">The React instance.</param>
+        /// <param name="invokeCallback">The invoke callback delegate.</param>
         /// <param name="moduleId">The module ID.</param>
         /// <param name="methodId">The method ID.</param>
         /// <param name="parameters">The parameters.</param>
         /// <returns>The value returned from the method.</returns>
         internal JToken InvokeSync(
-            IReactInstance reactInstance,
+            InvokeCallback invokeCallback,
             int moduleId,
             int methodId,
             JArray parameters)
@@ -149,7 +149,7 @@ namespace ReactNative.Bridge
                 throw new ArgumentOutOfRangeException(nameof(moduleId), "Call to unknown module: " + moduleId);
             }
 
-            return _moduleTable[moduleId].Invoke(reactInstance, methodId, parameters);
+            return _moduleTable[moduleId].Invoke(invokeCallback, methodId, parameters);
         }
 
         /// <summary>
@@ -225,12 +225,12 @@ namespace ReactNative.Bridge
 
             public INativeModule Target { get; }
 
-            public JToken Invoke(IReactInstance reactInstance, int methodId, JArray parameters)
+            public JToken Invoke(InvokeCallback invokeCallback, int methodId, JArray parameters)
             {
                 var method = _methods[methodId];
                 using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, method.TracingName).Start())
                 {
-                    return method.Method.Invoke(reactInstance, parameters);
+                    return method.Method.Invoke(invokeCallback, parameters);
                 }
             }
 

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleWrapperBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleWrapperBase.cs
@@ -109,15 +109,15 @@ namespace ReactNative.Bridge
         {
             private static readonly JToken s_null = JValue.CreateNull();
 
-            private readonly Func<IReactInstance, JArray, JToken> _func;
+            private readonly Func<InvokeCallback, JArray, JToken> _func;
 
             /// <summary>
             /// Instantiates the <see cref="NativeMethod"/>.
             /// </summary>
             /// <param name="type">Type of native method.</param>
             /// <param name="action">Delegate to invoke the native method.</param>
-            public NativeMethod(string type, Action<IReactInstance, JArray> action)
-                : this(type, (instance, args) => { action(instance, args); return s_null; })
+            public NativeMethod(string type, Action<InvokeCallback, JArray> action)
+                : this(type, (invokeCallback, args) => { action(invokeCallback, args); return s_null; })
             {
                 if (action == null)
                     throw new ArgumentNullException(nameof(action));
@@ -128,7 +128,7 @@ namespace ReactNative.Bridge
             /// </summary>
             /// <param name="type">Type of native method.</param>
             /// <param name="func">Delegate to invoke the native method.</param>
-            public NativeMethod(string type, Func<IReactInstance, JArray, JToken> func)
+            public NativeMethod(string type, Func<InvokeCallback, JArray, JToken> func)
             {
                 if (type == null)
                     throw new ArgumentNullException(nameof(type));
@@ -150,7 +150,7 @@ namespace ReactNative.Bridge
             /// <param name="reactInstance">The React instance.</param>
             /// <param name="arguments">The arguments.</param>
             /// <returns>The native method result.</returns>
-            public JToken Invoke(IReactInstance reactInstance, JArray arguments)
+            public JToken Invoke(InvokeCallback reactInstance, JArray arguments)
             {
                 return _func(reactInstance, arguments);
             }
@@ -164,20 +164,20 @@ namespace ReactNative.Bridge
             private static readonly JArray s_empty = new JArray();
 
             private readonly int _id;
-            private readonly IReactInstance _instance;
+            private readonly InvokeCallback _invokeCallback;
 
             /// <summary>
             /// Instantiates the <see cref="Callback"/>.
             /// </summary>
             /// <param name="id">The callback ID.</param>
-            /// <param name="instance">The React instance.</param>
-            public Callback(int id, IReactInstance instance)
+            /// <param name="invokeCallback">The React instance.</param>
+            public Callback(int id, InvokeCallback invokeCallback)
             {
-                if (instance == null)
-                    throw new ArgumentNullException(nameof(instance));
+                if (invokeCallback == null)
+                    throw new ArgumentNullException(nameof(invokeCallback));
 
                 _id = id;
-                _instance = instance;
+                _invokeCallback = invokeCallback;
             }
 
             /// <summary>
@@ -186,7 +186,7 @@ namespace ReactNative.Bridge
             /// <param name="arguments">The callback arguments.</param>
             public void Invoke(params object[] arguments)
             {
-                _instance.InvokeCallback(_id, arguments != null ? JArray.FromObject(arguments) : s_empty);
+                _invokeCallback(_id, arguments != null ? JArray.FromObject(arguments) : s_empty);
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactDelegateFactoryBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactDelegateFactoryBase.cs
@@ -41,7 +41,7 @@ namespace ReactNative
         /// <param name="nativeModule">The native module instance.</param>
         /// <param name="method">The method.</param>
         /// <returns>The invocation delegate.</returns>
-        public abstract Func<IReactInstance, JArray, JToken> Create(INativeModule nativeModule, MethodInfo method);
+        public abstract Func<InvokeCallback, JArray, JToken> Create(INativeModule nativeModule, MethodInfo method);
 
         /// <summary>
         /// Extracts the native method type from the method.
@@ -101,12 +101,12 @@ namespace ReactNative
         /// Create a callback.
         /// </summary>
         /// <param name="callbackToken">The callback ID token.</param>
-        /// <param name="reactInstance">The React instance.</param>
+        /// <param name="invokeCallback">The invoke callback delegate.</param>
         /// <returns>The callback.</returns>
-        protected static ICallback CreateCallback(JToken callbackToken, IReactInstance reactInstance)
+        protected static ICallback CreateCallback(JToken callbackToken, InvokeCallback invokeCallback)
         {
             var id = callbackToken.Value<int>();
-            return new Callback(id, reactInstance);
+            return new Callback(id, invokeCallback);
         }
 
         /// <summary>
@@ -114,12 +114,12 @@ namespace ReactNative
         /// </summary>
         /// <param name="resolveToken">The resolve callback ID token.</param>
         /// <param name="rejectToken">The reject callback ID token.</param>
-        /// <param name="reactInstance">The React instance.</param>
+        /// <param name="invokeCallback">The invoke callback delegate.</param>
         /// <returns>The promise.</returns>
-        protected static IPromise CreatePromise(JToken resolveToken, JToken rejectToken, IReactInstance reactInstance)
+        protected static IPromise CreatePromise(JToken resolveToken, JToken rejectToken, InvokeCallback invokeCallback)
         {
-            var resolveCallback = CreateCallback(resolveToken, reactInstance);
-            var rejectCallback = CreateCallback(rejectToken, reactInstance);
+            var resolveCallback = CreateCallback(resolveToken, invokeCallback);
+            var rejectCallback = CreateCallback(rejectToken, invokeCallback);
             return new Promise(resolveCallback, rejectCallback);
         }
 
@@ -128,17 +128,17 @@ namespace ReactNative
             private static readonly object[] s_empty = new object[0];
 
             private readonly int _id;
-            private readonly IReactInstance _instance;
+            private readonly InvokeCallback _invokeCallback;
 
-            public Callback(int id, IReactInstance instance)
+            public Callback(int id, InvokeCallback invokeCallback)
             {
                 _id = id;
-                _instance = instance;
+                _invokeCallback = invokeCallback;
             }
 
             public void Invoke(params object[] arguments)
             {
-                _instance.InvokeCallback(_id, JArray.FromObject(arguments ?? s_empty));
+                _invokeCallback(_id, JArray.FromObject(arguments ?? s_empty));
             }
         }
     }

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
@@ -281,7 +281,7 @@ namespace ReactNative.Bridge
                     return;
                 }
 
-                _parent._registry.Invoke(_parent, moduleId, methodId, parameters);
+                _parent._registry.Invoke(_parent.InvokeCallback, moduleId, methodId, parameters);
             }
 
             public JToken InvokeSync(int moduleId, int methodId, JArray parameters)
@@ -293,7 +293,7 @@ namespace ReactNative.Bridge
                     return null;
                 }
 
-                return _parent._registry.InvokeSync(_parent, moduleId, methodId, parameters);
+                return _parent._registry.InvokeSync(_parent.InvokeCallback, moduleId, methodId, parameters);
             }
 
             public void OnBatchComplete()

--- a/ReactWindows/ReactNative.Shared/CoreModulesPackageWrapper.cs
+++ b/ReactWindows/ReactNative.Shared/CoreModulesPackageWrapper.cs
@@ -55,7 +55,7 @@ namespace ReactNative
                     {
                         {
                             nameof(ReactNative.Modules.Core.DeviceEventManagerModule.invokeDefaultBackPressHandler),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.invokeDefaultBackPressHandler(
                                 )
                             )
@@ -96,7 +96,7 @@ namespace ReactNative
                     {
                         {
                             nameof(ReactNative.Modules.Core.ExceptionsManagerModule.reportFatalException),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.reportFatalException(
                                     args[0].ToObject<System.String>(),
                                     CastJToken<Newtonsoft.Json.Linq.JArray>(args[1]),
@@ -106,7 +106,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.Modules.Core.ExceptionsManagerModule.reportSoftException),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.reportSoftException(
                                     args[0].ToObject<System.String>(),
                                     CastJToken<Newtonsoft.Json.Linq.JArray>(args[1]),
@@ -116,7 +116,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.Modules.Core.ExceptionsManagerModule.updateExceptionMessage),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.updateExceptionMessage(
                                     args[0].ToObject<System.String>(),
                                     CastJToken<Newtonsoft.Json.Linq.JArray>(args[1]),
@@ -126,7 +126,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.Modules.Core.ExceptionsManagerModule.dismissRedbox),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.dismissRedbox(
                                 )
                             )
@@ -167,11 +167,11 @@ namespace ReactNative
                     {
                         {
                             nameof(ReactNative.Modules.DevSupport.SourceCodeModule.getScriptText),
-                            new NativeMethod("promise", (instance, args) =>
+                            new NativeMethod("promise", (invokeCallback, args) =>
                                 Module.getScriptText(
                                     new Promise(
-                                        new Callback(args[0].ToObject<int>(), instance),
-                                        new Callback(args[1].ToObject<int>(), instance)
+                                        new Callback(args[0].ToObject<int>(), invokeCallback),
+                                        new Callback(args[1].ToObject<int>(), invokeCallback)
                                     )
                                 )
                             )
@@ -195,7 +195,7 @@ namespace ReactNative
                     {
                         {
                             nameof(ReactNative.Modules.Core.Timing.createTimer),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.createTimer(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Int32>(),
@@ -206,7 +206,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.Modules.Core.Timing.deleteTimer),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.deleteTimer(
                                     args[0].ToObject<System.Int32>()
                                 )
@@ -214,7 +214,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.Modules.Core.Timing.setSendIdleEvents),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.setSendIdleEvents(
                                     args[0].ToObject<System.Boolean>()
                                 )
@@ -239,7 +239,7 @@ namespace ReactNative
                     {
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.removeRootView),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.removeRootView(
                                     args[0].ToObject<System.Int32>()
                                 )
@@ -247,7 +247,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.createView),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.createView(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.String>(),
@@ -258,7 +258,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.updateView),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.updateView(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.String>(),
@@ -268,7 +268,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.manageChildren),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.manageChildren(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Int32[]>(),
@@ -281,7 +281,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.setChildren),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.setChildren(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Int32[]>()
@@ -290,7 +290,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.replaceExistingNonRootView),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.replaceExistingNonRootView(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Int32>()
@@ -299,7 +299,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.removeSubviewsFromContainerWithID),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.removeSubviewsFromContainerWithID(
                                     args[0].ToObject<System.Int32>()
                                 )
@@ -307,56 +307,56 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.measure),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.measure(
                                     args[0].ToObject<System.Int32>(),
-                                    new Callback(args[1].ToObject<int>(), instance)
+                                    new Callback(args[1].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.measureInWindow),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.measureInWindow(
                                     args[0].ToObject<System.Int32>(),
-                                    new Callback(args[1].ToObject<int>(), instance)
+                                    new Callback(args[1].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.measureLayout),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.measureLayout(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Int32>(),
-                                    new Callback(args[2].ToObject<int>(), instance),
-                                    new Callback(args[3].ToObject<int>(), instance)
+                                    new Callback(args[2].ToObject<int>(), invokeCallback),
+                                    new Callback(args[3].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.measureLayoutRelativeToParent),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.measureLayoutRelativeToParent(
                                     args[0].ToObject<System.Int32>(),
-                                    new Callback(args[1].ToObject<int>(), instance),
-                                    new Callback(args[2].ToObject<int>(), instance)
+                                    new Callback(args[1].ToObject<int>(), invokeCallback),
+                                    new Callback(args[2].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.findSubviewIn),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.findSubviewIn(
                                     args[0].ToObject<System.Int32>(),
                                     CastJToken<Newtonsoft.Json.Linq.JArray>(args[1]),
-                                    new Callback(args[2].ToObject<int>(), instance)
+                                    new Callback(args[2].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.setJSResponder),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.setJSResponder(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Boolean>()
@@ -365,14 +365,14 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.clearJSResponder),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.clearJSResponder(
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.dispatchViewManagerCommand),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.dispatchViewManagerCommand(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.Int32>(),
@@ -382,28 +382,28 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.showPopupMenu),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.showPopupMenu(
                                     args[0].ToObject<System.Int32>(),
                                     args[1].ToObject<System.String[]>(),
-                                    new Callback(args[2].ToObject<int>(), instance),
-                                    new Callback(args[3].ToObject<int>(), instance)
+                                    new Callback(args[2].ToObject<int>(), invokeCallback),
+                                    new Callback(args[3].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.configureNextLayoutAnimation),
-                            new NativeMethod("async", (instance, args) =>
+                            new NativeMethod("async", (invokeCallback, args) =>
                                 Module.configureNextLayoutAnimation(
                                     CastJToken<Newtonsoft.Json.Linq.JObject>(args[0]),
-                                    new Callback(args[1].ToObject<int>(), instance),
-                                    new Callback(args[2].ToObject<int>(), instance)
+                                    new Callback(args[1].ToObject<int>(), invokeCallback),
+                                    new Callback(args[2].ToObject<int>(), invokeCallback)
                                 )
                             )
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.getConstantsForViewManager),
-                            new NativeMethod("sync", (instance, args) =>
+                            new NativeMethod("sync", (invokeCallback, args) =>
                                 Module.getConstantsForViewManager(
                                     args[0].ToObject<System.String>()
                                 )
@@ -411,7 +411,7 @@ namespace ReactNative
                         },
                         {
                             nameof(ReactNative.UIManager.UIManagerModule.getDefaultEventTypes),
-                            new NativeMethod("sync", (instance, args) =>
+                            new NativeMethod("sync", (invokeCallback, args) =>
                                 Module.getDefaultEventTypes(
                                 )
                             )

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -42,6 +42,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\INativeMethod.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\INativeModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\INativeModuleWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bridge\InvokeCallback.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IOnBatchCompleteListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IPromise.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\IReactBridge.cs" />


### PR DESCRIPTION
IReactInstance exposes a lot of functionality that is only relevant to the native bridge, not necessarily to native modules. This change limits the API exposure of INativeModules to only invoking JS callbacks.