### PR TITLE
Fix windows generator failing at certificate generation when verbose is true

### DIFF
--- a/local-cli/generator-windows/index.js
+++ b/local-cli/generator-windows/index.js
@@ -63,7 +63,7 @@ module.exports = yeoman.Base.extend({
         `Export-PfxCertificate -Cert "cert:\\CurrentUser\\My\\$($cert.Thumbprint)" -FilePath ${path.join('windows', this.name, this.name)}_TemporaryKey.pfx -Password $pwd`,
         '$cert.Thumbprint'
       ];
-      const certGenProcess = childProcess.spawnSync('powershell', ['-command', certGenCommand.join(';')], this.options.verbose ? { stdio: 'inherit' } : {});
+      const certGenProcess = childProcess.spawnSync('powershell', ['-command', certGenCommand.join(';')]);
 
       if (certGenProcess.status === 0) {
         const certGenProcessOutput = certGenProcess.stdout.toString().trim().split('\n');


### PR DESCRIPTION
When verbose is set to true, the output of the `certGen` command cannot be captured because `stdio` is set to `inherit`.  This causes the subsequent `stdout.toString()` to fail.  This PR fixes this so that `stdio` is not set to `inherit` even when `verbose` is true.

https://github.com/Microsoft/react-native-windows/blob/af14ccf347e58db85da2095ee739228448b21137/local-cli/generator-windows/index.js#L66-L69