### PR TITLE
[UWP] Added mouse move support and fixes some mouse enter/leave scenarios

### DIFF
--- a/Libraries/Components/View/PlatformViewPropTypes.windows.js
+++ b/Libraries/Components/View/PlatformViewPropTypes.windows.js
@@ -61,4 +61,76 @@ module.exports = {
     'no-hide-descendants',
     'yes-dont-hide-descendants',
   ]),
+
+  /**
+   * Mouse move handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseMove: PropTypes.func,
+
+  /**
+   * Mouse move (capturing phase) handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseMoveCapture: PropTypes.func,  
+
+  /**
+   * Mouse over handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseOver: PropTypes.func,
+
+  /**
+   * Mouse over (capturing phase) handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseOverCapture: PropTypes.func,  
+
+  /**
+   * Mouse out handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseOut: PropTypes.func,
+
+  /**
+   * Mouse out (capturing phase) handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseOutCapture: PropTypes.func,  
+
+  /**
+   * Mouse enter handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+
+  onMouseEnter: PropTypes.func,
+  /**
+   * Mouse leave handler. 
+   * This is explicitly defined here in order to be able to have an associated "handler detection" property 
+   * on the native side
+   *
+   * @platform windows
+   */
+  onMouseLeave: PropTypes.func,
 };

--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -277,6 +277,27 @@ namespace ReactNative.UIManager
             view.Effect = effect;
         }
 
+        /// <summary>
+        /// Detects the presence of a various mouse view handler for the view.
+        /// </summary>
+        /// <param name="view">The view instance.</param>
+        /// <param name="index">The prop index.</param>
+        /// <param name="handlerPresent">true if a mouse move handler is present.</param>
+        [ReactPropGroup(
+            "onMouseMove",
+            "onMouseMoveCapture",
+            "onMouseOver",
+            "onMouseOverCapture",
+            "onMouseOut",
+            "onMouseOutCapture",
+            "onMouseEnter",
+            "onMouseOutLeave")]
+        public void SetOnMouseHandler(TFrameworkElement view, int index, bool handlerPresent)
+        {
+            // The order of handler names HAS TO match order in ViewExtensions.MouseHandlerMask
+            view.SetMouseHandlerPresent((ViewExtensions.MouseHandlerMask)(1 << index), handlerPresent);
+        }
+
         private static void SetProjectionMatrix(TFrameworkElement view, Dimensions dimensions, JArray transforms)
         {
             var transformMatrix = TransformHelper.ProcessTransform(transforms);

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventType.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -40,5 +40,10 @@ namespace ReactNative.UIManager.Events
         /// Pointer exited event type.
         /// </summary>
         Exited,
+
+        /// <summary>
+        /// Pointer move event type.
+        /// </summary>
+        PointerMove
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventTypeExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventTypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -25,6 +25,8 @@ namespace ReactNative.UIManager.Events
                     return "topMouseOver";
                 case TouchEventType.Exited:
                     return "topMouseOut";
+                case TouchEventType.PointerMove:
+                    return "topMouseMoveCustom"; // TBA
                 default:
                     throw new NotSupportedException("Unsupported touch event type.");
             }

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventTypeExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventTypeExtensions.cs
@@ -26,7 +26,7 @@ namespace ReactNative.UIManager.Events
                 case TouchEventType.Exited:
                     return "topMouseOut";
                 case TouchEventType.PointerMove:
