### PR TITLE
Update to react-native@0.58.6-microsoft.41

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.39"
+    "react-native": "0.58.6-microsoft.41"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.39 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.39.tar.gz"
+    "react-native": "0.58.6-microsoft.41 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.41.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.39.tar.gz":
-  version "0.58.6-microsoft.39"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.39.tar.gz#6aff8f106a4016b1ac3681ef370d8dd3a8745d97"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.41.tar.gz":
+  version "0.58.6-microsoft.41"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.41.tar.gz#24101e6427b6164938b2a39d6e37ec1f15f294d4"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
01e2686e7 Applying package update to 0.58.6-microsoft.41
e64070a37 Rename misnamed file
6816c3c95 Applying package update to 0.58.6-microsoft.40
a1a6e4862 Added canBecomeKeyView override to RCTScrollView (#60)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2441)