### PR TITLE
Add v8runtime export to the def file

### DIFF
--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -54,6 +54,7 @@ EXPORTS
 ??1Value@jsi@facebook@@QEAA@XZ
 ??1Buffer@jsi@facebook@@UEAA@XZ
 ?makeChakraJsiRuntime@chakraruntime@jsi@facebook@@YA?AV?$unique_ptr@VRuntime@jsi@facebook@@U?$default_delete@VRuntime@jsi@facebook@@@std@@@std@@$$QEAUChakraJsiRuntimeArgs@123@@Z
+?makeV8Runtime@v8runtime@facebook@@YA?AV?$unique_ptr@VRuntime@jsi@facebook@@U?$default_delete@VRuntime@jsi@facebook@@@std@@@std@@XZ
 
 
 YGNodeNew

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -54,6 +54,7 @@ EXPORTS
 ??1Value@jsi@facebook@@QAE@XZ
 ??1Buffer@jsi@facebook@@UAE@XZ
 ?makeChakraJsiRuntime@chakraruntime@jsi@facebook@@YG?AV?$unique_ptr@VRuntime@jsi@facebook@@U?$default_delete@VRuntime@jsi@facebook@@@std@@@std@@$$QAUChakraJsiRuntimeArgs@123@@Z
+?makeV8Runtime@v8runtime@facebook@@YG?AV?$unique_ptr@VRuntime@jsi@facebook@@U?$default_delete@VRuntime@jsi@facebook@@@std@@@std@@XZ
 
 
 YGLog

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Platform.cpp"  Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_shared.cpp"  Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_win.cpp"  Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'"/>
+    <ClCompile Include="nov8.cpp" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' != 'true'"/>
     <ClCompile Include="$(YogaDir)\yoga\Utils.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGConfig.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGEnums.cpp" />

--- a/vnext/ReactCommon/nov8.cpp
+++ b/vnext/ReactCommon/nov8.cpp
@@ -1,0 +1,14 @@
+#include <memory>
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace v8runtime {
+
+// This exists just to satisfy the export requirements, so that we can share the same .def file between GitHub and the Office internal build system
+std::unique_ptr<jsi::Runtime> makeV8Runtime()
+{
+  std::abort();
+}
+
+} // namespace v8runtime
+} // namespace facebook


### PR DESCRIPTION
We don't want to fork the .def file between GitHub and the Office build system, so just add a dummy implementation for makeV8Runtime, until we figure out how to properly integrate V8 in the MsBuild build system.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2472)