### PR TITLE
Verify nuget can be packed during PR

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -40,6 +40,13 @@ jobs:
           script: node ../.ado/updateVersion.js
           workingDirectory: vnext
 
+      # since the above task will update the package.json, we want to ensure that we use the correct version for the nuget
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish updated package.json for nuget'
+        inputs:
+          PathtoPublish: 'vnext\package.json'
+          ArtifactName: 'UpdatedPackageJson'
+
       - task: Npm@1
         displayName: npm public publish (vnext)
         inputs:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -113,6 +113,12 @@ jobs:
     steps:
       - checkout: none #skip checking out the default repository resource
 
+      - task: DownloadBuildArtifacts@0
+        displayName: 'Download source Artifact'
+        inputs:
+          artifactName: UpdatedPackageJson
+          downloadPath: $(System.DefaultWorkingDirectory)
+
       - template: templates/prep-and-pack-nuget.yml
 
       - task: NuGetCommand@2

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -32,7 +32,7 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - template: npm-install-and-build.yml
+      - template: templates/npm-install-and-build.yml
 
       - task: CmdLine@2
         displayName: Update package version
@@ -82,7 +82,7 @@ jobs:
 
     steps:
 
-    - template: npm-install-and-build.yml
+    - template: templates/npm-install-and-build.yml
 
     - template: templates/vs-build.yml
       parameters:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -32,24 +32,7 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      # The Hosted 2019 pool machines look like they already have this, so it wouldn't be needed..
-      - task: CmdLine@2
-        displayName: Ensure yarn
-        inputs:
-          script: npm install -g yarn
-          workingDirectory: vnext
-
-      - task: CmdLine@2
-        displayName: yarn install
-        inputs:
-          script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd install --frozen-lockfile
-          workingDirectory: vnext
-
-      - task: CmdLine@2
-        displayName: yarn build
-        inputs:
-          script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd build
-          workingDirectory: vnext
+      - template: npm-install-and-build.yml
 
       - task: CmdLine@2
         displayName: Update package version
@@ -99,158 +82,14 @@ jobs:
 
     steps:
 
-    - task: NuGetCommand@2
-      displayName: NuGet restore - ReactWindows
-      inputs:
-        command: restore
-        restoreSolution: vnext/ReactWindows.sln
-        feedsToUse: config
-        #vstsFeed: # Required when feedsToUse == Select
-        #includeNuGetOrg: true # Required when feedsToUse == Select
-        nugetConfigPath: vnext/NuGet.config
-        #externalFeedCredentials: # Optional
-        #noCache: false
-        #disableParallelProcessing: false
-        restoreDirectory: packages/
-        verbosityRestore: Detailed # Options: quiet, normal, detailed
-        #packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg' # Required when command == Push
-        #nuGetFeedType: 'internal' # Required when command == Push# Options: internal, external
-        #publishVstsFeed: # Required when command == Push && NuGetFeedType == Internal
-        #publishPackageMetadata: true # Optional
-        #allowPackageConflicts: # Optional
-        #publishFeedCredentials: # Required when command == Push && NuGetFeedType == External
-        #verbosityPush: 'Detailed' # Options: quiet, normal, detailed
-        #packagesToPack: '**/*.csproj' # Required when command == Pack
-        #configuration: '$(BuildConfiguration)' # Optional
-        #packDestination: '$(Build.ArtifactStagingDirectory)' # Optional
-        #versioningScheme: 'off' # Options: off, byPrereleaseNumber, byEnvVar, byBuildNumber
-        #includeReferencedProjects: false # Optional
-        #versionEnvVar: # Required when versioningScheme == ByEnvVar
-        #majorVersion: '1' # Required when versioningScheme == ByPrereleaseNumber
-        #minorVersion: '0' # Required when versioningScheme == ByPrereleaseNumber
-        #patchVersion: '0' # Required when versioningScheme == ByPrereleaseNumber
-        #packTimezone: 'utc' # Required when versioningScheme == ByPrereleaseNumber# Options: utc, local
-        #includeSymbols: false # Optional
-        #toolPackage: # Optional
-        #buildProperties: # Optional
-        #basePath: # Optional
-        #verbosityPack: 'Detailed' # Options: quiet, normal, detailed
-        #arguments: # Required when command == Custom
+    - template: npm-install-and-build.yml
 
