### PR TITLE
Multi window support for context re-creation and other fixes

### DIFF
--- a/ReactWindows/ReactNative.Net46/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative.Net46/Touch/TouchHandler.cs
@@ -323,7 +323,7 @@ namespace ReactNative.Touch
 
             var touchEvent = new TouchEvent(touchEventType, touches, changedIndices, coalescingKey);
 
-            _view.GetReactContext()
+            _view.GetReactContext()?
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher
                 .DispatchEvent(touchEvent);

--- a/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
@@ -109,5 +109,13 @@ namespace ReactNative.UIManager
         {
             DispatcherHelpers.RunOnDispatcher(action);
         }
+
+        /// <summary>
+        /// Called when the host is shutting down.
+        /// </summary>
+        public new void OnDestroy()
+        {
+            DispatcherHelpers.RunOnDispatcher(base.OnDestroy);
+        }
     }
 }

--- a/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/UIViewOperationQueue.cs
@@ -115,7 +115,7 @@ namespace ReactNative.UIManager
         /// </summary>
         public new void OnDestroy()
         {
-            DispatcherHelpers.RunOnDispatcher(base.OnDestroy);
+            DispatcherHelpers.RunOnDispatcher(base.OnDestroy, true);
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleWrapperBaseTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Bridge/NativeModuleWrapperBaseTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using ReactNative.Bridge;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ReactNative.Tests.Bridge
 {
@@ -26,7 +27,7 @@ namespace ReactNative.Tests.Bridge
         }
 
         [Test]
-        public void NativeModuleWrapperBase_ProxiedValues()
+        public async Task NativeModuleWrapperBase_ProxiedValues()
         {
             var initialized = 0;
             var disposed = 0;
@@ -45,7 +46,7 @@ namespace ReactNative.Tests.Bridge
 
             wrapper.Initialize();
             Assert.AreEqual(1, initialized);
-            wrapper.OnReactInstanceDispose();
+            await wrapper.DisposeAsync();
             Assert.AreEqual(1, disposed);
         }
 
@@ -106,10 +107,10 @@ namespace ReactNative.Tests.Bridge
 
             public Action OnOnReactInstanceDispose;
 
-            public override void OnReactInstanceDispose()
+            public override Task OnReactInstanceDisposeAsync()
             {
                 OnOnReactInstanceDispose?.Invoke();
-                base.OnReactInstanceDispose();
+                return base.OnReactInstanceDisposeAsync();
             }
         }
     }

--- a/ReactWindows/ReactNative.Shared/Bridge/INativeModule.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/INativeModule.cs
@@ -18,7 +18,7 @@ namespace ReactNative.Bridge
     /// should extend <see cref="NativeModuleBase"/> or
     /// <see cref="ReactContextNativeModuleBase"/>.
     /// </remarks>
-    public interface INativeModule
+    public interface INativeModule : IAsyncDisposable
     {
         /// <summary>
         /// The action queue used by the native module.
@@ -63,10 +63,5 @@ namespace ReactNative.Bridge
         /// JavaScript modules.
         /// </summary>
         void Initialize();
-
-        /// <summary>
-        /// Called before a <see cref="IReactInstance"/> is disposed.
-        /// </summary>
-        void OnReactInstanceDispose();
     }
 }

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleBase.cs
@@ -9,6 +9,7 @@ using ReactNative.Tracing;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using static System.FormattableString;
 
 namespace ReactNative.Bridge
@@ -33,7 +34,7 @@ namespace ReactNative.Bridge
     /// </summary>
     /// <remarks>
     /// Default implementations of <see cref="Initialize"/> and 
-    /// <see cref="OnReactInstanceDispose"/> are provided for convenience.
+    /// <see cref="OnReactInstanceDisposeAsync"/> are provided for convenience.
     /// Subclasses need not call these base methods should they choose to
     /// override them.
     /// </remarks>
@@ -202,8 +203,34 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Called before a <see cref="IReactInstance"/> is disposed.
         /// </summary>
