### PR TITLE
Adding option to opt-out of bundle caching and always contact the development server

### DIFF
--- a/ReactWindows/Playground.Net46/AppReactPage.cs
+++ b/ReactWindows/Playground.Net46/AppReactPage.cs
@@ -4,6 +4,7 @@
 using ReactNative;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
+using System;
 using System.Collections.Generic;
 
 namespace Playground.Net46

--- a/ReactWindows/Playground.Net46/AppReactPage.cs
+++ b/ReactWindows/Playground.Net46/AppReactPage.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using ReactNative;
 using ReactNative.Modules.Core;
 using ReactNative.Shell;
-using System;
 using System.Collections.Generic;
 
 namespace Playground.Net46
@@ -32,6 +31,18 @@ namespace Playground.Net46
                 return true;
 #else
                 return false;
+#endif
+            }
+        }
+
+        public override bool UseBundleCaching
+        {
+            get
+            {
+#if DEBUG
+                return false;
+#else
+                return true;
 #endif
             }
         }

--- a/ReactWindows/ReactNative.Net46/ReactPage.cs
+++ b/ReactWindows/ReactNative.Net46/ReactPage.cs
@@ -98,6 +98,11 @@ namespace ReactNative
         public abstract bool UseDeveloperSupport { get; }
 
         /// <summary>
+        /// Signals whether bundle caching should be enabled
+        /// </summary>
+        public virtual bool UseBundleCaching { get; } = true;
+
+        /// <summary>
         /// The list of <see cref="IReactPackage"/>s used by the application.
         /// </summary>
         public abstract List<IReactPackage> Packages { get; }
@@ -216,6 +221,7 @@ namespace ReactNative
             var builder = new ReactInstanceManagerBuilder
             {
                 UseDeveloperSupport = UseDeveloperSupport,
+                UseBundleCaching = UseBundleCaching,
                 InitialLifecycleState = LifecycleState.BeforeCreate,
                 JavaScriptBundleFile = JavaScriptBundleFile,
                 JavaScriptMainModuleName = JavaScriptMainModuleName,

--- a/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
@@ -110,6 +110,12 @@ namespace ReactNative.DevSupport
             set;
         } = true;
 
+        public bool IsBundleCachingEnabled
+        {
+            get;
+            set;
+        } = true;
+
         public string SourceMapUrl
         {
             get

--- a/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
@@ -49,6 +49,12 @@ namespace ReactNative.DevSupport
             set;
         }
 
+        public bool IsBundleCachingEnabled
+        {
+            get;
+            set;
+        }
+
         public string SourceMapUrl
         {
             get

--- a/ReactWindows/ReactNative.Shared/DevSupport/IDevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/IDevSupportManager.cs
@@ -45,6 +45,11 @@ namespace ReactNative.DevSupport
         bool IsProgressDialogEnabled { get; set; }
 
         /// <summary>
+        /// Enables or disables the bundle caching option
+        /// </summary>
+        bool IsBundleCachingEnabled { get; set; }
+
+        /// <summary>
         /// The source map URL.
         /// </summary>
         string SourceMapUrl { get; }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -513,7 +513,7 @@ namespace ReactNative
 
         private Task<ReactContext> CreateReactContextFromDevManagerAsync(CancellationToken token)
         {
-            if (_devSupportManager.HasUpToDateBundleInCache())
+            if (_devSupportManager.IsBundleCachingEnabled && _devSupportManager.HasUpToDateBundleInCache())
             {
                 return CreateReactContextFromCachedPackagerBundleAsync(token);
             }

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManagerBuilder.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManagerBuilder.cs
@@ -22,6 +22,7 @@ namespace ReactNative
         private string _jsBundleFile;
         private string _jsMainModuleName;
         private bool _useDeveloperSupport;
+        private bool _useBundleCaching;
         private LifecycleState? _initialLifecycleState;
         private UIImplementationProvider _uiImplementationProvider;
         private Action<Exception> _nativeModuleCallExceptionHandler;
@@ -92,6 +93,18 @@ namespace ReactNative
             set
             {
                 _useDeveloperSupport = value;
+            }
+        }
+
+        /// <summary>
+        /// When <code>true</code>, bundle caching will be enabled;
+        /// Otherwise, <code>false</code>; bundle will not be cached;
+        /// </summary>
+        public bool UseBundleCaching
+        {
+            set
+            {
+                _useBundleCaching = value;
             }
         }
 
@@ -175,7 +188,7 @@ namespace ReactNative
                 _jsExecutorFactory = () => new ChakraJavaScriptExecutor();
             }
 
-            return new ReactInstanceManager(
+            var instance = new ReactInstanceManager(
                 _jsBundleFile,
                 _jsMainModuleName,
                 _packages,
@@ -185,6 +198,13 @@ namespace ReactNative
                 _jsExecutorFactory,
                 _nativeModuleCallExceptionHandler,
                 _lazyViewManagersEnabled);
+
+            if (instance.DevSupportManager != null)
+            {
+                instance.DevSupportManager.IsBundleCachingEnabled = _useBundleCaching;
+            }
+
+            return instance;
         }
     }
 }


### PR DESCRIPTION
If the JavaScript is changed between runs of the application the bundle loaded will not demonstrate the changes until Ctrl+R is executed.  This breaks the previous developer cycle of  being able to change the JavaScript and having those changes reflected on the next application run.

This was changed when the "HasUpToDateBundleInCache" check was added to the "ReactInstanceManager.CreateReactContextFromDevManagerAsync()" that will load the packager bundle from cache if it is up to date.

@rozele We discussed the possibility of adding a flag to allow the old behavior to be restored.  This is what I've done in this PR.  I've added a flag called "UseBundleCaching" to the ReactPage and ReactInstanceManager that will set the IsBundleCachingEnabled flag on the IDevSupportManager.  If the flag is true and the cached bundle is up to date then the "CreateReactContextFromCachedPackagerBundleAsync" is executed;  Otherwise the _devSupportManager.CreateReactContextFromPackagerAsync is executed.

I have chosen to set the default for the new flag to "true" so that the existing behavior is not changed.  Let me know if you'd like the flag to be false by default, which will force anybody who wants to use the bundle caching to opt-in rather than the other way around.