### PR TITLE
Update to react-native@0.58.6-microsoft.60

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.5.0",
     "typescript": "3.5.1",
-    "react-native": "0.58.6-microsoft.59"
+    "react-native": "0.58.6-microsoft.60"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.59 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.59.tar.gz"
+    "react-native": "0.58.6-microsoft.60 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.60.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.59.tar.gz":
-  version "0.58.6-microsoft.59"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.59.tar.gz#989739b7ca46efd9d900bc31b4d40af771d3b0fc"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.60.tar.gz":
+  version "0.58.6-microsoft.60"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.60.tar.gz#499c43d83b791e11986ce80eb73b4172d23c400d"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
e89924237 Applying package update to 0.58.6-microsoft.60
2b384a865 Pick up setUpGlobals.js change from https://github.com/facebook/react-native/commit/bccc92dfdd2d85933f2a9cb5c8d1773affb7acba#diff-3d750d038ea035cc40dd893c3a39e315 (#83)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2572)