### PR TITLE
Fix releases broken link

### DIFF
--- a/RNWCPP/docs/releases.md
+++ b/RNWCPP/docs/releases.md
@@ -1,8 +1,8 @@
-For overall release strategy for `react-native-windows`, see [Releases](../../rnwcpp-preview/Releases.md). 
+For overall release strategy for `react-native-windows`, see [Releases](../../Releases.md). 
 
 This document describes the release strategy for the _vnext_ effort around [React Native for Windows C++](../RNWCPP/README.md) happening in this branch (rnwcpp-preview). 
 
-The _vnext_ versioning will generally follow the same strategy as outlined in [Releases](../../rnwcpp-preview/Releases.md). Specifically,
+The _vnext_ versioning will generally follow the same strategy as outlined in [Releases](../../Releases.md). Specifically,
 
 - We release in lock-step with [facebook/react-native](https://github.com/facebook/react-native). I.e., for every release of `react-native`, we create a release of `react-native-windows` with a matching major version.
 - We will use a pre-release flag: `-vnext` - to differentiate this C++ implementation followed by the current rnwcpp version number.


### PR DESCRIPTION
Port of #2344 to point to master instead of rnwcpp-preview

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2361)