### PR TITLE
Add UWP only solution

### DIFF
--- a/RNWCPP/.ado/windows-vs-pr.yml
+++ b/RNWCPP/.ado/windows-vs-pr.yml
@@ -82,7 +82,28 @@ jobs:
           workingDirectory: RNWCPP
 
       - task: NuGetCommand@2
-        displayName: NuGet restore
+        displayName: NuGet restore - ReactWindows-UWP
+        inputs:
+          command: restore
+          restoreSolution: RNWCPP/ReactWindows-UWP.sln
+          feedsToUse: config
+          nugetConfigPath: RNWCPP/NuGet.config
+          restoreDirectory: packages/
+          verbosityRestore: Detailed # Options: quiet, normal, detailed
+
+      - task: MSBuild@1
+        displayName: MSBuild - ReactWindows-UWP
+        inputs:
+          solution: RNWCPP/ReactWindows-UWP.sln
+          msbuildVersion: '15.0' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+          msbuildArchitecture: 'x64' # Optional. Options: x86, x64
+          platform: $(BuildPlatform) # Optional
+          configuration: $(BuildConfiguration) # Optional
+          msbuildArguments: '/p:PreferredToolArchitecture=x64' # Optional
+          clean: true # Optional
+
+      - task: NuGetCommand@2
+        displayName: NuGet restore - ReactWindows
         inputs:
           command: restore
           restoreSolution: RNWCPP/ReactWindows.sln
@@ -132,6 +153,7 @@ jobs:
           workingDirectory: RNWCPP
 
       - task: MSBuild@1
+        displayName: MSBuild - ReactWindows
         inputs:
           solution: RNWCPP/ReactWindows.sln
           #msbuildLocationMethod: 'version' # Optional. Options: version, location

