### PR TITLE
Adds logic to support matching pre-release tag

### DIFF
--- a/local-cli/rnpm/windows/index.js
+++ b/local-cli/rnpm/windows/index.js
@@ -10,8 +10,12 @@ module.exports = [{
     description: 'The native project namespace.'
   }, {
     command: '--verbose',
-    description: 'Enables logging',
+    description: 'Enables logging.',
     default: false,
+  }, {
+    command: '--vnext',
+    description: 'Uses the RNWCPP bridge.',
+    default: false
   }]
 },{
   func: require('./src/wpf'),
@@ -25,7 +29,7 @@ module.exports = [{
     description: 'The native project namespace.'
   }, {
     command: '--verbose',
-    description: 'Enables logging',
+    description: 'Enables logging.',
     default: false,
   }]
 }

--- a/local-cli/rnpm/windows/src/common.js
+++ b/local-cli/rnpm/windows/src/common.js
@@ -50,19 +50,18 @@ function getMatchingVersion(version, prereleaseTag) {
               `Latest version of react-native-windows is ${latestVersion}, try switching to ` +
               `react-native@${semver.major(latestVersion)}.${semver.minor(latestVersion)}.*.`));
             }).catch(error => reject(new Error(`Could not find react-native-windows@${version}.`)));
-      } else if (!prereleaseTag) {
-        resolve(release.version);
-      } else {
-        var versions = Object.keys(release.versions);
+      } else if (prereleaseTag && release.version !== version) {
         var major = semver.major(version);
         var minor = semver.minor(version);
         var regex = new RegExp(`${major}\\.${minor}\\.\\d+-${prereleaseTag}\\.\\d+`);
+        var versions = Object.keys(release.versions);
         var candidates = versions.filter(v => regex.test(v)).sort((x, y) => semver.lt(x, y));
         if (candidates.length === 0) {
           reject(new Error(`Could not find react-native-windows@${version}-${prereleaseTag}.*.`));
         }
-
         resolve(candidates[0]);
+      } else {
+        resolve(release.version);
       }
     });
   });

--- a/local-cli/rnpm/windows/src/windows.js
+++ b/local-cli/rnpm/windows/src/windows.js
@@ -22,9 +22,8 @@ const REACT_NATIVE_WINDOWS_GENERATE_PATH = function() {
 module.exports = function windows(config, args, options) {
   const name = args[0] ? args[0] : Common.getReactNativeAppName();
   const ns = options.namespace ? options.namespace : name;
-  const version = options.windowsVersion ? options.windowsVersion : Common.getReactNativeVersion();
 
-  return Common.getInstallPackage(version)
+  return Common.getInstallPackage(options)
     .then(rnwPackage => {
       console.log(`Installing ${rnwPackage}...`);
       const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';

--- a/local-cli/rnpm/windows/src/wpf.js
+++ b/local-cli/rnpm/windows/src/wpf.js
@@ -22,9 +22,8 @@ const REACT_NATIVE_WPF_GENERATE_PATH = function() {
 module.exports = function windows(config, args, options) {
   const name = args[0] ? args[0] : Common.getReactNativeAppName();
   const ns = options.namespace ? options.namespace : name;
-  const version = options.windowsVersion ? options.windowsVersion : Common.getReactNativeVersion();
 
-  return Common.getInstallPackage(version)
+  return Common.getInstallPackage(options)
     .then(rnwPackage => {
       console.log(`Installing ${rnwPackage}...`);
       const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';


### PR DESCRIPTION
Adds logic to `rnpm-plugin-windows` to support matching a prerelease tag when selecting a vesion of react-native-windows. The idea here being that we can use a flag (e.g., the `--vnext` flag), which will request a specific prerelease version of the package. Then, while we are maintaining two versions of the bridge, we can allow users to generate projects for either bridge.

Towards #2108