### PR TITLE
feat(NativeAnimated): Adds 'subtraction' node type

### DIFF
--- a/RNWCS/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
+++ b/RNWCS/ReactWindows/ReactNative.Shared/Animated/NativeAnimatedNodesManager.cs
@@ -91,6 +91,9 @@ namespace ReactNative.Animated
                 case "addition":
                     node = new AdditionAnimatedNode(tag, config, this);
                     break;
+                case "subtraction":
+                    node = new SubtractionAnimatedNode(tag, config, this);
+                    break;
                 case "division":
                     node = new DivisionAnimatedNode(tag, config, this);
                     break;

--- a/RNWCS/ReactWindows/ReactNative.Shared/Animated/SubtractionAnimatedNode.cs
+++ b/RNWCS/ReactWindows/ReactNative.Shared/Animated/SubtractionAnimatedNode.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace ReactNative.Animated
+{
+    class SubtractionAnimatedNode : ValueAnimatedNode
+    {
+        private readonly NativeAnimatedNodesManager _manager;
+        private readonly int[] _inputNodes;
+
+        public SubtractionAnimatedNode(int tag, JObject config, NativeAnimatedNodesManager manager)
+            : base(tag, config)
+        {
+            _manager = manager;
+            _inputNodes = config.GetValue("input", StringComparison.Ordinal).ToObject<int[]>();
+        }
+
+        public override void Update()
+        {
+            for (int i = 0; i < _inputNodes.Length; ++i)
+            {
+                var valueNode = _manager.GetNodeById(_inputNodes[i]) as ValueAnimatedNode;
+                if (valueNode == null)
+                {
+                    throw new InvalidOperationException(
+                        "Illegal node ID set as an input for Animated.subtract node.");
+                }
+
+                var value = valueNode.Value;
+                if (i == 0)
+                {
+                    RawValue = value;
+                    continue;
+                }
+
+                RawValue -= value;
+            }
+        }
+    }
+}

--- a/RNWCS/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/RNWCS/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Animated\PropsAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\SpringAnimationDriver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\StyleAnimatedNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Animated\SubtractionAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\TrackingAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\TransformAnimatedNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animated\ValueAnimatedNode.cs" />


### PR DESCRIPTION
iOS and Android implemented 'subtraction' for NativeAnimated in [this](https://github.com/facebook/react-native/commit/4906f8d28cdbaf1b432494b473a4c61c1e193881) commit. This change adds the subtraction node type to `react-native-windows`.

Fixes #2300

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2301)