### PR TITLE
fixes to FormData network support

### DIFF
--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -146,7 +146,7 @@ std::vector<facebook::react::NativeModuleDescription> GetModules(
   modules.emplace_back(
     NetworkingModule::name,
     []() { return std::make_unique<NetworkingModule>(); },
-    messageQueue);
+    std::make_shared<WorkerMessageQueueThread>());
 
   modules.emplace_back(
     "Timing",

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -41,7 +41,7 @@ public:
     m_parent = nullptr;
   }
 
-  std::future<void> SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
+  void SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
     folly::dynamic bodyData, const std::string& responseType, bool useIncrementalUpdates, int64_t timeout, Callback cb) noexcept;
   void AbortRequest(int64_t requestId) noexcept;
   void ClearCookies() noexcept;
@@ -228,7 +228,7 @@ void AttachMultipartHeaders(
   }
 }
 
-std::future<void> NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
+void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
   folly::dynamic bodyData, const std::string& responseType, bool useIncrementalUpdates, int64_t timeout, Callback cb) noexcept
 {
   int64_t requestId = ++s_lastRequestId;
@@ -288,8 +288,8 @@ std::future<void> NetworkingModule::NetworkingHelper::SendRequest(const std::str
       {
         // file content request
         winrt::Windows::Foundation::Uri uri(facebook::react::unicode::utf8ToUtf16(bodyData["uri"].asString()));
-        winrt::Windows::Storage::StorageFile file = co_await winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
-        auto stream = co_await file.OpenReadAsync();
+        winrt::Windows::Storage::StorageFile file = winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri).get();
+        auto stream = file.OpenReadAsync().get();
         winrt::Windows::Web::Http::HttpStreamContent contentStream(stream);
         content = contentStream;
       }
@@ -307,9 +307,9 @@ std::future<void> NetworkingModule::NetworkingHelper::SendRequest(const std::str
           }
           else if (!formDataPart["uri"].empty()) {
             auto filePath = winrt::to_hstring(formDataPart["uri"].asString());
-            winrt::Windows::Storage::StorageFile file = co_await winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(filePath);
+            winrt::Windows::Storage::StorageFile file = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(filePath).get();
             
-            auto stream = co_await file.OpenReadAsync();
+            auto stream = file.OpenReadAsync().get();
             winrt::Windows::Web::Http::HttpStreamContent multipartFileValue(stream);
             AttachMultipartHeaders(multipartFileValue, formDataPart["headers"]);
             multiPartContent.Add(multipartFileValue, facebook::react::unicode::utf8ToUtf16(formDataPart["fieldName"].asString()));

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -41,7 +41,7 @@ public:
     m_parent = nullptr;
   }
 
-  void SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
+  std::future<void> SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
     folly::dynamic bodyData, const std::string& responseType, bool useIncrementalUpdates, int64_t timeout, Callback cb) noexcept;
   void AbortRequest(int64_t requestId) noexcept;
   void ClearCookies() noexcept;
@@ -228,7 +228,7 @@ void AttachMultipartHeaders(
   }
 }
 
-void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
+std::future<void> NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, const std::string& url, const folly::dynamic& headers,
   folly::dynamic bodyData, const std::string& responseType, bool useIncrementalUpdates, int64_t timeout, Callback cb) noexcept
 {
   int64_t requestId = ++s_lastRequestId;
@@ -288,8 +288,8 @@ void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, 
       {
         // file content request
         winrt::Windows::Foundation::Uri uri(facebook::react::unicode::utf8ToUtf16(bodyData["uri"].asString()));
-        winrt::Windows::Storage::StorageFile file = winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri).get();
-        auto stream = file.OpenReadAsync().get();
+        winrt::Windows::Storage::StorageFile file = co_await winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
+        auto stream = co_await file.OpenReadAsync();
         winrt::Windows::Web::Http::HttpStreamContent contentStream(stream);
         content = contentStream;
       }
@@ -307,9 +307,9 @@ void NetworkingModule::NetworkingHelper::SendRequest(const std::string& method, 
           }
           else if (!formDataPart["uri"].empty()) {
             auto filePath = winrt::to_hstring(formDataPart["uri"].asString());
-            winrt::Windows::Storage::StorageFile file = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(filePath).get();
+            winrt::Windows::Storage::StorageFile file = co_await winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(filePath);
             
-            auto stream = file.OpenReadAsync().get();
+            auto stream = co_await file.OpenReadAsync();
             winrt::Windows::Web::Http::HttpStreamContent multipartFileValue(stream);
             AttachMultipartHeaders(multipartFileValue, formDataPart["headers"]);
             multiPartContent.Add(multipartFileValue, facebook::react::unicode::utf8ToUtf16(formDataPart["fieldName"].asString()));


### PR DESCRIPTION
using FormData to send files currently asserts that .get() is called and blocking the UI thread.

Move networkingModule to run as a background thread native module -- the actual network request was async before but the prep code that processed the folly dynamic data was UI thread

tested existing network send requests that don't use formdata and our app that is using it, both working fine.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2570)