### PR TITLE
Fix deadlock when calling detach before attach has finished

### DIFF
--- a/RNWCPP/ReactUWP/Utils/LocalBundleReader.cpp
+++ b/RNWCPP/ReactUWP/Utils/LocalBundleReader.cpp
@@ -19,6 +19,8 @@ std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string& b
   winrt::hstring str(facebook::react::UnicodeConversion::Utf8ToUtf16(bundleUri));
   winrt::Windows::Foundation::Uri uri(str);
 
+  co_await winrt::resume_background();
+
   auto file = co_await winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
   auto hdata = co_await winrt::Windows::Storage::FileIO::ReadTextAsync(file);
 


### PR DESCRIPTION
see: https://github.com/Microsoft/react-native-windows/issues/2232

loading the js bundle needed to be able to wake up the UI thread to continue.  In detachRoot we block the UI thread waiting for the js thread to clear -- but if the js thread is still loading that file it will deadlock.

fix changes this function to resume on the background thread avoiding the hang.

I was able to test back to back calls of attachRoot, detachRoot no longer hang.

BUT if you call them from the same ui batch you will crash when we try to remove a root view of -1 when the root view create wasn't done yet.  As long as these requests queued up separately by the dispatcher you're fine which I tested.  It IS allowed to call detach->attach back to back in the same batch (live reload does this), just not attach->detach.