### PR TITLE
Cache heavily used JS method references in Native executor

### DIFF
--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
@@ -116,7 +116,13 @@ public:
     /// </summary>
     void SetCallSyncHook(CallSyncHandler^ handler);
 private:
+    JsErrorCode CheckAndGetMethodRef(const wchar_t* methodName, JsValueRef &value);
+    void SafeReleaseJsValueRef(JsValueRef &value);
+
     ChakraHost host;
+    JsValueRef callFunctionMethod;
+    JsValueRef invokeCallbackMethod;
+    JsValueRef flushQueueMethod;
 };
 
 };


### PR DESCRIPTION
Cache heavily used JS method references for better speed and memory consumption in the Native executor.
(inspired by a more or less similar fix in the Chakra executor)