+        [Obsolete("Deprecated in favor of OnReactInstanceDisposeAsync")]
         public virtual void OnReactInstanceDispose()
         {
+        }
+
+        /// <summary>
+        /// Disposes the module before the <see cref="IReactInstance"/> is disposed.
+        /// </summary>
+        /// <returns>
+        /// A task to await the dispose operation.
+        /// </returns>
+        public Task DisposeAsync()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            OnReactInstanceDispose();
+#pragma warning restore CS0618 // Type or member is obsolete
+            return OnReactInstanceDisposeAsync();
+        }
+
+        /// <summary>
+        /// Called before a <see cref="IReactInstance"/> is disposed.
+        /// </summary>
+        /// <returns>
+        /// A task to await the dispose operation.
+        /// </returns>
+        public virtual Task OnReactInstanceDisposeAsync()
+        {
+            return Task.CompletedTask;
         }
 
         private IReadOnlyDictionary<string, INativeMethod> InitializeMethods()

--- a/ReactWindows/ReactNative.Shared/Bridge/NativeModuleWrapperBase.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/NativeModuleWrapperBase.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using ReactNative.Bridge.Queue;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ReactNative.Bridge
 {
@@ -78,9 +79,12 @@ namespace ReactNative.Bridge
         public void Initialize() => Module.Initialize();
 
         /// <summary>
-        /// Called before a <see cref="IReactInstance"/> is disposed.
+        /// Disposes the module before the <see cref="IReactInstance"/> is disposed.
         /// </summary>
-        public void OnReactInstanceDispose() => Module.OnReactInstanceDispose();
+        /// <returns>
+        /// A task to await the dispose operation.
+        /// </returns>
+        public Task DisposeAsync() => Module.DisposeAsync();
 
         INativeModule INativeModuleWrapper.Module => Module;
 

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
@@ -174,7 +174,7 @@ namespace ReactNative.Bridge
 
             IsDisposed = true;
 
-            await QueueConfiguration.NativeModulesQueue.RunAsync(_registry.NotifyReactInstanceDispose).ConfigureAwait(false);
+            await QueueConfiguration.NativeModulesQueue.RunAsync(_registry.NotifyReactInstanceDisposeAsync).Unwrap().ConfigureAwait(false);
             await QueueConfiguration.JavaScriptQueue.RunAsync(() => _bridge?.Dispose()).ConfigureAwait(false);
             QueueConfiguration.Dispose();
         }

--- a/ReactWindows/ReactNative.Shared/Modules/Core/IReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/IReactChoreographer.cs
@@ -45,5 +45,11 @@ namespace ReactNative.Modules.Core
         /// </summary>
         /// <param name="callbackKey">The callback key.</param>
         void DeactivateCallback(string callbackKey);
+
+        /// <summary>
+        /// Returns true if the choreographer is associated with main I thread.
+        /// </summary>
+        /// <returns>true for the main choreographer</returns>
+        bool IsMainChoreographer();
     }
 }

--- a/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ReactChoreographer.cs
@@ -97,6 +97,15 @@ namespace ReactNative.Modules.Core
             }
         }
 
+        /// <summary>
+        /// Returns true if the choreographer is associated with main UI thread.
+        /// </summary>
+        /// <returns>true for the main choreographer</returns>
+        public bool IsMainChoreographer()
+        {
+            return this == s_instance;
+        }
+
 #if WINDOWS_UWP
         /// <summary>
         /// Factory for choreographer instances associated with non main-view dispatchers.

