### PR TITLE
fix(Yoga): Update Yoga version and use legacy stretch behavior

### DIFF
--- a/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/UIManager/BaseViewManager.cs
@@ -63,7 +63,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view instance.</param>
         /// <param name="opacity">The opacity value.</param>
-        [ReactProp("opacity", DefaultDouble = 1.0)]
+        [ReactProp(ViewProps.Opacity, DefaultDouble = 1.0)]
         public void SetOpacity(TFrameworkElement view, double opacity)
         {
             view.Opacity = opacity;
@@ -74,10 +74,10 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view instance.</param>
         /// <param name="overflow">The overflow value.</param>
-        [ReactProp("overflow")]
+        [ReactProp(ViewProps.Overflow)]
         public void SetOverflow(TFrameworkElement view, string overflow)
         {
-            if (overflow == "hidden")
+            if (overflow == ViewProps.Hidden)
             {
                 view.ClipToBounds = true;
             }
@@ -149,7 +149,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view.</param>
         /// <param name="pointerEventsValue">The pointerEvents mode.</param>
-        [ReactProp("pointerEvents")]
+        [ReactProp(ViewProps.PointerEvents)]
         public void SetPointerEvents(TFrameworkElement view, string pointerEventsValue)
         {
             var pointerEvents = EnumHelpers.ParseNullable<PointerEvents>(pointerEventsValue) ?? PointerEvents.Auto;
@@ -157,13 +157,13 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Called when view is detached from view hierarchy and allows for 
+        /// Called when view is detached from view hierarchy and allows for
         /// additional cleanup by the <see cref="IViewManager"/> subclass.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         /// <param name="view">The view.</param>
         /// <remarks>
-        /// Be sure to call this base class method to register for pointer 
+        /// Be sure to call this base class method to register for pointer
         /// entered and pointer exited events.
         /// </remarks>
         public override void OnDropViewInstance(ThemedReactContext reactContext, TFrameworkElement view)
@@ -175,7 +175,7 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Subclasses can override this method to install custom event 
+        /// Subclasses can override this method to install custom event
         /// emitters on the given view.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
@@ -183,7 +183,7 @@ namespace ReactNative.UIManager
         /// <remarks>
         /// Consider overriding this method if your view needs to emit events
         /// besides basic touch events to JavaScript (e.g., scroll events).
-        /// 
+        ///
         /// Make sure you call the base implementation to ensure base pointer
         /// event handlers are subscribed.
         /// </remarks>

--- a/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Image/ReactImageManager.cs
@@ -27,13 +27,13 @@ namespace ReactNative.Views.Image
 
         private readonly Dictionary<int, List<KeyValuePair<string, double>>> _imageSources =
             new Dictionary<int, List<KeyValuePair<string, double>>>();
-            
+
         private readonly ViewKeyedDictionary<Border, CornerRadiusManager> _borderToRadii =
             new ViewKeyedDictionary<Border, CornerRadiusManager>();
 
         private readonly ViewKeyedDictionary<Border, ThicknessManager> _borderToThickness =
             new ViewKeyedDictionary<Border, ThicknessManager>();
-            
+
         private readonly Lazy<ScaleTransform> _rtlScaleTransform = new Lazy<ScaleTransform>(() => new ScaleTransform
         {
             CenterX = 0.5,
@@ -90,7 +90,7 @@ namespace ReactNative.Views.Image
         /// </summary>
         /// <param name="view">The image view instance.</param>
         /// <param name="resizeMode">The scaling mode.</param>
-        [ReactProp("resizeMode")]
+        [ReactProp(ViewProps.ResizeMode)]
         public void SetResizeMode(Border view, string resizeMode)
         {
             if (resizeMode !=  null)
@@ -228,7 +228,7 @@ namespace ReactNative.Views.Image
         /// </summary>
         /// <param name="view">The image view instance.</param>
         /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(Border view, uint? color)
         {
             view.BorderBrush = color.HasValue

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -189,7 +189,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="view">The view instance</param>
         /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(PasswordBox view, uint? color)
         {
             view.BorderBrush = color.HasValue
@@ -251,7 +251,6 @@ namespace ReactNative.Views.TextInput
         /// <param name="isTabStop">
         /// <code>true</code> if the view is a tab stop, otherwise <code>false</code> (control can't get keyboard focus or accept keyboard input in this case).
         /// </param>
-        /// 
         [ReactProp("isTabStop")]
         public void SetIsTabStop(PasswordBox view, bool isTabStop)
         {
@@ -442,7 +441,7 @@ namespace ReactNative.Views.TextInput
                       textBox.GetTag(),
                       textBox.Password));
         }
-        
+
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             var textBox = (PasswordBox)sender;

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -196,7 +196,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="view">The view instance</param>
         /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(ReactTextBox view, uint? color)
         {
             view.BorderBrush = color.HasValue
@@ -269,7 +269,6 @@ namespace ReactNative.Views.TextInput
         /// <param name="isTabStop">
         /// <code>true</code> if the view is a tab stop, otherwise <code>false</code> (control can't get keyboard focus or accept keyboard input in this case).
         /// </param>
-        /// 
         [ReactProp("isTabStop")]
         public void SetIsTabStop(ReactTextBox view, bool isTabStop)
         {

--- a/ReactWindows/ReactNative.Shared/UIManager/LayoutShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/LayoutShadowNode.cs
@@ -334,10 +334,12 @@ namespace ReactNative.UIManager
             ViewProps.Margin,
             ViewProps.MarginVertical,
             ViewProps.MarginHorizontal,
-            ViewProps.MarginLeft,
-            ViewProps.MarginRight,
+            ViewProps.MarginStart,
+            ViewProps.MarginEnd,
             ViewProps.MarginTop,
             ViewProps.MarginBottom,
+            ViewProps.MarginLeft,
+            ViewProps.MarginRight,
             DefaultSingle = YogaConstants.Undefined)]
         public void SetMargins(int index, JValue margin)
         {
@@ -358,10 +360,12 @@ namespace ReactNative.UIManager
             ViewProps.Padding,
             ViewProps.PaddingVertical,
             ViewProps.PaddingHorizontal,
-            ViewProps.PaddingLeft,
-            ViewProps.PaddingRight,
+            ViewProps.PaddingStart,
+            ViewProps.PaddingEnd,
             ViewProps.PaddingTop,
             ViewProps.PaddingBottom,
+            ViewProps.PaddingLeft,
+            ViewProps.PaddingRight,
             DefaultSingle = YogaConstants.Undefined)]
         public virtual void SetPaddings(int index, JValue padding)
         {
@@ -401,6 +405,8 @@ namespace ReactNative.UIManager
         /// <param name="index">The spacing type index.</param>
         /// <param name="position">The position value.</param>
         [ReactPropGroup(
+            ViewProps.Start,
+            ViewProps.End,
             ViewProps.Left,
             ViewProps.Right,
             ViewProps.Top,
@@ -437,7 +443,7 @@ namespace ReactNative.UIManager
         /// <param name="shouldNotifyOnLayout">
         /// The flag signaling if the view should sent an event on layout.
         /// </param>
-        [ReactProp("onLayout")]
+        [ReactProp(ViewProps.OnLayout)]
         public void SetShouldNotifyOnLayout(bool shouldNotifyOnLayout)
         {
             ShouldNotifyOnLayout = shouldNotifyOnLayout;

--- a/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ReactShadowNode.cs
@@ -1334,10 +1334,7 @@ namespace ReactNative.UIManager
                         YogaConstants.IsUndefined(_padding.GetRaw(EdgeSpacing.All)))
                     {
                         SetPadding(_yogaNode, spacingType, _defaultPadding.GetRaw(spacingType));
-                    }
-                    else
-                    {
-                        SetPadding(_yogaNode, spacingType, _padding.GetRaw(spacingType));
+                        continue;
                     }
                 }
                 else if (spacingType == EdgeSpacing.Top || spacingType == EdgeSpacing.Bottom)
@@ -1347,10 +1344,7 @@ namespace ReactNative.UIManager
                         YogaConstants.IsUndefined(_padding.GetRaw(EdgeSpacing.All)))
                     {
                         SetPadding(_yogaNode, spacingType, _defaultPadding.GetRaw(spacingType));
-                    }
-                    else
-                    {
-                        SetPadding(_yogaNode, spacingType, _padding.GetRaw(spacingType));
+                        continue;
                     }
                 }
                 else
@@ -1358,12 +1352,11 @@ namespace ReactNative.UIManager
                     if (YogaConstants.IsUndefined(_padding.GetRaw(spacingType)))
                     {
                         SetPadding(_yogaNode, spacingType, _defaultPadding.GetRaw(spacingType));
-                    }
-                    else
-                    {
-                        SetPadding(_yogaNode, spacingType, _padding.GetRaw(spacingType));
+                        continue;
                     }
                 }
+
+                SetPadding(_yogaNode, spacingType, _padding.GetRaw(spacingType));
             }
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
@@ -25,7 +25,6 @@ namespace ReactNative.UIManager
         public const string AlignItems = "alignItems";
         public const string AlignSelf = "alignSelf";
         public const string AlignContent = "alignContent";
-        public const string Overflow = "overflow";
         public const string Display = "display";
         public const string Bottom = "bottom";
         public const string Collapsible = "collapsable";
@@ -46,6 +45,8 @@ namespace ReactNative.UIManager
         public const string MarginRight = "marginRight";
         public const string MarginTop = "marginTop";
         public const string MarginBottom = "marginBottom";
+        public const string MarginStart = "marginStart";
+        public const string MarginEnd = "marginEnd";
 
         public const string Padding = "padding";
         public const string PaddingVertical = "paddingVertical";
@@ -54,11 +55,15 @@ namespace ReactNative.UIManager
         public const string PaddingRight = "paddingRight";
         public const string PaddingTop = "paddingTop";
         public const string PaddingBottom = "paddingBottom";
+        public const string PaddingStart = "paddingStart";
+        public const string PaddingEnd = "paddingEnd";
 
         public const string Position = "position";
         public const string Right = "right";
         public const string Top = "top";
         public const string Width = "width";
+        public const string Start = "start";
+        public const string End = "end";
 
         public const string MinWidth = "minWidth";
         public const string MaxWidth = "maxWidth";
@@ -68,7 +73,9 @@ namespace ReactNative.UIManager
         public const string AspectRatio = "aspectRatio";
 
         // Props that sometimes may prevent us from collapsing views
-        public static string PointerEvents = "pointerEvents";
+        public const string PointerEvents = "pointerEvents";
+        public const string Auto = "auto";
+        public const string BoxNone = "box-none";
 
         // Props that affect more than just layout
         public const string Disabled = "disabled";
@@ -86,15 +93,23 @@ namespace ReactNative.UIManager
         public const string TextAlign = "textAlign";
         public const string TextAlignVertical = "textAlignVertical";
         public const string TextDecorationLine = "textDecorationLine";
-        public const string AllowFontScaling = "allowFontScaling";
+        public const string Opacity = "opacity";
+        public const string Overflow = "overflow";
+
+        public const string Hidden = "hidden";
+        public const string Visible = "visible";
 
         public const string AccessibilityTraits = "accessibilityTraits";
         public const string AccessibilityLabel = "accessibilityLabel";
         public const string ImportantForAccessibility = "importantForAccessibility";
         public const string AccessibilityLiveRegion = "accessibilityLiveRegion";
 
+        public const string AllowFontScaling = "allowFontScaling";
+
         public const string BorderWidth = "borderWidth";
         public const string BorderLeftWidth = "borderLeftWidth";
+        public const string BorderStartWidth = "borderStartWidth";
+        public const string BorderEndWidth = "borderEndWidth";
         public const string BorderTopWidth = "borderTopWidth";
         public const string BorderRightWidth = "borderRightWidth";
         public const string BorderBottomWidth = "borderBottomWidth";
@@ -103,6 +118,12 @@ namespace ReactNative.UIManager
         public const string BorderTopRightRadius = "borderTopRightRadius";
         public const string BorderBottomLeftRadius = "borderBottomLeftRadius";
         public const string BorderBottomRightRadius = "borderBottomRightRadius";
+        public const string BorderColor = "borderColor";
+        public const string BorderTopStartRadius = "borderTopStartRadius";
+        public const string BorderTopEndRadius = "borderTopEndRadius";
+        public const string BorderBottomStartRadius = "borderBottomStartRadius";
+        public const string BorderBottomEndRadius = "borderBottomEndRadius";
+        public const string OnLayout = "onLayout";
 
 #pragma warning restore CS1591
 
@@ -110,7 +131,21 @@ namespace ReactNative.UIManager
         /// Ordered list of margin spacing types.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "IReadOnlyList is immutable.")]
-        public static readonly IReadOnlyList<int> PaddingMarginSpacingTypes = 
+        public static readonly IReadOnlyList<int> BorderSpacingTypes =
+            new List<int>
+            {
+                EdgeSpacing.All,
+                EdgeSpacing.Top,
+                EdgeSpacing.Bottom,
+                EdgeSpacing.Left,
+                EdgeSpacing.Right,
+            };
+
+        /// <summary>
+        /// Ordered list of border spacing types.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "IReadOnlyList is immutable.")]
+        public static readonly IReadOnlyList<int> PaddingMarginSpacingTypes =
             new List<int>
             {
                 EdgeSpacing.All,
@@ -120,20 +155,8 @@ namespace ReactNative.UIManager
                 EdgeSpacing.End,
                 EdgeSpacing.Top,
                 EdgeSpacing.Bottom,
-            };
-
-        /// <summary>
-        /// Ordered list of border spacing types.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "IReadOnlyList is immutable.")]
-        public static readonly IReadOnlyList<int> BorderSpacingTypes =
-            new List<int>
-            {
-                EdgeSpacing.All,
                 EdgeSpacing.Left,
                 EdgeSpacing.Right,
-                EdgeSpacing.Top,
-                EdgeSpacing.Bottom,
             };
 
         /// <summary>
@@ -145,6 +168,8 @@ namespace ReactNative.UIManager
             {
                 EdgeSpacing.Start,
                 EdgeSpacing.End,
+                EdgeSpacing.Left,
+                EdgeSpacing.Right,
                 EdgeSpacing.Top,
                 EdgeSpacing.Bottom,
             };
@@ -152,8 +177,8 @@ namespace ReactNative.UIManager
         private static readonly HashSet<string> s_layoutOnlyProps =
             new HashSet<string>
             {
-                AlignItems,
                 AlignSelf,
+                AlignItems,
                 Collapsible,
                 Flex,
                 FlexBasis,
@@ -162,7 +187,6 @@ namespace ReactNative.UIManager
                 FlexShrink,
                 FlexWrap,
                 JustifyContent,
-                Overflow,
                 AlignContent,
                 Display,
 
@@ -172,6 +196,8 @@ namespace ReactNative.UIManager
                 Top,
                 Bottom,
                 Left,
+                Start,
+                End,
 
                 /* dimensions */
                 Width,
@@ -189,7 +215,9 @@ namespace ReactNative.UIManager
                 MarginRight,
                 MarginTop,
                 MarginBottom,
-                
+                MarginStart,
+                MarginEnd,
+
                 /* paddings */
                 Padding,
                 PaddingVertical,
@@ -198,6 +226,8 @@ namespace ReactNative.UIManager
                 PaddingRight,
                 PaddingTop,
                 PaddingBottom,
+                PaddingStart,
+                PaddingEnd,
             };
 
         /// <summary>
@@ -214,10 +244,10 @@ namespace ReactNative.UIManager
             {
                 return true;
             }
-            else if (PointerEvents == prop)
+            else if (prop == PointerEvents)
             {
-                var value = props.GetProperty(prop).Value<string>();
-                return value == "auto" || value == "box-none";
+                var value = props.Value<string>(prop);
+                return value == Auto || value == BoxNone;
             }
 
             // These are more aggressive optimizations based on property values.
@@ -229,12 +259,26 @@ namespace ReactNative.UIManager
 
                 switch (prop)
                 {
+                    case Opacity:
+                        // null opacity behaves like opacity = 1
+                        // Ignore if explicitly set to default opacity.
+                        return value == null || value.Value<double>() == 1.0;
+                    case BorderWidth:
+                        return value == null || value.Value<double>() == 0.0;
+                    case BorderLeftWidth:
+                        return value == null || value.Value<double>() == 0.0;
+                    case BorderTopWidth:
+                        return value == null || value.Value<double>() == 0.0;
+                    case BorderRightWidth:
+                        return value == null || value.Value<double>() == 0.0;
+                    case BorderBottomWidth:
+                        return value == null || value.Value<double>() == 0.0;
+                    case Overflow:
+                        return value == null || value.Value<string>() == Visible;
                     case AccessibilityTraits:
                         return value == null || value is JArray array && array.Count == 0;
-
                     case AccessibilityLabel:
                         return value == null || value.Type == JTokenType.String && value.Value<string>().Length == 0;
-
                     case ImportantForAccessibility:
                         return value == null || value.Type == JTokenType.String &&
                             (value.Value<string>().Length == 0 || value.Value<string>() == "auto");

--- a/ReactWindows/ReactNative.Shared/UIManager/YogaNodePool.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/YogaNodePool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Portions derived from React Native:
 // Copyright (c) 2015-present, Facebook, Inc.
 // Licensed under the MIT License.
@@ -23,13 +23,21 @@ namespace ReactNative.UIManager
                     {
                         if (s_instance == null)
                         {
-                            s_instance = new ObjectPool<YogaNode>(() => new YogaNode(), 1024);
+                            s_instance = new ObjectPool<YogaNode>(CreateInstance, 1024);
                         }
                     }
                 }
 
                 return s_instance;
             }
+        }
+
+        private static YogaNode CreateInstance()
+        {
+            return new YogaNode(new YogaConfig
+            {
+                UseLegacyStretchBehaviour = true,
+            });
         }
     }
 }

