### PR TITLE
Update to react-native@0.58.6-microsoft.43

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.42"
+    "react-native": "0.58.6-microsoft.43"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.42 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.42.tar.gz"
+    "react-native": "0.58.6-microsoft.43 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.43.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.42.tar.gz":
-  version "0.58.6-microsoft.42"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.42.tar.gz#920d0ecfe53f06fcbe9a836826fb65b656cc4137"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.43.tar.gz":
+  version "0.58.6-microsoft.43"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.43.tar.gz#779d0b593155bea3d9618c743e7833f634f6d735"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
6b436b7e4 Applying package update to 0.58.6-microsoft.43
b12a2109c Deleting empty files for now, as they confuse our sync to internal (#63)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2458)