### PR TITLE
Fixes to uwp / windesktop js stub files

### DIFF
--- a/RNWCPP/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windesktop.js
+++ b/RNWCPP/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windesktop.js
@@ -1,13 +1,12 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- */
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Portions copyright for react-native-windows:
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 var NativeModules = require('NativeModules');

--- a/RNWCPP/Libraries/Components/CheckBox/CheckBox.windesktop.js
+++ b/RNWCPP/Libraries/Components/CheckBox/CheckBox.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DatePicker/DatePickerIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/DatePicker/DatePickerIOS.uwp.js
@@ -1,44 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var React = require('React');
-var StyleSheet = require('StyleSheet');
-var Text = require('Text');
-var View = require('View');
-
-class DummyDatePickerIOS extends React.Component {
-  render() {
-    return (
-      <View style={[styles.dummyDatePickerIOS, this.props.style]}>
-        <Text style={styles.datePickerText}>DatePickerIOS is not supported on this platform!</Text>
-      </View>
-    );
-  }
-}
-
-var styles = StyleSheet.create({
-  dummyDatePickerIOS: {
-    height: 100,
-    width: 300,
-    backgroundColor: '#ffbcbc',
-    borderWidth: 1,
-    borderColor: 'red',
-    alignItems: 'center',
-    justifyContent: 'center',
-    margin: 10,
-  },
-  datePickerText: {
-    color: '#333333',
-    margin: 20,
-  }
-});
-
-module.exports = DummyDatePickerIOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DatePicker/DatePickerIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/DatePicker/DatePickerIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DatePickerAndroid/DatePickerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/DatePickerAndroid/DatePickerAndroid.uwp.js
@@ -1,20 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- * @flow
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-const DatePickerAndroid = {
-  async open(options: Object): Promise<Object> {
-    return Promise.reject({
-      message: 'DatePickerAndroid is not supported on this platform.'
-    });
-  },
-};
-
-module.exports = DatePickerAndroid;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DatePickerMacOS/DatePickerMacOS.uwp.js
+++ b/RNWCPP/Libraries/Components/DatePickerMacOS/DatePickerMacOS.uwp.js
@@ -1,44 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var React = require('React');
-var StyleSheet = require('StyleSheet');
-var Text = require('Text');
-var View = require('View');
-
-class dummyDatePickerMacOS extends React.Component {
-  render() {
-    return (
-      <View style={[styles.dummyDatePickerMacOS, this.props.style]}>
-        <Text style={styles.datePickerText}>DatePickerMacOS is not supported on this platform!</Text>
-      </View>
-    );
-  }
-}
-
-var styles = StyleSheet.create({
-  dummyDatePickerMacOS: {
-    height: 100,
-    width: 300,
-    backgroundColor: '#ffbcbc',
-    borderWidth: 1,
-    borderColor: 'red',
-    alignItems: 'center',
-    justifyContent: 'center',
-    margin: 10,
-  },
-  datePickerText: {
-    color: '#333333',
-    margin: 20,
-  }
-});
-
-module.exports = DummyDatePickerMacOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DatePickerMacOS/DatePickerMacOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/DatePickerMacOS/DatePickerMacOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/MaskedView/MaskedViewIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/MaskedView/MaskedViewIOS.uwp.js
@@ -1,12 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- * @flow
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/MaskedView/MaskedViewIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/MaskedView/MaskedViewIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Navigation/NavigatorIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/Navigation/NavigatorIOS.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Navigation/NavigatorIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/Navigation/NavigatorIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Picker/PickerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/Picker/PickerAndroid.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Picker/PickerAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/Picker/PickerAndroid.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Picker/PickerIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/Picker/PickerIOS.uwp.js
@@ -1,13 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * This is a controlled component version of RCTPickerIOS
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Picker/PickerIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/Picker/PickerIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ProgressViewIOS/ProgressViewIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/ProgressViewIOS/ProgressViewIOS.uwp.js
@@ -1,47 +1,5 @@
-
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var React = require('React');
-var StyleSheet = require('StyleSheet');
-var Text = require('Text');
-var View = require('View');
-
-class DummyProgressViewIOS extends React.Component {
-  render() {
-    return (
-      <View style={[styles.dummy, this.props.style]}>
-        <Text style={styles.text}>
-          ProgressViewIOS is not supported on this platform!
-        </Text>
-      </View>
-    );
-  }
-}
-
-var styles = StyleSheet.create({
-  dummy: {
-    width: 120,
-    height: 20,
-    backgroundColor: '#ffbcbc',
-    borderWidth: 1,
-    borderColor: 'red',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    color: '#333333',
-    margin: 5,
-    fontSize: 10,
-  }
-});
-
-module.exports = DummyProgressViewIOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/SafeAreaView/SafeAreaView.uwp.js
+++ b/RNWCPP/Libraries/Components/SafeAreaView/SafeAreaView.uwp.js
@@ -1,10 +1,8 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  * @flow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/SafeAreaView/SafeAreaView.windesktop.js
+++ b/RNWCPP/Libraries/Components/SafeAreaView/SafeAreaView.windesktop.js
@@ -1,11 +1,8 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  * @flow
  */
 'use strict';

