### PR TITLE
Adding multipart FormData functionality to UWP NetworkingModule

### DIFF
--- a/RNWCPP/ReactUWP/Modules/NetworkingModule.cpp
+++ b/RNWCPP/ReactUWP/Modules/NetworkingModule.cpp
@@ -214,6 +214,19 @@ void AttachContentHeaders(
     content.Headers().ContentEncoding().ParseAdd(facebook::react::UnicodeConversion::Utf8ToUtf16(contentEncoding));
 }
 
+void AttachMultipartHeaders(
+  winrt::Windows::Web::Http::IHttpContent content,
+  const folly::dynamic& headers)
+{
+  for (auto& header : headers.items())
+  {
+    auto& name = header.first.getString();
+    auto& value = header.second.getString();
+
+    content.Headers().Append(facebook::react::UnicodeConversion::Utf8ToUtf16(name), facebook::react::UnicodeConversion::Utf8ToUtf16(value));
+  }
+}
+
 void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
   folly::dynamic bodyData, const std::string& responseType, bool useIncrementalUpdates, int64_t timeout, Callback cb) noexcept
 {
@@ -288,16 +301,18 @@ void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, 
         for (auto& formDataPart : formData)
         {
           if (!formDataPart["string"].empty()) {
-            winrt::Windows::Web::Http::HttpStringContent partDataString { facebook::react::UnicodeConversion::Utf8ToUtf16(formDataPart["string"].asString()) };
-            multiPartContent.Add(partDataString, facebook::react::UnicodeConversion::Utf8ToUtf16(formDataPart["fieldName"].asString()));
+            winrt::Windows::Web::Http::HttpStringContent multipartStringValue { facebook::react::UnicodeConversion::Utf8ToUtf16(formDataPart["string"].asString()) };
+            AttachMultipartHeaders(multipartStringValue, formDataPart["headers"]);
+            multiPartContent.Add(multipartStringValue, facebook::react::UnicodeConversion::Utf8ToUtf16(formDataPart["fieldName"].asString()));
           }
           else if (!formDataPart["uri"].empty()) {
             auto filePath = winrt::to_hstring(formDataPart["uri"].asString());
             winrt::Windows::Storage::StorageFile file = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(filePath).get();
             
             auto stream = file.OpenReadAsync().get();
-            winrt::Windows::Web::Http::HttpStreamContent contentStream(stream);
-            multiPartContent.Add(contentStream, facebook::react::UnicodeConversion::Utf8ToUtf16(formDataPart["fieldName"].asString()));
+            winrt::Windows::Web::Http::HttpStreamContent multipartFileValue(stream);
+            AttachMultipartHeaders(multipartFileValue, formDataPart["headers"]);
+            multiPartContent.Add(multipartFileValue, facebook::react::UnicodeConversion::Utf8ToUtf16(formDataPart["fieldName"].asString()));
           }
         }
 


### PR DESCRIPTION
Adding ability to send multipart requests using the FormData object from JS. fetch/XHRRequests can now accept FormData payloads with either a string or a uri. String FormDataValue will result in a text part of the multi-part payload, while a uri to a local file will include that file's contents in its multipart section of the request. 

This implementation is similar to the [iOS](https://github.com/facebook/react-native/blob/master/Libraries/Network/RCTNetworking.mm)/[Android](https://github.com/facebook/react-native/blob/81fcaa151df4f81e1751719173376bebedb42f36/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java) FormData handling in react-native.
