### PR TITLE
Update to react-native@0.58.6-microsoft.37

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.36"
+    "react-native": "0.58.6-microsoft.37"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.36 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.36.tar.gz"
+    "react-native": "0.58.6-microsoft.37 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.37.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.36.tar.gz":
-  version "0.58.6-microsoft.36"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.36.tar.gz#8bd436641c21ab9756ff1aea75377e3344870ca2"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.37.tar.gz":
+  version "0.58.6-microsoft.37"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.37.tar.gz#e93eb05a8b8cf32593158c883867892b562bc429"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
ddd8b89b5 Applying package update to 0.58.6-microsoft.37
5cd586234 Add RCTSRWebSocket.h to the Copy Headers phase. (#61)

```