### PR TITLE
check isInError before calls to instanceWrapper

### DIFF
--- a/RNWCPP/ReactUWP/Base/UwpReactInstance.cpp
+++ b/RNWCPP/ReactUWP/Base/UwpReactInstance.cpp
@@ -351,12 +351,14 @@ void UwpReactInstance::UnregisterErrorCallback(ErrorCallbackCookie& cookie)
 
 void UwpReactInstance::DispatchEvent(int64_t viewTag, std::string eventName, folly::dynamic&& eventData)
 {
-  m_instanceWrapper->DispatchEvent(viewTag, eventName, std::move(eventData));
+  if (!IsInError())
+    m_instanceWrapper->DispatchEvent(viewTag, eventName, std::move(eventData));
 }
 
 void UwpReactInstance::CallJsFunction(std::string&& moduleName, std::string&& method, folly::dynamic&& params) noexcept
 {
-  m_instanceWrapper->GetInstance()->callJSFunction(std::move(moduleName), std::move(method), std::move(params));
+  if (!IsInError())
+    m_instanceWrapper->GetInstance()->callJSFunction(std::move(moduleName), std::move(method), std::move(params));
 }
 
 std::shared_ptr<facebook::react::MessageQueueThread> UwpReactInstance::GetNewUIMessageQueue() const


### PR DESCRIPTION
This fixes potential crashes when creating the instance fails and something like a native module tries to call into it.

This is possible right now if you start the sample app without the packager running, press 'load' so you end up a the red error screen, then minimize the window.  AppState tries to fire an event which runs into null objects inside of m_instanceWrapper.