### PR TITLE
Enqueue outgoing messages in background thread.

### DIFF
--- a/RNWCPP/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/RNWCPP/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -100,11 +100,6 @@ TEST_CLASS(RNTesterIntegrationTests)
     TestComponent("IntegrationTestHarnessTest");
   }
 
-  // Timer tests have been disabled in RN. (See RNTesterIntegrationTests.m)
-  BEGIN_TEST_METHOD_ATTRIBUTE(Timers)
-    TEST_IGNORE()
-    END_TEST_METHOD_ATTRIBUTE()
-
   TEST_METHOD(Timers)
   {
     TestComponent("TimersTest");
@@ -183,7 +178,7 @@ TEST_CLASS(RNTesterIntegrationTests)
 
   //ISS:3219193 - Fix intermittent errors, then re-enable.
   BEGIN_TEST_METHOD_ATTRIBUTE(WebSocket)
-    TEST_IGNORE()
+    //TEST_IGNORE()
   END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(WebSocket)
   {

--- a/RNWCPP/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/RNWCPP/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -100,6 +100,10 @@ TEST_CLASS(RNTesterIntegrationTests)
     TestComponent("IntegrationTestHarnessTest");
   }
 
+  // Timer tests have been disabled in RN. (See RNTesterIntegrationTests.m)
+  BEGIN_TEST_METHOD_ATTRIBUTE(Timers)
+    TEST_IGNORE()
+  END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(Timers)
   {
     TestComponent("TimersTest");

--- a/RNWCPP/Desktop/WebSocket.cpp
+++ b/RNWCPP/Desktop/WebSocket.cpp
@@ -251,13 +251,13 @@ void BaseWebSocket<Protocol, Socket, Resolver>::Stop()
 template<typename Protocol, typename Socket, typename Resolver>
 void BaseWebSocket<Protocol, Socket, Resolver>::EnqueueWrite(const string& message, bool binary)
 {
+  post(m_context, [this, message = std::move(message), binary]()
+  {
     m_writeRequests.emplace(std::move(message), binary);
-    if (!m_writeInProgress && ReadyState::Open == m_readyState)
-      post(m_context, [this]()
-      {
-        if (!m_writeRequests.empty())
-          PerformWrite();
-      });
+
+    if (!m_writeInProgress && ReadyState::Open == m_readyState && !m_writeRequests.empty())
+      PerformWrite();
+  });
 }
 
 template<typename Protocol, typename Socket, typename Resolver>

--- a/RNWCPP/Desktop/WebSocket.cpp
+++ b/RNWCPP/Desktop/WebSocket.cpp
@@ -255,7 +255,7 @@ void BaseWebSocket<Protocol, Socket, Resolver>::EnqueueWrite(const string& messa
   {
     m_writeRequests.emplace(std::move(message), binary);
 
-    if (!m_writeInProgress && ReadyState::Open == m_readyState && !m_writeRequests.empty())
+    if (!m_writeInProgress && ReadyState::Open == m_readyState)
       PerformWrite();
   });
 }

--- a/RNWCPP/Desktop/WebSocket.h
+++ b/RNWCPP/Desktop/WebSocket.h
@@ -26,8 +26,12 @@ class BaseWebSocket : public IWebSocket
   boost::beast::multi_buffer m_bufferIn;
   std::thread m_contextThread;
 
-  std::atomic_size_t m_pingRequests { 0 };
+  ///
+  // Must be modified exclusively from the context thread.
+  ///
   std::queue<std::pair<std::string, bool>> m_writeRequests;
+
+  std::atomic_size_t m_pingRequests { 0 };
   CloseCode m_closeCodeRequest { CloseCode::None };
   std::string m_closeReasonRequest;
 

--- a/RNWCPP/WindowsSampleCSharpApp/WindowsSampleCSharpApp.csproj
+++ b/RNWCPP/WindowsSampleCSharpApp/WindowsSampleCSharpApp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>WindowsSampleCSharpApp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
BaseWebSocket::m_writeRequests gets elements emplaced in the main thread, while dequeuing happens in the background thread. This could lead to race conditions.

This change ensures both reads and writes happen only in the background (IO context) thread without locking.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2255)