--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ReactNative.Modules.Core
 {
@@ -199,9 +200,10 @@ namespace ReactNative.Modules.Core
         /// <summary>
         /// Called before a <see cref="IReactInstance"/> is disposed.
         /// </summary>
-        public override void OnReactInstanceDispose()
+        public override Task OnReactInstanceDisposeAsync()
         {
             _idleCancellationDisposable.Dispose();
+            return Task.CompletedTask;
         }
 
         private void DoFrameSafe(object sender, object e)

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -223,11 +223,12 @@ namespace ReactNative.Modules.Network
         /// <summary>
         /// Called before a <see cref="IReactInstance"/> is disposed.
         /// </summary>
-        public override void OnReactInstanceDispose()
+        public override Task OnReactInstanceDisposeAsync()
         {
             _shuttingDown = true;
             _tasks.CancelAllTasks();
             _client.Dispose();
+            return Task.CompletedTask;
         }
 
         private async Task ProcessRequestFromUriAsync(

--- a/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative.Shared/ReactInstanceManager.cs
@@ -691,13 +691,23 @@ namespace ReactNative
 
             _lifecycleStateMachine.SetContext(null);
 
+            // Existing root views should be silenced before tearing down the context.
+            // Most of the work is done by the tearing down of the context itself, yet the native root views continue to exist,
+            // so things like "size changes" or touch handling should be stopped immediately.
             foreach (var rootView in _attachedRootViews)
             {
-                rootView.CleanupSafe();
+                // Inlining allowed
+                DispatcherHelpers.RunOnDispatcher(rootView.Dispatcher, () =>
+                {
+                    rootView.RemoveSizeChanged();
+
+                    rootView.StopTouchHandling();
+                }, true);
             }
 
             await reactContext.DisposeAsync();
             _devSupportManager.OnReactContextDestroyed(reactContext);
+
             // TODO: add memory pressure hooks
         }
 

--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -63,7 +63,7 @@ namespace ReactNative
         /// </summary>
         internal TouchHandler TouchHandler
         {
-            get;
+            get; private set;
         }
 
         /// <summary>
@@ -172,8 +172,6 @@ namespace ReactNative
         {
             DispatcherHelpers.AssertOnDispatcher(this);
 
-            TouchHandler.Dispose();
-
             var reactInstanceManager = _reactInstanceManager;
             var attachScheduled = _attachScheduled;
             _attachScheduled = false;
@@ -201,6 +199,23 @@ namespace ReactNative
             return result;
         }
 
+        internal void StartTouchHandling()
+        {
+            if (TouchHandler == null)
+            {
+                TouchHandler = new TouchHandler(this);
+            }
+        }
+
+        internal void StopTouchHandling()
+        {
+            if (TouchHandler != null)
+            {
+                TouchHandler.Dispose();
+                TouchHandler = null;
+            }
+        }
+
 #if WINDOWS_UWP
         /// <summary>
         /// Override ensuring the creation of an AutomationPeer for ReactRootView 
@@ -222,20 +237,6 @@ namespace ReactNative
             return peer;
         }
 #endif
-
-        internal void CleanupSafe()
-        {
-            // Inlining allowed
-            DispatcherHelpers.RunOnDispatcher(this.Dispatcher, Cleanup, true);
-        }
-
-        internal void Cleanup()
-        {
-            DispatcherHelpers.AssertOnDispatcher(this);
-
-            Children.Clear();
-            ViewExtensions.ClearData(this);
-        }
 
         private async Task MeasureOverrideHelperAsync()
         {

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -166,6 +166,8 @@ namespace ReactNative.UIManager
                     });
                 });
 
+                rootView.StartTouchHandling();
+
 #if WINDOWS_UWP
                 // Register view in DeviceInfoModule for tracking its dimensions
                 Context.GetNativeModule<DeviceInfoModule>().RegisterRootView(rootView, tag);
