### PR TITLE
Fixing assert in TouchEventHandler

### DIFF
--- a/RNWCPP/ReactUWP/Views/TouchEventHandler.cpp
+++ b/RNWCPP/ReactUWP/Views/TouchEventHandler.cpp
@@ -69,7 +69,7 @@ void TouchEventHandler::OnPointerPressed(const winrt::IInspectable& sender, cons
   if (!instance || instance->IsInError())
     return;
 
-  if (IndexOfPointerWithId(args.Pointer().PointerId()) == std::nullopt)
+  if (IndexOfPointerWithId(args.Pointer().PointerId()) != std::nullopt)
   {
     // A pointer with this ID already exists
     assert(false);


### PR DESCRIPTION
This assert is currently being hit on every touch event. I believe this need to hit only when the pointerId is not std::nullopt.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2342)