### PR TITLE
Fix to allow authorization header to be added.

### DIFF
--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -224,7 +224,7 @@ void AttachMultipartHeaders(
     auto& name = header.first.getString();
     auto& value = header.second.getString();
 
-    content.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+    content.Headers().Append(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
   }
 }
 
@@ -262,8 +262,10 @@ void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, 
           winrt::Windows::Web::Http::Headers::HttpMediaTypeHeaderValue::TryParse(facebook::react::unicode::utf8ToUtf16(value), contentType);
         else if (_stricmp(name.c_str(), "content-encoding") == 0)
           contentEncoding = value;
-        else
+        else if (_stricmp(name.c_str(), "authorization") == 0)
           request.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+        else
+          request.Headers().Append(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
       }
     }
 

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -224,7 +224,7 @@ void AttachMultipartHeaders(
     auto& name = header.first.getString();
     auto& value = header.second.getString();
 
-    content.Headers().Append(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+    content.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
   }
 }
 
@@ -263,7 +263,7 @@ void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, 
         else if (_stricmp(name.c_str(), "content-encoding") == 0)
           contentEncoding = value;
         else
-          request.Headers().Append(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+          request.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
       }
     }
 

--- a/vnext/ReactUWP/Views/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/ImageViewManager.cpp
@@ -198,7 +198,7 @@ namespace react { namespace uwp {
           auto& name = header.first.getString();
           auto& value = header.second.getString();
 
-          request.Headers().Append(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+          request.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
         }
       }
 

--- a/vnext/ReactUWP/Views/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/ImageViewManager.cpp
@@ -197,8 +197,10 @@ namespace react { namespace uwp {
         {
           auto& name = header.first.getString();
           auto& value = header.second.getString();
-
-          request.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+          if (_stricmp(name.c_str(), "authorization") == 0)
+            request.Headers().TryAppendWithoutValidation(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
+          else
+            request.Headers().Append(facebook::react::unicode::utf8ToUtf16(name), facebook::react::unicode::utf8ToUtf16(value));
         }
       }
 


### PR DESCRIPTION
fixes #2466 


Changing this to TryAppendWithoutValidation seems like the most developer friendly fix for this issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2467)