### PR TITLE
ScrollContentView and ScrollView cleanup

### DIFF
--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -27,6 +27,7 @@
 #include <Views/PopupViewManager.h>
 #include <Views/RawTextViewManager.h>
 #include <Views/RootViewManager.h>
+#include <Views/ScrollContentViewManager.h>
 #include <Views/ScrollViewManager.h>
 #include <Views/SwitchViewManager.h>
 #include <Views/TextInputViewManager.h>
@@ -93,6 +94,7 @@ REACTWINDOWS_API_(std::shared_ptr<facebook::react::IUIManager>) CreateUIManager(
   viewManagers.push_back(std::make_unique<PopupViewManager>(instance));
   viewManagers.push_back(std::make_unique<RawTextViewManager>(instance));
   viewManagers.push_back(std::make_unique<RootViewManager>(instance));
+  viewManagers.push_back(std::make_unique<ScrollContentViewManager>(instance));
   viewManagers.push_back(std::make_unique<ScrollViewManager>(instance));
   viewManagers.push_back(std::make_unique<SwitchViewManager>(instance));
   viewManagers.push_back(std::make_unique<TextViewManager>(instance));

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="Views\RawTextViewManager.h" />
     <ClInclude Include="Views\ReactControl.h" />
     <ClInclude Include="Views\RootViewManager.h" />
+    <ClInclude Include="Views\ScrollContentViewManager.h" />
     <ClInclude Include="Views\ScrollViewManager.h" />
     <ClInclude Include="Views\SwitchViewManager.h" />
     <ClInclude Include="Views\TextInputViewManager.h" />
@@ -275,6 +276,7 @@
     <ClCompile Include="Views\ReactControl.cpp" />
     <ClCompile Include="Views\ReactRootView.cpp" />
     <ClCompile Include="Views\RootViewManager.cpp" />
+    <ClCompile Include="Views\ScrollContentViewManager.cpp" />
     <ClCompile Include="Views\ScrollViewManager.cpp" />
     <ClCompile Include="Views\ShadowNodeBase.cpp" />
     <ClCompile Include="Views\SwitchViewManager.cpp" />

--- a/vnext/ReactUWP/ReactUWP.vcxproj.filters
+++ b/vnext/ReactUWP/ReactUWP.vcxproj.filters
@@ -209,12 +209,12 @@
     <ClCompile Include="Views\FlyoutViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
-    
     <ClCompile Include="Views\Impl\ScrollViewUWPImplementation.cpp">
       <Filter>Views\Impl</Filter>
     </ClCompile>
-    <ClCompile Include="SnapPointManagingContentControl.cpp">
-      <Filter>Views\Impl</Filter>
+    <ClCompile Include="Views\Impl\SnapPointManagingContentControl.cpp" />
+    <ClCompile Include="Views\ScrollContentViewManager.cpp">
+      <Filter>Views</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -425,12 +425,12 @@
     <ClInclude Include="Views\FlyoutViewManager.h">
       <Filter>Views</Filter>
     </ClInclude>
-    
     <ClInclude Include="Views\Impl\ScrollViewUWPImplementation.h">
       <Filter>Views\Impl</Filter>
     </ClInclude>
-    <ClInclude Include="SnapPointManagingContentControl.h">
-      <Filter>Views\Impl</Filter>
+    <ClInclude Include="Views\Impl\SnapPointManagingContentControl.h" />
+    <ClInclude Include="Views\ScrollContentViewManager.h">
+      <Filter>Views</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.cpp
+++ b/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.cpp
@@ -12,39 +12,8 @@ ScrollViewUWPImplementation::ScrollViewUWPImplementation(const winrt::ScrollView
   assert(scrollViewContent);
   const auto snapPointManager = scrollViewContent.as<SnapPointManagingContentControl>();
   assert(snapPointManager);
-  assert(snapPointManager->Content().as<winrt::StackPanel>());
 
   m_scrollViewer = winrt::make_weak(scrollViewer);
-}
-
-void ScrollViewUWPImplementation::ConvertScrollViewer(const winrt::ScrollViewer& scrollViewer)
-{
-  if (scrollViewer)
-  {
-    const auto snapPointManager = new SnapPointManagingContentControl();
-    snapPointManager->Content(winrt::StackPanel{});
-
-    scrollViewer.Content(*snapPointManager);
-  }
-}
-
-void ScrollViewUWPImplementation::AddView(const XamlView& child, uint32_t index)
-{
-  const auto contentCollection = ScrollViewerContent().Children();
-  assert(index <= contentCollection.Size());
-  contentCollection.InsertAt(index, child.as<winrt::UIElement>());
-}
-
-void ScrollViewUWPImplementation::RemoveAllChildren()
-{
-  ScrollViewerContent().Children().Clear();
-}
-
-void ScrollViewUWPImplementation::RemoveChildAt(uint32_t index)
-{
-  const auto contentCollection = ScrollViewerContent().Children();
-  assert(index < contentCollection.Size());
-  contentCollection.RemoveAt(index);
 }
 
 void ScrollViewUWPImplementation::SetHorizontal(bool horizontal)
@@ -62,7 +31,7 @@ void ScrollViewUWPImplementation::SnapToOffsets(const winrt::IVectorView<float>&
   ScrollViewerSnapPointManager()->SnapToOffsets(offsets);
 }
 
-void ScrollViewUWPImplementation::UpdateScrollableSize()
+void ScrollViewUWPImplementation::UpdateScrollableSize() const
 {
   if (const auto scrollViewer = m_scrollViewer.get())
   {
@@ -94,32 +63,20 @@ void ScrollViewUWPImplementation::UpdateScrollableSize()
   }
 }
 
-winrt::ScrollViewer ScrollViewUWPImplementation::ScrollViewer()
+winrt::ScrollViewer ScrollViewUWPImplementation::ScrollViewer() const
 {
   return m_scrollViewer.get();
 }
 
 // privates //
 
-winrt::com_ptr<SnapPointManagingContentControl>ScrollViewUWPImplementation::ScrollViewerSnapPointManager()
+winrt::com_ptr<SnapPointManagingContentControl> ScrollViewUWPImplementation::ScrollViewerSnapPointManager() const
 {
-  if (const auto scrollViewer = m_scrollViewer.get())
+  if (const auto scrollViewer = ScrollViewer())
   {
     if (const auto content = scrollViewer.Content())
     {
       return content.as<SnapPointManagingContentControl>();
-    }
-  }
-  return nullptr;
-}
-
-winrt::StackPanel ScrollViewUWPImplementation::ScrollViewerContent()
-{
-  if (const auto snapPointManagingContentControl = ScrollViewerSnapPointManager())
-  {
-    if (const auto content = snapPointManagingContentControl->Content())
-    {
-      return content.as<winrt::StackPanel>();
     }
   }
   return nullptr;

--- a/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.h
+++ b/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.h
@@ -28,24 +28,17 @@ class ScrollViewUWPImplementation
 {
 public:
   ScrollViewUWPImplementation(const winrt::ScrollViewer& scrollViewer);
-  static void ConvertScrollViewer(const winrt::ScrollViewer& scrollViewer);
-
-  void AddView(const XamlView& child, uint32_t index);
-  void RemoveAllChildren();
-  void RemoveChildAt(uint32_t index);
 
   void SetHorizontal(bool isHorizontal);
   void SnapToInterval(float interval);
   void SnapToOffsets(const winrt::IVectorView<float>& offsets);
 
-  void UpdateScrollableSize();
+  void UpdateScrollableSize() const;
 
-  winrt::ScrollViewer ScrollViewer();
-  winrt::com_ptr<SnapPointManagingContentControl> ScrollViewerSnapPointManager();
+  winrt::ScrollViewer ScrollViewer() const;
+  winrt::com_ptr<SnapPointManagingContentControl> ScrollViewerSnapPointManager() const;
 
 private:
-  winrt::StackPanel ScrollViewerContent();
-
   winrt::weak_ref<winrt::ScrollViewer> m_scrollViewer{};
 };
 

--- a/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
+++ b/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
@@ -10,6 +10,11 @@ SnapPointManagingContentControl::SnapPointManagingContentControl()
 
 }
 
+/*static*/ winrt::com_ptr<SnapPointManagingContentControl> SnapPointManagingContentControl::Create()
+{
+  return winrt::make_self<SnapPointManagingContentControl>();
+}
+
 void SnapPointManagingContentControl::SnapToInterval(float interval)
 {
   if (interval != m_interval)

--- a/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
+++ b/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
@@ -15,8 +15,12 @@ namespace uwp {
 
   class SnapPointManagingContentControl : public winrt::ContentControlT<SnapPointManagingContentControl, winrt::IScrollSnapPointsInfo>
   {
-  public:
+  private:
     SnapPointManagingContentControl();
+
+  public:
+    static winrt::com_ptr<SnapPointManagingContentControl> Create();
+    template <typename D, typename... Args> friend auto winrt::make_self(Args&& ... args);
 
     // ScrollView Implementation
     void SnapToInterval(float interval);

--- a/vnext/ReactUWP/Views/ScrollContentViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollContentViewManager.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "ScrollContentViewManager.h"
+
+namespace react { namespace uwp {
+
+ScrollContentViewManager::ScrollContentViewManager(const std::shared_ptr<IReactInstance>& reactInstance)
+  : Super(reactInstance)
+{
+}
+
+const char* ScrollContentViewManager::GetName() const
+{
+  return "RCTScrollContentView";
+}
+
+}}

--- a/vnext/ReactUWP/Views/ScrollContentViewManager.h
+++ b/vnext/ReactUWP/Views/ScrollContentViewManager.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Views/ViewViewManager.h>
+
+namespace react { namespace uwp {
+
+class ScrollContentViewManager : public ViewViewManager
+{
+  using Super = ViewViewManager;
+public:
+  ScrollContentViewManager(const std::shared_ptr<IReactInstance>& reactInstance);
+
+  const char* GetName() const override;
+};
+
+} }


### PR DESCRIPTION
2 sets of changes:
1. Add a ScrollContentView component type.  In the fb59merge branch of react-native I've already removed the 'uwp' condition we had in there which would create a View instead of a ScrollContentView as other platforms do -- removing one of the reasons 'uwp' needs the microsoft/react-native fork.  It is maybe possible to move some of ScrollView's code into here but I did not to keep it simple -- RN on iOS and Android have very little in their scrollcontentview to validate things or handle special platform differences for horiz/vert.

2. In stepping through the various ScrollView code I found some bugs and simplifications to make:
* There were 2 memory leaks from use of operator new without releasing, fixed one place to use a smartpointer and hide the ctor, the other one is now stack based and copied by value into a few event handlers.
* Simplified ScrollView helpers a bit, since we know scrollview will only have 1 child the add/remove elements we just set content and assert index 0
* removed the extra StackView we were creating and referencing with ScrollViewerContent().  we were always just putting 1 child View inside of that, that stackview impl wasn't complete, if you only used stackview it became apparent that you couldn't control direction of children and set other properties.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2545)