### PR TITLE
Add option to use TextBlock for simple text, take 2

### DIFF
--- a/Libraries/Text/Text.windows.js
+++ b/Libraries/Text/Text.windows.js
@@ -1,0 +1,328 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+/**
+ * This is derived from https://github.com/facebook/react-native/blob/76eebce3c20152fdd5386ec405524d0810770eea/Libraries/Text/Text.js
+ * 
+ */
+
+'use strict';
+
+const React = require('React');
+const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
+const TextAncestor = require('TextAncestor');
+const TextPropTypes = require('TextPropTypes');
+const Touchable = require('Touchable');
+const UIManager = require('UIManager');
+
+const createReactNativeComponentClass = require('createReactNativeComponentClass');
+const nullthrows = require('fbjs/lib/nullthrows');
+const processColor = require('processColor');
+
+import type {PressEvent} from 'CoreEventTypes';
+import type {NativeComponent} from 'ReactNative';
+import type {PressRetentionOffset, TextProps} from 'TextProps';
+
+type ResponseHandlers = $ReadOnly<{|
+  onStartShouldSetResponder: () => boolean,
+  onResponderGrant: (event: SyntheticEvent<>, dispatchID: string) => void,
+  onResponderMove: (event: SyntheticEvent<>) => void,
+  onResponderRelease: (event: SyntheticEvent<>) => void,
+  onResponderTerminate: (event: SyntheticEvent<>) => void,
+  onResponderTerminationRequest: () => boolean,
+|}>;
+
+type Props = $ReadOnly<{
+  ...TextProps,
+  forwardedRef: ?React.Ref<'RCTText' | 'RCTSimpleText' | 'RCTVirtualText'>,
+}>;
+
+type State = {|
+  touchable: {|
+    touchState: ?string,
+    responderID: ?number,
+  |},
+  isHighlighted: boolean,
+  createResponderHandlers: () => ResponseHandlers,
+  responseHandlers: ?ResponseHandlers,
+|};
+
+const PRESS_RECT_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
+
+const viewConfig = {
+  validAttributes: {
+    ...ReactNativeViewAttributes.UIView,
+    isHighlighted: true,
+    numberOfLines: true,
+    ellipsizeMode: true,
+    allowFontScaling: true,
+    disabled: true,
+    selectable: true,
+    selectionColor: true,
+    adjustsFontSizeToFit: true,
+    minimumFontScale: true,
+    textBreakStrategy: true,
+  },
+  uiViewClassName: 'RCTText',
+};
+
+const simpleViewConfig = {
+  validAttributes: {
+    ...ReactNativeViewAttributes.UIView,
+    isHighlighted: true,
+    numberOfLines: true,
+    ellipsizeMode: true,
+    allowFontScaling: true,
+    disabled: true,
+    selectable: true,
+    selectionColor: true,
+    adjustsFontSizeToFit: true,
+    minimumFontScale: true,
+    textBreakStrategy: true,
+    text: true,
+  },
+  uiViewClassName: 'RCTSimpleText',
+};
+
+/**
+ * A React component for displaying text.
+ *
+ * See https://facebook.github.io/react-native/docs/text.html
+ */
+class TouchableText extends React.Component<Props, State> {
+  static defaultProps = {
+    accessible: true,
+    allowFontScaling: true,
+    ellipsizeMode: 'tail',
+  };
+
+  touchableGetPressRectOffset: ?() => PressRetentionOffset;
+  touchableHandleActivePressIn: ?() => void;
+  touchableHandleActivePressOut: ?() => void;
+  touchableHandleLongPress: ?(event: PressEvent) => void;
+  touchableHandlePress: ?(event: PressEvent) => void;
+  touchableHandleResponderGrant: ?(
+    event: SyntheticEvent<>,
+    dispatchID: string,
+  ) => void;
+  touchableHandleResponderMove: ?(event: SyntheticEvent<>) => void;
+  touchableHandleResponderRelease: ?(event: SyntheticEvent<>) => void;
+  touchableHandleResponderTerminate: ?(event: SyntheticEvent<>) => void;
+  touchableHandleResponderTerminationRequest: ?() => boolean;
+
+  state = {
+    ...Touchable.Mixin.touchableGetInitialState(),
+    isHighlighted: false,
+    createResponderHandlers: this._createResponseHandlers.bind(this),
+    responseHandlers: null,
+  };
+
+  static getDerivedStateFromProps(nextProps: Props, prevState: State): ?State {
+    return prevState.responseHandlers == null && isTouchable(nextProps)
+      ? {
+          ...prevState,
+          responseHandlers: prevState.createResponderHandlers(),
+        }
+      : null;
+  }
+
+  static viewConfig = viewConfig;
+
+  static isSimpleText(props: Props): boolean {
+    const children = props.children;
+    return typeof children === 'string' || 
+      (Array.isArray(children) && children.length <= 1 && children.every(x => typeof x === 'string'));
+  }
+
+  static getDerivedSimpleTextProps(props: Props): Props {
+    const children = props.children;
+    let text = Array.isArray(children) ? children[0] : children;
+    let simpleProps = {};
+    Object.assign(simpleProps, props);
+    simpleProps.text = text;
+    delete simpleProps.children;
+    return simpleProps;
+  }
+
+  render(): React.Node {
+    let props = this.props;
+    if (isTouchable(props)) {
+      props = {
+        ...props,
+        ...this.state.responseHandlers,
+        isHighlighted: this.state.isHighlighted,
+      };
+    }
+    if (props.selectionColor != null) {
+      props = {
+        ...props,
+        selectionColor: processColor(props.selectionColor),
+      };
+    }
+    if (__DEV__) {
+      if (Touchable.TOUCH_TARGET_DEBUG && props.onPress != null) {
+        props = {
+          ...props,
+          style: [props.style, {color: 'magenta'}],
+        };
+      }
+    }
+    return (
+      <TextAncestor.Consumer>
+        {hasTextAncestor =>
+          hasTextAncestor ? (
+            <RCTVirtualText {...props} ref={props.forwardedRef} />
+          ) : (
+            <TextAncestor.Provider value={true}>
+              {RCTSimpleText && TouchableText.isSimpleText(props) ? (
+                <RCTSimpleText {...TouchableText.getDerivedSimpleTextProps(props)} ref={props.forwardedRef} />
+                ) : (
+                <RCTText {...props} ref={props.forwardedRef} />
+                )
+              }
+            </TextAncestor.Provider>
+          )
+        }
+      </TextAncestor.Consumer>
+    );
+  }
+
+  _createResponseHandlers(): ResponseHandlers {
+    return {
+      onStartShouldSetResponder: (): boolean => {
+        const {onStartShouldSetResponder} = this.props;
+        const shouldSetResponder =
+          (onStartShouldSetResponder == null
+            ? false
+            : onStartShouldSetResponder()) || isTouchable(this.props);
+
+        if (shouldSetResponder) {
+          this._attachTouchHandlers();
+        }
+        return shouldSetResponder;
+      },
+      onResponderGrant: (event: SyntheticEvent<>, dispatchID: string): void => {
+        nullthrows(this.touchableHandleResponderGrant)(event, dispatchID);
+        if (this.props.onResponderGrant != null) {
+          this.props.onResponderGrant.call(this, event, dispatchID);
+        }
+      },
+      onResponderMove: (event: SyntheticEvent<>): void => {
+        nullthrows(this.touchableHandleResponderMove)(event);
+        if (this.props.onResponderMove != null) {
+          this.props.onResponderMove.call(this, event);
+        }
+      },
+      onResponderRelease: (event: SyntheticEvent<>): void => {
+        nullthrows(this.touchableHandleResponderRelease)(event);
+        if (this.props.onResponderRelease != null) {
+          this.props.onResponderRelease.call(this, event);
+        }
+      },
+      onResponderTerminate: (event: SyntheticEvent<>): void => {
+        nullthrows(this.touchableHandleResponderTerminate)(event);
+        if (this.props.onResponderTerminate != null) {
+          this.props.onResponderTerminate.call(this, event);
+        }
+      },
+      onResponderTerminationRequest: (): boolean => {
+        const {onResponderTerminationRequest} = this.props;
+        if (!nullthrows(this.touchableHandleResponderTerminationRequest)()) {
+          return false;
+        }
+        if (onResponderTerminationRequest == null) {
+          return true;
+        }
+        return onResponderTerminationRequest();
+      },
+    };
+  }
+
+  /**
+   * Lazily attaches Touchable.Mixin handlers.
+   */
+  _attachTouchHandlers(): void {
+    if (this.touchableGetPressRectOffset != null) {
+      return;
+    }
+    for (const key in Touchable.Mixin) {
+      if (typeof Touchable.Mixin[key] === 'function') {
+        (this: any)[key] = Touchable.Mixin[key].bind(this);
+      }
+    }
+    this.touchableHandleActivePressIn = (): void => {
+      if (!this.props.suppressHighlighting && isTouchable(this.props)) {
+        this.setState({isHighlighted: true});
+      }
+    };
+    this.touchableHandleActivePressOut = (): void => {
+      if (!this.props.suppressHighlighting && isTouchable(this.props)) {
+        this.setState({isHighlighted: false});
+      }
+    };
+    this.touchableHandlePress = (event: PressEvent): void => {
+      if (this.props.onPress != null) {
+        this.props.onPress(event);
+      }
+    };
+    this.touchableHandleLongPress = (event: PressEvent): void => {
+      if (this.props.onLongPress != null) {
+        this.props.onLongPress(event);
+      }
+    };
+    this.touchableGetPressRectOffset = (): PressRetentionOffset =>
+      this.props.pressRetentionOffset == null
+        ? PRESS_RECT_OFFSET
+        : this.props.pressRetentionOffset;
+  }
+}
+
+const isTouchable = (props: Props): boolean =>
+  props.onPress != null ||
+  props.onLongPress != null ||
+  props.onStartShouldSetResponder != null;
+
+const RCTText = createReactNativeComponentClass(
+  viewConfig.uiViewClassName,
+  () => viewConfig,
+);
+
+const RCTVirtualText =
+  UIManager.RCTVirtualText == null
+    ? RCTText
+    : createReactNativeComponentClass('RCTVirtualText', () => ({
+        validAttributes: {
+          ...ReactNativeViewAttributes.UIView,
+          isHighlighted: true,
+        },
+        uiViewClassName: 'RCTVirtualText',
+      }));
+
+const RCTSimpleText =
+  UIManager.RCTSimpleText == null
+    ? RCTText
+    : createReactNativeComponentClass(
+        simpleViewConfig.uiViewClassName, 
+        () => simpleViewConfig
+    );
+
+const Text = (
+  props: TextProps,
+  forwardedRef: ?React.Ref<'RCTText' | 'RCTSimpleText' | 'RCTVirtualText'>,
+) => {
+  return <TouchableText {...props} forwardedRef={forwardedRef} />;
+};
+// $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
+const TextToExport = React.forwardRef(Text);
+
+// TODO: Deprecate this.
+TextToExport.propTypes = TextPropTypes;
+
+module.exports = (TextToExport: Class<NativeComponent<TextProps>>);

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Views\Scroll\ScrollView.cs" />
     <Compile Include="Views\Slider\ReactSliderManager.cs" />
     <Compile Include="Views\TextInput\PlaceholderAdorner.cs" />
