### PR TITLE
add DirectDebugging option for uwp Chakra

### DIFF
--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -368,7 +368,10 @@ void ChakraExecutor::initOnJSVMThread()
   // Add a pointer to ourselves so we can retrieve it later in our hooks
   JsSetContextData(m_context, this);
 
-#if !defined(USE_EDGEMODE_JSRT)
+#if defined(USE_EDGEMODE_JSRT)
+  if (enableDebugging)
+    JsStartDebugging();
+#else
   if (enableDebugging && m_instanceArgs.DebuggerConsoleRedirection) {
     JsValueRef debuggerConsoleObject;
     tls_runtimeTracker.DebugProtocolHandler->GetConsoleObject(&debuggerConsoleObject);

--- a/vnext/Chakra/ChakraJsiRuntime.cpp
+++ b/vnext/Chakra/ChakraJsiRuntime.cpp
@@ -46,6 +46,11 @@ ChakraJsiRuntime::ChakraJsiRuntime(ChakraJsiRuntimeArgs&& args)  noexcept
   // Note :: We currently assume that the runtime will be created and exclusively used in a single thread.
   JsSetCurrentContext(m_ctx);
 
+#if defined(USE_EDGEMODE_JSRT)
+  if (args.enableDebugging)
+    JsStartDebugging();
+#endif
+
   setupNativePromiseContinuation();
 
   std::call_once(s_runtimeVersionInitFlag, initRuntimeVersion);

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -220,6 +220,7 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance>& spThis, cons
     auto devSettings(std::make_shared<facebook::react::DevSettings>());
     devSettings->debugBundlePath = settings.DebugBundlePath;
     devSettings->useWebDebugger = settings.UseWebDebugger;
+    devSettings->useDirectDebugger = settings.UseDirectDebugger;
     devSettings->loggingCallback = std::move(settings.LoggingCallback);
     devSettings->jsExceptionCallback = std::move(settings.JsExceptionCallback);
 

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -26,6 +26,7 @@ struct ReactInstanceSettings
 {
   bool UseWebDebugger { false };
   bool UseLiveReload { false };
+  bool UseDirectDebugger{ false };
   bool UseJsi { true };
   std::string DebugBundlePath;
   facebook::react::NativeLoggingHook LoggingCallback;


### PR DESCRIPTION
This change makes it possible to debug script when we're using inproc Chakra.  Once this flag is on, you can attach or start debugging with the full VisualStudio.  (haven't tried to see how VSCode would work yet)

I've had this locally for awhile, useful when web debugger behavior is different from inproc.

(this arg is forwarded from devSettings to chakra instance inside existing code for win32 in oinstance.cpp)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2504)