### PR TITLE
Bug fix for delegated shadow nodes

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
@@ -450,12 +450,6 @@ namespace ReactNative.UIManager
             {
                 if (IsDelegatedLayout)
                 {
-                    if (!_hasChildLayoutChanged)
-                    {
-                        // We cache the "changed" value from the child Yoga node so we can mark
-                        // the current shadow node as seen separately from the child.
-                        _hasChildLayoutChanged = _yogaNode?.HasNewLayout ?? false;
-                    }
                     return _hasChildLayoutChanged;
                 }
                 return _yogaNode?.HasNewLayout ?? false;
@@ -574,6 +568,16 @@ namespace ReactNative.UIManager
                 }
 
                 _yogaNode.SetMeasureFunction(value);
+            }
+        }
+
+        public void BeforeDispatchUpdatesToDescendants()
+        {
+            if (IsDelegatedLayout)
+            {
+                // We cache the "changed" value from the child Yoga node so we can mark
+                // the current shadow node as seen separately from the child.
+                _hasChildLayoutChanged = _yogaNode?.HasNewLayout ?? false;
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
@@ -571,16 +571,6 @@ namespace ReactNative.UIManager
             }
         }
 
-        public void BeforeDispatchUpdatesToDescendants()
-        {
-            if (IsDelegatedLayout)
-            {
-                // We cache the "changed" value from the child Yoga node so we can mark
-                // the current shadow node as seen separately from the child.
-                _hasChildLayoutChanged = _yogaNode?.HasNewLayout ?? false;
-            }
-        }
-
         /// <summary>
         /// Sets the margin for the node.
         /// </summary>
@@ -1301,6 +1291,16 @@ namespace ReactNative.UIManager
             _nodeUpdated = true;
             var parent = Parent;
             parent?.MarkUpdated();
+        }
+
+        internal void BeforeDispatchUpdatesToDescendants()
+        {
+            if (IsDelegatedLayout)
+            {
+                // We cache the "changed" value from the child Yoga node so we can mark
+                // the current shadow node as seen separately from the child.
+                _hasChildLayoutChanged = _yogaNode?.HasNewLayout ?? false;
+            }
         }
 
         private void UpdateNativeChildrenCountInParent(int delta)

--- a/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIImplementation.cs
@@ -877,6 +877,8 @@ namespace ReactNative.UIManager
             float absoluteX,
             float absoluteY)
         {
+            cssNode.BeforeDispatchUpdatesToDescendants();
+
             if (!cssNode.HasUpdates)
             {
                 return;


### PR DESCRIPTION
A subtle bug had been introduced with the delegated shadow nodes:

We piggyback on ReactShadownNode.HasNewLayout to compute/cache the "has new layout" from the delegated shadow node, as part of processing  ReactShadownNode.HasUpdates.
Relying on method with side effect proved to be bad choice, HasNewLayout can be easily shortcut if _nodeUpdated is true (HasUpdates => _nodeUpdated || HasNewLayout || IsDirty)

The fix moves the relevant code to an independent step.