### PR TITLE
enable inline source maps

### DIFF
--- a/vnext/ReactWindowsCore/DevServerHelper.h
+++ b/vnext/ReactWindowsCore/DevServerHelper.h
@@ -42,7 +42,7 @@ private:
 	}
 
 	static constexpr const char s_DeviceLocalhost[] = "localhost:8081";
-	static constexpr const char BundleUrlFormat[] = "http://%s/%s.bundle?platform=%s&dev=%s&hot=%s";
+	static constexpr const char BundleUrlFormat[] = "http://%s/%s.bundle?platform=%s&dev=%s&hot=%s&inlineSourceMap=true";
 	static constexpr const char SourceMapUrlFormat[] = "http://%s/%s.map?platform=%s&dev=%s&hot=%s";
 	static constexpr const char LaunchDevToolsCommandUrlFormat[] = "http://%s/launch-js-devtools";
 	static constexpr const char OnChangeEndpointUrlFormat[] = "http://%s/onchange";


### PR DESCRIPTION
We have been adding this to get source maps working with a project we made from the c# template (well started with the c# template then replaced the app project with c++/winrt).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2553)