### PR TITLE
Expose selection from RN.Text

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -250,6 +250,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Views\Text\ReactRunShadowNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\Text\ReactSpanShadowNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\Text\ReactSpanViewManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Views\Text\ReactTextBlockSelectionEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\Text\ReactTextInlineViewManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\TextInput\InputScopeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\TextInput\ReactPasswordBoxShadowNode.cs" />

--- a/ReactWindows/ReactNative.Shared/Views/Text/ReactTextBlockSelectionEvent.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/ReactTextBlockSelectionEvent.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+using ReactNative.UIManager.Events;
+
+namespace ReactNative.Views.Text
+{
+    class ReactTextBlockSelectionEvent : Event
+    {
+        private readonly string _selectedText;
+
+        public ReactTextBlockSelectionEvent(int viewTag, string selectedText)
+            : base(viewTag)
+        {
+            _selectedText = selectedText;
+        }
+
+        public override string EventName
+        {
+            get
+            {
+                return "topSelectionChange";
+            }
+        }
+
+        public override void Dispatch(RCTEventEmitter eventEmitter)
+        {
+            var eventData = new JObject
+            {
+                { "selectedText", _selectedText },
+            };
+            eventEmitter.receiveEvent(ViewTag, EventName, eventData);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
+++ b/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\Text\ReactTextViewManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="UnitTestApp.xaml">

--- a/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
@@ -23,7 +23,7 @@ namespace ReactNative.Tests.Views.Text
             TextPointer start = paragraph.ContentStart.GetPositionAtOffset(8, LogicalDirection.Forward);
             TextPointer end = paragraph.ContentStart.GetPositionAtOffset(12, LogicalDirection.Forward);
             var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
-            Assert.AreEqual(text, "test");
+            Assert.AreEqual(text, @"test");
         }
 
         [UTFAC.UITestMethod]
@@ -49,7 +49,7 @@ namespace ReactNative.Tests.Views.Text
             TextPointer start = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
             TextPointer end = paragraph.ContentStart.GetPositionAtOffset(54, LogicalDirection.Forward);
             var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
-            Assert.AreEqual(text, "Four");
+            Assert.AreEqual(text, @"Four");
         }
 
         [UTFAC.UITestMethod]
@@ -75,7 +75,7 @@ namespace ReactNative.Tests.Views.Text
             TextPointer start = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
             TextPointer end = paragraph.ContentStart.GetPositionAtOffset(54, LogicalDirection.Forward);
             var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
-            Assert.AreEqual(text, "Four");
+            Assert.AreEqual(text, @"Four");
         }
 
         [UTFAC.UITestMethod]
@@ -102,6 +102,32 @@ namespace ReactNative.Tests.Views.Text
             TextPointer end = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
             var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
             Assert.AreEqual(text, @"http://www.test.com/");
+        }
+
+        [UTFAC.UITestMethod]
+        public void ReactTextViewManager_Selection_InlineUIContainer()
+        {
+            // <Span><Run>Sample test text.</Run><Run>Second text.</Run></Span><Run>Third text.</Run><InlineUIContainer><TextBlock Text='InlineUIContainerText'/></InlineUIContainer>
+            Span span = new Span();
+            Run run = new Run();
+            run.Text = "Sample test text.";
+            span.Inlines.Add(run);
+            Run run1 = new Run();
+            run1.Text = "Second text.";
+            span.Inlines.Add(run1);
+            Run run2 = new Run();
+            run2.Text = "Third text.";
+            InlineUIContainer inlineUIContainer = new InlineUIContainer();
+            TextBlock tb = new TextBlock();
+            tb.Text = "InlineUIContainerText";
+            inlineUIContainer.Child = tb;
+
+            RichTextBlock rtb = CreateWithInlines(new Inline[] { span, run2, inlineUIContainer });
+            Paragraph paragraph = rtb.Blocks.First() as Paragraph;
+            TextPointer start = paragraph.ContentStart.GetPositionAtOffset(49, LogicalDirection.Forward);
+            TextPointer end = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
+            var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
+            Assert.AreEqual(text, @"InlineUIContainerText");
         }
 
         private RichTextBlock CreateWithInlines(Inline[] inlines)

--- a/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
@@ -78,6 +78,32 @@ namespace ReactNative.Tests.Views.Text
             Assert.AreEqual(text, "Four");
         }
 
