### PR TITLE
Fix Horizontal ScrollView.

### DIFF
--- a/RNWCPP/ReactUWP/Base/UwpReactInstance.cpp
+++ b/RNWCPP/ReactUWP/Base/UwpReactInstance.cpp
@@ -217,7 +217,7 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance>& spThis, cons
   assert(m_uiDispatcher == nullptr && m_defaultNativeThread == nullptr && m_jsThread == nullptr && m_initThread == nullptr && m_instanceWrapper == nullptr);
 
   m_started = true;
-  m_uiDispatcher = Windows::UI::Core::CoreWindow::GetForCurrentThread().Dispatcher();
+  m_uiDispatcher = winrt::CoreWindow::GetForCurrentThread().Dispatcher();
   m_defaultNativeThread = std::make_shared<react::uwp::UIMessageQueueThread>(m_uiDispatcher);
 
   // Objects that must be created on the UI thread

--- a/RNWCPP/ReactUWP/ReactUWP.vcxproj
+++ b/RNWCPP/ReactUWP/ReactUWP.vcxproj
@@ -188,6 +188,8 @@
     <ClInclude Include="Views\cppwinrt\winrt\react.uwp.h" />
     <ClInclude Include="Views\DatePickerViewManager.h" />
     <ClInclude Include="Views\ImageViewManager.h" />
+    <ClInclude Include="Views\Impl\ScrollViewUWPImplementation.h" />
+    <ClInclude Include="Views\Impl\SnapPointManagingContentControl.h" />
     <ClInclude Include="Views\PickerViewManager.h" />
     <ClInclude Include="Views\PopupViewManager.h" />
     <ClInclude Include="Views\RawTextViewManager.h" />
@@ -256,6 +258,8 @@
     <ClCompile Include="Views\DatePickerViewManager.cpp" />
     <ClCompile Include="Views\FrameworkElementViewManager.cpp" />
     <ClCompile Include="Views\ImageViewManager.cpp" />
+    <ClCompile Include="Views\Impl\ScrollViewUWPImplementation.cpp" />
+    <ClCompile Include="Views\Impl\SnapPointManagingContentControl.cpp" />
     <ClCompile Include="Views\PickerViewManager.cpp" />
     <ClCompile Include="Views\PopupViewManager.cpp" />
     <ClCompile Include="Views\RawTextViewManager.cpp" />

--- a/RNWCPP/ReactUWP/ReactUWP.vcxproj.filters
+++ b/RNWCPP/ReactUWP/ReactUWP.vcxproj.filters
@@ -200,6 +200,12 @@
     <ClCompile Include="Views\ViewControl.cpp">
       <Filter>Views</Filter>
     </ClCompile>
+    <ClCompile Include="Views\Impl\ScrollViewUWPImplementation.cpp">
+      <Filter>Views\Impl</Filter>
+    </ClCompile>
+    <ClCompile Include="SnapPointManagingContentControl.cpp">
+      <Filter>Views\Impl</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Modules\DeviceInfoModule.h">
@@ -400,6 +406,12 @@
     <ClInclude Include="Views\ViewControl.h">
       <Filter>Views</Filter>
     </ClInclude>
