### PR TITLE
Update to react-native@0.58.6-microsoft.36

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.34"
+    "react-native": "0.58.6-microsoft.36"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.34 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.34.tar.gz"
+    "react-native": "0.58.6-microsoft.36 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.36.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.34.tar.gz":
-  version "0.58.6-microsoft.34"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.34.tar.gz#5d1676aa073f7264971bfd27f51d98fdfd55c33e"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.36.tar.gz":
+  version "0.58.6-microsoft.36"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.36.tar.gz#8bd436641c21ab9756ff1aea75377e3344870ca2"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
47dd25684 Applying package update to 0.58.6-microsoft.36
52bb7ce8d Fixes for devmain (#58)
e4e31a0ff Applying package update to 0.58.6-microsoft.35
d8ef2252d Add fabric to published branches

```