### PR TITLE
Allow V8 to not be required for VS project

### DIFF
--- a/RNWCPP/.ado/evergreen.js
+++ b/RNWCPP/.ado/evergreen.js
@@ -72,7 +72,7 @@ function createPr() {
         throw new Error(err || body.errorCode);
       }
 
-      if (!body.pullRequestId) {
+      if (!body.id) {
         throw new Error('Failed to create PR.\nBody : ' + JSON.stringify(body));
       }
     }

--- a/RNWCPP/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/RNWCPP/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -149,7 +149,6 @@
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets" Condition="Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets')" />
-    <Import Project="..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets" Condition="'$(Platform)' != 'arm' AND Exists('..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -160,6 +159,5 @@
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets'))" />
-    <Error Condition="'$(Platform)' != 'arm' AND !Exists('..\packages\Office.Google_V8.1.6.0')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Office.Google_V8.1.6.0'))" />
   </Target>
 </Project>

--- a/RNWCPP/Desktop.DLL/packages.config
+++ b/RNWCPP/Desktop.DLL/packages.config
@@ -5,5 +5,4 @@
   <package id="Microsoft.ChakraCore.Debugger" version="0.0.0.29" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.1" targetFramework="native" developmentDependency="true" />
   <package id="OpenSSL.Windows-1.0.2n" version="0.0.1" targetFramework="native" />
-  <package id="Office.Google_V8" version="1.6.0" targetFramework="native" />
 </packages>

--- a/RNWCPP/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/RNWCPP/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -136,7 +136,6 @@
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets" Condition="Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets')" />
-    <Import Project="..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets" Condition="'$(Platform)' != 'arm' AND Exists('..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -147,7 +146,6 @@
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets'))" />
-    <Error Condition="'$(Platform)' != 'arm' AND !Exists('..\packages\Office.Google_V8.1.6.0')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Office.Google_V8.1.6.0'))" />
   </Target>
   <Target Name="Test">
     <Exec Command="$(OutDir)$(TargetFileName)" IgnoreStandardErrorWarningFormat="true" />

--- a/RNWCPP/Desktop/React.Windows.Desktop.vcxproj
+++ b/RNWCPP/Desktop/React.Windows.Desktop.vcxproj
@@ -160,7 +160,6 @@
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets" Condition="Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" />
     <Import Project="..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets" Condition="Exists('..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets')" />
-    <Import Project="..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets" Condition="'$(Platform)' != 'arm' AND Exists('..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -171,6 +170,5 @@
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ChakraCore.Debugger.0.0.0.29\build\native\Microsoft.ChakraCore.Debugger.targets'))" />
-    <Error Condition="'$(Platform)' != 'arm' AND !Exists('..\packages\Office.Google_V8.1.6.0')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Office.Google_V8.1.6.0'))" />
   </Target>
 </Project>

--- a/RNWCPP/Desktop/packages.config
+++ b/RNWCPP/Desktop/packages.config
@@ -5,5 +5,4 @@
   <package id="Microsoft.ChakraCore.Debugger" version="0.0.0.29" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.10.1" targetFramework="native" developmentDependency="true" />
   <package id="OpenSSL.Windows-1.0.2n" version="0.0.1" targetFramework="native" />
-  <package id="Office.Google_V8" version="1.6.0" targetFramework="native" />
 </packages>

--- a/RNWCPP/ReactCommon/ReactCommon.vcxproj
+++ b/RNWCPP/ReactCommon/ReactCommon.vcxproj
@@ -90,7 +90,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
-    <Import Project="..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets" Condition="'$(Platform)' != 'arm' AND Exists('..\packages\Office.Google_V8.1.6.0\build\Office.Google_V8.targets')" />
   </ImportGroup>
   <ItemGroup>
     <ClInclude Include="..\stubs\sys\mman.h" />
@@ -138,9 +137,9 @@
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jschelpers\Value.h" Condition="'$(NOJSC)' != 'true'" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\instrumentation.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\JSCRuntime.h" Condition="'$(NOJSC)' != 'true'" />
-    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime.h" Condition="'$(Platform)' != 'arm'"/>
-    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_impl.h" Condition="'$(Platform)' != 'arm'"/>
-    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\V8Platform.h" Condition="'$(Platform)' != 'arm'"/>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime.h" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_impl.h" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\V8Platform.h" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\jsi-inl.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\jsi.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\JSIDynamic.h" />
@@ -184,9 +183,9 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSIExecutor.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSINativeModules.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.cpp" Condition="'$(NOJSC)' != 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Platform.cpp"  Condition="'$(Platform)' != 'arm'"/>
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_shared.cpp"  Condition="'$(Platform)' != 'arm'"/>
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_win.cpp"  Condition="'$(Platform)' != 'arm'"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Platform.cpp"  Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_shared.cpp"  Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_win.cpp"  Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
     <ClCompile Include="$(YogaDir)\yoga\Utils.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGConfig.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGEnums.cpp" />
