### PR TITLE
Fix link to system requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The GitHub issues are intended for bug reports and feature requests. For help an
 
 ## Contributing
 
-- Install the [requirements](#requirements)
+- Install the [system requirements](#system-requirements)
 - Check out the React Native Windows code itself and install npm dependencies
 ```
 git clone --recursive https://github.com/ReactWindows/react-native-windows.git


### PR DESCRIPTION
Just pointing to right place on the page and giving the link the same text as the section it goes to