### PR TITLE
Improve js download error handling

### DIFF
--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -17,7 +17,6 @@
 #include <NativeModuleProvider.h>
 
 #include "UnicodeConversion.h"
-#include "folly/json.h"
 
 // Standard View Managers
 #include <Views/ActivityIndicatorViewManager.h>

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -398,11 +398,11 @@ static std::string PrettyError(const std::string& error) noexcept
       {
         prettyError.replace(pos, 2, "\r\n", 2);
       }
-      if (prettyError[pos + 1] == 'b')
+      else if (prettyError[pos + 1] == 'b')
       {
         prettyError.replace(pos, 2, "\b", 2);
       }
-      if (prettyError[pos + 1] == 't')
+      else if (prettyError[pos + 1] == 't')
       {
         prettyError.replace(pos, 2, "\t", 2);
       }

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
@@ -54,7 +54,7 @@ std::future<std::pair<std::string, bool>> DownloadFromAsync(const std::string& u
   reader.UnicodeEncoding(winrt::Windows::Storage::Streams::UnicodeEncoding::Utf8);
   uint32_t len = reader.UnconsumedBufferLength();
   std::string result;
-  if (len || response.IsSuccessStatusCode())
+  if (len > 0 || response.IsSuccessStatusCode())
   {
     std::vector<uint8_t> data(len);
     reader.ReadBytes(data);

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -79,6 +79,7 @@ void ReactControl::HandleInstanceErrorOnUIThread()
 
     // Format TextBlock
     m_errorTextBlock.TextAlignment(winrt::TextAlignment::Center);
+    m_errorTextBlock.TextWrapping(winrt::TextWrapping::Wrap);
     m_errorTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
     m_errorTextBlock.Foreground(winrt::SolidColorBrush(winrt::Colors::White()));
     winrt::Thickness margin = { 10.0f, 10.0f, 10.0f, 10.0f };

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -501,6 +501,19 @@ void InstanceImpl::loadBundleInternal(std::string&& jsBundleRelativePath, bool s
   // load JS
   if (m_devSettings->useWebDebugger)
   {
+    // First attempt to get download the Js locally, to catch any bundling errors before
+    // attempting to load the actual script.
+    auto jsBundleString = m_devManager->GetJavaScriptFromServer(
+      m_devSettings->debugHost,
+      m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,
+      m_devSettings->platformName);
+
+    if (m_devManager->HasException())
+    {
+      m_devSettings->errorCallback(jsBundleString);
+      return;
+    }
+
     try
     {
       auto bundleUrl = DevServerHelper::get_BundleUrl(


### PR DESCRIPTION
These are changes to address:
https://github.com/microsoft/react-native-windows/issues/2431
where if you had a typo in your js, we didn't show an error and a second reload would hang the app.

We will now download js before starting web debugging (web debugging asks the debugger to download the js too, but when there are errors it doesn't send any response on the socket).  This more closely matches what ios/Android does (we don't have progress UI yet like they do).

Our download js code wasn't sending back the error text if there was an error, just an exception would fire.  Changed our download code to be able to report the error string back so you can see what line/character triggered the error . (your cmd prompt packager probably also told you).

In our error displaying logic, add text wrapping so super long strings are not off the window, and add a bit of JSON pretty printing to convert \u0000, newlines, tabs, into characters.  other escapes like \\ are still present but readable.