### PR TITLE
Update to react-native@0.58.6-microsoft.34

### DIFF
--- a/RNWCPP/package.json
+++ b/RNWCPP/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.31"
+    "react-native": "0.58.6-microsoft.34"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.31 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.31.tar.gz"
+    "react-native": "0.58.6-microsoft.34 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.34.tar.gz"
   }
 }

--- a/RNWCPP/yarn.lock
+++ b/RNWCPP/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.31.tar.gz":
-  version "0.58.6-microsoft.31"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.31.tar.gz#9a8b080e3a55df41017f560efce9ddc52e1903ed"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.34.tar.gz":
+  version "0.58.6-microsoft.34"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.34.tar.gz#5d1676aa073f7264971bfd27f51d98fdfd55c33e"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
83de24139 Applying package update to 0.58.6-microsoft.34
ea4aa0454 Cross platform/engine/storage abstraction for original and prepared scripts (#55)
b981b8310 Applying package update to 0.58.6-microsoft.33
2ff9a7936 Bump version to match published version
1ddb201d9 More publish fixes
3a2f8cfac Update publish logic
e2b196ee1 More publish updates
db2b3c0e6 Dont republish on package.json changes
f0fba6f19 Prepare publish script for work in fb59merge

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2395)