### PR TITLE
fixes for new folly consumption

### DIFF
--- a/RNWCPP/Desktop.DLL/react-native-win32.x64.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.x64.def
@@ -9,6 +9,7 @@ EXPORTS
 ??4dynamic@folly@@QEAAAEAU01@$$QEAU01@@Z
 ??4dynamic@folly@@QEAAAEAU01@AEBU01@@Z
 ??8dynamic@folly@@QEBA_NAEBU01@@Z
+?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z
 ?callJSFunction@Instance@react@facebook@@UEAAX$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QEAUdynamic@folly@@@Z
 ?CreateAsyncStorageModule@react@facebook@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@PEB_W@Z
 ?createI18nModule@windows@react@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$unique_ptr@UII18nModule@windows@react@@U?$default_delete@UII18nModule@windows@react@@@std@@@4@@Z

--- a/RNWCPP/Desktop.DLL/react-native-win32.x86.def
+++ b/RNWCPP/Desktop.DLL/react-native-win32.x86.def
@@ -9,6 +9,7 @@ EXPORTS
 ??4dynamic@folly@@QAEAAU01@$$QAU01@@Z
 ??4dynamic@folly@@QAEAAU01@ABU01@@Z
 ??8dynamic@folly@@QBE_NABU01@@Z
+?at@dynamic@folly@@QGBEABU12@V?$Range@PBD@2@@Z
 ?callJSFunction@Instance@react@facebook@@UAEX$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QAUdynamic@folly@@@Z
 ?CreateAsyncStorageModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@PB_W@Z
 ?createI18nModule@windows@react@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$unique_ptr@UII18nModule@windows@react@@U?$default_delete@UII18nModule@windows@react@@@std@@@4@@Z

--- a/RNWCPP/Desktop/msoFolly.h
+++ b/RNWCPP/Desktop/msoFolly.h
@@ -12,6 +12,7 @@
 #pragma warning( disable : 4068 )
 #pragma warning( disable : 4146 )
 #pragma warning( disable : 4100 )
+#pragma warning( disable : 4324 ) // structure was padded due to alignment specifier
 #pragma push_macro("CHECK")
 #pragma push_macro("Check")
 #pragma push_macro("max")

--- a/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
+++ b/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
@@ -2,6 +2,7 @@ EXPORTS
 ??0ColdClass@cold_detail@folly@@QAA@XZ
 ?atImpl@dynamic@folly@@AGBAABU12@ABU12@@Z
 ??Adynamic@folly@@QGAAAAU01@V?$Range@PBD@1@@Z
+?at@dynamic@folly@@QGBAABU12@V?$Range@PBD@2@@Z
 ??0TypeError@folly@@QAA@ABU01@@Z
 ??0TypeError@folly@@QAA@$$QAU01@@Z
 ?destroy@dynamic@folly@@AAAXXZ

--- a/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -12,6 +12,7 @@ EXPORTS
 ?destroy@dynamic@folly@@AEAAXXZ
 ??8dynamic@folly@@QEBA_NAEBU01@@Z
 ??Adynamic@folly@@QEGAAAEAU01@V?$Range@PEBD@1@@Z
+?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z
 ??4dynamic@folly@@QEAAAEAU01@$$QEAU01@@Z
 ?hash@dynamic@folly@@QEBA_KXZ
 ??0TypeError@folly@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4Type@dynamic@1@@Z

--- a/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/RNWCPP/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -8,6 +8,7 @@ EXPORTS
 ??4dynamic@folly@@QAEAAU01@$$QAU01@@Z
 ?atImpl@dynamic@folly@@AGBEABU12@ABU12@@Z
 ??Adynamic@folly@@QGAEAAU01@V?$Range@PBD@1@@Z
+?at@dynamic@folly@@QGBEABU12@V?$Range@PBD@2@@Z
 ?destroy@dynamic@folly@@AAEXXZ
 ??0TypeError@folly@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4Type@dynamic@1@@Z
 ??0TypeError@folly@@QAE@ABU01@@Z

--- a/RNWCPP/Universal.SampleApp/HostingPane.xaml.cpp
+++ b/RNWCPP/Universal.SampleApp/HostingPane.xaml.cpp
@@ -59,6 +59,11 @@ void EnsureExportedFunctions(bool createThings)
     dy.asInt();
     dy.asString();
     dy.asBool();
+    dy[0];
+    dy["test"];
+    const folly::dynamic& cdy = dy;
+    cdy[0];
+    cdy["test"];
   }
 }
 


### PR DESCRIPTION
1. We use a wrapper msoFolly.h to suppress warnings around including the folly headers.
with the recent folly upgrade we're seeing this warning (which we treat as error) in many projects, add 4324 (structure was padded due to alignment specifier) to the warnings we suppress

2. Need to add an additional export for using operator[]'str' with a const folly::dynamic

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2369)