### PR TITLE
Fix fontStyle exception on WPF

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -91,7 +91,7 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -154,7 +154,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(PasswordBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? new FontStyle();
         }
 

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -150,7 +150,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(ReactTextBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? new FontStyle();
         }
 

--- a/ReactWindows/ReactNative.Shared/Views/Text/FontStyleHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/FontStyleHelpers.cs
@@ -3,6 +3,7 @@
 
 #if WINDOWS_UWP
 using Windows.UI.Text;
+using ReactNative.Reflection;
 #else
 using System.Windows;
 #endif
@@ -11,6 +12,20 @@ namespace ReactNative.Views.Text
 {
     static class FontStyleHelpers
     {
+        public static FontStyle? ParseFontStyle(string fontStyleString)
+        {
+#if WINDOWS_UWP
+            return EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+#else
+            switch (fontStyleString)
+            {
+                case "normal": return FontStyles.Normal;  
+                case "italic": return FontStyles.Italic;
+                default: return null;
+            }
+#endif
+        }
+
         public static FontWeight? ParseFontWeight(string fontWeightString)
         {
             var fontWeightNumeric = fontWeightString != null

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactSpanShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactSpanShadowNode.cs
@@ -86,7 +86,7 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactPasswordBoxShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactPasswordBoxShadowNode.cs
@@ -128,7 +128,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleSValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleSValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleSValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/Views/TextInput/ReactTextInputShadowNode.cs
@@ -145,7 +145,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
@@ -97,7 +97,7 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(string fontStyleValue)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleValue);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleValue);
             if (_fontStyle != fontStyle)
             {
                 _fontStyle = fontStyle;

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -185,7 +185,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(PasswordBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? FontStyle.Normal;
         }
 

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -188,7 +188,7 @@ namespace ReactNative.Views.TextInput
         [ReactProp(ViewProps.FontStyle)]
         public void SetFontStyle(ReactTextBox view, string fontStyleString)
         {
-            var fontStyle = EnumHelpers.ParseNullable<FontStyle>(fontStyleString);
+            var fontStyle = FontStyleHelpers.ParseFontStyle(fontStyleString);
             view.FontStyle = fontStyle ?? FontStyle.Normal;
         }
 


### PR DESCRIPTION
Fix fontStyle exception on WPF and unify all fontStyle parser to FontStyleHelpers.ParseFontStyle().
This is the same as the #1191 pull request with plus an aesthetic fix.