### PR TITLE
Do not let functions under facebook::react::unicode throw upon invalid Unicode characters.

### DIFF
--- a/vnext/Desktop.UnitTests/UnicodeConversionTest.cpp
+++ b/vnext/Desktop.UnitTests/UnicodeConversionTest.cpp
@@ -32,6 +32,24 @@ public:
     Assert::IsTrue(utf8ToUtf16(SimpleTestStringBomUtf8, strlen(SimpleTestStringBomUtf8)) == SimpleTestStringBomUtf16);
   }
 
+  TEST_METHOD(utf8ToUtf16InvalidCharacterTest)
+  {
+    constexpr const char* const invalidUtf8 = "\xed\xa3\xa9";
+
+    // The binary representation for invalidUtf8 is
+    //     11101101 10100011 10101001
+    // which idicates that all three bytes is used to encode one (invalid)
+    // character. One would expect MultiByteToWideChar to output u"\xfffd"
+    // (U+FFFD encodede on UTF-16) when given invalidUtf8 as input, but oddly, it
+    // outputs u"\xfffd\xfffd". However, the reason for this behavior is
+    // irrelevant, as what we care about is that invalid UTF-8 characters do not
+    // cause utf8ToUtf16() to throw any exception.
+
+    std::wstring replacementUtf16{ reinterpret_cast<const wchar_t*>(u"\xfffd\xfffd") };
+
+    Assert::IsTrue(utf8ToUtf16(invalidUtf8) == replacementUtf16);
+  }
+
   TEST_METHOD(utf16ToUtf8SimpleTestNoBom)
   {
     Assert::IsTrue(utf16ToUtf8(SimpleTestStringNoBomUtf16, wcslen(SimpleTestStringNoBomUtf16)) == SimpleTestStringNoBomUtf8);
@@ -40,6 +58,16 @@ public:
   TEST_METHOD(utf16ToUtf8SimpleTestBom)
   {
     Assert::IsTrue(utf16ToUtf8(SimpleTestStringBomUtf16, wcslen(SimpleTestStringBomUtf16)) == SimpleTestStringBomUtf8);
+  }
+
+  TEST_METHOD(utf16ToUtf8InvalidCharacterTest)
+  {
+    constexpr const char16_t* const invalidUtf16 = u"\xd8e9";
+
+    // This is U+FFFD encoded in UTF-8.
+    std::string replacementUtf8{ "\xef\xbf\xbd" };
+
+    Assert::IsTrue(utf16ToUtf8(invalidUtf16) == replacementUtf8);
   }
 
   TEST_METHOD(SymmetricConversionNoBom)

--- a/vnext/ReactWindowsCore/unicode.cpp
+++ b/vnext/ReactWindowsCore/unicode.cpp
@@ -39,8 +39,9 @@ std::wstring utf8ToUtf16(const char* utf8, size_t utf8Len)
 
   const int utf8Length = static_cast<int>(utf8Len);
 
-  // Fail if an invalid UTF-8 character is encountered in the input string.
-  constexpr DWORD flags = MB_ERR_INVALID_CHARS;
+  // We do not specify MB_ERR_INVALID_CHARS here, which means that invalid UTF-8
+  // characters are replaced with U+FFFD.
+  constexpr DWORD flags = 0;
 
   const int utf16Length = ::MultiByteToWideChar(
     CP_UTF8,       // Source string is in UTF-8.
@@ -128,8 +129,9 @@ std::string utf16ToUtf8(const wchar_t* utf16, size_t utf16Len)
 
   const int utf16Length = static_cast<int>(utf16Len);
 
-  // Fail if an invalid UTF-16 character is encountered in the input string.
-  constexpr DWORD flags = WC_ERR_INVALID_CHARS;
+  // We do not specify WC_ERR_INVALID_CHARS here, which means that invalid
+  // UTF-16 characters are replaced with U+FFFD.
+  constexpr DWORD flags = 0;
 
   const int utf8Length = ::WideCharToMultiByte(
     CP_UTF8,       // Destination string is in UTF-8.
@@ -226,6 +228,6 @@ std::string utf16ToUtf8(const std::u16string_view& utf16)
 }
 #endif
 
-} // namespace utilities
+} // namespace unicode
 } // namespace react
 } // namespace facebook


### PR DESCRIPTION
The functions under facebook::react::unicode all throw when they encounter invalid Unicode characters. This PR changes them so that they replace the invalid character(s) with U+FFFD.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2590)