### PR TITLE
Fix Unittest build, internal build fixes

### DIFF
--- a/vnext/ReactUWP/CMakeLists.txt
+++ b/vnext/ReactUWP/CMakeLists.txt
@@ -44,6 +44,8 @@ set(SOURCES
 	Views/FlyoutViewManager.cpp
 	Views/FrameworkElementViewManager.cpp
 	Views/ImageViewManager.cpp
+	Views/Impl/ScrollViewUWPImplementation.cpp
+	Views/Impl/SnapPointManagingContentControl.cpp
 	Views/PickerViewManager.cpp
 	Views/PopupViewManager.cpp
 	Views/RawTextViewManager.cpp
@@ -70,6 +72,7 @@ add_definitions(-DRN_PLATFORM=uwp)
 target_compile_definitions(React.UWPStatic PRIVATE UNICODE _UNICODE JSI_EXPORT REACTWINDOWS_BUILD REACTWINDOWS_STATIC)
 target_compile_options(React.UWPStatic PRIVATE /await /wd4996)
 
+target_include_directories(React.UWPStatic PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../shared")
 target_include_directories(React.UWPStatic PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/ABI/idl")
 
 target_include_directories(React.UWPStatic PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/..")

--- a/vnext/Universal.UnitTests/CMakeLists.txt
+++ b/vnext/Universal.UnitTests/CMakeLists.txt
@@ -52,6 +52,7 @@ find_package(VSCppUnitTest REQUIRED)
 add_definitions(-DREACTWINDOWS_STATIC)
 
 # The Visual Studio builds are a complete spaghetti crapshoot of interdependencies; please let's kill it so we can start cleaning up the code
+target_include_directories(ReactWindows.Universal.UnitTests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../shared")
 target_include_directories(ReactWindows.Universal.UnitTests PRIVATE ${VC_UNITTEST_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}
 	"./../ReactUWP"
 	"./../ReactWindowsCore"

--- a/vnext/Universal.UnitTests/React.Windows.Universal.UnitTests.vcxproj
+++ b/vnext/Universal.UnitTests/React.Windows.Universal.UnitTests.vcxproj
@@ -61,7 +61,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>/await /bigobj %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactUWP;$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)ReactUWP;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(YogaDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactUWP;$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)ReactUWP;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)Shared;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(YogaDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>RN_PLATFORM=uwp;USE_EDGEMODE_JSRT;GTEST_LANG_CXX11=1;WIN32_LEAN_AND_MEAN;NOMINMAX;FOLLY_NO_CONFIG;RN_EXPORT=;WIN32=0;WINRT=1;NOJSC;_HAS_AUTO_PTR_ETC;BOOST_ASIO_WINDOWS_APP;BOOST_BEAST_USE_WIN32_FILE=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT>true</CompileAsWinRT>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/vnext/include/CppWinRTIncludes.h
+++ b/vnext/include/CppWinRTIncludes.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <winrt\Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 
 namespace winrt
 {


### PR DESCRIPTION
1) fix the universal.unittest build which is not enabled by default.  There is an assumption of PCH coming from shared which wasn't true for this project with the new scrollview code (controls.primitives.h being included)

2) fix the winrt cmake builds to also use the shared pch.  We'll probably turn off the cmake build soon but right now this blocks auto integrate from github to internal.

3) use forward slash in includes, OACR will flag that


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2490)