### PR TITLE
Support Dev Options Menu on Windows 10 VM

### DIFF
--- a/ReactWindows/ReactNative/ReactRootViewExtensions.cs
+++ b/ReactWindows/ReactNative/ReactRootViewExtensions.cs
@@ -42,13 +42,13 @@ namespace ReactNative
                 {
                     if (e.VirtualKey == VirtualKey.Shift)
                     {
-                        s_isShiftKeyDown = e.EventType == CoreAcceleratorKeyEventType.KeyDown;
+                        s_isShiftKeyDown = IsKeyDown(e.EventType);
                     }
                     else if (e.VirtualKey == VirtualKey.Control)
                     {
-                        s_isControlKeyDown = e.EventType == CoreAcceleratorKeyEventType.KeyDown;
+                        s_isControlKeyDown = IsKeyDown(e.EventType);
                     }
-                    else if (e.EventType == CoreAcceleratorKeyEventType.KeyDown && s_isShiftKeyDown && e.VirtualKey == VirtualKey.F10)
+                    else if (IsKeyDown(e.EventType) && s_isShiftKeyDown && e.VirtualKey == VirtualKey.F10)
                     {
                         reactInstanceManager.DevSupportManager.ShowDevOptionsDialog();
                     }
@@ -58,6 +58,11 @@ namespace ReactNative
                     }
                 }
             }
+        }
+
+        private static bool IsKeyDown(CoreAcceleratorKeyEventType t)
+        {
+            return t == CoreAcceleratorKeyEventType.KeyDown || t == CoreAcceleratorKeyEventType.SystemKeyDown;
         }
     }
 }


### PR DESCRIPTION
For Windows 10 VM on Parallels on Mac with touchbar, we need to detect SystemKeyDown in addition to KeyDown events.

Fixes #2045