### PR TITLE
Set filtering metadata for RNTesterIntegrationTests::WebSocket

### DIFF
--- a/RNWCPP/.ado/windows-vs-pr.yml
+++ b/RNWCPP/.ado/windows-vs-pr.yml
@@ -226,7 +226,7 @@ jobs:
           #testConfiguration: # Required when testSelector == TestPlan
           #tcmTestRun: '$(test.RunId)' # Optional
           searchFolder: '$(Build.SourcesDirectory)\RNWCPP\target\$(BuildPlatform)\$(BuildConfiguration)'
-          #testFiltercriteria: # Optional
+          testFiltercriteria: (FullyQualifiedName~RNTesterIntegrationTests)&(Owner!=Unstable)
           #runOnlyImpactedTests: False # Optional
           #runAllTestsAfterXBuilds: '50' # Optional
           #uiTests: false # Optional
@@ -239,7 +239,7 @@ jobs:
           #runInParallel: False # Optional
           runTestsInIsolation: true # Optional
           #codeCoverageEnabled: False # Optional
-          otherConsoleOptions: '--Tests:"RNTesterIntegrationTests"' # TODO re-add WebSocketModuleIntegrationTest  # Optional
+          #otherConsoleOptions: '--Tests:"RNTesterIntegrationTests"' # TODO re-add WebSocketModuleIntegrationTest  # Optional
           #distributionBatchType: 'basedOnTestCases' # Optional. Options: basedOnTestCases, basedOnExecutionTime, basedOnAssembly
           #batchingBasedOnAgentsOption: 'autoBatchSize' # Optional. Options: autoBatchSize, customBatchSize
           #customBatchSizeValue: '10' # Required when distributionBatchType == BasedOnTestCases && BatchingBasedOnAgentsOption == CustomBatchSize

--- a/RNWCPP/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/RNWCPP/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -182,7 +182,7 @@ TEST_CLASS(RNTesterIntegrationTests)
 
   //ISS:3219193 - Fix intermittent errors, then re-enable.
   BEGIN_TEST_METHOD_ATTRIBUTE(WebSocket)
-    TEST_IGNORE()
+    TEST_OWNER(L"Unstable")
   END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(WebSocket)
   {


### PR DESCRIPTION
In order to enable or disable unreliable tests without making code changes (and thus, pull requests), we should annotate problematic tests so they can be filtered out by the Azure DevOps build task.

Currently, VSTest doesn't support filtering by custom arbitrary attributes (See https://github.com/Microsoft/vstest/issues/1763), so we use the `Owner` attribute as follows:

```
vstest.host.exe <path\to\Test.dll> /TestCaseFilter:Owner!=Unstable
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2286)