### PR TITLE
Update to react-native@0.58.6-microsoft.45

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.44"
+    "react-native": "0.58.6-microsoft.45"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.44 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.44.tar.gz"
+    "react-native": "0.58.6-microsoft.45 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.45.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.44.tar.gz":
-  version "0.58.6-microsoft.44"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.44.tar.gz#5a7ae69060bf219b14036dd269a6e9854ca2aaca"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.45.tar.gz":
+  version "0.58.6-microsoft.45"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.45.tar.gz#a7a7d1cf46e0afc131fdca9676afdccb539296a9"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
7b572245f Applying package update to 0.58.6-microsoft.45
0de1126cd Fix Office droid build (#65)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2463)