### PR TITLE
Enabling further C++ strict conformance (/permissive-)

### DIFF
--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -11,7 +11,8 @@ namespace Microsoft {
 namespace VisualStudio {
 namespace CppUnitTestFramework {
 
-static std::wstring ToString(const facebook::react::test::TestStatus& status)
+template <>
+std::wstring ToString<facebook::react::test::TestStatus>(const facebook::react::test::TestStatus& status)
 {
   return ToString(static_cast<unsigned int>(status));
 }

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -20,7 +20,7 @@ TEST_CLASS(WebSocketModuleTest)
     SIZE = 5
   };
 
-  char* MethodName[static_cast<size_t>(MethodId::SIZE)]
+  const char* MethodName[static_cast<size_t>(MethodId::SIZE)]
   {
     "connect",
     "close",

--- a/vnext/Desktop/LegacyWebSocket.cpp
+++ b/vnext/Desktop/LegacyWebSocket.cpp
@@ -428,9 +428,9 @@ void LegacySecureWebSocket<Protocol, Socket, Resolver>::Handshake(const IWebSock
 {
   this->m_stream->next_layer().async_handshake(ssl::stream_base::client, [this, options = std::move(options)](boostecr ec)
   {
-    if (ec && m_errorHandler)
+    if (ec && this->m_errorHandler)
     {
-      m_errorHandler({ ec.message(), IWebSocket::ErrorType::Connection });
+      this->m_errorHandler({ ec.message(), IWebSocket::ErrorType::Connection });
     }
     else
     {

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -34,6 +34,9 @@
   <PropertyGroup Label="NOJSC">
     <NOJSC>true</NOJSC>
   </PropertyGroup>
+  <PropertyGroup Label="Permissive">
+    <ENABLEPermissive>true</ENABLEPermissive>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
   <PropertyGroup Label="Configuration">

--- a/vnext/Desktop/msoFolly.h
+++ b/vnext/Desktop/msoFolly.h
@@ -13,6 +13,7 @@
 #pragma warning( disable : 4146 )
 #pragma warning( disable : 4100 )
 #pragma warning( disable : 4324 ) // structure was padded due to alignment specifier
+#pragma warning( disable : 4643 ) // Forward declaring 'T' in namespace std is not permitted by the C++ Standard.
 #pragma push_macro("CHECK")
 #pragma push_macro("Check")
 #pragma push_macro("max")

--- a/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
+++ b/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
@@ -61,6 +61,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;RN_EXPORT=;NOJSC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/vnext/PropertySheets/Warnings.props
+++ b/vnext/PropertySheets/Warnings.props
@@ -28,6 +28,8 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
+      <!-- /permissive- by default to enforce standards conformance, unless ENABLEPermissive has been set -->
+      <AdditionalOptions Condition="'$(ENABLEPermissive)' == ''">/permissive- %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>$(OfficePreDisabledWarnings);$(ExtraWarningsToDisable);$(DisableSpecificWarnings)</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level4</WarningLevel>

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -81,7 +81,7 @@
       <PreprocessorDefinitions>REACTWINDOWS_BUILD;RN_PLATFORM=uwp;USE_EDGEMODE_JSRT;NOMINMAX;FOLLY_NO_CONFIG;RN_EXPORT=;JSI_EXPORT=;WIN32=0;WINRT=1;NOJSC;_HAS_AUTO_PTR_ETC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Pch;$(ReactNativeWindowsDir)ReactUWP\GeneratedWinmdHeader;$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactUWP;$(YogaDir);$(ReactNativeDir)\ReactCommon;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)Shared;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalOptions>/await /permissive- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <ShowIncludes>false</ShowIncludes>
     </ClCompile>
     <Link>

--- a/vnext/ReactWindowsCore/UnicodeConversion.cpp
+++ b/vnext/ReactWindowsCore/UnicodeConversion.cpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <exception>
+#include <stdexcept>
 
 namespace facebook {
 namespace react {

--- a/vnext/Universal.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Universal.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -12,7 +12,8 @@ namespace Microsoft {
 namespace VisualStudio {
 namespace CppUnitTestFramework {
 
-static std::wstring ToString(const facebook::react::test::TestStatus& status)
+template <>
+std::wstring ToString<facebook::react::test::TestStatus>(const facebook::react::test::TestStatus& status)
 {
   return ToString(static_cast<unsigned int>(status));
 }

--- a/vnext/Universal.SampleApp/MainPage.xaml.cpp
+++ b/vnext/Universal.SampleApp/MainPage.xaml.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 //
 // MainPage.xaml.cpp
@@ -60,9 +60,9 @@ void WindowsSampleApp::MainPage::RemovePane(HostingPane^ pane)
     unsigned int countColumns = x_PaneContainer->ColumnDefinitions->Size;
     for (;index < countColumns; ++index)
     {
-      auto pane  = dynamic_cast<HostingPane^>(x_PaneContainer->Children->GetAt(index));
-      if (pane != nullptr)
-        pane->SetValue(Grid::ColumnProperty, index);
+      auto hostingPane  = dynamic_cast<HostingPane^>(x_PaneContainer->Children->GetAt(index));
+      if (hostingPane != nullptr)
+        hostingPane->SetValue(Grid::ColumnProperty, index);
       else
         assert(false);
     }

--- a/vnext/Universal.SampleApp/React.Windows.Universal.SampleApp.vcxproj
+++ b/vnext/Universal.SampleApp/React.Windows.Universal.SampleApp.vcxproj
@@ -51,6 +51,8 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
@@ -62,7 +64,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalOptions>/await /bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/await /bigobj /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;4800;28204;4146;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(FollyDir);$(ReactNativeDir)\ReactCommon;$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactUWP;$(YogaDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;FOLLY_NO_CONFIG;NOMINMAX;NOJSC;_HAS_AUTO_PTR_ETC;RN_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
add permissive- to our options in warnings.props so stricter C++ conformance is enabled by default.  Previously we only had it enabled in the ReactUWP folder.
With a few related build config changes:
* /cx projects require 2phase turned off, our sample app and test project have cx enabled right now
* turned off for the Desktop folder, @JunielKatarn to followup on fixing the boost socket integration

The fixes needed were mostly in test code.
I brought in one fix from my VS2019 pull request that is still in progress.

Also this adds a warning disable in msoFolly.h requested by office engineering working on compiler upgrades and hitting this warning in folly usage.