### PR TITLE
Multi window race condition fixes

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -422,7 +422,7 @@ namespace ReactNative
             rootView.Children.Clear();
             ViewExtensions.ClearData(rootView);
 
-            await DispatcherHelpers.CallOnDispatcher(() =>
+            await DispatcherHelpers.CallOnDispatcher(async () =>
             {
                 _attachedRootViews.Add(rootView);
 
@@ -433,11 +433,11 @@ namespace ReactNative
                 var currentReactContext = _currentReactContext;
                 if (currentReactContext != null)
                 {
-                    AttachMeasuredRootViewToInstance(rootView, currentReactContext.ReactInstance);
+                    await AttachMeasuredRootViewToInstanceAsync(rootView, currentReactContext.ReactInstance);
                 }
 
                 return true;
-           }, true); // inlining allowed
+           }, true).Unwrap(); // inlining allowed
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace ReactNative
             try
             {
                 var reactContext = await CreateReactContextCoreAsync(jsExecutorFactory, jsBundleLoader, token);
-                SetupReactContext(reactContext);
+                await SetupReactContextAsync(reactContext);
                 return reactContext;
             }
             catch (OperationCanceledException)
@@ -607,7 +607,7 @@ namespace ReactNative
             return null;
         }
 
-        private void SetupReactContext(ReactContext reactContext)
+        private async Task SetupReactContextAsync(ReactContext reactContext)
         {
             DispatcherHelpers.AssertOnDispatcher();
             if (_currentReactContext != null)
@@ -624,7 +624,7 @@ namespace ReactNative
 
             foreach (var rootView in _attachedRootViews)
             {
-                AttachMeasuredRootViewToInstance(rootView, reactInstance);
+                await AttachMeasuredRootViewToInstanceAsync(rootView, reactInstance);
             }
         }
 
@@ -634,13 +634,13 @@ namespace ReactNative
             _defaultBackButtonHandler?.Invoke();
         }
 