-                    return "topMouseMoveCustom"; // TBA
+                    return "topMouseMoveCustom"; // Using a non-clashing name until this one propagates: https://github.com/facebook/react/commit/e96dc140599363029bd05565d58bcd4a432db370
                 default:
                     throw new NotSupportedException("Unsupported touch event type.");
             }

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
@@ -265,6 +265,20 @@ namespace ReactNative.UIManager
                     }
                 },
                 {
+                    TouchEventType.PointerMove.GetJavaScriptEventName(),
+                    new JObject
+                    {
+                        {
+                            "phasedRegistrationNames",
+                            new JObject
+                            {
+                                { "bubbled", "onMouseMove" },
+                                { "captured", "onMouseMoveCapture" },
+                            }
+                        }
+                    }
+                },
+                {
                     "topFocus",
                     new JObject
                     {

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewExtensions.cs
@@ -15,6 +15,19 @@ namespace ReactNative.UIManager
             new ConcurrentDictionary<object, ViewData>();
         private static readonly IReactCompoundView s_defaultCompoundView = new ReactDefaultCompoundView();
 
+        [Flags]
+        public enum MouseHandlerMask
+        {
+            MouseMove =        0x01,
+            MouseMoveCapture = 0x02,
+            MouseOver =        0x04,
+            MouseOverCapture = 0x08,
+            MouseOut =         0x10,
+            MouseOutCapture =  0x20,
+            MouseEnter =       0x40,
+            MouseLeave =       0x80
+        }
+
         /// <summary>
         /// Sets the pointer events for the view.
         /// </summary>
@@ -159,6 +172,50 @@ namespace ReactNative.UIManager
             return elementData.Context;
         }
 
+        /// <summary>
+        /// Sets mouse handler presence for the view. Tracks multiple handlers, whereas the getter returns an "OR" value.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="handlerMask">Affected handlers.</param>
+        /// <param name="handlerPresent">true if handler present, false otherwise.</param>
+        internal static void SetMouseHandlerPresent(this object view, MouseHandlerMask handlerMask, bool handlerPresent)
+        {
+            if (view == null)
+                throw new ArgumentNullException(nameof(view));
+
+            var data = s_properties.GetOrAdd(view, (v) => new ViewData());
+            if (handlerPresent)
+            {
+                data.MouseHandlers |= handlerMask;
+            }
+            else
+            {
+                data.MouseHandlers &= ~handlerMask;
+            }
+        }
+
+        /// <summary>
+        /// Gets the mouse handler presence for the view.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="handlerMask">Affected handlers.</param>
+        /// <returns>
+        /// true if a any handler from the handlerMask is enabled on the view, false otherwise.
+        /// </returns>
+        public static bool GetMouseHandlerPresent(this object view, MouseHandlerMask handlerMask)
+        {
+            if (view == null)
+                throw new ArgumentNullException(nameof(view));
+
+            if (s_properties.TryGetValue(view, out var elementData))
+            {
+                return (elementData.MouseHandlers & handlerMask) != 0;
+            }
+
+            return false;
+        }
+
+
         internal static void ClearData(this object view)
         {
             s_properties.TryRemove(view, out _);
@@ -173,6 +230,8 @@ namespace ReactNative.UIManager
             public int? Tag { get; set; }
 
             public IReactCompoundView CompoundView { get; set; }
+
+            public MouseHandlerMask MouseHandlers { get; set; }
         }
     }
 }

--- a/ReactWindows/ReactNative.Tests/UIManager/UIManagerModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/UIManagerModuleTests.cs
@@ -69,6 +69,8 @@ namespace ReactNative.Tests.UIManager
                 Assert.AreEqual("onMouseOverCapture", constants.GetMap("genericBubblingEventTypes").GetMap("topMouseOver").GetMap("phasedRegistrationNames").GetValue("captured").Value<string>());
                 Assert.AreEqual("onMouseOut", constants.GetMap("genericBubblingEventTypes").GetMap("topMouseOut").GetMap("phasedRegistrationNames").GetValue("bubbled").Value<string>());
                 Assert.AreEqual("onMouseOutCapture", constants.GetMap("genericBubblingEventTypes").GetMap("topMouseOut").GetMap("phasedRegistrationNames").GetValue("captured").Value<string>());
+                Assert.AreEqual("onMouseMove", constants.GetMap("genericBubblingEventTypes").GetMap("topMouseMoveCustom").GetMap("phasedRegistrationNames").GetValue("bubbled").Value<string>());
+                Assert.AreEqual("onMouseMoveCapture", constants.GetMap("genericBubblingEventTypes").GetMap("topMouseMoveCustom").GetMap("phasedRegistrationNames").GetValue("captured").Value<string>());
 
                 Assert.AreEqual("onSelectionChange", constants.GetMap("genericDirectEventTypes").GetMap("topSelectionChange").GetValue("registrationName").Value<string>());
                 Assert.AreEqual("onLoadingStart", constants.GetMap("genericDirectEventTypes").GetMap("topLoadingStart").GetValue("registrationName").Value<string>());

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -364,7 +364,7 @@ namespace ReactNative.Touch
 
         private static bool ShouldSendPointerMoveEvent(DependencyObject view)
         {
-            // This is a bubbling event, so we have to check if mouse move hanlder is hooked to any ancestor 
+            // This is a bubbling event, so we have to check if mouse move handler is hooked to any ancestor 
             return RootViewHelper.GetReactViewHierarchy(view).Any(
                 v => v.GetMouseHandlerPresent(
                     ViewExtensions.MouseHandlerMask.MouseMove |
@@ -543,7 +543,6 @@ namespace ReactNative.Touch
                 }
             }
         }
