### PR TITLE
No need to use @providesModule anymore

### DIFF
--- a/RNWCPP/.npmignore
+++ b/RNWCPP/.npmignore
@@ -30,7 +30,7 @@ win32
 WindowsSampleCSharpApp
 NuGet.Config
 package-deps.json
-react-native-win.build.log
+react-native-windows.build.log
 ReactWin32.nuspec
 ReactWindows-CopyToStaging.bat
 ReactWindows-TestNuspec.bat

--- a/RNWCPP/Libraries/Components/DatePicker/DatePickerIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/DatePicker/DatePickerIOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule DatePickerIOS
  */
 
 'use strict';

--- a/RNWCPP/Libraries/Components/DatePickerAndroid/DatePickerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/DatePickerAndroid/DatePickerAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule DatePickerAndroid
  * @flow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/DatePickerMacOS/DatePickerMacOS.uwp.js
+++ b/RNWCPP/Libraries/Components/DatePickerMacOS/DatePickerMacOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule DatePickerMacOS
  */
 
 'use strict';

--- a/RNWCPP/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule DrawerLayoutAndroid
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/MaskedView/MaskedViewIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/MaskedView/MaskedViewIOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule MaskedViewIOS
  * @flow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/Navigation/NavigatorIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/Navigation/NavigatorIOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule NavigatorIOS
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/Picker/PickerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/Picker/PickerAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule PickerAndroid
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/Picker/PickerIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/Picker/PickerIOS.uwp.js
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule PickerIOS
- *
  * This is a controlled component version of RCTPickerIOS
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule ProgressBarAndroid
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/ProgressViewIOS/ProgressViewIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/ProgressViewIOS/ProgressViewIOS.uwp.js
@@ -6,8 +6,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule ProgressViewIOS
  */
 
 'use strict';

--- a/RNWCPP/Libraries/Components/SafeAreaView/SafeAreaView.uwp.js
+++ b/RNWCPP/Libraries/Components/SafeAreaView/SafeAreaView.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule SafeAreaView
  * @flow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.uwp.js
@@ -6,8 +6,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule SegmentedControlIOS
  */
 
 'use strict';

--- a/RNWCPP/Libraries/Components/StatusBar/StatusBarIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/StatusBar/StatusBarIOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule StatusBarIOS
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/TabBarIOS/TabBarIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/TabBarIOS/TabBarIOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule TabBarIOS
  * @flow
  */
 

--- a/RNWCPP/Libraries/Components/TabBarIOS/TabBarItemIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/TabBarIOS/TabBarItemIOS.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule TabBarItemIOS
  */
 
 'use strict';

--- a/RNWCPP/Libraries/Components/TextInput/TextInput.uwp.js
+++ b/RNWCPP/Libraries/Components/TextInput/TextInput.uwp.js
@@ -1,6 +1,5 @@
 /**
  *
- * @providesModule TextInput
  * @flow
  * @format
  */

--- a/RNWCPP/Libraries/Components/TextInput/TextInputState.uwp.js
+++ b/RNWCPP/Libraries/Components/TextInput/TextInputState.uwp.js
@@ -1,6 +1,5 @@
 /**
  *
- * @providesModule TextInputState
  * @flow
  *
  * This class is responsible for coordinating the "focused"

--- a/RNWCPP/Libraries/Components/TimePickerAndroid/TimePickerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/TimePickerAndroid/TimePickerAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule TimePickerAndroid
  * @flow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/ToastAndroid/ToastAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ToastAndroid/ToastAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule ToastAndroid
  * @noflow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/ToolbarAndroid/ToolbarAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ToolbarAndroid/ToolbarAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule ToolbarAndroid
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/View/PlatformViewPropTypes.uwp.js
+++ b/RNWCPP/Libraries/Components/View/PlatformViewPropTypes.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule PlatformViewPropTypes
  * @flow
  */
 

--- a/RNWCPP/Libraries/Components/ViewPager/ViewPagerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ViewPager/ViewPagerAndroid.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule ViewPagerAndroid
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Components/WebView/WebView.uwp.js
+++ b/RNWCPP/Libraries/Components/WebView/WebView.uwp.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule WebView
  */
 'use strict';
 

--- a/RNWCPP/Libraries/Image/Image.uwp.js
+++ b/RNWCPP/Libraries/Image/Image.uwp.js
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 /**
- * @providesModule Image
  * @flow
  */
 // NOTE: this is a shrinked copy paste of ios impl.

--- a/RNWCPP/Universal.SampleApp/index.uwp.js
+++ b/RNWCPP/Universal.SampleApp/index.uwp.js
@@ -21,7 +21,7 @@ import {
   DatePicker,
   Popup,
   Picker
-} from 'react-native-win';
+} from 'react-native-windows';
 
 class TicTacButton extends Component {
   constructor(props) {

--- a/RNWCPP/package.json
+++ b/RNWCPP/package.json
@@ -28,7 +28,7 @@
         "uwp"
       ],
       "providesModuleNodeModules": [
-        "react-native-win"
+        "react-native-windows"
       ]
     }
   },

--- a/RNWCPP/rn-cli.config.js
+++ b/RNWCPP/rn-cli.config.js
@@ -29,7 +29,7 @@ if (fs.existsSync(path.resolve(__dirname, '../../scripts/metro-resources.js'))) 
 
   config.resolver.extraNodeModules['react-native'] = path.resolve(__dirname, '../react-native');
   config.resolver.extraNodeModules['react-native/Libraries/Image/AssetRegistry'] = path.resolve(__dirname, '../react-native/Libraries/Image/AssetRegistry.js');
-  config.resolver.providesModuleNodeModules = ['react-native', 'react-native-win'];
+  config.resolver.providesModuleNodeModules = ['react-native', 'react-native-windows'];
 } else {
   const rootRnPath = path.resolve(require.resolve('react-native'), '../../..');
 
@@ -38,14 +38,13 @@ if (fs.existsSync(path.resolve(__dirname, '../../scripts/metro-resources.js'))) 
     resolver: {
       extraNodeModules: {},
       platforms,
-      providesModuleNodeModules: ['@microsoft\\\\react-native', 'react-native-win'],
+      providesModuleNodeModules: ['react-native-windows'],
     },
     projectRoot: __dirname,
   };
 
   config.resolver.extraNodeModules['react-native'] = rootRnPath;
-  config.resolver.extraNodeModules['react-native'] = rootRnPath;
-  config.resolver.extraNodeModules['react-native-win'] = __dirname;
+  config.resolver.extraNodeModules['react-native-windows'] = __dirname;
   config.resolver.extraNodeModules['react-native/Libraries/Image/AssetRegistry'] = path.resolve(
     rootRnPath,
     'Libraries/Image/AssetRegistry.js'

--- a/RNWCPP/src/Libraries/Components/CalendarView/CalendarView.tsx
+++ b/RNWCPP/src/Libraries/Components/CalendarView/CalendarView.tsx
@@ -1,7 +1,3 @@
-/**
- *
- * @providesModule CalendarView
- */
 'use strict';
 
 import * as React from 'react';

--- a/RNWCPP/src/Libraries/Components/DatePicker/DatePicker.tsx
+++ b/RNWCPP/src/Libraries/Components/DatePicker/DatePicker.tsx
@@ -1,7 +1,3 @@
-/**
- *
- * @providesModule DatePicker
- */
 'use strict';
 
 import * as React from 'react';


### PR DESCRIPTION
Removes the legacy @providesModule comment at the top of many of the modules.  This is no longer needed since RN 0.57.

Also a couple of small fixups from the package rename