### PR TITLE
Dispose TouchHandler on ReactRootView.StopReactApplication*

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -172,6 +172,8 @@ namespace ReactNative
         {
             DispatcherHelpers.AssertOnDispatcher(this);
 
+            TouchHandler.Dispose();
+
             var reactInstanceManager = _reactInstanceManager;
             if (!_attachScheduled && reactInstanceManager != null)
             {


### PR DESCRIPTION
TouchHandler classes have a Dispose method that unsubscribes the instances from touch events.
This method is not currently called.

The fix adds the call to ReactRootView.StopReactApplicationAsync. It addresses a race condition that was exacerbated by a bug in our application (app closed the root view on click):
- application calls ReactRootView.StopReactApplicationAsync
- around that time, user clicks the area
- some events (like capture lost, etc.) may get dispatched to TouchHandler after the root view has lost its custom properties (tag, react context)
- the code in TouchHandler crashes when trying to execute _view.GetReactContext().