### PR TITLE
Changes to prepare for RN58

### DIFF
--- a/RNWCPP/Chakra/ChakraExecutor.h
+++ b/RNWCPP/Chakra/ChakraExecutor.h
@@ -46,9 +46,13 @@ private:
 
 class ChakraExecutor;
 
-class WorkerRegistration : public noncopyable
+class WorkerRegistration
 {
 public:
+  WorkerRegistration(const WorkerRegistration&) = delete;
+  WorkerRegistration& operator=(const WorkerRegistration&) = delete;
+  WorkerRegistration() = default;
+
   explicit WorkerRegistration(ChakraExecutor* executor_, ChakraObject jsObj_) :
     executor(executor_),
     jsObj(std::move(jsObj_))

--- a/RNWCPP/Chakra/ChakraValue.h
+++ b/RNWCPP/Chakra/ChakraValue.h
@@ -18,7 +18,6 @@
 #endif
 
 #include "Utf8DebugExtensions.h"
-#include <jschelpers/noncopyable.h>
 
 namespace facebook {
 namespace react {
@@ -31,9 +30,12 @@ enum JSPropertyAttributes
   kJSPropertyAttributeNone
 };
 
-class ChakraString : public noncopyable
+class ChakraString
 {
 public:
+  ChakraString& operator=(const ChakraString&) = delete;
+  ChakraString() = default;
+
   explicit ChakraString(const char* utf8)
   {
     JsValueRef value = nullptr;
@@ -144,9 +146,13 @@ private:
 };
 
 
-class ChakraObject : public noncopyable
+class ChakraObject
 {
 public:
+  ChakraObject(const ChakraObject&) = delete;
+  ChakraObject& operator=(const ChakraObject&) = delete;
+  ChakraObject() = default;
+
   ChakraObject(JsValueRef obj) :
     m_obj(obj)
   {
@@ -232,9 +238,12 @@ private:
   ChakraValue callAsFunction(JsValueRef thisObj, int nArgs, const JsValueRef args[]) const;
 };
 
-class ChakraValue : public noncopyable
+class ChakraValue
 {
 public:
+  ChakraValue(const ChakraValue&) = delete;
+  ChakraValue& operator=(const ChakraValue&) = delete;
+  ChakraValue() = default;
   ChakraValue(JsValueRef value);
   ChakraValue(ChakraValue&&);
 

--- a/RNWCPP/Libraries/Components/TextInput/TextInput.uwp.js
+++ b/RNWCPP/Libraries/Components/TextInput/TextInput.uwp.js
@@ -5,7 +5,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const EventEmitter = require('EventEmitter');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const React = require('React');
@@ -13,21 +12,14 @@ const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const ReactNative = require('ReactNative');
 const StyleSheet = require('StyleSheet');
-const Text = require('Text');
 const TextAncestor = require('TextAncestor');
 const TextInputState = require('TextInputState');
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
  * found when Flow v0.54 was deployed. To see the error delete this comment and
  * run Flow. */
 const TimerMixin = require('react-timer-mixin');
-const ViewPropTypes = require('ViewPropTypes');
 
 const requireNativeComponent = require('requireNativeComponent');
-/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
- * found when Flow v0.54 was deployed. To see the error delete this comment and
- * run Flow. */
-const warning = require('fbjs/lib/warning');
-
 
 var RCTTextInput = requireNativeComponent('RCTTextInput'); // TODO(windows ISS)
 
@@ -152,174 +144,6 @@ const TextInput = createReactClass({
     },
   },
 
-  propTypes: {
-    ...ViewPropTypes,
-    /**
-     * If `false`, disables spell-check style (i.e. red underlines).
-     * The default value is inherited from `autoCorrect`.
-     * @platform ios
-     */
-    spellCheck: PropTypes.bool,
-    /**
-     * If `true`, focuses the input on `componentDidMount`.
-     * The default value is `false`.
-     */
-    autoFocus: PropTypes.bool,
-    /**
-     * Specifies whether fonts should scale to respect Text Size accessibility settings. The
-     * default is `true`.
-     */
-    allowFontScaling: PropTypes.bool,
-    /**
-     * If `false`, text is not editable. The default value is `true`.
-     */
-    editable: PropTypes.bool,
-    /**
-     * Limits the maximum number of characters that can be entered. Use this
-     * instead of implementing the logic in JS to avoid flicker.
-     */
-    maxLength: PropTypes.number,
-    /**
-     * If `true`, the text input can be multiple lines.
-     * The default value is `false`.
-     */
-    multiline: PropTypes.bool,
-    /**
-     * Callback that is called when the text input is blurred.
-     */
-    onBlur: PropTypes.func,
-    /**
-     * Callback that is called when the text input is focused.
-     */
-    onFocus: PropTypes.func,
-    /**
-     * Callback that is called when the text input's text changes.
-     */
-    onChange: PropTypes.func,
-    /**
-     * Callback that is called when the text input's text changes.
-     * Changed text is passed as an argument to the callback handler.
-     */
-    onChangeText: PropTypes.func,
-    /**
-     * Callback that is called when the text input's content size changes.
-     * This will be called with
-     * `{ nativeEvent: { contentSize: { width, height } } }`.
-     *
-     * Only called for multiline text inputs.
-     */
-    onContentSizeChange: PropTypes.func,
-    /**
-     * Callback that is called when text input ends.
-     */
-    onEndEditing: PropTypes.func,
-    /**
-     * Callback that is called when the text input selection is changed.
-     * This will be called with
-     * `{ nativeEvent: { selection: { start, end } } }`.
-     */
-    onSelectionChange: PropTypes.func,
-    /**
-     * Callback that is called when a key is pressed.
-     * This will be called with `{ nativeEvent: { key: keyValue } }`
-     * where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and
-     * the typed-in character otherwise including `' '` for space.
-     * Fires before `onChange` callbacks.
-     */
-    onKeyPress: PropTypes.func,
-    /**
-     * Invoked on mount and layout changes with `{x, y, width, height}`.
-     */
-    onLayout: PropTypes.func,
-    /**
-     * Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`.
-     * May also contain other properties from ScrollEvent but on Android contentSize
-     * is not provided for performance reasons.
-     */
-    onScroll: PropTypes.func,
-    /**
-     * The string that will be rendered before text input has been entered.
-     */
-    placeholder: PropTypes.string,
-    /**
-     * The text color of the placeholder string.
-     */
-    placeholderTextColor: ColorPropType,
-    /**
-     * If `false`, scrolling of the text view will be disabled.
-     * The default value is `true`. Does only work with 'multiline={true}'.
-     */
-    scrollEnabled: PropTypes.bool, // TODO(OSS Candidate ISS#2710739)
-    /**
-     * If `true`, the text input obscures the text entered so that sensitive text
-     * like passwords stay secure. The default value is `false`. Does not work with 'multiline={true}'.
-     */
-    secureTextEntry: PropTypes.bool,
-    /**
-     * The highlight and cursor color of the text input.
-     */
-    selectionColor: ColorPropType,
-    /**
-     * The start and end of the text input's selection. Set start and end to
-     * the same value to position the cursor.
-     */
-    selection: PropTypes.shape({
-      start: PropTypes.number.isRequired,
-      end: PropTypes.number,
-    }),
-    /**
-     * The value to show for the text input. `TextInput` is a controlled
-     * component, which means the native value will be forced to match this
-     * value prop if provided. For most uses, this works great, but in some
-     * cases this may cause flickering - one common cause is preventing edits
-     * by keeping value the same. In addition to simply setting the same value,
-     * either set `editable={false}`, or set/update `maxLength` to prevent
-     * unwanted edits without flicker.
-     */
-    value: PropTypes.string,
-    /**
-     * Provides an initial value that will change when the user starts typing.
-     * Useful for simple use-cases where you do not want to deal with listening
-     * to events and updating the value prop to keep the controlled state in sync.
-     */
-    defaultValue: PropTypes.string,
-    /**
-     * If `true`, clears the text field automatically when editing begins.
-     * @platform ios
-     */
-    clearTextOnFocus: PropTypes.bool,
-    /**
-     * If `true`, all text will automatically be selected on focus.
-     */
-    selectTextOnFocus: PropTypes.bool,
-    /**
-     * Note that not all Text styles are supported, an incomplete list of what is not supported includes:
-     *
-     * - `borderLeftWidth`
-     * - `borderTopWidth`
-     * - `borderRightWidth`
-     * - `borderBottomWidth`
-     * - `borderTopLeftRadius`
-     * - `borderTopRightRadius`
-     * - `borderBottomRightRadius`
-     * - `borderBottomLeftRadius`
-     *
-     * see [Issue#7070](https://github.com/facebook/react-native/issues/7070)
-     * for more detail.
-     *
-     * [Styles](docs/style.html)
-     */
-    style: Text.propTypes.style,
-    /**
-     * If `true`, caret is hidden. The default value is `false`.
-     * This property is supported only for single-line TextInput component on iOS.
-     */
-    caretHidden: PropTypes.bool,
-    /*
-     * If `true`, contextMenuHidden is hidden. The default value is `false`.
-     */
-    contextMenuHidden: PropTypes.bool,
-  },
   getDefaultProps(): Object {
     return {
       allowFontScaling: true,

--- a/RNWCPP/Libraries/Components/WebView/WebView.uwp.js
+++ b/RNWCPP/Libraries/Components/WebView/WebView.uwp.js
@@ -8,22 +8,15 @@
  */
 'use strict';
 
-var EdgeInsetsPropType = require('EdgeInsetsPropType');
 var React = require('React');
 var ReactNative = require('ReactNative');
-var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
 var UIManager = require('UIManager');
 var View = require('View');
-var ViewPropTypes = require('ViewPropTypes');
 
-var deprecatedPropType = require('deprecatedPropType');
 var keyMirror = require('fbjs/lib/keyMirror');
-var merge = require('merge');
 var requireNativeComponent = require('requireNativeComponent');
 var resolveAssetSource = require('resolveAssetSource');
-
-const PropTypes = require('prop-types');
 
 const createReactClass = require('create-react-class');
 
@@ -39,102 +32,6 @@ var WebViewState = keyMirror({
  * Renders a native WebView.
  */
 var WebView = createReactClass({
-
-  propTypes: {
-    ...ViewPropTypes,
-    renderError: PropTypes.func,
-    renderLoading: PropTypes.func,
-    onLoad: PropTypes.func,
-    onLoadEnd: PropTypes.func,
-    onLoadStart: PropTypes.func,
-    onError: PropTypes.func,
-    automaticallyAdjustContentInsets: PropTypes.bool,
-    contentInset: EdgeInsetsPropType,
-    onNavigationStateChange: PropTypes.func,
-    startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
-    style: ViewPropTypes.style,
-
-    html: deprecatedPropType(
-      PropTypes.string,
-      'Use the `source` prop instead.'
-    ),
-
-    url: deprecatedPropType(
-      PropTypes.string,
-      'Use the `source` prop instead.'
-    ),
-
-    /**
-     * Loads static html or a uri (with optional headers) in the WebView.
-     */
-    source: PropTypes.oneOfType([
-      PropTypes.shape({
-        /*
-         * The URI to load in the WebView. Can be a local or remote file.
-         */
-        uri: PropTypes.string,
-        /*
-         * The HTTP Method to use. Defaults to GET if not specified.
-         * NOTE: On Android, only GET and POST are supported.
-         */
-        method: PropTypes.oneOf(['GET', 'POST']),
-        /*
-         * Additional HTTP headers to send with the request.
-         * NOTE: On Android, this can only be used with GET requests.
-         */
-        headers: PropTypes.object,
-        /*
-         * The HTTP body to send with the request. This must be a valid
-         * UTF-8 string, and will be sent exactly as specified, with no
-         * additional encoding (e.g. URL-escaping or base64) applied.
-         * NOTE: On Android, this can only be used with POST requests.
-         */
-        body: PropTypes.string,
-      }),
-      PropTypes.shape({
-        /*
-         * A static HTML page to display in the WebView.
-         */
-        html: PropTypes.string,
-        /*
-         * The base URL to be used for any relative links in the HTML.
-         */
-        baseUrl: PropTypes.string,
-      }),
-      /*
-       * Used internally by packager.
-       */
-      PropTypes.number,
-    ]),
-
-    /**
-     * Used on Android and Windows only, JS is enabled by default for WebView on iOS
-     * @platform android, windows
-     */
-    javaScriptEnabled: PropTypes.bool,
-    
-    /**
-     * Used on Windows only, controls whether Indexed DB is enabled or not
-     * @platform windows
-     */
-    indexedDbEnabled: PropTypes.bool,
-
-    /**
-     * Sets the JS to be injected when the webpage loads.
-     */
-    injectedJavaScript: PropTypes.string,
-
-    /**
-     * Used to locate this view in end-to-end tests.
-     */
-    testID: PropTypes.string,
-
-    /**
-     * Determines whether HTML5 audio & videos require the user to tap before they can
-     * start playing. The default value is `false`.
-     */
-    mediaPlaybackRequiresUserAction: PropTypes.bool,
-  },
 
   getInitialState: function() {
     return {

--- a/RNWCPP/Libraries/Image/Image.uwp.js
+++ b/RNWCPP/Libraries/Image/Image.uwp.js
@@ -7,22 +7,16 @@
 // TODO: provide real uwp implementation
 'use strict';
 
-const EdgeInsetsPropType = require('EdgeInsetsPropType');
 const ImageResizeMode = require('ImageResizeMode');
-const ImageSourcePropType = require('ImageSourcePropType');
-const ImageStylePropTypes = require('ImageStylePropTypes');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const NativeModules = require('NativeModules');
 const React = require('React');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheet = require('StyleSheet');
-const StyleSheetPropType = require('StyleSheetPropType');
 
 const flattenStyle = require('flattenStyle');
 const requireNativeComponent = require('requireNativeComponent');
 const resolveAssetSource = require('resolveAssetSource');
-
-const PropTypes = require('prop-types');
 
 const ImageViewManager = NativeModules.ImageViewManager;
 
@@ -126,77 +120,6 @@ const createReactClass = require('create-react-class');
  */
 // $FlowFixMe(>=0.41.0)
 const Image = createReactClass({
-  propTypes: {
-    /**
-     * > `ImageResizeMode` is an `Enum` for different image resizing modes, set via the
-     * > `resizeMode` style property on `Image` components. The values are `contain`, `cover`,
-     * > `stretch`, `center`, `repeat`.
-     */
-    style: StyleSheetPropType(ImageStylePropTypes),
-    /**
-     * The image source (either a remote URL or a local file resource).
-     *
-     * This prop can also contain several remote URLs, specified together with
-     * their width and height and potentially with scale/other URI arguments.
-     * The native side will then choose the best `uri` to display based on the
-     * measured size of the image container. A `cache` property can be added to
-     * control how networked request interacts with the local cache.
-     */
-    source: ImageSourcePropType,
-    /**
-     * Determines how to resize the image when the frame doesn't match the raw
-     * image dimensions.
-     *
-     * - `cover`: Scale the image uniformly (maintain the image's aspect ratio)
-     * so that both dimensions (width and height) of the image will be equal
-     * to or larger than the corresponding dimension of the view (minus padding).
-     *
-     * - `contain`: Scale the image uniformly (maintain the image's aspect ratio)
-     * so that both dimensions (width and height) of the image will be equal to
-     * or less than the corresponding dimension of the view (minus padding).
-     *
-     * - `stretch`: Scale width and height independently, This may change the
-     * aspect ratio of the src.
-     *
-     * - `repeat`: Repeat the image to cover the frame of the view. The
-     * image will keep it's size and aspect ratio. (iOS only)
-     */
-    resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch', 'repeat', 'center']),
-      /**
-     * The text that's read by the screen reader when the user interacts with
-     * the image.
-     * @platform ios
-     */
-    accessibilityLabel: PropTypes.string,
-    /**
-     * A unique identifier for this element to be used in UI Automation
-     * testing scripts.
-     */
-    testID: PropTypes.string,
-    /**
-     * Invoked on mount and layout changes with
-     * `{nativeEvent: {layout: {x, y, width, height}}}`.
-     */
-    onLayout: PropTypes.func,
-    /**
-     * Invoked on load start.
-     *
-     * e.g., `onLoadStart={(e) => this.setState({loading: true})}`
-     */
-    onLoadStart: PropTypes.func,
-    /**
-     * Invoked on load error with `{nativeEvent: {error}}`.
-     */
-    onError: PropTypes.func,
-    /**
-     * Invoked when load completes successfully.
-     */
-    onLoad: PropTypes.func,
-    /**
-     * Invoked when load either succeeds or fails.
-     */
-    onLoadEnd: PropTypes.func,
-  },
 
   statics: {
     resizeMode: ImageResizeMode,


### PR DESCRIPTION
PropTypes are in the process of being removed, so removing some of them ahead of 58 to make 58 merge easier.

Also stop using noncopyable, as its been deleted in 58

It appears that the only remaining changes would be to update versions of
react-native, react and fbjs in package.json.

Note this doesn't update folly, which did happen in 58 RN.  Although it appears that it runs with the old version, so that may not block things.