### PR TITLE
Reduce warnings emitted by the ReactNative.Net46 project

### DIFF
--- a/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Net46/Bridge/DispatcherHelpers.cs
@@ -10,10 +10,16 @@ using System.Windows.Threading;
 
 namespace ReactNative.Bridge
 {
+    /// <summary>
+    /// A set of helpers for dispatcher access.
+    /// </summary>
     public static class DispatcherHelpers
     {
         private static Dispatcher s_mainDispatcher;
 
+        /// <summary>
+        /// Gets the main dispatcher for the app.
+        /// </summary>
         public static Dispatcher MainDispatcher
         {
             get
@@ -47,11 +53,21 @@ namespace ReactNative.Bridge
             s_mainDispatcher = Dispatcher.CurrentDispatcher;
         }
 
+        /// <summary>
+        /// Checks if the main dispatcher has been set
+        /// </summary>
+        /// <returns>
+        /// <code>true</code> if the dispatcher has been set,
+        /// otherwise <code>false</code>.
+        /// </returns>
         public static bool IsDispatcherSet()
         {
             return s_mainDispatcher != null;
         }
 
+        /// <summary>
+        /// Asserts that the current thread has dispatcher access.
+        /// </summary>
         public static void AssertOnDispatcher()
         {
             if (!IsOnDispatcher())
@@ -60,6 +76,13 @@ namespace ReactNative.Bridge
             }
         }
 
+        /// <summary>
+        /// Checks if the current thread has dispatcher access.
+        /// </summary>
+        /// <returns>
+        /// <code>true</code> if the current thread has main dispatcher access,
+        /// otherwise <code>false</code>.
+        /// </returns>
         public static bool IsOnDispatcher()
         {
             AssertDispatcherSet();
@@ -67,11 +90,23 @@ namespace ReactNative.Bridge
             return MainDispatcher.CheckAccess();
         }
 
+        /// <summary>
+        /// Checks if the current thread has access to the specified dispatcher.
+        /// </summary>
+        /// <param name="dispatcher">The dispatcher to be checked</param>
+        /// <returns>
+        /// <code>true</code> if the current thread has main dispatcher access,
+        /// otherwise <code>false</code>.
+        /// </returns>
         public static bool IsOnDispatcher(Dispatcher dispatcher)
         {
             return dispatcher.CheckAccess();
         }
 
+        /// <summary>
+        /// Asserts that the current thread has access to the dispatcher associated with the specified dependency object.
+        /// </summary>
+        /// <param name="dependencyObject">The dependency object who's dispatcher will be checked</param>
         public static void AssertOnDispatcher(DependencyObject dependencyObject)
         {
             AssertDispatcherSet();
@@ -82,6 +117,11 @@ namespace ReactNative.Bridge
             }
         }
 
+        /// <summary>
+        /// Invokes an action on the main dispatcher.
+        /// </summary>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="allowInlining">True if inlining is allowed when calling thread is on the main dispatcher.</param>
         public static void RunOnDispatcher(Action action, bool allowInlining = false)
         {
             AssertDispatcherSet();
@@ -89,6 +129,12 @@ namespace ReactNative.Bridge
             RunOnDispatcher(DispatcherPriority.Normal, action, allowInlining);
         }
 
+        /// <summary>
+        /// Invokes an action on the main dispatcher with custom priority.
+        /// </summary>
+        /// <param name="priority">The priority.</param>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="allowInlining">True if inlining is allowed when calling thread is on the main dispatcher.</param>
         public static void RunOnDispatcher(DispatcherPriority priority, Action action, bool allowInlining = false)
         {
             AssertDispatcherSet();
@@ -108,11 +154,25 @@ namespace ReactNative.Bridge
             }
 
         }
+
+        /// <summary>
+        /// Invokes an action on a specified dispatcher.
+        /// </summary>
+        /// <param name="dispatcher">The dispatcher.</param>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="allowInlining">True if inlining is allowed when calling thread is on the same dispatcher as the one in the parameter.</param>
         public static void RunOnDispatcher(Dispatcher dispatcher, Action action, bool allowInlining = false)
         {
             RunOnDispatcher(dispatcher, DispatcherPriority.Normal, action, allowInlining);
         }
 
+        /// <summary>
+        /// Invokes an action on a specified dispatcher and priority
+        /// </summary>
+        /// <param name="dispatcher">The dispatcher.</param>
+        /// <param name="priority">The priority.</param>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="allowInlining">True if inlining is allowed when calling thread is on the same dispatcher as the one in the parameter.</param>
         public static void RunOnDispatcher(Dispatcher dispatcher, DispatcherPriority priority, Action action, bool allowInlining = false)
         {
             AssertDispatcherSet();
@@ -167,6 +227,12 @@ namespace ReactNative.Bridge
             }
         }
 
+        /// <summary>
+        /// Cleans up the dispatcher helpers.
+        /// </summary>
+        /// <remarks>
+        /// No-op on WPF
+        /// </remarks>
         public static void Reset()
         {
             // No-op on WPF

--- a/ReactWindows/ReactNative.Net46/Modules/Launch/LauncherModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Launch/LauncherModule.cs
@@ -49,7 +49,7 @@ namespace ReactNative.Modules.Launch
         /// The promise that should be resolved after the URL is opened.
         /// </param>
         [ReactMethod]
-        public async void openURL(string url, IPromise promise)
+        public void openURL(string url, IPromise promise)
         {
             if (url == null)
             {
@@ -76,7 +76,7 @@ namespace ReactNative.Modules.Launch
         /// The promise used to return the result of the check.
         /// </param>
         [ReactMethod]
-        public async void canOpenURL(string url, IPromise promise)
+        public void canOpenURL(string url, IPromise promise)
         {
             if (url == null)
             {

--- a/ReactWindows/ReactNative.Net46/Modules/NetInfo/INetworkInformation.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/NetInfo/INetworkInformation.cs
@@ -34,9 +34,19 @@ namespace ReactNative.Modules.NetInfo
         void Stop();
     }
 
+    /// <summary>
+    /// Describes a network connectivity change event
+    /// </summary>
     public class NetworkConnectivityChangedEventArgs : EventArgs
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether the network is available
+        /// </summary>
         public bool IsAvailable { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying additional network connectivity status
+        /// </summary>
         public string ConnectionStatus { get; set; }
     }
 }

--- a/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
@@ -96,5 +96,18 @@ namespace ReactNative.UIManager
                 return false;
             }
         }
+
+        /// <summary>
+        /// Invokes action on MainDispatcher.
+        /// </summary>
+        /// <param name="tag">The react tag which specifies view.</param>
+        /// <param name="action">The action to invoke.</param>
+        /// <remarks>
+        /// <paramref name="tag"/> is not used, always runs on main dispatcher.
+        /// </remarks>
+        public void InvokeAction(int tag, Action action)
+        {
+            DispatcherHelpers.RunOnDispatcher(action);
+        }
     }
 }


### PR DESCRIPTION
The ReactNative.Net46 project emits several C# and C++ warnings when it is built.  This introduces warnings into projects that have a dependency on React Native Windows.  This PR only addresses the C# warnings.  The C++ warnings are in yoga and would need to be addressed in that repository.