### PR TITLE
Update to react-native@0.58.6-microsoft.27

### DIFF
--- a/RNWCPP/package.json
+++ b/RNWCPP/package.json
@@ -56,10 +56,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.26"
+    "react-native": "0.58.6-microsoft.27"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.26 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.26.tar.gz"
+    "react-native": "0.58.6-microsoft.27 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.27.tar.gz"
   }
 }

--- a/RNWCPP/yarn.lock
+++ b/RNWCPP/yarn.lock
@@ -3572,9 +3572,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.26.tar.gz":
-  version "0.58.6-microsoft.26"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.26.tar.gz#8d4e767320f6a5d88c59e986060fcbf9b6954490"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.27.tar.gz":
+  version "0.58.6-microsoft.27"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.27.tar.gz#dfd31ecc06b11d188dc9498657f7324597a0c581"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
eb5ca7d16 Applying package update to 0.58.6-microsoft.27
7042cdba5 Fix c4244 (#49)
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2303)