### PR TITLE
fix nuget packaging

### DIFF
--- a/vnext/ReactWindows-CopyToStaging.bat
+++ b/vnext/ReactWindows-CopyToStaging.bat
@@ -43,7 +43,11 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\jsi.h                           %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\jsi-inl.h                       %DESTROOT%\inc\jsi
+%COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\ScriptStore.h                   %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\V8Runtime.h                     %DESTROOT%\inc\jsi
+%COPYCMD%  %SRCROOT%\react-native-win\Chakra\ChakraCoreDebugger.h                 %DESTROOT%\inc\jsi
+%COPYCMD%  %SRCROOT%\react-native-win\Chakra\ChakraJsiRuntimeArgs.h               %DESTROOT%\inc\jsi
+%COPYCMD%  %SRCROOT%\react-native-win\Chakra\ChakraJsiRuntimeFactory.h            %DESTROOT%\inc\jsi
 
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\Yoga\Yoga\Yoga.h                    %DESTROOT%\inc\yoga
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\Yoga\Yoga\YGMacros.h                %DESTROOT%\inc\yoga

--- a/vnext/ReactWindows-CopyToStaging.bat
+++ b/vnext/ReactWindows-CopyToStaging.bat
@@ -22,6 +22,7 @@ mkdir %DESTROOT% >nul 2>&1
 mkdir %DESTROOT%\inc >nul 2>&1
 mkdir %DESTROOT%\inc\cxxreact >nul 2>&1
 mkdir %DESTROOT%\inc\jschelpers >nul 2>&1
+mkdir %DESTROOT%\inc\jsi >nul 2>&1
 mkdir %DESTROOT%\inc\yoga >nul 2>&1
 mkdir %DESTROOT%\inc\ReactWin32 >nul 2>&1
 mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
@@ -39,6 +40,10 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\cxxreact\NativeToJsBridge.h         %DESTROOT%\inc\cxxreact
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\cxxreact\NativeModule.h             %DESTROOT%\inc\cxxreact
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\cxxreact\PlatformBundleInfo.h       %DESTROOT%\inc\cxxreact
+
+%COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\jsi.h                           %DESTROOT%\inc\jsi
+%COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\jsi-inl.h                       %DESTROOT%\inc\jsi
+%COPYCMD%  %SRCROOT%\react-native\ReactCommon\jsi\V8Runtime.h                     %DESTROOT%\inc\jsi
 
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\Yoga\Yoga\Yoga.h                    %DESTROOT%\inc\yoga
 %COPYCMD%  %SRCROOT%\react-native\ReactCommon\Yoga\Yoga\YGMacros.h                %DESTROOT%\inc\yoga


### PR DESCRIPTION
PRs 2461 & 2428 added jsi files to be copied in CopyHeaders.inc
2428 added inc/jsi to be part of the .nuspec file but didn't update the staging script that goes with the nuspec.

This updates the staging script and includes all the files that CopyHeaders.inc has for jsi.  Our internal nuget packages has been broken since 2428.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2473)