### PR TITLE
Folly export fixes, minor cleanups

### DIFF
--- a/RNWCPP/Desktop.UnitTests/EmptyUIManagerModule.cpp
+++ b/RNWCPP/Desktop.UnitTests/EmptyUIManagerModule.cpp
@@ -118,23 +118,21 @@ std::map<std::string, folly::dynamic> EmptyUIManagerModule::getConstants()
   return std::move(constants);
 }
 
-//TODO: Solve linking problems in lambda implementations.
-//      (i.e.) LNK2001: unresolved external symbol mallocx, rallocx, mallctlbymib...
 auto EmptyUIManagerModule::getMethods() -> std::vector<Method>
 {
   return
   {
     Method("removeRootView", [this](dynamic args)
   {
-    //m_manager->removeRootView(jsArgAsInt(args, 0));
+    m_manager->removeRootView(jsArgAsInt(args, 0));
   }),
     Method("createView", [this](dynamic args)
   {
-    //m_manager->createView(jsArgAsInt(args, 0), jsArgAsString(args, 1), jsArgAsInt(args, 2), jsArgAsDynamic(args, 3));
+    m_manager->createView(jsArgAsInt(args, 0), jsArgAsString(args, 1), jsArgAsInt(args, 2), jsArgAsDynamic(args, 3));
   }),
     Method("setChildren", [this](dynamic args)
   {
-    //m_manager->setChildren(jsArgAsInt(args, 0), jsArgAsArray(args, 1));
+    m_manager->setChildren(jsArgAsInt(args, 0), jsArgAsArray(args, 1));
   }),
   };
 }

--- a/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
+++ b/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
@@ -13,6 +13,10 @@ EXPORTS
 ?str_to_bool@detail@folly@@YA?AV?$Expected@_NW4ConversionCode@folly@@@2@PAV?$Range@PBD@2@@Z
 ?size@dynamic@folly@@QBAIXZ
 ?toJson@folly@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABUdynamic@1@@Z
+?checkedMalloc@folly@@YAPAXI@Z
+?demangle@folly@@YA?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PBD@Z
+??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
+?__throw_bad_alloc@std@@YAXXZ
 ??0ReactRootView@uwp@react@@QAA@UDependencyObject@Xaml@UI@Windows@winrt@@@Z
 ?InitializeLogging@react@facebook@@YAX$$QAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPAUINativeTraceHandler@12@@Z
@@ -30,3 +34,14 @@ EXPORTS
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_K@detail@folly@@YA?AV?$Expected@_KW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
+
+mallocxWeak
+rallocxWeak
+xallocxWeak
+sallocxWeak
+dallocxWeak
+sdallocxWeak
+nallocxWeak
+mallctlWeak
+mallctlnametomibWeak
+mallctlbymibWeak

--- a/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -65,3 +65,14 @@ EXPORTS
 
 ?__throw_bad_alloc@std@@YAXXZ
 ?demangle@folly@@YA?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PEBD@Z
+
+mallocxWeak
+rallocxWeak
+xallocxWeak
+sallocxWeak
+dallocxWeak
+sdallocxWeak
+nallocxWeak
+mallctlWeak
+mallctlnametomibWeak
+mallctlbymibWeak

--- a/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -43,3 +43,14 @@ EXPORTS
 
 ?__throw_bad_alloc@std@@YGXXZ
 ?demangle@folly@@YG?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PBD@Z
+
+mallocxWeak
+rallocxWeak
+xallocxWeak
+sallocxWeak
+dallocxWeak
+sdallocxWeak
+nallocxWeak
+mallctlWeak
+mallctlnametomibWeak
+mallctlbymibWeak

--- a/RNWCPP/Universal.SampleApp/HostingPane.xaml.cpp
+++ b/RNWCPP/Universal.SampleApp/HostingPane.xaml.cpp
@@ -53,6 +53,13 @@ void EnsureExportedFunctions(bool createThings)
     auto control = react::uwp::CreateReactRootView(react::uwp::XamlView(nullptr), L"componentname", nullptr);
     facebook::react::Instance* pInstance = nullptr;
     pInstance->callJSFunction("m", "f", folly::dynamic());
+
+    // verify folly exports
+    folly::dynamic dy = folly::dynamic();
+    dy.asDouble();
+    dy.asInt();
+    dy.asString();
+    dy.asBool();
   }
 }
 

--- a/RNWCPP/include/ReactUWP/Views/ViewManagerBase.h
+++ b/RNWCPP/include/ReactUWP/Views/ViewManagerBase.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <ViewManager.h>
+#include <ReactWindowsCore/ViewManager.h>
 
 #include <IReactInstance.h>
 #include <XamlView.h>


### PR DESCRIPTION
Add additional exports so folly dynamic asDouble/asInt/asBool/asString can be referenced outside
improves what you can do with custom viewmanagers: https://github.com/Microsoft/react-native-windows/issues/2102

minor cleanup:
1. EmptyUIManagerModule is linking fine with current exports, bring back commented out code
1. Tweaked an include in ViewManagerBase.h so include\ReactWindowsCore doesn't need to be on the include list to consume it (just \include and \include\ReactUWP)