-
 
         class ReactPointer
         {

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
+using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Input;
 using Windows.UI.ViewManagement;
@@ -28,6 +29,8 @@ namespace ReactNative.Touch
 
         private uint _pointerIDs;
 
+        private readonly Dictionary<uint, HashSet<DependencyObject>> _pointersInViews;
+
         public TouchHandler(FrameworkElement view)
         {
             _view = view;
@@ -39,7 +42,10 @@ namespace ReactNative.Touch
                 { UIElement.PointerReleasedEvent, new PointerEventHandler(OnPointerReleased) },
                 { UIElement.PointerCanceledEvent, new PointerEventHandler(OnPointerCanceled) },
                 { UIElement.PointerCaptureLostEvent, new PointerEventHandler(OnPointerCaptureLost) },
+                { UIElement.PointerExitedEvent, new PointerEventHandler(OnPointerExited) },
             };
+
+            _pointersInViews = new Dictionary<uint, HashSet<DependencyObject>>();
 
             foreach (KeyValuePair<RoutedEvent, PointerEventHandler> handler in _pointerHandlers)
             {
@@ -53,6 +59,7 @@ namespace ReactNative.Touch
             {
                 _view.RemoveHandler(handler.Key, handler.Value);
             }
+            _pointersInViews.Clear();
         }
 
         private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
@@ -68,24 +75,10 @@ namespace ReactNative.Touch
             var reactView = GetReactViewTarget(e) as UIElement;
             if (reactView != null && _view.CapturePointer(e.Pointer))
             {
-                var viewPoint = e.GetCurrentPoint(reactView);
-                var reactTag = reactView.GetReactCompoundView().GetReactTagAtPoint(reactView, viewPoint.Position);
-                var pointer = new ReactPointer
-                {
-                    Target = reactTag,
-                    PointerId = e.Pointer.PointerId,
-                    Identifier = ++_pointerIDs,
-                    PointerType = e.Pointer.PointerDeviceType.GetPointerDeviceTypeName(),
-                    IsLeftButton = viewPoint.Properties.IsLeftButtonPressed,
-                    IsRightButton = viewPoint.Properties.IsRightButtonPressed,
-                    IsMiddleButton = viewPoint.Properties.IsMiddleButtonPressed,
-                    IsHorizontalMouseWheel = viewPoint.Properties.IsHorizontalMouseWheel,
-                    IsEraser = viewPoint.Properties.IsEraser,
-                    ReactView = reactView,
-                };
+                // Pointer pressing updates the enter/leave state
+                UpdatePointersInViews(reactView, rootPoint, e);
 
-                UpdatePointerForEvent(pointer, rootPoint, viewPoint);
-
+                var pointer = CreateReactPointer(reactView, rootPoint, e, true);
                 var pointerIndex = _pointers.Count;
                 _pointers.Add(pointer);
                 DispatchTouchEvent(TouchEventType.Start, _pointers, pointerIndex);
@@ -97,9 +90,34 @@ namespace ReactNative.Touch
             var pointerIndex = IndexOfPointerWithId(e.Pointer.PointerId);
             if (pointerIndex != -1)
             {
+                // Touch/Dragging case
                 var pointer = _pointers[pointerIndex];
                 UpdatePointerForEvent(pointer, e);
                 DispatchTouchEvent(TouchEventType.Move, _pointers, pointerIndex);
+            }
+            else
+            {
+                // Moving case (with no buttons pressed)
+                var originalSource = e.OriginalSource as DependencyObject;
+                var rootPoint = e.GetCurrentPoint(_view);
+                var reactView = GetReactViewTarget(e) as UIElement;
+                if (reactView != null)
+                {
+                    // Moving a non captured pointer updates the enter/leave state
+                    UpdatePointersInViews(reactView, rootPoint, e);
+                    if (ShouldSendPointerMoveEvent(reactView))
+                    {
+                        var pointer = CreateReactPointer(reactView, rootPoint, e, true);
+                        pointerIndex = _pointers.Count;
+                        _pointers.Add(pointer);
+                        DispatchTouchEvent(TouchEventType.PointerMove, _pointers, pointerIndex);
+                        _pointers.Remove(pointer);
+                        if (_pointers.Count == 0)
+                        {
+                            _pointerIDs = 0;
+                        }
+                    }
+                }
             }
         }
 
@@ -136,6 +154,16 @@ namespace ReactNative.Touch
 
                 _view.ReleasePointerCapture(e.Pointer);
             }
