### PR TITLE
Workaround note for current compat bug in Getting Started guide

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -54,6 +54,8 @@ yarn add rnpm-plugin-windows --dev
 
 #### Initialize your project
 
+***temporary workaround***: At this time, there is a new bug that will prevent the next step from working. From your project directory, delete `package-lock.json`, open `package.json` in a text editor and change the `"dependencies"` section for `react-native` to: `"react-native": "0.55.*"`, then save & close. Next, delete the entire `node_modules` directory in your project directory and run, `npm install` from your project directory. You can then proceed to the next intended step for this guide.  
+
 Initialize your React Native Windows project in the project directory by running:
 ```
 react-native windows


### PR DESCRIPTION
The current Getting Started guide requires a workaround due to react-native being set to `0.57.x` after running `react-native init <project name>`; it currently needs to be `0.55.x` which console error messages will clearly indicate. Currently this bug is preventing the use of the command, `react-native windows` until applying the workaround.

Whatever is occurring when `react-native init <project name>` runs fixing the version incompatibilities would be optimal, but I don't know how or where to address that, so for now I can at least provide this workaround for react-native windows newbies like myself.