### PR TITLE
Passing original URI string to the NavigationStateChange JS callback

### DIFF
--- a/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
@@ -373,7 +373,7 @@ namespace ReactNative.Views.Web
                     new WebViewLoadEvent(
                          tag,
                          WebViewLoadEvent.TopLoadingStart,
-                         e.Uri?.ToString(),
+                         e.Uri?.OriginalString,
                          true,
                          webView.DocumentTitle,
                          webView.CanGoBack,
@@ -417,7 +417,7 @@ namespace ReactNative.Views.Web
                     new WebViewLoadEvent(
                         webView.GetTag(),
                         WebViewLoadEvent.TopLoadingFinish,
-                        e.Uri?.ToString(),
+                        e.Uri?.OriginalString,
                         false,
                         webView.DocumentTitle,
                         webView.CanGoBack,


### PR DESCRIPTION
**Problem:**
When navigating to UriEncoded url - it is decoded by the webView and decoded Uri will be passed back to JS client via `onNavigationStateChange` event. This behavior will trigger React Props update since original Uri might be encoded and Uri.ToString(), that was used before, has been already decoded. It results in extra navigation performed by the webView (page reload)

**Sample:**
JS client requested navigation to https://www.bing.com/entityexplore?q=Restaurants&filters=bar%3A"local"&foo=1&form=CSS4LR where queryParams are  UriComponentEncoded.
However, the callback will be invoked with:
https://www.bing.com/entityexplore?q=Restaurants&filters=bar:"local"&foo=1&form=CSS4LR
where `%3A` was decoded to `:`

Due to design of [Controlled](https://reactjs.org/docs/forms.html) React components - encoded and decoded URI from the sample above will be treated as 2 different urls which will trigger `render()` that ends up in `ReactWebViewManager.OnAfterUpdateTransaction()`. Which will start page navigation again.

**Suggested solution:**
Passing original url via a callback. This way we are not making any url modification and alligning behavior with other platforms.