### PR TITLE
Ensuring that ReactInstance Initialize returns only after initialization of modules is complete

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Internal/MockReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Internal/MockReactInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
@@ -73,7 +73,7 @@ namespace ReactNative.Tests
             throw new NotImplementedException();
         }
 
-        public void Initialize()
+        public Task InitializeAsync()
         {
             throw new NotImplementedException();
         }

--- a/ReactWindows/ReactNative.Shared/Bridge/IReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IReactInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -29,8 +29,8 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Initializes the instance.
         /// </summary>
-        void Initialize();
-        
+        System.Threading.Tasks.Task InitializeAsync();
+
         /// <summary>
         /// Invokes a JavaScript function.
         /// </summary>

--- a/ReactWindows/ReactNative.Shared/Bridge/IReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/IReactInstance.cs
@@ -6,6 +6,7 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge.Queue;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ReactNative.Bridge
 {
@@ -29,7 +30,7 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Initializes the instance.
         /// </summary>
-        System.Threading.Tasks.Task InitializeAsync();
+        Task InitializeAsync();
 
         /// <summary>
         /// Invokes a JavaScript function.

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
@@ -75,7 +75,7 @@ namespace ReactNative.Bridge
             return _registry.GetModule<T>();
         }
 
-        public void Initialize()
+        public async Task InitializeAsync()
         {
             DispatcherHelpers.AssertOnDispatcher();
             if (_initialized)
@@ -84,7 +84,7 @@ namespace ReactNative.Bridge
             }
 
             _initialized = true;
-            QueueConfiguration.NativeModulesQueue.Dispatch(_registry.NotifyReactInstanceInitialize);
+            await QueueConfiguration.NativeModulesQueue.RunAsync(_registry.NotifyReactInstanceInitializeAsync).Unwrap();
         }
 
         public async Task InitializeBridgeAsync(CancellationToken token)

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -751,12 +751,12 @@ namespace ReactNative
 
             reactContext.InitializeWithInstance(reactInstance);
 
-            reactInstance.Initialize();
-
             using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "RunJavaScriptBundle").Start())
             {
-                await reactInstance.InitializeBridgeAsync(token).ConfigureAwait(false);
+                await reactInstance.InitializeBridgeAsync(token);
             }
+
+            await reactInstance.InitializeAsync().ConfigureAwait(false);
 
             return reactContext;
         }

--- a/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
@@ -81,14 +81,14 @@ namespace ReactNative.Tests.Bridge
 
             var instance = await DispatcherHelpers.CallOnDispatcherAsync(() => builder.Build());
             reactContext.InitializeWithInstance(instance);
-            await DispatcherHelpers.RunOnDispatcherAsync(() => instance.Initialize());
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await instance.InitializeAsync());
 
             var caught = false;
-            await DispatcherHelpers.RunOnDispatcherAsync(() =>
+            await DispatcherHelpers.CallOnDispatcherAsync(async () =>
             {
                 try
                 {
-                    instance.Initialize();
+                    await instance.InitializeAsync();
                 }
                 catch (InvalidOperationException)
                 {

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -354,8 +354,8 @@ namespace ReactNative.Tests.UIManager.Events
             {
                 var instance = CreateReactInstance(context, executor);
                 context.InitializeWithInstance(instance);
-                instance.Initialize();
                 await instance.InitializeBridgeAsync(CancellationToken.None);
+                await instance.InitializeAsync();
                 return instance;
             });
 


### PR DESCRIPTION
Change Summary:
Changed ReactInstance.Initialize to ReactInstance.InitializeAsync which awaits for Initialization of modules
Swap the call order of ReactInstance.Initialize and ReactInstance.InitializeBridgeAsync
Updated the test code to reflect the new signatures

Problem this solves:
When the modules are initialized, they may start calling JSModules right away (potentially in another thread). So we need to ensure that the bridge is initialized before the modules are initialized.

Further, once ReactInstance.Initialize returns, the caller, naturally, assumes that the ReactInstance is initialized and so is free to start using RNModules, but the RNModules may still be executing their Initialization code on the RNModule thread. We now ensure that ReactInstance.InitializeAsync returns only after all the RNModule's Initialize methods are executed.