### PR TITLE
fix focus event errors being reported.

### DIFF
--- a/RNWCPP/ReactUWP/Views/ViewViewManager.cpp
+++ b/RNWCPP/ReactUWP/Views/ViewViewManager.cpp
@@ -162,23 +162,11 @@ const char* ViewViewManager::GetName() const
 folly::dynamic ViewViewManager::GetExportedCustomDirectEventTypeConstants() const
 {
   auto directEvents = Super::GetExportedCustomDirectEventTypeConstants();
-  directEvents["topFocus"] = folly::dynamic::object("registrationName", "onFocus");
-  directEvents["topBlur"] = folly::dynamic::object("registrationName", "onBlur");
   directEvents["topClick"] = folly::dynamic::object("registrationName", "onClick");
   directEvents["topAccessibilityTap"] = folly::dynamic::object("registrationName", "onAccessibilityTap");
 
   return directEvents;
 }
-
-folly::dynamic ViewViewManager::GetExportedCustomBubblingEventTypeConstants() const
-{
-  auto bubblingEvents = Super::GetExportedCustomBubblingEventTypeConstants();
-  bubblingEvents["topFocusIn"] = folly::dynamic::object("registrationName", "onFocusIn");
-  bubblingEvents["topFocusOut"] = folly::dynamic::object("registrationName", "onFocusOut");
-
-  return bubblingEvents;
-}
-
 
 facebook::react::ShadowNode* ViewViewManager::createShadow() const
 {
@@ -230,13 +218,11 @@ XamlView ViewViewManager::CreateViewControl(int64_t tag)
   contentControl.GotFocus([=](auto &&, auto &&)
   {
     DispatchEvent(tag, "topFocus", std::move(folly::dynamic::object("target", tag)));
-    DispatchEvent(tag, "topFocusIn", std::move(folly::dynamic::object("target", tag)));
   });
 
   contentControl.LostFocus([=](auto &&, auto &&)
   {
     DispatchEvent(tag, "topBlur", std::move(folly::dynamic::object("target", tag)));
-    DispatchEvent(tag, "topFocusOut", std::move(folly::dynamic::object("target", tag)));
   });
 
   contentControl.KeyDown([=](auto &&, winrt::KeyRoutedEventArgs const& e)

--- a/RNWCPP/ReactUWP/Views/ViewViewManager.h
+++ b/RNWCPP/ReactUWP/Views/ViewViewManager.h
@@ -19,7 +19,6 @@ public:
 
   folly::dynamic GetNativeProps() const override;
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
-  folly::dynamic GetExportedCustomBubblingEventTypeConstants() const override;
   facebook::react::ShadowNode* createShadow() const override;
 
   void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;


### PR DESCRIPTION
When I added bubbling focusIn/out that started generating some exceptions from checking code because we started declaring onFocus as both bubbling and direct.

This changes onFocus/onBlur from View to just be bubbling and remove the direct code.  The registration on topFocus/topBlur is in viewmanagerbase in the set of standard event types.

now that focus/blur is bubbling we don't need focusIn/out