### PR TITLE
Commiting updates to docs upon end of Milestone 1

### DIFF
--- a/RNWCPP/README.md
+++ b/RNWCPP/README.md
@@ -3,97 +3,14 @@ See the official [React Native website](https://facebook.github.io/react-native/
 
 In this branch, we are working on a rewrite of React Native for Windows10 built in C++ that reuses the C++ core bridge implementation from Facebook’s React Native.  This will allow React Native for Windows10 to innovate and provide features by sharing the same core as Facebook’s React Native. See [Status](https://github.com/Microsoft/react-native-windows#status) for more details.
 
+## Status and roadmap
+The development of the React Native Windows C++ implementation is ongoing. You can take a look at [Milestones](https://github.com/Microsoft/react-native-windows/milestones) and [Projects](https://github.com/Microsoft/react-native-windows/projects) for a view on the work streams and tasks. 
+
 # Getting Started
-This is a summary of setup steps needed to install and work with React Native for Windows10 (C++). See the [React Native Getting Started Guide](http://facebook.github.io/react-native/docs/getting-started.html) for React Native details.
+See [Getting Started Guide for React Native Windows C++](docs/GettingStarted.md).
 
-## System requirements
-* You can run React-Native for Windows10 apps only on Windows 10 devices; sdk version: 10.0.14393.795 or higher.
-* [Visual Studio 2017](https://www.visualstudio.com/downloads) with the following options:
-  * Workloads
-    * Universal Windows Platform development
-      * Enable the optional 'C++ Universal Windows Platform tools'
-    * Desktop development with C++
-  * Individual Components
-    * Development activities
-      * Node.js development support
-    * SDKs, libraries, and frameworks
-      * Windows 10 SDK (10.0.14393.0)
-      * Windows 10 SDK (10.0.17763.0)
+# Opening issues
+If you encounter a bug with the React Native Windows C++ implementation or have a feature request, we would like to hear about it. Search the [existing issues](https://github.com/Microsoft/react-native-windows/issues?label%3Arnwcpp) and try to make sure your problem doesn’t already exist before opening a new issue. It’s helpful if you include the version of Windows, React Native, React Native Windows plugin, and device family (i.e., desktop, Xbox, etc.) you’re using. Please include a stack trace and reduced repro case when appropriate, too.
 
-## Install dependencies
-* [Git](https://git-scm.com/download/win)
-* [Node.js](https://nodejs.org) (last verified with version 8.14.0)
-* [Chrome](https://www.google.com/chrome/) (*optional*, but needed for JS debugging)
-* [NuGet](https://dist.nuget.org/index.html)<br/>
-  Add `NuGet.exe`'s location to `PATH`.
-* [NuGet Credential Provider](https://nuget.pkgs.visualstudio.com/_apis/public/nuget/client/CredentialProviderBundle.zip)<br/>
-  Add `CredentialProvider.VSS.exe`'s location to `PATH`.
-
-
-## Build Steps
-1. Clone the repo
-    ```cmd
-    git clone https://github.com/Microsoft/react-native-windows.git
-    cd react-native-windows
-    ```
-2. Checkout the rnwcpp-preview branch
-    ```cmd
-    git checkout rnwcpp-preview
-    ```
-3. Install dependencies. This step may take a while on the first run due to dependency download.
-    ```cmd
-    cd RNWCPP
-    npm install
-    ```
-
-4. Build solution.
-    * Using MSBuild
-    ```cmd
-    MSBuild.exe [/p:Platform=$(TargetPlatform)] [/p:Configuration=$(TargetConfiguration)]
-    ```
-
-    * Using Visual Studio IDE
-      1. Open `ReactWindows-UWP.sln`.
-      2. Set your `Platform` to `x86` or `x64` and `Configuration ` to `Debug`.
-      3. Select `Project / Build Solution (Ctrl+Shift+B)`
-
-5. *[Optional]* Install [react-devtools](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools) for enhanced JS debugging:
-
-    ```cmd
-   npm install -g react-devtools
-   ```
-
-## Running the Sample Universal Windows App
-1. Run `npm run build`.
-2. Run `Scripts\launchPackager.bat`.
-3. *[Optional]* If you want to debug the JS code:
-   - Make sure Chrome is running if you're not already running it
-   - If you want to use the react-devtools that you installed earlier, run `react-devtools`
-4. In Visual Studio, set React.Windows.Universal.SampleApp as the StartUp Project.
-   - If you didn't already, make sure to set your `Platform` to `x86` or `x64` and `Configuration ` to `Debug`.
-5. Run project (`F5` or `Debug / Start Debugging`).
-6. If you chose to skip step 3 above, make sure to uncheck the "Web Debugger" checkbox.
-7. Press the "Load" button on the left side of the Windows 10 application window that appears.
-
-The selected ReactNative app (defaulted to `Bootstrap`) should start in the bottom of the application window.
-
-Try these samples by entering the JS file name and App names below into the textboxes at the top of the application window before pressing "Load":
-   - Sample: JavaScript file: `Universal.SampleApp\index.uwp` App Name: `Bootstrap`
-   - RNTester: JavaScript file: `lib\RNTester\RNTesterApp.uwp` App Name: `RNTesterApp`
-
-If you did choose to debug the JS code with "Web Debugger" enabled, Chrome should have loaded `http://localhost:8081/debugger-ui/` in a new tab. Press `F12` or `Ctrl+Shift+I` in Chrome to open its Developer Tools.
-
-**Note:** If nothing happened, make sure you started the packager (and if debugging the JS code, Chrome and the react-devtools) before step 7.
-
-## Running Unit Tests
-1. Run `Scripts\UnitTest.ps1 [-Platform <test platform> -Configuration <test configuration>]`.
-
-## Running Integration Tests
-### PowerShell
-1. Run `Scripts\IntegrationTests.ps1 -Run`. This runs all Desktop tests.
-### Visual Studio
-1. Run `Scripts\IntegrationTests.ps1` to start the JS bundler and WebSocket server.
-2. In the `Test Explorer` window, select and run any desired tests.
-
-Defaults for platform and configuration are `x64`, `Debug`.
-
+# Contributing
+See [Contributing guidelines](docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native Windows C++. 

--- a/RNWCPP/docs/GettingStarted.md
+++ b/RNWCPP/docs/GettingStarted.md
@@ -1,0 +1,81 @@
+# Getting Started Guide for React Native Windows C++
+
+This is a summary of setup steps needed to install and work with React Native for Windows10 (C++). See the [React Native Getting Started Guide](http://facebook.github.io/react-native/docs/getting-started.html) for React Native details.
+
+## System requirements
+* You can run React-Native for Windows10 apps only on Windows 10 devices; sdk version: 10.0.14393.795 or higher.
+* [Visual Studio 2017](https://www.visualstudio.com/downloads) with the following options:
+  * Workloads
+    * Universal Windows Platform development
+      * Enable the optional 'C++ Universal Windows Platform tools'
+    * Desktop development with C++
+  * Individual Components
+    * Development activities
+      * Node.js development support
+    * SDKs, libraries, and frameworks
+      * Windows 10 SDK (10.0.14393.0)
+      * Windows 10 SDK (10.0.17763.0)
+
+## Dependencies
+* Install the dependencies [specified by React Native](http://facebook.github.io/react-native/docs/getting-started.html#node-python2-jdk). Specifically, make sure a recent version of [Node.js](https://nodejs.org) is installed. [Chocolatey](https://chocolatey.org/) is the React Native recommended installation method. On an elevated Command Prompt, run:
+```
+choco install nodejs
+```
+* Install [Chrome](https://www.google.com/chrome/) (*optional*, but needed for JS debugging)
+
+## Installing React Native
+
+* Install React Native command line interface using NPM:
+```
+npm install -g react-native-cli
+```
+* Initialize your React Native project
+
+Next, [generate a React Native project](http://facebook.github.io/react-native/docs/getting-started.html#creating-a-new-application). In the directory you would like your React Native Windows project directory, run:
+```
+react-native init <project name>
+```
+Navigate into this newly created directory:
+```
+cd <project name>
+```
+
+## Installing React Native Windows C++
+
+* Install the React Native Windows command line interface ([rnpm-plugin-windows](https://www.npmjs.com/package/rnpm-plugin-windows)).
+If you are using NPM, run
+```
+npm install --save rnpm-plugin-windows
+```
+If you are using Yarn, run
+```
+yarn add rnpm-plugin-windows
+```
+
+* Next, initialize your React Native Windows C++ project in the project directory by running:
+```
+react-native windows --template vnext
+```
+
+## Running a React Native Windows App
+
+*Note: Make sure Chrome is launched and running before running a React Native Windows app.*
+
+### Without Visual Studio
+
+In your React Native Windows project directory, run:
+```
+react-native run-windows
+```
+A new Command Prompt window will open with the React packager as well as a React Native Windows app. You can now start developing! :tada:
+
+### With Visual Studio
+
+- Open the solution file in the application folder in Visual Studio (e.g., `AwesomeProject/windows/AwesomeProject.sln`)
+- Select the `Debug` configuration and the `x64` platform from the combo box controls to the left of the `Run` button and underneath the `Team` and `Tools` menu item.
+- Run `yarn start` from your project directory, and wait for the React Native packager to report success.
+- Click the `Run` button to the right of the platform combo box control in VS, or select the `Debug`->`Start without Debugging` menu item. You now see your new app! :tada:
+
+## Troubleshooting
+* Use VS 2017. Issue [#2320](https://github.com/Microsoft/react-native-windows/issues/2320) tracks support for CLI with VS 2019.
+* If after running the app the packager does not update (or) app does not show React Native content - close the packager command prompt window and the app, run `yarn start` and run the app again.  Issue [#2311](https://github.com/Microsoft/react-native-windows/issues/2311) is tracking a known issue on this.


### PR DESCRIPTION
Separating out Getting started into a sub-doc and updating the landing ReadMe file for RNWCPP with updates upon completion of Milestone 1.  Fixes #2105 

We can do a subsequent wider update to the master readme and consolidate docs between RNWCS and RNWCPP after merging rnwcpp-preview to master.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2329)