### PR TITLE
Header should include all its reqs

### DIFF
--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #define STRING_(s) #s
 #define STRING(s) STRING_(s)


### PR DESCRIPTION
DevSettings.h shouldn't require that people include <vector> first.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2468)