### PR TITLE
Update to react-native@0.58.6-microsoft.44

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.42"
+    "react-native": "0.58.6-microsoft.44"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.42 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.42.tar.gz"
+    "react-native": "0.58.6-microsoft.44 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.44.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.42.tar.gz":
-  version "0.58.6-microsoft.42"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.42.tar.gz#920d0ecfe53f06fcbe9a836826fb65b656cc4137"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.44.tar.gz":
+  version "0.58.6-microsoft.44"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.44.tar.gz#5a7ae69060bf219b14036dd269a6e9854ca2aaca"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
4e841abc5 Applying package update to 0.58.6-microsoft.44
98d09810d Merge branch 'publish-temp-1557780649132'
1e6ff2899 Separate V8 code from the core JSI library (#64)
6b436b7e4 Applying package update to 0.58.6-microsoft.43
b12a2109c Deleting empty files for now, as they confuse our sync to internal (#63)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2459)