### PR TITLE
Open touch keyboard for TextInput when getting focused in touch mode

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -13,6 +13,7 @@ using ReactNative.Views.Text;
 using System;
 using Windows.System;
 using Windows.UI.Text;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
@@ -547,6 +548,12 @@ namespace ReactNative.Views.TextInput
             if (commandId == FocusTextInput)
             {
                 view.Focus(FocusState.Programmatic);
+                
+                // Open the touch keyboard if the device is in touch mode
+                if (UIViewSettings.GetForCurrentView().UserInteractionMode == UserInteractionMode.Touch)
+                {
+                    InputPane.GetForCurrentView().TryShow();
+                }
             }
             else if (commandId == BlurTextInput)
             {


### PR DESCRIPTION
In iOS and Android, if you use a `TextInput` and it gets focused, the onscreen keyboard opens automatically. So if you navigate to a screen with an input, you can auto-focus it, that opens up the keyboard directly and the user can start typing.

With RNWindows, currently the input is focused but no keyboard is shown. This is fine for most applications, but if there is no keyboard connected, this means that the user has to click on an already focused input field to open up the keyboard.

With this implementation, the keyboard opens when the `UserInteractionMode` is touch. I also tried using the `KeyboardCapabilities`, but on the Surface 4 it also showed connected keyboards when there were none.