### PR TITLE
Implement "tracking" native animation, fixes crash in RNTester

### DIFF
--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -246,7 +246,7 @@ namespace ReactNative.Animated
         {
             if (_activeAnimations.TryGetValue(animationId, out var animation))
             {
-                animation.EndCallback.Invoke(new JObject
+                animation.EndCallback?.Invoke(new JObject
                 {
                     { "finished", false },
                 });
@@ -497,7 +497,7 @@ namespace ReactNative.Animated
                 if (animatedNode == animation.AnimatedValue)
                 {
                     // Invoke animation end callback with {finished: false}
-                    animation.EndCallback.Invoke(new JObject
+                    animation.EndCallback?.Invoke(new JObject
                     {
                         { "finished", false }, 
                     });

--- a/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -106,6 +106,9 @@ namespace ReactNative.Animated
                 case "transform":
                     node = new TransformAnimatedNode(tag, config, this);
                     break;
+                case "tracking":
+                    node = new TrackingAnimatedNode(tag, config, this);
+                    break;
                 default:
                     throw new InvalidOperationException(Invariant($"Unsupported node type: '{type}'"));
             }
@@ -472,7 +475,7 @@ namespace ReactNative.Animated
                     var animation = _activeAnimations[animationId];
                     if (animation.HasFinished)
                     {
-                        animation.EndCallback.Invoke(new JObject
+                        animation.EndCallback?.Invoke(new JObject
                         {
                             { "finished", true },
                         });

--- a/ReactWindows/ReactNative.Shared/Animated/TrackingAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/TrackingAnimatedNode.cs
@@ -32,7 +32,7 @@ namespace ReactNative.Animated
         public override void Update()
         {
             AnimatedNode toValue = _manager.GetNodeById(_toValueNode);
-            _animationConfig["toValue"] = (toValue as ValueAnimatedNode).Value;
+            _animationConfig["toValue"] = ((ValueAnimatedNode)toValue).Value;
             _manager.StartAnimatingNode(_animationId, _valueNode, _animationConfig, null);
         }
     }

--- a/ReactWindows/ReactNative.Shared/Animated/TrackingAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/TrackingAnimatedNode.cs
@@ -4,7 +4,6 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
-using System;
 
 namespace ReactNative.Animated
 {
@@ -38,3 +37,4 @@ namespace ReactNative.Animated
         }
     }
 }
+

--- a/ReactWindows/ReactNative.Shared/Animated/TrackingAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/TrackingAnimatedNode.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace ReactNative.Animated
+{
+
+    class TrackingAnimatedNode : AnimatedNode
+    {
+        private readonly NativeAnimatedNodesManager _manager;
+
+        private readonly int _animationId;
+        private readonly int _toValueNode;
+        private readonly int _valueNode;
+        private readonly JObject _animationConfig;
+
+        public TrackingAnimatedNode(int tag, JObject config, NativeAnimatedNodesManager manager)
+            : base(tag)
+        {
+            _manager = manager; 
+            _animationId = config.Value<int>("animationId");
+            _toValueNode = config.Value<int>("toValue");
+            _valueNode = config.Value<int>("value");
+
+            var animationConfig = config.Value<JObject>("animationConfig");
+            _animationConfig = (JObject)animationConfig.DeepClone();
+        }
+
+        public override void Update()
+        {
+            AnimatedNode toValue = _manager.GetNodeById(_toValueNode);
+            _animationConfig["toValue"] = (toValue as ValueAnimatedNode).Value;
+            _manager.StartAnimatingNode(_animationId, _valueNode, _animationConfig, null);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Animated\PropsAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\SpringAnimationDriver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\StyleAnimatedNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Animated\TrackingAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\TransformAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\ValueAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bridge\CompiledReactDelegateFactory.cs" />


### PR DESCRIPTION
This "every platform has its own implementation in random languages for common code" approach has its drawbacks.. Sometime a "tracking a value" native animation showed up in RN, and we were left behind.