--- a/RNWCPP/README.md
+++ b/RNWCPP/README.md
@@ -65,7 +65,7 @@ This is a summary of setup steps needed to install and work with React Native fo
     ```
 
     * Using Visual Studio IDE
-      1. Open `ReactWindows.sln`.
+      1. Open `ReactWindows-UWP.sln`.
       2. Set your `Platform` to `x86` or `x64` and `Configuration ` to `Debug`.
       3. Select `Project / Build Solution (Ctrl+Shift+B)`
 

--- a/RNWCPP/ReactWindows-UWP.sln
+++ b/RNWCPP/ReactWindows-UWP.sln
@@ -1,0 +1,259 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27310.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Universal.SampleApp", "Universal.SampleApp\React.Windows.Universal.SampleApp.vcxproj", "{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD} = {A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}
+		{11C084A3-A57C-4296-A679-CAC17B603144} = {11C084A3-A57C-4296-A679-CAC17B603144}
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B} = {2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Folly", "Folly\Folly.vcxproj", "{A990658C-CE31-4BCC-976F-0FC6B1AF693D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactUWP", "ReactUWP\ReactUWP.vcxproj", "{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactCommon", "ReactCommon\ReactCommon.vcxproj", "{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "ReactWindowsCore\ReactWindowsCore.vcxproj", "{11C084A3-A57C-4296-A679-CAC17B603144}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{41B38B66-3EFF-4661-AEE3-CD5E40F56BCD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EEE39425-10FD-4DB3-924E-D31CDA3DCC73}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
+		NuGet.Config = NuGet.Config
+		ReactWin32.nuspec = ReactWin32.nuspec
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Universal.UnitTests", "Universal.UnitTests\React.Windows.Universal.UnitTests.vcxproj", "{6F713CA6-6BFE-4DF8-932D-4E49745C967E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "PropertySheets", "{6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}"
+	ProjectSection(SolutionItems) = preProject
+		PropertySheets\ARM.props = PropertySheets\ARM.props
+		PropertySheets\Debug.props = PropertySheets\Debug.props
+		PropertySheets\React.Cpp.props = PropertySheets\React.Cpp.props
+		PropertySheets\Release.props = PropertySheets\Release.props
+		PropertySheets\Warnings.props = PropertySheets\Warnings.props
+		PropertySheets\Win32.props = PropertySheets\Win32.props
+		PropertySheets\x64.props = PropertySheets\x64.props
+		PropertySheets\x86.props = PropertySheets\x86.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "StaticLibrary", "StaticLibrary", "{43A78B84-278B-4B99-8887-4029D551173E}"
+	ProjectSection(SolutionItems) = preProject
+		PropertySheets\StaticLibrary\ARM.props = PropertySheets\StaticLibrary\ARM.props
+		PropertySheets\StaticLibrary\Debug.props = PropertySheets\StaticLibrary\Debug.props
+		PropertySheets\StaticLibrary\Release.props = PropertySheets\StaticLibrary\Release.props
+		PropertySheets\StaticLibrary\Win32.props = PropertySheets\StaticLibrary\Win32.props
+		PropertySheets\StaticLibrary\x64.props = PropertySheets\StaticLibrary\x64.props
+		PropertySheets\StaticLibrary\x86.props = PropertySheets\StaticLibrary\x86.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Application", "Application", "{102E37B8-4BE5-4DC1-A650-16706EFB3306}"
+	ProjectSection(SolutionItems) = preProject
+		PropertySheets\Application\ARM.props = PropertySheets\Application\ARM.props
+		PropertySheets\Application\Debug.props = PropertySheets\Application\Debug.props
+		PropertySheets\Application\Release.props = PropertySheets\Application\Release.props
+		PropertySheets\Application\Win32.props = PropertySheets\Application\Win32.props
+		PropertySheets\Application\x64.props = PropertySheets\Application\x64.props
+		PropertySheets\Application\x86.props = PropertySheets\Application\x86.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DynamicLibrary", "DynamicLibrary", "{2EB5E646-7EB4-4FED-B1A8-0AEEF2D32268}"
+	ProjectSection(SolutionItems) = preProject
+		PropertySheets\DynamicLibrary\ARM.props = PropertySheets\DynamicLibrary\ARM.props
+		PropertySheets\DynamicLibrary\Debug.props = PropertySheets\DynamicLibrary\Debug.props
+		PropertySheets\DynamicLibrary\Release.props = PropertySheets\DynamicLibrary\Release.props
+		PropertySheets\DynamicLibrary\Win32.props = PropertySheets\DynamicLibrary\Win32.props
+		PropertySheets\DynamicLibrary\x64.props = PropertySheets\DynamicLibrary\x64.props
+		PropertySheets\DynamicLibrary\x86.props = PropertySheets\DynamicLibrary\x86.props
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shared", "Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
+EndProject
+Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "IntegrationTests", "IntegrationTestScripts\IntegrationTests.njsproj", "{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Universal.IntegrationTests", "Universal.IntegrationTests\React.Windows.Universal.IntegrationTests.vcxproj", "{069986C5-80F3-4A56-AF79-F24EBB05941F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.IntegrationTests", "IntegrationTests\React.Windows.IntegrationTests.vcxproj", "{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra", "Chakra\Chakra.vcxitems", "{C38970C0-5FBF-4D69-90D8-CBAC225AE895}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Third Party", "Third Party", "{978A75A5-B8D2-4306-9AEF-D00793F33F5F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReactNative", "ReactNative", "{F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Folly", "Folly", "{41F31595-2F20-4D6B-A6CF-60444415012A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsSampleCSharpApp", "WindowsSampleCSharpApp\WindowsSampleCSharpApp.csproj", "{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}"
+EndProject
+Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
+		Chakra\Chakra.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
+		Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|ARM.ActiveCfg = Debug|ARM
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|ARM.Build.0 = Debug|ARM
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|ARM.Deploy.0 = Debug|ARM
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|x64.ActiveCfg = Debug|x64
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|x64.Build.0 = Debug|x64
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|x64.Deploy.0 = Debug|x64
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|x86.ActiveCfg = Debug|Win32
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|x86.Build.0 = Debug|Win32
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Debug|x86.Deploy.0 = Debug|Win32
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|ARM.ActiveCfg = Release|ARM
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|ARM.Build.0 = Release|ARM
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|ARM.Deploy.0 = Release|ARM
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|x64.ActiveCfg = Release|x64
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|x64.Build.0 = Release|x64
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|x64.Deploy.0 = Release|x64
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|x86.ActiveCfg = Release|Win32
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|x86.Build.0 = Release|Win32
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}.Release|x86.Deploy.0 = Release|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM.ActiveCfg = Debug|ARM
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM.Build.0 = Debug|ARM
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x64.ActiveCfg = Debug|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x64.Build.0 = Debug|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x86.ActiveCfg = Debug|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x86.Build.0 = Debug|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|ARM.ActiveCfg = Release|ARM
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|ARM.Build.0 = Release|ARM
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x64.ActiveCfg = Release|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x64.Build.0 = Release|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x86.ActiveCfg = Release|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x86.Build.0 = Release|Win32
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|ARM.ActiveCfg = Debug|ARM
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|ARM.Build.0 = Debug|ARM
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|x64.ActiveCfg = Debug|x64
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|x64.Build.0 = Debug|x64
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|x86.ActiveCfg = Debug|Win32
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Debug|x86.Build.0 = Debug|Win32
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|ARM.ActiveCfg = Release|ARM
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|ARM.Build.0 = Release|ARM
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|x64.ActiveCfg = Release|x64
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|x64.Build.0 = Release|x64
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|x86.ActiveCfg = Release|Win32
+		{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}.Release|x86.Build.0 = Release|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|ARM.ActiveCfg = Debug|ARM
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|ARM.Build.0 = Debug|ARM
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x64.ActiveCfg = Debug|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x64.Build.0 = Debug|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x86.ActiveCfg = Debug|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x86.Build.0 = Debug|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|ARM.ActiveCfg = Release|ARM
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|ARM.Build.0 = Release|ARM
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x64.ActiveCfg = Release|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x64.Build.0 = Release|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x86.ActiveCfg = Release|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x86.Build.0 = Release|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|ARM.ActiveCfg = Debug|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|ARM.Build.0 = Debug|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x64.ActiveCfg = Debug|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x64.Build.0 = Debug|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x86.ActiveCfg = Debug|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Debug|x86.Build.0 = Debug|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|ARM.ActiveCfg = Release|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|ARM.Build.0 = Release|ARM
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x64.ActiveCfg = Release|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x64.Build.0 = Release|x64
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x86.ActiveCfg = Release|Win32
+		{11C084A3-A57C-4296-A679-CAC17B603144}.Release|x86.Build.0 = Release|Win32
+		{6F713CA6-6BFE-4DF8-932D-4E49745C967E}.Debug|ARM.ActiveCfg = Debug|Win32
+		{6F713CA6-6BFE-4DF8-932D-4E49745C967E}.Debug|x64.ActiveCfg = Debug|x64
+		{6F713CA6-6BFE-4DF8-932D-4E49745C967E}.Debug|x86.ActiveCfg = Debug|Win32
+		{6F713CA6-6BFE-4DF8-932D-4E49745C967E}.Release|ARM.ActiveCfg = Release|Win32
+		{6F713CA6-6BFE-4DF8-932D-4E49745C967E}.Release|x64.ActiveCfg = Release|x64
+		{6F713CA6-6BFE-4DF8-932D-4E49745C967E}.Release|x86.ActiveCfg = Release|Win32
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Release|ARM.ActiveCfg = Release|Any CPU
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Release|x64.ActiveCfg = Release|Any CPU
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Release|x86.ActiveCfg = Release|Any CPU
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|ARM.ActiveCfg = Debug|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|x64.ActiveCfg = Debug|x64
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|x64.Build.0 = Debug|x64
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|x64.Deploy.0 = Debug|x64
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|x86.ActiveCfg = Debug|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|x86.Build.0 = Debug|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Debug|x86.Deploy.0 = Debug|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|ARM.ActiveCfg = Release|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|x64.ActiveCfg = Release|x64
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|x64.Build.0 = Release|x64
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|x64.Deploy.0 = Release|x64
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|x86.ActiveCfg = Release|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|x86.Build.0 = Release|Win32
+		{069986C5-80F3-4A56-AF79-F24EBB05941F}.Release|x86.Deploy.0 = Release|Win32
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|ARM.ActiveCfg = Debug|ARM
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|ARM.Build.0 = Debug|ARM
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x64.ActiveCfg = Debug|x64
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x64.Build.0 = Debug|x64
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x86.ActiveCfg = Debug|Win32
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x86.Build.0 = Debug|Win32
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Release|ARM.ActiveCfg = Release|ARM
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Release|ARM.Build.0 = Release|ARM
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Release|x64.ActiveCfg = Release|x64
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Release|x64.Build.0 = Release|x64
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Release|x86.ActiveCfg = Release|Win32
+		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Release|x86.Build.0 = Release|Win32
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|ARM.ActiveCfg = Debug|ARM
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|ARM.Build.0 = Debug|ARM
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|ARM.Deploy.0 = Debug|ARM
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|x64.ActiveCfg = Debug|x64
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|x64.Build.0 = Debug|x64
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|x64.Deploy.0 = Debug|x64
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|x86.ActiveCfg = Debug|x86
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|x86.Build.0 = Debug|x86
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Debug|x86.Deploy.0 = Debug|x86
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|ARM.ActiveCfg = Release|ARM
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|ARM.Build.0 = Release|ARM
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|ARM.Deploy.0 = Release|ARM
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|x64.ActiveCfg = Release|x64
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|x64.Build.0 = Release|x64
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|x64.Deploy.0 = Release|x64
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|x86.ActiveCfg = Release|x86
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|x86.Build.0 = Release|x86
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA}.Release|x86.Deploy.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189} = {41B38B66-3EFF-4661-AEE3-CD5E40F56BCD}
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {41F31595-2F20-4D6B-A6CF-60444415012A}
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD} = {F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF}
+		{43A78B84-278B-4B99-8887-4029D551173E} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
+		{102E37B8-4BE5-4DC1-A650-16706EFB3306} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
+		{2EB5E646-7EB4-4FED-B1A8-0AEEF2D32268} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
+		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32} = {F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF}
+		{F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
+		{41F31595-2F20-4D6B-A6CF-60444415012A} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
+		{7119A2D9-2EC8-4070-BAE9-85859B94B8BA} = {41B38B66-3EFF-4661-AEE3-CD5E40F56BCD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C1055EEE-3785-4C0E-8934-FBAA21BFF90C}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This adds a copy of the ReactWindows solution without the Win32 projects so that 3rd party developers can build RNWCPP. 

#2170 and #2154 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2252)