### PR TITLE
Update to react-native@0.58.6-microsoft.61

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,10 +65,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.58.6-microsoft.60"
+    "react-native": "0.58.6-microsoft.61"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.60 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.60.tar.gz"
+    "react-native": "0.58.6-microsoft.61 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.61.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4111,9 +4111,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.60.tar.gz":
-  version "0.58.6-microsoft.60"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.60.tar.gz#499c43d83b791e11986ce80eb73b4172d23c400d"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.61.tar.gz":
+  version "0.58.6-microsoft.61"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.61.tar.gz#bc91f92c93102ecc637193194a9e6a1fa5bb873a"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
862667fdd Applying package update to 0.58.6-microsoft.61
1b28f7e8b Rojain/jsc (#84)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2597)