### PR TITLE
Export UnicodeConversion.h

### DIFF
--- a/RNWCPP/CopyHeaders.inc
+++ b/RNWCPP/CopyHeaders.inc
@@ -1057,6 +1057,7 @@ COPYFILES_PASS0 = \
 	ReactWindows\ReactWindowsCore\Tracing.h; \
 	ReactWindows\include\ReactWindowsCore\ViewManager.h; \
 	ReactWindows\include\ReactWindowsCore\II18nModule.h; \
+	ReactWindows\include\ReactWindowsCore\UnicodeConversion.h; \
 	ReactWindows\Desktop\JSBigStringResourceDll.h; \
 
 COPYFILES_PASS0 = \

--- a/RNWCPP/Desktop.DLL/react-native-win32.oss.x64.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.oss.x64.def
@@ -37,7 +37,8 @@ EXPORTS
 ?toJson@folly@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUdynamic@1@@Z
 ?typeName@dynamic@folly@@QEBAPEBDXZ
 ?updateProperties@ShadowNode@react@facebook@@UEAAX$$QEBUdynamic@folly@@@Z
-?utf16toUTF8@unicode@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBG_K@Z
+?Utf16ToUtf8@UnicodeConversion@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
+?Utf8ToUtf16@UnicodeConversion@react@facebook@@YA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 
 YGNodeNew
 YGNodeNewWithConfig

--- a/RNWCPP/Desktop.DLL/react-native-win32.oss.x86.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.oss.x86.def
@@ -34,7 +34,6 @@ EXPORTS
 ?typeName@dynamic@folly@@QBEPBDXZ
 ?updateProperties@ShadowNode@react@facebook@@UAEX$$QBUdynamic@folly@@@Z
 ?Utf16ToUtf8@UnicodeConversion@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?Utf16ToUtf8@UnicodeConversion@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
 ?Utf8ToUtf16@UnicodeConversion@react@facebook@@YG?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@IHttpResource@react@facebook@@SG?AV?$unique_ptr@UIHttpResource@react@facebook@@U?$default_delete@UIHttpResource@react@facebook@@@std@@@std@@XZ
 ?Make@IWebSocket@react@facebook@@SG?AV?$unique_ptr@UIWebSocket@react@facebook@@U?$default_delete@UIWebSocket@react@facebook@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z

--- a/RNWCPP/Desktop.DLL/react-native-win32.x64.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.x64.def
@@ -44,7 +44,6 @@ EXPORTS
 ?typeName@dynamic@folly@@QEBAPEBDXZ
 ?updateProperties@ShadowNode@react@facebook@@UEAAX$$QEBUdynamic@folly@@@Z
 ?Utf16ToUtf8@UnicodeConversion@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?Utf16ToUtf8@UnicodeConversion@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
 ?Utf8ToUtf16@UnicodeConversion@react@facebook@@YA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 
 YGNodeNew

--- a/RNWCPP/Desktop.DLL/react-native-win32.x86.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.x86.def
@@ -39,7 +39,6 @@ EXPORTS
 ?typeName@dynamic@folly@@QBEPBDXZ
 ?updateProperties@ShadowNode@react@facebook@@UAEX$$QBUdynamic@folly@@@Z
 ?Utf16ToUtf8@UnicodeConversion@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?Utf16ToUtf8@UnicodeConversion@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
 ?Utf8ToUtf16@UnicodeConversion@react@facebook@@YG?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@IHttpResource@react@facebook@@SG?AV?$unique_ptr@UIHttpResource@react@facebook@@U?$default_delete@UIHttpResource@react@facebook@@@std@@@std@@XZ
 ?Make@IWebSocket@react@facebook@@SG?AV?$unique_ptr@UIWebSocket@react@facebook@@U?$default_delete@UIWebSocket@react@facebook@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z

--- a/RNWCPP/Desktop.DLL/react-native-win32.x86sdx.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.x86sdx.def
@@ -35,7 +35,6 @@ EXPORTS
 ?updateProperties@ShadowNode@react@facebook@@UAEX$$QBUdynamic@folly@@@Z
 
 ?Utf16ToUtf8@UnicodeConversion@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?Utf16ToUtf8@UnicodeConversion@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
 ?Utf8ToUtf16@UnicodeConversion@react@facebook@@YA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@IHttpResource@react@facebook@@SA?AV?$unique_ptr@UIHttpResource@react@facebook@@U?$default_delete@UIHttpResource@react@facebook@@@std@@@std@@XZ
 ?Make@IWebSocket@react@facebook@@SA?AV?$unique_ptr@UIWebSocket@react@facebook@@U?$default_delete@UIWebSocket@react@facebook@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z

--- a/RNWCPP/ReactWin32.nuspec
+++ b/RNWCPP/ReactWin32.nuspec
@@ -15,7 +15,6 @@
     <file src="target\x64\Ship\React.Windows.Desktop.DLL\react-native-win32.*" target="lib\ship\x64" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
 
     <file src="inc\cxxreact\*" target="inc\cxxreact"/>
-    <file src="inc\jschelpers\*" target="inc\jschelpers"/>
     <file src="inc\Yoga\*.*" target="inc\Yoga"/>
     <file src="inc\folly\**\*.*" target="inc" />
     <file src="inc\stubs\**\*.*" target="inc" />


### PR DESCRIPTION
Since unicode.h was removed from RN58, this exports a replacement.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2280)