### PR TITLE
add more accessiblilityRole support on View.  add focusIn/Out events to View

### DIFF
--- a/RNWCPP/ReactUWP/Views/ViewControl.cpp
+++ b/RNWCPP/ReactUWP/Views/ViewControl.cpp
@@ -48,10 +48,28 @@ namespace winrt::react::uwp::implementation
     {
       auto viewControl = Owner().as<::react::uwp::ViewControl>();
 
-      if (viewControl->AccessibilityRole() == ::react::uwp::AccessibilityRoles::Button)
-        return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Button;
-
-      return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Group;
+      switch(viewControl->AccessibilityRole())
+      {
+        case ::react::uwp::AccessibilityRoles::Button:
+        case ::react::uwp::AccessibilityRoles::ImageButton:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Button;
+        case ::react::uwp::AccessibilityRoles::Link:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Hyperlink;
+        case ::react::uwp::AccessibilityRoles::Image:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Image;
+        case ::react::uwp::AccessibilityRoles::KeyboardKey:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Custom;
+        case ::react::uwp::AccessibilityRoles::Text:
+        case ::react::uwp::AccessibilityRoles::Summary:
+        case ::react::uwp::AccessibilityRoles::Header:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Text;
+        case ::react::uwp::AccessibilityRoles::Adjustable:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Slider;
+        case ::react::uwp::AccessibilityRoles::Search:
+        case ::react::uwp::AccessibilityRoles::Unknown:
+        default:
+          return winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType::Group;
+      }
     }
 
     Windows::Foundation::IInspectable DynamicAutomationPeer::GetPatternCore(Windows::UI::Xaml::Automation::Peers::PatternInterface const& patternInterface) const
@@ -59,7 +77,8 @@ namespace winrt::react::uwp::implementation
       auto viewControl = Owner().as<::react::uwp::ViewControl>();
 
       if (patternInterface == Windows::UI::Xaml::Automation::Peers::PatternInterface::Invoke &&
-          viewControl->AccessibilityRole() == ::react::uwp::AccessibilityRoles::Button)
+          (viewControl->AccessibilityRole() == ::react::uwp::AccessibilityRoles::Button || 
+           viewControl->AccessibilityRole() == ::react::uwp::AccessibilityRoles::ImageButton))
       {
         return *this;
       }

--- a/RNWCPP/ReactUWP/Views/ViewViewManager.cpp
+++ b/RNWCPP/ReactUWP/Views/ViewViewManager.cpp
@@ -162,13 +162,23 @@ const char* ViewViewManager::GetName() const
 folly::dynamic ViewViewManager::GetExportedCustomDirectEventTypeConstants() const
 {
   auto directEvents = Super::GetExportedCustomDirectEventTypeConstants();
-  directEvents["topTextInputFocus"] = folly::dynamic::object("registrationName", "onFocus");
-  directEvents["topTextInputBlur"] = folly::dynamic::object("registrationName", "onBlur");
+  directEvents["topFocus"] = folly::dynamic::object("registrationName", "onFocus");
+  directEvents["topBlur"] = folly::dynamic::object("registrationName", "onBlur");
   directEvents["topClick"] = folly::dynamic::object("registrationName", "onClick");
   directEvents["topAccessibilityTap"] = folly::dynamic::object("registrationName", "onAccessibilityTap");
 
   return directEvents;
 }
+
+folly::dynamic ViewViewManager::GetExportedCustomBubblingEventTypeConstants() const
+{
+  auto bubblingEvents = Super::GetExportedCustomBubblingEventTypeConstants();
+  bubblingEvents["topFocusIn"] = folly::dynamic::object("registrationName", "onFocusIn");
+  bubblingEvents["topFocusOut"] = folly::dynamic::object("registrationName", "onFocusOut");
+
+  return bubblingEvents;
+}
+
 
 facebook::react::ShadowNode* ViewViewManager::createShadow() const
 {
@@ -219,12 +229,14 @@ XamlView ViewViewManager::CreateViewControl(int64_t tag)
 
   contentControl.GotFocus([=](auto &&, auto &&)
   {
-    DispatchEvent(tag, "topTextInputFocus", std::move(folly::dynamic::object("target", tag)));
+    DispatchEvent(tag, "topFocus", std::move(folly::dynamic::object("target", tag)));
+    DispatchEvent(tag, "topFocusIn", std::move(folly::dynamic::object("target", tag)));
   });
 
   contentControl.LostFocus([=](auto &&, auto &&)
   {
-    DispatchEvent(tag, "topTextInputBlur", std::move(folly::dynamic::object("target", tag)));
+    DispatchEvent(tag, "topBlur", std::move(folly::dynamic::object("target", tag)));
+    DispatchEvent(tag, "topFocusOut", std::move(folly::dynamic::object("target", tag)));
   });
 
   contentControl.KeyDown([=](auto &&, winrt::KeyRoutedEventArgs const& e)
@@ -360,8 +372,26 @@ void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dyna
             pViewShadowNode->AccessibilityRole(AccessibilityRoles::None);
           else if (role == "button")
             pViewShadowNode->AccessibilityRole(AccessibilityRoles::Button);
+          else if (role == "link")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Link);
+          else if (role == "search")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Search);
+          else if (role == "image")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Image);
+          else if (role == "keyboardkey")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::KeyboardKey);
+          else if (role == "text")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Text);
+          else if (role == "adjustable")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Adjustable);
+          else if (role == "imagebutton")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::ImageButton);
+          else if (role == "header")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Header);
+          else if (role == "summary")
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Summary);
           else
-            pViewShadowNode->AccessibilityRole(AccessibilityRoles::None);
+            pViewShadowNode->AccessibilityRole(AccessibilityRoles::Unknown);
         }
         else if (propertyValue.isNull())
         {

--- a/RNWCPP/ReactUWP/Views/ViewViewManager.h
+++ b/RNWCPP/ReactUWP/Views/ViewViewManager.h
@@ -19,6 +19,7 @@ public:
 
   folly::dynamic GetNativeProps() const override;
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
+  folly::dynamic GetExportedCustomBubblingEventTypeConstants() const override;
   facebook::react::ShadowNode* createShadow() const override;
 
   void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;

--- a/RNWCPP/include/ReactUWP/Views/ShadowNodeBase.h
+++ b/RNWCPP/include/ReactUWP/Views/ShadowNodeBase.h
@@ -42,7 +42,6 @@ enum AccessibilityRoles : uint8_t
 {
   None = 0,
   Button,
-  /*
   Link,
   Search,
   Image,
@@ -52,7 +51,7 @@ enum AccessibilityRoles : uint8_t
   ImageButton,
   Header,
   Summary,
-  */
+  Unknown,
   CountRoles
 };
 


### PR DESCRIPTION
2 changes:
1) Hook up more AccessibilityRole values.  These are matching win32 though perhaps 'Header' should map to UIA Header instead of Text

2) add focusIn/Out events which are bubbling focus events matching web
-- this is the more time critical change for one of our projects to be able to detect when focus is in a touchable.  Right now touchable doesn't expose the onFocus/onBlur direct events so you can't detect if you're focused.