### PR TITLE
JSI compat fixes

### DIFF
--- a/vnext/ReactUWP/Polyester/IconViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/IconViewManager.cpp
@@ -70,7 +70,7 @@ void IconViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
 
     if (propertyName == "color")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         glyphs.Fill(BrushFrom(propertyValue));
 #if FUTURE
       else if (propertyValue.isNull())

--- a/vnext/ReactUWP/Views/DatePickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/DatePickerViewManager.cpp
@@ -92,14 +92,14 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "firstDayOfWeek")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         datePicker.FirstDayOfWeek(static_cast<winrt::DayOfWeek>(propertyValue.asInt()));
       else if (propertyValue.isNull())
         datePicker.ClearValue(winrt::CalendarDatePicker::FirstDayOfWeekProperty());
     }
     else if (propertyName == "maxDate")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
       {
         m_maxTime = propertyValue.asInt();
         updateMaxDate = true;
@@ -111,7 +111,7 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "minDate")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
       {
         m_minTime = propertyValue.asInt();
         updateMinDate = true;
@@ -130,7 +130,7 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "selectedDate")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
       {
         m_selectedTime = propertyValue.asInt();
         updateSelectedDate = true;
@@ -142,7 +142,7 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "timeZoneOffsetInSeconds")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         m_timeZoneOffsetInSeconds = propertyValue.asInt();
       else if (propertyValue.isNull())
         m_timeZoneOffsetInSeconds = 0;

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -198,7 +198,7 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "target")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
       {
         m_targetTag = propertyValue.asInt();
         updateTargetElement = true;

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -95,7 +95,7 @@ void PopupShadowNode::updateProperties(const folly::dynamic&& props)
 
     if (propertyName == "target")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         m_targetTag = propertyValue.asInt();
       else
         m_targetTag = -1;
@@ -116,14 +116,14 @@ void PopupShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "horizontalOffset")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         popup.HorizontalOffset(propertyValue.asDouble());
       else if (propertyValue.isNull())
         popup.ClearValue(winrt::Popup::HorizontalOffsetProperty());
     }
     else if (propertyName == "verticalOffset")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         popup.VerticalOffset(propertyValue.asDouble());
       else if (propertyValue.isNull())
         popup.ClearValue(winrt::Popup::VerticalOffsetProperty());

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -243,7 +243,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "maxLength")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         textBox.MaxLength(static_cast<int32_t>(propertyValue.asInt()));
       else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::MaxLengthProperty());
@@ -259,7 +259,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic&& props)
     {
       if (textBox.try_as<winrt::ITextBlock6>())
       {
-        if (propertyValue.isInt())
+        if (propertyValue.isNumber())
           textBox.PlaceholderForeground(SolidColorBrushFrom(propertyValue));
         else if (propertyValue.isNull())
           textBox.ClearValue(winrt::TextBox::PlaceholderForegroundProperty());
@@ -286,7 +286,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic&& props)
     }
     else if (propertyName == "selectionColor")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         textBox.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
       else if (propertyValue.isNull())
         textBox.ClearValue(winrt::TextBox::SelectionHighlightColorProperty());

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -95,7 +95,7 @@ void TextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
     else if (propertyName == "numberOfLines")
     {
       if (propertyValue.isNumber())
-        textBlock.MaxLines(static_cast<int32_t>(propertyValue.getInt()));
+        textBlock.MaxLines(static_cast<int32_t>(propertyValue.asInt()));
       else if (propertyValue.isNull())
         textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
     }

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -94,7 +94,7 @@ void TextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
     }
     else if (propertyName == "numberOfLines")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
         textBlock.MaxLines(static_cast<int32_t>(propertyValue.getInt()));
       else if (propertyValue.isNull())
         textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
@@ -122,7 +122,7 @@ void TextViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly
     }
     else if (propertyName == "selectionColor")
     {
-      if (propertyValue.isInt())
+      if (propertyValue.isNumber())
       {
         textBlock.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
       }

--- a/vnext/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
@@ -61,11 +61,11 @@ JSExceptionInfo ExceptionsManagerModule::CreateExceptionInfo(const folly::dynami
   // 1. an exception message string.
   // 2. an array containing stack information.
   // 3. an exceptionID int.
-  assert(args.type() == folly::dynamic::ARRAY);
+  assert(args.isArray());
   assert(args.size() == 3);
-  assert(args[0].type() == folly::dynamic::STRING);
-  assert(args[1].type() == folly::dynamic::ARRAY);
-  assert(args[2].type() == folly::dynamic::INT64);
+  assert(args[0].isString());
+  assert(args[1].isArray());
+  assert(args[2].isNumber());
   assert(facebook::xplat::jsArgAsInt(args, 2) <= std::numeric_limits<uint32_t>::max());
 
   JSExceptionInfo jsExceptionInfo;
@@ -81,7 +81,7 @@ JSExceptionInfo ExceptionsManagerModule::CreateExceptionInfo(const folly::dynami
   {
     // Each dynamic object is a map containing information about the stack frame:
     // method (string), arguments (array), filename(string), line number (int) and column number (int).
-    assert(stackFrame.type() == folly::dynamic::OBJECT);
+    assert(stackFrame.isObject());
     assert(stackFrame.size() >= 4); // 4 in 0.57, 5 in 0.58+ (arguments added)
 
     std::stringstream stackFrameInfo;
@@ -106,13 +106,13 @@ std::string ExceptionsManagerModule::RetrieveValueFromMap(const folly::dynamic &
   auto iterator = map.find(key);
   if (iterator != map.items().end())
   {
-    assert(iterator->second.type() == type);
     if (type == folly::dynamic::STRING)
     {
       value = iterator->second.asString();
     }
     else
     {
+      assert(iterator->second.isNumber());
       std::stringstream stream;
       stream << iterator->second.asInt();
       value = stream.str();

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -440,7 +440,17 @@ std::vector<facebook::xplat::module::CxxModule::Method> UIManagerModule::getMeth
 	{
 		Method("getConstantsForViewManager", [manager](dynamic argsJson) -> dynamic
 		{
-			auto args = folly::parseJson(argsJson.asString());
+      dynamic args;
+      if (argsJson.isString())
+      {
+        args = folly::parseJson(argsJson.asString());
+      }
+      else
+      {
+        // In JSI mode this is an array
+        assert(argsJson.isArray());
+        args = argsJson;
+      }
 			return manager->getConstantsForViewManager(jsArgAsString(args, 0));
 		}, SyncTag),
 		Method("removeRootView", [manager](dynamic args)


### PR DESCRIPTION
## isInt Fixes:
This fixes the ExceptionManagerModule that had a bunch of INT64 checks to allow any number.  With JSI nothing will be an int, everything numeric is a double.

Fixes all the remaining viewmanagers with isInt references, only minor one left checks both isint and isdouble.
Across the repo the only other isInt is in sandbox that someone in win32 should update and test.

## Also:
getConstantsForViewManager in non-jsi mode is called with a string that is an array with a string in it, e.g. "['Text']".  In JSI Mode it comes in as an array, added code to handle both cases.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2501)