### PR TITLE
WebViewManager: check previousUri before starting new navigation

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Web/ReactWebViewManager.cs
@@ -113,6 +113,12 @@ namespace ReactNative.Views.Web
                 var uri = source.Value<string>("uri");
                 if (uri != null)
                 {
+                    string previousUri = view.Source?.OriginalString;
+                    if (!String.IsNullOrWhiteSpace(previousUri) && previousUri.Equals(uri))
+                    {
+                        return;
+                    }
+
                     using (var request = new HttpRequestMessage())
                     {
                         var sourceUri = new Uri(uri);

--- a/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
@@ -286,6 +286,12 @@ namespace ReactNative.Views.Web
                     // HTML files need to be loaded with the ms-appx-web schema.
                     uri = uri.Replace("ms-appx:", "ms-appx-web:");
 
+                    string previousUri = view.Source?.OriginalString;
+                    if (!String.IsNullOrWhiteSpace(previousUri) && previousUri.Equals(uri))
+                    {
+                        return;
+                    }
+
                     using (var request = new HttpRequestMessage())
                     {
                         request.RequestUri = new Uri(uri);


### PR DESCRIPTION
**Problem:**
Due to Connected Components pattern in React - `ReactWebViewManager` might recieve `PropsUpdate` event from React with the same url as it has been already navigated to. In this case webView will start another navigation, which results in web page reload.

**Example:**
- JS trigger openUrl('https://foo.com');
- RNWebViewManager sends onNavigationStateChanged('https://foo.com') callback
- User clicks on the button inside foo.com which navigates him to https://foo.com/bar.
- RNWebViewManager sends onNavigationStateChanged('https://foo.com/bar') callback
- Since url has changed JS code will trigger `React` to update `WebViewManager` by updated props.
=> Here WebViewManager will trigger another navigation to 'https://foo.com/bar' despite the fact that this Url has been just loaded.

**Solution:**
Every time before starting new navigation based on props update - check if webView has been already navigated to the same page to prevent double-reloading.

The same behavior and solution was found in Android [ReactWebViewManager.java](https://github.com/facebook/react-native/blob/6e359c4589b0627de59332ce56fe28804425a609/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java#L506)