### PR TITLE
Workaround for a "UnauthorizedAccessException" during startup

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/I18N/I18NUtil.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/I18N/I18NUtil.cs
@@ -91,7 +91,12 @@ namespace ReactNative.Modules.I18N
                 // We use GetForViewIndependentUse because the customary GetForCurrentView throws exception when
                 // an associated CoreWindow is not present, condition that happens during background activation scenarios.
                 // GetForViewIndependentUse is good enough for the LayoutDirection resource (it's not view or display dependent)
-                return ResourceContext.GetForViewIndependentUse().QualifierValues["LayoutDirection"] == "RTL";
+
+                // More, sometimes the retrieval of the "LayoutDirection" values fails with "UnauthorizedAccessException"
+                // because of a peculiarity of the QualifierValues on some OS'es (it keeps just a weak reference to the ResourceContext)
+                // We mitigate by pinning ResourceContext locally
+                var context = ResourceContext.GetForViewIndependentUse();
+                return context.QualifierValues["LayoutDirection"] == "RTL";
 #else
                 return CultureInfo.CurrentCulture.TextInfo.IsRightToLeft;
 #endif


### PR DESCRIPTION
In the following line: 
    ResourceContext.GetForViewIndependentUse().QualifierValues["LayoutDirection"]
the QualifierValues contain weak references to the underlying ResourceContext, so the look up of "LayoutDirection" key may fail with UnauthorizedAccessException if the GC kicked in before the lookup.

We pin the ResourceContext returned by GetForViewIndependentUse() locally to guarantee its lifetime for the duration of the lookup.
