### PR TITLE
Protect against early calls to Timers module

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/Timing.cs
@@ -30,7 +30,7 @@ namespace ReactNative.Modules.Core
 
         private readonly SerialDisposable _idleCancellationDisposable = new SerialDisposable();
 
-        private JSTimers _jsTimersModule;
+        private readonly Lazy<JSTimers> _jsTimersModule;
         private bool _suspended;
 
         private bool _sendIdleEvents;
@@ -45,6 +45,7 @@ namespace ReactNative.Modules.Core
             _timers = new HeapBasedPriorityQueue<TimerData>(
                 Comparer<TimerData>.Create((x, y) => 
                     x.TargetTime.CompareTo(y.TargetTime)));
+            _jsTimersModule = new Lazy<JSTimers>(() => Context.GetJavaScriptModule<JSTimers>());
         }
 
         /// <summary>
@@ -63,7 +64,6 @@ namespace ReactNative.Modules.Core
         /// </summary>
         public override void Initialize()
         {
-            _jsTimersModule = Context.GetJavaScriptModule<JSTimers>();
             Context.AddLifecycleEventListener(this);
         }
 
@@ -137,7 +137,7 @@ namespace ReactNative.Modules.Core
         {
             if (duration == 0 && !repeat)
             {
-                _jsTimersModule.callTimers(new[] { callbackId });
+                _jsTimersModule.Value.callTimers(new[] { callbackId });
                 return;
             }
 
@@ -250,7 +250,7 @@ namespace ReactNative.Modules.Core
 
             if (ready.Count > 0)
             {
-                _jsTimersModule.callTimers(ready);
+                _jsTimersModule.Value.callTimers(ready);
             }
         }
 


### PR DESCRIPTION
createTimer can be called before the native Timing module was initialized due to the way RNW initialization works.
The fix makes the reference to the JSTimers module initialized on demand.