### PR TITLE
fixed initial state of password box

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -280,6 +280,17 @@ namespace ReactNative.Views.TextInput
             view.MaxLength = maxCharLength;
         }
 
+		/// <summary>
+		/// Sets the password prop on the <see cref="PasswordBox"/>.
+		/// </summary>
+		/// <param name="view">The view instance.</param>
+		/// <param name="value">The value.</param>
+		[ReactProp("text")]
+		public void SetText(PasswordBox view, string value)
+		{
+			view.Password = value;
+		}
+
         /// <summary>
         /// Sets the keyboard type on the <see cref="PasswordBox"/>.
         /// </summary>


### PR DESCRIPTION
Fixes the initial state of the password input field according to https://github.com/Microsoft/react-native-windows/issues/1934
