### PR TITLE
fix(CLI): Ensure CLI downloads current version

### DIFF
--- a/current/local-cli/rnpm/windows/index.js
+++ b/current/local-cli/rnpm/windows/index.js
@@ -10,12 +10,11 @@ module.exports = [{
     description: 'The native project namespace.'
   }, {
     command: '--verbose',
-    description: 'Enables logging',
+    description: 'Enables logging.',
     default: false,
   }, {
     command: '--template [template]',
-    description: 'Template to install. Possible values vnext, csharp',
-    default: 'csharp',
+    description: 'Template to install. E.g., `vnext`.',
   }]
 },{
   func: require('./src/wpf'),

--- a/current/local-cli/rnpm/windows/package.json
+++ b/current/local-cli/rnpm/windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rnpm-plugin-windows",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "rnpm plugin that generates a Windows template project",
   "main": "index.js",
   "keywords": [

--- a/vnext/local-cli/generate-windows.js
+++ b/vnext/local-cli/generate-windows.js
@@ -13,11 +13,14 @@ const {
  * @param  {String} projectDir root project directory (i.e. contains index.js)
  * @param  {String} name       name of the root JS module for this app
  * @param  {String} ns         namespace for the project
+ * @param  {Object} options    command line options container
  */
 function generateWindows (projectDir, name, ns, options) {
   if (!fs.existsSync(projectDir)) {
     fs.mkdirSync(projectDir);
   }
+
+  installDependencies(options);
 
   copyProjectTemplateAndReplace(
     path.join(__dirname, 'generator-windows', 'templates'),
@@ -25,8 +28,6 @@ function generateWindows (projectDir, name, ns, options) {
     name,
     { ns }
   );
-
-  installDependencies(options);
 }
 
 module.exports = generateWindows;

--- a/vnext/local-cli/generate-windows.js
+++ b/vnext/local-cli/generate-windows.js
@@ -2,7 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
-const copyProjectTemplateAndReplace = require('./generator-windows').copyProjectTemplateAndReplace;
+const {
+  copyProjectTemplateAndReplace,
+  installDependencies,
+ } = require('./generator-windows');
 
 /**
  * Simple utility for running the Windows generator.
@@ -11,16 +14,19 @@ const copyProjectTemplateAndReplace = require('./generator-windows').copyProject
  * @param  {String} name       name of the root JS module for this app
  * @param  {String} ns         namespace for the project
  */
-function generateWindows (projectDir, name, ns) {
+function generateWindows (projectDir, name, ns, options) {
   if (!fs.existsSync(projectDir)) {
     fs.mkdirSync(projectDir);
   }
+
   copyProjectTemplateAndReplace(
     path.join(__dirname, 'generator-windows', 'templates'),
     projectDir,
     name,
     { ns }
   );
+
+  installDependencies(options);
 }
 
 module.exports = generateWindows;

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -116,17 +116,20 @@ function installDependencies(options) {
     reactNativeVersion = reactNativeVersion.substring(delimIndex + depDelim.length);
   }
 
+  console.log(chalk.green('Updating to compatible version of react-native:'));
+  console.log(chalk.white(`    ${reactNativeVersion}`));
+
   // Patch package.json to have proper react-native version and install
   const projectPackageJsonPath = path.join(cwd, 'package.json');
   const projectPackageJson = JSON.parse(fs.readFileSync(projectPackageJsonPath, { encoding: 'UTF8' }));
   projectPackageJson.scripts.start = 'node node_modules/react-native-windows/Scripts/cli.js start';
   projectPackageJson.dependencies['react-native'] = reactNativeVersion;
-  fs.writeFileSync(packageJsonPath, JSON.stringify(projectPackageJson, null, 2));
+  fs.writeFileSync(projectPackageJsonPath, JSON.stringify(projectPackageJson, null, 2));
 
   // Install dependencies using correct package manager
   const isYarn = fs.existsSync(path.join(cwd, 'yarn.lock'));
-  const execOptions = options.verbose ? { stdio: 'inherit' } : {};
-  execSync(isYarn ? `yarn` : `npm i`, execOptions);
+  const execOptions = options && options.verbose ? { stdio: 'inherit' } : {};
+  childProcess.execSync(isYarn ? `yarn` : `npm i`, execOptions);
 }
 
 module.exports = {

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const username = require('username');
 const uuid = require('uuid');
 const childProcess = require('child_process');
+const fs = require('fs');
 const os = require('os');
 const {
   createDir,
@@ -102,6 +103,33 @@ function copyProjectTemplateAndReplace(
   console.log(chalk.white('   react-native run-windows'));
 }
 
+function installDependencies(options) {
+  const cwd = process.cwd();
+
+  // Extract react-native peer dependency version
+  const vnextPackageJsonPath = path.join(cwd, 'node_modules', 'react-native-windows', 'package.json');
+  const vnextPackageJson = JSON.parse(fs.readFileSync(vnextPackageJsonPath, { encoding: 'UTF8' }));
+  let reactNativeVersion = vnextPackageJson.peerDependencies['react-native'];
+  const depDelim = ' || ';
+  const delimIndex = reactNativeVersion.indexOf(depDelim);
+  if (delimIndex !== -1) {
+    reactNativeVersion = reactNativeVersion.substring(delimIndex + depDelim.length);
+  }
+
+  // Patch package.json to have proper react-native version and install
+  const projectPackageJsonPath = path.join(cwd, 'package.json');
+  const projectPackageJson = JSON.parse(fs.readFileSync(projectPackageJsonPath, { encoding: 'UTF8' }));
+  projectPackageJson.scripts.start = 'node node_modules/react-native-windows/Scripts/cli.js start';
+  projectPackageJson.dependencies['react-native'] = reactNativeVersion;
+  fs.writeFileSync(packageJsonPath, JSON.stringify(projectPackageJson, null, 2));
+
+  // Install dependencies using correct package manager
+  const isYarn = fs.existsSync(path.join(cwd, 'yarn.lock'));
+  const execOptions = options.verbose ? { stdio: 'inherit' } : {};
+  execSync(isYarn ? `yarn` : `npm i`, execOptions);
+}
+
 module.exports = {
-  copyProjectTemplateAndReplace
+  copyProjectTemplateAndReplace,
+  installDependencies
 };


### PR DESCRIPTION
The CLI is currently attempting to install pre-release versions of react-native-windows, and because "vnext" > "rc" in terms of semver, it's always picking up the vnext version.

This change assumes that all current versions will be tagged with `current-<major>.<minor>`, and if no version with such a tag exists for the corresponding react-native version, then we error out.

This installer plugin is becoming a bit overcomplicated. We should consider a rewrite within the next few months.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2559)