### PR TITLE
Show console.error as dismiss-able red-box, same as other platforms 

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Core/ExceptionsManagerModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Core/ExceptionsManagerModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -63,13 +63,20 @@ namespace ReactNative.Modules.Core
         /// <param name="details">The exception stack trace.</param>
         /// <param name="exceptionId">An identifier for the exception.</param>
         /// <remarks>
-        /// Should not trigger a red box dialog or runtime exception.
+        /// Will either trigger a dismissable red box dialog or a log line.
         /// </remarks>
         [ReactMethod]
         public void reportSoftException(string title, JArray details, int exceptionId)
         {
-            var stackTrace = StackTraceHelper.ConvertJavaScriptStackTrace(details);
-            RnLog.Warn(ReactConstants.RNW, $"Soft Exception: {title}\n{stackTrace.PrettyPrint()}");
+            if (_devSupportManager.IsEnabled)
+            {
+                _devSupportManager.ShowNewJavaScriptError(title, details, exceptionId);
+            }
+            else
+            {
+                var stackTrace = StackTraceHelper.ConvertJavaScriptStackTrace(details);
+                RnLog.Warn(ReactConstants.RNW, $"Soft Exception: {title}\n{stackTrace.PrettyPrint()}");
+            }
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml
+++ b/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml
@@ -8,7 +8,8 @@
     mc:Ignorable="d"
     Background="#E80000"
     PrimaryButtonText="Reload JavaScript"
-    PrimaryButtonClick="ContentDialog_PrimaryButtonClick">
+    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
+    Loaded="ContentDialog_Loaded">
     <ContentDialog.Resources>
         <DataTemplate x:Key="StackFrameTemplate"
                       x:DataType="devsupport:IStackFrame">

--- a/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml.cs
+++ b/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
@@ -79,6 +81,22 @@ namespace ReactNative.DevSupport
             {
                 _stackTrace = value;
                 OnNotifyPropertyChanged();
+            }
+        }
+
+        private void ContentDialog_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is ContentDialog dialog)
+            {
+                // To be uncommented when target SDK is at least RS2
+                // if (ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Controls.ContentDialog", "CloseButtonText"))
+                // {
+                //    dialog.CloseButtonText = "Dismiss";
+                // }
+                // else
+                {
+                    dialog.SecondaryButtonText = "Dismiss";
+                }
             }
         }
 


### PR DESCRIPTION
Affects dev mode. 
We redirect "soft exceptions" to a red box too. Added a "Dismiss" button as well.