### PR TITLE
Update to react-native@0.58.6-microsoft.56

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.55"
+    "react-native": "0.58.6-microsoft.56"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.55 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.55.tar.gz"
+    "react-native": "0.58.6-microsoft.56 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.56.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.55.tar.gz":
-  version "0.58.6-microsoft.55"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.55.tar.gz#f711a5d4d49ba781545d8faeaff22e7385e7c1a8"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.56.tar.gz":
+  version "0.58.6-microsoft.56"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.56.tar.gz#1d10c9505051253292ea4b44d64bfbce89113f5f"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
f51c85c1e Applying package update to 0.58.6-microsoft.56
d059e3e8a Adding option to exclude all libs while building ReactAndroid aar (#79)

```