--- a/RNWCPP/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.uwp.js
@@ -1,47 +1,5 @@
-
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var React = require('React');
-var StyleSheet = require('StyleSheet');
-var Text = require('Text');
-var View = require('View');
-
-class DummySegmentedControlIOS extends React.Component {
-  render() {
-    return (
-      <View style={[styles.dummy, this.props.style]}>
-        <Text style={styles.text}>
-          SegmentedControlIOS is not supported on this platform!
-        </Text>
-      </View>
-    );
-  }
-}
-
-var styles = StyleSheet.create({
-  dummy: {
-    width: 120,
-    height: 50,
-    backgroundColor: '#ffbcbc',
-    borderWidth: 1,
-    borderColor: 'red',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    color: '#333333',
-    margin: 5,
-    fontSize: 10,
-  }
-});
-
-module.exports = DummySegmentedControlIOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/StatusBar/StatusBarIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/StatusBar/StatusBarIOS.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/StatusBar/StatusBarIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/StatusBar/StatusBarIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/TabBarIOS/TabBarIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/TabBarIOS/TabBarIOS.uwp.js
@@ -1,36 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- * @flow
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const TabBarItemIOS = require('TabBarItemIOS');
-const View = require('View');
-
-class DummyTabBarIOS extends React.Component {
-  static Item = TabBarItemIOS;
-
-  render() {
-    return (
-      <View style={[this.props.style, styles.tabGroup]}>
-        {this.props.children}
-      </View>
-    );
-  }
-}
-
-const styles = StyleSheet.create({
-  tabGroup: {
-    flex: 1,
-  }
-});
-
-module.exports = DummyTabBarIOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/TabBarIOS/TabBarIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/TabBarIOS/TabBarIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/TabBarIOS/TabBarItemIOS.uwp.js
+++ b/RNWCPP/Libraries/Components/TabBarIOS/TabBarItemIOS.uwp.js
@@ -1,42 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var React = require('React');
-var View = require('View');
-var StyleSheet = require('StyleSheet');
-
-class DummyTab extends React.Component {
-  render() {
-    if (!this.props.selected) {
-      return <View />;
-    }
-    return (
-      <View style={[this.props.style, styles.tab]}>
-        {this.props.children}
-      </View>
-    );
-  }
-}
-
-var styles = StyleSheet.create({
-  tab: {
-    // TODO(5405356): Implement overflow: visible so position: absolute isn't useless
-    // position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    borderColor: 'red',
-    borderWidth: 1,
-  }
-});
-
-module.exports = DummyTab;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/TabBarIOS/TabBarItemIOS.windesktop.js
+++ b/RNWCPP/Libraries/Components/TabBarIOS/TabBarItemIOS.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/TextInput/TextInput.uwp.js
+++ b/RNWCPP/Libraries/Components/TextInput/TextInput.uwp.js
@@ -1,8 +1,12 @@
-/**
- *
- * @flow
- * @format
- */
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Portions copyright for react-native-windows:
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 const EventEmitter = require('EventEmitter');

