### PR TITLE
Update to react-native@0.58.6-microsoft.55

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.54"
+    "react-native": "0.58.6-microsoft.55"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.54 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.54.tar.gz"
+    "react-native": "0.58.6-microsoft.55 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.55.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.54.tar.gz":
-  version "0.58.6-microsoft.54"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.54.tar.gz#23006bb606ce1df689e9865d499994a70dac4f38"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.55.tar.gz":
+  version "0.58.6-microsoft.55"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.55.tar.gz#f711a5d4d49ba781545d8faeaff22e7385e7c1a8"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
6c7522deb Applying package update to 0.58.6-microsoft.55
0804147ad Changed the showsVerticalScrollIndicator and showsHorizontalScrollIndicator default values on macOS to match iOS and Android. (#77)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2525)