### PR TITLE
Update to react-native@0.58.6-microsoft.58

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.56"
+    "react-native": "0.58.6-microsoft.58"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.56 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.56.tar.gz"
+    "react-native": "0.58.6-microsoft.58 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.58.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.56.tar.gz":
-  version "0.58.6-microsoft.56"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.56.tar.gz#1d10c9505051253292ea4b44d64bfbce89113f5f"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.58.tar.gz":
+  version "0.58.6-microsoft.58"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.58.tar.gz#3c43eb8896b08ac4a977e7098cc246b9cacb757f"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
5285cbf21 Applying package update to 0.58.6-microsoft.58
02ce26f29 Adding back the Accessibility Actions that were mistakenly remove in … (#81)
5fe9c4f8d Applying package update to 0.58.6-microsoft.57
5315faf9a Using optimized V8 bins (#78)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2541)