### PR TITLE
Removing default padding on FlyoutPresenter

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -274,6 +274,7 @@ void FlyoutShadowNode::AdjustDefaultFlyoutStyle()
   winrt::Style flyoutStyle({ L"Windows.UI.Xaml.Controls.FlyoutPresenter", winrt::TypeKind::Metadata });
   flyoutStyle.Setters().Append(winrt::Setter(winrt::FrameworkElement::MaxWidthProperty(), winrt::box_value(50000)));
   flyoutStyle.Setters().Append(winrt::Setter(winrt::FrameworkElement::MaxHeightProperty(), winrt::box_value(50000)));
+  flyoutStyle.Setters().Append(winrt::Setter(winrt::Control::PaddingProperty(), winrt::box_value(0)));
   m_flyout.FlyoutPresenterStyle(flyoutStyle);
 }
 


### PR DESCRIPTION
The generic XAML Flyout has a default padding of 
            <Thickness x:Key="FlyoutContentThemePadding">12,11,12,12</Thickness>.
We need to override this for RNW. RNW consumers can set their own padding on any embedded content if they need to.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2567)