--- a/RNWCPP/Libraries/Components/TextInput/TextInputState.uwp.js
+++ b/RNWCPP/Libraries/Components/TextInput/TextInputState.uwp.js
@@ -1,3 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Portions copyright for react-native-windows:
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 /**
  *
  * @flow

--- a/RNWCPP/Libraries/Components/TimePickerAndroid/TimePickerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/TimePickerAndroid/TimePickerAndroid.uwp.js
@@ -1,20 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- * @flow
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-const TimePickerAndroid = {
-  async open(options: Object): Promise<Object> {
-    return Promise.reject({
-      message: 'TimePickerAndroid is not supported on this platform.'
-    });
-  },
-};
-
-module.exports = TimePickerAndroid;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/TimePickerAndroid/TimePickerAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/TimePickerAndroid/TimePickerAndroid.windesktop.js
@@ -1,14 +1,5 @@
-/**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- * @format
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ToastAndroid/ToastAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ToastAndroid/ToastAndroid.uwp.js
@@ -1,25 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- * @noflow
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var warning = require('fbjs/lib/warning');
-
-var ToastAndroid = {
-
-  show: function (
-    message: string,
-    duration: number
-  ): void {
-    warning(false, 'ToastAndroid is not supported on this platform.');
-  },
-
-};
-
-module.exports = ToastAndroid;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ToastAndroid/ToastAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/ToastAndroid/ToastAndroid.windesktop.js
@@ -1,26 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @noflow
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
-var warning = require('fbjs/lib/warning');
-
-var ToastAndroid = {
-
-  show: function (
-    message: string,
-    duration: number
-  ): void {
-    warning(false, 'ToastAndroid is not supported on this platform.');
-  },
-
-};
-
-module.exports = ToastAndroid;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ToolbarAndroid/ToolbarAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ToolbarAndroid/ToolbarAndroid.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ToolbarAndroid/ToolbarAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/ToolbarAndroid/ToolbarAndroid.windesktop.js
@@ -1,12 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/Touchable/TouchableNativeFeedback.windesktop.js
+++ b/RNWCPP/Libraries/Components/Touchable/TouchableNativeFeedback.windesktop.js
@@ -1,12 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/View/PlatformViewPropTypes.uwp.js
+++ b/RNWCPP/Libraries/Components/View/PlatformViewPropTypes.uwp.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- * @flow
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 module.export = {};

--- a/RNWCPP/Libraries/Components/View/PlatformViewPropTypes.windesktop.js
+++ b/RNWCPP/Libraries/Components/View/PlatformViewPropTypes.windesktop.js
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- */
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 module.export = {};

--- a/RNWCPP/Libraries/Components/ViewPager/ViewPagerAndroid.uwp.js
+++ b/RNWCPP/Libraries/Components/ViewPager/ViewPagerAndroid.uwp.js
@@ -1,11 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/ViewPager/ViewPagerAndroid.windesktop.js
+++ b/RNWCPP/Libraries/Components/ViewPager/ViewPagerAndroid.windesktop.js
@@ -1,12 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Components/WebView/WebView.uwp.js
+++ b/RNWCPP/Libraries/Components/WebView/WebView.uwp.js
@@ -1,11 +1,13 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Portions copyright for react-native-windows:
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 'use strict';
 
 var React = require('React');

--- a/RNWCPP/Libraries/Components/WebView/WebView.windesktop.js
+++ b/RNWCPP/Libraries/Components/WebView/WebView.windesktop.js
@@ -1,12 +1,5 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Image/Image.uwp.js
+++ b/RNWCPP/Libraries/Image/Image.uwp.js
@@ -1,8 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Portions copyright for react-native-windows:
+//
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-/**
- * @flow
- */
 // NOTE: this is a shrinked copy paste of ios impl.
 // TODO: provide real uwp implementation
 'use strict';

--- a/RNWCPP/Libraries/Vibration/VibrationIOS.uwp.js
+++ b/RNWCPP/Libraries/Vibration/VibrationIOS.uwp.js
@@ -1,14 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 'use strict';
 
-var warning = require('fbjs/lib/warning');
-
-var VibrationIOS = {
-  vibrate: function() {
-    warning('VibrationIOS is not supported on this platform!');
-  }
-};
-
-module.exports = VibrationIOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/Libraries/Vibration/VibrationIOS.windesktop.js
+++ b/RNWCPP/Libraries/Vibration/VibrationIOS.windesktop.js
@@ -1,14 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 'use strict';
 
-var warning = require('fbjs/lib/warning');
-
-var VibrationIOS = {
-  vibrate: function() {
-    warning('VibrationIOS is not supported on this platform!');
-  }
-};
-
-module.exports = VibrationIOS;
+module.exports = require('UnimplementedView');

--- a/RNWCPP/src/Libraries/Components/DatePicker/DatePicker.tsx
+++ b/RNWCPP/src/Libraries/Components/DatePicker/DatePicker.tsx
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 import * as React from 'react';

--- a/RNWCPP/src/Libraries/Components/DatePicker/DatePicker.uwp.tsx
+++ b/RNWCPP/src/Libraries/Components/DatePicker/DatePicker.uwp.tsx
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 'use strict';
 
 import { requireNativeComponent, StyleSheet } from 'react-native';

--- a/RNWCPP/src/Libraries/Components/DatePicker/DatePickerProps.ts
+++ b/RNWCPP/src/Libraries/Components/DatePicker/DatePickerProps.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { ViewProps } from 'react-native';
 
 export interface IDatePickerProps extends ViewProps {


### PR DESCRIPTION
Fixes copyright headers in the Libraries folder, we had missed before
Change uwp stubs to use unimplementedview instead of rendering something saying control X is not supported on this platform.  DatePickerMacOS.uwp had a typo in it so using it would generate exceptions before - why I was looking in this area in the first place.

Add missing headers in uwp datepicker

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2306)