### PR TITLE
Self layout elements not always visible after an update

### DIFF
--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -48,10 +48,17 @@ YGSize DefaultYogaSelfMeasureFunc(YGNodeRef node, float width, YGMeasureMode wid
     winrt::Windows::Foundation::Size availableSpace(constrainToWidth, constrainToHeight);
 
     // Clear out current size so it doesn't constrain the measurement
-    element.ClearValue(winrt::FrameworkElement::WidthProperty());
-    element.ClearValue(winrt::FrameworkElement::HeightProperty());
+    auto widthProp = winrt::FrameworkElement::WidthProperty();
+    auto heightProp = winrt::FrameworkElement::HeightProperty();
+    auto origWidth = element.GetValue(widthProp);
+    auto origHeight = element.GetValue(heightProp);
+    element.ClearValue(widthProp);
+    element.ClearValue(heightProp);
 
     element.Measure(availableSpace);
+
+    element.SetValue(widthProp, origWidth);
+    element.SetValue(heightProp, origHeight);
   }
   catch (winrt::hresult_error const& )
   {


### PR DESCRIPTION
This is fixing a regression from the perf changes in https://github.com/microsoft/react-native-windows/commit/60aebbe985c7f29d23bf2eaed249535087cfcd3c  (where we don't call SetLayoutProps on every element in every update anymore).

With self layout elements, we clear the width/height when measuring.  In incremental update items are usually still measured but if the values are the same as before, SetLayoutProps isn't called now.  This fix puts back whatever width/height was there before the clear to maintain previous layout.

Alternatively we could mark self measure nodes as always dirty in self measure, in the case where things DO update we are doing more work now, but in the incremental case this is probably preferred (and we don't want to generate extra onLayout events)


Also, updated our Yoga debug printing helper to log full info.  I couldn't see the relevant part of the tree in our app I was debugging with the existing ~4k output it was getting truncated at.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2520)