### PR TITLE
LocalBundleReader.cpp perf improvement.

### DIFF
--- a/vnext/ReactUWP/Utils/LocalBundleReader.cpp
+++ b/vnext/ReactUWP/Utils/LocalBundleReader.cpp
@@ -27,19 +27,19 @@ std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string& b
   // Read the buffer manually to avoid a Utf8 -> Utf16 -> Utf8 encoding roundtrip.
   auto fileBuffer { co_await winrt::Windows::Storage::FileIO::ReadBufferAsync(file) };
   auto dataReader{ winrt::Windows::Storage::Streams::DataReader::FromBuffer(fileBuffer) };
-  std::vector<uint8_t>* data = new std::vector<uint8_t>(fileBuffer.Length() + 1);
+  std::vector<uint8_t> data(fileBuffer.Length() + 1);
 
   // manually place the null byte at the end.
-  (*data)[fileBuffer.Length()] = 0;
+  data[fileBuffer.Length()] = 0;
 
   // Construct the array_view to slice into the first fileBuffer.Length bytes.
   // DataReader.ReadBytes will read as many bytes as are present in the array_view.
   // The backing vector has fileBuffer.Length() + 1 bytes, without an explicit end it will read 1 byte to many and throw.
-  winrt::array_view<uint8_t> arrayView{ data->data(), data->data() + fileBuffer.Length() };
+  winrt::array_view<uint8_t> arrayView{ data.data(), data.data() + fileBuffer.Length() };
   dataReader.ReadBytes(arrayView);
   dataReader.Close();
 
-  co_return std::string(reinterpret_cast<const char*>(data->data()));
+  co_return std::string(reinterpret_cast<const char*>(data.data()));
 }
 
 std::string LocalBundleReader::LoadBundle(const std::string& bundlePath)

--- a/vnext/ReactUWP/Utils/LocalBundleReader.cpp
+++ b/vnext/ReactUWP/Utils/LocalBundleReader.cpp
@@ -28,7 +28,7 @@ std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string& b
   auto fileBuffer { co_await winrt::Windows::Storage::FileIO::ReadBufferAsync(file) };
   auto dataReader{ winrt::Windows::Storage::Streams::DataReader::FromBuffer(fileBuffer) };
 
-  std::string script(fileBuffer.Length(), '\0');
+  std::string script(fileBuffer.Length() + 1, '\0');
 
   // Construct the array_view to slice into the first fileBuffer.Length bytes.
   // DataReader.ReadBytes will read as many bytes as are present in the array_view.

--- a/vnext/ReactUWP/Utils/LocalBundleReader.cpp
+++ b/vnext/ReactUWP/Utils/LocalBundleReader.cpp
@@ -6,6 +6,7 @@
 #include "LocalBundleReader.h"
 #include "unicode.h"
 #include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Storage.Streams.h>
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage
@@ -22,9 +23,23 @@ std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string& b
   co_await winrt::resume_background();
 
   auto file = co_await winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
-  auto hdata = co_await winrt::Windows::Storage::FileIO::ReadTextAsync(file);
 
-  co_return facebook::react::unicode::utf16ToUtf8(std::wstring(hdata.data()));
+  // Read the buffer manually to avoid a Utf8 -> Utf16 -> Utf8 encoding roundtrip.
+  auto fileBuffer { co_await winrt::Windows::Storage::FileIO::ReadBufferAsync(file) };
+  auto dataReader{ winrt::Windows::Storage::Streams::DataReader::FromBuffer(fileBuffer) };
+  std::vector<uint8_t>* data = new std::vector<uint8_t>(fileBuffer.Length() + 1);
+
+  // manually place the null byte at the end.
+  (*data)[fileBuffer.Length()] = 0;
+
+  // Construct the array_view to slice into the first fileBuffer.Length bytes.
+  // DataReader.ReadBytes will read as many bytes as are present in the array_view.
+  // The backing vector has fileBuffer.Length() + 1 bytes, without an explicit end it will read 1 byte to many and throw.
+  winrt::array_view<uint8_t> arrayView{ data->data(), data->data() + fileBuffer.Length() };
+  dataReader.ReadBytes(arrayView);
+  dataReader.Close();
+
+  co_return std::string(reinterpret_cast<const char*>(data->data()));
 }
 
 std::string LocalBundleReader::LoadBundle(const std::string& bundlePath)


### PR DESCRIPTION
Avoid round trip from utf8 -> utf16 -> utf8

Using the ReadTextAsync function will internally convert a utf8 file to utf16, but we need a utf8 string to match the interface.

Using file buffers and streams avoids the overhead of the character conversions. Just read the utf8 file into a utf8 buffer.

On Xbox this saves about 60ms of CPU time.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2609)