### PR TITLE
Do not open dev menu on ALT GR and Y key press

### DIFF
--- a/ReactWindows/ReactNative/ReactRootViewExtensions.cs
+++ b/ReactWindows/ReactNative/ReactRootViewExtensions.cs
@@ -48,8 +48,7 @@ namespace ReactNative
                     {
                         s_isControlKeyDown = e.EventType == CoreAcceleratorKeyEventType.KeyDown;
                     }
-                    else if ((s_isShiftKeyDown && e.VirtualKey == VirtualKey.F10) ||
-                              (e.EventType == CoreAcceleratorKeyEventType.KeyDown && e.VirtualKey == VirtualKey.Menu))
+                    else if (s_isShiftKeyDown && e.VirtualKey == VirtualKey.F10 && e.EventType != CoreAcceleratorKeyEventType.Character)
                     {
                         reactInstanceManager.DevSupportManager.ShowDevOptionsDialog();
                     }

--- a/ReactWindows/ReactNative/ReactRootViewExtensions.cs
+++ b/ReactWindows/ReactNative/ReactRootViewExtensions.cs
@@ -48,7 +48,7 @@ namespace ReactNative
                     {
                         s_isControlKeyDown = e.EventType == CoreAcceleratorKeyEventType.KeyDown;
                     }
-                    else if (s_isShiftKeyDown && e.VirtualKey == VirtualKey.F10 && e.EventType != CoreAcceleratorKeyEventType.Character)
+                    else if (e.EventType == CoreAcceleratorKeyEventType.KeyDown && s_isShiftKeyDown && e.VirtualKey == VirtualKey.F10)
                     {
                         reactInstanceManager.DevSupportManager.ShowDevOptionsDialog();
                     }


### PR DESCRIPTION
When clicking on ALT GR, following AcceleratorKeyActivated events are thrown:

e.VirtualKey: Control and e.EventType: KeyDown
e.VirtualKey: Menu and e.EventType: KeyDown
e.VirtualKey: Control and e.EventType: SystemKeyUp
e.VirtualKey: Menu and e.EventType: KeyUp

This triggers the dev menu when inserting some special chars as "@" on non US keyboards

When clicking on Y key, following events are thrown:

e.VirtualKey: Y and e.EventType: KeyDown
e.VirtualKey: F10 and e.EventType: Character
e.VirtualKey: Y and e.EventType: KeyUp

This sometimes triggers the dev menu, as Y triggers an F10 Character

This PR prevents unwanted dev menu triggering