### PR TITLE
update ExceptionManagerModule assert for 0.58 compat

### DIFF
--- a/RNWCPP/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
+++ b/RNWCPP/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
@@ -82,7 +82,7 @@ JSExceptionInfo ExceptionsManagerModule::CreateExceptionInfo(const folly::dynami
     // Each dynamic object is a map containing information about the stack frame:
     // method (string), filename(string), line number (int) and column number (int).
     assert(stackFrame.type() == folly::dynamic::OBJECT);
-    assert(stackFrame.size() == 4);
+    assert(stackFrame.size() >= 4);
 
     std::stringstream stackFrameInfo;
 


### PR DESCRIPTION
with 0.58 a 5th arg now exists and this very noisy assert fires on every level of the callstack

quick fix is update the assert, longer term we can make use of the new parameter (I am forgetting now, i think its parameters or something)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2322)