@@ -189,6 +191,8 @@ namespace ReactNative.UIManager
             await DispatcherHelpers.CallOnDispatcher(rootView.Dispatcher, () =>
             {
                 rootView.RemoveSizeChanged();
+
+                rootView.StopTouchHandling();
 #if WINDOWS_UWP
                 // Unregister view from DeviceInfoModule
                 Context.GetNativeModule<DeviceInfoModule>().UnregisterRootView(rootView);
@@ -634,9 +638,11 @@ namespace ReactNative.UIManager
         /// <summary>
         /// Called before a <see cref="IReactInstance"/> is disposed.
         /// </summary>
-        public override void OnReactInstanceDispose()
+        public override Task OnReactInstanceDisposeAsync()
         {
+            _uiImplementation.OnDestroy();
             _eventDispatcher.OnReactInstanceDispose();
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueueInstance.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIViewOperationQueueInstance.cs
@@ -404,7 +404,11 @@ namespace ReactNative.UIManager
             // Must be called in the context of the dispatcher thread corresponding to this queue
             _reactChoreographer.DispatchUICallback -= OnRenderingSafe;
 
-            (_reactChoreographer as IDisposable).Dispose();
+            // Don't dispose main choreographer, there's a great chance it will be reused
+            if (!_reactChoreographer.IsMainChoreographer())
+            {
+                (_reactChoreographer as IDisposable).Dispose();
+            }
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
@@ -183,9 +183,11 @@ namespace ReactNative.Tests.Bridge
                 OnInitialized?.Invoke();
             }
 
-            public override void OnReactInstanceDispose()
+            public override Task OnReactInstanceDisposeAsync()
             {
                 OnReactInstanceDisposeCalls++;
+
+                return Task.CompletedTask;
             }
         }
 
@@ -206,9 +208,10 @@ namespace ReactNative.Tests.Bridge
                 }
             }
 
-            public override void OnReactInstanceDispose()
+            public override Task OnReactInstanceDisposeAsync()
             {
                 _onDispose();
+                return Task.CompletedTask;
             }
         }
 

--- a/ReactWindows/ReactNative/Modules/Image/ImageLoaderModule.cs
+++ b/ReactWindows/ReactNative/Modules/Image/ImageLoaderModule.cs
@@ -174,9 +174,10 @@ namespace ReactNative.Modules.Image
             promise.Resolve(result);
         }
 
-        public override void OnReactInstanceDispose()
+        public override Task OnReactInstanceDisposeAsync()
         {
             _prefetchRequests.CancelAllTasks();
+            return Task.CompletedTask;
         }
     }
 }

--- a/ReactWindows/ReactNative/Modules/Location/LocationModule.cs
+++ b/ReactWindows/ReactNative/Modules/Location/LocationModule.cs
@@ -143,9 +143,10 @@ namespace ReactNative.Modules.Location
             _currentSubscription.Disposable = Disposable.Empty;
         }
 
-        public override void OnReactInstanceDispose()
+        public override Task OnReactInstanceDisposeAsync()
         {
             _currentSubscription.Dispose();
+            return Task.CompletedTask;
         }
 
         private static JObject ConvertGeoposition(Geoposition geoposition)

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -317,9 +317,11 @@ namespace ReactNative.Modules.Storage
             }
         }
 
-        public override void OnReactInstanceDispose()
+        public override Task OnReactInstanceDisposeAsync()
         {
             _mutex.Dispose();
+
+            return Task.CompletedTask;
         }
 
         private async Task<string> GetAsync(string key)

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -252,7 +252,7 @@ namespace ReactNative.Touch
 
             var touchEvent = new TouchEvent(touchEventType, touches, changedIndices, coalescingKey);
 
-            _view.GetReactContext()
+            _view.GetReactContext()?
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher
                 .DispatchEvent(touchEvent);


### PR DESCRIPTION
Fixed the cleanup/leaks of the 2 "recreate react context" scenarios:
- signing out
- reload JS (CTRL/R, etc)

For all cases (single/multi window) made sure:
- all view/view manager state is cleaned by making sure the usual NativeViewHierarchy.DropView code paths are called for al cases
- keep touch handlers disabled during the limbo phase

For multi window we correctly destroy the old choreographers so new ones can take their place.
All JS root view apps are restarted after a "recreate react context". If the fresh JS app can't support these re-appearing ghost root views, it's that app's responsibility to close the secondary top level windows.

Note: this includes Eric Rozell's "asynchronous module dispose" commit: rozele@f67fc1b