+    <Compile Include="Views\Text\ReactSimpleTextViewManager.cs" />
     <Compile Include="Views\Text\ReactTextCompoundView.cs" />
     <Compile Include="Views\Text\ReactTextShadowNode.cs" />
     <Compile Include="Views\Text\ReactTextViewManager.cs" />

--- a/ReactWindows/ReactNative.Net46/Shell/MainReactPackage.cs
+++ b/ReactWindows/ReactNative.Net46/Shell/MainReactPackage.cs
@@ -75,6 +75,7 @@ namespace ReactNative.Shell
         {
             return new List<IViewManager>
             {
+                new ReactSimpleTextViewManager(),
                 //new ReactFlipViewManager(),
                 new ReactImageManager(),
                 new ReactProgressBarViewManager(),

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactSimpleTextViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactSimpleTextViewManager.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Windows.Controls;
+
+namespace ReactNative.Views.Text
+{
+    /// <summary>
+    /// The view manager for simple text views.
+    /// </summary>
+    public class ReactSimpleTextViewManager : ReactTextViewManager
+    {
+        /// <summary>
+        /// Name of the view manager.
+        /// </summary>
+        public override string Name
+        {
+            get
+            {
+                return "RCTSimpleText";
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of children for the view.
+        /// </summary>
+        /// <param name="parent">The view parent.</param>
+        /// <returns>The number of children.</returns>
+        public override int GetChildCount(TextBlock parent)
+        {
+            return 0;
+        }
+
+        /// <summary>
+        /// Removes the children from the view.
+        /// </summary>
+        /// <param name="parent">The view parent.</param>
+        public override void RemoveAllChildren(TextBlock parent)
+        {
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextCompoundView.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextCompoundView.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using ReactNative.UIManager;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -13,7 +14,8 @@ namespace ReactNative.Views.Text
         {
             var richTextBlock = reactView.As<TextBlock>();
             var textPointer = richTextBlock.GetPositionFromPoint(point, true);
-            return textPointer.Parent.GetTag();
+            var parentView = RootViewHelper.GetReactViewHierarchy(textPointer.Parent).First();
+            return parentView.GetTag();
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/RootViewHelper.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/RootViewHelper.cs
@@ -9,6 +9,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 #else
 using System.Windows;
+using System.Windows.Documents;
 using System.Windows.Media;
 #endif
 
@@ -104,12 +105,24 @@ namespace ReactNative.UIManager
 
             if (!findRoot)
             {
-                return (view as FrameworkElement)?.Parent;
+                var frameworkElement = view as FrameworkElement;
+                if (frameworkElement != null)
+                {
+                    return frameworkElement.Parent;
+                }
+#if !WINDOWS_UWP
+
+                var frameworkContentElement = view as FrameworkContentElement;
+                if (frameworkContentElement != null)
+                {
+                    return frameworkContentElement.Parent;
+                }
+#endif
+
+                return null;
             }
-            else
-            {
-                return VisualTreeHelper.GetParent(view);
-            }
+
+            return VisualTreeHelper.GetParent(view);
         }
     }
 }

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -171,6 +171,8 @@
     <Compile Include="Views\Switch\ReactSwitchShadowNode.cs" />
     <Compile Include="Views\TextInput\ReactPasswordBoxManager.cs" />
     <Compile Include="Views\TextInput\ReactTextInputManager.cs" />
+    <Compile Include="Views\Text\ReactSimpleTextShadowNode.cs" />
+    <Compile Include="Views\Text\ReactSimpleTextViewManager.cs" />
     <Compile Include="Views\Text\ReactTextCompoundView.cs" />
     <Compile Include="Views\Text\ReactTextShadowNode.cs" />
     <Compile Include="Views\Text\ReactTextViewManager.cs" />

--- a/ReactWindows/ReactNative/Shell/MainReactPackage.cs
+++ b/ReactWindows/ReactNative/Shell/MainReactPackage.cs
@@ -83,6 +83,7 @@ namespace ReactNative.Shell
         {
             return new List<IViewManager>
             {
+                new ReactSimpleTextViewManager(),
                 new ReactFlipViewManager(),
                 new ReactImageManager(),
                 new ReactProgressBarViewManager(),

--- a/ReactWindows/ReactNative/Views/Text/ReactSimpleTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactSimpleTextShadowNode.cs
@@ -6,17 +6,18 @@ using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using System;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
+using Windows.Foundation;
+using Windows.UI.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 namespace ReactNative.Views.Text
 {
     /// <summary>
     /// The shadow node implementation for text views.
     /// </summary>
-    public class ReactTextShadowNode : LayoutShadowNode
+    public class ReactSimpleTextShadowNode : LayoutShadowNode
     {
         private int _letterSpacing;
         private int _numberOfLines;
@@ -24,36 +25,34 @@ namespace ReactNative.Views.Text
         private double? _fontSize;
         private double _lineHeight;
 
+        private bool _allowFontScaling;
+
         private FontStyle? _fontStyle;
         private FontWeight? _fontWeight;
-        private TextAlignment _textAlignment = TextAlignment.Left;
+        private TextAlignment _textAlignment = TextAlignment.DetectFromContent;
 
         private string _fontFamily;
 
-        private string _text;
+        private string _text = "";
 
         /// <summary>
         /// Instantiates a <see cref="ReactTextShadowNode"/>.
         /// </summary>
-        public ReactTextShadowNode()
+        public ReactSimpleTextShadowNode()
         {
             MeasureFunction = (node, width, widthMode, height, heightMode) =>
                 MeasureText(this, node, width, widthMode, height, heightMode);
         }
 
         /// <summary>
-        /// Sets the text for the node.
+        /// Sets the text on the view.
         /// </summary>
         /// <param name="text">The text.</param>
         [ReactProp("text")]
         public void SetText(string text)
         {
-            var nonNullText = text ?? "";
-            if (_text != nonNullText)
-            {
-                _text = nonNullText;
-                MarkUpdated();
-            }
+            _text = text ?? "";
+            MarkUpdated();
         }
 
         /// <summary>
@@ -94,7 +93,7 @@ namespace ReactNative.Views.Text
             var fontWeight = FontStyleHelpers.ParseFontWeight(fontWeightValue);
             if (_fontWeight.HasValue != fontWeight.HasValue ||
                 (_fontWeight.HasValue && fontWeight.HasValue &&
-                _fontWeight.Value != fontWeight.Value))
+                _fontWeight.Value.Weight != fontWeight.Value.Weight))
             {
                 _fontWeight = fontWeight;
                 MarkUpdated();
@@ -123,7 +122,7 @@ namespace ReactNative.Views.Text
         [ReactProp(ViewProps.LetterSpacing)]
         public void SetLetterSpacing(int letterSpacing)
         {
-            var spacing = 50*letterSpacing; // TODO: Find exact multiplier (50) to match iOS
+            var spacing = 50 * letterSpacing; // TODO: Find exact multiplier (50) to match iOS
 
             if (_letterSpacing != spacing)
             {
@@ -168,12 +167,26 @@ namespace ReactNative.Views.Text
         public void SetTextAlign(string textAlign)
         {
             var textAlignment = textAlign == "auto" || textAlign == null ?
-                TextAlignment.Left :
+                TextAlignment.DetectFromContent :
                 EnumHelpers.Parse<TextAlignment>(textAlign);
 
             if (_textAlignment != textAlignment)
             {
                 _textAlignment = textAlignment;
+                MarkUpdated();
+            }
+        }
+
+        /// <summary>
+        /// Set fontScaling
+        /// </summary>
+        /// <param name="allowFontScaling">Max number of lines.</param>
+        [ReactProp(ViewProps.AllowFontScaling)]
+        public virtual void SetAllowFontScaling(bool allowFontScaling)
+        {
+            if (_allowFontScaling != allowFontScaling)
+            {
+                _allowFontScaling = allowFontScaling;
                 MarkUpdated();
             }
         }
@@ -202,7 +215,7 @@ namespace ReactNative.Views.Text
             dirty();
         }
 
-        private static YogaSize MeasureText(ReactTextShadowNode textNode, YogaNode node, float width, YogaMeasureMode widthMode, float height, YogaMeasureMode heightMode)
+        private static YogaSize MeasureText(ReactSimpleTextShadowNode textNode, YogaNode node, float width, YogaMeasureMode widthMode, float height, YogaMeasureMode heightMode)
         {
             // TODO: Measure text with DirectWrite or other API that does not
             // require dispatcher access. Currently, we're instantiating a
@@ -210,18 +223,12 @@ namespace ReactNative.Views.Text
             // its Dispatcher thread to calculate layout.
             var textBlock = new TextBlock
             {
-                TextAlignment = TextAlignment.Left,
                 TextWrapping = TextWrapping.Wrap,
+                TextAlignment = TextAlignment.DetectFromContent,
                 TextTrimming = TextTrimming.CharacterEllipsis,
             };
 
             textNode.UpdateTextBlockCore(textBlock, true);
-
-            for (var i = 0; i < textNode.ChildCount; ++i)
-            {
-                var child = textNode.GetChildAt(i);
-                textBlock.Inlines.Add(ReactInlineShadowNodeVisitor.Apply(child));
-            }
 
             var normalizedWidth = YogaConstants.IsUndefined(width) ? double.PositiveInfinity : width;
             var normalizedHeight = YogaConstants.IsUndefined(height) ? double.PositiveInfinity : height;
@@ -232,7 +239,7 @@ namespace ReactNative.Views.Text
         }
 
         /// <summary>
-        /// Updates the properties of a <see cref="TextBlock"/> view.
+        /// Updates the properties of a <see cref="RichTextBlock"/> view.
         /// </summary>
         /// <param name="textBlock">The view.</param>
         public void UpdateTextBlock(TextBlock textBlock)
@@ -242,32 +249,16 @@ namespace ReactNative.Views.Text
 
         private void UpdateTextBlockCore(TextBlock textBlock, bool measureOnly)
         {
-            if (ChildCount == 0 && _text != null)
-            {
-                textBlock.Text = _text;
-            }
-
-            textBlock.LineHeight = _lineHeight != 0 ? _lineHeight : double.NaN;
+            textBlock.CharacterSpacing = _letterSpacing;
+            textBlock.LineHeight = _lineHeight;
+            textBlock.MaxLines = _numberOfLines;
             textBlock.TextAlignment = _textAlignment;
+            textBlock.FontFamily = _fontFamily != null ? new FontFamily(_fontFamily) : FontFamily.XamlAutoFontFamily;
             textBlock.FontSize = _fontSize ?? 15;
-            textBlock.FontStyle = _fontStyle ?? new FontStyle();
+            textBlock.FontStyle = _fontStyle ?? FontStyle.Normal;
             textBlock.FontWeight = _fontWeight ?? FontWeights.Normal;
-
-            if (_fontFamily != null)
-            {
-                // convert font string into something WPF can use
-                // https://msdn.microsoft.com/en-us/library/ms753303(v=vs.110).aspx
-                // e.g. FontFamily(new System.Uri("pack://application:,,,/"), "./Assets/#fontname")
-                string[] path = _fontFamily.Split('/');
-                path = path.Take(path.Count() - 1).ToArray();
-                string cleanPath = "./" + string.Join("/", path) + "/";
-                string[] fontParts = _fontFamily.Split('#');
-                textBlock.FontFamily = new FontFamily(new System.Uri("pack://application:,,,/"), cleanPath + "#" + fontParts.Last());
-            }
-            else
-            {
-                textBlock.FontFamily = new FontFamily();
-            }
+            textBlock.IsTextScaleFactorEnabled = _allowFontScaling;
+            textBlock.Text = _text;
 
             if (!measureOnly)
             {
@@ -276,25 +267,6 @@ namespace ReactNative.Views.Text
                     GetPadding(YogaEdge.Top),
                     GetPadding(YogaEdge.Right),
                     GetPadding(YogaEdge.Bottom));
-            }
-        }
-
-        /// <summary>
-        /// This method will be called by <see cref="UIManagerModule"/> once
-        /// per batch, before calculating layout. This will only be called for
-        /// nodes that are marked as updated with <see cref="MarkUpdated"/> or
-        /// require layout (i.e., marked with <see cref="ReactShadowNode.dirty"/>).
-        /// </summary>
-        public override void OnBeforeLayout()
-        {
-            // Run flexbox on the children which are inline views.
-            for (var i = 0; i < ChildCount; ++i)
-            {
-                var child = GetChildAt(i);
-                if (!(child is ReactInlineShadowNode))
-                {
-                    child.CalculateLayout();
-                }
             }
         }
     }

--- a/ReactWindows/ReactNative/Views/Text/ReactSimpleTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactSimpleTextViewManager.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using ReactNative.Accessibility;
+using ReactNative.Reflection;
+using ReactNative.UIManager;
+using ReactNative.UIManager.Annotations;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace ReactNative.Views.Text
+{
+    /// <summary>
+    /// The view manager for text views.
+    /// </summary>
+    public class ReactSimpleTextViewManager : BaseViewManager<TextBlock, ReactSimpleTextShadowNode>
+    {
+        /// <summary>
+        /// The name of the view manager.
+        /// </summary>
+        public override string Name
+        {
+            get
+            {
+                return "RCTSimpleText";
+            }
+        }
+
+        /// <summary>
+        /// Creates the shadow node instance.
+        /// </summary>
+        /// <returns>The shadow node instance.</returns>
+        public override ReactSimpleTextShadowNode CreateShadowNodeInstance()
+        {
+            return new ReactSimpleTextShadowNode();
+        }
+
+        /// <summary>
+        /// Sets the font color for the node.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp(ViewProps.Color, CustomType = "Color")]
+        public void SetColor(TextBlock view, uint? color)
+        {
+            view.Foreground = color.HasValue
+                ? new SolidColorBrush(ColorHelpers.Parse(color.Value))
+                : null;
+        }
+
+        /// <summary>
+        /// Sets whether or not the text is selectable.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="selectable">A flag indicating whether or not the text is selectable.</param>
+        [ReactProp("selectable")]
+        public void SetSelectable(TextBlock view, bool selectable)
+        {
+            view.IsTextSelectionEnabled = selectable;
+        }
+
+        ///<summary>
+        /// Sets <see cref="ImportantForAccessibility"/> for the TextBlock.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="importantForAccessibilityValue">The string to be parsed as <see cref="ImportantForAccessibility"/>.</param>
+        [ReactProp(ViewProps.ImportantForAccessibility)]
+        public void SetImportantForAccessibility(TextBlock view, string importantForAccessibilityValue)
+        {
+            var importantForAccessibility = EnumHelpers.ParseNullable<ImportantForAccessibility>(importantForAccessibilityValue) ?? ImportantForAccessibility.Auto;
+            AccessibilityHelper.SetImportantForAccessibility(view, importantForAccessibility);
+        }
+
+        /// <summary>
+        /// Receive extra updates from the shadow node.
+        /// </summary>
+        /// <param name="root">The root view.</param>
+        /// <param name="extraData">The extra data.</param>
+        public override void UpdateExtraData(TextBlock root, object extraData)
+        {
+            var textNode = extraData as ReactSimpleTextShadowNode;
+            if (textNode != null)
+            {
+                textNode.UpdateTextBlock(root);
+            }
+        }
+
+        /// <summary>
+        /// Creates the view instance.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <returns>The view instance.</returns>
+        protected override TextBlock CreateViewInstance(ThemedReactContext reactContext)
+        {
+            var textBlock = new TextBlock
+            {
+                IsTextSelectionEnabled = false,
+                TextAlignment = TextAlignment.DetectFromContent,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                TextWrapping = TextWrapping.Wrap,
+            };
+
+            return textBlock;
+        }
+    }
+}


### PR DESCRIPTION
Simple text, i.e., text with only a single raw text node as a child (or an array with one raw text child), can be transformed into a TextBlock with a Text property, instead of a RichTextBlock with a Paragraph of Inlines. This change detects in the React Native Text node has a single raw text child/array element, and if so, uses the RCTSimpleText native component.

Fixes #1252