### PR TITLE
Update to react-native@0.58.6-microsoft.59

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.3.3",
-    "react-native": "0.58.6-microsoft.58"
+    "react-native": "0.58.6-microsoft.59"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.58 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.58.tar.gz"
+    "react-native": "0.58.6-microsoft.59 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.59.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.58.tar.gz":
-  version "0.58.6-microsoft.58"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.58.tar.gz#3c43eb8896b08ac4a977e7098cc246b9cacb757f"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.59.tar.gz":
+  version "0.58.6-microsoft.59"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.59.tar.gz#989739b7ca46efd9d900bc31b4d40af771d3b0fc"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
197c4fca0 Applying package update to 0.58.6-microsoft.59
25ab1a468 param requires double quotes instead of single (#82)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2554)