+        [UTFAC.UITestMethod]
+        public void ReactTextViewManager_Selection_HyperlinkText()
+        {
+            // <Span><Run>Sample test text.</Run><Run>Second text.</Run></Span><Run>Third text.</Run><Span><Hyperlink NavigateUri='http://www.test.com'>HyperlinkTest.</Hyperlink></Span>
+            Span span = new Span();
+            Run run = new Run();
+            run.Text = "Sample test text.";
+            span.Inlines.Add(run);
+            Run run1 = new Run();
+            run1.Text = "Second text.";
+            span.Inlines.Add(run1);
+            Run run2 = new Run();
+            run2.Text = "Third text.";
+            Span span1 = new Span();
+            Hyperlink hyperlink = new Hyperlink();
+            hyperlink.NavigateUri = new System.Uri("http://www.test.com");
+            span1.Inlines.Add(hyperlink);
+
+            RichTextBlock rtb = CreateWithInlines(new Inline[] { span, run2, span1 });
+            Paragraph paragraph = rtb.Blocks.First() as Paragraph;
+            TextPointer start = paragraph.ContentStart.GetPositionAtOffset(49, LogicalDirection.Forward);
+            TextPointer end = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
+            var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
+            Assert.AreEqual(text, @"http://www.test.com/");
+        }
+
         private RichTextBlock CreateWithInlines(Inline[] inlines)
         {
             RichTextBlock rtb = new RichTextBlock();

--- a/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
@@ -26,6 +26,32 @@ namespace ReactNative.Tests.Views.Text
             Assert.AreEqual(text, "test");
         }
 
+        [UTFAC.UITestMethod]
+        public void ReactTextViewManager_Selection_SpanText()
+        {
+            // <Span><Run>Sample test text.</Run><Run>Second text.</Run></Span><Run>Third text.</Run><Span><Run>Fourth text.</Run></Span>
+            Span span = new Span();
+            Run run = new Run();
+            run.Text = "Sample test text.";
+            span.Inlines.Add(run);
+            Run run1 = new Run();
+            run1.Text = "Second text.";
+            span.Inlines.Add(run1);
+            Run run2 = new Run();
+            run2.Text = "Third text.";
+            Span span1 = new Span();
+            Run run3 = new Run();
+            run3.Text = "Fourth text.";
+            span1.Inlines.Add(run3);
+
+            RichTextBlock rtb = CreateWithInlines(new Inline[] { span, run2, span1 });
+            Paragraph paragraph = rtb.Blocks.First() as Paragraph;
+            TextPointer start = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
+            TextPointer end = paragraph.ContentStart.GetPositionAtOffset(54, LogicalDirection.Forward);
+            var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
+            Assert.AreEqual(text, "Four");
+        }
+
         private RichTextBlock CreateWithInlines(Inline[] inlines)
         {
             RichTextBlock rtb = new RichTextBlock();

--- a/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
@@ -52,6 +52,32 @@ namespace ReactNative.Tests.Views.Text
             Assert.AreEqual(text, "Four");
         }
 