-    # The Hosted 2019 pool machines look like they already have this, so it wouldn't be needed..
-    - task: CmdLine@2
-      displayName: Ensure yarn
-      inputs:
-        script: npm install -g yarn
-        workingDirectory: vnext
+    - template: templates/vs-build.yml
+      parameters:
+        BuildConfiguration: $(BuildConfiguration)
+        BuildPlatform: $(BuildPlatform)
 
-    - task: CmdLine@2
-      displayName: yarn install
-      inputs:
-        script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd install --frozen-lockfile
-        workingDirectory: vnext
-
-    - task: CmdLine@2
-      displayName: yarn build
-      inputs:
-        script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd build
-        workingDirectory: vnext
-
-    - task: MSBuild@1
-      displayName: MSBuild - ReactWindows
-      inputs:
-        solution: vnext/ReactWindows.sln
-        #msbuildLocationMethod: 'version' # Optional. Options: version, location
-        msbuildVersion: '15.0' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-        msbuildArchitecture: 'x64' # Optional. Options: x86, x64
-        #msbuildLocation: # Optional
-        platform: $(BuildPlatform) # Optional
-        configuration: $(BuildConfiguration) # Optional
-        msbuildArguments: '/p:PreferredToolArchitecture=x64' # Optional
-        clean: true # Optional
-        #maximumCpuCount: false # Optional
-        #restoreNugetPackages: false # Optional
-        #logProjectEvents: false # Optional
-        #createLogFile: false # Optional
-        #logFileVerbosity: 'normal' # Optional. Options: quiet, minimal, normal, detailed, diagnostic
-
-    - task: BatchScript@1
-      displayName: 'Copy Nuget source files'
-      inputs:
-        filename: 'vnext\ReactWindows-CopyToStaging2.bat'
-        arguments: '$(build.artifactstagingdirectory)'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
-
-    - task: PowerShell@2
-      displayName: 'Stage Sources'
-      inputs:
-        targetType: filePath
-        filePath: 'vnext\Scripts\Tfs\Layout-Headers.ps1'
-        arguments: '-TargetRoot $(Build.ArtifactStagingDirectory)'
-      enabled: false
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: debug arm'
-      inputs:
-        PathtoPublish: 'vnext\target\ARM\Debug'
-        ArtifactName: 'ReactWindows-debug-arm'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'arm'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: ship arm'
-      inputs:
-        PathtoPublish: 'vnext\target\ARM\Release'
-        ArtifactName: 'ReactWindows-ship-arm'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq(variables['BuildPlatform'], 'arm'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts debug x86'
-      inputs:
-        PathtoPublish: 'vnext\target\x86\Debug'
-        ArtifactName: 'ReactWindows-debug-x86'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts ship x86'
-      inputs:
-        PathtoPublish: 'vnext\target\x86\Release'
-        ArtifactName: 'ReactWindows-ship-x86'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq(variables['BuildPlatform'], 'x86'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts debug x64'
-      inputs:
-        PathtoPublish: 'vnext\target\x64\debug'
-        ArtifactName: 'ReactWindows-debug-x64'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x64'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts ship x64'
-      inputs:
-        PathtoPublish: 'vnext\target\x64\Release'
-        ArtifactName: 'ReactWindows-ship-x64'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq(variables['BuildPlatform'], 'x64'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts - Nuget Source files'
-      inputs:
-        PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: 'ReactWindows-source'
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Build Artifacts'
-      inputs:
-        PathtoPublish: 'vnext\ReactWindows\target'
-        ArtifactName: ReactWindows
-      enabled: false
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Sources'
-      inputs:
-        ArtifactName: ReactWindows
-      enabled: false
-      condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
+    - template: templates/publish-build-artifacts-for-nuget.yml
 
     - task: PublishSymbols@2
       displayName: 'Publish symbols path'
@@ -266,88 +105,9 @@ jobs:
       name: OE Standard Pool
     steps:
       - checkout: none #skip checking out the default repository resource
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download debug arm Artifact'
-        inputs:
-          artifactName: ReactWindows-debug-arm
-          downloadPath: $(System.DefaultWorkingDirectory)
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download ship arm Artifact'
-        inputs:
-          artifactName: ReactWindows-ship-arm
-          downloadPath: $(System.DefaultWorkingDirectory)
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download debug x86 Artifact'
-        inputs:
-          artifactName: ReactWindows-debug-x86
-          downloadPath: $(System.DefaultWorkingDirectory)
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download ship x86 Artifact'
-        inputs:
-          artifactName: ReactWindows-ship-x86
-          downloadPath: $(System.DefaultWorkingDirectory)
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download debug x64 Artifact'
-        inputs:
-          artifactName: ReactWindows-debug-x64
-          downloadPath: $(System.DefaultWorkingDirectory)
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download ship x64 Artifact'
-        inputs:
-          artifactName: ReactWindows-ship-x64
-          downloadPath: $(System.DefaultWorkingDirectory)
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download source Artifact'
-        inputs:
-          artifactName: ReactWindows-source
-          downloadPath: $(System.DefaultWorkingDirectory)
 
-      - task: CopyFiles@2
-        displayName: 'Copy Win32 debug x64 files'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-debug-x64'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x64/Debug'
-      - task: CopyFiles@2
-        displayName: 'Copy Win32 debug x86 files'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-debug-x86'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x86/Debug'
-      - task: CopyFiles@2
-        displayName: 'Copy Win32 ship x64 files'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-ship-x64'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x64/ship'
-      - task: CopyFiles@2
-        displayName: 'Copy Win32 ship x86 files'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-ship-x86'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x86/ship'
-      - task: CopyFiles@2
-        displayName: 'Copy arm debug'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-debug-arm'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/arm/debug'
-      - task: CopyFiles@2
-        displayName: 'Copy arm ship'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-ship-arm'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/arm/ship'
-      - task: CopyFiles@2
-        displayName: 'Copy Nuget source files'
-        inputs:
-          SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-source'
-          TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot'
-      - task: colinsalmcorner.colinsalmcorner-buildtasks.replace-tokens-task.ReplaceTokens@1
-        displayName: 'Replace branch name in nuspec'
-        inputs:
-          filePattern: '$(System.DefaultWorkingDirectory)/NugetRoot/ReactWin32.nuspec'
-          secretTokens: 'BuildBuildNumber:$(Build.BuildNumber)'
-      - task: NuGetCommand@2
-        displayName: 'NuGet pack'
-        inputs:
-          command: pack
-          packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/ReactWin32.nuspec'
-          packDestination: '$(System.DefaultWorkingDirectory)/NugetRoot/'
+      - template: templates/prep-and-pack-nuget.yml
+
       - task: NuGetCommand@2
         displayName: 'NuGet push'
         inputs:

--- a/.ado/templates/npm-install-and-build.yml
+++ b/.ado/templates/npm-install-and-build.yml
@@ -1,0 +1,21 @@
+steps:
+  # The Hosted 2019 pool machines look like they already have this, so it wouldn't be needed..
+  - task: CmdLine@2
+    displayName: Ensure yarn
+    inputs:
+      script: npm install -g yarn
+      workingDirectory: vnext
+
+  - task: CmdLine@2
+    displayName: yarn install
+    inputs:
+      script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd install --frozen-lockfile
+      workingDirectory: vnext
+
+  - template: stop-packagers.yml
+
+  - task: CmdLine@2
+    displayName: yarn build
+    inputs:
+      script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd build
+      workingDirectory: vnext

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,0 +1,84 @@
+
+steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download debug arm Artifact'
+    inputs:
+      artifactName: ReactWindows-debug-arm
+      downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download ship arm Artifact'
+    inputs:
+      artifactName: ReactWindows-ship-arm
+      downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download debug x86 Artifact'
+    inputs:
+      artifactName: ReactWindows-debug-x86
+      downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download ship x86 Artifact'
+    inputs:
+      artifactName: ReactWindows-ship-x86
+      downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download debug x64 Artifact'
+    inputs:
+      artifactName: ReactWindows-debug-x64
+      downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download ship x64 Artifact'
+    inputs:
+      artifactName: ReactWindows-ship-x64
+      downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download source Artifact'
+    inputs:
+      artifactName: ReactWindows-source
+      downloadPath: $(System.DefaultWorkingDirectory)
+
+  - task: CopyFiles@2
+    displayName: 'Copy Win32 debug x64 files'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-debug-x64'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x64/Debug'
+  - task: CopyFiles@2
+    displayName: 'Copy Win32 debug x86 files'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-debug-x86'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x86/Debug'
+  - task: CopyFiles@2
+    displayName: 'Copy Win32 ship x64 files'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-ship-x64'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x64/ship'
+  - task: CopyFiles@2
+    displayName: 'Copy Win32 ship x86 files'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-ship-x86'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/x86/ship'
+  - task: CopyFiles@2
+    displayName: 'Copy arm debug'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-debug-arm'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/arm/debug'
+  - task: CopyFiles@2
+    displayName: 'Copy arm ship'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-ship-arm'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot/target/arm/ship'
+  - task: CopyFiles@2
+    displayName: 'Copy Nuget source files'
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-source'
+      TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot'
+  - task: colinsalmcorner.colinsalmcorner-buildtasks.replace-tokens-task.ReplaceTokens@1
+    displayName: 'Replace branch name in nuspec'
+    inputs:
+      filePattern: '$(System.DefaultWorkingDirectory)/NugetRoot/ReactWin32.nuspec'
+      secretTokens: 'BuildBuildNumber:$(Build.BuildNumber)'
+  - task: NuGetCommand@2
+    displayName: 'NuGet pack'
+    inputs:
+      command: pack
+      packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/ReactWin32.nuspec'
+      packDestination: '$(System.DefaultWorkingDirectory)/NugetRoot/'

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -35,11 +35,6 @@ steps:
     inputs:
       artifactName: ReactWindows-source
       downloadPath: $(System.DefaultWorkingDirectory)
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download source Artifact'
-    inputs:
-      artifactName: UpdatedPackageJson
-      downloadPath: $(System.DefaultWorkingDirectory)
 
   - task: CopyFiles@2
     displayName: 'Copy Win32 debug x64 files'
@@ -81,7 +76,12 @@ steps:
     inputs:
       targetType: inline # filePath | inline
       script: |
-        $lines = Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/UpdatedPackageJson/package.json | Where {$_ -match '^\s*"version":.*'} 
+        if (Test-Path $env:SYSTEM_DEFAULTWORKINGDIRECTORY/UpdatedPackageJson/package.json) {
+          $lines = Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/UpdatedPackageJson/package.json | Where {$_ -match '^\s*"version":.*'} 
+          $npmVersion = $lines.Trim().Split()[1].Trim('",');
+        } else {
+          $npmVersion = "0.0.1-pr"
+        }
         (Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec
   - task: NuGetCommand@2
     displayName: 'NuGet pack'

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -78,7 +78,7 @@ steps:
       script: |
         $npmVersion = $env:npmPackageVersion
         if (!$npmVersion) {
-          $lines = Get-Content ($env:SYSTEM_DEFAULTWORKINGDIRECTORY) + / vnext/package.json | Where {$_ -match '^\s*"version":.*'} 
+          $lines = Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/vnext/package.json | Where {$_ -match '^\s*"version":.*'} 
           $npmVersion = $lines.Trim().Split()[1].Trim('",');
         }
         (Get-Content vnext/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactWin32.nuspec

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -78,7 +78,7 @@ steps:
       script: |
         $npmVersion = $env:npmPackageVersion
         if (!$npmVersion) {
-          $lines = Get-Content ($env:System.DefaultWorkingDirectory) + / vnext/package.json | Where {$_ -match '^\s*"version":.*'} 
+          $lines = Get-Content ($env:SYSTEM_DEFAULTWORKINGDIRECTORY) + / vnext/package.json | Where {$_ -match '^\s*"version":.*'} 
           $npmVersion = $lines.Trim().Split()[1].Trim('",');
         }
         (Get-Content vnext/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactWin32.nuspec

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -35,6 +35,11 @@ steps:
     inputs:
       artifactName: ReactWindows-source
       downloadPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download source Artifact'
+    inputs:
+      artifactName: UpdatedPackageJson
+      downloadPath: $(System.DefaultWorkingDirectory)
 
   - task: CopyFiles@2
     displayName: 'Copy Win32 debug x64 files'
@@ -76,12 +81,8 @@ steps:
     inputs:
       targetType: inline # filePath | inline
       script: |
-        $npmVersion = $env:npmPackageVersion
-        if (!$npmVersion) {
-          $lines = Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/vnext/package.json | Where {$_ -match '^\s*"version":.*'} 
-          $npmVersion = $lines.Trim().Split()[1].Trim('",');
-        }
-        (Get-Content vnext/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactWin32.nuspec
+        $lines = Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/UpdatedPackageJson/package.json | Where {$_ -match '^\s*"version":.*'} 
+        (Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec
   - task: NuGetCommand@2
     displayName: 'NuGet pack'
     inputs:

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -71,11 +71,17 @@ steps:
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)/ReactWindows-source'
       TargetFolder: '$(System.DefaultWorkingDirectory)/NugetRoot'
-  - task: colinsalmcorner.colinsalmcorner-buildtasks.replace-tokens-task.ReplaceTokens@1
-    displayName: 'Replace branch name in nuspec'
+  - task: PowerShell@2
+    displayName: Extract version from package.json, and put it in nuspec
     inputs:
-      filePattern: '$(System.DefaultWorkingDirectory)/NugetRoot/ReactWin32.nuspec'
-      secretTokens: 'BuildBuildNumber:$(Build.BuildNumber)'
+      targetType: inline # filePath | inline
+      script: |
+        $npmVersion = $env:npmPackageVersion
+        if (!$npmVersion) {
+          $lines = Get-Content ($env:System.DefaultWorkingDirectory) + / vnext/package.json | Where {$_ -match '^\s*"version":.*'} 
+          $npmVersion = $lines.Trim().Split()[1].Trim('",');
+        }
+        (Get-Content vnext/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactWin32.nuspec
   - task: NuGetCommand@2
     displayName: 'NuGet pack'
     inputs:

--- a/.ado/templates/publish-build-artifacts-for-nuget.yml
+++ b/.ado/templates/publish-build-artifacts-for-nuget.yml
@@ -1,0 +1,80 @@
+
+steps:
+
+  - task: BatchScript@1
+    displayName: 'Copy Nuget source files'
+    inputs:
+      filename: 'vnext\ReactWindows-CopyToStaging2.bat'
+      arguments: '$(build.artifactstagingdirectory)'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
+
+  - task: PowerShell@2
+    displayName: 'Stage Sources'
+    inputs:
+      targetType: filePath
+      filePath: 'vnext\Scripts\Tfs\Layout-Headers.ps1'
+      arguments: '-TargetRoot $(Build.ArtifactStagingDirectory)'
+    enabled: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: debug arm'
+    inputs:
+      PathtoPublish: 'vnext\target\ARM\Debug'
+      ArtifactName: 'ReactWindows-debug-arm'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'arm'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: ship arm'
+    inputs:
+      PathtoPublish: 'vnext\target\ARM\Release'
+      ArtifactName: 'ReactWindows-ship-arm'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq(variables['BuildPlatform'], 'arm'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifacts debug x86'
+    inputs:
+      PathtoPublish: 'vnext\target\x86\Debug'
+      ArtifactName: 'ReactWindows-debug-x86'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifacts ship x86'
+    inputs:
+      PathtoPublish: 'vnext\target\x86\Release'
+      ArtifactName: 'ReactWindows-ship-x86'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq(variables['BuildPlatform'], 'x86'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifacts debug x64'
+    inputs:
+      PathtoPublish: 'vnext\target\x64\debug'
+      ArtifactName: 'ReactWindows-debug-x64'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x64'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifacts ship x64'
+    inputs:
+      PathtoPublish: 'vnext\target\x64\Release'
+      ArtifactName: 'ReactWindows-ship-x64'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq(variables['BuildPlatform'], 'x64'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifacts - Nuget Source files'
+    inputs:
+      PathtoPublish: '$(build.artifactstagingdirectory)'
+      ArtifactName: 'ReactWindows-source'
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Build Artifacts'
+    inputs:
+      PathtoPublish: 'vnext\ReactWindows\target'
+      ArtifactName: ReactWindows
+    enabled: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Sources'
+    inputs:
+      ArtifactName: ReactWindows
+    enabled: false
+    condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x86'))

--- a/.ado/templates/stop-packagers.yml
+++ b/.ado/templates/stop-packagers.yml
@@ -1,0 +1,11 @@
+steps:
+  - task: PowerShell@2
+    displayName: Cleanup any packagers left over from other builds
+    inputs:
+      targetType: inline # filePath | inline
+      script: |
+        echo "ports:{"
+        echo ${env:RNTester.PackagerPort}
+        echo "}"
+        Get-NetTCPConnection -LocalPort 8081 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
+        Get-NetTCPConnection -LocalPort 5555 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }

--- a/.ado/templates/vs-build.yml
+++ b/.ado/templates/vs-build.yml
@@ -1,0 +1,63 @@
+parameters:
+  BuildConfiguration: ''
+  BuildPlatform: ''
+
+steps:
+
+  - template: stop-packagers.yml
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore - ReactWindows
+    inputs:
+      command: restore
+      restoreSolution: vnext/ReactWindows.sln
+      feedsToUse: config
+      #vstsFeed: # Required when feedsToUse == Select
+      #includeNuGetOrg: true # Required when feedsToUse == Select
+      nugetConfigPath: vnext/NuGet.config
+      #externalFeedCredentials: # Optional
+      #noCache: false
+      #disableParallelProcessing: false
+      restoreDirectory: packages/
+      verbosityRestore: Detailed # Options: quiet, normal, detailed
+      #packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg' # Required when command == Push
+      #nuGetFeedType: 'internal' # Required when command == Push# Options: internal, external
+      #publishVstsFeed: # Required when command == Push && NuGetFeedType == Internal
+      #publishPackageMetadata: true # Optional
+      #allowPackageConflicts: # Optional
+      #publishFeedCredentials: # Required when command == Push && NuGetFeedType == External
+      #verbosityPush: 'Detailed' # Options: quiet, normal, detailed
+      #packagesToPack: '**/*.csproj' # Required when command == Pack
+      #configuration: '$(BuildConfiguration)' # Optional
+      #packDestination: '$(Build.ArtifactStagingDirectory)' # Optional
+      #versioningScheme: 'off' # Options: off, byPrereleaseNumber, byEnvVar, byBuildNumber
+      #includeReferencedProjects: false # Optional
+      #versionEnvVar: # Required when versioningScheme == ByEnvVar
+      #majorVersion: '1' # Required when versioningScheme == ByPrereleaseNumber
+      #minorVersion: '0' # Required when versioningScheme == ByPrereleaseNumber
+      #patchVersion: '0' # Required when versioningScheme == ByPrereleaseNumber
+      #packTimezone: 'utc' # Required when versioningScheme == ByPrereleaseNumber# Options: utc, local
+      #includeSymbols: false # Optional
+      #toolPackage: # Optional
+      #buildProperties: # Optional
+      #basePath: # Optional
+      #verbosityPack: 'Detailed' # Options: quiet, normal, detailed
+      #arguments: # Required when command == Custom
+
+  - task: MSBuild@1
+    displayName: MSBuild - ReactWindows
+    inputs:
+      solution: vnext/ReactWindows.sln
+      #msbuildLocationMethod: 'version' # Optional. Options: version, location
+      msbuildVersion: '15.0' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+      msbuildArchitecture: 'x64' # Optional. Options: x86, x64
+      #msbuildLocation: # Optional
+      platform: ${{ parameters.BuildPlatform }} # Optional
+      configuration:  ${{ parameters.BuildConfiguration }}  # Optional
+      msbuildArguments: '/p:PreferredToolArchitecture=x64' # Optional
+      clean: true # Optional
+      #maximumCpuCount: false # Optional
+      #restoreNugetPackages: false # Optional
+      #logProjectEvents: false # Optional
+      #createLogFile: false # Optional
+      #logFileVerbosity: 'normal' # Optional. Options: quiet, minimal, normal, detailed, diagnostic

--- a/.ado/updateVersion.js
+++ b/.ado/updateVersion.js
@@ -58,6 +58,7 @@ function updateVersion() {
     }
   }
 
+  console.log(`##vso[task.setvariable variable=npmPublishVersion]${releaseVersion}`);
   pkgJson.version = releaseVersion;
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
   console.log(`Updating package.json to version ${releaseVersion}`);

--- a/.ado/updateVersion.js
+++ b/.ado/updateVersion.js
@@ -58,7 +58,6 @@ function updateVersion() {
     }
   }
 
-  console.log(`##vso[task.setvariable variable=npmPublishVersion]${releaseVersion}`);
   pkgJson.version = releaseVersion;
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
   console.log(`Updating package.json to version ${releaseVersion}`);

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -41,7 +41,7 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - template: npm-install-and-build.yml
+      - template: templates/npm-install-and-build.yml
 
       - task: NuGetCommand@2
         displayName: NuGet restore - ReactWindows-UWP
@@ -132,7 +132,7 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - template: npm-install-and-build.yml
+      - template: templates/npm-install-and-build.yml
 
       - template: templates/vs-build.yml
         parameters:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -141,6 +141,7 @@ jobs:
 
       - task: VSTest@2
         displayName: Run Desktop Unit Tests
+        timeoutInMinutes: 10 # Set smaller timeout for UTs, since there have been some hangs, and this allows the job to timeout quicker
         condition: and(succeeded(), ne(variables['BuildPlatform'], 'ARM'))
         inputs:
           testSelector: 'testAssemblies' # Options: testAssemblies, testPlan, testRun

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -41,24 +41,7 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      # The Hosted 2019 pool machines look like they already have this, so it wouldn't be needed..
-      - task: CmdLine@2
-        displayName: Ensure yarn
-        inputs:
-          script: npm install -g yarn
-          workingDirectory: vnext
-
-      - task: CmdLine@2
-        displayName: yarn install
-        inputs:
-          script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd install --frozen-lockfile
-          workingDirectory: vnext
-
-      - task: CmdLine@2
-        displayName: yarn build
-        inputs:
-          script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd build
-          workingDirectory: vnext
+      - template: npm-install-and-build.yml
 
       - task: NuGetCommand@2
         displayName: NuGet restore - ReactWindows-UWP
@@ -114,7 +97,7 @@ jobs:
           script: del SampleApp.uwp.bundle
           workingDirectory: vnext
 
-  - job: WindowsVSPR
+  - job: RnwNativePRBuild
     displayName: Windows Visual Studio with Win32 PR
     strategy:
       matrix:
@@ -149,102 +132,12 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: PowerShell@2
-        displayName: Cleanup any packagers left over from other builds
-        inputs:
-          targetType: inline # filePath | inline
-          script: |
-            echo "ports:{"
-            echo ${env:RNTester.PackagerPort}
-            echo "}"
-            Get-NetTCPConnection -LocalPort 8081 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
-            Get-NetTCPConnection -LocalPort 5555 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
+      - template: npm-install-and-build.yml
 
-      # The Hosted 2019 pool machines look like they already have this, so it wouldn't be needed..
-      - task: CmdLine@2
-        displayName: Ensure yarn
-        inputs:
-          script: npm install -g yarn
-          workingDirectory: vnext
-
-      - task: CmdLine@2
-        displayName: yarn install
-        inputs:
-          script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd install --frozen-lockfile
-          workingDirectory: vnext
-
-      - task: PowerShell@2
-        displayName: Cleanup any packagers left over from other builds
-        inputs:
-          targetType: inline # filePath | inline
-          script: |
-            echo "ports:{"
-            echo ${env:RNTester.PackagerPort}
-            echo "}"
-            Get-NetTCPConnection -LocalPort 8081 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
-            Get-NetTCPConnection -LocalPort 5555 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
-
-      - task: CmdLine@2
-        displayName: yarn build
-        inputs:
-          script: $(APPDATA)\npm\node_modules\yarn\bin\yarn.cmd build
-          workingDirectory: vnext
-
-      - task: NuGetCommand@2
-        displayName: NuGet restore - ReactWindows
-        inputs:
-          command: restore
-          restoreSolution: vnext/ReactWindows.sln
-          feedsToUse: config
-          #vstsFeed: # Required when feedsToUse == Select
-          #includeNuGetOrg: true # Required when feedsToUse == Select
-          nugetConfigPath: vnext/NuGet.config
-          #externalFeedCredentials: # Optional
-          #noCache: false
-          #disableParallelProcessing: false
-          restoreDirectory: packages/
-          verbosityRestore: Detailed # Options: quiet, normal, detailed
-          #packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg' # Required when command == Push
-          #nuGetFeedType: 'internal' # Required when command == Push# Options: internal, external
-          #publishVstsFeed: # Required when command == Push && NuGetFeedType == Internal
-          #publishPackageMetadata: true # Optional
-          #allowPackageConflicts: # Optional
-          #publishFeedCredentials: # Required when command == Push && NuGetFeedType == External
-          #verbosityPush: 'Detailed' # Options: quiet, normal, detailed
-          #packagesToPack: '**/*.csproj' # Required when command == Pack
-          #configuration: '$(BuildConfiguration)' # Optional
-          #packDestination: '$(Build.ArtifactStagingDirectory)' # Optional
-          #versioningScheme: 'off' # Options: off, byPrereleaseNumber, byEnvVar, byBuildNumber
-          #includeReferencedProjects: false # Optional
-          #versionEnvVar: # Required when versioningScheme == ByEnvVar
-          #majorVersion: '1' # Required when versioningScheme == ByPrereleaseNumber
-          #minorVersion: '0' # Required when versioningScheme == ByPrereleaseNumber
-          #patchVersion: '0' # Required when versioningScheme == ByPrereleaseNumber
-          #packTimezone: 'utc' # Required when versioningScheme == ByPrereleaseNumber# Options: utc, local
-          #includeSymbols: false # Optional
-          #toolPackage: # Optional
-          #buildProperties: # Optional
-          #basePath: # Optional
-          #verbosityPack: 'Detailed' # Options: quiet, normal, detailed
-          #arguments: # Required when command == Custom
-
-      - task: MSBuild@1
-        displayName: MSBuild - ReactWindows
-        inputs:
-          solution: vnext/ReactWindows.sln
-          #msbuildLocationMethod: 'version' # Optional. Options: version, location
-          msbuildVersion: '15.0' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-          msbuildArchitecture: 'x64' # Optional. Options: x86, x64
-          #msbuildLocation: # Optional
-          platform: $(BuildPlatform) # Optional
-          configuration: $(BuildConfiguration) # Optional
-          msbuildArguments: '/p:PreferredToolArchitecture=x64' # Optional
-          clean: true # Optional
-          #maximumCpuCount: false # Optional
-          #restoreNugetPackages: false # Optional
-          #logProjectEvents: false # Optional
-          #createLogFile: false # Optional
-          #logFileVerbosity: 'normal' # Optional. Options: quiet, minimal, normal, detailed, diagnostic
+      - template: templates/vs-build.yml
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildPlatform: $(BuildPlatform)
 
       - task: VSTest@2
         displayName: Run Desktop Unit Tests
@@ -340,14 +233,18 @@ jobs:
           #rerunFailedTestCasesMaxLimit: '5' # Optional
           #rerunMaxAttempts: '3' # Optional
 
-      - task: PowerShell@2
-        displayName: Cleanup any packagers left over from other builds
-        condition: and(always(), ne(variables['BuildPlatform'], 'ARM'))
-        inputs:
-          targetType: inline # filePath | inline
-          script: |
-            echo "ports:{"
-            echo ${env:RNTester.PackagerPort}
-            echo "}"
-            Get-NetTCPConnection -LocalPort 8081 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
-            Get-NetTCPConnection -LocalPort 5555 -ErrorAction Ignore | ForEach-Object { Stop-Process $_.OwningProcess -ErrorAction Ignore }
+
+      - template: templates/stop-packagers.yml
+
+      - template: templates/publish-build-artifacts-for-nuget.yml
+
+
+  - job: RNWNugetPR
+    dependsOn: RnwNativePRBuild
+    displayName: React-Native-Windows Build and Pack Nuget
+    pool:
+      name: OE Standard Pool
+    steps:
+      - checkout: none #skip checking out the default repository resource
+
+      - template: templates/prep-and-pack-nuget.yml


### PR DESCRIPTION
We've been hitting a bunch of breaks lately where the nuget cannot be build, but we dont find out until the change is checked in and the publish build fails.

This will add validation to PRs to verify that the nuget can be packed.  This also cleans up a bunch of the duplication within the build tasks by moving various logic to shared build templates.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2498)