### PR TITLE
add null check in UIManager::updateView

### DIFF
--- a/RNWCPP/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/RNWCPP/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -310,11 +310,15 @@ void UIManager::setChildren(int64_t viewTag, folly::dynamic&& childrenTags)
 void UIManager::updateView(int64_t tag, const std::string& className, folly::dynamic&& props)
 {
   m_nativeUIManager->ensureInBatch();
-  auto& shadowNode = m_nodeRegistry.getNode(tag);
-  if (!shadowNode.m_zombie)
-    shadowNode.updateProperties(std::move(props));
+	ShadowNode* pShadowNode = FindShadowNodeForTag(tag);
+	// Guard against setNative calls to removed views
+	if (pShadowNode == nullptr)
+		return;
 
-  m_nativeUIManager->UpdateView(shadowNode, props);
+  if (!pShadowNode->m_zombie)
+    pShadowNode->updateProperties(std::move(props));
+
+  m_nativeUIManager->UpdateView(*pShadowNode, props);
 }
 
 void UIManager::RemoveShadowNode(ShadowNode& nodeToRemove)


### PR DESCRIPTION
We've been running into a crash here, where a view is being asked to update after it was removed from the tree.  

While we're also looking at fixing the js where setNative from something holding an element past their life on screen appear to be the trigger, native can protect itself from crashing.  Android implementation does have a null check in their implementation, looks like ios/Mac doesn't need one due to ObjC nil object behavior handling calls to nil objects as just returning nil