### PR TITLE
Remove JSCTemp dependency

### DIFF
--- a/RNWCPP/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/RNWCPP/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -144,7 +144,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets" Condition="'$(NOJSC)' != 'true' AND Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" />
     <Import Project="..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets" Condition="Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
@@ -156,7 +155,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="'$(NOJSC)' != 'true' AND !Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets'))" />
     <Error Condition="!Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />

--- a/RNWCPP/Desktop.DLL/packages.config
+++ b/RNWCPP/Desktop.DLL/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="boost_date_time-vc141" version="1.68.0.0" targetFramework="native" />
-  <package id="JavaScriptCore-Temp" version="1.1.2" targetFramework="native" />
   <package id="Microsoft.ChakraCore.Debugger" version="0.0.0.29" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.1" targetFramework="native" developmentDependency="true" />
   <package id="OpenSSL.Windows-1.0.2n" version="0.0.1" targetFramework="native" />

--- a/RNWCPP/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/RNWCPP/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -131,7 +131,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets" Condition="Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" />
     <Import Project="..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets" Condition="Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
@@ -143,7 +142,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets'))" />
     <Error Condition="!Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />

--- a/RNWCPP/Desktop.IntegrationTests/packages.config
+++ b/RNWCPP/Desktop.IntegrationTests/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="boost_date_time-vc141" version="1.68.0.0" targetFramework="native" />
-  <package id="JavaScriptCore-Temp" version="1.1.2" targetFramework="native" />
   <package id="Microsoft.ChakraCore.Debugger" version="0.0.0.29" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.1" targetFramework="native" developmentDependency="true" />
   <package id="OpenSSL.Windows-1.0.2n" version="0.0.1" targetFramework="native" />

--- a/RNWCPP/Desktop/React.Windows.Desktop.vcxproj
+++ b/RNWCPP/Desktop/React.Windows.Desktop.vcxproj
@@ -155,7 +155,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets" Condition="'$(NOJSC)' != 'true' AND Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" />
     <Import Project="..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets" Condition="Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
@@ -167,7 +166,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="'$(NOJSC)' != 'true' AND !Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets'))" />
     <Error Condition="!Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />

--- a/RNWCPP/Desktop/packages.config
+++ b/RNWCPP/Desktop/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="boost_date_time-vc141" version="1.68.0.0" targetFramework="native" />
-  <package id="JavaScriptCore-Temp" version="1.1.2" targetFramework="native" />
   <package id="Microsoft.ChakraCore.Debugger" version="0.0.0.29" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.1" targetFramework="native" developmentDependency="true" />
   <package id="OpenSSL.Windows-1.0.2n" version="0.0.1" targetFramework="native" />

--- a/RNWCPP/IntegrationTests/React.Windows.IntegrationTests.vcxproj
+++ b/RNWCPP/IntegrationTests/React.Windows.IntegrationTests.vcxproj
@@ -100,14 +100,12 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
-    <Import Project="..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets" Condition="Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
-    <Error Condition="!Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets'))" />
   </Target>
   <Target Name="Test">
     <Exec Command="$(OutDir)$(TargetFileName)" IgnoreStandardErrorWarningFormat="true" />

--- a/RNWCPP/IntegrationTests/packages.config
+++ b/RNWCPP/IntegrationTests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
-  <package id="JavaScriptCore-Temp" version="1.1.2" targetFramework="native" />
 </packages>

--- a/RNWCPP/ReactCommon/ReactCommon.vcxproj
+++ b/RNWCPP/ReactCommon/ReactCommon.vcxproj
@@ -89,7 +89,6 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets" Condition="'$(NOJSC)' != 'true' AND Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" />
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets" Condition="'$(Platform)' != 'arm' AND Exists('..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets')" />
   </ImportGroup>
@@ -205,7 +204,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="'$(NOJSC)' != 'true' AND !Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets'))" />
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="'$(Platform)' != 'arm' AND !Exists('..\packages\Office.Google_V8.1.6.0')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Office.Google_V8.1.6.0'))" />
   </Target>

--- a/RNWCPP/ReactWin32SandboxSample/ReactWin32SandboxSample.vcxproj
+++ b/RNWCPP/ReactWin32SandboxSample/ReactWin32SandboxSample.vcxproj
@@ -105,7 +105,6 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets" Condition="Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" />
-    <Import Project="..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets" Condition="'$(NOJSC)' != 'true' AND Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" />
     <Import Project="..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets" Condition="Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" />
   </ImportGroup>
@@ -115,7 +114,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets'))" />
-    <Error Condition="'$(NOJSC)' != 'true' AND !Exists('..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JavaScriptCore-Temp.1.1.2\build\native\JavaScriptCore-Temp.targets'))" />
     <Error Condition="!Exists('..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenSSL.Windows-1.0.2n.0.0.1\build\native\OpenSSL.Windows-1.0.2n.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.vc140.1.10.1\build\native\Microsoft.ChakraCore.vc140.targets'))" />
   </Target>

--- a/RNWCPP/ReactWin32SandboxSample/packages.config
+++ b/RNWCPP/ReactWin32SandboxSample/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="boost_date_time-vc141" version="1.68.0.0" targetFramework="native" />
-  <package id="JavaScriptCore-Temp" version="1.1.2" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.1" targetFramework="native" developmentDependency="true" />
   <package id="OpenSSL.Windows-1.0.2n" version="0.0.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
I think this dependency can just be removed.  It isn't used in windows, and I dont think will affect our internal builds.  #2169 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2208)