### PR TITLE
require AttachRoot to be called from UI thread

### DIFF
--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -121,12 +121,15 @@ void ReactControl::AttachRoot() noexcept
     });
   });
 
-  // Schedule initialization that must happen on the UI thread
-  m_reactInstance->DefaultNativeMessageQueueThread()->runOnQueue([this]() {
-    m_touchEventHandler->AddTouchHandlers(m_xamlRootView);
-    auto initialProps = m_initialProps;
-    m_reactInstance->AttachMeasuredRootView(m_pParent, std::move(initialProps));
-  });
+  // We assume Attach has been called from the UI thread
+#ifdef DEBUG
+  auto coreWindow = winrt::CoreWindow::GetForCurrentThread();
+  assert(coreWindow != nullptr);
+#endif
+
+  m_touchEventHandler->AddTouchHandlers(m_xamlRootView);
+  auto initialProps = m_initialProps;
+  m_reactInstance->AttachMeasuredRootView(m_pParent, std::move(initialProps));
 
   m_isAttached = true;
 }


### PR DESCRIPTION
(fix race condition with AttachRoot + DetachRoot)

Currently AttachRoot can be called from a background thread (in theory) and it queues up the work that needs to be done on a ui thread.  This can cause problems when used with DetachRoot, which does not queue work on the ui thread - it just runs code immediately.  If detach is called before Attach's deferred work runs, we will crash detaching (trying to find a rootview of -1).   OneNote team has hit this internally where they use a different UI thread dispatching layer whose timing isn't the same as standard (combines things together aggressively), where it is hard to workaround the timing crash.

Looking back in the history we did this a very long time ago when live reload would be invoked from a background thread.  Since then the live reload path already makes this call from a UI thread so that path doesn't need updating either.

I've tested our test apps, live reload, internal apps with this change and everyone was already always making calls from a UI thread.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2551)