### PR TITLE
Create a separate uwp nuget

### DIFF
--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -83,9 +83,10 @@ steps:
           $npmVersion = "0.0.1-pr"
         }
         (Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec
+        (Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactUwp.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactUwp.nuspec
   - task: NuGetCommand@2
     displayName: 'NuGet pack'
     inputs:
       command: pack
-      packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/ReactWin32.nuspec'
+      packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/React*.nuspec'
       packDestination: '$(System.DefaultWorkingDirectory)/NugetRoot/'

--- a/vnext/.npmignore
+++ b/vnext/.npmignore
@@ -23,7 +23,7 @@ react-native-windows.build.log
 ReactWin32.nuspec
 ReactWindows-CopyToStaging.bat
 ReactWindows-TestNuspec.bat
-ReactWindows.nuspec
+ReactUwp.nuspec
 ReactWindows.sln
 ReactWindows-UWP.sln
 **/*.inc

--- a/vnext/ReactUwp.nuspec
+++ b/vnext/ReactUwp.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>OfficeReact.Uwp</id>
+    <version>__BuildBuildNumber__</version>
+    <description>Contains Windows Implementation of React-Native</description>
+    <authors>Microsoft</authors>
+    <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+  </metadata>
+  <files>
+    <file src="inc\cxxreact\*" target="inc\cxxreact"/>
+    <file src="inc\jsi\*" target="inc\jsi"/>
+    <file src="inc\Yoga\*.*" target="inc\Yoga"/>
+    <file src="inc\folly\**\*.*" target="inc" />
+    <file src="inc\stubs\**\*.*" target="inc" />
+
+    <file src="inc\ReactWin32\msoFolly.h" target="inc\msoFolly"/>
+    <file src="inc\ReactWindowsCore\AbiSafe.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\DevSettings.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\INativeUIManager.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\IUIManager.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\IWebSocket.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\InstanceManager.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\IReactRootView.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\JSBigAbiString.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\Logging.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\MemoryTracker.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\NativeModuleProvider.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\Sandbox\SandboxEndpoint.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\ShadowNode.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\Tracing.h" target="inc"/>
+    <file src="inc\ReactWindowsCore\Modules\I18nModule.h" target="inc"/>
+
+    <file src="inc\include\**\*.*" target="inc\include" />
+
+    <!-- Windows Universal artifacts -->
+    <file src="target\x86\Debug\ReactUWP\React.UWP.*"      target="lib\debug\x86"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="target\x86\Ship\ReactUWP\React.UWP.*"       target="lib\ship\x86"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="target\x64\Debug\ReactUWP\React.UWP.*"      target="lib\debug\x64"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="target\x64\Ship\ReactUWP\React.UWP.*"       target="lib\ship\x64"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="target\ARM\Debug\ReactUWP\React.UWP.*"      target="lib\debug\arm"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="target\ARM\Ship\ReactUWP\React.UWP.*"       target="lib\ship\arm"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+
+  </files>
+</package>

--- a/vnext/ReactWindows-CopyToStaging.bat
+++ b/vnext/ReactWindows-CopyToStaging.bat
@@ -62,4 +62,5 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 %COPYCMD%  %SRCROOT%\react-native-win\include                                     %DESTROOT%\inc\include
 
 %COPYCMD%  %SRCROOT%\react-native-win\ReactWin32.nuspec                           %DESTROOT%
+%COPYCMD%  %SRCROOT%\react-native-win\ReactUwp.nuspec                             %DESTROOT%
 

--- a/vnext/ReactWindows-CopyToStaging2.bat
+++ b/vnext/ReactWindows-CopyToStaging2.bat
@@ -66,4 +66,5 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 %COPYCMD%  %SRCROOT%\include                                              %DESTROOT%\inc\include
 
 %COPYCMD%  %SRCROOT%\ReactWin32.nuspec                                    %DESTROOT%
+%COPYCMD%  %SRCROOT%\ReactUwp.nuspec                                      %DESTROOT%
 

--- a/vnext/ReactWindows-TestNuspec.bat
+++ b/vnext/ReactWindows-TestNuspec.bat
@@ -43,4 +43,6 @@ mkdir %DESTROOT%\target\%%p\ship >nul 2>&1
 
 @echo on
 sed s/__BuildBuildNumber__/%VERSION%/g %DESTROOT%\ReactWin32.nuspec > %DESTROOT%\ReactWin32.versioned.nuspec
+sed s/__BuildBuildNumber__/%VERSION%/g %DESTROOT%\ReactUwp.nuspec > %DESTROOT%\ReactUwp.versioned.nuspec
 nuget.exe pack %DESTROOT%\ReactWin32.versioned.nuspec -NonInteractive -OutputDirectory %DESTROOT% -Verbosity Detailed
+nuget.exe pack %DESTROOT%\ReactUwp.versioned.nuspec -NonInteractive -OutputDirectory %DESTROOT% -Verbosity Detailed

--- a/vnext/ReactWindows-UWP.sln
+++ b/vnext/ReactWindows-UWP.sln
@@ -34,7 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		NuGet.Config = NuGet.Config
-		ReactWin32.nuspec = ReactWin32.nuspec
+		ReactUwp.nuspec = ReactUwp.nuspec
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/vnext/ReactWindows.sln
+++ b/vnext/ReactWindows.sln
@@ -47,6 +47,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		NuGet.Config = NuGet.Config
 		ReactWin32.nuspec = ReactWin32.nuspec
+		ReactUwp.nuspec = ReactUwp.nuspec
 		README.md = README.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
This will allow us to rev the UWP version independently of the win32 version.

Once UWP is using this nuget, we'll remove the uwp bits from the win32 nuget.