### PR TITLE
Support min version from rs3 to rs2

### DIFF
--- a/RNWCPP/CHANGELOG.md
+++ b/RNWCPP/CHANGELOG.md
@@ -445,7 +445,7 @@ Fri, 01 Feb 2019 21:37:51 GMT
 
 - Make react-native-win not depend on sdx-platform build scripts
 - uwp - Add back pressed event firing from View temporarily
-- uwp - update SDK dependency to RS5, runtime target RS3+, permissive-
+- uwp - update SDK dependency to RS5, runtime target RS2+, permissive-
 - Add popup component for uwp
 - autosync
 - V8 Inspector

--- a/RNWCPP/Playground/Playground/Playground.csproj
+++ b/RNWCPP/Playground/Playground/Playground.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/RNWCPP/PropertySheets/React.Cpp.props
+++ b/RNWCPP/PropertySheets/React.Cpp.props
@@ -1,12 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <!-- Use RS5 SDK (10.0.17763.0)  Support running on RS3+ (10.0.16299.0) -->
+    <!-- Use RS5 SDK (10.0.17763.0)  Support running on RS2+ (10.0.15063.0) -->
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/RNWCPP/ReactUWP/Views/TextInputViewManager.cpp
+++ b/RNWCPP/ReactUWP/Views/TextInputViewManager.cpp
@@ -167,25 +167,28 @@ void TextInputShadowNode::createView()
     });
   }
 
