### PR TITLE
add layoutanimationtests to cmake unit tests

### DIFF
--- a/RNWCPP/Desktop.UnitTests/CMakeLists.txt
+++ b/RNWCPP/Desktop.UnitTests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
 	AsyncStorageManagerTest.cpp
 	AsyncStorageTest.cpp
 	EmptyUIManagerModule.cpp
+	LayoutAnimationTests.cpp
 	UIManagerModuleTest.cpp
 	UtilsTest.cpp
 	WebSocketJSExecutorTest.cpp


### PR DESCRIPTION
Missing cmakelist addition to correct upstream uptake of LayoutAnimation changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2372)