### PR TITLE
Fix race condition that can trigger the duplicate registration of a root view

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -173,12 +173,12 @@ namespace ReactNative
             DispatcherHelpers.AssertOnDispatcher(this);
 
             var reactInstanceManager = _reactInstanceManager;
-            if (!_attachScheduled && reactInstanceManager != null)
+            var attachScheduled = _attachScheduled;
+            _attachScheduled = false;
+            if (!attachScheduled && reactInstanceManager != null)
             {
                 await reactInstanceManager.DetachRootViewAsync(this);
             }
-
-            _attachScheduled = false;
         }
 
         /// <summary>
@@ -242,11 +242,11 @@ namespace ReactNative
             _wasMeasured = true;
 
             var reactInstanceManager = _reactInstanceManager;
-            if (_attachScheduled && reactInstanceManager != null)
+            var attachScheduled = _attachScheduled;
+            _attachScheduled = false;
+            if (attachScheduled && reactInstanceManager != null)
             {
                 await reactInstanceManager.AttachMeasuredRootViewAsync(this);
-
-                _attachScheduled = false;
             }
         }
 


### PR DESCRIPTION
A corner case exists when all these are true:
- A root view is created and its adding to React instance is deferred for when the measuring happens.
- More than one MeasureOverride happen in a quick sequence
- The second (for ex.) MeasureOverride is executed before the first one completed the "reactInstanceManager.AttachMeasuredRootViewAsync(this)". 

The end result is the *this ReactRootView being added more than once. Results are catastrophic.

Fixed by correctly taking a snapshot/resetting the flag before any asynchronous operation is launched.
 