### PR TITLE
fix for running in web debugging mode

### DIFF
--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -422,7 +422,7 @@ InstanceImpl::InstanceImpl(std::string&& jsBundleBasePath,
     m_moduleRegistry);
 
   // All JSI runtimes do support host objects and hence the native modules proxy.
-  const bool isNativeModulesProxyAvailable = m_devSettings->jsiRuntimeHolder != nullptr;
+  const bool isNativeModulesProxyAvailable = m_devSettings->jsiRuntimeHolder != nullptr && !m_devSettings->useWebDebugger;
   if (!isNativeModulesProxyAvailable)
   {
     folly::dynamic configArray = folly::dynamic::array;


### PR DESCRIPTION
set native module info when using web debugging.

alternatively we should suppress creating the jsiRuntimeHolder when web debugging (in uwpreactinstance)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2500)