### PR TITLE
Update to react-native@0.58.6-microsoft.31

### DIFF
--- a/RNWCPP/package.json
+++ b/RNWCPP/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.29"
+    "react-native": "0.58.6-microsoft.31"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.29 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.29.tar.gz"
+    "react-native": "0.58.6-microsoft.31 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.31.tar.gz"
   }
 }

--- a/RNWCPP/yarn.lock
+++ b/RNWCPP/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.29.tar.gz":
-  version "0.58.6-microsoft.29"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.29.tar.gz#f02b2e83c521eef8c7f2ad6020a21e2587b9683d"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.31.tar.gz":
+  version "0.58.6-microsoft.31"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.31.tar.gz#9a8b080e3a55df41017f560efce9ddc52e1903ed"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
9ac211631 Applying package update to 0.58.6-microsoft.31
a9a1962d5 Fixing devmain build break for droid 64 bit platforms (#56)
d95b02e19 Applying package update to 0.58.6-microsoft.30
18ff6d411 Building RN droid for 64 bit plats (#54)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2370)