### PR TITLE
Check build has happened before running bundler

### DIFF
--- a/vnext/rn-cli.config.js
+++ b/vnext/rn-cli.config.js
@@ -56,5 +56,10 @@ if (fs.existsSync(path.resolve(__dirname, '../../scripts/metro-resources.js'))) 
 config.resolver.extraNodeModules['SnapshotViewIOS'] = path.resolve(__dirname, 'Libraries/RCTTest/SnapshotViewIOS');
 config.resolver.hasteImplModulePath = path.resolve(__dirname, 'jest/hasteImpl.js');
 
+// Check that we have built our JS files before running the bundler, otherwise we'll get a harder to diagnose "Unable to resolve module" error
+if (!fs.existsSync(path.resolve(__dirname, 'lib/Libraries/Components/AccessibilityInfo/AccessibilityInfo.uwp.js'))) {
+  throw new Error(`[31m\nThis package must be built before running the bundler.  Did you mean to run "[39m[33myarn build[39m[31m" first?[39m\n`);
+}
+
 module.exports = config;
 


### PR DESCRIPTION
A better fix for #2448 , which will just tell the user what they need to do when they hit that case.  Instead of hiding it in a troubleshooting doc.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2453)