### PR TITLE
Add enableJit and debug host to ReactInstanceSettings

### DIFF
--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -225,6 +225,8 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance>& spThis, cons
     devSettings->useDirectDebugger = settings.UseDirectDebugger;
     devSettings->loggingCallback = std::move(settings.LoggingCallback);
     devSettings->jsExceptionCallback = std::move(settings.JsExceptionCallback);
+    devSettings->useJITCompilation = settings.EnableJITCompilation;
+    devSettings->debugHost = settings.DebugHost;
 
     if (settings.UseLiveReload)
     {

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -29,6 +29,8 @@ struct ReactInstanceSettings
   bool UseLiveReload { false };
   bool UseDirectDebugger{ false };
   bool UseJsi { true };
+  bool EnableJITCompilation { true };
+  std::string DebugHost;
   std::string DebugBundlePath;
   facebook::react::NativeLoggingHook LoggingCallback;
   std::function<void(facebook::react::JSExceptionInfo&&)> JsExceptionCallback;


### PR DESCRIPTION
Allow apps to easily toggle jit and set a debug host. Debug host setting makes remote device (xbox) debugging easier, min bar for #2403

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2585)