--- a/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/Views/View/ReactViewManager.cs
@@ -32,7 +32,7 @@ namespace ReactNative.Views.View
             new ViewKeyedDictionary<BorderedCanvas, ThicknessManager>();
 
         /// <summary>
-        /// The name of this view manager. This will be the name used to 
+        /// The name of this view manager. This will be the name used to
         /// reference this view manager from JavaScript.
         /// </summary>
         public override string Name => ViewProps.ViewClassName;
@@ -175,7 +175,7 @@ namespace ReactNative.Views.View
         /// </summary>
         /// <param name="view">The view panel.</param>
         /// <param name="color">The color hex code.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(BorderedCanvas view, uint? color)
         {
             view.BorderBrush = color.HasValue
@@ -238,7 +238,7 @@ namespace ReactNative.Views.View
         }
 
         /// <summary>
-        /// Called when view is detached from view hierarchy and allows for 
+        /// Called when view is detached from view hierarchy and allows for
         /// additional cleanup.
         /// </summary>
         /// <param name="reactContext">The React context.</param>

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -71,7 +71,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view instance.</param>
         /// <param name="opacity">The opacity value.</param>
-        [ReactProp("opacity", DefaultDouble = 1.0)]
+        [ReactProp(ViewProps.Opacity, DefaultDouble = 1.0)]
         public void SetOpacity(TFrameworkElement view, double opacity)
         {
             view.Opacity = opacity;
@@ -82,10 +82,10 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view instance.</param>
         /// <param name="overflow">The overflow value.</param>
-        [ReactProp("overflow")]
+        [ReactProp(ViewProps.Overflow)]
         public void SetOverflow(TFrameworkElement view, string overflow)
         {
-            if (overflow == "hidden")
+            if (overflow == ViewProps.Hidden)
             {
                 var dimensionBoundProperties = GetOrCreateDimensionBoundProperties(view);
                 dimensionBoundProperties.OverflowHidden = true;
@@ -152,7 +152,7 @@ namespace ReactNative.UIManager
 
             view.ManipulationMode = manipulationMode;
         }
-        
+
         /// <summary>
         /// Sets the accessibility label of the element.
         /// </summary>
@@ -214,7 +214,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view.</param>
         /// <param name="pointerEventsValue">The pointerEvents mode.</param>
-        [ReactProp("pointerEvents")]
+        [ReactProp(ViewProps.PointerEvents)]
         public void SetPointerEvents(TFrameworkElement view, string pointerEventsValue)
         {
             var pointerEvents = EnumHelpers.ParseNullable<PointerEvents>(pointerEventsValue) ?? PointerEvents.Auto;
@@ -246,13 +246,13 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Called when view is detached from view hierarchy and allows for 
+        /// Called when view is detached from view hierarchy and allows for
         /// additional cleanup by the <see cref="IViewManager"/> subclass.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         /// <param name="view">The view.</param>
         /// <remarks>
-        /// Be sure to call this base class method to register for pointer 
+        /// Be sure to call this base class method to register for pointer
         /// entered and pointer exited events.
         /// </remarks>
         public override void OnDropViewInstance(ThemedReactContext reactContext, TFrameworkElement view)

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -97,7 +97,7 @@ namespace ReactNative.Views.Image
         /// </summary>
         /// <param name="view">The image view instance.</param>
         /// <param name="resizeMode">The scaling mode.</param>
-        [ReactProp("resizeMode")]
+        [ReactProp(ViewProps.ResizeMode)]
         public void SetResizeMode(Border view, string resizeMode)
         {
             if (resizeMode != null)
@@ -232,7 +232,7 @@ namespace ReactNative.Views.Image
         /// </summary>
         /// <param name="view">The image view instance.</param>
         /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(Border view, uint? color)
         {
             view.BorderBrush = color.HasValue
@@ -295,7 +295,7 @@ namespace ReactNative.Views.Image
         }
 
         /// <summary>
-        /// Called when view is detached from view hierarchy and allows for 
+        /// Called when view is detached from view hierarchy and allows for
         /// additional cleanup.
         /// </summary>
         /// <param name="reactContext">The React context.</param>

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -230,7 +230,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="view">The view instance</param>
         /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(PasswordBox view, uint? color)
         {
             if (color.HasValue)
@@ -315,7 +315,6 @@ namespace ReactNative.Views.TextInput
         /// <param name="isTabStop">
         /// <code>true</code> if the view is a tab stop, otherwise <code>false</code> (control can't get keyboard focus or accept keyboard input in this case).
         /// </param>
-        /// 
         [ReactProp("isTabStop")]
         public void SetIsTabStop(PasswordBox view, bool isTabStop)
         {
@@ -509,7 +508,7 @@ namespace ReactNative.Views.TextInput
                       textBox.GetTag(),
                       textBox.Password));
         }
-        
+
         private void OnKeyDown(object sender, KeyRoutedEventArgs e)
         {
             var textBox = (PasswordBox)sender;

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -278,7 +278,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="view">The view instance</param>
         /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
+        [ReactProp(ViewProps.BorderColor, CustomType = "Color")]
         public void SetBorderColor(ReactTextBox view, uint? color)
         {
             if (color.HasValue)
@@ -344,7 +344,7 @@ namespace ReactNative.Views.TextInput
         {
             view.TextAlignment = EnumHelpers.Parse<TextAlignment>(alignment);
         }
- 
+
         /// <summary>
         /// Sets the text alignment prop on the <see cref="ReactTextBox"/>.
         /// </summary>
@@ -479,7 +479,7 @@ namespace ReactNative.Views.TextInput
         {
             view.MaxHeight = height;
         }
-    
+
         /// <summary>
         /// Sets whether the view is a tab stop.
         /// </summary>
@@ -487,7 +487,6 @@ namespace ReactNative.Views.TextInput
         /// <param name="isTabStop">
         /// <code>true</code> if the view is a tab stop, otherwise <code>false</code> (control can't get keyboard focus or accept keyboard input in this case).
         /// </param>
-        /// 
         [ReactProp("isTabStop")]
         public void SetIsTabStop(ReactTextBox view, bool isTabStop)
         {
@@ -584,7 +583,7 @@ namespace ReactNative.Views.TextInput
                 {
                     return;
                 }
-                
+
                 view.TextChanging -= OnTextChanging;
                 view.TextChanged -= OnTextChanged;
 
@@ -737,7 +736,7 @@ namespace ReactNative.Views.TextInput
                       textBox.GetTag(),
                       textBox.Text));
         }
-        
+
         private void OnKeyDown(object sender, KeyRoutedEventArgs e)
         {
             var textBox = (ReactTextBox)sender;


### PR DESCRIPTION
Specifically, this forks from facebook/yoga@006f646, and adds some fixes we had previously put in the ReactWindows/yoga@vprev branch.

This also includes some additional fixes to Yoga (e.g., the YogaConstants incorrectly defined `Undefined` as `NaN` rather than a very large number). This also adds `Start` and `End` props for `margin`, `padding`, and `position`.

Also, iOS and Android use the "legacy" stretch behavior option for Yoga, which allows all containers to use the maximum space, as opposed to the minimum space allowed (i.e., similar to an implied `alignSelf: 'stretch'`). This change exposes that API to react-native-windows and ensures each shadow node sets the config value.

Fixes #2012