### PR TITLE
Update to react-native@0.58.6-microsoft.47

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -3,8 +3,8 @@
   "version": "0.58.0-vnext.99",
   "license": "MIT",
   "repository": {
-    "type" : "git",
-    "url" : "git@github.com:microsoft/react-native-windows.git",
+    "type": "git",
+    "url": "git@github.com:microsoft/react-native-windows.git",
     "directory": "vnext"
   },
   "description": "ReactNative Windows implementation using react-native's c++ ReactCommon bridge",
@@ -64,10 +64,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.46"
+    "react-native": "0.58.6-microsoft.47"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.46 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.46.tar.gz"
+    "react-native": "0.58.6-microsoft.47 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.47.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.46.tar.gz":
-  version "0.58.6-microsoft.46"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.46.tar.gz#10319597b3902c2ddd91a14851f0ac6ccf65b1a1"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.47.tar.gz":
+  version "0.58.6-microsoft.47"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.47.tar.gz#ed0e288c4d86e63e72690b06e54ca8f804ba146c"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
148ebdeb3 Applying package update to 0.58.6-microsoft.47
dd28949a9 RCTWebViewManager.m was missing from the macOS target (#70)
3e493bfed Merge branch 'publish-temp-1557956704598'
14729eddc Removing Chakra specific hack from JSIExecutor (#66)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2479)