### PR TITLE
Chakracore debugger console redirection support

### DIFF
--- a/vnext/Chakra/ChakraCoreDebugger.h
+++ b/vnext/Chakra/ChakraCoreDebugger.h
@@ -91,6 +91,13 @@ public:
 
     return result;
   }
+
+  JsErrorCode GetConsoleObject(JsValueRef *consoleObject)
+  {
+    JsErrorCode result = JsDebugProtocolHandlerCreateConsoleObject(m_protocolHandler, consoleObject);
+
+    return result;
+  }
 };
 
 

--- a/vnext/Chakra/ChakraCoreDebugger.h
+++ b/vnext/Chakra/ChakraCoreDebugger.h
@@ -92,7 +92,7 @@ public:
     return result;
   }
 
-  JsErrorCode GetConsoleObject(JsValueRef *consoleObject)
+  JsErrorCode GetConsoleObject(JsValueRef* consoleObject)
   {
     JsErrorCode result = JsDebugProtocolHandlerCreateConsoleObject(m_protocolHandler, consoleObject);
 

--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -369,14 +369,14 @@ void ChakraExecutor::initOnJSVMThread()
   JsSetContextData(m_context, this);
 
 #if !defined(USE_EDGEMODE_JSRT)
-  if (enableDebugging) {
+  if (enableDebugging && m_instanceArgs.DebuggerConsoleRedirection) {
     JsValueRef debuggerConsoleObject;
     tls_runtimeTracker.DebugProtocolHandler->GetConsoleObject(&debuggerConsoleObject);
 
     JsValueRef undefinedValue = JS_INVALID_REFERENCE;
     JsGetUndefinedValue(&undefinedValue);
 
-    if (debuggerConsoleObject != JS_INVALID_REFERENCE && debuggerConsoleObject != undefinedValue && m_instanceArgs.DebuggerConsoleRedirection) {
+    if (debuggerConsoleObject != JS_INVALID_REFERENCE && debuggerConsoleObject != undefinedValue) {
       needToRedirectConsoleToDebugger = true;
     }
   }

--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -369,14 +369,16 @@ void ChakraExecutor::initOnJSVMThread()
   JsSetContextData(m_context, this);
 
 #if !defined(USE_EDGEMODE_JSRT)
-  JsValueRef debuggerConsoleObject;
-  tls_runtimeTracker.DebugProtocolHandler->GetConsoleObject(&debuggerConsoleObject);
+  if (enableDebugging) {
+    JsValueRef debuggerConsoleObject;
+    tls_runtimeTracker.DebugProtocolHandler->GetConsoleObject(&debuggerConsoleObject);
 
-  JsValueRef undefinedValue = JS_INVALID_REFERENCE;
-  JsGetUndefinedValue(&undefinedValue);
+    JsValueRef undefinedValue = JS_INVALID_REFERENCE;
+    JsGetUndefinedValue(&undefinedValue);
 
-  if (enableDebugging && debuggerConsoleObject != JS_INVALID_REFERENCE && debuggerConsoleObject != undefinedValue && m_instanceArgs.DebuggerConsoleRedirection) {
-    needToRedirectConsoleToDebugger = true;
+    if (debuggerConsoleObject != JS_INVALID_REFERENCE && debuggerConsoleObject != undefinedValue && m_instanceArgs.DebuggerConsoleRedirection) {
+      needToRedirectConsoleToDebugger = true;
+    }
   }
 #endif
 

--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -234,25 +234,25 @@ JsErrorCode ChakraExecutor::RedirectConsoleToDebugger(JsValueRef debuggerConsole
     return JsErrorNotImplemented;
   }
 
-  std::string script = "";
+const char* script = 
+  "function patchConsoleObject$$1(global, console, debugConsole) {\n"
+   "var obj = {};\n"
+   "for (var fn in console) {\n"
+      "if (typeof console[fn] === \"function\") {\n"
+        "(function(name) {\n"
+          "obj[name] = function(...rest) {\n"
+            "console[name](rest);\n"
+              "if (name in debugConsole && typeof debugConsole[name] === \"function\") {\n"
+                "debugConsole[name](rest);\n"
+              "}\n"
+          "}\n"
+        "})(fn);\n"
+      "}\n"
+    "}\n"
+    "global.console = obj;\n"
+  "}\n"
+  "patchConsoleObject$$1;\n";
 
-  script = script + "function patchConsoleObject$$1(global, console, debugConsole) {\n";
-  script = script + "var obj = {};\n";
-  script = script + "for (var fn in console) {\n";
-  script = script + "if (typeof console[fn] === \"function\") {\n";
-  script = script + "(function(name) {\n";
-  script = script + "obj[name] = function(...rest) {\n";
-  script = script + "console[name](rest);\n";
-  script = script + "if (name in debugConsole && typeof debugConsole[name] === \"function\") {\n";
-  script = script + "debugConsole[name](rest);\n";
-  script = script + "}\n";
-  script = script + "}\n";
-  script = script + "})(fn);\n";
-  script = script + "}\n";
-  script = script + "}\n";
-  script = script + "global.console = obj;\n";
-  script = script + "}\n";
-  script = script + "patchConsoleObject$$1;\n";
 
 
   JsValueRef patchFunction = JS_INVALID_REFERENCE;
@@ -261,7 +261,7 @@ JsErrorCode ChakraExecutor::RedirectConsoleToDebugger(JsValueRef debuggerConsole
   IfFailRet(JsCreateString("", 0, &scriptUrl));
 
   JsValueRef scriptContentValue = JS_INVALID_REFERENCE;
-  IfFailRet(JsCreateString(script.c_str(), script.length(), &scriptContentValue));
+  IfFailRet(JsCreateString(script, strlen(script), &scriptContentValue));
   IfFailRet(JsRun(scriptContentValue, JS_SOURCE_CONTEXT_NONE, scriptUrl, JsParseScriptAttributeLibraryCode, &patchFunction));
 
   JsValueRef args[4] = { undefinedValue, globalObject, consoleObject, debuggerConsoleObject };
@@ -375,8 +375,8 @@ void ChakraExecutor::initOnJSVMThread()
   JsValueRef undefinedValue = JS_INVALID_REFERENCE;
   JsGetUndefinedValue(&undefinedValue);
 
-  if (debuggerConsoleObject == JS_INVALID_REFERENCE || debuggerConsoleObject == undefinedValue) {
-    isPatchingRequired = false;
+  if (enableDebugging && debuggerConsoleObject != JS_INVALID_REFERENCE && debuggerConsoleObject != undefinedValue && m_instanceArgs.DebuggerConsoleRedirection) {
+    needToRedirectConsoleToDebugger = true;
   }
 #endif
 
@@ -562,13 +562,13 @@ void ChakraExecutor::loadApplicationScript(std::unique_ptr<const JSBigString> sc
 #endif
 
 #if !defined(USE_EDGEMODE_JSRT)
-  if (m_instanceArgs.DebuggerConsoleRedirection && isPatchingRequired) {
+  if (needToRedirectConsoleToDebugger) {
     JsValueRef debuggerConsoleObject;
     tls_runtimeTracker.DebugProtocolHandler->GetConsoleObject(&debuggerConsoleObject);
       
     JsErrorCode result = RedirectConsoleToDebugger(debuggerConsoleObject);
     if (result == JsNoError) {
-      isPatchingRequired = false;
+      needToRedirectConsoleToDebugger = false;
     }
   }
 #endif

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -158,6 +158,8 @@ private:
     std::unique_ptr<DebugProtocolHandler>& debugProtocolHandler, std::unique_ptr<DebugService>& debugService);
   static void CHAKRA_CALLBACK ProcessDebuggerCommandQueueCallback(void* callbackState);
   void ProcessDebuggerCommandQueue();
+  bool isPatchingRequired = true;
+  JsErrorCode RedirectConsoleToDebugger(JsValueRef debuggerConsoleObject);
 #endif
   void flush();
   void flushQueueImmediate(ChakraValue&&);

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -158,7 +158,7 @@ private:
     std::unique_ptr<DebugProtocolHandler>& debugProtocolHandler, std::unique_ptr<DebugService>& debugService);
   static void CHAKRA_CALLBACK ProcessDebuggerCommandQueueCallback(void* callbackState);
   void ProcessDebuggerCommandQueue();
-  bool isPatchingRequired = true;
+  bool needToRedirectConsoleToDebugger = false;
   JsErrorCode RedirectConsoleToDebugger(JsValueRef debuggerConsoleObject);
 #endif
   void flush();

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -54,7 +54,7 @@ struct ChakraInstanceArgs
   /**
   * @brief Whether to enable ChakraCore console redirection to debugger.
   */
-  bool DebuggerConsoleRedirection{ false };
+  bool DebuggerConsoleRedirection { false };
 
   /**
   * @brief Port number to use when debugging.

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -52,6 +52,11 @@ struct ChakraInstanceArgs
   bool EnableNativePerformanceNow { true };
 
   /**
+  * @brief Whether to enable ChakraCore console redirection to debugger.
+  */
+  bool DebuggerConsoleRedirection{ false };
+
+  /**
   * @brief Port number to use when debugging.
   */
   uint16_t DebuggerPort { 9229 };

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -66,6 +66,9 @@ struct DevSettings
   /// Debugging will start as soon as the react native instance is loaded.
   bool useWebDebugger{ false };
 
+  // Enables ChakraCore console redirection to debugger
+  bool debuggerConsoleRedirection{ false };
+
   /// Dispatcher for notifications about JS engine memory consumption.
   std::shared_ptr<MemoryTracker> memoryTracker;
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -387,7 +387,8 @@ InstanceImpl::InstanceImpl(std::string&& jsBundleBasePath,
       instanceArgs.LoggingCallback = m_devSettings->loggingCallback;
 
       instanceArgs.EnableNativePerformanceNow = m_devSettings->enableNativePerformanceNow;
-
+      instanceArgs.DebuggerConsoleRedirection = m_devSettings->debuggerConsoleRedirection;
+      
       if (!m_devSettings->useJITCompilation)
       {
 #if (defined(_MSC_VER) && !defined(WINRT))


### PR DESCRIPTION
When direct debugging is enabled and using the ChakraCore JavaScript engine, allow the debugger to show console output. This is done by patching global.console with a console object which calls the original console object as well as the ChakraCore debugger console object.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2457)