+    <ClInclude Include="Views\Impl\ScrollViewUWPImplementation.h">
+      <Filter>Views\Impl</Filter>
+    </ClInclude>
+    <ClInclude Include="SnapPointManagingContentControl.h">
+      <Filter>Views\Impl</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="EndPoints\dll\react-native-uwp.arm.def">
@@ -524,6 +536,9 @@
     </Filter>
     <Filter Include="Views\cppwinrt">
       <UniqueIdentifier>{4dbf6aed-54f8-4ebd-b99d-667a4b380d8a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Views\Impl">
+      <UniqueIdentifier>{101c2d4a-d343-4771-969f-29af0c9f46b2}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/RNWCPP/ReactUWP/Views/Impl/ScrollViewUWPImplementation.cpp
+++ b/RNWCPP/ReactUWP/Views/Impl/ScrollViewUWPImplementation.cpp
@@ -1,0 +1,128 @@
+#include "pch.h"
+
+#include "ScrollViewUWPImplementation.h"
+
+namespace react {
+namespace uwp {
+
+ScrollViewUWPImplementation::ScrollViewUWPImplementation(const winrt::ScrollViewer& scrollViewer)
+{
+  assert(scrollViewer);
+  auto scrollViewContent = scrollViewer.Content();
+  assert(scrollViewContent);
+  auto snapPointManager = scrollViewContent.as<SnapPointManagingContentControl>();
+  assert(snapPointManager);
+  assert(snapPointManager->Content().as<winrt::StackPanel>());
+
+  m_scrollViewer = winrt::make_weak(scrollViewer);
+}
+
+void ScrollViewUWPImplementation::ConvertScrollViewer(const winrt::ScrollViewer& scrollViewer)
+{
+  if (scrollViewer)
+  {
+    auto snapPointManager = new SnapPointManagingContentControl();
+    snapPointManager->Content(winrt::StackPanel{});
+
+    scrollViewer.Content(*snapPointManager);
+  }
+}
+
+void ScrollViewUWPImplementation::AddView(const XamlView& child, int64_t index)
+{
+  auto contentCollection = ScrollViewerContent().Children();
+  assert(index <= contentCollection.Size());
+  contentCollection.InsertAt(index, child.as<winrt::UIElement>());
+}
+
+void ScrollViewUWPImplementation::RemoveAllChildren()
+{
+  ScrollViewerContent().Children().Clear();
+}
+
+void ScrollViewUWPImplementation::RemoveChildAt(int64_t index)
+{
+  auto contentCollection = ScrollViewerContent().Children();
+  assert(index < contentCollection.Size());
+  contentCollection.RemoveAt(index);
+}
+
+void ScrollViewUWPImplementation::SetHorizontal(bool horizontal)
+{
+  ScrollViewerSnapPointManager()->SetHorizontal(horizontal);
+}
+
+void ScrollViewUWPImplementation::SnapToInterval(float interval)
+{
+  ScrollViewerSnapPointManager()->SnapToInterval(interval);
+}
+
+void ScrollViewUWPImplementation::SnapToOffsets(const winrt::IVectorView<float>& offsets)
+{
+  ScrollViewerSnapPointManager()->SnapToOffsets(offsets);
+}
+
+void ScrollViewUWPImplementation::UpdateScrollableSize()
+{
+  if (auto scrollViewer = m_scrollViewer.get())
+  {
+    switch (scrollViewer.HorizontalSnapPointsAlignment())
+    {
+    case winrt::SnapPointsAlignment::Near:
+      ScrollViewerSnapPointManager()->SetWidthBounds(0, scrollViewer.ScrollableWidth());
+      break;
+    case winrt::SnapPointsAlignment::Center:
+      ScrollViewerSnapPointManager()->SetWidthBounds((scrollViewer.ActualWidth() / 2), scrollViewer.ScrollableWidth() + (scrollViewer.ActualWidth() / 2));
+      break;
+    case winrt::SnapPointsAlignment::Far:
+      ScrollViewerSnapPointManager()->SetWidthBounds(scrollViewer.ActualWidth(), scrollViewer.ScrollableWidth() + scrollViewer.ActualWidth());
+      break;
+    }
+
+    switch (scrollViewer.VerticalSnapPointsAlignment())
+    {
+    case winrt::SnapPointsAlignment::Near:
+      ScrollViewerSnapPointManager()->SetHeightBounds(0, scrollViewer.ScrollableWidth());
+      break;
+    case winrt::SnapPointsAlignment::Center:
+      ScrollViewerSnapPointManager()->SetHeightBounds((scrollViewer.ActualHeight() / 2) + 1, scrollViewer.ScrollableWidth() + (scrollViewer.ActualHeight() / 2));
+      break;
+    case winrt::SnapPointsAlignment::Far:
+      ScrollViewerSnapPointManager()->SetHeightBounds(scrollViewer.ActualHeight(), scrollViewer.ScrollableWidth() + scrollViewer.ActualHeight());
+      break;
+    }
+  }
+}
+
+winrt::ScrollViewer ScrollViewUWPImplementation::ScrollViewer()
+{
+  return m_scrollViewer.get();
+}
+
+// privates //
+
+winrt::com_ptr<SnapPointManagingContentControl>ScrollViewUWPImplementation::ScrollViewerSnapPointManager()
+{
+  if (auto scrollViewer = m_scrollViewer.get())
+  {
+    if (auto content = scrollViewer.Content())
+    {
+      return content.as<SnapPointManagingContentControl>();
+    }
+  }
+  return nullptr;
+}
+
+winrt::StackPanel ScrollViewUWPImplementation::ScrollViewerContent()
+{
+  if (auto snapPointManagingContentControl = ScrollViewerSnapPointManager())
+  {
+    if (auto content = snapPointManagingContentControl->Content())
+    {
+      return content.as<winrt::StackPanel>();
+    }
+  }
+  return nullptr;
+}
+
+} }

--- a/RNWCPP/ReactUWP/Views/Impl/ScrollViewUWPImplementation.h
+++ b/RNWCPP/ReactUWP/Views/Impl/ScrollViewUWPImplementation.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "pch.h"
+
+#include "SnapPointManagingContentControl.h"
+
+#include <Utils/PropertyUtils.h>
+#include <Utils/ValueUtils.h>
+
+#include <IReactInstance.h>
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+
+namespace winrt {
+  using namespace Windows::Foundation;
+  using namespace Windows::Foundation::Collections;
+  using namespace Windows::UI::Xaml;
+  using namespace Windows::UI::Xaml::Controls;
+  using namespace Windows::UI::Xaml::Controls::Primitives;
+}
+
+namespace react {
+namespace uwp {
+
+class ScrollViewUWPImplementation
+{
+public:
+  ScrollViewUWPImplementation(const winrt::ScrollViewer& scrollViewer);
+  static void ConvertScrollViewer(const winrt::ScrollViewer& scrollViewer);
+
+  void AddView(const XamlView& child, int64_t index);
+  void RemoveAllChildren();
+  void RemoveChildAt(int64_t index);
+
+  void SetHorizontal(bool isHorizontal);
+  void SnapToInterval(float interval);
+  void SnapToOffsets(const winrt::IVectorView<float>& offsets);
+
+  void UpdateScrollableSize();
+
+  winrt::ScrollViewer ScrollViewer();
+  winrt::com_ptr<SnapPointManagingContentControl> ScrollViewerSnapPointManager();
+
+private:
+  winrt::StackPanel ScrollViewerContent();
+
+  winrt::weak_ref<winrt::ScrollViewer> m_scrollViewer{};
+};
+
+} }

--- a/RNWCPP/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
+++ b/RNWCPP/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
@@ -1,0 +1,171 @@
+#include "pch.h"
+
+#include "SnapPointManagingContentControl.h"
+
+namespace react {
+namespace uwp {
+
+SnapPointManagingContentControl::SnapPointManagingContentControl()
+{
+
+}
+
+void SnapPointManagingContentControl::SnapToInterval(float interval)
+{
+  if (interval != m_interval)
+  {
+    m_interval = interval;
+    m_horizontalSnapPointsChangedEventSource(*this, nullptr);
+    m_verticalSnapPointsChangedEventSource(*this, nullptr);
+  }
+}
+
+void SnapPointManagingContentControl::SnapToOffsets(const winrt::IVectorView<float>& offsets)
+{
+  m_offsets = offsets;
+  m_interval = 0;
+  m_horizontalSnapPointsChangedEventSource(*this, nullptr);
+  m_verticalSnapPointsChangedEventSource(*this, nullptr);
+}
+
+bool SnapPointManagingContentControl::AreHorizontalSnapPointsRegular()
+{
+  return m_interval;
+}
+
+bool SnapPointManagingContentControl::AreVerticalSnapPointsRegular()
+{
+  return m_interval;
+}
+
+winrt::event_token SnapPointManagingContentControl::HorizontalSnapPointsChanged(winrt::EventHandler<winrt::IInspectable> const& value)
+{
+  return m_horizontalSnapPointsChangedEventSource.add(value);
+}
+void SnapPointManagingContentControl::HorizontalSnapPointsChanged(winrt::event_token const& token)
+{
+  m_horizontalSnapPointsChangedEventSource.remove(token);
+}
+
+winrt::event_token SnapPointManagingContentControl::VerticalSnapPointsChanged(winrt::EventHandler<winrt::IInspectable> const& value)
+{
+  return m_verticalSnapPointsChangedEventSource.add(value);
+}
+void SnapPointManagingContentControl::VerticalSnapPointsChanged(winrt::event_token const& token)
+{
+  m_verticalSnapPointsChangedEventSource.remove(token);
+}
+
+winrt::IVectorView<float> SnapPointManagingContentControl::GetIrregularSnapPoints(winrt::Orientation orientation, winrt::SnapPointsAlignment alignment)
+{
+  auto retVal = winrt::single_threaded_vector<float>();
+
+  if (m_offsets && m_offsets.Size())
+  {
+    if (m_snapToStart)
+    {
+      retVal.Append(m_horizontal ? m_startWidth : m_startHeight);
+    }
+    for (auto offset : m_offsets)
+    {
+      retVal.Append(offset);
+    }
+    if (m_snapToEnd)
+    {
+      retVal.Append(m_horizontal ? m_endWidth : m_endHeight);
+    }
+  }
+
+  return retVal.GetView();
+}
+
+float SnapPointManagingContentControl::GetRegularSnapPoints(winrt::Orientation orientation, winrt::SnapPointsAlignment alignment, float offset)
+{
+  return m_interval;
+}
+
+void SnapPointManagingContentControl::SetHorizontal(bool horizontal)
+{
+  if (m_horizontal != horizontal)
+  {
+    m_horizontal = horizontal;
+
+    if (m_endHeight != m_endWidth)
+    {
+      if (horizontal)
+      {
+        m_horizontalSnapPointsChangedEventSource(*this, nullptr);
+      }
+      else
+      {
+        m_verticalSnapPointsChangedEventSource(*this, nullptr);
+      }
+    }
+  }
+}
+
+void SnapPointManagingContentControl::SetWidthBounds(float startWidth, float endWidth)
+{
+  auto const update = [this, startWidth, endWidth]()
+  {
+    return
+      [this, endWidth]()
+      {
+        if (m_endWidth != endWidth)
+        {
+          m_endWidth = endWidth;
+          return true;
+        }
+        return false;
+      }()
+      ||
+      [this, startWidth]()
+      {
+        if (m_startWidth != startWidth)
+        {
+          m_startWidth = startWidth;
+          return true;
+        }
+        return false;
+      }();
+  }();
+
+  if (update && m_horizontal && m_offsets && m_offsets.Size())
+  {
+    m_horizontalSnapPointsChangedEventSource(*this, nullptr);
+  }
+}
+
+void SnapPointManagingContentControl::SetHeightBounds(float startHeight, float endHeight)
+{
+  auto const update = [this, startHeight, endHeight]()
+  {
+    return
+      [this, endHeight]()
+      {
+        if (m_endHeight != endHeight)
+        {
+          m_endHeight = endHeight;
+          return true;
+        }
+        return false;
+      }()
+      ||
+      [this, startHeight]()
+      {
+        if (m_startHeight != startHeight)
+        {
+          m_startHeight = startHeight;
+          return true;
+        }
+        return false;
+      }();
+  }();
+
+  if (!m_horizontal && m_offsets && m_offsets.Size())
+  {
+    m_verticalSnapPointsChangedEventSource(*this, nullptr);
+  }
+}
+
+} }

--- a/RNWCPP/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
+++ b/RNWCPP/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "pch.h"
+
+namespace winrt {
+  using namespace Windows::Foundation;
+  using namespace Windows::Foundation::Collections;
+  using namespace Windows::UI::Xaml;
+  using namespace Windows::UI::Xaml::Controls;
+  using namespace Windows::UI::Xaml::Controls::Primitives;
+}
+
+namespace react {
+namespace uwp {
+
+  class SnapPointManagingContentControl : public winrt::ContentControlT<SnapPointManagingContentControl, winrt::IScrollSnapPointsInfo>
+  {
+  public:
+    SnapPointManagingContentControl();
+
+    // ScrollView Implementation
+    void SnapToInterval(float interval);
+    void SnapToOffsets(const winrt::IVectorView<float>& offsets);
+
+    // IScrollSnapPointsInfo Implementation
+    bool AreHorizontalSnapPointsRegular();
+    bool AreVerticalSnapPointsRegular();
+
+    winrt::event_token HorizontalSnapPointsChanged(winrt::EventHandler<winrt::IInspectable> const& value);
+    void HorizontalSnapPointsChanged(winrt::event_token const& token);
+
+    winrt::event_token VerticalSnapPointsChanged(winrt::EventHandler<winrt::IInspectable> const& value);
+    void VerticalSnapPointsChanged(winrt::event_token const& token);
+
+    winrt::IVectorView<float> GetIrregularSnapPoints(winrt::Orientation orientation, winrt::SnapPointsAlignment alignment);
+
+    float GetRegularSnapPoints(winrt::Orientation orientation, winrt::SnapPointsAlignment alignment, float offset);
+
+    // Helpers
+    void SetHorizontal(bool horizontal);
+    void SetHeightBounds(float startHeight, float endHeight);
+    void SetWidthBounds(float startWidth, float endWidth);
+
+  private:
+    float m_interval{ 0 };
+    winrt::IVectorView<float> m_offsets{};
+    bool m_snapToStart{ true };
+    bool m_snapToEnd{ true };
+    winrt::event<winrt::EventHandler<winrt::IInspectable>> m_horizontalSnapPointsChangedEventSource;
+    winrt::event<winrt::EventHandler<winrt::IInspectable>> m_verticalSnapPointsChangedEventSource;
+
+    bool m_horizontal{ false };
+    float m_startHeight{ 0 };
+    float m_startWidth{ 0 };
+    float m_endHeight{ INFINITY };
+    float m_endWidth{ INFINITY };
+  };
+} }

--- a/RNWCPP/ReactUWP/Views/ScrollViewManager.cpp
+++ b/RNWCPP/ReactUWP/Views/ScrollViewManager.cpp
@@ -77,6 +77,8 @@ folly::dynamic ScrollViewManager::GetExportedCustomDirectEventTypeConstants() co
 XamlView ScrollViewManager::CreateViewCore(int64_t tag)
 {
   winrt::ScrollViewer scrollViewer;
+  scrollViewer.HorizontalScrollBarVisibility(winrt::ScrollBarVisibility::Visible);
+  scrollViewer.VerticalScrollBarVisibility(winrt::ScrollBarVisibility::Visible);
 
   AddHandlers(scrollViewer, tag);
 

--- a/RNWCPP/ReactUWP/Views/ScrollViewManager.h
+++ b/RNWCPP/ReactUWP/Views/ScrollViewManager.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include "pch.h"
+
 #include <Views/ControlViewManager.h>
+#include "Impl/ScrollViewUWPImplementation.h"
 
 namespace react { namespace uwp {
 
@@ -22,6 +25,9 @@ public:
   void RemoveAllChildren(XamlView parent) override;
   void RemoveChildAt(XamlView parent, int64_t index) override;
 
+  void SnapToInterval(XamlView parent, float interval);
+  void SnapToOffsets(XamlView parent, const winrt::IVectorView<float>& offsets);
+
   void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
   void DispatchCommand(XamlView viewToUpdate, int64_t commandId, const folly::dynamic& commandArgs) override;
 
@@ -29,12 +35,24 @@ protected:
   XamlView CreateViewCore(int64_t tag) override;
 
 private:
-  void AddHandlers(winrt::Windows::UI::Xaml::Controls::ScrollViewer& scrollViewer, int64_t tag);
+  void AddHandlers(const winrt::ScrollViewer& scrollViewer, int64_t tag);
   void EmitScrollEvent(
-    winrt::Windows::UI::Xaml::Controls::ScrollViewer& scrollViewer,
+    const winrt::ScrollViewer& scrollViewer,
     int64_t tag,
     const char* eventName,
     double x, double y, double zoom);
+
+  bool m_isScrollingFromInertia{ false };
+  bool m_isScrolling{ false };
+
+  std::map<int64_t, float> m_zoomFactors{};
+
+  std::map<int64_t, winrt::FrameworkElement::SizeChanged_revoker> m_scrollViewerSizeChangedRevokers{};
+  std::map<int64_t, winrt::FrameworkElement::SizeChanged_revoker> m_contentSizeChangedRevokers{};
+  std::map<int64_t, winrt::ScrollViewer::ViewChanged_revoker> m_scrollViewerViewChangedRevokers{};
+  std::map<int64_t, winrt::ScrollViewer::ViewChanging_revoker> m_scrollViewerViewChangingRevokers{};
+  std::map<int64_t, winrt::ScrollViewer::DirectManipulationCompleted_revoker> m_scrollViewerDirectManipulationCompletedRevokers{};
+  std::map<int64_t, winrt::ScrollViewer::DirectManipulationStarted_revoker> m_scrollViewerDirectManipulationStartedRevokers{};
 };
 
 } }

--- a/RNWCPP/Shared/pch.h
+++ b/RNWCPP/Shared/pch.h
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
 #ifdef WINRT
 #include <SDKDDKVer.h>
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+
+#include "CppWinRTIncludes.h"
+
 #endif
 
 #include <windows.h>

--- a/RNWCPP/include/CppWinRTIncludes.h
+++ b/RNWCPP/include/CppWinRTIncludes.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include <winrt\Windows.UI.Xaml.Controls.Primitives.h>
+
+namespace winrt
+{
+  using namespace ::winrt::Windows::UI::Core;
+}


### PR DESCRIPTION
The UWP ScrollViewer requires that HorizontalScrollBarVisibility not be Disabled in order for the ScrollViewer to be horizontally scrollable. The default value for HorizontalScrollBarVisibility is Disabled so for ReactNative ScrollView's which do not set showsHorizontalScrollIndicator but set horizontal to true we were providing an improperly configured ScrollViewer for the native implementation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2316)