### PR TITLE
Ensure the initial display metrics are set.

### DIFF
--- a/ReactWindows/ReactNative/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -186,7 +186,7 @@ namespace ReactNative.Modules.DeviceInfo
             // Default metric for main window
             // TODO It would make sense to make default actively focused window and not the main in the future
             var mainView = _registeredViews.Values.FirstOrDefault(v => v.RootView.Dispatcher == DispatcherHelpers.MainDispatcher);
-            var defaultMetric = mainView == null ? DisplayMetrics.Empty : mainView.CurrentDisplayMetrics;
+            var defaultMetric = mainView == null ? GetInitialDisplayMetrics() : mainView.CurrentDisplayMetrics;
             dimensions.Add("window", GetDimensions(defaultMetric));
 
             foreach (var info in _registeredViews.Values)
@@ -211,6 +211,17 @@ namespace ReactNative.Modules.DeviceInfo
                 { "scale", displayMetrics.Scale },
                 /* TODO: density and DPI needed? */
             };
+        }
+
+        private static DisplayMetrics GetInitialDisplayMetrics()
+        {
+            if (CoreApplication.MainView.CoreWindow != null)
+            {
+                // TODO: blocking call not ideal, but potentially inlined
+                return DispatcherHelpers.CallOnDispatcher(DisplayMetrics.GetForCurrentView, true).Result;
+            }
+
+            return DisplayMetrics.Empty;
         }
     }
 }

--- a/ReactWindows/ReactNative/Modules/DeviceInfo/DeviceInfoModule.cs
+++ b/ReactWindows/ReactNative/Modules/DeviceInfo/DeviceInfoModule.cs
@@ -186,8 +186,8 @@ namespace ReactNative.Modules.DeviceInfo
             // Default metric for main window
             // TODO It would make sense to make default actively focused window and not the main in the future
             var mainView = _registeredViews.Values.FirstOrDefault(v => v.RootView.Dispatcher == DispatcherHelpers.MainDispatcher);
-            var defaultMetric = mainView == null ? GetInitialDisplayMetrics() : mainView.CurrentDisplayMetrics;
-            dimensions.Add("window", GetDimensions(defaultMetric));
+            var defaultMetrics = mainView == null ? GetDefaultDisplayMetrics() : mainView.CurrentDisplayMetrics;
+            dimensions.Add("window", GetDimensions(defaultMetrics));
 
             foreach (var info in _registeredViews.Values)
             {
@@ -213,11 +213,11 @@ namespace ReactNative.Modules.DeviceInfo
             };
         }
 
-        private static DisplayMetrics GetInitialDisplayMetrics()
+        private static DisplayMetrics GetDefaultDisplayMetrics()
         {
             if (CoreApplication.MainView.CoreWindow != null)
             {
-                // TODO: blocking call not ideal, but potentially inlined
+                // TODO: blocking call not ideal, but should be inlined in almost all cases
                 return DispatcherHelpers.CallOnDispatcher(DisplayMetrics.GetForCurrentView, true).Result;
             }
 

--- a/ReactWindows/ReactNative/UIManager/DisplayMetrics.cs
+++ b/ReactWindows/ReactNative/UIManager/DisplayMetrics.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using ReactNative.Modules.DeviceInfo;
+using Windows.Graphics.Display;
+using Windows.UI.ViewManagement;
 
 namespace ReactNative.UIManager
 {
@@ -26,6 +28,13 @@ namespace ReactNative.UIManager
         {
             var bounds = viewInfo.ApplicationView.VisibleBounds;
             var scale = viewInfo.DisplayInformation.RawPixelsPerViewPixel;
+            return new DisplayMetrics(bounds.Width, bounds.Height, scale);
+        }
+
+        public static DisplayMetrics GetForCurrentView()
+        {
+            var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+            var scale = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
             return new DisplayMetrics(bounds.Width, bounds.Height, scale);
         }
     }


### PR DESCRIPTION
We need to calculate display metrics before running the JS bundle, in order for things like `StyleSheet.hairlineWidth` and other style-related settings that are initialized from the `Dimensions` module. This change also checks to make sure a CoreWindow exists on the MainView, so we can continue to support background mode.

Fixes #1986, #2020