### PR TITLE
Update to react-native@0.58.6-microsoft.64

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -64,10 +64,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.58.6-microsoft.63"
+    "react-native": "0.58.6-microsoft.64"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.63 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.63.tar.gz"
+    "react-native": "0.58.6-microsoft.64 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.64.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4583,9 +4583,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.63.tar.gz":
-  version "0.58.6-microsoft.63"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.63.tar.gz#5f7cb30522b596963a20f39e8c43ff85fcc88c67"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.64.tar.gz":
+  version "0.58.6-microsoft.64"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.64.tar.gz#96775e8ce0dbed90d3ce11f3a47f988daec11580"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
0a39cfc10 Applying package update to 0.58.6-microsoft.64
3369b9dd3 Update build logic to bump version before nuget pack

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2607)