### PR TITLE
Update to react-native@0.58.6-microsoft.46

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,10 +59,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.45"
+    "react-native": "0.58.6-microsoft.46"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.45 || https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.45.tar.gz"
+    "react-native": "0.58.6-microsoft.46 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.46.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.45.tar.gz":
-  version "0.58.6-microsoft.45"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.45.tar.gz#a7a7d1cf46e0afc131fdca9676afdccb539296a9"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.46.tar.gz":
+  version "0.58.6-microsoft.46"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.46.tar.gz#10319597b3902c2ddd91a14851f0ac6ccf65b1a1"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
f4d8fb6da Applying package update to 0.58.6-microsoft.46
8a1b08448 Workaround crash during layout on macOS when a large number of flex (#69)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2478)