+        [UTFAC.UITestMethod]
+        public void ReactTextViewManager_Selection_BoldUnderlineText()
+        {
+            // <Bold><Run>Sample test text.</Run><Run>Second text.</Run></Bold><Run>Third text.</Run><Underline><Run>Fourth text.</Run></Underline>
+            Bold bold = new Bold();
+            Run run = new Run();
+            run.Text = "Sample test text.";
+            bold.Inlines.Add(run);
+            Run run1 = new Run();
+            run1.Text = "Second text.";
+            bold.Inlines.Add(run1);
+            Run run2 = new Run();
+            run2.Text = "Third text.";
+            Underline underline = new Underline();
+            Run run3 = new Run();
+            run3.Text = "Fourth text.";
+            underline.Inlines.Add(run3);
+
+            RichTextBlock rtb = CreateWithInlines(new Inline[] { bold, run2, underline });
+            Paragraph paragraph = rtb.Blocks.First() as Paragraph;
+            TextPointer start = paragraph.ContentStart.GetPositionAtOffset(50, LogicalDirection.Forward);
+            TextPointer end = paragraph.ContentStart.GetPositionAtOffset(54, LogicalDirection.Forward);
+            var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
+            Assert.AreEqual(text, "Four");
+        }
+
         private RichTextBlock CreateWithInlines(Inline[] inlines)
         {
             RichTextBlock rtb = new RichTextBlock();

--- a/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/Views/Text/ReactTextViewManagerTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using UTFAC = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.AppContainer;
+using ReactNative.Views.Text;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Documents;
+
+namespace ReactNative.Tests.Views.Text
+{
+    [TestClass]
+    public class ReactTextViewManagerTests
+    {
+        [UTFAC.UITestMethod]
+        public void ReactTextViewManager_Selection_PlainText()
+        {
+            Run run = new Run();
+            run.Text = "Sample test text.";
+            RichTextBlock rtb = CreateWithInlines(new Inline[] {run});
+            Paragraph paragraph = rtb.Blocks.First() as Paragraph;
+            TextPointer start = paragraph.ContentStart.GetPositionAtOffset(8, LogicalDirection.Forward);
+            TextPointer end = paragraph.ContentStart.GetPositionAtOffset(12, LogicalDirection.Forward);
+            var text = ReactTextViewManager.GetStringByStartAndEndPointers(rtb, start, end);
+            Assert.AreEqual(text, "test");
+        }
+
+        private RichTextBlock CreateWithInlines(Inline[] inlines)
+        {
+            RichTextBlock rtb = new RichTextBlock();
+            Paragraph par = new Paragraph();
+            foreach (Inline inline in inlines)
+            {
+                par.Inlines.Add(inline);
+            }
+            rtb.Blocks.Add(par);
+            return rtb;
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -241,7 +241,19 @@ namespace ReactNative.Views.Text
             TextPointer selectionStart = view.SelectionStart;
             TextPointer selectionEnd = view.SelectionEnd;
 
-            if (selectionStart == null || selectionEnd == null || selectionStart == selectionEnd)
+            return GetStringByStartAndEndPointers(view, selectionStart, selectionEnd);
+        }
+
+        /// <summary>
+        /// Returns a text representation of the elements between <paramref name="start"/> and <paramref name="end"/> in the RichTextBlock.
+        /// </summary>
+        /// <param name="view">The RichTextBlock.</param>
+        /// <param name="start">Start TextPointer.</param>
+        /// <param name="end">End TextPointer.</param>
+        /// <returns></returns>
+        public static string GetStringByStartAndEndPointers(RichTextBlock view, TextPointer start, TextPointer end)
+        {
+            if (start == null || end == null || start == end)
             {
                 return null;
             }
@@ -250,7 +262,7 @@ namespace ReactNative.Views.Text
             StringBuilder selectedText = new StringBuilder();
             Debug.Assert(view.Blocks.Count == 1, "RichTextBlock is expected to contain only one paragraph.");
             Paragraph paragraph = view.Blocks.First() as Paragraph;
-            ProcessSelectedInlines(paragraph.Inlines, selectedText, false, selectionStart, selectionEnd);
+            ProcessSelectedInlines(paragraph.Inlines, selectedText, false, start, end);
 
             return selectedText.ToString();
         }
@@ -264,7 +276,7 @@ namespace ReactNative.Views.Text
         /// <param name="selectionStart">TextPointer to selection start.</param>
         /// <param name="selectionEnd">TextPointer to selection end.</param>
         /// <returns>'true' if recursion terminal condition is met.</returns>
-        private bool ProcessSelectedInlines(
+        private static bool ProcessSelectedInlines(
             InlineCollection inlines,
             StringBuilder selectedText,
             bool accumulate,

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -7,7 +7,9 @@ using ReactNative.Accessibility;
 using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
@@ -184,6 +186,192 @@ namespace ReactNative.Views.Text
             richTextBlock.SetReactCompoundView(s_compoundView);
 
             return richTextBlock;
+        }
+
+        /// <summary>
+        /// Installing the event emitters for the RichTextBlock control.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The RichTextBlock view instance.</param>
+        protected override void AddEventEmitters(ThemedReactContext reactContext, RichTextBlock view)
+        {
+            base.AddEventEmitters(reactContext, view);
+            view.SelectionChanged += OnSelectionChanged;
+        }
+
+        /// <summary>
+        /// Called when view is detached from view hierarchy and allows for 
+        /// additional cleanup by the <see cref="ReactTextViewManager"/>.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view.</param>
+        public override void OnDropViewInstance(ThemedReactContext reactContext, RichTextBlock view)
+        {
+            base.OnDropViewInstance(reactContext, view);
+            view.SelectionChanged -= OnSelectionChanged;
+        }
+
+        /// <summary>
+        /// Called when selection changes for the RichTextBlock.
+        /// </summary>
+        /// <param name="sender">The RichTextBlock that is the source of the event.</param>
+        /// <param name="e">Event arguments.</param>
+        private void OnSelectionChanged(object sender, RoutedEventArgs e)
+        {
+            RichTextBlock view = sender as RichTextBlock;
+            string selection = GetSelectedString(view);
+
+            // Fire the event.
+            view.GetReactContext()
+                .GetNativeModule<UIManagerModule>()
+                .EventDispatcher
+                .DispatchEvent(
+                    new ReactTextBlockSelectionEvent(
+                        view.GetTag(),
+                        selection));
+        }
+
+        /// <summary>
+        /// Returns a text representation of the selection in the RichTextBlock.
+        /// </summary>
+        /// <param name="view">The RichTextBlock.</param>
+        /// <returns>Text representation of the selection.</returns>
+        private string GetSelectedString(RichTextBlock view)
+        {
+            TextPointer selectionStart = view.SelectionStart;
+            TextPointer selectionEnd = view.SelectionEnd;
+
+            if (selectionStart == null || selectionEnd == null || selectionStart == selectionEnd)
+            {
+                return null;
+            }
+
+            // Parse the RichTextBlock contents.
+            StringBuilder selectedText = new StringBuilder();
+            Debug.Assert(view.Blocks.Count == 1, "RichTextBlock is expected to contain only one paragraph.");
+            Paragraph paragraph = view.Blocks.First() as Paragraph;
+            ProcessSelectedInlines(paragraph.Inlines, selectedText, false, selectionStart, selectionEnd);
+
+            return selectedText.ToString();
+        }
+
+        /// <summary>
+        /// Recursively processes InlineCollection and builds text representation of the RichTextBlock selected content.
+        /// </summary>
+        /// <param name="inlines">InlineCollection to be processed.</param>
+        /// <param name="selectedText">Will contain the text representation upon procedure completion.</param>
+        /// <param name="accumulate">If 'true', includes inlines as part of the processed selection.</param>
+        /// <param name="selectionStart">TextPointer to selection start.</param>
+        /// <param name="selectionEnd">TextPointer to selection end.</param>
+        /// <returns>'true' if recursion terminal condition is met.</returns>
+        private bool ProcessSelectedInlines(
+            InlineCollection inlines,
+            StringBuilder selectedText,
+            bool accumulate,
+            TextPointer selectionStart,
+            TextPointer selectionEnd)
+        {
+            foreach (Inline inline in inlines)
+            {
+                // Begin building the string from selectionStart.
+                if (!accumulate && (object.ReferenceEquals(inline, selectionStart.Parent) || selectionStart.Offset <= inline.ContentEnd.Offset))
+                {
+                    accumulate = true;
+                }
+
+                // Check for terminal condition.
+                if (inline.ContentStart.Offset > selectionEnd.Offset)
+                {
+                    return true;
+                }
+
+                switch (inline)
+                {
+                    case Hyperlink hyperlink:
+                        if (hyperlink.NavigateUri != null)
+                        {
+                            if (accumulate)
+                            {
+                                selectedText.Append(hyperlink.NavigateUri.ToString());
+                            }
+                        }
+                        else
+                        {
+                            if (ProcessSelectedInlines(hyperlink.Inlines, selectedText, accumulate, selectionStart, selectionEnd))
+                            {
+                                return true;
+                            }
+                        }
+                        break;
+                    // Also covers Bold, Italic, Underline.
+                    case Span span:
+                        if (ProcessSelectedInlines(span.Inlines, selectedText, accumulate, selectionStart, selectionEnd))
+                        {
+                            return true;
+                        }
+                        break;
+                    case Run run:
+                        if (accumulate)
+                        {
+                            int rangeStart = 0;
+                            // Check for selection start in this run.
+                            if (object.ReferenceEquals(inline, selectionStart.Parent))
+                            {
+                                rangeStart = selectionStart.Offset - inline.ContentStart.Offset;
+                            }
+                            // Check for selection end in this run.
+                            if (object.ReferenceEquals(inline, selectionEnd.Parent))
+                            {
+                                int rangeEnd = selectionEnd.Offset - inline.ContentStart.Offset;
+                                selectedText.Append(run.Text.Substring(rangeStart, rangeEnd - rangeStart));
+                            }
+                            else
+                            {
+                                selectedText.Append(run.Text.Substring(rangeStart));
+                            }
+                        }
+                        break;
+                    case LineBreak lineBreak:
+                        if (accumulate)
+                        {
+                            selectedText.AppendLine();
+                        }
+                        break;
+                    case InlineUIContainer inlineUIContainer:
+                        if (accumulate)
+                        {
+                            // Since InlineUIContainer can contain any UIElement as a child, we'll make some assumptions in order to simplify processing.
+                            // 1. Entire InlineUIContainer content is considered selected.
+                            // 2. If the child is a TextBlock, its Text property returns the entire content properly (since it can't contain InlineUIContainers).
+                            // 3. If the InlineUIContainer Child is a Panel, we process only TextBlock children (and not RichTextBlocks) so that we limit recursion.
+                            if (inlineUIContainer.Child is TextBlock textBlock)
+                            {
+                                selectedText.Append(textBlock.Text);
+                            }
+                            else if (inlineUIContainer.Child is Panel panel)
+                            {
+                                foreach (UIElement uiElement in panel.Children)
+                                {
+                                    if (uiElement is TextBlock panelTextBlock)
+                                    {
+                                        selectedText.Append(panelTextBlock.Text);
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                }
+
+                // Check for terminal condition.
+                if (object.ReferenceEquals(inline, selectionEnd.Parent))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
This will expose selection from RichTextBlock. When selection occurs, the code parses the content and builds a text string equivalent of the content (with certain assumptions). This is intended to allow for partial select/copy/paste functionality. Unit tests were also added.