### PR TITLE
AsyncStorageModule should propagate the errors from lower layers to the callers

### DIFF
--- a/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PCLStorage;
 using ReactNative.Bridge;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -50,6 +51,10 @@ namespace ReactNative.Modules.Storage
                     var value = await GetAsync(key).ConfigureAwait(false);
                     data.Add(new JArray(key, value));
                 }
+            }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
             }
             finally
             {
@@ -107,6 +112,10 @@ namespace ReactNative.Modules.Storage
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
@@ -150,6 +159,10 @@ namespace ReactNative.Modules.Storage
                         break;
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
             }
             finally
             {
@@ -207,6 +220,10 @@ namespace ReactNative.Modules.Storage
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
@@ -225,6 +242,8 @@ namespace ReactNative.Modules.Storage
         [ReactMethod]
         public async void clear(ICallback callback)
         {
+            var error = default(JObject);
+
             await _mutex.WaitAsync().ConfigureAwait(false);
             try
             {
@@ -234,17 +253,29 @@ namespace ReactNative.Modules.Storage
                     await storageFolder.DeleteAsync().ConfigureAwait(false);
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
             }
 
-            callback.Invoke();
+            if (error != null)
+            {
+                callback.Invoke(error);
+            }
+            else
+            {
+                callback.Invoke();
+            }
         }
 
         [ReactMethod]
         public async void getAllKeys(ICallback callback)
         {
+            var error = default(JObject);
             var keys = new JArray();
 
             await _mutex.WaitAsync().ConfigureAwait(false);
@@ -264,12 +295,23 @@ namespace ReactNative.Modules.Storage
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
             }
 
-            callback.Invoke(null, keys);
+            if (error != null)
+            {
+                callback.Invoke(error);
+            }
+            else
+            {
+                callback.Invoke(null, keys);
+            }
         }
 
         public override void OnReactInstanceDispose()

--- a/ReactWindows/ReactNative.Shared/Modules/Storage/AsyncStorageHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Storage/AsyncStorageHelpers.cs
@@ -157,5 +157,15 @@ namespace ReactNative.Modules.Storage
         {
             return GetError(key, "Invalid Value");
         }
+
+        public static JObject GetError(System.Exception ex)
+        {
+            return new JObject
+            {
+                { "hresult", ex.HResult.ToString("X8") },
+                { "message", ex.Message },
+                { "key", ex.GetType().Name },
+            };
+        }
     }
 }

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -54,6 +54,10 @@ namespace ReactNative.Modules.Storage
                     data.Add(new JArray(key, value));
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
@@ -110,6 +114,10 @@ namespace ReactNative.Modules.Storage
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
@@ -153,6 +161,10 @@ namespace ReactNative.Modules.Storage
                         break;
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
             }
             finally
             {
@@ -210,6 +222,10 @@ namespace ReactNative.Modules.Storage
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
@@ -228,6 +244,8 @@ namespace ReactNative.Modules.Storage
         [ReactMethod]
         public async void clear(ICallback callback)
         {
+            var error = default(JObject);
+
             await _mutex.WaitAsync().ConfigureAwait(false);
             try
             {
@@ -238,17 +256,29 @@ namespace ReactNative.Modules.Storage
                     _cachedFolder = null;
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
             }
 
-            callback.Invoke();
+            if (error != null)
+            {
+                callback.Invoke(error);
+            }
+            else
+            {
+                callback.Invoke();
+            }
         }
 
         [ReactMethod]
         public async void getAllKeys(ICallback callback)
         {
+            var error = default(JObject);
             var keys = new JArray();
 
             await _mutex.WaitAsync().ConfigureAwait(false);
@@ -268,12 +298,23 @@ namespace ReactNative.Modules.Storage
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = AsyncStorageHelpers.GetError(ex);
+            }
             finally
             {
                 _mutex.Release();
             }
 
-            callback.Invoke(null, keys);
+            if (error != null)
+            {
+                callback.Invoke(error);
+            }
+            else
+            {
+                callback.Invoke(null, keys);
+            }
         }
 
         public override void OnReactInstanceDispose()


### PR DESCRIPTION
Issue: As of now AsyncStorageModule does not catch any exceptions from the lower layers and so the caller would not know about those errors and this will most likely result in the app crashing since those exceptions might leak as unhandled exceptions.

Fix: Adding catch blocks at the appropriate places and calling the error callback with the exception details.