### PR TITLE
Register react-native-windows as an out-of-tree platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     "yeoman-generator": "^0.21.2"
   },
   "rnpm": {
+    "haste": {
+      "platforms": ["windows"],
+      "providesModuleNodeModules": ["react-native-windows"]
+    },
     "plugin": "./local-cli/index.js",
     "platform": "./local-cli/platform.js"
   }


### PR DESCRIPTION
React Native 0.57 [will let out-of-tree platforms register themselves](https://github.com/facebook/react-native/commit/03476a225e012a0285650780430d64fc79674f0f) using a "haste" key under the "rnpm" key in package.json. This pull will let react-native-windows get picked up by the React Native bundler.

Right now against 0.57 a complete bundle is not yet possible - the bundler sees the files with the `.windows.js` suffix, but because RNWindows is currently meant for RN 0.55 the structure is slightly different and some files are missing, e.g.:

```
Error: Unable to resolve module `ViewContext` from `{snipped}/node_modules/react-native-windows/Libraries/Image/Image.windows.js`: Module `ViewContext` does not exist in the Haste module map
```