### PR TITLE
Small fix on exception propagation in DispatcherHelpers Call* helper

### DIFF
--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -229,7 +229,15 @@ namespace ReactNative.Bridge
         {
             if (allowInlining && IsOnDispatcher(dispatcher))
             {
-                return Task.FromResult(func());
+                try
+                {
+                    T result = func();
+                    return Task.FromResult(result);
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException<T>(ex);
+                }
             }
             else
             {
@@ -237,8 +245,15 @@ namespace ReactNative.Bridge
 
                 RunOnDispatcher(dispatcher, () =>
                 {
-                    var result = func();
-                    taskCompletionSource.SetResult(result);
+                    try
+                    {
+                        var result = func();
+                        taskCompletionSource.SetResult(result);
+                    }
+                    catch (Exception ex)
+                    {
+                        taskCompletionSource.SetException(ex);
+                    }
                 });
 
                 return taskCompletionSource.Task;


### PR DESCRIPTION
Fixed error processing in CallOnDispatcher. The method is of a "Task<something>" type, so it shouldn't spill exceptions. Both types of results (successful and failure) have to be passed back in the Task.