### PR TITLE
Ensure dll gets updated version before build

### DIFF
--- a/.ado/bumpFileVersions.js
+++ b/.ado/bumpFileVersions.js
@@ -1,0 +1,8 @@
+// @ts-check
+// Just bump the local version numbers in the files...
+
+const {
+  updateVersionsInFiles,
+} = require("./versionUtils");
+
+updateVersionsInFiles();

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -89,6 +89,13 @@ jobs:
 
     steps:
 
+      # The RnwNpmPublish task does this too before publishing the npm package,
+      # but when each slice checks out code, its not going to have those changes
+    - task: CmdLine@2
+      displayName: Update version numbers to align with publishing version
+      inputs:
+        script: node ../.ado/bumpFileVersions.js
+
     - template: templates/npm-install-and-build.yml
 
     - template: templates/vs-build.yml

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -1,0 +1,71 @@
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+
+const publishBranchName = process.env.BUILD_SOURCEBRANCH.match(
+  /refs\/heads\/(.*)/
+)[1];
+
+const pkgJsonPath = path.resolve(__dirname, "../vnext/package.json");
+
+const win32VersionRcPath = path.resolve(
+  __dirname,
+  "../vnext/Desktop.DLL/Version.rc"
+);
+
+function updateVersionsInFiles() {
+  const branchVersionSuffix = publishBranchName.match(/(fb.*merge)|(fabric)/)
+    ? `-${publishBranchName}`
+    : "";
+
+  let pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+
+  let releaseVersion = pkgJson.version;
+
+  const versionStringRegEx = new RegExp(
+    `(.*-vnext)(-${publishBranchName})?\\.([0-9]*)`
+  );
+  const versionGroups = versionStringRegEx.exec(releaseVersion);
+  if (versionGroups) {
+    releaseVersion =
+      versionGroups[1] +
+      branchVersionSuffix +
+      "." +
+      (parseInt(versionGroups[3]) + 1);
+  } else {
+    if (releaseVersion.indexOf("-") === -1) {
+      releaseVersion = releaseVersion + `-vnext${branchVersionSuffix}.0`;
+    } else {
+      console.log("Invalid version to publish");
+      process.exit(1);
+    }
+  }
+
+  pkgJson.version = releaseVersion;
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+  console.log(`Updating package.json to version ${releaseVersion}`);
+
+  let versionRC = fs.readFileSync(win32VersionRcPath).toString();
+  versionRC = versionRC.replace(
+    /#define VER_FILEVERSION_STR\s+"[^"]+"/,
+    `#define VER_FILEVERSION_STR "${releaseVersion}"`
+  );
+  versionRC = versionRC.replace(
+    /#define VER_FILEVERSION\s+.+/,
+    `#define VER_FILEVERSION ${releaseVersion.split(".")[0]},${
+      releaseVersion.split(".")[1]
+    },${releaseVersion.split(".")[2].split("-")[0]},${parseInt(
+      versionGroups[3]
+    ) + 1}`
+  );
+  fs.writeFileSync(win32VersionRcPath, versionRC);
+
+  return releaseVersion;
+}
+
+module.exports = {
+  pkgJsonPath,
+  publishBranchName,
+  updateVersionsInFiles,
+  win32VersionRcPath
+};


### PR DESCRIPTION
Currently the dll will get built with the previous build number, since the slice builds dont have the changes done by the npm publish slice.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2594)