### PR TITLE
Added logging framework

### DIFF
--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -6,8 +6,26 @@
 #include "JsIndexedModulesUnbundle.h"
 #include "SerializedSourceContext.h"
 #include <stdint.h>
+#include "asprintf.h"
 
 const unsigned int MagicFileHeader = 0xFB0BD1E5;
+
+// Initializing by default to write debug output if there is a need to trace
+// any log messages before NativeJavaScriptExecutor::InitializeHost gets initialized
+extern "C" std::function<void(int, const wchar_t *)> g_loggingCallback = [=](int level, const wchar_t *logline)
+{
+#ifdef _DEBUG
+    OutputDebugStringW(LogLevelToString(level));
+    OutputDebugStringW(logline);
+    OutputDebugStringW(L"\n");
+#endif
+};
+
+#ifdef _DEBUG
+extern "C" bool g_isLoggingEnabled = true;
+#else
+extern "C" bool g_isLoggingEnabled = false;
+#endif
 
 void ThrowException(const wchar_t* szException)
 {
@@ -31,40 +49,32 @@ JsErrorCode DefineHostCallback(JsValueRef globalObject, const wchar_t *callbackN
     return JsNoError;
 }
 
-wchar_t* LogLevel(int logLevel)
-{
-    switch (logLevel)
-    {
-    case 0:
-        return L"Trace";
-    case 1:
-        return L"Info";
-    case 2:
-        return L"Warn";
-    case 3:
-        return L"Error";
-    default:
-        return L"Log";
-    }
-}
-
 JsValueRef CALLBACK NativeLoggingCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState)
 {
-#ifdef _DEBUG
-    wchar_t buff[56];
-    double logLevelIndex;
-    JsNumberToDouble(arguments[2], &logLevelIndex);
-    swprintf(buff, 56, L"[JS %s] ", LogLevel((int)logLevelIndex));
-    OutputDebugStringW(buff);
-    
-	// Memory is owned by JS engine and is GC'ed later.
-    const wchar_t* szResult;
-    size_t sResult;
-    JsStringToPointer(arguments[1], &szResult, &sResult);
-    OutputDebugStringW(szResult);
+    if (g_isLoggingEnabled) {
 
-    OutputDebugStringW(L"\n");
-#endif
+        double logLevelIndex;
+        JsNumberToDouble(arguments[2], &logLevelIndex);
+
+        const wchar_t *szBuf;
+        size_t bufLen;
+        auto status = JsStringToPointer(arguments[1], &szBuf, &bufLen);
+        if (status == JsNoError)
+        {
+            g_loggingCallback((int)logLevelIndex, szBuf);
+            return JS_INVALID_REFERENCE;
+        }
+
+        wchar_t* szError = NULL;
+        if (_aswprintf(&szError, L"NativeLoggingCallback: Error '%u' while trying to get a string pointer from JsStringToPointer", status) < 0)
+        {
+            g_loggingCallback(3, L"NativeLoggingCallback: Fatal error");
+            return JS_INVALID_REFERENCE;
+        }
+
+        g_loggingCallback(3, szError);
+        free(szError);
+    }
     return JS_INVALID_REFERENCE;
 }
 
@@ -76,6 +86,7 @@ JsErrorCode ChakraHost::LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE
 	*hFile = CreateFile2(szPath, dwShareMode, FILE_SHARE_READ, OPEN_EXISTING, nullptr);
 	if (*hFile == INVALID_HANDLE_VALUE)
 	{
+        g_loggingCallback(3, L"ChakraHost fatal condition #1");
 		return JsErrorFatal;
 	}
 
@@ -83,7 +94,8 @@ JsErrorCode ChakraHost::LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE
 	*hMap = CreateFileMapping(*hFile, nullptr, flProtect, 0, 0, L"ReactNativeMapping");
 	if (*hMap == NULL)
 	{
-		CloseHandle(*hFile);
+        g_loggingCallback(3, L"ChakraHost fatal condition #2");
+        CloseHandle(*hFile);
 		return JsErrorFatal;
 	}
 
@@ -91,7 +103,8 @@ JsErrorCode ChakraHost::LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE
 	*pData = (BYTE*)MapViewOfFile(*hMap, dwDesiredAccess, 0, 0, 0);
 	if (*pData == NULL)
 	{
-		CloseHandle(*hMap);
+        g_loggingCallback(3, L"ChakraHost fatal condition #3");
+        CloseHandle(*hMap);
 		CloseHandle(*hFile);
 		return JsErrorFatal;
 	}
@@ -118,25 +131,30 @@ JsErrorCode ChakraHost::LoadFileContents(const wchar_t* szPath, wchar_t** pszDat
 
 	if (rawBytes == nullptr)
 	{
-		return JsErrorFatal;
+        g_loggingCallback(3, L"ChakraHost fatal condition #4");
+        return JsErrorFatal;
 	}
 
 	fread(rawBytes, sizeof(char), lengthBytes, file);
 	if (fclose(file))
 	{
-		return JsErrorFatal;
+        g_loggingCallback(3, L"ChakraHost fatal condition #5");
+        free(rawBytes);
+        return JsErrorFatal;
 	}
 
 	*pszData = (wchar_t *)calloc(lengthBytes + 1, sizeof(wchar_t));
 	if (*pszData == nullptr)
 	{
-		free(rawBytes);
+        g_loggingCallback(3, L"ChakraHost fatal condition #6");
+        free(rawBytes);
 		return JsErrorFatal;
 	}
 
 	if (MultiByteToWideChar(CP_UTF8, 0, rawBytes, lengthBytes + 1, *pszData, lengthBytes + 1) == 0)
 	{
-		free(*pszData);
+        g_loggingCallback(3, L"ChakraHost fatal condition #8");
+        free(*pszData);
 		free(rawBytes);
 		return JsErrorFatal;
 	}

--- a/ReactWindows/ChakraBridge/pch.h
+++ b/ReactWindows/ChakraBridge/pch.h
@@ -16,6 +16,28 @@
 
 #include <windows.h>
 
+extern "C" std::function<void(int, const wchar_t *)> g_loggingCallback;
+extern "C" bool g_isLoggingEnabled;
+
+#ifdef _DEBUG
+inline wchar_t* LogLevelToString(int logLevel)
+{
+    switch (logLevel)
+    {
+    case 0:
+        return L"Trace";
+    case 1:
+        return L"Info";
+    case 2:
+        return L"Warn";
+    case 3:
+        return L"Error";
+    default:
+        return L"Log";
+    }
+}
+#endif
+
 #define IfFailRetNullPtr(v) \
     { \
         JsErrorCode status = (v); \

--- a/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative.Net46/Modules/Storage/AsyncStorageModule.cs
@@ -7,6 +7,8 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PCLStorage;
 using ReactNative.Bridge;
+using ReactNative.Common;
+using ReactNative.Tracing;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,6 +65,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiGet: {error}");
                 callback.Invoke(error);
             }
             else
@@ -123,6 +126,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiSet: {error}");
                 callback.Invoke(error);
             }
             else
