### PR TITLE
Update to react-native@0.58.6-microsoft.30

### DIFF
--- a/RNWCPP/package.json
+++ b/RNWCPP/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.27"
+    "react-native": "0.58.6-microsoft.30"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.27 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.27.tar.gz"
+    "react-native": "0.58.6-microsoft.30 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.30.tar.gz"
   }
 }

--- a/RNWCPP/yarn.lock
+++ b/RNWCPP/yarn.lock
@@ -3577,9 +3577,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.27.tar.gz":
-  version "0.58.6-microsoft.27"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.27.tar.gz#dfd31ecc06b11d188dc9498657f7324597a0c581"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.30.tar.gz":
+  version "0.58.6-microsoft.30"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.30.tar.gz#b1a6f2252a358b49ef78b31a447b737035e6cbeb"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
d95b02e19 Applying package update to 0.58.6-microsoft.30
18ff6d411 Building RN droid for 64 bit plats (#54)
895364ab0 Applying package update to 0.58.6-microsoft.29
ae26ec256 Various fixes to get react-native-windows building with updated folly (#52)
75cae008b Applying package update to 0.58.6-microsoft.28
708af8bde Version bump for glog and folly to match that of RN 0.58.6 (#50)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2363)