### PR TITLE
Cleaning up XAML Flyout when shadow node view is dropped.

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -96,6 +96,7 @@ public:
   void AddView(ShadowNode& child, int64_t index) override;
   void createView() override;
   static void OnFlyoutClosed(IReactInstance& instance, int64_t tag, bool newValue);
+  void onDropViewInstance() override;
   void removeAllChildren() override;
   void updateProperties(const folly::dynamic&& props) override;
   
@@ -138,7 +139,7 @@ void FlyoutShadowNode::createView()
   m_flyout.Closing([=](winrt::FlyoutBase /*flyoutbase*/, winrt::FlyoutBaseClosingEventArgs args)
   {
     auto instance = wkinstance.lock();
-    if (!m_updating && instance != nullptr && !m_isLightDismissEnabled && m_flyout.IsOpen())
+    if (!m_updating && instance != nullptr && !m_isLightDismissEnabled && m_isOpen)
     {
       args.Cancel(true);
     }
@@ -156,6 +157,11 @@ void FlyoutShadowNode::createView()
 {
   folly::dynamic eventData = folly::dynamic::object("target", tag)("isOpen", newValue);
   instance.DispatchEvent(tag, "topDismiss", std::move(eventData));
+}
+
+void FlyoutShadowNode::onDropViewInstance() {
+  m_isOpen = false;
+  m_flyout.Hide();
 }
 
 void FlyoutShadowNode::removeAllChildren()


### PR DESCRIPTION
When the flyout is in Light-dismiss disabled mode, the FlyoutPresenter element remains on the screen after the Flyout is 'closed'. The element disappears after any subsequent user action (it's in light-dismiss mode), but it's very ugly. 
 
The problem is that in certain scenarios (including this one), the view containing the flyout is dropped before the 'IsOpen' property of the Flyout is updated. This blocks the XAML Flyout from ever getting a chance to clean itself up. 

My fix overrides the onDropViewInstance for the FlyoutShadowNode and calls Hide() on the internal flyout object. 
(WI: 3391070)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2564)