### PR TITLE
[NetworkingModule]: enabled auto-redirects. Fixed response sent to SimpleWebClient

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Modules/Network/NetworkingModuleTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/Network/NetworkingModuleTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Newtonsoft.Json.Linq;
@@ -344,7 +344,7 @@ namespace ReactNative.Tests.Modules.Network
             var headerData = onReceivedData[2].Value<JObject>();
             Assert.AreEqual("bar", headerData.Value<string>("X-Foo"));
 
-            Assert.AreEqual(uri.AbsolutePath, onReceivedData[3].Value<string>());
+            Assert.AreEqual(uri.AbsoluteUri, onReceivedData[3].Value<string>());
 
             onComplete.WaitOne();
             Assert.IsNotNull(onCompleteData);
@@ -596,6 +596,48 @@ namespace ReactNative.Tests.Modules.Network
             Assert.IsNotNull(onCompleteData);
             AssertNotRequestError(onCompleteData);
             Assert.AreEqual(expected, builder.ToString());
+        }
+
+        [Test]
+        public void NetworkingModule_Response_RedirectedUrl()
+        {
+            var uri = new Uri("http://example.com");
+            var redirectedUri = new Uri("http://foo.com/api?bar=123&token=abcd");
+
+            var onReceived = new AutoResetEvent(false);
+            var onReceivedData = default(JArray);
+
+            var module = CreateNetworkingModule(new MockHttpClient(request =>
+            {
+                // simulating redirect
+                request.RequestUri = redirectedUri;
+#if WINDOWS_UWP
+                var response = new HttpResponseMessage(HttpStatusCode.Ok);
+#else
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+#endif
+                response.RequestMessage = request;
+
+                return response;
+            }),
+            new MockInvocationHandler((name, args) =>
+            {
+                if (name == "emit" && args.Length == 2)
+                {
+                    var eventName = args[0] as string;
+                    if (eventName == "didReceiveNetworkData")
+                    {
+                        onReceivedData = args[1] as JArray;
+                        onReceived.Set();
+                    }
+                }
+            }));
+
+            module.sendRequest("get", uri, 42, null, null, "text", false, 1000);
+
+            onReceived.WaitOne();
+            Assert.AreEqual(42, onReceivedData[0].Value<int>());
+            Assert.AreEqual(redirectedUri.AbsoluteUri, onReceivedData[3].Value<string>());
         }
 
         private static void AssertNotRequestError(JArray onCompleteData)

--- a/ReactWindows/ReactNative.Shared.Tests/Modules/Network/NetworkingModuleTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/Network/NetworkingModuleTests.cs
@@ -625,7 +625,7 @@ namespace ReactNative.Tests.Modules.Network
                 if (name == "emit" && args.Length == 2)
                 {
                     var eventName = args[0] as string;
-                    if (eventName == "didReceiveNetworkData")
+                    if (eventName == "didReceiveNetworkResponse")
                     {
                         onReceivedData = args[1] as JArray;
                         onReceived.Set();

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -423,7 +423,7 @@ namespace ReactNative.Modules.Network
                 requestId,
                 (int)response.StatusCode,
                 headerData,
-                response.RequestMessage.RequestUri.AbsolutePath,
+                response.RequestMessage.RequestUri.AbsoluteUri,
             };
 
             EventEmitter.emit("didReceiveNetworkResponse", args);
@@ -517,7 +517,7 @@ namespace ReactNative.Modules.Network
                 new HttpClient(
                     new HttpBaseProtocolFilter
                     {
-                        AllowAutoRedirect = false,
+                        AllowAutoRedirect = true,
                     }));
         }
     }


### PR DESCRIPTION
- Enabled auto redirects for network requests
**Comment:** without this changes every redirected request will be [rejected](https://github.com/Microsoft/SimpleRestClients/blob/43f734945370206b0d03a8ef77c6eeb24de902a3/src/SimpleWebRequest.ts#L676) by `SimpleWebRequest` JS module.
- Fixed response.url that will be send back to `SimpleWebRequest` JS module
**Comment:** in most of the cases, such as auth stories we are interested in "final" url after all redirections because this url will contain `a token` or any other parameter we need to use later. That is why it is important to return full url back to the JS XmlHttpRequests module.
Example: for url = http://foo.com/api?status=ok&code=bar
`Uri.AbsolutePath:` /api
`Uri.AbsoluteUri:` http://foo.com/api?status=ok&code=bar