### PR TITLE
Passing original URI in navigationStateChange callback for .NET46

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
@@ -203,7 +203,7 @@ namespace ReactNative.Views.Web
         private void OnLoadCompleted(object sender, NavigationEventArgs e)
         {
             var webView = (WebBrowser)sender;
-            LoadFinished(webView, e.Uri?.ToString());
+            LoadFinished(webView, e.Uri?.OriginalString);
 
             if (webView.IsLoaded)
             {
@@ -238,7 +238,7 @@ namespace ReactNative.Views.Web
                     new WebViewLoadingEvent(
                          webView.GetTag(),
                          "Start",
-                         e.Uri?.ToString(),
+                         e.Uri?.OriginalString,
                          true,
                          "Title Unavailable",
                          webView.CanGoBack,


### PR DESCRIPTION
Same changes as described and merged [here](https://github.com/Microsoft/react-native-windows/pull/1909) for .NET46