-        private void AttachMeasuredRootViewToInstance(
+        private async Task AttachMeasuredRootViewToInstanceAsync(
             ReactRootView rootView,
             IReactInstance reactInstance)
         {
             DispatcherHelpers.AssertOnDispatcher();
-            var rootTag = reactInstance.GetNativeModule<UIManagerModule>()
-                .AddMeasuredRootView(rootView);
+            var rootTag = await reactInstance.GetNativeModule<UIManagerModule>()
+                .AddMeasuredRootViewAsync(rootView);
 
             var jsAppModuleName = rootView.JavaScriptModuleName;
             var appParameters = new Dictionary<string, object>

--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -134,7 +134,9 @@ namespace ReactNative
 
             var getReactContextTaskTask =
                 DispatcherHelpers.CallOnDispatcher(async () => await _reactInstanceManager.GetOrCreateReactContextAsync(CancellationToken.None), true);
- 
+
+            await getReactContextTaskTask.Unwrap();
+
             // We need to wait for the initial `Measure` call, if this view has
             // not yet been measured, we set the `_attachScheduled` flag, which
             // will enable deferred attachment of the root node.
@@ -146,8 +148,6 @@ namespace ReactNative
             {
                 _attachScheduled = true;
             }
-
-            await getReactContextTaskTask.Unwrap();
         }
 
         /// <summary>
@@ -167,6 +167,7 @@ namespace ReactNative
         /// <remarks>
         /// Has to be called under the dispatcher associated with the view.
         /// </remarks>
+        /// <returns>Aeaitable task.</returns>
         public async Task StopReactApplicationAsync()
         {
             DispatcherHelpers.AssertOnDispatcher(this);
@@ -176,6 +177,8 @@ namespace ReactNative
             {
                 await reactInstanceManager.DetachRootViewAsync(this);
             }
+
+            _attachScheduled = false;
         }
 
         /// <summary>
@@ -241,9 +244,9 @@ namespace ReactNative
             var reactInstanceManager = _reactInstanceManager;
             if (_attachScheduled && reactInstanceManager != null)
             {
-                _attachScheduled = false;
-
                 await reactInstanceManager.AttachMeasuredRootViewAsync(this);
+
+                _attachScheduled = false;
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -167,7 +167,7 @@ namespace ReactNative
         /// <remarks>
         /// Has to be called under the dispatcher associated with the view.
         /// </remarks>
-        /// <returns>Aeaitable task.</returns>
+        /// <returns>Awaitable task.</returns>
         public async Task StopReactApplicationAsync()
         {
             DispatcherHelpers.AssertOnDispatcher(this);

--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -663,6 +663,7 @@ namespace ReactNative.UIManager
             _tagsToViewManagers.Add(tag, _rootViewManager);
             _rootTags.Add(tag, true);
 
+            // Keeping here for symmetry, tag on root views is set early, in UIManagerModule.AddMeasuredRootViewAsync
             ViewExtensions.SetTag(view, tag);
             ViewExtensions.SetReactContext(view, themedContext);
 #if WINDOWS_UWP

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -125,7 +125,7 @@ namespace ReactNative.UIManager
         /// JavaScript can use the returned tag with to add or remove children 
         /// to this view through <see cref="manageChildren(int, int[], int[], int[], int[], int[])"/>.
         /// </remarks>
-        public int AddMeasuredRootView(ReactRootView rootView)
+        public async Task<int> AddMeasuredRootViewAsync(ReactRootView rootView)
         {
             // Called on main dispatcher thread
             DispatcherHelpers.AssertOnDispatcher();
@@ -133,9 +133,12 @@ namespace ReactNative.UIManager
             var tag = _nextRootTag;
             _nextRootTag += RootViewTagIncrement;
 
+            // Set tag early to accomodate raceing removals done by DetachRootViewAsync
+            rootView.SetTag(tag);
+
             var context = new ThemedReactContext(Context);
 
-            DispatcherHelpers.RunOnDispatcher(rootView.Dispatcher, () =>
+            await DispatcherHelpers.CallOnDispatcher(rootView.Dispatcher, () =>
             {
                 var width = rootView.ActualWidth;
                 var height = rootView.ActualHeight;
@@ -167,6 +170,7 @@ namespace ReactNative.UIManager
                 // Register view in DeviceInfoModule for tracking its dimensions
                 Context.GetNativeModule<DeviceInfoModule>().RegisterRootView(rootView, tag);
 #endif
+                return true;
             }, true); // Allow inlining
 
             return tag;

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -133,7 +133,7 @@ namespace ReactNative.UIManager
             var tag = _nextRootTag;
             _nextRootTag += RootViewTagIncrement;
 
-            // Set tag early to accomodate raceing removals done by DetachRootViewAsync
+            // Set tag early in case of concurrent DetachRootViewAsync
             rootView.SetTag(tag);
 
             var context = new ThemedReactContext(Context);

--- a/ReactWindows/ReactNative.Tests/Internal/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/DispatcherHelpers.cs
@@ -9,16 +9,26 @@ namespace ReactNative.Tests
 {
     static class DispatcherHelpers
     {
-        public static async Task RunOnDispatcherAsync(Action action)
+        public static Task RunOnDispatcherAsync(Action action)
         {
-            await App.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, new DispatchedHandler(action)).AsTask().ConfigureAwait(false);
+            return RunOnDispatcherAsync(App.Dispatcher, action);
         }
 
-        public static async Task<T> CallOnDispatcherAsync<T>(Func<T> func)
+        public static async Task RunOnDispatcherAsync(CoreDispatcher dispatcher, Action action)
+        {
+            await dispatcher.RunAsync(CoreDispatcherPriority.Normal, new DispatchedHandler(action)).AsTask().ConfigureAwait(false);
+        }
+
+        public static Task<T> CallOnDispatcherAsync<T>(Func<T> func)
+        {
+            return CallOnDispatcherAsync<T>(App.Dispatcher, func);
+        }
+
+        public static async Task<T> CallOnDispatcherAsync<T>(CoreDispatcher dispatcher, Func<T> func)
         {
             var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await RunOnDispatcherAsync(() =>
+            await RunOnDispatcherAsync(dispatcher, () =>
             {
                 try
                 {
@@ -34,11 +44,16 @@ namespace ReactNative.Tests
             return await tcs.Task.ConfigureAwait(false);
         }
 
-        public static async Task CallOnDispatcherAsync(Func<Task> asyncFunc)
+        public static Task CallOnDispatcherAsync(Func<Task> asyncFunc)
+        {
+            return CallOnDispatcherAsync(App.Dispatcher, asyncFunc);
+        }
+
+        public static async Task CallOnDispatcherAsync(CoreDispatcher dispatcher, Func<Task> asyncFunc)
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await RunOnDispatcherAsync(async () =>
+            await RunOnDispatcherAsync(dispatcher, async () =>
             {
                 try
                 {
@@ -54,11 +69,16 @@ namespace ReactNative.Tests
             await tcs.Task.ConfigureAwait(false);
         }
 
-        public static async Task<T> CallOnDispatcherAsync<T>(Func<Task<T>> asyncFunc)
+        public static Task<T> CallOnDispatcherAsync<T>(Func<Task<T>> asyncFunc)
+        {
+            return CallOnDispatcherAsync(App.Dispatcher, asyncFunc);
+        }
+
+        public static async Task<T> CallOnDispatcherAsync<T>(CoreDispatcher dispatcher, Func<Task<T>> asyncFunc)
         {
             var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await RunOnDispatcherAsync(async () =>
+            await RunOnDispatcherAsync(dispatcher, async () =>
             {
                 try
                 {

--- a/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
+++ b/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
@@ -21,6 +21,12 @@
     <DependencyConfiguration>Debug</DependencyConfiguration>
     <PackageCertificateThumbprint>F0FB82837F45EE9E0EFC3B38576F3C1523EAC45A</PackageCertificateThumbprint>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'DebugBundle'">
+    <DependencyConfiguration>Debug</DependencyConfiguration>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' or '$(Configuration)' == 'ReleaseBundle'">
+    <DependencyConfiguration>Release</DependencyConfiguration>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>

--- a/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
+++ b/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile>ReactNative.Tests_TemporaryKey.pfx</PackageCertificateKeyFile>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">14.0</UnitTestPlatformVersion>
+    <DependencyConfiguration>Debug</DependencyConfiguration>
     <PackageCertificateThumbprint>F0FB82837F45EE9E0EFC3B38576F3C1523EAC45A</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -111,6 +112,7 @@
     <Compile Include="Modules\Storage\AsyncStorageModuleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactInstanceManagerTests.cs" />
+    <Compile Include="ReactRootViewTests.cs" />
     <Compile Include="UIManager\BorderedCanvasTests.cs" />
     <Compile Include="UIManager\Events\EventDispatcherTests.cs" />
     <Compile Include="UIManager\Events\EventTests.cs" />
@@ -142,6 +144,7 @@
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="Resources\immediate.js" />
+    <Content Include="Resources\mwtest.js" />
     <Content Include="Resources\sync.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -157,6 +160,13 @@
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\Yoga\csharp\Yoga\bin\Universal\$(Platform)\$(DependencyConfiguration)\yoga.dll">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
   <Import Project="..\ReactNative.Shared.Tests\ReactNative.Shared.Tests.projitems" Label="Shared" />
   <ItemGroup>

--- a/ReactWindows/ReactNative.Tests/ReactRootViewTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactRootViewTests.cs
@@ -45,6 +45,41 @@ namespace ReactNative.Tests
             await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
         }
 
+        [TestMethod]
+        public async Task ReactRootView_SecondaryWindowStress()
+        {
+            var jsBundleFile = "ms-appx:///Resources/mwtest.js";
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
+
+            var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
+                () => manager.CreateReactContextAsync(CancellationToken.None));
+
+            int currentDelay = 2000;
+
+            for (int i = 0; i < 30; i++)
+            {
+                currentDelay /= 2;
+
+                // Create a window
+                var dispatcher = await CreateView(() =>
+                {
+                    var rv = new ReactRootView();
+                    rv.StartReactApplication(
+                        manager,
+                        "alt_window",
+                        null);
+                    return rv;
+                });
+
+                await Task.Delay(currentDelay);
+
+                await CloseView(manager, dispatcher);
+            }
+
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
+        }
+
         private static ReactInstanceManager CreateReactInstanceManager(string jsBundleFile, LifecycleState initialLifecycleState = LifecycleState.Foreground)
         {
             ReactNative.Bridge.DispatcherHelpers.Initialize();

--- a/ReactWindows/ReactNative.Tests/ReactRootViewTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactRootViewTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using ReactNative.Bridge;
+using ReactNative.Common;
+using ReactNative.Modules.Core;
+using ReactNative.UIManager;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace ReactNative.Tests
+{
+    [TestClass]
+    public class ReactRootViewTests
+    {
+        [TestMethod]
+        public async Task ReactRootView_SecondaryWindow()
+        {
+            var jsBundleFile = "ms-appx:///Resources/mwtest.js";
+            ReactInstanceManager manager = null;
+            await DispatcherHelpers.CallOnDispatcherAsync(() => manager = CreateReactInstanceManager(jsBundleFile));
+
+            var reactContext = await DispatcherHelpers.CallOnDispatcherAsync(
+                () => manager.CreateReactContextAsync(CancellationToken.None));
+
+            var dispatcher = await CreateView(() =>
+            {
+                var rv = new ReactRootView();
+                rv.StartReactApplication(
+                    manager,
+                    "alt_window",
+                    null);
+                return rv;
+            });
+
+            await CloseView(manager, dispatcher);
+
+            await DispatcherHelpers.CallOnDispatcherAsync(async () => await DisposeInstanceManager(manager));
+        }
+
+        private static ReactInstanceManager CreateReactInstanceManager(string jsBundleFile, LifecycleState initialLifecycleState = LifecycleState.Foreground)
+        {
+            ReactNative.Bridge.DispatcherHelpers.Initialize();
+            ReactChoreographer.Initialize();
+
+            return new ReactInstanceManagerBuilder
+            {
+                InitialLifecycleState = initialLifecycleState,
+                JavaScriptBundleFile = jsBundleFile,
+            }.Build();
+        }
+
+        private static async Task DisposeInstanceManager(ReactInstanceManager manager)
+        {
+            await manager.DisposeAsync();
+
+            // Go back to the initial state as set by the host test app
+            ReactNative.Bridge.DispatcherHelpers.Initialize();
+        }
+
+        private static async Task<CoreDispatcher> CreateView(Func<ReactRootView> rootViewCreateAction)
+        {
+            var dispatcherTask = DispatcherHelpers.CallOnDispatcherAsync<CoreDispatcher>(async () =>
+            {
+                    CoreApplicationView newView = CoreApplication.CreateNewView();
+                    int newViewId = 0;
+                    var dispatcher = newView.Dispatcher;
+
+                    await DispatcherHelpers.CallOnDispatcherAsync(dispatcher, () =>
+                    {
+                        Frame frame = new Frame();
+
+                        Window.Current.Content = frame;
+
+                        frame.Content = new Page
+                        {
+                            Content = rootViewCreateAction(),
+                        };
+
+                        // You have to activate the window in order to show it later.
+                        Window.Current.Activate();
+
+                        newViewId = ApplicationView.GetForCurrentView().Id;
+
+                        return true;
+                    });
+
+                    bool viewShown = await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newViewId);
+
+                    return dispatcher;
+            });
+
+            return await dispatcherTask;
+        }
+
+        private static async Task CloseView(ReactInstanceManager manager, CoreDispatcher dispatcher)
+        {
+            await DispatcherHelpers.CallOnDispatcherAsync(dispatcher, async () =>
+            {
+                var window = Window.Current;
+                if (window != null)
+                {
+                    var frame = window.Content as Frame;
+                    if (frame != null)
+                    {
+                        var page = frame.Content as Page;
+                        if (page != null)
+                        {
+                            var rootView = page.Content as ReactRootView;
+                            if (rootView != null)
+                            {
+                                await rootView.StopReactApplicationAsync();
+
+                                Window.Current.Close();
+                                page.Content = null;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/Resources/mwtest.js
+++ b/ReactWindows/ReactNative.Tests/Resources/mwtest.js
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+function require(name) {
+  return this[name];
+}
+
+// Extract the remoteRootView method from config
+var modconfig = __fbBatchedBridgeConfig.remoteModuleConfig;
+var uiManagerModuleId = modconfig.findIndex(descr => descr[0] === 'UIManager');
+var uiManagerConfig = modconfig[uiManagerModuleId];
+var removeRootMethodId = uiManagerConfig[2].findIndex(name => name === 'removeRootView');
+
+var FunctionCalls = new Array();
+var CallbackCalls = new Array();
+var BatchedBridge =
+  {
+    'callFunctionReturnFlushedQueue': function (moduleId, methodId, args) {
+      FunctionCalls.push([moduleId, methodId, args]);
+
+      if (moduleId === 'AppRegistry' &&
+        methodId === 'unmountApplicationComponentAtRootTag') {
+        return [[uiManagerModuleId], [removeRootMethodId], [[args[0]]]];
+      } else {
+        return [[], [], []];
+      }
+    },
+    'invokeCallbackAndReturnFlushedQueue': function (callbackId, args) {
+      CallbackCalls.push([callbackId, args]);
+      return [[], [], []];
+    },
+    'flushedQueue': function (args) {
+      return [[], [], []];
+    }
+  };
+
+var __fbBatchedBridge = BatchedBridge;
+
+


### PR DESCRIPTION
1. Sometimes JS tried to create views before the parent root view has been added to shadow tree. This is due to UIManagerModule.AddMeasuredRootView being a "fire and forget" method. We made this an awaitable asynchronous function, so now AppRegistry.runApplication is only called after the measured root view addition completed.
2. Back to back "create/remove" root view operations had some corner cases (trying to remove a root view when its tag hasn't been set yet, or trying to remove a root view that is still waiting for measuring to occur)
Fixed those.
3. Added a stress UT.