### PR TITLE
Fix flag handling in RecreateReactContextAsync

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -286,7 +286,20 @@ namespace ReactNative
                         "create context background call.");
                 }
 
-                return await CreateReactContextCoreAsync(token);
+                ReactContext context = null;
+                try
+                {
+                    context = await CreateReactContextCoreAsync(token);
+                }
+                finally
+                {
+                    if (context == null)
+                    {
+                        _hasStartedCreatingInitialContext = false;
+                    }
+                }
+
+                return context;
             }
         }
 


### PR DESCRIPTION
Some time ago the handling of _hasStartedCreatingInitialContext was fixed to take into account failure scenarios (when the returning context is null). For some reason this tweak was not done in RecreateReactContextAsync.

Perhaps this is due to the name of the variable ending up not being very correct anymore.. Due to the serialization done by the awaitable lock, _hasStartedCreatingInitialContext == true means context exists, and _hasStartedCreatingInitialContext == false that it doesn't.

So a call of RecreateReactContextAsync that fails moves ReactInstanceManager into an unrecoverable state (_hasStartedCreatingInitialContext remains true, whereas context remains null).
The fix tries to address this issue.