### PR TITLE
Update CLI template to match file name

### DIFF
--- a/RNWCPP/local-cli/generator-windows/templates/App.windows.js
+++ b/RNWCPP/local-cli/generator-windows/templates/App.windows.js
@@ -19,7 +19,7 @@ class <%=name%> extends Component {
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
-          To get started, edit index.windows.js
+          To get started, edit app.windows.js
         </Text>
       </View>
     );

--- a/RNWCPP/local-cli/generator-windows/templates/app.windows.bundle
+++ b/RNWCPP/local-cli/generator-windows/templates/app.windows.bundle
@@ -2,7 +2,7 @@
  * 
  * Be sure to generate this file using the CLI:
  *
- * react-native bundle --platform windows --entry-file index.windows.js 
+ * react-native bundle --platform windows --entry-file app.windows.js 
  *   --bundle-output windows\<%=name%>\ReactAssets\index.windows.bundle
  *   --assets-dest windows\<%=name%>\ReactAssets
  *


### PR DESCRIPTION
App suggests editing "index.windows.js" to get started, but the file name is "app.windows.js"

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2317)