### PR TITLE
Fix for #2040, #782, #1542

### DIFF
--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -487,8 +487,16 @@ namespace ReactNative.Modules.Network
                 {
 #if WINDOWS_UWP
                     case "authorization":
-                        var headerParts = header[1].Trim().Split(new[] { ' ' }, 2);
-                        request.Headers.Authorization = new HttpCredentialsHeaderValue(headerParts[0].Trim(), headerParts[1].Trim());
+                        var authParts = header[1].Trim().Split(new[] { ' ' }, 2);
+                        if (authParts.Length == 2)
+                        {
+                            request.Headers.Authorization = new HttpCredentialsHeaderValue(authParts[0].Trim(), authParts[1].Trim());
+                        }
+                        else
+                        {
+                            request.Headers.Add(key, header[1]);
+                        }
+                        
                         break;
 #endif
                     case "content-encoding":

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -486,8 +486,8 @@ namespace ReactNative.Modules.Network
                 var key = header[0];
                 switch (key.ToLowerInvariant())
                 {
-                    case "authorization":
 #if WINDOWS_UWP
+                    case "authorization":
                         // Regex for RFC 2617
                         var regex = new Regex(@"^(?<scheme>\w+)\s*(?<token>(\w+\s*[=:]\s*""?[^,""]*""?\s*,?\s*)+)$");
                         var match = regex.Match(header[1].Trim());
@@ -498,13 +498,11 @@ namespace ReactNative.Modules.Network
                         }
                         else
                         {
-                            //If other different types of Authorization header which does not belongs to RFC2617.
                             request.Headers.Add(key, header[1]);
                         }
-#else
-                        request.Headers.Add(key, header[1]);
-#endif
+
                         break;
+#endif
                     case "content-encoding":
                     case "content-length":
                     case "content-type":

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -486,6 +486,7 @@ namespace ReactNative.Modules.Network
                 switch (key.ToLowerInvariant())
                 {
                      case "authorization":
+#if WINDOWS_UWP
                         //create scheme from user's Authorization first word
                         string createScheme = header[1].Split(' ')[0];
 
@@ -509,7 +510,9 @@ namespace ReactNative.Modules.Network
                             //If other diffrent types of Authorization header which does not belongs to RFC2617.
                             request.Headers.Add(key, header[1]);
                         }
- 
+#else
+                        request.Headers.Add(key, header[1]);
+#endif
                         break;
                     case "content-encoding":
                     case "content-length":

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -488,19 +488,8 @@ namespace ReactNative.Modules.Network
                 {
 #if WINDOWS_UWP
                     case "authorization":
-                        // Regex for RFC 2617
-                        var regex = new Regex(@"^(?<scheme>\w+)\s*(?<token>(\w+\s*[=:]\s*""?[^,""]*""?\s*,?\s*)+)$");
-                        var match = regex.Match(header[1].Trim());
-                        if (match.Success)
-                        {
-                            var authHeader = new HttpCredentialsHeaderValue(match.Groups["scheme"].Value, match.Groups["token"].Value);
-                            request.Headers.Authorization = authHeader;
-                        }
-                        else
-                        {
-                            request.Headers.Add(key, header[1]);
-                        }
-
+                        var headerParts = header[1].Trim().Split(new[] { ' ' }, 2);
+                        request.Headers.Authorization = new HttpCredentialsHeaderValue(headerParts[0].Trim(), headerParts[1].Trim());
                         break;
 #endif
                     case "content-encoding":

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -14,7 +14,6 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text.RegularExpressions;
 #if WINDOWS_UWP
 using Windows.Storage;
 using Windows.Web.Http;

--- a/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
+++ b/ReactWindows/ReactNative.Shared/Modules/Network/NetworkingModule.cs
@@ -485,6 +485,32 @@ namespace ReactNative.Modules.Network
                 var key = header[0];
                 switch (key.ToLowerInvariant())
                 {
+                     case "authorization":
+                        //create scheme from user's Authorization first word
+                        string createScheme = header[1].Split(' ')[0];
+
+                        //Remove above added scheme from authorization because it's already added
+                        string completeToken = header[1].Replace(header[1].Split(' ')[0], "");
+
+                        //To create HttpCredentialHedaerValue scheme should not be empty 
+                        if (createScheme.Trim().Length > 0 && completeToken.Contains("\""))
+                        {
+                            /*
+                             * If Header is in format of RFC 2617
+                             * The below code will not remove double quotes from the value.
+                             * This will re-create auth header with double quotes.
+                             */
+                            var authHdr = new Windows.Web.Http.Headers.HttpCredentialsHeaderValue(createScheme.Trim(), completeToken);
+                            request.Headers.Authorization = authHdr;
+
+                        }
+                        else
+                        {
+                            //If other diffrent types of Authorization header which does not belongs to RFC2617.
+                            request.Headers.Add(key, header[1]);
+                        }
+ 
+                        break;
                     case "content-encoding":
                     case "content-length":
                     case "content-type":


### PR DESCRIPTION
This pull request contains fix for Authorization header having double quotes, and will also take care of other different types of Authorization header. 

Modified File count: 1
File Name: NetworkingModule.cs, 
Added logic to add header of any kind without neglecting double quotes  inside switch case block of ApplyHeader method.
@rozele Please review