### PR TITLE
Readme path updates

### DIFF
--- a/current/README.md
+++ b/current/README.md
@@ -1,5 +1,5 @@
 # ReactNative for Windows (current)
-![Hero Image with Logo](../.github/hero2.png)
+![Hero Image with Logo](https://raw.githubusercontent.com/microsoft/react-native-windows/master/.github/hero2.png)
 
 See the official [React Native website](https://facebook.github.io/react-native/) for an introduction to React Native. See [main landing page](https://github.com/microsoft/react-native-windows) for more details on overall direction of `react-native-windows`. 
 
@@ -9,7 +9,7 @@ This `current` subdirectory holds support for an existing React Native for Windo
 
 We anticipate that there will be increased activity in the overall repository related to the `vnext` refactoring effort, but that overall effort allocated to the existing architecture will be minimized. See [Opening Issues](#opening-issues) for details on how to open issues if you encounter bugs with the existing architecture.
 
-We are working on releasing a `v0.58` and a subsequent `v0.59` for the existing architecture in order to ensure existing apps can continue to upgrade to match `react-native` versions while the `vnext` implementation is in progress. See [releases](docs/Releases.md) for more information on `react-native-windows` release strategy.
+We are working on releasing a `v0.58` and a subsequent `v0.59` for the existing architecture in order to ensure existing apps can continue to upgrade to match `react-native` versions while the `vnext` implementation is in progress. See [releases](./docs/Releases.md) for more information on `react-native-windows` release strategy.
 
 ## System Requirements
 
@@ -21,13 +21,13 @@ We are working on releasing a `v0.58` and a subsequent `v0.59` for the existing 
 *Note*: Development on React Native Windows itself currently requires Visual Studio 2017. It is not supported with VS Code, but we will gladly accept pull requests to enable a great developer experience in those environments.
 
 ## Getting Started
-See Getting Started Guide for [React Native for Windows - current](docs/GettingStarted.md) to begin developing apps using `react-native-windows`. 
+See Getting Started Guide for [React Native for Windows - current](./docs/GettingStarted.md) to begin developing apps using `react-native-windows`. 
 
 ## Documentation
 
 [React Native already has great documentation](https://facebook.github.io/react-native/docs/getting-started.html), and we're working to ensure the React Native Windows is part of that documentation story. Check out the [React documentation](http://facebook.github.io/react/) for further details about the React API in general.
 
-For information on parity status with Android and iOS, including details on implemented and missing components and modules, along with related issues for missing features from partial implementations, go [here](docs/CoreParityStatus.md)
+For information on parity status with Android and iOS, including details on implemented and missing components and modules, along with related issues for missing features from partial implementations, go [here](./docs/CoreParityStatus.md)
 
 ### Showing the Debug Menu
 
@@ -37,7 +37,7 @@ For information on parity status with Android and iOS, including details on impl
 ### Extending React Native
 
 - See [Extending React Native](https://github.com/microsoft/react-native-windows#extending-react-native) for more general information on community modules and other extension capabilities. 
-- Read the guides on [Native Modules for Windows](docs/NativeModulesWindows.md) and [Native UI Components for Windows](docs/NativeComponentsWindows.md) if you are interested in extending native functionality.
+- Read the guides on [Native Modules for Windows](./docs/NativeModulesWindows.md) and [Native UI Components for Windows](./docs/NativeComponentsWindows.md) if you are interested in extending native functionality.
 
 ## Opening issues
 If you encounter a bug with the `current` architecture, we would like to hear about it. Search the [existing issues](https://github.com/microsoft/react-native-windows/issues?label%3A.NET) and try to make sure your problem doesn’t already exist before opening a new issue. It’s helpful if you include the version of Windows, React Native, React Native Windows plugin, and device family (i.e., desktop, Xbox, etc.) you’re using. Please include a stack trace and reduced repro case when appropriate, too.
@@ -45,4 +45,4 @@ If you encounter a bug with the `current` architecture, we would like to hear ab
 Please continue to report issues as you encounter them, but be sure to use the [correct template](https://github.com/microsoft/react-native-windows/issues/new?assignees=rozele&labels=.NET&template=DOTNET.md) for issues related to the existing `react-native-windows` implementation.
 
 ## Contributing
-See [Contributing guidelines](docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native Windows - current. 
+See [Contributing guidelines](./docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native Windows - current. 

--- a/vnext/README.md
+++ b/vnext/README.md
@@ -1,5 +1,5 @@
 # ReactNative for Windows (vnext)
-![Hero Image with Logo](../.github/hero2.png)
+![Hero Image with Logo](https://raw.githubusercontent.com/microsoft/react-native-windows/master/.github/hero2.png)
 
 See the official [React Native website](https://facebook.github.io/react-native/) for an introduction to React Native. See [main landing page](https://github.com/microsoft/react-native-windows) for more details on overall direction of `react-native-windows`. 
 
@@ -10,7 +10,7 @@ In this `vnext` sub-folder, we are working on a rewrite of `react-native-windows
 ## Status and roadmap
 The development of the React Native Windows `vnext` implementation is ongoing. You can take a look at [Milestones](https://github.com/microsoft/react-native-windows/milestones) and [Projects](https://github.com/microsoft/react-native-windows/projects) for a view on the work streams and tasks. 
 
-The `vnext` package currently supports `v0.58` of corresponding `react-native` major version. See [releases](docs/releases.md) for more information on `vnext` release strategy.
+The `vnext` package currently supports `v0.58` of corresponding `react-native` major version. See [releases](./docs/releases.md) for more information on `vnext` release strategy.
 
 ## Documentation
 [React Native already has great documentation](https://facebook.github.io/react-native/docs/getting-started.html), and we're working to ensure the React Native Windows is part of that documentation story. Check out the [React documentation](http://facebook.github.io/react/) for further details about the React API in general.
@@ -20,12 +20,12 @@ Coming soon - we will be publishing more documentation including some of the fol
 - Guides on how to extend native Windows capabilties in C# and C++ using `vnext` 
 
 ## Getting Started
-See [Getting Started Guide for React Native Windows C++](docs/GettingStarted.md).
+See [Getting Started Guide for React Native Windows C++](./docs/GettingStarted.md).
 
 ## Opening issues
-If you encounter a bug with the React Native Windows C++ implementation or have a feature request, we would like to hear about it. Search the [existing issues](https://github.com/microsoft/react-native-windows/issues?label%3Avnext) and try to make sure your problem doesn’t already exist before opening a new issue. It’s helpful if you include the version of Windows, React Native, React Native Windows plugin, and device family (i.e., desktop, Xbox, etc.) you’re using. Please include a stack trace and reduced repro case when appropriate, too.
+If you encounter a bug with the React Native Windows C++ implementation or have a feature request, we would like to hear about it. Search the [existing issues](https://github.com/microsoft/react-native-windows/issues?q=is%3Aissue+is%3Aopen+label%3Avnext) and try to make sure your problem doesn’t already exist before opening a new issue. It’s helpful if you include the version of Windows, React Native, React Native Windows plugin, and device family (i.e., desktop, Xbox, etc.) you’re using. Please include a stack trace and reduced repro case when appropriate, too.
 
 Please make sure to use the [correct template](https://github.com/microsoft/react-native-windows/issues/new?labels=vnext&template=vnext.md) for issues related to the vnext `react-native-windows` implementation.
 
 ## Contributing
-See [Contributing guidelines](docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native Windows C++. 
+See [Contributing guidelines](./docs/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native Windows C++. 


### PR DESCRIPTION
The image used in both readmes is in a parent folder that is not being published. Switched the path to the full github url. 

The other relative links in the readmes are also broken. I believe this might also fix those. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2489)