### PR TITLE
Update to react-native@0.58.6-microsoft.49

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -64,10 +64,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.48"
+    "react-native": "0.58.6-microsoft.49"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.48 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.48.tar.gz"
+    "react-native": "0.58.6-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.49.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.48.tar.gz":
-  version "0.58.6-microsoft.48"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.48.tar.gz#e12782a6e30999089f3a2159ffe2639cf1ff32d5"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.49.tar.gz":
+  version "0.58.6-microsoft.49"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.49.tar.gz#6cbe33001d92e7e8adf88155b83a02f41f3b611f"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
769569d42 Applying package update to 0.58.6-microsoft.49
4535e574e Update publish logic
c195fcacd Merge branch 'publish-temp-1558101878534'
7cce20ef0 Temp fix for comments crash (#68)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2507)