+        }
+
+        private void OnPointerExited(object sender, PointerRoutedEventArgs e)
+        {
+            // UWP only calls this on the "_view" when pointer exits it. There's no bubbling from children involved
+            // Documentation is a little confusing on this one.
+
+            // Update the "pointers in views" state
+            var rootPoint = e.GetCurrentPoint(_view);
+            UpdatePointersInViews(null, rootPoint, e);
         }
 
         private int IndexOfPointerWithId(uint pointerId)
@@ -209,15 +237,102 @@ namespace ReactNative.Touch
 
             return source;
         }
+       
+        private void UpdatePointersInViews(UIElement reactView, PointerPoint rootPoint, PointerRoutedEventArgs e)
+        {
+            // Create list of react views that should be tracked
+            var newViews = reactView != null ? new HashSet<DependencyObject>(RootViewHelper.GetReactViewHierarchy(reactView)) :
+                new HashSet<DependencyObject>();
+
+            // Get existing list of react views for the pointer id
+            HashSet<DependencyObject> existingViews;
+            if (!_pointersInViews.TryGetValue(e.Pointer.PointerId, out existingViews))
+            {
+                existingViews = new HashSet<DependencyObject>();
+            }
+
+            // Return quick if list didn't change
+            if (newViews.SetEquals(existingViews))
+            {
+                return;
+            }
+
+            // Notify the tags that disappeared from the list if:
+            // - there's still a tag associated with the view (it hasn't been removed from tree)
+            // - there's a need (driven by handlers hooked on the JS side) to send events
+            foreach (var existingView in existingViews)
+            {
+                if (!newViews.Contains(existingView) &&
+                    existingView.HasTag() &&
+                    ShouldSendPointerEnterLeaveOverOutEvent(existingView, out var enterOrLeave, out var overOrOut))
+                {
+                    // XXX pass granular enterOrLeave/overOrOut
+                    OnPointerEnteredExited(TouchEventType.Exited, (UIElement)existingView, rootPoint, e);
+                }
+            }
+
+            // Notify the new views that showed up if:
+            // - there's a need (driven by handlers hooked on the JS side) to send events
+            foreach (var newView in newViews)
+            {
+                if (!existingViews.Contains(newView) &&
+                    ShouldSendPointerEnterLeaveOverOutEvent(newView, out var enterOrLeave, out var overOrOut))
+                {
+                    // TBA
+                    OnPointerEnteredExited(TouchEventType.Entered, (UIElement)newView, rootPoint, e);
+                }
+            }
+
+            _pointersInViews[e.Pointer.PointerId] = newViews;
+        }
+
+        private ReactPointer CreateReactPointer(UIElement reactView, PointerPoint rootPoint, PointerRoutedEventArgs e, bool detectSubcomponent)
+        {
+            var viewPoint = e.GetCurrentPoint(reactView);
+            var reactTag = detectSubcomponent ?
+                reactView.GetReactCompoundView().GetReactTagAtPoint(reactView, viewPoint.Position) :
+                reactView.GetTag();
+            var pointer = new ReactPointer
+            {
+                Target = reactTag,
+                PointerId = e.Pointer.PointerId,
+                Identifier = ++_pointerIDs,
+                PointerType = e.Pointer.PointerDeviceType.GetPointerDeviceTypeName(),
+                IsLeftButton = viewPoint.Properties.IsLeftButtonPressed,
+                IsRightButton = viewPoint.Properties.IsRightButtonPressed,
+                IsMiddleButton = viewPoint.Properties.IsMiddleButtonPressed,
+                IsHorizontalMouseWheel = viewPoint.Properties.IsHorizontalMouseWheel,
+                IsEraser = viewPoint.Properties.IsEraser,
+                ReactView = reactView,
+            };
+
+            UpdatePointerForEvent(pointer, rootPoint, viewPoint, e.KeyModifiers);
+            return pointer;
+        }
+
+        private void OnPointerEnteredExited(TouchEventType eventType, UIElement view, PointerPoint rootPoint, PointerRoutedEventArgs e)
+        {
+            var pointer = CreateReactPointer(view, rootPoint, e, false);
+            view.GetReactContext()?
+                    .GetNativeModule<UIManagerModule>()
+                    .EventDispatcher
+                    .DispatchEvent(
+                        new PointerEnterExitEvent(eventType, view.GetTag(), pointer));
+            // Keeps resetting the identifier if no other non-moving pointer is present
+            if (_pointers.Count == 0)
+            {
+                _pointerIDs = 0;
+            }
+        }
 
         private void UpdatePointerForEvent(ReactPointer pointer, PointerRoutedEventArgs e)
         {
             var rootPoint = e.GetCurrentPoint(_view);
             var viewPoint = e.GetCurrentPoint(pointer.ReactView);
-            UpdatePointerForEvent(pointer, rootPoint, viewPoint);
+            UpdatePointerForEvent(pointer, rootPoint, viewPoint, e.KeyModifiers);
         }
 