@@ -171,6 +175,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiRemove: {error}");
                 callback.Invoke(error);
             }
             else
@@ -231,6 +236,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiMerge: {error}");
                 callback.Invoke(error);
             }
             else
@@ -264,6 +270,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.clear: {error}");
                 callback.Invoke(error);
             }
             else
@@ -306,6 +313,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.getAllKeys: {error}");
                 callback.Invoke(error);
             }
             else

--- a/ReactWindows/ReactNative.Shared/Animated/PropsAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/PropsAnimatedNode.cs
@@ -104,7 +104,7 @@ namespace ReactNative.Animated
 
             if (!updated)
             {
-                Tracer.Error(ReactConstants.Tag, "Native animation workaround, frame lost as result of race condition.", null);
+                RnLog.Warn(ReactConstants.RNW, $"Native animation workaround, frame lost as result of race condition.");
             }
         }
     }

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactContext.cs
@@ -4,10 +4,11 @@
 // Licensed under the MIT License.
 
 using ReactNative.Bridge.Queue;
+using ReactNative.Common;
+using ReactNative.Tracing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -450,7 +451,7 @@ namespace ReactNative.Bridge
             }
             else
             {
-                ExceptionDispatchInfo.Capture(exception).Throw();
+                RnLog.Fatal(ReactConstants.RNW, exception, $"Unhandled Exception in React Context");
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactInstance.cs
@@ -121,7 +121,7 @@ namespace ReactNative.Bridge
         {
             if (IsDisposed)
             {
-                Tracer.Write(ReactConstants.Tag, "Invoking JS callback after bridge has been destroyed.");
+                RnLog.Warn(ReactConstants.RNW, $"Invoking JS callback after bridge has been destroyed.");
                 return;
             }
 
@@ -155,7 +155,8 @@ namespace ReactNative.Bridge
                 {
                     if (_bridge == null)
                     {
-                        throw new InvalidOperationException("Bridge has not been initialized.");
+                        RnLog.Error(ReactConstants.RNW, $"Invoking JS callback before bridge has been initialized. tracingName:{tracingName}.");
+                        throw new InvalidOperationException($"Bridge has not been initialized. tracingName:{tracingName}.");
                     }
 
                     _bridge.CallFunction(module, method, arguments);

--- a/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Common;
+using ReactNative.Tracing;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -324,11 +325,11 @@ namespace ReactNative.Chakra.Executor
             {
                 var message = arguments[1].ToString();
                 var logLevel = (LogLevel)(int)arguments[2].ToDouble();
-                Debug.WriteLine($"[JS {logLevel}] {message}");
+                RnLog.Info("JS", $"{logLevel} {message}");
             }
             catch
             {
-                Debug.WriteLine("Unable to process JavaScript console statement");
+                RnLog.Error("JS", $"Unable to process JavaScript console statement");
             }
 
             return JavaScriptValue.Undefined;

--- a/ReactWindows/ReactNative.Shared/Common/ReactConstants.cs
+++ b/ReactWindows/ReactNative.Shared/Common/ReactConstants.cs
@@ -13,6 +13,11 @@ namespace ReactNative.Common
         /// <summary>
         /// Trace tag for React components.
         /// </summary>
-        public const int Tag = 0; 
+        public const int Tag = 0;
+
+        /// <summary>
+        /// Trace tag (RnLog style) for React components.
+        /// </summary>
+        public const string RNW = "RNW";
     }
 }

--- a/ReactWindows/ReactNative.Shared/DevSupport/DebugServerException.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DebugServerException.cs
@@ -76,7 +76,7 @@ namespace ReactNative.DevSupport
                 }
                 catch (JsonException ex)
                 {
-                    Tracer.Error(ReactConstants.Tag, "Failure deserializing debug server exception message.", ex);
+                    RnLog.Error(ReactConstants.RNW, ex, $"Failure deserializing debug server exception message.");
                 }
             }
 

--- a/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DevSupportManager.cs
@@ -12,7 +12,7 @@ using ReactNative.Tracing;
 using System;
 using System.IO;
 using System.Reactive.Disposables;
-using System.Runtime.ExceptionServices;
+
 using System.Threading;
 using System.Threading.Tasks;
 #if WINDOWS_UWP
@@ -152,7 +152,7 @@ namespace ReactNative.DevSupport
             }
             else
             {
-                ExceptionDispatchInfo.Capture(exception).Throw();
+                RnLog.Fatal(ReactConstants.RNW, exception, $"Exception caught in top handler");
             }
         }
 
@@ -187,7 +187,6 @@ namespace ReactNative.DevSupport
             }
             else
             {
-                Tracer.Error(ReactConstants.Tag, "Exception in native call from JavaScript.", exception);
                 ShowNewError(message, StackTraceHelper.ConvertNativeStackTrace(exception), NativeErrorCookie);
             }
         }
@@ -412,9 +411,12 @@ namespace ReactNative.DevSupport
 
         public async void HandleReloadJavaScript()
         {
+            RnLog.Info(ReactConstants.RNW, $"DevSupportManager: HandleReloadJavaScript - entry");
             using (await _reactInstanceCommandsHandler.LockAsync())
             {
+                RnLog.Info(ReactConstants.RNW, $"DevSupportManager: HandleReloadJavaScript - execute");
                 await CreateReactContextFromPackagerAsync(CancellationToken.None);
+                RnLog.Info(ReactConstants.RNW, $"DevSupportManager: HandleReloadJavaScript - done");
             }
         }
 
