### PR TITLE
update ExceptionsManagerModule assert to work with 57

### DIFF
--- a/RNWCPP/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
+++ b/RNWCPP/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
@@ -82,7 +82,7 @@ JSExceptionInfo ExceptionsManagerModule::CreateExceptionInfo(const folly::dynami
     // Each dynamic object is a map containing information about the stack frame:
     // method (string), arguments (array), filename(string), line number (int) and column number (int).
     assert(stackFrame.type() == folly::dynamic::OBJECT);
-    assert(stackFrame.size() == 5);
+    assert(stackFrame.size() >= 4); // 4 in 0.57, 5 in 0.58+ (arguments added)
 
     std::stringstream stackFrameInfo;
 


### PR DESCRIPTION
We have a project that uses the latest native code with 0.57 based JS at the moment, temporarily updating this assert so we don't crash on exception handling with that project.

Maybe should update some of this assert code to be under ifdef debug since it seems to fire in ship builds too

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2362)