-  textBox.CharacterReceived([=](auto&&, winrt::CharacterReceivedRoutedEventArgs const& args) {
-    auto instance = wkinstance.lock();
-    std::string key;
-    wchar_t s[2] = L" ";
-    s[0] = args.Character();
-    key = facebook::react::UnicodeConversion::Utf16ToUtf8(s, 1);
+  if (textBox.try_as<winrt::IUIElement7>())
+  {
+    textBox.CharacterReceived([=](auto&&, winrt::CharacterReceivedRoutedEventArgs const& args) {
+      auto instance = wkinstance.lock();
+      std::string key;
+      wchar_t s[2] = L" ";
+      s[0] = args.Character();
+      key = facebook::react::UnicodeConversion::Utf16ToUtf8(s, 1);
 
-    if (key.compare("\r") == 0) {
-      key = "Enter";
-    }
-    else if (key.compare("\b") == 0) {
-      key = "Backspace";
-    }
+      if (key.compare("\r") == 0) {
+        key = "Enter";
+      }
+      else if (key.compare("\b") == 0) {
+        key = "Backspace";
+      }
 
-    if (!m_updating && instance != nullptr) {
-      folly::dynamic eventData = folly::dynamic::object("target", tag)("key", folly::dynamic(key));
-      instance->DispatchEvent(tag, "topTextInputKeyPress", std::move(eventData));
-    }
-  });
+      if (!m_updating && instance != nullptr) {
+        folly::dynamic eventData = folly::dynamic::object("target", tag)("key", folly::dynamic(key));
+        instance->DispatchEvent(tag, "topTextInputKeyPress", std::move(eventData));
+      }
+      });
+  }
 }
 void TextInputShadowNode::updateProperties(const folly::dynamic&& props)
 {
@@ -251,10 +254,13 @@ void TextInputShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (pair.first == "placeholderTextColor")
     {
-      if (pair.second.isInt())
-        textBox.PlaceholderForeground(SolidColorBrushFrom(pair.second));
-      else if (pair.second.isNull())
-        textBox.ClearValue(winrt::TextBox::PlaceholderForegroundProperty());
+      if (textBox.try_as<winrt::ITextBlock6>())
+      {
+        if (pair.second.isInt())
+          textBox.PlaceholderForeground(SolidColorBrushFrom(pair.second));
+        else if (pair.second.isNull())
+          textBox.ClearValue(winrt::TextBox::PlaceholderForegroundProperty());
+      }
     }
     else if (pair.first == "scrollEnabled")
     {

--- a/RNWCPP/Universal.SampleApp/Bundle/Universal.SampleApp/index.uwp.bundle
+++ b/RNWCPP/Universal.SampleApp/Bundle/Universal.SampleApp/index.uwp.bundle
@@ -1387,7 +1387,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _reactNativeWindows = _$$_REQUIRE(_dependencyMap[10], "react-native-windows");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\Universal.SampleApp\\index.uwp.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\Universal.SampleApp\\index.uwp.js";
 
   var TicTacButton = function (_Component) {
     (0, _inherits2.default)(TicTacButton, _Component);
@@ -5917,7 +5917,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectWithoutProperties = _$$_REQUIRE(_dependencyMap[2], "@babel/runtime/helpers/objectWithoutProperties");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\ActivityIndicator\\ActivityIndicator.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\ActivityIndicator\\ActivityIndicator.js";
 
   var Platform = _$$_REQUIRE(_dependencyMap[3], "Platform");
 
@@ -7797,7 +7797,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   }
 },62,[63,64],"node_modules\\react-is\\index.js");
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-  /** @license React v16.8.5
+  /** @license React v16.8.6
    * react-is.production.min.js
    *
    * Copyright (c) Facebook, Inc. and its affiliates.
@@ -7935,7 +7935,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   };
 },63,[],"node_modules\\react-is\\cjs\\react-is.production.min.js");
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-  /** @license React v16.8.5
+  /** @license React v16.8.6
    * react-is.development.js
    *
    * Copyright (c) Facebook, Inc. and its affiliates.
@@ -9801,7 +9801,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _extends = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/extends");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\View\\View.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\View\\View.js";
 
   var React = _$$_REQUIRE(_dependencyMap[1], "React");
 
@@ -23272,7 +23272,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
     function parse(stackString) {
       var lines = stackString.split('\n');
       return lines.reduce(function (stack, line) {
-        var parseResult = parseChrome(line) || parseWinjs(line) || parseGecko(line) || parseNode(line);
+        var parseResult = parseChrome(line) || parseWinjs(line) || parseGecko(line) || parseJSC(line) || parseNode(line);
 
         if (parseResult) {
           stack.push(parseResult);
@@ -23353,6 +23353,24 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
         methodName: parts[1] || UNKNOWN_FUNCTION,
         arguments: parts[2] ? parts[2].split(',') : [],
         lineNumber: parts[4] ? +parts[4] : null,
+        column: parts[5] ? +parts[5] : null
+      };
+    }
+
+    var javaScriptCoreRe = /^(?:\s*([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$/i;
+
+    function parseJSC(line) {
+      var parts = javaScriptCoreRe.exec(line);
+
+      if (!parts) {
+        return null;
+      }
+
+      return {
+        file: parts[3],
+        methodName: parts[1] || UNKNOWN_FUNCTION,
+        arguments: [],
+        lineNumber: +parts[4],
         column: parts[5] ? +parts[5] : null
       };
     }
@@ -31781,7 +31799,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   }(WebSocketHMRClient);
 
   module.exports = HMRClient;
-},163,[3,5,8,9,164,166],"node_modules\\metro\\src\\lib\\bundle-modules\\HMRClient.js");
+},163,[3,5,8,9,164,166],"node_modules\\react-native\\node_modules\\metro\\src\\lib\\bundle-modules\\HMRClient.js");
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   "use strict";
 
@@ -31881,7 +31899,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   }(EventEmitter);
 
   module.exports = WebSocketHMRClient;
-},164,[3,4,5,8,9,165],"node_modules\\metro\\src\\lib\\bundle-modules\\WebSocketHMRClient.js");
+},164,[3,4,5,8,9,165],"node_modules\\react-native\\node_modules\\metro\\src\\lib\\bundle-modules\\WebSocketHMRClient.js");
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
@@ -32144,7 +32162,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
   }
 
   module.exports = injectUpdate;
-},166,[],"node_modules\\metro\\src\\lib\\bundle-modules\\injectUpdate.js");
+},166,[],"node_modules\\react-native\\node_modules\\metro\\src\\lib\\bundle-modules\\injectUpdate.js");
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
@@ -43858,7 +43876,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\UnimplementedViews\\UnimplementedView.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\UnimplementedViews\\UnimplementedView.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -43916,7 +43934,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\ART\\ReactNativeART.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\ART\\ReactNativeART.js";
 
   var Color = _$$_REQUIRE(_dependencyMap[5], "art/core/color");
 
@@ -45511,7 +45529,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Button.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Button.js";
 
   var Platform = _$$_REQUIRE(_dependencyMap[6], "Platform");
 
@@ -45699,7 +45717,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[7], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Text\\Text.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Text\\Text.js";
 
   var DeprecatedTextPropTypes = _$$_REQUIRE(_dependencyMap[8], "DeprecatedTextPropTypes");
 
@@ -46123,7 +46141,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\Touchable.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\Touchable.js";
 
   var BoundingDimensions = _$$_REQUIRE(_dependencyMap[1], "BoundingDimensions");
 
@@ -46863,7 +46881,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\TouchableHighlight.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\TouchableHighlight.js";
 
   var DeprecatedColorPropType = _$$_REQUIRE(_dependencyMap[1], "DeprecatedColorPropType");
 
@@ -47899,7 +47917,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\TouchableNativeFeedback.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\TouchableNativeFeedback.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -47979,7 +47997,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\TouchableOpacity.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Touchable\\TouchableOpacity.js";
 
   var Animated = _$$_REQUIRE(_dependencyMap[1], "Animated");
 
@@ -52220,7 +52238,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Animated\\src\\createAnimatedComponent.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Animated\\src\\createAnimatedComponent.js";
 
   var _require = _$$_REQUIRE(_dependencyMap[7], "./AnimatedEvent"),
       AnimatedEvent = _require.AnimatedEvent;
@@ -52427,7 +52445,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\FlatList.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\FlatList.js";
 
   var deepDiffer = _$$_REQUIRE(_dependencyMap[7], "deepDiffer");
 
@@ -52740,7 +52758,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[8], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\VirtualizedList.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\VirtualizedList.js";
 
   var Batchinator = _$$_REQUIRE(_dependencyMap[9], "Batchinator");
 
@@ -54720,7 +54738,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\RefreshControl\\RefreshControl.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\RefreshControl\\RefreshControl.js";
 
   var Platform = _$$_REQUIRE(_dependencyMap[6], "Platform");
 
@@ -54825,7 +54843,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[1], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\ScrollView\\ScrollView.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\ScrollView\\ScrollView.js";
 
   var AnimatedImplementation = _$$_REQUIRE(_dependencyMap[2], "AnimatedImplementation");
 
@@ -55723,7 +55741,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\ScrollView\\ScrollViewStickyHeader.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\ScrollView\\ScrollViewStickyHeader.js";
 
   var AnimatedImplementation = _$$_REQUIRE(_dependencyMap[5], "AnimatedImplementation");
 
@@ -56335,7 +56353,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _extends = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/extends");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\Libraries\\Image\\Image.uwp.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\Libraries\\Image\\Image.uwp.js";
 
   var ImageResizeMode = _$$_REQUIRE(_dependencyMap[1], "ImageResizeMode");
 
@@ -56474,7 +56492,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _objectSpread = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/objectSpread");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\SectionList.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\SectionList.js";
 
   var Platform = _$$_REQUIRE(_dependencyMap[7], "Platform");
 
@@ -56597,7 +56615,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[7], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\VirtualizedSectionList.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\VirtualizedSectionList.js";
 
   var Platform = _$$_REQUIRE(_dependencyMap[8], "Platform");
 
@@ -57337,7 +57355,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Image\\ImageBackground.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Image\\ImageBackground.js";
 
   var Image = _$$_REQUIRE(_dependencyMap[7], "Image");
 
@@ -57519,7 +57537,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\TextInput\\InputAccessoryView.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\TextInput\\InputAccessoryView.js";
 
   var DeprecatedColorPropType = _$$_REQUIRE(_dependencyMap[5], "DeprecatedColorPropType");
 
@@ -57592,7 +57610,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Keyboard\\KeyboardAvoidingView.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Keyboard\\KeyboardAvoidingView.js";
 
   var Keyboard = _$$_REQUIRE(_dependencyMap[7], "Keyboard");
 
@@ -57806,7 +57824,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _extends = _$$_REQUIRE(_dependencyMap[1], "@babel/runtime/helpers/extends");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\ListView\\ListView.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Lists\\ListView\\ListView.js";
 
   var InternalListViewType = _$$_REQUIRE(_dependencyMap[2], "InternalListViewType");
 
@@ -58719,7 +58737,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Modal\\Modal.js",
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Modal\\Modal.js",
       _container;
 
   var AppContainer = _$$_REQUIRE(_dependencyMap[6], "AppContainer");
@@ -58906,7 +58924,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\ReactNative\\AppContainer.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\ReactNative\\AppContainer.js";
 
   var EmitterSubscription = _$$_REQUIRE(_dependencyMap[5], "EmitterSubscription");
 
@@ -59083,7 +59101,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\Inspector.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\Inspector.js";
 
   var Dimensions = _$$_REQUIRE(_dependencyMap[5], "Dimensions");
 
@@ -59412,7 +59430,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\InspectorOverlay.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\InspectorOverlay.js";
 
   var Dimensions = _$$_REQUIRE(_dependencyMap[5], "Dimensions");
 
@@ -59524,7 +59542,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\ElementBox.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\ElementBox.js";
 
   var BorderBox = _$$_REQUIRE(_dependencyMap[6], "BorderBox");
 
@@ -59652,7 +59670,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\BorderBox.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\BorderBox.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -59819,7 +59837,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\InspectorPanel.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\InspectorPanel.js";
 
   var ElementProperties = _$$_REQUIRE(_dependencyMap[5], "ElementProperties");
 
@@ -60054,7 +60072,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\ElementProperties.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\ElementProperties.js";
 
   var BoxInspector = _$$_REQUIRE(_dependencyMap[5], "BoxInspector");
 
@@ -60260,7 +60278,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\BoxInspector.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\BoxInspector.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -60452,7 +60470,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\StyleInspector.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\StyleInspector.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -60598,7 +60616,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\NetworkOverlay.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\NetworkOverlay.js";
 
   var FlatList = _$$_REQUIRE(_dependencyMap[5], "FlatList");
 
@@ -61541,7 +61559,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\PerformanceOverlay.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Inspector\\PerformanceOverlay.js";
 
   var PerformanceLogger = _$$_REQUIRE(_dependencyMap[5], "PerformanceLogger");
 
@@ -61642,7 +61660,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\YellowBox.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\YellowBox.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -61846,7 +61864,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxList.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxList.js";
 
   var Dimensions = _$$_REQUIRE(_dependencyMap[7], "Dimensions");
 
@@ -62066,7 +62084,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxButton.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxButton.js";
 
   var React = _$$_REQUIRE(_dependencyMap[0], "React");
 
@@ -62126,7 +62144,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxPressable.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxPressable.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -62240,7 +62258,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspector.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspector.js";
 
   var Platform = _$$_REQUIRE(_dependencyMap[5], "Platform");
 
@@ -62501,7 +62519,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _toConsumableArray = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/toConsumableArray");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\Data\\YellowBoxCategory.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\Data\\YellowBoxCategory.js";
 
   var React = _$$_REQUIRE(_dependencyMap[1], "React");
 
@@ -62654,7 +62672,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorFooter.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorFooter.js";
 
   var React = _$$_REQUIRE(_dependencyMap[0], "React");
 
@@ -62761,7 +62779,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorHeader.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorHeader.js";
 
   var Image = _$$_REQUIRE(_dependencyMap[0], "Image");
 
@@ -62937,7 +62955,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorSourceMapStatus.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorSourceMapStatus.js";
 
   var Animated = _$$_REQUIRE(_dependencyMap[5], "Animated");
 
@@ -63117,7 +63135,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorStackFrame.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxInspectorStackFrame.js";
 
   var React = _$$_REQUIRE(_dependencyMap[0], "React");
 
@@ -63202,7 +63220,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[4], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxListRow.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\YellowBox\\UI\\YellowBoxListRow.js";
 
   var React = _$$_REQUIRE(_dependencyMap[5], "React");
 
@@ -63720,7 +63738,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Picker\\Picker.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Picker\\Picker.js";
 
   var PickerAndroid = _$$_REQUIRE(_dependencyMap[6], "PickerAndroid");
 
@@ -63827,7 +63845,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _extends = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/extends");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Slider\\Slider.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Slider\\Slider.js";
 
   var ReactNative = _$$_REQUIRE(_dependencyMap[1], "ReactNative");
 
@@ -63926,7 +63944,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Switch\\Switch.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Components\\Switch\\Switch.js";
 
   var SwitchNativeComponent = _$$_REQUIRE(_dependencyMap[7], "SwitchNativeComponent");
 
@@ -64339,7 +64357,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[6], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Experimental\\SwipeableRow\\SwipeableFlatList.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Experimental\\SwipeableRow\\SwipeableFlatList.js";
 
   var React = _$$_REQUIRE(_dependencyMap[7], "React");
 
@@ -64498,7 +64516,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Experimental\\SwipeableRow\\SwipeableRow.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Experimental\\SwipeableRow\\SwipeableRow.js";
 
   var Animated = _$$_REQUIRE(_dependencyMap[6], "Animated");
 
@@ -65055,7 +65073,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _inherits = _$$_REQUIRE(_dependencyMap[5], "@babel/runtime/helpers/inherits");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\Experimental\\SwipeableRow\\SwipeableListView.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\Experimental\\SwipeableRow\\SwipeableListView.js";
 
   var ListView = _$$_REQUIRE(_dependencyMap[6], "ListView");
 
@@ -65323,7 +65341,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _extends = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/extends");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\Libraries\\Components\\TextInput\\TextInput.uwp.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\Libraries\\Components\\TextInput\\TextInput.uwp.js";
 
   var EventEmitter = _$$_REQUIRE(_dependencyMap[1], "EventEmitter");
 
@@ -65642,7 +65660,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\Libraries\\Components\\WebView\\WebView.uwp.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\Libraries\\Components\\WebView\\WebView.uwp.js";
 
   var React = _$$_REQUIRE(_dependencyMap[0], "React");
 
@@ -66158,7 +66176,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 
   var _extends = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/extends");
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\ReactNative\\renderApplication.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\ReactNative\\renderApplication.js";
 
   var AppContainer = _$$_REQUIRE(_dependencyMap[1], "AppContainer");
 
@@ -66214,7 +66232,7 @@ __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, e
 __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var _jsxFileName = "F:\\code\\rnw\\RNWCPP\\node_modules\\react-native\\Libraries\\ReactNative\\ReactFabricIndicator.js";
+  var _jsxFileName = "D:\\repo\\react-native-windows\\RNWCPP\\node_modules\\react-native\\Libraries\\ReactNative\\ReactFabricIndicator.js";
 
   var React = _$$_REQUIRE(_dependencyMap[0], "React");
 


### PR DESCRIPTION
Partial implementation for issue #2366, and I don't have any automation testing and don't implement any pipeline yet.

1. min version to rs2
2. Fix crashes for textbox.
3. sync the bundle file.

I manually verified React.Windows.Universal.SampleApp on rs2.

We have several ways to check if os supports interface or not from code:
1. ` winrt::ApiInformation::IsPropertyPresent(L"Windows.UI.Xaml.Controls.Control", L"CornerRadius")`
2.  `winrt::ApiInformation::IsMethodPresent(L"Windows.UI.ViewManagement.ApplicationView", L"GetDisplayRegions")`
3. `winrt::ApiInformation::IsTypePresent(L"Windows.UI.Xaml.Media.ThemeShadow")`
4. `winrt::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);`
5. `textBox.try_as<winrt::ITextBlock6>()`

Here I just choose the last one. 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native-windows/pull/2399)