### PR TITLE
Harden selection property for null

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -222,6 +222,10 @@ namespace ReactNative.Views.TextInput
         [ReactProp("selection")]
         public void SetSelection(ReactTextBox view, JObject selection)
         {
+            if (selection == null) {
+                return;
+            }
+
             var start = selection.Value<int>("start");
             var textLength = view.Text?.Length ?? 0;
             var normalizedStart = Math.Min(start, textLength);


### PR DESCRIPTION
A recurring condition that seems to be happening more with recent RN versions is TextInput.selection being pass a "null" object.
I couldn't find/trace this in the JS counterpart, I wonder whether there's some property cleaning done by RN or something similar.

Nevertheless, both the iOS and Android implementations have an "if" to bail out in this case.