### PR TITLE
Update to react-native@0.58.6-microsoft.38

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.37"
+    "react-native": "0.58.6-microsoft.38"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.37 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.37.tar.gz"
+    "react-native": "0.58.6-microsoft.38 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.38.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.37.tar.gz":
-  version "0.58.6-microsoft.37"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.37.tar.gz#e93eb05a8b8cf32593158c883867892b562bc429"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.38.tar.gz":
+  version "0.58.6-microsoft.38"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.38.tar.gz#189e7d5d7ec23515684c1a72eb48cac61d1e2a4a"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
4c79d7cfd Applying package update to 0.58.6-microsoft.38
3b7bdd3ca Internal build updates

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2434)