### PR TITLE
Update to react-native@0.58.6-microsoft.54

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.51"
+    "react-native": "0.58.6-microsoft.54"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.51 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.51.tar.gz"
+    "react-native": "0.58.6-microsoft.54 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.54.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.51.tar.gz":
-  version "0.58.6-microsoft.51"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.51.tar.gz#0f3928d5139343aafdbef79cdf9389b9bbeae392"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.54.tar.gz":
+  version "0.58.6-microsoft.54"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.54.tar.gz#23006bb606ce1df689e9865d499994a70dac4f38"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
46afff897 Applying package update to 0.58.6-microsoft.54
e64310bec Remove accidental debug code (#75)
b6da98af4 Applying package update to 0.58.6-microsoft.53
e0e026d24 Include more files in droid nuget (#74)
a7418337e Applying package update to 0.58.6-microsoft.52
a8d2cd712 Include built binaries in droid nuget (#73)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2523)