### PR TITLE
Update msbuildtools.js with VS 2019 path

### DIFF
--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -9,7 +9,7 @@ const shell = require('shelljs');
 const Version = require('./version');
 const checkRequirements = require('./checkRequirements');
 
-const MSBUILD_VERSIONS = ['15.0', '14.0', '12.0', '4.0'];
+const MSBUILD_VERSIONS = ['16.0', '15.0', '14.0', '12.0', '4.0'];
 
 class MSBuildTools {
   constructor(version, localPath) {
@@ -64,13 +64,20 @@ class MSBuildTools {
 
 function checkMSBuildVersion(version) {
   let toolsPath = null;
+  
   // This path is maintained and VS has promised to keep it valid.
   const vsWherePath = path.join(process.env['ProgramFiles(x86)'], '/Microsoft Visual Studio/Installer/vswhere.exe');
-  // Check if VS 2017 is installed and if true, go there to find MSBuild.
+  
+  // Check if vswhere is present and try to find MSBuild.
   if (fs.existsSync(vsWherePath)) {
-    const vsPath = child_process.execSync(`"${vsWherePath}" -latest -products * Microsoft.Component.MSBuild -property installationPath -version [4.0,16.0)`).toString().split(EOL)[0];
+    const vsPath = child_process.execSync(`"${vsWherePath}" -latest -products * Microsoft.Component.MSBuild -property installationPath`).toString().split(EOL)[0];
+    
+    // VS 2019 changed path naming convention
+    const vsVersion = (version == '16.0') ? 'Current' : version;
+
     // look for the specified version of msbuild
-    const msBuildPath = path.join(vsPath, 'MSBuild', version, 'Bin/MSBuild.exe');
+    const msBuildPath = path.join(vsPath, 'MSBuild', vsVersion, 'Bin/MSBuild.exe');
+
     toolsPath = fs.existsSync(msBuildPath) ? path.dirname(msBuildPath) : null;
   } else {
     const query = `reg query HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions\\${version} /s /v MSBuildToolsPath`;
@@ -92,7 +99,7 @@ function checkMSBuildVersion(version) {
   }
 
   // We found something so return MSBuild Tools.
-  if (toolsPath){
+  if (toolsPath) {
     console.log(chalk.green(`Found MSBuild v${version} at ${toolsPath}`));
     return new MSBuildTools(version, toolsPath);
   }
@@ -103,7 +110,8 @@ function checkMSBuildVersion(version) {
 
 module.exports.findAvailableVersion = function () {
   const versions = MSBUILD_VERSIONS.map(checkMSBuildVersion);
-  const msbuildTools = versions[0] || versions[1] || versions[2] || versions[3];
+  const msbuildTools = versions.find(Boolean);
+
   if (!msbuildTools) {
     throw new Error('MSBuild tools not found');
   }

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -37,10 +37,16 @@ class MSBuildTools {
       '/p:AppxBundle=Never'
     ];
 
-    // Set platform toolset for VS2017 (this way we can keep the base sln file working for vs2015)
+    // Set platform toolset for VS 2017 (this way we can keep the base sln file working for VS 2015)
     if (this.version === '15.0') {
       args.push('/p:PlatformToolset=v141');
       args.push('/p:VisualStudioVersion=15.0');
+    }
+
+    // Set platform toolset for VS 2019
+    if (this.version === '16.0') {
+      args.push('/p:PlatformToolset=v142');
+      args.push('/p:VisualStudioVersion=16.0');
     }
 
     if (config) {


### PR DESCRIPTION
VS 2019 changed the msbuild location. Updating path in msbuildtools.js


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2539)