-        private void UpdatePointerForEvent(ReactPointer pointer, PointerPoint rootPoint, PointerPoint viewPoint)
+        private void UpdatePointerForEvent(ReactPointer pointer, PointerPoint rootPoint, PointerPoint viewPoint, VirtualKeyModifiers keyModifiers)
         {
             var positionInRoot = rootPoint.Position;
             var positionInView = viewPoint.Position;
@@ -230,9 +345,44 @@ namespace ReactNative.Touch
             pointer.Force = rootPoint.Properties.Pressure;
             pointer.IsBarrelButtonPressed = rootPoint.Properties.IsBarrelButtonPressed;
 
-            pointer.ShiftKey = Window.Current.CoreWindow.GetKeyState(Windows.System.VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-            pointer.AltKey = Window.Current.CoreWindow.GetKeyState(Windows.System.VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
-            pointer.CtrlKey = Window.Current.CoreWindow.GetKeyState(Windows.System.VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            pointer.ShiftKey = keyModifiers.HasFlag(VirtualKeyModifiers.Shift);
+            pointer.AltKey = keyModifiers.HasFlag(VirtualKeyModifiers.Menu);
+            pointer.CtrlKey = keyModifiers.HasFlag(VirtualKeyModifiers.Control);
+        }
+
+        private static bool ShouldSendPointerMoveEvent(DependencyObject view)
+        {
+            // This is a bubbling event, so we have to check if mouse move hanlder is hooked to any ancestor 
+            return RootViewHelper.GetReactViewHierarchy(view).Any(
+                v => v.GetMouseHandlerPresent(
+                    ViewExtensions.MouseHandlerMask.MouseMove |
+                    ViewExtensions.MouseHandlerMask.MouseMoveCapture));
+        }
+
+        private static bool ShouldSendPointerEnterLeaveOverOutEvent(DependencyObject view, out bool enterOrLeave, out bool overOrOut)
+        {
+            // "view" parameter can be any view in the view hierarchy starting from the chosen react target.
+            // Due to the way the choosing of the react target works, these views are guaranteed not to be "box-only" nor "none".
+            // Still, some can be "box-none", and they should NOT be chosen as enter/leave/over/out targets
+            if (view.GetPointerEvents() == PointerEvents.BoxNone)
+            {
+                enterOrLeave = false;
+                overOrOut = false;
+                return false;
+            }
+
+            enterOrLeave = view.GetMouseHandlerPresent(
+                    ViewExtensions.MouseHandlerMask.MouseEnter |
+                    ViewExtensions.MouseHandlerMask.MouseLeave);
+
+            overOrOut = RootViewHelper.GetReactViewHierarchy(view).Any(
+                v => v.GetMouseHandlerPresent(
+                    ViewExtensions.MouseHandlerMask.MouseOver |
+                    ViewExtensions.MouseHandlerMask.MouseOverCapture |
+                    ViewExtensions.MouseHandlerMask.MouseOut |
+                    ViewExtensions.MouseHandlerMask.MouseOutCapture));
+
+            return enterOrLeave || overOrOut;
         }
 
         private void DispatchTouchEvent(TouchEventType touchEventType, List<ReactPointer> activePointers, int pointerIndex)
@@ -245,7 +395,7 @@ namespace ReactNative.Touch
 
             var changedIndices = new JArray
             {
-                JToken.FromObject(pointerIndex)
+                pointerIndex
             };
 
             var coalescingKey = activePointers[pointerIndex].PointerId;
@@ -300,7 +450,7 @@ namespace ReactNative.Touch
             {
                 get
                 {
-                    return _touchEventType == TouchEventType.Move;
+                    return _touchEventType == TouchEventType.Move || _touchEventType == TouchEventType.PointerMove;
                 }
             }
 
@@ -320,7 +470,59 @@ namespace ReactNative.Touch
                 eventEmitter.receiveTouches(EventName, _touches, _changedIndices);
             }
         }
-        
+
+        class PointerEnterExitEvent : Event
+        {
+            private readonly TouchEventType _touchEventType;
+            private readonly ReactPointer _pointer;
+
+            public PointerEnterExitEvent(TouchEventType touchEventType, int viewTag, ReactPointer pointer)
+                : base(viewTag)
+            {
+                _touchEventType = touchEventType;
+                _pointer = pointer;
+            }
+
+            public override string EventName
+            {
+                get
+                {
+                    return _touchEventType.GetJavaScriptEventName();
+                }
+            }
+
+            public override bool CanCoalesce
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public override void Dispatch(RCTEventEmitter eventEmitter)
+            {
+                var eventData = JObject.FromObject(_pointer);
+
+                var enterLeaveEventName = default(string);
+                if (_touchEventType == TouchEventType.Entered)
+                {
+                    enterLeaveEventName = "topMouseEnter";
+                }
+                else if (_touchEventType == TouchEventType.Exited)
+                {
+                    enterLeaveEventName = "topMouseLeave";
+                }
+
+                if (enterLeaveEventName != null)
+                {
+                    eventEmitter.receiveEvent(ViewTag, enterLeaveEventName, eventData);
+                }
+
+                eventEmitter.receiveEvent(ViewTag, EventName, eventData);
+            }
+        }
+
+
         class ReactPointer
         {
             [JsonProperty(PropertyName = "target")]

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -438,57 +438,5 @@ namespace ReactNative.UIManager
 
             public JArray MatrixTransform { get; set; }
         }
-
-        class PointerEnterExitEvent : Event
-        {
-            private readonly TouchEventType _touchEventType;
-
-            public PointerEnterExitEvent(TouchEventType touchEventType, int viewTag)
-                : base(viewTag)
-            {
-                _touchEventType = touchEventType;
-            }
-
-            public override string EventName
-            {
-                get
-                {
-                    return _touchEventType.GetJavaScriptEventName();
-                }
-            }
-
-            public override bool CanCoalesce
-            {
-                get
-                {
-                    return false;
-                }
-            }
-
-            public override void Dispatch(RCTEventEmitter eventEmitter)
-            {
-                var eventData = new JObject
-                {
-                    { "target", ViewTag },
-                };
-
-                var enterLeaveEventName = default(string);
-                if (_touchEventType == TouchEventType.Entered)
-                {
-                    enterLeaveEventName = "topMouseEnter";
-                }
-                else if (_touchEventType == TouchEventType.Exited)
-                {
-                    enterLeaveEventName = "topMouseLeave";
-                }
-
-                if (enterLeaveEventName != null)
-                {
-                    eventEmitter.receiveEvent(ViewTag, enterLeaveEventName, eventData);
-                }
-
-                eventEmitter.receiveEvent(ViewTag, EventName, eventData);
-            }
-        }
     }
 }


### PR DESCRIPTION
1. Added "mouse move" support.
2. Change "mouse enter/leave/over/out" to rely mainly on "mouse move" events rather than on UIElement.PointerEnered/Exited. The latter are fired when OS decides the pointer enter/left what it thinks is the hit target, but that is wrong in some scenarios like "box-none" views overlapping non-related views.
The new mechanism basically makes all events consistent with the target resolution offered by the TouchHandler.GetReactViewTarget.