### PR TITLE
fix(NativeModules): Propagate exceptions in sync native methods

### DIFF
--- a/RNWCS/ReactWindows/ChakraBridge/CallSyncHandler.h
+++ b/RNWCS/ReactWindows/ChakraBridge/CallSyncHandler.h
@@ -9,6 +9,6 @@ using namespace Platform;
 
 namespace ChakraBridge {
 
-public delegate String^ CallSyncHandler(int moduleId, int methodId, String^ args);
+public delegate ChakraStringResult CallSyncHandler(int moduleId, int methodId, String^ args);
 
 }

--- a/RNWCS/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/RNWCS/ReactWindows/ReactNative.Shared/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -381,8 +381,18 @@ namespace ReactNative.Chakra.Executor
             var moduleId = (int)arguments[1].ToDouble();
             var methodId = (int)arguments[2].ToDouble();
             var args = (JArray)ConvertJson(arguments[3]);
-            var result = _callSyncHook(moduleId, methodId, args);
-            return ConvertJson(result);
+            
+            try
+            {
+                var result = _callSyncHook(moduleId, methodId, args);
+                return ConvertJson(result);
+            }
+            catch (Exception e)
+            {
+                var error = JavaScriptValue.CreateError(JavaScriptValue.FromString(e.Message));
+                Native.JsSetException(error);
+                return JavaScriptValue.Invalid;
+            }
         }
         #endregion
 

--- a/RNWCS/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
+++ b/RNWCS/ReactWindows/ReactNative/Chakra/Executor/NativeJavaScriptExecutor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using ChakraBridge;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
@@ -246,7 +247,24 @@ namespace ReactNative.Chakra.Executor
                 throw new ArgumentNullException(nameof(callSyncHook));
 
             _executor.SetCallSyncHook((moduleId, methodId, args) =>
-                callSyncHook(moduleId, methodId, JArray.Parse(args))?.ToString(Formatting.None) ?? "null");
+            {
+                try
+                {
+                    var result = callSyncHook(moduleId, methodId, JArray.Parse(args))?.ToString(Formatting.None) ?? "null";
+                    return new ChakraStringResult
+                    {
+                        Result = result,
+                    };
+                }
+                catch (Exception e)
+                {
+                    return new ChakraStringResult
+                    {
+                        Result = e.Message,
+                        ErrorCode = -1 /* Only has to be non-zero */,
+                    };
+                }
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
All view managers in React Native should be loaded with `UIManager.getViewManagerConfig()`, which internally will attempt to load native view manager constants [here](https://github.com/facebook/react-native/blob/d9a82221a457fe4d4e9dda73bb5680024e704e92/Libraries/ReactNative/UIManager.js#L33-L39) via a sync native method. There is a try/catch around this block because many JS-only modules will result in a native exception.

Because we were not propagating this native exception, it was resulting in an app crash rather than a caught JS exception. This change ensures that native exceptions are propagated from sync native methods in both variants of the JavaScript executor in the C# solution.

Fixes #1883

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2299)