### PR TITLE
Perf improvements

### DIFF
--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -303,7 +303,7 @@ static void StyleYogaNode(ShadowNodeBase& shadowNode, const YGNodeRef yogaNode, 
     return;
 
   for (const auto& pair : props.items()) {
-    const auto& key = pair.first;
+    const std::string& key = pair.first.getString();
     const auto& value = pair.second;
 
     if (key == "flexDirection") {

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -205,7 +205,7 @@ static YGValue YGValueOrDefault(const folly::dynamic& value, YGValue defaultValu
 
   if (value.isString())
   {
-    std::string str = value.asString();
+    std::string str = value.getString();
     if (str == "auto")
       return YGValue{ YGUndefined, YGUnitAuto };
     if (str.length() > 0 && str.back() == '%')
@@ -842,6 +842,10 @@ void NativeUIManager::DoLayout()
     for (auto& tagToYogaNode : m_tagsToYogaNodes) {
       int64_t tag = tagToYogaNode.first;
       YGNodeRef yogaNode = tagToYogaNode.second.get();
+
+      if (!YGNodeGetHasNewLayout(yogaNode))
+        continue;
+      YGNodeSetHasNewLayout(yogaNode, false);
 
       float left = YGNodeLayoutGetLeft(yogaNode);
       float top = YGNodeLayoutGetTop(yogaNode);

--- a/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
@@ -76,12 +76,12 @@ void ButtonViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const fol
   if (button == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "disabled")
+    if (propertyName == "disabled")
     {
       if (propertyValue.isBool())
         button.IsEnabled(!propertyValue.asBool());

--- a/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
@@ -70,7 +70,7 @@ XamlView ButtonViewManager::CreateViewCore(int64_t tag)
   return button;
 }
 
-void ButtonViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void ButtonViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto button = nodeToUpdate->GetView().as<winrt::Button>();
   if (button == nullptr)

--- a/vnext/ReactUWP/Polyester/ButtonViewManager.h
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.h
@@ -17,7 +17,7 @@ public:
   folly::dynamic GetNativeProps() const override;
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
 
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
 protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Polyester/HyperlinkViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/HyperlinkViewManager.cpp
@@ -75,17 +75,17 @@ void HyperlinkViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const 
   if (button == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
-   if (propertyName.asString() == "disabled")
+   if (propertyName == "disabled")
    {
       if (propertyValue.isBool())
         button.IsEnabled(!propertyValue.asBool());
    }
-   else if (propertyName.asString() == "tooltip")
+   else if (propertyName == "tooltip")
    {
      if (propertyValue.isString())
      {
@@ -94,7 +94,7 @@ void HyperlinkViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const 
        winrt::ToolTipService::SetToolTip(button, tooltip);
      }
    }
-   else if (propertyName.asString() == "url")
+   else if (propertyName == "url")
    {
      winrt::Uri myUri(asHstring(propertyValue));
      button.NavigateUri(myUri);

--- a/vnext/ReactUWP/Polyester/HyperlinkViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/HyperlinkViewManager.cpp
@@ -69,7 +69,7 @@ folly::dynamic HyperlinkViewManager::GetExportedCustomDirectEventTypeConstants()
   return directEvents;
 }
 
-void HyperlinkViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void HyperlinkViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto button = nodeToUpdate->GetView().as<winrt::HyperlinkButton>();
   if (button == nullptr)

--- a/vnext/ReactUWP/Polyester/HyperlinkViewManager.h
+++ b/vnext/ReactUWP/Polyester/HyperlinkViewManager.h
@@ -17,7 +17,7 @@ public:
   folly::dynamic GetNativeProps() const override;
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
 
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
 protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Polyester/IconViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/IconViewManager.cpp
@@ -63,9 +63,9 @@ void IconViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
   if (glyphs == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "color")

--- a/vnext/ReactUWP/Polyester/IconViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/IconViewManager.cpp
@@ -57,7 +57,7 @@ XamlView IconViewManager::CreateViewCore(int64_t tag)
   return glyphs;
 }
 
-void IconViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void IconViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto glyphs = nodeToUpdate->GetView().as<winrt::Glyphs>();
   if (glyphs == nullptr)

--- a/vnext/ReactUWP/Polyester/IconViewManager.h
+++ b/vnext/ReactUWP/Polyester/IconViewManager.h
@@ -16,7 +16,7 @@ public:
   const char* GetName() const override;
   folly::dynamic GetNativeProps() const override;
 
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
 protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Utils/PropertyHandlerUtils.h
+++ b/vnext/ReactUWP/Utils/PropertyHandlerUtils.h
@@ -65,10 +65,10 @@ struct json_type_traits;
 template<typename T>
 struct json_type_traits<std::vector<T>>
 {
-  static std::vector<T> parseJson(folly::dynamic& obj)
+  static std::vector<T> parseJson(const folly::dynamic& obj)
   {
     std::vector<T> result;
-    for (auto& item : obj)
+    for (const auto& item : obj)
     {
       result.push_back(json_type_traits<T>::parseJson(item));
     }
@@ -79,7 +79,7 @@ struct json_type_traits<std::vector<T>>
 template<>
 struct json_type_traits<folly::dynamic>
 {
-  static folly::dynamic& parseJson(folly::dynamic& obj)
+  static const folly::dynamic& parseJson(const folly::dynamic& obj)
   {
     return obj;
   }
@@ -88,7 +88,7 @@ struct json_type_traits<folly::dynamic>
 template<>
 struct json_type_traits<double>
 {
-  static double parseJson(folly::dynamic& obj)
+  static double parseJson(const folly::dynamic& obj)
   {
     return obj.asDouble();
   }
@@ -97,14 +97,14 @@ struct json_type_traits<double>
 template<>
 struct json_type_traits<std::string>
 {
-  static std::string parseJson(folly::dynamic& obj)
+  static std::string parseJson(const folly::dynamic& obj)
   {
     return obj.asString();
   }
 };
 
 #define RCT_BEGIN_PROPERTY_MAP(className) \
-  std::unordered_map<std::string, std::function<void(react::uwp::XamlView&, folly::dynamic&)>> m_propertyHandlers;\
+  std::unordered_map<std::string, std::function<void(react::uwp::XamlView&, const folly::dynamic&)>> m_propertyHandlers;\
   void SetupPropertyHandlersInternal() { \
   typedef className class_name;
 
@@ -112,7 +112,7 @@ struct json_type_traits<std::string>
   { \
     typedef typename get_argument_type<1, decltype(&class_name::handler)>::type second_argument_t; \
     typedef typename std::remove_const_t<std::remove_reference_t<second_argument_t>> argument_type_t; \
-    m_propertyHandlers[name] = [this](react::uwp::XamlView& view, folly::dynamic& prop){ \
+    m_propertyHandlers[name] = [this](react::uwp::XamlView& view, const folly::dynamic& prop){ \
       typedef decltype(json_type_traits<argument_type_t>::parseJson(prop)) value_type_t; \
       value_type_t value = json_type_traits<argument_type_t>::parseJson(prop); \
       handler(view, value); \
@@ -121,7 +121,7 @@ struct json_type_traits<std::string>
 
 
 #define RCT_END_PROPERTY_MAP() } \
-  void UpdatePropertiesInternal(react::uwp::XamlView& view, folly::dynamic& diffMap) { \
+  void UpdatePropertiesInternal(react::uwp::XamlView& view, const folly::dynamic& diffMap) { \
     for (auto& pair : diffMap.items()) \
     { \
       auto propHandler = m_propertyHandlers.find(pair.first.asString()); \

--- a/vnext/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/ReactUWP/Utils/PropertyUtils.h
@@ -332,7 +332,7 @@ bool TryUpdateFontProperties(const T& element, const folly::dynamic& propertyNam
   {
     if (propertyValue.isString())
     {
-      const std::string value = propertyValue.asString();
+      const std::string& value = propertyValue.getString();
       winrt::Windows::UI::Text::FontWeight fontWeight;
       if (value == "normal")
         fontWeight = winrt::Windows::UI::Text::FontWeights::Normal();
@@ -371,7 +371,7 @@ bool TryUpdateFontProperties(const T& element, const folly::dynamic& propertyNam
   {
     if (propertyValue.isString())
     {
-      element.FontStyle((propertyValue.asString() == "italic")
+      element.FontStyle((propertyValue.getString() == "italic")
         ? winrt::Windows::UI::Text::FontStyle::Italic
         : winrt::Windows::UI::Text::FontStyle::Normal);
     }
@@ -411,7 +411,7 @@ bool TryUpdateTextAlignment(const T& element, const folly::dynamic& propertyName
   {
     if (propertyValue.isString())
     {
-      auto value = propertyValue.asString();
+      const std::string& value = propertyValue.getString();
       SetTextAlignment(element, value);
     }
     else if (propertyValue.isNull())
@@ -447,7 +447,7 @@ bool TryUpdateTextTrimming(const T& element, const folly::dynamic& propertyName,
   {
     if (propertyValue.isString())
     {
-      auto value = propertyValue.asString();
+      const std::string& value = propertyValue.getString();
       SetTextTrimming(element, value);
     }
     else if (propertyValue.isNull())
@@ -475,7 +475,7 @@ bool TryUpdateTextDecorationLine(const T& element, const folly::dynamic& propert
     {
       using winrt::Windows::UI::Text::TextDecorations;
 
-      const std::string value = propertyValue.asString();
+      const std::string& value = propertyValue.getString();
       TextDecorations decorations = TextDecorations::None;
       if (value == "none")
         decorations = TextDecorations::None;
@@ -517,7 +517,7 @@ bool TryUpdateFlowDirection(const T& element, const folly::dynamic& propertyName
   {
     if (propertyValue.isString())
     {
-      auto value = propertyValue.asString();
+      const std::string& value = propertyValue.getString();
       SetFlowDirection(element, value);
     }
     else if (propertyValue.isNull())
@@ -558,7 +558,7 @@ bool TryUpdateOrientation(const T& element, const folly::dynamic& propertyName, 
     }
     else if (propertyValue.isString())
     {
-      auto valueString = propertyValue.asString();
+      const std::string& valueString = propertyValue.getString();
       if (valueString == "horizontal")
         element.Orientation(Orientation::Horizontal);
       else if (valueString == "vertical")

--- a/vnext/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/ReactUWP/Utils/PropertyUtils.h
@@ -101,7 +101,7 @@ void SetBorderBrush(const T& element, const winrt::Windows::UI::Xaml::Media::Bru
 }
 
 template <class T>
-bool TryUpdateBackgroundBrush(T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateBackgroundBrush(T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "backgroundColor")
   {
@@ -125,7 +125,7 @@ void UpdateCornerRadius(ShadowNodeBase* node, T& element, ShadowCorners corner, 
 }
 
 template <class T>
-bool TryUpdateForeground(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateForeground(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "color")
   {
@@ -141,7 +141,7 @@ bool TryUpdateForeground(const T& element, const folly::dynamic& propertyName, c
 }
 
 template <class T>
-bool TryUpdateBorderProperties(ShadowNodeBase* node, T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateBorderProperties(ShadowNodeBase* node, T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   bool isBorderProperty = true;
 
@@ -196,7 +196,7 @@ bool TryUpdateBorderProperties(ShadowNodeBase* node, T& element, const folly::dy
 }
 
 template <class T>
-bool TryUpdatePadding(ShadowNodeBase* node, const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdatePadding(ShadowNodeBase* node, const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   bool isPaddingProperty = true;
 
@@ -254,7 +254,7 @@ bool TryUpdatePadding(ShadowNodeBase* node, const T& element, const folly::dynam
 }
 
 template <class T>
-bool TryUpdateCornerRadius(ShadowNodeBase* node, T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateCornerRadius(ShadowNodeBase* node, T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "borderTopLeftRadius")
   {
@@ -310,7 +310,7 @@ bool TryUpdateCornerRadius(ShadowNodeBase* node, T& element, const folly::dynami
 }
 
 template <class T>
-bool TryUpdateFontProperties(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateFontProperties(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   bool isFontProperty = true;
 
@@ -405,7 +405,7 @@ void SetTextAlignment(const T& element, const std::string& value)
 }
 
 template <class T>
-bool TryUpdateTextAlignment(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateTextAlignment(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "textAlign")
   {
@@ -441,7 +441,7 @@ void SetTextTrimming(const T& element, const std::string& value)
 }
 
 template <class T>
-bool TryUpdateTextTrimming(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateTextTrimming(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "ellipsizeMode")
   {
@@ -462,7 +462,7 @@ bool TryUpdateTextTrimming(const T& element, const folly::dynamic& propertyName,
 }
 
 template <class T>
-bool TryUpdateTextDecorationLine(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateTextDecorationLine(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "textDecorationLine")
   {
@@ -511,7 +511,7 @@ void SetFlowDirection(const T& element, const std::string& value)
 }
 
 template <class T>
-bool TryUpdateFlowDirection(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateFlowDirection(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if ((propertyName == "writingDirection") || (propertyName == "direction"))
   {
@@ -532,7 +532,7 @@ bool TryUpdateFlowDirection(const T& element, const folly::dynamic& propertyName
 }
 
 template <class T>
-bool TryUpdateCharacterSpacing(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateCharacterSpacing(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "letterSpacing" || propertyName == "characterSpacing")
   {
@@ -548,7 +548,7 @@ bool TryUpdateCharacterSpacing(const T& element, const folly::dynamic& propertyN
 }
 
 template <class T>
-bool TryUpdateOrientation(const T& element, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+bool TryUpdateOrientation(const T& element, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "orientation")
   {
@@ -571,7 +571,7 @@ bool TryUpdateOrientation(const T& element, const folly::dynamic& propertyName, 
   return false;
 }
 
-inline bool TryUpdateMouseEvents(ShadowNodeBase* node, const folly::dynamic& propertyName, const folly::dynamic& propertyValue)
+inline bool TryUpdateMouseEvents(ShadowNodeBase* node, const std::string& propertyName, const folly::dynamic& propertyValue)
 {
   if (propertyName == "onMouseEnter")
     node->m_onMouseEnter = !propertyValue.isNull() && propertyValue.asBool();

--- a/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
@@ -44,7 +44,7 @@ XamlView ActivityIndicatorViewManager::CreateViewCore(int64_t tag)
   return progressRing;
 }
 
-void ActivityIndicatorViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void ActivityIndicatorViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto progressRing = nodeToUpdate->GetView().as<winrt::ProgressRing>();
   if (progressRing == nullptr)

--- a/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
@@ -50,9 +50,9 @@ void ActivityIndicatorViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate
   if (progressRing == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "animating")

--- a/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
@@ -55,7 +55,7 @@ void ActivityIndicatorViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "animating")
+    if (propertyName == "animating")
     {
       if (propertyValue.isBool())
         progressRing.IsActive(propertyValue.asBool());

--- a/vnext/ReactUWP/Views/ActivityIndicatorViewManager.h
+++ b/vnext/ReactUWP/Views/ActivityIndicatorViewManager.h
@@ -16,7 +16,7 @@ public:
   const char* GetName() const override;
   folly::dynamic GetNativeProps() const override;
 
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
 protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Views/CheckboxViewManager.cpp
+++ b/vnext/ReactUWP/Views/CheckboxViewManager.cpp
@@ -125,14 +125,14 @@ void CheckBoxViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-   if (propertyName.asString() == "disabled")
+   if (propertyName == "disabled")
    {
      if (propertyValue.isBool())
        checkbox.IsEnabled(!propertyValue.asBool());
      else if (pair.second.isNull())
        checkbox.ClearValue(winrt::Control::IsEnabledProperty());
    }
-   else if (propertyName.asString() == "checked")
+   else if (propertyName == "checked")
    {
      if (propertyValue.isBool())
        checkbox.IsChecked(propertyValue.asBool());

--- a/vnext/ReactUWP/Views/CheckboxViewManager.cpp
+++ b/vnext/ReactUWP/Views/CheckboxViewManager.cpp
@@ -114,7 +114,7 @@ XamlView CheckBoxViewManager::CreateViewCore(int64_t tag)
   return checkbox;
 }
 
-void CheckBoxViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void CheckBoxViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto checkbox = nodeToUpdate->GetView().as<winrt::CheckBox>();
   if (checkbox == nullptr)

--- a/vnext/ReactUWP/Views/CheckboxViewManager.cpp
+++ b/vnext/ReactUWP/Views/CheckboxViewManager.cpp
@@ -120,9 +120,9 @@ void CheckBoxViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const f
   if (checkbox == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
    if (propertyName == "disabled")

--- a/vnext/ReactUWP/Views/CheckboxViewManager.h
+++ b/vnext/ReactUWP/Views/CheckboxViewManager.h
@@ -19,7 +19,7 @@ public:
 
   facebook::react::ShadowNode* createShadow() const override;
 
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
   void DispatchCommand(XamlView viewToUpdate, int64_t commandId, const folly::dynamic& commandArgs) override;
 
 protected:

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -40,9 +40,9 @@ void ControlViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const fo
 
   if (control != nullptr)
   {
-    for (auto& pair : reactDiffMap.items())
+    for (const auto& pair : reactDiffMap.items())
     {
-      const folly::dynamic& propertyName = pair.first;
+      const std::string& propertyName = pair.first.getString();
       const folly::dynamic& propertyValue = pair.second;
 
       if (TryUpdateBackgroundBrush(control, propertyName, propertyValue))

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -32,7 +32,7 @@ folly::dynamic ControlViewManager::GetNativeProps() const
   return props;
 }
 
-void ControlViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void ControlViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto control(nodeToUpdate->GetView().as<winrt::Control>());
 

--- a/vnext/ReactUWP/Views/DatePickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/DatePickerViewManager.cpp
@@ -73,7 +73,7 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
 
   for (auto& pair : props.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "dayOfWeekFormat")

--- a/vnext/ReactUWP/Views/DatePickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/DatePickerViewManager.cpp
@@ -76,28 +76,28 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "dayOfWeekFormat")
+    if (propertyName == "dayOfWeekFormat")
     {
       if (propertyValue.isString())
         datePicker.DayOfWeekFormat(asHstring(propertyValue));
       else if (propertyValue.isNull())
         datePicker.ClearValue(winrt::CalendarDatePicker::DayOfWeekFormatProperty());
     }
-    else if (propertyName.asString() == "dateFormat")
+    else if (propertyName == "dateFormat")
     {
       if (propertyValue.isString())
         datePicker.DateFormat(asHstring(propertyValue));
       else if (propertyValue.isNull())
         datePicker.ClearValue(winrt::CalendarDatePicker::DateFormatProperty());
     }
-    else if (propertyName.asString() == "firstDayOfWeek")
+    else if (propertyName == "firstDayOfWeek")
     {
       if (propertyValue.isInt())
         datePicker.FirstDayOfWeek(static_cast<winrt::DayOfWeek>(propertyValue.asInt()));
       else if (propertyValue.isNull())
         datePicker.ClearValue(winrt::CalendarDatePicker::FirstDayOfWeekProperty());
     }
-    else if (propertyName.asString() == "maxDate")
+    else if (propertyName == "maxDate")
     {
       if (propertyValue.isInt())
       {
@@ -109,7 +109,7 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
         datePicker.ClearValue(winrt::CalendarDatePicker::MaxDateProperty());
       }
     }
-    else if (propertyName.asString() == "minDate")
+    else if (propertyName == "minDate")
     {
       if (propertyValue.isInt())
       {
@@ -121,14 +121,14 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
         datePicker.ClearValue(winrt::CalendarDatePicker::MinDateProperty());
       }
     }
-    else if (propertyName.asString() == "placeholderText")
+    else if (propertyName == "placeholderText")
     {
       if (propertyValue.isString())
         datePicker.PlaceholderText(asHstring(propertyValue));
       else if (propertyValue.isNull())
         datePicker.ClearValue(winrt::CalendarDatePicker::PlaceholderTextProperty());
     }
-    else if (propertyName.asString() == "selectedDate")
+    else if (propertyName == "selectedDate")
     {
       if (propertyValue.isInt())
       {
@@ -140,7 +140,7 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
         datePicker.ClearValue(winrt::CalendarDatePicker::DateProperty());
       }
     }
-    else if (propertyName.asString() == "timeZoneOffsetInSeconds")
+    else if (propertyName == "timeZoneOffsetInSeconds")
     {
       if (propertyValue.isInt())
         m_timeZoneOffsetInSeconds = propertyValue.asInt();

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -171,7 +171,7 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic&& props)
 
   for (auto& pair : props.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "isLightDismissEnabled")

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -174,14 +174,14 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic&& props)
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "isLightDismissEnabled")
+    if (propertyName == "isLightDismissEnabled")
     {
       if (propertyValue.isBool())
         m_isLightDismissEnabled = propertyValue.asBool();
       else if (propertyValue.isNull())
         m_isLightDismissEnabled = true;
     }
-    else if (propertyName.asString() == "isOpen")
+    else if (propertyName == "isOpen")
     {
       if (propertyValue.isBool())
       {
@@ -189,12 +189,12 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic&& props)
         updateIsOpen = true;
       }
     }
-    else if (propertyName.asString() == "placement")
+    else if (propertyName == "placement")
     {
       auto placement = json_type_traits<winrt::FlyoutPlacementMode>::parseJson(propertyValue);
       m_flyout.Placement(placement);
     }
-    else if (propertyName.asString() == "target")
+    else if (propertyName == "target")
     {
       if (propertyValue.isInt())
       {

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -69,7 +69,7 @@ folly::dynamic FrameworkElementViewManager::GetNativeProps() const
 }
 
 
-void FrameworkElementViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void FrameworkElementViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto element(nodeToUpdate->GetView().as<winrt::FrameworkElement>());
   if (element != nullptr)

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -74,9 +74,9 @@ void FrameworkElementViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate,
   auto element(nodeToUpdate->GetView().as<winrt::FrameworkElement>());
   if (element != nullptr)
   {
-    for (auto& pair : reactDiffMap.items())
+    for (const auto& pair : reactDiffMap.items())
     {
-      const folly::dynamic& propertyName = pair.first;
+      const std::string& propertyName = pair.first.getString();
       const folly::dynamic& propertyValue = pair.second;
 
       if (propertyName == "opacity")

--- a/vnext/ReactUWP/Views/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/ImageViewManager.cpp
@@ -66,7 +66,7 @@ namespace react {
 template<>
 struct json_type_traits<react::uwp::ImageSource>
 {
-  static react::uwp::ImageSource parseJson(folly::dynamic& json)
+  static react::uwp::ImageSource parseJson(const folly::dynamic& json)
   {
     react::uwp::ImageSource source;
     for (auto& item : json.items())
@@ -94,7 +94,7 @@ struct json_type_traits<react::uwp::ImageSource>
 template<>
 struct json_type_traits<winrt::Windows::UI::Xaml::Media::Stretch>
 {
-  static winrt::Windows::UI::Xaml::Media::Stretch parseJson(folly::dynamic& json)
+  static winrt::Windows::UI::Xaml::Media::Stretch parseJson(const folly::dynamic& json)
   {
     winrt::Windows::UI::Xaml::Media::Stretch stretch;
     if (json == "cover")
@@ -134,7 +134,7 @@ namespace react { namespace uwp {
     return image;
   }
 
-  void ImageViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+  void ImageViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
   {
     auto image = nodeToUpdate->GetView().as<winrt::Image>();
     if (image == nullptr)
@@ -231,7 +231,7 @@ namespace react { namespace uwp {
     EmitImageEvent(instanceWeak.lock(), image, "topLoadEnd", source);
   }
 
-  void ImageViewManager::setSource(winrt::Image image, folly::dynamic& data)
+  void ImageViewManager::setSource(winrt::Image image, const folly::dynamic& data)
   {
     auto instance = m_wkReactInstance.lock();
     if (instance == nullptr)

--- a/vnext/ReactUWP/Views/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/ImageViewManager.cpp
@@ -140,15 +140,18 @@ namespace react { namespace uwp {
     if (image == nullptr)
       return;
 
-    for (auto& pair : reactDiffMap.items())
+    for (const auto& pair : reactDiffMap.items())
     {
-      if (pair.first == "source")
+      const std::string& propertyName = pair.first.getString();
+      const folly::dynamic& propertyValue = pair.second;
+
+      if (propertyName == "source")
       {
-        setSource(image, pair.second);
+        setSource(image, propertyValue);
       }
-      else if (pair.first == "resizeMode")
+      else if (propertyName == "resizeMode")
       {
-        auto stretch = json_type_traits<winrt::Windows::UI::Xaml::Media::Stretch>::parseJson(pair.second);
+        auto stretch = json_type_traits<winrt::Windows::UI::Xaml::Media::Stretch>::parseJson(propertyValue);
         image.Stretch(stretch);
       }
 

--- a/vnext/ReactUWP/Views/ImageViewManager.h
+++ b/vnext/ReactUWP/Views/ImageViewManager.h
@@ -20,7 +20,7 @@ namespace react { namespace uwp {
     ImageViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
 
     const char* GetName() const override;
-    void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+    void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
     folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
     folly::dynamic GetNativeProps() const override;
@@ -29,7 +29,7 @@ namespace react { namespace uwp {
     XamlView CreateViewCore(int64_t tag) override;
 
   private:
-    void setSource(winrt::Windows::UI::Xaml::Controls::Image image, folly::dynamic& sources);
+    void setSource(winrt::Windows::UI::Xaml::Controls::Image image, const folly::dynamic& sources);
   };
 
   class ImageViewManagerModule : public facebook::xplat::module::CxxModule

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -86,7 +86,7 @@ void PickerShadowNode::updateProperties(const folly::dynamic&& props)
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "editable")
+    if (propertyName == "editable")
     {
       if (m_isEditableComboboxSupported)
       {
@@ -96,7 +96,7 @@ void PickerShadowNode::updateProperties(const folly::dynamic&& props)
           combobox.ClearValue(winrt::ComboBox::IsEditableProperty());
       }
     }
-    else if (propertyName.asString() == "text")
+    else if (propertyName == "text")
     {
       if (m_isEditableComboboxSupported)
       {
@@ -106,12 +106,12 @@ void PickerShadowNode::updateProperties(const folly::dynamic&& props)
           combobox.ClearValue(winrt::ComboBox::TextProperty());
       }
     }
-    else if (propertyName.asString() == "enabled")
+    else if (propertyName == "enabled")
     {
       if (propertyValue.isBool())
         combobox.IsEnabled(propertyValue.asBool());
     }
-    else if (propertyName.asString() == "selectedIndex")
+    else if (propertyName == "selectedIndex")
     {
       if (propertyValue.isNumber())
       {
@@ -123,7 +123,7 @@ void PickerShadowNode::updateProperties(const folly::dynamic&& props)
         updateSelectedIndex = true;
       }
     }
-    else if (propertyName.asString() == "items")
+    else if (propertyName == "items")
     {
       if (propertyValue.isArray())
       {

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -83,7 +83,7 @@ void PickerShadowNode::updateProperties(const folly::dynamic&& props)
   auto combobox = GetView().as<winrt::ComboBox>();
   for (auto& pair : props.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "editable")

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -90,7 +90,7 @@ void PopupShadowNode::updateProperties(const folly::dynamic&& props)
 
   for (auto& pair : props.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "target")

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -93,35 +93,35 @@ void PopupShadowNode::updateProperties(const folly::dynamic&& props)
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "target")
+    if (propertyName == "target")
     {
       if (propertyValue.isInt())
         m_targetTag = propertyValue.asInt();
       else
         m_targetTag = -1;
     }
-    else if (propertyName.asString() == "isOpen")
+    else if (propertyName == "isOpen")
     {
       if (propertyValue.isBool())
-        popup.IsOpen(propertyValue.asBool());
+        popup.IsOpen(propertyValue.getBool());
       else if (propertyValue.isNull())
         popup.ClearValue(winrt::Popup::IsOpenProperty());
     }
-    else if (propertyName.asString() == "isLightDismissEnabled")
+    else if (propertyName == "isLightDismissEnabled")
     {
       if (propertyValue.isBool())
-        popup.IsLightDismissEnabled(propertyValue.asBool());
+        popup.IsLightDismissEnabled(propertyValue.getBool());
       else if (propertyValue.isNull())
         popup.ClearValue(winrt::Popup::IsLightDismissEnabledProperty());
     }
-    else if (propertyName.asString() == "horizontalOffset")
+    else if (propertyName == "horizontalOffset")
     {
       if (propertyValue.isInt())
         popup.HorizontalOffset(propertyValue.asDouble());
       else if (propertyValue.isNull())
         popup.ClearValue(winrt::Popup::HorizontalOffsetProperty());
     }
-    else if (propertyName.asString() == "verticalOffset")
+    else if (propertyName == "verticalOffset")
     {
       if (propertyValue.isInt())
         popup.VerticalOffset(propertyValue.asDouble());

--- a/vnext/ReactUWP/Views/RawTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/RawTextViewManager.cpp
@@ -40,7 +40,7 @@ XamlView RawTextViewManager::CreateViewCore(int64_t tag)
   return run;
 }
 
-void RawTextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void RawTextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto run = nodeToUpdate->GetView().as<winrt::Run>();
   if (run == nullptr)

--- a/vnext/ReactUWP/Views/RawTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/RawTextViewManager.cpp
@@ -46,11 +46,14 @@ void RawTextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const fo
   if (run == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    if (pair.first == "text")
+    const std::string& propertyName = pair.first.getString();
+    const folly::dynamic& propertyValue = pair.second;
+
+    if (propertyName == "text")
     {
-      run.Text(asHstring(pair.second));
+      run.Text(asHstring(propertyValue));
     }
   }
   Super::UpdateProperties(nodeToUpdate, reactDiffMap);

--- a/vnext/ReactUWP/Views/RawTextViewManager.h
+++ b/vnext/ReactUWP/Views/RawTextViewManager.h
@@ -16,7 +16,7 @@ public:
   RawTextViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
 
   const char* GetName() const override;
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
   void SetLayoutProps(ShadowNodeBase& nodeToUpdate, XamlView viewToUpdate, float left, float top, float width, float height) override;
   bool RequiresYogaNode() const override;

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -122,8 +122,9 @@ void ScrollViewShadowNode::updateProperties(const folly::dynamic&& reactDiffMap)
 
   for (const auto& pair : reactDiffMap.items())
   {
-    const auto propertyName = pair.first;
-    const auto propertyValue = pair.second;
+    const std::string& propertyName = pair.first.getString();
+    const folly::dynamic& propertyValue = pair.second;
+  
     if (propertyName == "horizontal")
     {
       const auto [valid, horizontal] = getPropertyAndValidity(propertyValue, false);

--- a/vnext/ReactUWP/Views/SwitchViewManager.cpp
+++ b/vnext/ReactUWP/Views/SwitchViewManager.cpp
@@ -92,7 +92,7 @@ XamlView SwitchViewManager::CreateViewCore(int64_t tag)
   return toggleSwitch;
 }
 
-void SwitchViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void SwitchViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto toggleSwitch = nodeToUpdate->GetView().as<winrt::ToggleSwitch>();
   if (toggleSwitch == nullptr)

--- a/vnext/ReactUWP/Views/SwitchViewManager.cpp
+++ b/vnext/ReactUWP/Views/SwitchViewManager.cpp
@@ -98,9 +98,9 @@ void SwitchViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const fol
   if (toggleSwitch == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
    if (propertyName == "disabled")

--- a/vnext/ReactUWP/Views/SwitchViewManager.cpp
+++ b/vnext/ReactUWP/Views/SwitchViewManager.cpp
@@ -103,14 +103,14 @@ void SwitchViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dy
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-   if (propertyName.asString() == "disabled")
+   if (propertyName == "disabled")
    {
       if (propertyValue.isBool())
         toggleSwitch.IsEnabled(!propertyValue.asBool());
       else if (pair.second.isNull())
         toggleSwitch.ClearValue(winrt::Control::IsEnabledProperty());
    }
-   else if (propertyName.asString() == "value")
+   else if (propertyName == "value")
    {
      if (propertyValue.isBool())
        toggleSwitch.IsOn(propertyValue.asBool());

--- a/vnext/ReactUWP/Views/SwitchViewManager.h
+++ b/vnext/ReactUWP/Views/SwitchViewManager.h
@@ -16,7 +16,7 @@ public:
   const char* GetName() const override;
   folly::dynamic GetNativeProps() const override;
   facebook::react::ShadowNode* createShadow() const override;
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
 protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -200,111 +200,114 @@ void TextInputShadowNode::updateProperties(const folly::dynamic&& props)
   auto control = textBox.as<winrt::Control>();
   for (auto& pair : props.items())
   {
-    if (TryUpdateFontProperties(control, pair.first, pair.second))
+    const std::string& propertyName = pair.first.getString();
+    const folly::dynamic& propertyValue = propertyName;
+
+    if (TryUpdateFontProperties(control, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateTextAlignment(textBox, pair.first, pair.second))
+    else if (TryUpdateTextAlignment(textBox, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateCharacterSpacing(control, pair.first, pair.second))
+    else if (TryUpdateCharacterSpacing(control, propertyName, propertyValue))
     {
       continue;
     }
-    else if (pair.first == "multiline")
+    else if (propertyName == "multiline")
     {
-      if (pair.second.isBool())
-        textBox.TextWrapping(pair.second.asBool() ? winrt::TextWrapping::Wrap : winrt::TextWrapping::NoWrap);
-      else if (pair.second.isNull())
+      if (propertyValue.isBool())
+        textBox.TextWrapping(propertyValue.asBool() ? winrt::TextWrapping::Wrap : winrt::TextWrapping::NoWrap);
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::TextWrappingProperty());
     }
-    else if (pair.first == "allowFontScaling")
+    else if (propertyName == "allowFontScaling")
     {
-      if (pair.second.isBool())
-        textBox.IsTextScaleFactorEnabled(pair.second.asBool());
-      else if (pair.second.isNull())
+      if (propertyValue.isBool())
+        textBox.IsTextScaleFactorEnabled(propertyValue.asBool());
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::Control::IsTextScaleFactorEnabledProperty());
     }
-    else if (pair.first == "clearTextOnFocus")
+    else if (propertyName == "clearTextOnFocus")
     {
-      if (pair.second.isBool())
-        m_shouldClearTextOnFocus = pair.second.asBool();
+      if (propertyValue.isBool())
+        m_shouldClearTextOnFocus = propertyValue.asBool();
     }
-    else if (pair.first == "editable")
+    else if (propertyName == "editable")
     {
-      if (pair.second.isBool())
-        textBox.IsReadOnly(!pair.second.asBool());
-      else if (pair.second.isNull())
+      if (propertyValue.isBool())
+        textBox.IsReadOnly(!propertyValue.asBool());
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::IsReadOnlyProperty());
     }
-    else if (pair.first == "maxLength")
+    else if (propertyName == "maxLength")
     {
-      if (pair.second.isInt())
-        textBox.MaxLength(static_cast<int32_t>(pair.second.asInt()));
-      else if (pair.second.isNull())
+      if (propertyValue.isInt())
+        textBox.MaxLength(static_cast<int32_t>(propertyValue.asInt()));
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::MaxLengthProperty());
     }
-    else if (pair.first == "placeholder")
+    else if (propertyName == "placeholder")
     {
-      if (pair.second.isString())
-        textBox.PlaceholderText(asHstring(pair.second));
-      else if (pair.second.isNull())
+      if (propertyValue.isString())
+        textBox.PlaceholderText(asHstring(propertyValue));
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::PlaceholderTextProperty());
     }
-    else if (pair.first == "placeholderTextColor")
+    else if (propertyName == "placeholderTextColor")
     {
       if (textBox.try_as<winrt::ITextBlock6>())
       {
-        if (pair.second.isInt())
-          textBox.PlaceholderForeground(SolidColorBrushFrom(pair.second));
-        else if (pair.second.isNull())
+        if (propertyValue.isInt())
+          textBox.PlaceholderForeground(SolidColorBrushFrom(propertyValue));
+        else if (propertyValue.isNull())
           textBox.ClearValue(winrt::TextBox::PlaceholderForegroundProperty());
       }
     }
-    else if (pair.first == "scrollEnabled")
+    else if (propertyName == "scrollEnabled")
     {
-      if (pair.second.isBool() && textBox.TextWrapping() == winrt::TextWrapping::Wrap)
+      if (propertyValue.isBool() && textBox.TextWrapping() == winrt::TextWrapping::Wrap)
       {
-        auto scrollMode = pair.second.asBool() ? winrt::ScrollMode::Auto : winrt::ScrollMode::Disabled;
+        auto scrollMode = propertyValue.asBool() ? winrt::ScrollMode::Auto : winrt::ScrollMode::Disabled;
         winrt::ScrollViewer::SetVerticalScrollMode(textBox, scrollMode);
         winrt::ScrollViewer::SetHorizontalScrollMode(textBox, scrollMode);
       }
     }
-    else if (pair.first == "selection")
+    else if (propertyName == "selection")
     {
-      if (pair.second.isObject())
+      if (propertyValue.isObject())
       {
-        auto selection = json_type_traits<Selection>::parseJson(pair.second);
+        auto selection = json_type_traits<Selection>::parseJson(propertyValue);
 
         if (selection.isValid())
           textBox.Select(selection.start, selection.end - selection.start);
       }
     }
-    else if (pair.first == "selectionColor")
+    else if (propertyName == "selectionColor")
     {
-      if (pair.second.isInt())
-        textBox.SelectionHighlightColor(SolidColorBrushFrom(pair.second));
-      else if (pair.second.isNull())
+      if (propertyValue.isInt())
+        textBox.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::SelectionHighlightColorProperty());
     }
-    else if (pair.first == "selectTextOnFocus")
+    else if (propertyName == "selectTextOnFocus")
     {
-      if (pair.second.isBool())
-        m_shouldSelectTextOnFocus = pair.second.asBool();
+      if (propertyValue.isBool())
+        m_shouldSelectTextOnFocus = propertyValue.asBool();
     }
-    else if (pair.first == "spellCheck")
+    else if (propertyName == "spellCheck")
     {
-      if (pair.second.isBool())
-        textBox.IsSpellCheckEnabled(pair.second.asBool());
-      else if (pair.second.isNull())
+      if (propertyValue.isBool())
+        textBox.IsSpellCheckEnabled(propertyValue.asBool());
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::IsSpellCheckEnabledProperty());
     }
-    else if (pair.first == "text")
+    else if (propertyName == "text")
     {
-      if (pair.second.isString())
-        textBox.Text(asHstring(pair.second));
-      else if (pair.second.isNull())
+      if (propertyValue.isString())
+        textBox.Text(asHstring(propertyValue));
+      else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::TextProperty());
     }
   }

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -53,7 +53,7 @@ XamlView TextViewManager::CreateViewCore(int64_t tag)
   return textBlock;
 }
 
-void TextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void TextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto textBlock = nodeToUpdate->GetView().as<winrt::TextBlock>();
   if (textBlock == nullptr)

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -59,69 +59,72 @@ void TextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
   if (textBlock == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    if (TryUpdateForeground(textBlock, pair.first, pair.second))
+    const std::string& propertyName = pair.first.getString();
+    const folly::dynamic& propertyValue = pair.second;
+
+    if (TryUpdateForeground(textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateFontProperties(textBlock, pair.first, pair.second))
+    else if (TryUpdateFontProperties(textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdatePadding(nodeToUpdate, textBlock, pair.first, pair.second))
+    else if (TryUpdatePadding(nodeToUpdate, textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateTextAlignment(textBlock, pair.first, pair.second))
+    else if (TryUpdateTextAlignment(textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateTextTrimming(textBlock, pair.first, pair.second))
+    else if (TryUpdateTextTrimming(textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateTextDecorationLine(textBlock, pair.first, pair.second))
+    else if (TryUpdateTextDecorationLine(textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateCharacterSpacing(textBlock, pair.first, pair.second))
+    else if (TryUpdateCharacterSpacing(textBlock, propertyName, propertyValue))
     {
       continue;
     }
-    else if (pair.first == "numberOfLines")
+    else if (propertyName == "numberOfLines")
     {
-      if (pair.second.isInt())
-        textBlock.MaxLines(static_cast<int32_t>(pair.second.getInt()));
-      else if (pair.second.isNull())
+      if (propertyValue.isInt())
+        textBlock.MaxLines(static_cast<int32_t>(propertyValue.getInt()));
+      else if (propertyValue.isNull())
         textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
     }
-    else if (pair.first == "lineHeight")
+    else if (propertyName == "lineHeight")
     {
-      if (pair.second.isNumber())
-        textBlock.LineHeight(static_cast<int32_t>(pair.second.asDouble()));
-      else if (pair.second.isNull())
+      if (propertyValue.isNumber())
+        textBlock.LineHeight(static_cast<int32_t>(propertyValue.asDouble()));
+      else if (propertyValue.isNull())
         textBlock.ClearValue(winrt::TextBlock::LineHeightProperty());
     }
-    else if (pair.first == "selectable")
+    else if (propertyName == "selectable")
     {
-      if (pair.second.isBool())
-        textBlock.IsTextSelectionEnabled(pair.second.asBool());
-      else if (pair.second.isNull())
+      if (propertyValue.isBool())
+        textBlock.IsTextSelectionEnabled(propertyValue.asBool());
+      else if (propertyValue.isNull())
         textBlock.ClearValue(winrt::TextBlock::IsTextSelectionEnabledProperty());
     }
-    else if (pair.first == "allowFontScaling")
+    else if (propertyName == "allowFontScaling")
     {
-      if (pair.second.isBool())
-        textBlock.IsTextScaleFactorEnabled(pair.second.asBool());
+      if (propertyValue.isBool())
+        textBlock.IsTextScaleFactorEnabled(propertyValue.asBool());
       else
         textBlock.ClearValue(winrt::TextBlock::IsTextScaleFactorEnabledProperty());
     }
-    else if (pair.first == "selectionColor")
+    else if (propertyName == "selectionColor")
     {
-      if (pair.second.isInt())
+      if (propertyValue.isInt())
       {
-        textBlock.SelectionHighlightColor(SolidColorBrushFrom(pair.second));
+        textBlock.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
       }
       else
         textBlock.ClearValue(winrt::TextBlock::SelectionHighlightColorProperty());

--- a/vnext/ReactUWP/Views/TextViewManager.h
+++ b/vnext/ReactUWP/Views/TextViewManager.h
@@ -16,7 +16,7 @@ public:
   facebook::react::ShadowNode* createShadow() const override;
 
   const char* GetName() const override;
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
   void AddView(XamlView parent, XamlView child, int64_t index) override;
   void RemoveAllChildren(XamlView parent) override;

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -199,7 +199,7 @@ void ViewManagerBase::ReplaceChild(XamlView parent, XamlView oldChild, XamlView 
   assert(false);
 }
 
-void ViewManagerBase::UpdateProperties(ShadowNodeBase* nodeToUpdate, dynamic reactDiffMap)
+void ViewManagerBase::UpdateProperties(ShadowNodeBase* nodeToUpdate, const dynamic& reactDiffMap)
 {
   // Directly dirty this node since non-layout changes like the text property do not trigger relayout
   //  There isn't actually a yoga node for RawText views, but it will invalidate the ancestors which

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -98,10 +98,10 @@ dynamic ViewManagerBase::GetConstants() const
 
   const auto bubblingEventTypesConstants = GetExportedCustomBubblingEventTypeConstants();
   if (!bubblingEventTypesConstants.empty())
-    constants["bubblingEventTypes"] = bubblingEventTypesConstants;
+    constants["bubblingEventTypes"] = std::move(bubblingEventTypesConstants);
   const auto directEventTypesConstants = GetExportedCustomDirectEventTypeConstants();
   if (!directEventTypesConstants.empty())
-    constants["directEventTypes"] = directEventTypesConstants;
+    constants["directEventTypes"] = std::move(directEventTypesConstants);
 
   return constants;
 }

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -209,9 +209,9 @@ void ViewManagerBase::UpdateProperties(ShadowNodeBase* nodeToUpdate, const dynam
   if (instance != nullptr)
     static_cast<NativeUIManager*>(instance->NativeUIManager())->DirtyYogaNode(tag);
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "onLayout")

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -285,7 +285,7 @@ folly::dynamic ViewViewManager::GetNativeProps() const
   return props;
 }
 
-void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto* pViewShadowNode = static_cast<ViewShadowNode*>(nodeToUpdate);
   bool shouldBeControl = pViewShadowNode->IsControl();

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -323,7 +323,7 @@ void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dyna
       {
         if (propertyValue.isString())
         {
-          bool clipChildren = propertyValue.asString() == "hidden";
+          bool clipChildren = propertyValue.getString() == "hidden";
           pPanel->ClipChildren(clipChildren);
         }
       }
@@ -331,14 +331,14 @@ void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dyna
       {
         if (propertyValue.isString())
         {
-          bool hitTestable = propertyValue.asString() != "none";
+          bool hitTestable = propertyValue.getString() != "none";
           pPanel->IsHitTestVisible(hitTestable);
         }
       }
       else if (propertyName == "acceptsKeyboardFocus")
       {
         if (propertyValue.isBool())
-          shouldBeControl = propertyValue.asBool();
+          shouldBeControl = propertyValue.getBool();
       }
       else if (propertyName == "accessibilityRole")
       {
@@ -346,7 +346,7 @@ void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dyna
         // non-Touchable scenarios
         if (propertyValue.isString())
         {
-          auto role = propertyValue.asString();
+          const std::string& role = propertyValue.getString();
           if (role == "none")
             pViewShadowNode->AccessibilityRole(AccessibilityRoles::None);
           else if (role == "button")
@@ -402,7 +402,7 @@ void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dyna
       else if (propertyName == "enableFocusRing")
       {
         if (propertyValue.isBool())
-          pViewShadowNode->EnableFocusRing(propertyValue.asBool());
+          pViewShadowNode->EnableFocusRing(propertyValue.getBool());
         else if (propertyValue.isNull())
           pViewShadowNode->EnableFocusRing(false);
       }

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -293,9 +293,9 @@ void ViewViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
   auto pPanel = pViewShadowNode->GetViewPanel();
   if (pPanel != nullptr)
   {
-    for (auto& pair : reactDiffMap.items())
+    for (const auto& pair : reactDiffMap.items())
     {
-      const folly::dynamic& propertyName = pair.first;
+      const std::string& propertyName = pair.first.getString();
       const folly::dynamic& propertyValue = pair.second;
 
       if (TryUpdateBackgroundBrush(*pPanel, propertyName, propertyValue))

--- a/vnext/ReactUWP/Views/ViewViewManager.h
+++ b/vnext/ReactUWP/Views/ViewViewManager.h
@@ -22,7 +22,7 @@ public:
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
   facebook::react::ShadowNode* createShadow() const override;
 
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
   // Yoga Layout
   void SetLayoutProps(ShadowNodeBase& nodeToUpdate, XamlView viewToUpdate, float left, float top, float width, float height) override;

--- a/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
@@ -36,7 +36,7 @@ XamlView VirtualTextViewManager::CreateViewCore(int64_t tag)
   return winrt::Span();
 }
 
-void VirtualTextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void VirtualTextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto span = nodeToUpdate->GetView().as<winrt::Span>();
   if (span == nullptr)

--- a/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
@@ -42,19 +42,22 @@ void VirtualTextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, cons
   if (span == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
+    const std::string& propertyName = pair.first.getString();
+    const folly::dynamic& propertyValue = pair.second;
+
     // FUTURE: In the future cppwinrt will generate code where static methods on base types can
     // be called.  For now we specify the base type explicitly
-    if (TryUpdateForeground<winrt::TextElement>(span, pair.first, pair.second))
+    if (TryUpdateForeground<winrt::TextElement>(span, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateFontProperties<winrt::TextElement>(span, pair.first, pair.second))
+    else if (TryUpdateFontProperties<winrt::TextElement>(span, propertyName, propertyValue))
     {
       continue;
     }
-    else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, pair.first, pair.second))
+    else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, propertyName, propertyValue))
     {
       continue;
     }

--- a/vnext/ReactUWP/Views/VirtualTextViewManager.h
+++ b/vnext/ReactUWP/Views/VirtualTextViewManager.h
@@ -14,7 +14,7 @@ public:
   VirtualTextViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
 
   const char* GetName() const override;
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
   void AddView(XamlView parent, XamlView child, int64_t index) override;
   void RemoveAllChildren(XamlView parent) override;

--- a/vnext/ReactUWP/Views/WebViewManager.cpp
+++ b/vnext/ReactUWP/Views/WebViewManager.cpp
@@ -41,7 +41,7 @@ namespace react { namespace uwp {
     return winrt::WebView();
   }
 
-  void WebViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+  void WebViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
   {
     XamlView view = nodeToUpdate->GetView();
     UpdatePropertiesInternal(view, reactDiffMap);

--- a/vnext/ReactUWP/Views/WebViewManager.h
+++ b/vnext/ReactUWP/Views/WebViewManager.h
@@ -22,7 +22,7 @@ namespace react {
 template<>
 struct json_type_traits<react::uwp::WebSource>
 {
-  static react::uwp::WebSource parseJson(folly::dynamic& json)
+  static react::uwp::WebSource parseJson(const folly::dynamic& json)
   {
     react::uwp::WebSource source;
     for (auto& item : json.items())
@@ -49,7 +49,7 @@ namespace react { namespace uwp {
     WebViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
 
     const char* GetName() const override;
-    void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+    void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
     folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
     folly::dynamic GetNativeProps() const override;

--- a/vnext/Universal.SampleApp/CustomViewManager.cpp
+++ b/vnext/Universal.SampleApp/CustomViewManager.cpp
@@ -107,7 +107,7 @@ react::uwp::XamlView CustomFrameworkElementViewManager::CreateViewCore(int64_t t
   return checkbox;
 }
 
-void CustomFrameworkElementViewManager::UpdateProperties(react::uwp::ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap)
+void CustomFrameworkElementViewManager::UpdateProperties(react::uwp::ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
 {
   auto checkbox = nodeToUpdate->GetView().as<winrt::CheckBox>();
   if (checkbox == nullptr)

--- a/vnext/Universal.SampleApp/CustomViewManager.cpp
+++ b/vnext/Universal.SampleApp/CustomViewManager.cpp
@@ -113,9 +113,9 @@ void CustomFrameworkElementViewManager::UpdateProperties(react::uwp::ShadowNodeB
   if (checkbox == nullptr)
     return;
 
-  for (auto& pair : reactDiffMap.items())
+  for (const auto& pair : reactDiffMap.items())
   {
-    const folly::dynamic& propertyName = pair.first;
+    const std::string& propertyName = pair.first.getString();
     const folly::dynamic& propertyValue = pair.second;
 
     if (propertyName == "disabled")

--- a/vnext/Universal.SampleApp/CustomViewManager.cpp
+++ b/vnext/Universal.SampleApp/CustomViewManager.cpp
@@ -118,14 +118,14 @@ void CustomFrameworkElementViewManager::UpdateProperties(react::uwp::ShadowNodeB
     const folly::dynamic& propertyName = pair.first;
     const folly::dynamic& propertyValue = pair.second;
 
-    if (propertyName.asString() == "disabled")
+    if (propertyName == "disabled")
     {
       if (propertyValue.isBool())
         checkbox.IsEnabled(!propertyValue.asBool());
       else if (propertyValue.isNull())
         checkbox.ClearValue(winrt::Control::IsEnabledProperty());
     }
-    else if (propertyName.asString() == "test")
+    else if (propertyName == "test")
     {
       if (propertyValue.isBool())
       {

--- a/vnext/Universal.SampleApp/CustomViewManager.h
+++ b/vnext/Universal.SampleApp/CustomViewManager.h
@@ -20,7 +20,7 @@ public:
 
   facebook::react::ShadowNode* createShadow() const override;
 
-  void UpdateProperties(react::uwp::ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(react::uwp::ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
   void DispatchCommand(react::uwp::XamlView viewToUpdate, int64_t commandId, const folly::dynamic& commandArgs) override;
 
 protected:

--- a/vnext/include/ReactUWP/Views/ControlViewManager.h
+++ b/vnext/include/ReactUWP/Views/ControlViewManager.h
@@ -16,7 +16,7 @@ public:
   ControlViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
 
   folly::dynamic GetNativeProps() const override;
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 };
 
 } }

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -14,7 +14,7 @@ public:
   FrameworkElementViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
 
   folly::dynamic GetNativeProps() const override;
-  void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap) override;
+  void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap) override;
 
 protected:
   virtual void TransferProperties(XamlView oldView, XamlView newView) override;

--- a/vnext/include/ReactUWP/Views/ViewManagerBase.h
+++ b/vnext/include/ReactUWP/Views/ViewManagerBase.h
@@ -57,7 +57,7 @@ public:
   virtual void RemoveChildAt(XamlView parent, int64_t index);
   virtual void ReplaceChild(XamlView parent, XamlView oldChild, XamlView newChild);
 
-  virtual void UpdateProperties(ShadowNodeBase* nodeToUpdate, folly::dynamic reactDiffMap);
+  virtual void UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap);
 
   virtual void DispatchCommand(XamlView viewToUpdate, int64_t commandId, const folly::dynamic& commandArgs);
 


### PR DESCRIPTION
A handful of perf improvements mostly looking at reducing frequency of allocations

1. add shortcut like other platforms to not call SetLayoutProps on every element after DoLayout, only the things that changed
2. reduce cases of dynamic.asFoo to getFoo when we already checked the type, reduce asString() which returns a copy
3. in UpdateProperties() pass dynamic as const ref instead of copy (exported interface change)
4. Make code consistent that iterates the diff of property updates
> every place that looks are property name now does so as a string instead of many that did dynamic == "", which ends up creating a new dynamic and copies the string every time.

A second round will follow but this accumulated a lot of change already

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2495)