@@ -476,6 +478,8 @@ namespace ReactNative.DevSupport
 
         private void ShowNewError(string message, IStackFrame[] stack, int errorCookie)
         {
+            RnLog.Error(ReactConstants.RNW, $"Showing RedBox with message: {message}");
+
             DispatcherHelpers.RunOnDispatcher(() =>
             {
                 if (_redBoxDialog == null)

--- a/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
+++ b/ReactWindows/ReactNative.Shared/DevSupport/DisabledDevSupportManager.cs
@@ -5,9 +5,10 @@
 
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Common;
 using ReactNative.Modules.DevSupport;
+using ReactNative.Tracing;
 using System;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -75,7 +76,7 @@ namespace ReactNative.DevSupport
 
         public void HandleException(Exception exception)
         {
-            DispatcherHelpers.RunOnDispatcher(() => ExceptionDispatchInfo.Capture(exception).Throw());
+            RnLog.Fatal(ReactConstants.RNW, exception, $"Exception caught in top handler");
         }
 
         public void HandleReloadJavaScript()

--- a/ReactWindows/ReactNative.Shared/Modules/AppState/AppStateModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/AppState/AppStateModule.cs
@@ -5,7 +5,9 @@
 
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Common;
 using ReactNative.Modules.Core;
+using ReactNative.Tracing;
 
 namespace ReactNative.Modules.AppState
 {
@@ -53,9 +55,11 @@ namespace ReactNative.Modules.AppState
         {
             get
             {
+                var currentAppState = _appState;
+                RnLog.Info(ReactConstants.RNW, $"AppStateModule: initial appState is {currentAppState}");
                 return new JObject
                 {
-                    { "initialAppState", _appState }
+                    { "initialAppState", currentAppState }
                 };
             }
         }
@@ -101,21 +105,25 @@ namespace ReactNative.Modules.AppState
         [ReactMethod]
         public void getCurrentAppState(ICallback success, ICallback error)
         {
-            success.Invoke(CreateAppStateEventMap());
+            var currentAppState = _appState;
+            RnLog.Info(ReactConstants.RNW, $"AppStateModule: getCurrentAppState returned {currentAppState}");
+            success.Invoke(CreateAppStateEventMap(currentAppState));
         }
 
-        private JObject CreateAppStateEventMap()
+        private JObject CreateAppStateEventMap(string currentAppState)
         {
             return new JObject
             {
-                { "app_state", _appState },
+                { "app_state", currentAppState },
             };
         }
 
         private void SendAppStateChangeEvent()
         {
+            var currentAppState = _appState;
+            RnLog.Info(ReactConstants.RNW, $"AppStateModule: appStateDidChange to {currentAppState}");
             Context.GetJavaScriptModule<RCTDeviceEventEmitter>()
-                .emit("appStateDidChange", CreateAppStateEventMap());
+                .emit("appStateDidChange", CreateAppStateEventMap(currentAppState));
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Modules/Core/ExceptionsManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ExceptionsManagerModule.cs
@@ -69,7 +69,7 @@ namespace ReactNative.Modules.Core
         public void reportSoftException(string title, JArray details, int exceptionId)
         {
             var stackTrace = StackTraceHelper.ConvertJavaScriptStackTrace(details);
-            Tracer.Write(ReactConstants.Tag, title + Environment.NewLine + stackTrace.PrettyPrint());
+            RnLog.Warn(ReactConstants.RNW, $"Soft Exception: {title}\n{stackTrace.PrettyPrint()}");
         }
 
         /// <summary>
@@ -109,7 +109,10 @@ namespace ReactNative.Modules.Core
             else
             {
                 var stackTrace = StackTraceHelper.ConvertJavaScriptStackTrace(details);
-                throw new JavaScriptException(title, stackTrace.PrettyPrint());
+
+                // JavaScriptAppException type can be used by custom implementations of RnLog.Fatal
+                // to detect the Javascript exception scenario for reporting purposes. 
+                throw new JavaScriptAppException(title, stackTrace);
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/Modules/Core/JavaScriptAppException.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/JavaScriptAppException.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using ReactNative.DevSupport;
+using System;
+
+namespace ReactNative.Modules.Core
+{
+    /// <summary>
+    /// A class for JavaScript exceptions where the an itemized (per frame) stack is available.
+    /// </summary>
+    public class JavaScriptAppException : JavaScriptException
+    {
+        /// <summary>
+        /// Instantiates the <see cref="JavaScriptException"/>.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="stackTrace">The JavaScript stack trace.</param>
+        public JavaScriptAppException(string message, IStackFrame[] stackTrace)
+            : base(message, stackTrace.PrettyPrint())
+        {
+            JavaScriptStackTraceItemized = stackTrace;
+        }
+
+        /// <summary>
+        /// The exception stack trace.
+        /// </summary>
+        public IStackFrame[] JavaScriptStackTraceItemized
+        {
+            get;
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -105,6 +105,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Collections\HeapBasedPriorityQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\ListExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\AsyncLock.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Modules\Core\JavaScriptAppException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\InetHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\LifecycleState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\LifecycleStateMachine.cs" />
@@ -163,6 +164,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\EnumHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ExpressionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ReflectionHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\DebugLogTracer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\LogTracerBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\MultiLogTracer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\RnLog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Annotations\ReactPropAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Annotations\ReactPropBaseAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Annotations\ReactPropGroupAttribute.cs" />

--- a/ReactWindows/ReactNative.Shared/ReactRootView.cs
+++ b/ReactWindows/ReactNative.Shared/ReactRootView.cs
@@ -5,7 +5,9 @@
 
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Common;
 using ReactNative.Touch;
+using ReactNative.Tracing;
 using ReactNative.UIManager;
 using System;
 using System.Diagnostics;
@@ -120,6 +122,7 @@ namespace ReactNative
 
         private async Task StartReactApplicationAsync(ReactInstanceManager reactInstanceManager, string moduleName, JObject initialProps)
         {
+            RnLog.Info(ReactConstants.RNW, $"ReactRootView: StartReactApplicationAsync ({moduleName}) - entry");
             // This is called under the dispatcher associated with the view.
             DispatcherHelpers.AssertOnDispatcher(this);
 
@@ -148,6 +151,8 @@ namespace ReactNative
             {
                 _attachScheduled = true;
             }
+
+            RnLog.Info(ReactConstants.RNW, $"ReactRootView: StartReactApplicationAsync ({moduleName}) - done ({(_attachScheduled ? "with scheduled work" : "completely")})");
         }
 
         /// <summary>
@@ -170,6 +175,7 @@ namespace ReactNative
         /// <returns>Awaitable task.</returns>
         public async Task StopReactApplicationAsync()
         {
+            RnLog.Info(ReactConstants.RNW, $"ReactRootView: StopReactApplicationAsync ({JavaScriptModuleName}) - entry");
             DispatcherHelpers.AssertOnDispatcher(this);
 
             var reactInstanceManager = _reactInstanceManager;
@@ -179,6 +185,8 @@ namespace ReactNative
             {
                 await reactInstanceManager.DetachRootViewAsync(this);
             }
+
+            RnLog.Info(ReactConstants.RNW, $"ReactRootView: StopReactApplicationAsync ({JavaScriptModuleName}) - done");
         }
 
         /// <summary>
@@ -258,7 +266,7 @@ namespace ReactNative
             task.ContinueWith(
                 t =>
                 {
-                    Debug.Fail("Exception in fire and forget asynchronous function", t.Exception.ToString());
+                    RnLog.Fatal(ReactConstants.RNW, t.Exception, $"Exception in fire and forget asynchronous function");
                 },
                 TaskContinuationOptions.OnlyOnFaulted);
         }

--- a/ReactWindows/ReactNative.Shared/Tracing/DebugLogTracer.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/DebugLogTracer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Text;
+
+namespace ReactNative.Tracing
+{
+    /// <summary>
+    /// Logs events to the Debug console.
+    /// </summary>
+    public sealed class DebugLogTracer : LogTracerBase
+    {
+        private static DebugLogTracer instance = new DebugLogTracer();
+        private DebugLogTracer() {
+        }
+
+        /// <summary>
+        /// The singleton instance of DebugLogTracer.
+        /// </summary>
+        public static DebugLogTracer Instance
+        {
+            get => instance;
+        }
+
+        /// <inheritdoc />
+        protected override void AppendInternal(EventLevel eventLevel, string eventName, FormattableString message, Exception exception)
+        {
+            StringBuilder toLog = new StringBuilder($"[{eventLevel:g}] [{eventName}] {message}");
+            if (exception != null)
+            {
+                toLog.AppendLine().Append(FormatException(exception));
+            }
+            Debug.WriteLine(toLog.ToString());
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Tracing/LogTracerBase.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/LogTracerBase.cs
@@ -10,7 +10,7 @@ namespace ReactNative.Tracing
     /// The interface is designed to be able to integrate other logging
     /// frameworks like nlog, log4net, etc
     /// </summary>
-    public abstract class LogTracerBase
+    public abstract class LogTracerBase: IDisposable
     {
         private EventLevel _verbosityLevel = EventLevel.Verbose;
 
@@ -101,6 +101,17 @@ namespace ReactNative.Tracing
             {
                 return ex.ToString();
             }
+        }
+
+        /// <summary>
+        /// Disposes the log tracer.
+        /// </summary>
+        /// <remarks>
+        /// The current implementation does a Flush
+        /// </remarks>
+        public virtual void Dispose()
+        {
+            Flush();
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Tracing/LogTracerBase.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/LogTracerBase.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Text;
+
+namespace ReactNative.Tracing
+{
+    /// <summary>
+    /// Generic interface to provide log tracer functionality
+    /// Used by <see cref="RnLog"/> class to trace log messages.
+    /// The interface is designed to be able to integrate other logging
+    /// frameworks like nlog, log4net, etc
+    /// </summary>
+    public abstract class LogTracerBase
+    {
+        private EventLevel _verbosityLevel = EventLevel.Verbose;
+
+        /// <summary>
+        /// Logs a message if the event level is as verbose or less verbose than the tracer verbosity level.
+        /// </summary>
+        /// <param name="eventLevel">Event level <see cref="EventLevel"/></param>
+        /// <param name="eventName">Name of the event</param>
+        /// <param name="message">Log message</param>
+        /// <param name="exception">Optional exception to include with event</param>
+        public void Append(EventLevel eventLevel, string eventName, FormattableString message, Exception exception = null)
+        {
+            if (eventLevel <= _verbosityLevel)
+            {
+                AppendInternal(eventLevel, eventName, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Flushes any internal buffers to whatever their final destination should be synchronously. Subclasses
+        /// that keep internal buffers should override this method - it is a no-op by default.
+        /// </summary>
+        public virtual void Flush()
+        {
+            // no op by default
+        }
+
+        /// <summary>
+        /// Crashes the application.
+        /// </summary>
+        public virtual void CrashApplication(FormattableString message, Exception exception = null)
+        {
+            if (exception == null)
+            {
+                exception = new InvalidOperationException("<null exception>");
+            }
+            Environment.FailFast(message.ToString(), exception);
+        }
+
+        /// <summary>
+        /// Logs an event message unconditionally
+        /// </summary>
+        /// <param name="eventLevel">Event level <see cref="EventLevel"/></param>
+        /// <param name="eventName">Name of the event</param>
+        /// <param name="message">Log message</param>
+        /// <param name="exception">Optional exception to include with event</param>
+        protected abstract void AppendInternal(EventLevel eventLevel, string eventName, FormattableString message, Exception exception);
+
+        /// <summary>
+        /// Sets the threshold for log events - events more verbose than this will not be logged.
+        /// </summary>
+        /// <param name="verbosityLevel">The maximally verbose EventLevel to log</param>
+        public void SetVerbosityLevel(EventLevel verbosityLevel)
+        {
+            _verbosityLevel = verbosityLevel;
+        }
+
+        /// <summary>
+        /// Converts an exception into a string formatted nicely so that it can be logged.
+        /// </summary>
+        /// <param name="ex">The exception to format into a string.</param>
+        /// <returns>The exception represented as a nicely formatted string.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "This code must not fail in any case since it's not critical.")]
+        protected static string FormatException(Exception ex)
+        {
+            if (ex == null)
+            {
+                return "<null exception>";
+            }
+            else if (ex is AggregateException aex)
+            {
+                try
+                {
+                    var sb = new StringBuilder();
+                    sb.Append("AggregateException. Inner exceptions count=" + aex.InnerExceptions.Count).AppendLine();
+                    for (int i = 0; i < aex.InnerExceptions.Count; i++)
+                    {
+                        sb.Append("Inner exception #" + i).AppendLine().Append(FormatException(aex.InnerExceptions[i])).AppendLine();
+                    }
+                    return sb.ToString();
+                }
+                catch (Exception excp)
+                {
+                    return "Failed to get inner exceptions " + excp;
+                }
+            }
+            else
+            {
+                return ex.ToString();
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Tracing/MultiLogTracer.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/MultiLogTracer.cs
@@ -35,6 +35,21 @@ namespace ReactNative.Tracing
             }
         }
 
+        /// <summary>
+        /// Disposes the log tracer.
+        /// </summary>
+        /// <remarks>
+        /// The current implementation defers to the list of log tracers
+        /// </remarks>
+        public override void Dispose()
+        {
+            foreach (var tracer in _tracers)
+            {
+                tracer.Dispose();
+            }
+            _tracers.Clear();
+        }
+
         /// <inheritdoc />
         protected override void AppendInternal(EventLevel eventLevel, string eventName, FormattableString message, Exception exception)
         {

--- a/ReactWindows/ReactNative.Shared/Tracing/MultiLogTracer.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/MultiLogTracer.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace ReactNative.Tracing
+{
+    /// <summary>
+    /// Utility class that allows multiple tracers to accept logs from RnLog.
+    /// </summary>
+    /// <remarks>
+    /// Note that MultiLogTracer itself can have a VerbosityLevel specified, which will filter before forwarding
+    /// to any of the child tracers.
+    /// </remarks>
+    public class MultiLogTracer : LogTracerBase
+    {
+        private readonly ICollection<LogTracerBase> _tracers;
+
+        /// <summary>
+        /// Accepts the list of LogTracerBase instances to log to.
+        /// </summary>
+        /// <param name="tracers">The list to log to</param>
+        public MultiLogTracer(ICollection<LogTracerBase> tracers)
+        {
+            this._tracers = tracers;
+        }
+
+        /// <summary>
+        /// Calls Flush for all child tracers.
+        /// </summary>
+        public override void Flush()
+        {
+            foreach (var tracer in _tracers)
+            {
+                tracer.Flush();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void AppendInternal(EventLevel eventLevel, string eventName, FormattableString message, Exception exception)
+        {
+            foreach (var tracer in _tracers)
+            {
+                tracer.Append(eventLevel, eventName, message, exception);
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Tracing/RnLog.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/RnLog.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Diagnostics.Tracing;
+
+namespace ReactNative.Tracing
+{
+    // Here are the goals of this API:
+    //   - A common logging API that can be used by React Native apps and modules for
+    //     helping to diagnose bugs that happen in debug and release builds.
+    //   - The implementation should be configurable by the app so the app can log to
+    //     ETW, to a file, or to wherever else it might want.
+    //   - The API is designed to be similar to the React Native Android logging API
+    //     to make it easier for React Native Android module authors to write React
+    //     Native Windows modules. For reference, here's the React Native Android API:
+    //     https://github.com/facebook/fresco/blob/8fc70f1699d14706caffbcc7cacb20c7d02f4b9d/fbcore/src/main/java/com/facebook/common/logging/FLog.java
+    //   - Each log statement should have several pieces of information associated
+    //     with it:
+    //     - A string message which the developer can use to log any information
+    //       they want.
+    //     - A log level which is useful for filtering and understanding the nature
+    //       of the message (e.g. info, warn, error).
+    //     - A contextual name so we know what generated the message (e.g. a class
+    //       or module name).
+    //
+    // Comparison with other logging APIs
+    //   Windows comes with several logging APIs that are available to C#:
+    //     - System.Diagnostics.Debug
+    //     - System.Diagnostics.Trace
+    //     - System.Diagnostics.Tracing
+    //     - Windows.Foundation.Diagnostics.LoggingChannel
+    //
+    //   None of these APIs forces you to associate a contextual name (e.g.
+    //   a class or module name) with your log statement to help track who
+    //   generated the message. Consequently, we've decided to build an API
+    //   on top of the Windows logging APIs rather than recommending to use
+    //   the Windows logging APIs directly.
+    //
+    //   React Native Windows has another logging API called ReactNative.Tracing.Tracer.
+    //   Tracer is different in that it's a non-public API which is focused on
+    //   logging to understand the performance of React Native Windows internals. Whereas
+    //   RnLog is a public API focused on logging for the purposes of diagnosing bugs.
+
+    /// <summary>
+    /// A logging API that can be used by React Native apps and modules for helping
+    /// to diagnose bugs that happen in debug and release builds.
+    /// </summary>
+    public static class RnLog
+    {
+        /// <summary>
+        /// By default use DebugLogTracer
+        /// </summary>
+        private static LogTracerBase logTracer = DebugLogTracer.Instance;
+
+        /// <summary>
+        /// Sets log tracer to be used to log a message. Allows only one tracer to be used at the time. By default DebugLogTracer will be used.
+        /// This wasn't implemented as a thread safe because of:
+        /// - ILogTracer shouldn't be changed a lot of times, in general it should be one time action when app starts
+        /// - Any thread safety issues should be addressed in ILogTracer to avoid performance penalty of doing it on that high level
+        /// </summary>
+        /// <param name="tracer">Log tracer object</param>
+        public static void SetLogTracer(LogTracerBase tracer)
+        {
+            logTracer = tracer;
+        }
+
+        private static void WriteLogLine(EventLevel eventLevel, string tag, FormattableString message, Exception exception = null)
+        {
+            if (logTracer != null)
+            {
+                logTracer.Append(eventLevel, tag, message, exception);
+            }
+        }
+
+        /// <summary>
+        /// Log an informational message.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the log message. Usually a class or React Native module name.</param>
+        /// <param name="message">Message format to log.</param>
+        public static void Info(string tag, FormattableString message)
+        {
+            Info(tag, null, message);
+        }
+
+        /// <summary>
+        /// Log an informational message.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the log message. Usually a class or React Native module name.</param>
+        /// <param name="exception">Exception to include with log (may be null).</param>
+        /// <param name="message">Message format to log.</param>
+        public static void Info(string tag, Exception exception, FormattableString message)
+        {
+            WriteLogLine(EventLevel.Informational, tag, message, exception);
+        }
+
+        /// <summary>
+        /// Log a warning message.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the log message. Usually a class or React Native module name.</param>
+        /// <param name="message">The message to log.</param>
+        public static void Warn(string tag, FormattableString message)
+        {
+            Warn(tag, null, message);
+        }
+
+        /// <summary>
+        /// Log a warning message.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the log message. Usually a class or React Native module name.</param>
+        /// <param name="exception">Exception to include with log (may be null).</param>
+        /// <param name="message">The message to log.</param>
+        public static void Warn(string tag, Exception exception, FormattableString message)
+        {
+            WriteLogLine(EventLevel.Warning, tag, message, exception);
+        }
+
+        /// <summary>
+        /// Log an error message.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the log message. Usually a class or React Native module name.</param>
+        /// <param name="message">The message to log.</param>
+        public static void Error(string tag, FormattableString message)
+        {
+            Error(tag, null, message);
+        }
+
+        /// <summary>
+        /// Log an error message.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the log message. Usually a class or React Native module name.</param>
+        /// <param name="exception">Exception to include with log (may be null).</param>
+        /// <param name="message">The message to log.</param>
+        public static void Error(string tag, Exception exception, FormattableString message)
+        {
+            WriteLogLine(EventLevel.Error, tag, message, exception);
+        }
+
+        /// <summary>
+        /// Log an error message and crash the application.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the crash. Usually a class or React Native module name.</param>
+        /// <param name="message">The message to log/include in crash report.</param>
+        public static void Fatal(string tag, FormattableString message)
+        {
+            Fatal(tag, null, message);
+        }
+
+        /// <summary>
+        /// Log an error message and crash the application.
+        /// </summary>
+        /// <param name="tag">Identifies the source of the crash. Usually a class or React Native module name.</param>
+        /// <param name="exception">Exception to include with crash report (may be null).</param>
+        /// <param name="message">The message to log/include in crash report.</param>
+        public static void Fatal(string tag, Exception exception, FormattableString message)
+        {
+            Error(tag, exception, message);
+            Flush();
+            logTracer.CrashApplication(message, exception);
+        }
+
+        /// <summary>
+        /// Crash the application (legacy, to be removed)
+        /// </summary>
+        /// <param name="exception">Exception to include with crash report.</param>
+        public static void CrashApplication(Exception exception)
+        {
+            Fatal("Legacy", exception, $"{ exception.Message}");
+        }
+
+        /// <summary>
+        /// Synchronously flush the logTracer so that any logs in memory are written to their final destination.
+        /// </summary>
+        public static void Flush()
+        {
+            logTracer.Flush();
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Shared/Tracing/RnLog.cs
+++ b/ReactWindows/ReactNative.Shared/Tracing/RnLog.cs
@@ -151,18 +151,9 @@ namespace ReactNative.Tracing
         /// <param name="message">The message to log/include in crash report.</param>
         public static void Fatal(string tag, Exception exception, FormattableString message)
         {
-            Error(tag, exception, message);
+            WriteLogLine(EventLevel.Critical, tag, message, exception);
             Flush();
             logTracer.CrashApplication(message, exception);
-        }
-
-        /// <summary>
-        /// Crash the application (legacy, to be removed)
-        /// </summary>
-        /// <param name="exception">Exception to include with crash report.</param>
-        public static void CrashApplication(Exception exception)
-        {
-            Fatal("Legacy", exception, $"{ exception.Message}");
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.cs
@@ -6,6 +6,7 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Bridge.Queue;
+using ReactNative.Common;
 using ReactNative.Modules.DeviceInfo;
 using ReactNative.Tracing;
 using ReactNative.UIManager.Events;
@@ -207,7 +208,7 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Schedule a block to be executed on the UI thread. Useful if you need to execute
+        /// Schedule a block to be executed on the main UI thread. Useful if you need to execute
         /// view logic after all currently queued view updates have completed.
         /// </summary>
         /// <param name="block">The UI block.</param>
@@ -217,7 +218,7 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Schedule a block to be executed on the UI thread. Useful if you need to execute
+        /// Schedule a block to be executed on a UI thread. Useful if you need to execute
         /// view logic after all currently queued view updates have completed.
         /// </summary>
         /// <param name="block">The UI block.</param>
@@ -228,7 +229,7 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Schedule a block to be executed on the UI thread. Useful if you need to execute
+        /// Schedule a block to be executed on the main UI thread. Useful if you need to execute
         /// need view logic before all currently queued view updates have completed.
         /// </summary>
         /// <param name="block">The UI block.</param>
@@ -268,6 +269,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public async void removeRootView(int rootViewTag)
         {
+            RnLog.Info(ReactConstants.RNW, $"UIManagerModule: removeRootView ({rootViewTag}) - entry");
+
             // A cleanup task should be waiting here
             if (!_rootViewCleanupTasks.TryRemove(rootViewTag, out var cleanupTask))
             {
@@ -277,6 +280,7 @@ namespace ReactNative.UIManager
             await _uiImplementation.RemoveRootViewAsync(rootViewTag);
 
             cleanupTask.SetResult(true);
+            RnLog.Info(ReactConstants.RNW, $"UIManagerModule: removeRootView ({rootViewTag}) - done");
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Accessibility/AccessibilityHelper.cs
+++ b/ReactWindows/ReactNative/Accessibility/AccessibilityHelper.cs
@@ -9,7 +9,8 @@ using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
 #if PERF_LOG
-using System.Diagnostics;
+using ReactNative.Common;
+using ReactNative.Tracing;
 #endif
 using System.Linq;
 using System.Text;
@@ -456,11 +457,11 @@ namespace ReactNative.Accessibility
             s_treeContext.Value.Dirty = false;
 
 #if PERF_LOG
-            Debug.WriteLine($"Stats: ElementCount: {s_treeContext.Value.ElementCount}, " +
-                                   $"MarkedDirtyNodesCount: {s_treeContext.Value.MarkedDirtyNodesCount}, " +
-                                   $"DirtyNodesCount(before): {savedDirtyNodesCount}, " +
-                                   $"DirtyNodesCount(after): {s_treeContext.Value.DirtyNodesCount}, " +
-                                   $"ProcessedNodesCount: {s_treeContext.Value.ProcessedNodesCount}");
+            RnLog.Info(ReactConstants.RNW, $"Stats: ElementCount: {s_treeContext.Value.ElementCount}, " +
+                                           $"MarkedDirtyNodesCount: {s_treeContext.Value.MarkedDirtyNodesCount}, " +
+                                           $"DirtyNodesCount(before): {savedDirtyNodesCount}, " +
+                                           $"DirtyNodesCount(after): {s_treeContext.Value.DirtyNodesCount}, " +
+                                           $"ProcessedNodesCount: {s_treeContext.Value.ProcessedNodesCount}");
             s_treeContext.Value.MarkedDirtyNodesCount = 0;
 #endif
         }

--- a/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
+++ b/ReactWindows/ReactNative/Bridge/DispatcherHelpers.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using ReactNative.Common;
+using ReactNative.Tracing;
 using System;
 using System.Diagnostics;
 using System.Threading;
@@ -197,7 +199,7 @@ namespace ReactNative.Bridge
                 dispatcher.RunAsync(priority, action).AsTask().ContinueWith(
                     t =>
                     {
-                        Debug.Fail("Exception in fire and forget asynchronous function", t.Exception.ToString());
+                        RnLog.Fatal(ReactConstants.RNW, t.Exception, $"Exception in fire and forget asynchronous function");
                     },
                     TaskContinuationOptions.OnlyOnFaulted);
             }

--- a/ReactWindows/ReactNative/Bridge/Queue/LayoutActionQueue.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/LayoutActionQueue.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using ReactNative.Common;
 #if CREATE_LAYOUT_THREAD
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Windows.ApplicationModel.Core;
+using ReactNative.Tracing;
 #endif
 
 namespace ReactNative.Bridge.Queue
@@ -13,8 +15,6 @@ namespace ReactNative.Bridge.Queue
     class LayoutActionQueue : DispatcherActionQueue
     {
 #if CREATE_LAYOUT_THREAD
-        private const int E_ILLEGAL_METHOD_CALL = -2147483634; // 0x80000000E
-
         private static readonly Lazy<CoreApplicationView> s_layoutApplicationView = new Lazy<CoreApplicationView>(() =>
         {
             CoreApplicationView newView = null;
@@ -22,20 +22,19 @@ namespace ReactNative.Bridge.Queue
             {
                 newView = CoreApplication.CreateNewView();
             }
-            catch (COMException ex)
+            catch (Exception ex)
             {
-                if (ex.HResult == E_ILLEGAL_METHOD_CALL)
-                {
-                    // Corner case: UWP scenarios that start with no main window.
-                    // The OS doesn't allow the creation of new views in this case.
-                    // We fall back to main view/dispatcher.
-                    Debug.WriteLine("Can't create layout manager view; falling back to main view.");
-                    newView = CoreApplication.MainView;
-                }
-                else
-                {
-                    throw;
-                }
+                // Corner case: UWP scenarios that starts with no main window.
+                // The OS doesn't allow the creation of new views in this case.
+                //
+                // This is a COMException with HResult == E_ILLEGAL_METHOD_CALL (0x80000000E) when regular managed code,
+                // or an InvalidOperationException when using .NET Native.
+                // So we don't bother filtering exceptions
+                //
+                // We fall back to main view/dispatcher permanently, for now.
+                // A "fail over" to normal behavior will have to be implemented, eventually
+                RnLog.Warn(ReactConstants.RNW, $"Can't create layout manager view; falling back to main view.");
+                newView = CoreApplication.MainView;
             }
             return newView;
         });

--- a/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -4,8 +4,9 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Common;
+using ReactNative.Tracing;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -21,6 +22,14 @@ namespace ReactNative.Chakra.Executor
 
         private readonly ChakraBridge.NativeJavaScriptExecutor _executor;
         private readonly bool _useSerialization;
+
+        /// <summary>
+        /// Initializes the hooking of JS logging to RnLog.
+        /// </summary>
+        static public void StartRnLogging()
+        {
+            ChakraBridge.NativeJavaScriptExecutor.OnNewLogLine += JsExecutorOnNewLogLine;
+        }
 
         /// <summary>
         /// Instantiates the <see cref="NativeJavaScriptExecutor"/>.
@@ -40,6 +49,29 @@ namespace ReactNative.Chakra.Executor
             _executor = new ChakraBridge.NativeJavaScriptExecutor();
             Native.ThrowIfError((JavaScriptErrorCode)_executor.InitializeHost());
             _useSerialization = useSerialization;
+        }
+
+        private static void JsExecutorOnNewLogLine(ChakraBridge.LogLevel logLevel, string logline)
+        {
+            // ChakraBridge.LogLevel value is lost when it gets marshaled to .Net native optimized code,
+            // we need to do a proper marshaling to get actual value
+            // Also, JavaScript already has a log level in the message, hence just RnLog.Info
+            string tag = "JS";
+            FormattableString message = $"{logline}";
+
+            switch (logLevel)
+            {
+                case ChakraBridge.LogLevel.Error:
+                    RnLog.Error(tag, message);
+                    break;
+                case ChakraBridge.LogLevel.Warning:
+                    RnLog.Warn(tag, message);
+                    break;
+                case ChakraBridge.LogLevel.Info:
+                case ChakraBridge.LogLevel.Trace:
+                    RnLog.Info(tag, message);
+                    break;
+            }
         }
 
         /// <summary>
@@ -136,12 +168,12 @@ namespace ReactNative.Chakra.Executor
                             if (exc.ErrorCode == JavaScriptErrorCode.BadSerializedScript)
                             {
                                 // Bytecode format is dependent on Chakra engine version, so an OS upgrade may require a recompilation
-                                Debug.WriteLine("Serialized bytecode script is corrupted or wrong format, will generate new one");
+                                RnLog.Warn(ReactConstants.RNW, $"Serialized bytecode script is corrupted or wrong format, will generate new one");
                             }
                             else
                             {
                                 // Some more severe error. We still have a chance (recompiling), so we keep continuing.
-                                Debug.WriteLine($"Failed to run serialized bytecode script ({exc.ToString()}), will generate new one");
+                                RnLog.Error(ReactConstants.RNW, exc, $"Failed to run serialized bytecode script, will generate new one");
                             }
 
                             File.Delete(binPath);
@@ -149,7 +181,7 @@ namespace ReactNative.Chakra.Executor
                     }
                     else
                     {
-                        Debug.WriteLine("Serialized bytecode script doesn't exist or is obsolete, will generate one");
+                        RnLog.Info(ReactConstants.RNW, $"Serialized bytecode script doesn't exist or is obsolete, will generate one");
                     }
 
                     if (!ranSuccessfully)
@@ -169,7 +201,7 @@ namespace ReactNative.Chakra.Executor
                             }
                             catch (Exception ex)
                             {
-                                Debug.WriteLine($"Failed to generate serialized bytecode script ({ex.ToString()}).");
+                                RnLog.Error(ReactConstants.RNW, ex, $"Failed to generate serialized bytecode script.");
                                 // It's fine if the bytecode couldn't be generated: RN can still use the JS bundle.
                             }
                         });

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -6,6 +6,8 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.Common;
+using ReactNative.Tracing;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,6 +67,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiGet: {error}");
                 callback.Invoke(error);
             }
             else
@@ -125,6 +128,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiSet: {error}");
                 callback.Invoke(error);
             }
             else
@@ -173,6 +177,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiRemove: {error}");
                 callback.Invoke(error);
             }
             else
@@ -233,6 +238,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.multiMerge: {error}");
                 callback.Invoke(error);
             }
             else
@@ -267,6 +273,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.clear: {error}");
                 callback.Invoke(error);
             }
             else
@@ -309,6 +316,7 @@ namespace ReactNative.Modules.Storage
 
             if (error != null)
             {
+                RnLog.Warn(ReactConstants.RNW, $"Error in AsyncStorageModule.getAllKeys: {error}");
                 callback.Invoke(error);
             }
             else

--- a/ReactWindows/ReactNative/Modules/WebSocket/WebSocketModule.cs
+++ b/ReactWindows/ReactNative/Modules/WebSocket/WebSocketModule.cs
@@ -74,9 +74,7 @@ namespace ReactNative.Modules.WebSocket
         {
             if (!_webSocketConnections.TryGetValue(id, out var webSocket))
             {
-                Tracer.Write(
-                    ReactConstants.Tag,
-                    Invariant($"Cannot close WebSocket. Unknown WebSocket id {id}."));
+                RnLog.Warn(ReactConstants.RNW, $"Cannot close WebSocket. Unknown WebSocket id {id}.");
 
                 return;
             }
@@ -91,10 +89,7 @@ namespace ReactNative.Modules.WebSocket
             }
             catch (Exception ex)
             {
-                Tracer.Error(
-                    ReactConstants.Tag,
-                    Invariant($"Could not close WebSocket connection for id '{id}'."),
-                    ex);
+                RnLog.Error(ReactConstants.RNW, ex, $"Could not close WebSocket connection for id '{id}'.");
             }
         }
 

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ReactRootViewExtensions.cs" />
     <Compile Include="Touch\PointerDeviceTypeExtensions.cs" />
     <Compile Include="Touch\TouchHandler.cs" />
+    <Compile Include="Tracing\EtwLogTracer.cs" />
     <Compile Include="Tracing\LoggingActivityBuilder.cs" />
     <Compile Include="Tracing\LoggingActivityBuilderExtensions.generated.cs">
       <AutoGen>True</AutoGen>

--- a/ReactWindows/ReactNative/Tracing/EtwLogTracer.cs
+++ b/ReactWindows/ReactNative/Tracing/EtwLogTracer.cs
@@ -47,5 +47,17 @@ namespace ReactNative.Tracing
                     exception = FormatException(exception)
                 });
         }
+
+        /// <summary>
+        /// Disposes the log tracer.
+        /// </summary>
+        /// <remarks>
+        /// The current implementation disposes the event source
+        /// </remarks>
+        public override void Dispose()
+        {
+            eventSource.Dispose();
+            eventSource = null;
+        }
     }
 }

--- a/ReactWindows/ReactNative/Tracing/EtwLogTracer.cs
+++ b/ReactWindows/ReactNative/Tracing/EtwLogTracer.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+
+namespace ReactNative.Tracing
+{
+    /// <summary>
+    /// Logs events as Etw events to SkypeEventSource.
+    /// </summary>
+    public class EtwLogTracer : LogTracerBase
+    {
+        private EventSource eventSource;
+
+        /// <summary>
+        /// Accepts the source name used for the EventSource.
+        /// </summary>
+        /// <param name="eventSourceName">The source name</param>
+        public EtwLogTracer(string eventSourceName)
+        {
+            // For EtwSelfDescribingEventFormat tracelogging the guid is automatically computed from the name.
+            eventSource = new EventSource(eventSourceName, EventSourceSettings.EtwSelfDescribingEventFormat);
+        }
+
+        /// <summary>
+        /// Logs an event to the SkypeEventSource ETW
+        /// </summary>
+        /// <param name="eventLevel">Level of the event</param>
+        /// <param name="eventName">Name of the event</param>
+        /// <param name="message">Log message</param>
+        /// <param name="exception">Optional exception to include with event</param>
+        protected override void AppendInternal(EventLevel eventLevel, string eventName, FormattableString message, Exception exception)
+        {
+            var options = new EventSourceOptions
+            {
+                Opcode = EventOpcode.Info,
+                Keywords = EventKeywords.None,
+                Level = eventLevel
+            };
+
+            eventSource.Write(
+                eventName,
+                options,
+                new
+                {
+                    message,
+                    timestamp = DateTime.Now.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fffzzz", CultureInfo.InvariantCulture),
+                    exception = FormatException(exception)
+                });
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Tracing/Tracer.cs
+++ b/ReactWindows/ReactNative/Tracing/Tracer.cs
@@ -7,7 +7,8 @@ using Windows.Foundation.Diagnostics;
 namespace ReactNative.Tracing
 {
     /// <summary>
-    /// Tracing helpers for the application.
+    /// Tracing helpers for understanding the performance of React Native Windows
+    /// internals.
     /// </summary>
     static class Tracer
     {

--- a/ReactWindows/ReactNative/Tracing/Tracer.cs
+++ b/ReactWindows/ReactNative/Tracing/Tracer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -50,36 +50,6 @@ namespace ReactNative.Tracing
             else
             {
                 return null;
-            }
-        }
-
-        /// <summary>
-        /// Write an event.
-        /// </summary>
-        /// <param name="tag">The trace tag.</param>
-        /// <param name="eventName">The event name.</param>
-        public static void Write(int tag, string eventName)
-        {
-            if (Instance.Enabled)
-            {
-                Instance.LogEvent(eventName, null, LoggingLevel.Information, new LoggingOptions
-                {
-                    Tags = tag
-                });
-            }
-        }
-
-        /// <summary>
-        /// Write an error event.
-        /// </summary>
-        /// <param name="tag">The trace tag.</param>
-        /// <param name="eventName">The event name.</param>
-        /// <param name="ex">The exception.</param>
-        public static void Error(int tag, string eventName, Exception ex)
-        {
-            if (Instance.Enabled)
-            {
-                Instance.LogEvent(eventName, null, LoggingLevel.Error);
             }
         }
     }

--- a/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
@@ -4,6 +4,7 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using ReactNative.Modules.Core;
+using ReactNative.Tracing;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -586,7 +587,7 @@ namespace ReactNative.UIManager
                     }
                     else
                     {
-                        Debug.WriteLine($"View with tag {tag} not found due to race condition");
+                        RnLog.Warn(nameof(UIViewOperationQueue), $"View with tag '{tag}' not found due to race condition");
                     }
                 });
             }


### PR DESCRIPTION
Added a generic RnLog static class with the usual Info/Warn/Error/Fatal calls (the last one also crashes the application)
A plug-able implementation (based on logTracerBase base class) allows for applications to customize the logging pipeline. The default implementation uses Debug.WriteLine for logging and Environment.FailFast for crashing.
Added some log lines to instance initialization code and some modules.
The existing Tracer class (for UWP) remains in place solely for RNW performance measuring.
