### PR TITLE
Fixing sizing issues with Flyout (WI: 3362439)

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -14,6 +14,7 @@
 
 namespace winrt {
   using namespace Windows::UI::Xaml::Controls::Primitives;
+  using namespace Windows::UI::Xaml::Interop;
 }
 
 template<>
@@ -100,6 +101,7 @@ public:
   
 private:
   void SetTargetFrameworkElement();
+  void AdjustDefaultFlyoutStyle();
 
   winrt::FrameworkElement m_targetElement = nullptr;
   winrt::Flyout m_flyout = nullptr;
@@ -213,7 +215,17 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic&& props)
   }
 
   if (updateIsOpen)
-    m_isOpen ? winrt::FlyoutBase::ShowAttachedFlyout(m_targetElement) : m_flyout.Hide();
+  {
+    if (m_isOpen)
+    {
+      AdjustDefaultFlyoutStyle();
+      winrt::FlyoutBase::ShowAttachedFlyout(m_targetElement);
+    }
+    else
+    {
+      m_flyout.Hide();
+    }
+  }
 
   // TODO: hook up view props to the flyout (m_flyout) instead of setting them on the dummy view.
   //Super::updateProperties(std::move(props));
@@ -245,6 +257,13 @@ void FlyoutShadowNode::SetTargetFrameworkElement()
   }
 }
 
+void FlyoutShadowNode::AdjustDefaultFlyoutStyle()
+{
+  winrt::Style flyoutStyle({ L"Windows.UI.Xaml.Controls.FlyoutPresenter", winrt::TypeKind::Metadata });
+  flyoutStyle.Setters().Append(winrt::Setter(winrt::FrameworkElement::MaxWidthProperty(), winrt::box_value(50000)));
+  flyoutStyle.Setters().Append(winrt::Setter(winrt::FrameworkElement::MaxHeightProperty(), winrt::box_value(50000)));
+  m_flyout.FlyoutPresenterStyle(flyoutStyle);
+}
 
 FlyoutViewManager::FlyoutViewManager(const std::shared_ptr<IReactInstance>& reactInstance)
   : Super(reactInstance)


### PR DESCRIPTION
The XAML Flyout has a default MaxWidth/MaxHeight of 456/758. This size is too restrictive for RNW. This change sets the max width/height of the flyout to an arbitrarily large size. This will allow RNW consumers to set their own limits.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2493)