### PR TITLE
Flyout dismissal

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -288,7 +288,6 @@ winrt::Popup FlyoutShadowNode::GetFlyoutParentPopup() const
   return nullptr;
 }
 
-
 FlyoutViewManager::FlyoutViewManager(const std::shared_ptr<IReactInstance>& reactInstance)
   : Super(reactInstance)
 {

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -183,7 +183,7 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic&& props)
         m_isLightDismissEnabled = propertyValue.asBool();
       else if (propertyValue.isNull())
         m_isLightDismissEnabled = true;
-      if (m_targetElement != nullptr)
+      if (m_isOpen)
       {
         auto popup = GetFlyoutParentPopup();
         if (popup != nullptr)
@@ -281,10 +281,8 @@ winrt::Popup FlyoutShadowNode::GetFlyoutParentPopup() const
 {
   // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against RS6
   winrt::Windows::Foundation::Collections::IVectorView<winrt::Popup> popups = winrt::VisualTreeHelper::GetOpenPopups(winrt::Window::Current());
-  for (auto popup : popups)
-  {
-    return popup;
-  };
+  if (popups.Size() > 0)
+    return popups.GetAt(0);
   return nullptr;
 }
 


### PR DESCRIPTION
Currently, setting IsLightDismissalEnabled to false in the Flyout doesn't block light dismiss when the App loses focus. 

This behavior is due to the XAML implementation of the light dismiss logic in the Flyout/Popup code. The loss of focus by the Flyout bypasses the code path that would normally raise the 'Closing' event where we would have had the chance to 'cancel' the dismissal. 

Keith Melmon:
"When the window is being deactivated, we iterate through all open Popups and dismiss any Popup that is light dismiss enabled.  This is different from the light dismiss logic that runs when you click inside the window, which will only attempt to close the top-most open Popup – this code path goes through the extra step of raising the Closing event."  

Luckily though, Keith also provided a workaround that resolves the issue.

"Just after opening the Flyout, use VisualTreeHelper to retrieve the list of currently open Popups.  The first Popup in this list will be the one for the Flyout just opened.  Grab this Popup and set Popup.IsLightDismissEnabled = false.  This will prevent the window activation code from dismissing it.  Strangely, in my testing, I still saw the Popup getting light dismissed when clicking inside the window, so the current technique of marking the Closing event with Cancel=true is currently required."

Two caveats to the workaround:
	1) When we begin targeting 19h1, we need to conditionally use the new API, VisualTreeHelper::GetOpenPopupsForXamlRoot, instead of GetOpenPopups, in order to support Xaml Islands.
	2) If we add support for nested flyouts, we will need to refine the workaround.

See WI: 3320141 "Control Light dismiss when focus leaves the App window" for the background on this. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2519)