### PR TITLE
Update to react-native@0.58.6-microsoft.50

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -64,10 +64,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.49"
+    "react-native": "0.58.6-microsoft.50"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.49.tar.gz"
+    "react-native": "0.58.6-microsoft.50 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.50.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.49.tar.gz":
-  version "0.58.6-microsoft.49"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.49.tar.gz#6cbe33001d92e7e8adf88155b83a02f41f3b611f"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.50.tar.gz":
+  version "0.58.6-microsoft.50"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.50.tar.gz#e95889e7239f0847397116df0ab0f6c4a2c9ffbc"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
03149424e Applying package update to 0.58.6-microsoft.50
3a48fce10 Verify android nuget during pr (#72)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2508)