### PR TITLE
Clean up publish tasks

### DIFF
--- a/RNWCPP/.ado/publish.yml
+++ b/RNWCPP/.ado/publish.yml
@@ -20,12 +20,6 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: CmdLine@1
-        displayName: 'npm auth'
-        inputs:
-          filename: npm
-          arguments: 'config set $(publishnpmfeed)/registry/:_authToken $(npmTokenOffice)'
-
       # The Hosted 2019 pool machines look like they already have this, so it wouldn't be needed..
       - task: CmdLine@2
         displayName: Ensure yarn
@@ -46,16 +40,10 @@ jobs:
           workingDirectory: RNWCPP
 
       - task: CmdLine@2
-        displayName: Do Publish
+        displayName: Update package version
         inputs:
-          script: node .ado/publish.js
+          script: node .ado/updateVersion.js
           workingDirectory: RNWCPP
-
-      - task: CmdLine@1
-        displayName: 'npm unauth'
-        inputs:
-          filename: npm
-          arguments: 'config set $(publishnpmfeed)/registry/:_authToken XXXXX'
 
       - task: Npm@1
         displayName: npm public publish (vnext)

--- a/RNWCPP/.ado/updateVersion.js
+++ b/RNWCPP/.ado/updateVersion.js
@@ -1,4 +1,4 @@
-// Used to publish react-native-win
+// Used to update the package version 
 
 const fs = require("fs");
 const path = require("path");
@@ -17,7 +17,7 @@ function exec(command) {
   }
 }
 
-function doPublish() {
+function updateVersion() {
   const publishBranchName = process.env.publishBranchName;
   const tempPublishBranch = `publish-${Date.now()}`;
 
@@ -63,16 +63,6 @@ function doPublish() {
   exec(`git push origin HEAD:${tempPublishBranch} --follow-tags --verbose`);
   exec(`git push origin tag ${tagName}`);
 
-  // TODO - change this to publish directly to public NPM feed.
-  const npmrcFileContents = `@office-iss:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
-registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/	
-always-auth=true`;
-  const npmrcFileName = path.resolve(__dirname, "../.npmrc");
-  fs.writeFileSync(npmrcFileName, npmrcFileContents);
-  exec(`npm publish --tag vnext`);
-  // delete npmrc file before submitting changes to git
-  fs.unlinkSync(npmrcFileName);
-
   exec(`git checkout ${publishBranchName}`);
   exec(`git pull origin ${publishBranchName}`);
   exec(`git merge ${tempPublishBranch} --no-edit`);
@@ -83,4 +73,4 @@ always-auth=true`;
   exec(`git push origin --delete -d ${tempPublishBranch}`);
 }
 
-doPublish();
+updateVersion();


### PR DESCRIPTION
Since we're now publishing directly to the public NPM feed, we can remove the office registry code. Also renamed publish.js since all it does now is update the package version and tag the commit. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2324)