@@ -205,6 +204,5 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
-    <Error Condition="'$(Platform)' != 'arm' AND !Exists('..\packages\Office.Google_V8.1.6.0')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Office.Google_V8.1.6.0'))" />
   </Target>
 </Project>

--- a/RNWCPP/ReactCommon/packages.config
+++ b/RNWCPP/ReactCommon/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
-  <package id="Office.Google_V8" version="1.6.0" targetFramework="native" />
 </packages>

--- a/RNWCPP/Shared/CMakeLists.txt
+++ b/RNWCPP/Shared/CMakeLists.txt
@@ -28,6 +28,8 @@ find_package(OpenSSL REQUIRED)
 
 target_link_libraries(ReactWindowsShared PUBLIC folly reactcommon reactwindowscore chakra Boost::boost OpenSSL::SSL OpenSSL::Crypto)
 
+#target_compile_definitions(ReactWindowsShared PUBLIC USE_V8)
+
 if(WINRT)
 	target_compile_definitions(ReactWindowsShared PRIVATE UNICODE=1 _UNICODE=1)
 	target_compile_definitions(ReactWindowsShared PUBLIC WIN32=0 WINRT=1 BOOST_ASIO_WINDOWS_APP BOOST_BEAST_USE_WIN32_FILE=0)

--- a/RNWCPP/Shared/OInstance.cpp
+++ b/RNWCPP/Shared/OInstance.cpp
@@ -180,6 +180,7 @@ private:
   facebook::react::ChakraInstanceArgs args_;
 };
 
+#if defined(USE_V8)
 class V8JSIExecutorFactory : public JSExecutorFactory {
 public:
   std::unique_ptr<JSExecutor> createJSExecutor(
@@ -197,6 +198,7 @@ public:
       nullptr);
   }
 };
+#endif // USE_V8
 
 #else
 
@@ -214,7 +216,7 @@ private:
   facebook::react::ChakraInstanceArgs args_;
 };
 
-
+#if defined(USE_V8)
 class V8JSIExecutorFactory : public JSExecutorFactory {
 public:
   std::unique_ptr<JSExecutor> createJSExecutor(
@@ -225,6 +227,7 @@ public:
 
   V8JSIExecutorFactory() { std::abort(); }
 };
+#endif // USE_V8
 
 
 #endif
@@ -453,9 +456,11 @@ InstanceImpl::InstanceImpl(std::string&& jsBundleBasePath,
     case JSIMode::ChakraJSI:
       jsef = std::make_shared<ChakraJSIExecutorFactory>(std::move(instanceArgs));
       break;
+#if defined(USE_V8)
     case JSIMode::V8JSI:
       jsef = std::make_shared<V8JSIExecutorFactory>();
       break;
+#endif // USE_V8
     }
 
   }

--- a/RNWCPP/Shared/sources.inc
+++ b/RNWCPP/Shared/sources.inc
@@ -5,6 +5,8 @@ INCLUDES = $(INCLUDES); \
 	$(PKGBOOST)\lib\native\include; \
 	$(PKGJAVASCRIPTCORE_TEMP)\build\native\include; \
 
+C_DEFINES = $(C_DEFINES) -D USE_V8
+
 SOURCES_SHARED = \
 	..\AsyncStorageModule.cpp \
 	..\InstanceManager.cpp \

--- a/RNWCPP/V8Inspector/V8Inspector.vcxproj
+++ b/RNWCPP/V8Inspector/V8Inspector.vcxproj
@@ -107,7 +107,6 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\react-native-win\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\react-native-win\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\react-native-win\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets" Condition="Exists('..\react-native-win\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" />
-    <Import Project="..\react-native-win\packages\Office.Google_V8.1.3.0\build\Office.Google_V8.targets" Condition="'$(Platform)' == 'x64' AND Exists('..\react-native-win\packages\Office.Google_V8.1.3.0\build\Office.Google_V8.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -115,6 +114,5 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\react-native-win\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\react-native-win\packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\react-native-win\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\react-native-win\packages\boost_date_time-vc141.1.68.0.0\build\boost_date_time-vc141.targets'))" />
-    <Error Condition="!Exists('..\react-native-win\packages\Office.Google_V8.1.3.0\build\Office.Google_V8.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\react-native-win\packages\Office.Google_V8.1.3.0\build\Office.Google_V8.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
Remove need for V8 nuget for public consumption.
This removes the blocking part of #2153 . 