### PR TITLE
Fix crash on mouse move/click

### DIFF
--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -208,8 +208,9 @@ namespace ReactNative.Touch
                 var adjustedPoint = AdjustPointForStatusBar(point);
 
                 // Get the first view in at the pointer point that is not `box-none`.
+                // Note: Rounding related errors can keep the position outside all react views, hence using FirstOrDefault.
                 var nonBoxOnlyView = VisualTreeHelper.FindElementsInHostCoordinates(adjustedPoint, _view)
-                    .First(v => v.HasTag() && v.GetPointerEvents() != PointerEvents.BoxNone);
+                    .FirstOrDefault(v => v.HasTag() && v.GetPointerEvents() != PointerEvents.BoxNone);
 
                 // Update the enumerator for the non-`box-only` view.
                 enumerator = RootViewHelper.GetReactViewHierarchy(nonBoxOnlyView).GetEnumerator();


### PR DESCRIPTION
There seems to be an inconsistency between the OS chosen touch target and the views found by VisualTreeHelper.FindElementsInHostCoordinates, almost for sure due to rounding differences.

When clicking/moving mouse close to the root view boundary (just under window title bar, for example), the resulting rootPoint may end up with very close to 0 negative Y coordinate.
This triggers VisualTreeHelper.FindElementsInHostCoordinates to return nothing useful, crashing the First(predicate) call.

We use FirstOrDefault now (GetReactViewHierarchy does return an empty enumerable if parameter is null)