### PR TITLE
Update to react-native@0.59.0-microsoft.1

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -64,10 +64,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.58.6-microsoft.63"
+    "react-native": "0.59.0-microsoft.1"
   },
   "peerDependencies": {
     "react": "16.6.3",
-    "react-native": "0.58.6-microsoft.63 || https://github.com/microsoft/react-native/archive/v0.58.6-microsoft.63.tar.gz"
+    "react-native": "0.59.0-microsoft.1 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.1.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -829,6 +829,46 @@
   resolved "https://registry.yarnpkg.com/@microsoft/package-deps-hash/-/package-deps-hash-2.2.157.tgz#5f1aca71740e1422558bc5573989640382287a05"
   integrity sha512-P+fxCvF/WXi0MzJaWzbrer76VBur1uJKpUicr5NOCYIsqz9TkzRSUuDoO3rm6T2+2CzYCDx9UWcPGfoBkn5/FQ==
 
+"@react-native-community/cli@^1.2.1":
+  version "1.9.8"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-1.9.8.tgz#8488699f78b146cab2d7451951c4218671812cdc"
+  integrity sha512-/qd1fRJzisTjYpfNJ4NGYYM6cWhnTbmTTUPzi3yHTpfWWtyepAl8MLf6RbXaC8menCkg1jGkke6hD4rDoUJK0A==
+  dependencies:
+    chalk "^1.1.1"
+    commander "^2.19.0"
+    compression "^1.7.1"
+    connect "^3.6.5"
+    denodeify "^1.2.1"
+    envinfo "^5.7.0"
+    errorhandler "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    execa "^1.0.0"
+    fs-extra "^7.0.1"
+    glob "^7.1.1"
+    graceful-fs "^4.1.3"
+    inquirer "^3.0.6"
+    lodash "^4.17.5"
+    metro "^0.51.0"
+    metro-config "^0.51.0"
+    metro-core "^0.51.0"
+    metro-memory-fs "^0.51.0"
+    metro-react-native-babel-transformer "^0.51.0"
+    mime "^1.3.4"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    morgan "^1.9.0"
+    node-fetch "^2.2.0"
+    node-notifier "^5.2.1"
+    opn "^3.0.2"
+    plist "^3.0.0"
+    semver "^5.0.3"
+    serve-static "^1.13.1"
+    shell-quote "1.6.1"
+    slash "^2.0.0"
+    ws "^1.1.0"
+    xcode "^2.0.0"
+    xmldoc "^0.4.0"
+
 "@types/es6-collections@^0.5.29":
   version "0.5.31"
   resolved "https://registry.yarnpkg.com/@types/es6-collections/-/es6-collections-0.5.31.tgz#faad21c930cd0ea7f71f51b9e5b555796c5ab23f"
@@ -1568,7 +1608,7 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-commander@^2.12.1, commander@^2.9.0, commander@~2.20.0:
+commander@^2.12.1, commander@^2.19.0, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -3280,10 +3320,10 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
-metro-babel-register@^0.49.1:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.49.2.tgz#746c73311135bd6c2af4d83c2cc6c5cbcf0e8a65"
-  integrity sha512-xx+SNwJ3Dl4MmSNn1RpUGc7b5pyTxXdpqpE7Fuk499rZffypVI1uhKOjKt2lwQhlyD03sXuvB/m3RdEg3mivWg==
+metro-babel-register@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.51.0.tgz#d86d3f2d90b45c7a3c6ae67a53bd1e50bad7a24d"
+  integrity sha512-rhdvHFOZ7/ub019A3+aYs8YeLydb02/FAMsKr2Nz2Jlf6VUxWrMnrcT0NYX16F9TGdi2ulRlJ9dwvUmdhkk+Bw==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"
@@ -3298,6 +3338,13 @@ metro-babel-register@^0.49.1:
     core-js "^2.2.2"
     escape-string-regexp "^1.0.5"
 
+metro-babel-transformer@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.51.0.tgz#9ee5199163ac46b2057527b3f8cbd8b089ffc03e"
+  integrity sha512-M7KEY/hjD3E8tJEliWgI0VOSaJtqaznC0ItM6FiMrhoGDqqa1BvGofl+EPcKqjBSOV1UgExua/T1VOIWbjwQsw==
+  dependencies:
+    "@babel/core" "^7.0.0"
+
 metro-babel-transformer@0.51.1:
   version "0.51.1"
   resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.51.1.tgz#97be9e2b96c78aa202b52ae05fb86f71327aef72"
@@ -3305,10 +3352,10 @@ metro-babel-transformer@0.51.1:
   dependencies:
     "@babel/core" "^7.0.0"
 
-metro-babel7-plugin-react-transform@0.49.2:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.49.2.tgz#d4c43faa6f2b91cc1b244a36a5d708ae8d39dbb2"
-  integrity sha512-LpJT8UvqF/tvVqEwiLUTMjRPhEGdI8e2dr3424XaRANba3j0nqmrbKdJQsPE8TrcqMWR4RHmfsXk0ti5QrEvJg==
+metro-babel7-plugin-react-transform@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.51.0.tgz#af27dd81666b91f05d2b371b0d6d283c585e38b6"
+  integrity sha512-dZ95kXcE2FJMoRsYhxr7YLCbOlHWKwe0bOpihRhfImDTgFfuKIzU4ROQwMUbE0NCbzB+ATFsa2FZ3pHDJ5GI0w==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
@@ -3319,13 +3366,13 @@ metro-babel7-plugin-react-transform@0.51.1:
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
-metro-cache@0.49.2:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.49.2.tgz#355dd3dba9fbd805a7ca6f55646216d35ca98225"
-  integrity sha512-GFeK4bPQn/U9bbRlVPhu2dYMe/b/GsNOFPEResOxr0kQreHV81rs6Jzcr4pU+9HY7vFiEQ1oggnsLUmANuRyPQ==
+metro-cache@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.51.0.tgz#d51448e429feacdd0a9c6d097a9e6ed10441adc7"
+  integrity sha512-E3x45VsOGAiwJv+9sXcygsLAiCsDYiNq2uX1krPj04rbQ2EO/oQkSuNy78i58K+g3pDXns222LDKX6boCehkFw==
   dependencies:
     jest-serializer "24.0.0-alpha.6"
-    metro-core "0.49.2"
+    metro-core "0.51.0"
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
 
@@ -3339,15 +3386,15 @@ metro-cache@0.51.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
 
-metro-config@0.49.2, metro-config@^0.49.1:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.49.2.tgz#d9dd0cc32fdb9731b4685b0019c98874a6e4443b"
-  integrity sha512-olh50qIMWd+Mj47TQeFnIW9NIquMpfq2g2NT5k+rwI38Xfk+KBnV4BamxtzZuViH7eQI06+Cdyu4NvcZffBXGg==
+metro-config@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.51.0.tgz#3a32d4fb226f2ec6ac1d851ecda75e363150037c"
+  integrity sha512-MyhAPWWo7IKC6+8XmEIJRWdyQ6tq7CcamOmgDvCbRYgaz94dS44ikY2Np+og+obVMhwVi+zcSv/YpJECJSc0mQ==
   dependencies:
     cosmiconfig "^5.0.5"
-    metro "0.49.2"
-    metro-cache "0.49.2"
-    metro-core "0.49.2"
+    metro "0.51.0"
+    metro-cache "0.51.0"
+    metro-core "0.51.0"
     pretty-format "24.0.0-alpha.6"
 
 metro-config@0.51.1, metro-config@^0.51.0:
@@ -3361,14 +3408,14 @@ metro-config@0.51.1, metro-config@^0.51.0:
     metro-core "0.51.1"
     pretty-format "24.0.0-alpha.6"
 
-metro-core@0.49.2, metro-core@^0.49.1:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.49.2.tgz#e3d7f9f02454863fc047bd75c2e37d5544c72d1a"
-  integrity sha512-kqhvNPOUTUWOqfm4nFF8l0zWMp2BKO1BUx5KY7osFnVTUpDkuq9Iy433FqEFVhA2jUISrmnd0CTIPcDQyFNllQ==
+metro-core@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.51.0.tgz#96318b135597345cb842f8eb50d2e14e31085ddf"
+  integrity sha512-HXjlYeCNU/5/w01lw+bLCh3Pd9B32LixjprD6+TVu2abDq+ySOX4m8iMV0v5LJ3uyngqyTovyHuEXd0xa6HX3w==
   dependencies:
     jest-haste-map "24.0.0-alpha.6"
     lodash.throttle "^4.1.1"
-    metro-resolver "0.49.2"
+    metro-resolver "0.51.0"
     wordwrap "^1.0.0"
 
 metro-core@0.51.1, metro-core@^0.51.0:
@@ -3381,20 +3428,20 @@ metro-core@0.51.1, metro-core@^0.51.0:
     metro-resolver "0.51.1"
     wordwrap "^1.0.0"
 
-metro-memory-fs@^0.49.1:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.49.2.tgz#af3128b8a60d02d4aed427558b42c8d210a5543c"
-  integrity sha512-bt7ve7iud5gU4Duo9MVMqohJ0nBxILHmQxFhDXOvJnttiDuIfQQUK84pVlo8maNkFbN8uxEJPLBjpD1DC1IOxA==
+metro-memory-fs@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.51.0.tgz#a020e00e3676fa5dae1ace196f066ebd3233c7b4"
+  integrity sha512-hk8nZpy4I56Nfr0CKEsG2vx9C2s6heNX3jody+p+QsAjWDleoK7nEffVSY3r5EVj+DaA8PIL9iCLk7wVDB99nw==
 
 metro-memory-fs@^0.51.0:
   version "0.51.1"
   resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.51.1.tgz#624291f5956b0fd11532d80b1b85d550926f96c9"
   integrity sha512-dXVUpLPLwfQcYHd1HlqHGVzBsiwvUdT92TDSbdc10152TP+iynHBqLDWbxt0MAtd6c/QXwOuGZZ1IcX3+lv5iw==
 
-metro-minify-uglify@0.49.2:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.49.2.tgz#f3b8615cb0e9afd714e4952842bcb9f4d71b4822"
-  integrity sha512-LfnR5N2784pnHe5ShioNkLHyUA1unDU6iLivehX2Waxno1oIP3xKYl/u/VTDET4L8AvLwa5HFACE2hbiWjGQ2Q==
+metro-minify-uglify@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.51.0.tgz#788d820cfdc6b306f6c7d16a7d5ccd8239130ed3"
+  integrity sha512-8JW5M+2WhlaAvQrgFy77bgMoBdbuWReMxdEjJiLxES1yyS5hm90g6J+NZVDpRL/lXA8zt3FO1OQDxAehHL+Ipw==
   dependencies:
     uglify-es "^3.1.9"
 
@@ -3405,10 +3452,10 @@ metro-minify-uglify@0.51.1:
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.49.2:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.49.2.tgz#8d53610e044e0c9a53a03d307e1c51f9e8577abc"
-  integrity sha512-N0+4ramShYCHSAVEPUNWIZuKZskWj8/RDSoinhadHpdpHORMbMxLkexSOVHLluB+XFQ+DENLEx5oVPYwOlENBA==
+metro-react-native-babel-preset@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.51.0.tgz#978d960acf2d214bbbe43e59145878d663bd07de"
+  integrity sha512-Y/aPeLl4RzY8IEAneOyDcpdjto/8yjIuX9eUWRngjSqdHYhGQtqiSBpfTpo0BvXpwNRLwCLHyXo58gNpckTJFw==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.0.0"
     "@babel/plugin-proposal-export-default-from" "^7.0.0"
@@ -3443,7 +3490,7 @@ metro-react-native-babel-preset@0.49.2:
     "@babel/plugin-transform-typescript" "^7.0.0"
     "@babel/plugin-transform-unicode-regex" "^7.0.0"
     "@babel/template" "^7.0.0"
-    metro-babel7-plugin-react-transform "0.49.2"
+    metro-babel7-plugin-react-transform "0.51.0"
     react-transform-hmr "^1.0.4"
 
 metro-react-native-babel-preset@0.51.1:
@@ -3487,6 +3534,16 @@ metro-react-native-babel-preset@0.51.1:
     metro-babel7-plugin-react-transform "0.51.1"
     react-transform-hmr "^1.0.4"
 
+metro-react-native-babel-transformer@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.51.0.tgz#57a695e97a19d95de63c9633f9d0dc024ee8e99a"
+  integrity sha512-VFnqtE0qrVmU1HV9B04o53+NZHvDwR+CWCoEx4+7vCqJ9Tvas741biqCjah9xtifoKdElQELk6x0soOAWCDFJA==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    babel-preset-fbjs "^3.0.1"
+    metro-babel-transformer "0.51.0"
+    metro-react-native-babel-preset "0.51.0"
+
 metro-react-native-babel-transformer@^0.51.0:
   version "0.51.1"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.51.1.tgz#bac34f988c150c725cd1875c13701cc2032615f9"
@@ -3497,10 +3554,10 @@ metro-react-native-babel-transformer@^0.51.0:
     metro-babel-transformer "0.51.1"
     metro-react-native-babel-preset "0.51.1"
 
-metro-resolver@0.49.2:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.49.2.tgz#b7580d7a24fdf96170a9d4099a66b29a18e6e5f8"
-  integrity sha512-Si9/A+jNQmVWlLSi6fXSG1tDEanYu99PMz/cAvM+aZy1yX9RyqfJzHzWVdr4lrNh+4DKCgDea94B9BjezqNYyw==
+metro-resolver@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.51.0.tgz#d17bec214a3f2540e56c6c6342b0d88342946fa2"
+  integrity sha512-QgItSLeF/yMZ/9/AZPs5laPH8EcQ0Yk+H6B48NHyTdRYNuY3eyO2Tw3M/fsTG9y48D2XNj82z58u2A5tfOO8rw==
   dependencies:
     absolute-path "^0.0.0"
 
@@ -3511,10 +3568,10 @@ metro-resolver@0.51.1:
   dependencies:
     absolute-path "^0.0.0"
 
-metro-source-map@0.49.2:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.49.2.tgz#0f9e3d0286fc9549652c99b56b7aa2aec12372e7"
-  integrity sha512-gUQ9wq8iR05QeMqRbAJ+L961LVfoNKLBXSeEzHxoDNSwZ7jFYLMKn0ofLlfMy0S1javZGisS51l5OScLt83naQ==
+metro-source-map@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.51.0.tgz#f4404902d4319f05574ac4591d79c25932d1dc4f"
+  integrity sha512-25TA0pGLnKK3qKJ5CWBfvOA9UIgfCTlk03jg4Dh97xPLFixQ31XedrRa1LMhs6XJWv3QPyYFkLWNUzpwWvPrXA==
   dependencies:
     source-map "^0.5.6"
 
@@ -3525,10 +3582,10 @@ metro-source-map@0.51.1:
   dependencies:
     source-map "^0.5.6"
 
-metro@0.49.2, metro@^0.49.1:
-  version "0.49.2"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.49.2.tgz#0fd615d9f451893a0816721b46e94dcf49dda0f6"
-  integrity sha512-GSNMigeQq+QQ++qwEnWx0hjtYCZIvogn4JuqpKqOyVqNbg+aIheJPvxfDzjF9OXM5WHuNsTfGLW8n5kbUmQJSg==
+metro@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.51.0.tgz#8c0d1d5c3ad78fb86e7085d5a712a6ef623f2ffa"
+  integrity sha512-yUudHe27BLLFQUf/DQ8ATOdtw/uaIEBlJS1ffBTA4W6flborJbN07uQQmFFBW+a9wC1CtA3UhyfDGJBCeNFWAg==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.0.0"
@@ -3541,7 +3598,7 @@ metro@0.49.2, metro@^0.49.1:
     async "^2.4.0"
     babel-preset-fbjs "^3.0.1"
     buffer-crc32 "^0.2.13"
-    chalk "^1.1.1"
+    chalk "^2.4.1"
     concat-stream "^1.6.0"
     connect "^3.6.5"
     debug "^2.2.0"
@@ -3551,18 +3608,20 @@ metro@0.49.2, metro@^0.49.1:
     fs-extra "^1.0.0"
     graceful-fs "^4.1.3"
     image-size "^0.6.0"
+    invariant "^2.2.4"
     jest-haste-map "24.0.0-alpha.6"
     jest-worker "24.0.0-alpha.6"
     json-stable-stringify "^1.0.1"
     lodash.throttle "^4.1.1"
     merge-stream "^1.0.1"
-    metro-cache "0.49.2"
-    metro-config "0.49.2"
-    metro-core "0.49.2"
-    metro-minify-uglify "0.49.2"
-    metro-react-native-babel-preset "0.49.2"
-    metro-resolver "0.49.2"
-    metro-source-map "0.49.2"
+    metro-babel-transformer "0.51.0"
+    metro-cache "0.51.0"
+    metro-config "0.51.0"
+    metro-core "0.51.0"
+    metro-minify-uglify "0.51.0"
+    metro-react-native-babel-preset "0.51.0"
+    metro-resolver "0.51.0"
+    metro-source-map "0.51.0"
     mime-types "2.1.11"
     mkdirp "^0.5.1"
     node-fetch "^2.2.0"
@@ -3576,7 +3635,7 @@ metro@0.49.2, metro@^0.49.1:
     throat "^4.1.0"
     wordwrap "^1.0.0"
     write-file-atomic "^1.2.0"
-    ws "^1.1.0"
+    ws "^1.1.5"
     xpipe "^1.0.5"
     yargs "^9.0.0"
 
@@ -4367,7 +4426,7 @@ plist@2.0.1:
     xmlbuilder "8.2.2"
     xmldom "0.1.x"
 
-plist@^3.0.0:
+plist@^3.0.0, plist@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
   integrity sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==
@@ -4526,7 +4585,7 @@ react-deep-force-update@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"
   integrity sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA==
 
-react-devtools-core@^3.4.2:
+react-devtools-core@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-3.6.1.tgz#51af81ceada65209bbccb8b547a01187cd1cbf04"
   integrity sha512-I/LSX+tpeTrGKaF1wXSfJ/kP+6iaP2JfshEjW8LtQBdz6c6HhzOJtjZXhqOUrAdysuey8M1/JgPY1flSVVt8Ig==
@@ -4583,9 +4642,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.63.tar.gz":
-  version "0.58.6-microsoft.63"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.58.6-microsoft.63.tar.gz#5f7cb30522b596963a20f39e8c43ff85fcc88c67"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.1.tar.gz":
+  version "0.59.0-microsoft.1"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.1.tar.gz#e865f34cc8dcf1f0acdd4a2b7bb59db6d9469b9f"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"
@@ -4614,17 +4673,17 @@ react-native-local-cli@^1.0.0-alpha.5:
     "@babel/plugin-transform-template-literals" "^7.2.0"
     "@babel/plugin-transform-unicode-regex" "^7.2.0"
     "@babel/runtime" "^7.4.0"
+    "@react-native-community/cli" "^1.2.1"
     absolute-path "^0.0.0"
     art "^0.10.0"
     base64-js "^1.1.2"
-    chalk "^1.1.1"
+    chalk "^2.4.1"
     commander "^2.9.0"
     compression "^1.7.1"
     connect "^3.6.5"
     create-react-class "^15.6.3"
     debug "^2.2.0"
     denodeify "^1.2.1"
-    envinfo "^5.7.0"
     errorhandler "^1.5.0"
     escape-string-regexp "^1.0.5"
     event-target-shim "^1.0.5"
@@ -4634,12 +4693,14 @@ react-native-local-cli@^1.0.0-alpha.5:
     glob "^7.1.1"
     graceful-fs "^4.1.3"
     inquirer "^3.0.6"
+    invariant "^2.2.4"
     lodash "^4.17.5"
-    metro "^0.49.1"
-    metro-babel-register "^0.49.1"
-    metro-config "^0.49.1"
-    metro-core "^0.49.1"
-    metro-memory-fs "^0.49.1"
+    metro "0.51.0"
+    metro-babel-register "0.51.0"
+    metro-config "0.51.0"
+    metro-core "0.51.0"
+    metro-memory-fs "0.51.0"
+    metro-react-native-babel-transformer "0.51.0"
     mime "^1.3.4"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
@@ -4655,8 +4716,8 @@ react-native-local-cli@^1.0.0-alpha.5:
     promise "^7.1.1"
     prop-types "^15.5.8"
     react-clone-referenced-element "^1.0.1"
-    react-devtools-core "^3.4.2"
-    regenerator-runtime "^0.11.0"
+    react-devtools-core "^3.6.0"
+    regenerator-runtime "^0.13.2"
     rimraf "^2.5.4"
     schedule "0.3.0"
     scheduler "0.11.3"
@@ -4665,7 +4726,6 @@ react-native-local-cli@^1.0.0-alpha.5:
     shell-quote "1.6.1"
     stacktrace-parser "^0.1.3"
     ws "^1.1.5"
-    xcode "^1.0.0"
     xmldoc "^0.4.0"
     yargs "^9.0.0"
 
@@ -4755,11 +4815,6 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -5113,10 +5168,24 @@ simple-plist@^0.2.1:
     bplist-parser "0.1.1"
     plist "2.0.1"
 
+simple-plist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.0.0.tgz#bed3085633b22f371e111f45d159a1ccf94b81eb"
+  integrity sha512-043L2rO80LVF7zfZ+fqhsEkoJFvW8o59rt/l4ctx1TJWoTx7/jkiS1R5TatD15Z1oYnuLJytzE7gcnnBuIPL2g==
+  dependencies:
+    bplist-creator "0.0.7"
+    bplist-parser "0.1.1"
+    plist "^3.0.1"
+
 sisteransi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
   integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slide@^1.1.5:
   version "1.1.6"
@@ -5839,6 +5908,14 @@ xcode@^1.0.0:
   integrity sha512-hllHFtfsNu5WbVzj8KbGNdI3NgOYmTLZqyF4a9c9J1aGMhAdxmLLsXlpG0Bz8fEtKh6I3pyargRXN0ZlLpcF5w==
   dependencies:
     simple-plist "^0.2.1"
+    uuid "^3.3.2"
+
+xcode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-2.0.0.tgz#134f1f94c26fbfe8a9aaa9724bfb2772419da1a2"
+  integrity sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==
+  dependencies:
+    simple-plist "^1.0.0"
     uuid "^3.3.2"
 
 xml-parser@^1.2.1:


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
1f9d27162 Applying package update to 0.59.0-microsoft.1
41e55273b Remove fbmerge from version number
2097c80c4 Merge pull request #51 from microsoft/fb59merge
93b1fbe15 merge master
0a39cfc10 Applying package update to 0.58.6-microsoft.64
3369b9dd3 Update build logic to bump version before nuget pack
c47d0723c Added User-Defined `BUNDLE_CONFIG = $(SRCROOT)/../rn-cli.config.js` setting to RNTester-macOS and RNTester-tvOS targets to match RNTester (ios) target.
2436bc9fb Added `export EXTRA_PACKAGER_ARGS="--reactNativePath $SRCROOT/../"` to Run Script step in RNTester-macOS and RNTester-tvOS targets to match RNTester (ios) target. Added CGSize non-zero test in -[RCTView displayLayer:] to prevent assert in UIGraphicsEndImageContext().
744d415e9 Merge remote-tracking branch 'ms/master' into fb59merge
c50445cf7 Fix rn-cli.config.js to include 'ios' in haste platforms array. Add tvOS 12 integration test reference images.
6e3037ba7 Merge remote-tracking branch 'ms/master' into fb59merge
232c1b9c5 Fix RCTBaseTextInputView.m to build for tvOS under. Fix to React.xcodeproj/project.pbxproj to include JSCExecutorFactory.mm in tvOS target. Fix to package.json/yarn.lock to update detox to 12.2.0 so that it works in macOS Mojave and later. Fix to scripts/react-native-xcode.sh so that ip.txt is not written for mac RNTester builds.
16969ba74 Update regenerator-runtime to match 59
6147701a7 fix android flow errors
086d39fa9 supress final flow issues
1ff553228 Fix a bunch of flow errors
ab5b1e0b2 Format fix
606f8846b Disable fetchDepth for now
a8d71b1ce merge master
51f4d1e7c Applying package update to 0.59.0-microsoft-fb59merge.19
f1aa5d685 Building RN with the GCC toolchain and GNU stl as these are getting used in devmain
f381ea60e Applying package update to 0.59.0-microsoft-fb59merge.18
ffb07e55b remove 'uwp' special case in ScrollView.js
ddc648db4 Applying package update to 0.59.0-microsoft-fb59merge.17
ae5419f95 Fix CI
621f4a609 Applying package update to 0.59.0-microsoft-fb59merge.16
a3cd96c7c Merge branch 'fb59merge' of https://github.com/Microsoft/react-native into fb59merge
adb7f955d merge master
41a5bdef0 Applying package update to 0.59.0-microsoft-fb59merge.15
c1cd12f34 Merge branch 'fb59merge' of https://github.com/Microsoft/react-native into fb59merge
c16128592 Update pom rewrite logic
5600ccb8a Applying package update to 0.59.0-microsoft-fb59merge.14
bc0261fba Merge branch 'fb59merge' of github.com:Microsoft/react-native into fb59merge
1cfbd7eb4 yarn format
c050e28c5 Applying package update to 0.59.0-microsoft-fb59merge.13
2e64c10da merge master
44d7ce253 Applying package update to 0.59.0-microsoft-fb59merge.12
7300f9ae7 merge master
0a7e52979 Applying package update to 0.59.0-microsoft-fb59merge.11
934505809 Merge branch 'fb59merge' of https://github.com/Microsoft/react-native into fb59merge
3d88c120e fb 0.59.0 merged and running for Mac platform
5d16e72f6 Applying package update to 0.59.0-microsoft-fb59merge.10
4539cda45 ios building, linking, running for RNTester
2a9634717 Applying package update to 0.59.0-microsoft-fb59merge.9
c25d215af Merge a bunch of non-apple files - including circleci's config to get circleci builds running
125a28374 Applying package update to 0.59.0-microsoft-fb59merge.8
b127f894e Merge branch 'fb59merge' of https://github.com/Microsoft/react-native into fb59merge
16aa847a1 merge master
23523c510 Applying package update to 0.59.0-microsoft-fb59merge.7
1df36c2cb Get android bundle building
e0cd519fe Applying package update to 0.59.0-microsoft-fb59merge.6
8f55ab65f Turn off the usage of bitfields in yoga style until we sync to version with the fixes for MSC
afe079b79 Applying package update to 0.59.0-microsoft-fb59merge.5
4214af21f Merge branch 'fb59merge' of https://github.com/Microsoft/react-native into fb59merge
70066ee63 Resolve js merges required to get UWP bundle building
589e92bf1 Applying package update to 0.59.0-microsoft-fb59merge.4
e4ca929e4 Merge branch 'master' into fb59merge
205ff68aa Applying package update to 0.59.0-microsoft-fb59merge.3
925532d42 Android initial merge
362abd98c Applying package update to 0.59.0-microsoft-fb59merge.2
98dda8f9e Merge branch 'fb59merge' of https://github.com/Microsoft/react-native into fb59merge
e81755d39 Merge react-native-implementation.*
ca4520a37 Applying package update to 0.59.0-microsoft-fb59merge.1
7be4e4364 Dont publish fbmerge versions as @latest
42b9b776e Applying package update to 0.59.0-microsoft-fb59merge.0
cbbace4be When building fbmerge branch, just do quick tagging for publish
74ba0895a Resolve conflicts to get ReactCommon building in RNW.
45bb86d5d merge master -> fb59merge
976ffd274 merge package.json
f0340548a more merge
fedfabcec facebook 59.0 merge- with conflicts
7c73f2bb5 [0.59.0] Bump version numbers
fa190bab3 Fix flow error
9f5946bdc Fix DatePicker tests
f6ca4d0a9 Add prop to configure `importantForAutofill`. (#22763)
ffa6d2921 Disable Snapshot tests for Text component on iOS
f0bc49145 Remove duplicated Yoga compile sources to prevent "duplicate symbols" errors when linking using -force_load (#23823)
456a98472 Fix image wrong scale factor when load image from file system (#23446)
8d95e734b Text: Implement textAlign justify for android O+ (#22477)
caba1cb2e Fix crash when calling substring() on a string containing emoji. (#23609)
370947d2b Bump Jest version
9cb4d3f2c [0.59.0-rc.3] Bump version numbers
52cdb7cf2 React sync for revisions f24a0da...8e25ed2
c1392c2ff Toggle secureTextEntry cursor spacing (#23524)
8e5eb6389 add talkback navigation support for links and header (#22447)
2b7346f4b Fix two bugs with Location when not using ACCESS_FINE_LOCATION (#10291)
d7c4c37f0 Use existing character set in POST body when possible (#23603)
4cad73731 Prevent okhttp from adding ;charset=utf8 to ContentType Header (#23580)
fee503174 Fix IllegalArgumentException when creating CookieManager
fbf039b12 add nullable annotations to some ViewManager methods (#23610)
f9097017d Don't reconnect inspector if connection refused (#22625)
52e51368e ReactTextView extends AppCompatTextView (#23321)
56fc63036 SYSTEM_ALERT_WINDOW only in debug builds (#23504)
dff3f609f Map TextInput textContentType strings to Objective-C constants (#22611)
40603bc9c [0.59.0-rc.2] Bump version numbers
415cc2578 Add `folly_compiler_flags` to Core subspec (#23488)
179d49060 Add autoComplete prop (#21575)
2f33b50f4 Don't attempt to load RCTDevLoadingView lazily
176865597 [0.59.0-rc.1] Bump version numbers
7df641618 Invalidate Gradle cache
a7906b0d1 Invalidate Buck cache
171c24d9d Invalidate Yarn cache
72f44a273 Merge branch '0.59-stable' of github.com:facebook/react-native into 0.59-stable
51a7ad55a bump android plugin to 3.3.1 (#23473)
01d5a3bcc react_native_config available to all Android versions (#23470)
560a484fc Revert "[0.59.0-rc.1] Bump version numbers"
99ebebdee Revert "Use current user in cache key"
85a2e7146 Revert "Fix id command"
ad279eef3 Fix id command
c532dfd23 Use current user in cache key
ce046f0b1 Individually accept licenses
dcb7e5c2a Auto-accept licenses and unblock CI
199de26f4 [0.59.0-rc.1] Bump version numbers
4cb164670 fix: bring local-cli back
11c12d522 Resolves #23390: cxxreact, jsi and jsiexecutor depends on DoubleConversion and glog. (#23430)
5a314690f [0.59.0-rc.0] Bump version numbers
51b66c02f Do not use cache during release deploy
2bc055a22 Revert "[0.59.0-rc.0] Bump version numbers"
af6de4e8c [0.59.0-rc.0] Bump version numbers
b2f5e451c Revert to prior Circle CI Android config
cef5ad696 Revert "[0.59.0-rc.0] Bump version numbers"
517c165da [0.59.0-rc.0] Bump version numbers
8b75677fd Revert "[0.59.0-rc.0] Bump version numbers"
d47aa28ef [0.59.0-rc.0] Bump version numbers
aca5f05ff Set ReactNativePath while building RNTester
7f5e04443 Fix Android Gradle build
724d83a96 improve Android Network Security config (#23429)
e6d8ac842 @Nonnull annotation for ReactPackage (#23415)
818f6bb24 bump targetSdkVersion to 28 (#23431)
d37ffc3cf Fix React Native calling CLI wo location
a962cb659 Revert "[0.59.0-rc.0] Bump version numbers"
d059e7470 [0.59.0-rc.0] Bump version numbers
1f099672b Fix React Native calling private CLI APIs
9f96606d3 Revert "[0.59.0-rc.0] Bump version numbers"
69e5c2ddc [0.59.0-rc.0] Bump version numbers
977458442 Revert "add basic signature in template (#22665)"
a252aee2e Bump CLI dependency
06bc4b5b7 Explicitly set path to React Native for development
5e1504b0f Update CLI dependency
e2bd7db73 Merge AlertIOS with Alert (#23318)
4ac65f541 Add deprecation warning for MaskedViewIOS (#23398)
7b33d6b0b fix WritableArray, WritableMap nullable annotations (#23397)
77300ca91 Add deprecation warning for ViewPagerAndroid (#23395)
3c74b6ea3 Bring back the unit tests for the Cxx implementation
daa79b0f9 Add Platform module for web target (#23387)
344b32bb6 TM iOS: avoid bad memory access when passing prop name to a lambda
2c09c06a4 Enable support for using new MobileConfigNativeModule in RN Core/Fabric C++
a15e72347 Support MobileConfig in Fabric Core C++ in FB4A and Catalyst
864a30185 Add more init perf markers
48ba44087 Remove unused code in ReactTextView
222e65088 Fabric: Systraces are temporary disabled in Fabric C++ code
77838b550 Fabric: Systraces are back
78be6efda JSI: Minor tweaks for building on MSVC (#23367)
aefb05941 Exclude RN templates from internal linters
2af13b447 React sync for revisions aa94237...f24a0da
34763bf7f Update script to parse all specs in folder
17e169407 Stop preallocation views on the main thread
c6c5a173b DatePickerDialogModule supports only FragmentActivity (#23371)
be361d0fc TimePickerDialogModule supports only FragmentActivity (#23372)
9ff43abe6 Prevent crash when scrollEnabled used in singleline textinput (#23361)
b8246ac89 Make REACT_CLASS public so we can use a provider
f83281e2c Disable OverlappingRendering for ReactTextView
cdd615136 Revert RCTRootView's backgroundColor to white (#23358)
ae11993d0 Add a Metro configuration with inline require/import
43b56ecb2 Separate RTL examples in RNTester (#23354)
d9c0dfe35 Add a deprecation warning when importing NetInfo (#23383)
bf888a758 Add deprecation warning while importing Slider component (#23385)
ffe37487b Deprecation warning for AsyncStorage (#23384)
1a26f97eb Clang-format for all files in Fabric folder
64d6ea8b0 Moving ObjC specific clang-format rules to the common config
bf58ba96f Fabric: Stop preallocation views on the main thread
392e89676 add prettier check in ci (#23382)
62599fa8f Add deprecation notice to ImageStore (#23330)
d2fc19f4a fix lint error/warnings (#23333)
8ccc55fbd Prepare Groovy scripts for Kotlin DSL migration (#23355)
c93cbdf1b Nonnull annotations for native modules (#23353)
d9f34bdbb TM iOS: added helper to check whether a class is TurboModule compatible
21290b569 Fabric: Enable all Fabric tests for Android
6a71d5125 Trivial rename
fd3b8f200 Fabric: Introducing Better: For faster, clear and ideomatic codebase
7ecf55fc9 Enforce rules-of-hooks via eslint
ccefc700d React sync for revisions 6bf5e85...aa94237 (#23320)
b640b6faf nullable annotations to ReadableMap, WritableMap, ReadableArray, Writable. (#23329)
d002d3032 Danger, be nice to PRs. (#23334)
af41a5350 make xplat lints explicit
0bde29e19 Consider SSTs in Platform.isTesting
a6bdacb25 Kill react-native-git-upgrade
5319cb29a Move `.clang-format` to repo root (#23328)
5ed749e1b Move codegen into packages/react-native-codegen
f307ac7c5 Fixes capitalized I's when emojiis are present after the text being edited. (#21951)
9842e3901 Fabric: folly::dynamic was replaced with RawValue in prop-parsing infra
b0c827536 Fabric: Lost comment in EventQueue
2332cb6fe Fabric: A bunch of `#ifdef ANDROID`
94925d5eb TM iOS: Verify that module class conforms to RCTTurboModule before instantiating
3e9f9cfe4 TM iOS: Util to check if an id is TurboModule instance
adc141057 ReactPicker extends AppCompatSpinner (#23303)
3cca9e76c Partially implemented view recycling for Slider with note to improve
550a14c21 ImageResponseObserverCoordinator does not need to be shared_ptr
1a76f28fb Rename labels in stale.yml (#23319)
9bcd98f1a Update issue templates (#23296)
cf52ab561 add back buildToolsVersion to build.gradle (#23316)
8a5614b28 Add jest test to ensure consistency between AnimatedMock and AnimatedImplementation
833429dd6 ReactSlider extends AppCompatSeekBar (#23304)
185320db2 Initialize internals of ReadableNativeMap with the correct initial capacity
aa3fc0910 Move CoreModulesPackage to use TurboReactPackage
fb8ba3fe9 Enhance image freshness check before stored into cache (#23226)
a4840e7ae remove redundant targetApi and version checks (#23302)
b6318acba Support image props for Slider component, feature parity with pre-Fabric Slider
7f646a5b6 Remove AnimatedImplementation spread from AnimatedMock
10c835214 Fix flow typing of Text
cae6beff7 JSBigString.h: Remove duplicate include of 'unistd.h' (#23297)
3b9604fed ReactActivity extends AppCompatActivity (#23278)
d53dbb0df SuppressLint("MissingPermission") in Location, NetInfo, Vibration mod… (#23294)
38eb2a70a Enable Java8 (#23295)
8beb4bb58 Various minor changes to allow compliation with msvc (#22182)
4d95e85f6 remove unnecessary Android version checks (#23277)
9a7fff9eb Introduce generic `warnOnce` function for warning messages (#22109)
52bdf3405 Add support for intent:// URIs
45686c86e Mock Animated for testing
f37093319 Start using getConstants
ffc9908be Back out "[Flow] Set wait_for_recheck=true to work around crash"
7f2788887 Add performance counters for Fabric
c493cfe70 remove ViewHelper, use ViewCompat instead (#23280)
05ebf7717 Apply the fix for CJK languages on single-line text fields. (#22546)
8ae185280 TM iOS: guard against nullptr in module lookup
aa39cb6d9 Remove assertion on TurboModule existence
e1451cadd Only call __turboModuleProxy when it exists
0e1d4ecbb Make `==` operator for `YGStyle` free function
5184f0d7a User-defined literals for `YGValue`
c599625df Set wait_for_recheck=true to work around crash
e4fd9babe Fix regression of VirtualizedList jumpy header (#22025)
cca1cdf9b Fix typo of startSurface comments (#23264)
58437cd10 fix checkbox casting crash in old android versions (#23281)
9ccde378b Allow changing the project path in react-native-xcode.sh (#23273)
9f72e6a5d Fix duplicate symbols linker error in xcodeproj (#23284)
7ee13cc84 Refine Keyboard API Event typings (#23272)
2aa240176 Fix broken jsiexecutor search path. (#23274)
4989123f8 Fix for Image displayName, currently displaying as <Component> in tests (#23287)
c7b57f198 Remove jest and jest-junit from runtime dependencies (#23276)
842b9c106 Temporary remove systraces from Fabric core code
811090952 Add QPL marker to track time it takes to load .so file from RN
28b8b8e37 Use feature flags in Fabric C++ core, in particular for paragraph measurement caching
1bbb69355 TM: trimming down module dependencies when getting NativeModules
05f35c296 Expose isLocalUserInfoKey to keyboard event notifications (#23245)
dda2b82a0 ReactActivity extends FragmentActivity (#22662)
5ee738659 Update xplat/js to 0.92.0
84572c405 apply Network Security Config file (fixes #22375) (part 2 of #23105) (#23135)
32cb9ec49 Fix Inverted Horizontal ScrollView on Android (#23233)
e4364faa3 Fixes alert view block first responder (#23240)
07d1075f3 bump soloader to 0.6.0 (#23239)
e2bd70aff Marker for baseline callbacks
d2b231672 Marker for measure callbacks
14e8c1486 Adjust pull-bot configuration for new PR template (#23236)
10e4a851a Address some paragraph measure cache follow-up nits
36916ee99 Fix portability issues to Linux, FreeBSD, and older libc++
1e6f5344d avoid double lookup of a nativemodule when resolving turbomodule
0ceefb40d Enable module lookup in TurboModules
dfcbf9729 Adds fixes for react-native-windows UWP (#848)
c435ff382 Revert D13895627: [react-native][PR] [iOS] Enhance image freshness check before stored into cache
e98d5a289 Enhance image freshness check before stored into cache (#23226)
e405e84fc Fix Native Rotation Android (#18872)
02697291f Remove TabbarIOS from OSS
8a50bc3ab iOS: Make each module implement getTurboModuleWithJsInvoker: instead of having centralized provider
bbcb97a29 Location Services: don't reset desiredAccuracy on every update/error (#23209)
4c10f9321 Make perspective transformation look exactly same on iOS and Android (#18302)
7bb7f0159 Update Pull Request and Issue templates. (#23187)
6feb3dc83 Include PreAllocateViewMountItem into the eager initialization of Fabric classes
16a6e5104 Optimize pre-allocation of views
4c69ccd0f Revert D13860038: [react-native][PR] Add ability to control scroll animation duration for Android
c16fadb7c Track how much measure cache entries are used
47a5bcbca Remove TabBarExample from Screenshot Tests (#23206)
f506019e8 count cache hits
0dafa0de6 Layout marker metadata
fc6a4b6db Pass layout marker data along
c72302924 Introduce first marker
f1a3137b4 Add `MarkerSection`
27b4d2156 Always write the manifest in multiRemove (#18613)
7b8235a95 Expose AsyncLocalStorage get/set methods (#18454)
745484c89 Remove height styling when keyboard closed (#16965)
7e8b81049 Add ability to control scroll animation duration for Android (#22884)
8afa0378c SystemUiVisibility overwritten bug (#17370)
52d9f2627 Remove unused constexpr
43601f1a1 Add function to set marker callbacks
1db55803f Add `YGMarkerLayout`
e804124e6 Rename `YGMarkerType` to `YGMarker`
ac90c4fd6 Fix warnings in JSI (#23201)
7ff9456f2 - create missing AndroidDrawable flow types in ViewPropTypes.js. (#23192)
9a9370481 Fix Detox tests after upgrading to latest CLI (#23191)
0bf6a8e91 Remove ReactInstanceManager out of FabricJSIModuleProvider
2b356590f Remove components out of Bindings
cf0c37b08 Remove UIProp class from redex and proguard rules, it doesn't exist
88bc80c51 Update hash functions to use folly::hash::hash_combine
6418e30e9 Small changes to get Profile build working
10b521815 Add QPL marker to track time it takes to load .so file from RN
ec9fe4881 Back out "[react-native][PR] [fix] Fixing overscrolling issue on Virtualized List"
a159a33c0 Added: informational error message on getting Android drawable folder… (#17751)
46aaa0227 Make the load-script-error less misleading (#17055)
54534e79d CameraRoll support for Videos and Photos showed in same time (#16429)
11df0eae5 Add rejectResponderTermination prop to TextInput (#16755)
7cbdd7b6a Remove replaceOkHttpClient method (#16972)
5a87093e1 Fix Warnings in Xcode (#23184)
d0cd3cae1 Add ImageIO related C nullable check to prevent crash (#23186)
959a13363 Disable no-inline-styles lint rule for RNTester (#23169)
4d5f85ed4 Fixing overscrolling issue on Virtualized List (#23181)
8508da425 Disable animation native driver in AnimatedGratuisousApp of RNTester (#23172)
b0302eca2 Separate MaskedViewExample into individual examples (#23168)
46f3285a3 Fix issue #21065 getInspectorDataForViewTag is not a function (#21237)
90850cace Critical improvements for Map and Set polyfills.
dd8f5de06 Fix small typo in comments of reactDecodedImageBytes (#23165)
03c16bdde Template Tweak
a9049442f Fabric: Use LRU to cache results of ParagraphShadowNode::measure
af1f2728a Label issues that use the Bug Report template (#23162)
b905548a3 Fabric: Replace ImageLoader promise implementation with observer model
2ed1bb2e0 Flow strict-local in TimePickerAndroid.android.ios.js (#22714)
3a33e7518 Fix textTransform when used with other text styles on Android (#22670)
27617be9b RNTesterSnapshotTests update ios snapshot images due to layout changes (#23152)
61ca11965 Replace deprecated `stringByReplacingPercentEscapesUsingEncoding:` with `stringByAddingPercentEncodingWithAllowedCharacters:` (#19792)
5be50d482 - update to gradle 4.10.1 or high (#23103)
1024dc251 Change location of iOS build cache directory to ~/Library/Caches/ (#22688)
103880b3c Add image bytes property of UIImage (#22731)
5218932b1 fix: change template to work with jest (#23150)
7795a672d Android: Add error description to Image onError callback (#22737)
527fc9d19 Globally disable LayoutAnimation during Snapshot Tests
67e7f1694 Feature/action sheet destructive button indexes (#18254)
5c0dcddc0 Expose initialAppState constant from Android native AppState module (#19935)
e4d7fc06c Fixed string ref which was causing alert on react <Strictmode> (#23146)
f4def0062 Delete functionality for shared childen
9351dd6c6 migrate ci to official docker (#21477)
988366a41 update xcode version to 2.0.0 (#23051)
4936d284d Android: Add a maxFontSizeMultiplier prop to <Text> and <TextInput> (#23069)
5bc709d51 Temporary render <View> for <AndroidTextInput> component
9793b05bf Friendlier Danger bot (#23124)
9968d0c20 Rename dev settings menu preferences file as it conflicts with fennec's (#23123)
803480aef Remove AlertExample from RNTester in iOS (#23099)
ad52f5262 Fix SwipeableActionButton styling. (#23113)
9672c2e24 Add CF_RETURNS_NOT_RETAINED annotate for Objective-C method which returns Core Foundation object (#23122)
3b0b7ce8c Add Network Security Config file (fixes #22375) (#23105)
25f7b0e87 Fix SectionList layout of RNTester on iOS (#23119)
5ed31ce52 Fix RCTImageLoader multi thread crash (#22746)
5503355a0 ActivityIndicator (#23104)
5bbed4385 android support library 28.0.0 (#23109)
67ad72fa3 Add types to RCTSnapshotNativeComponent (#23111)
70227fec6 RCTTabBar (#23118)
62395d09e Fabric: Add Fabric-compatible Slider component to iOS (ObjC code)
c40a782b3 Fabric: Add Fabric-compatible Slider component to iOS
dda193ae7 Streamline templates (#23107)
b718d3372 Eager load Fabric classes
fe6f6cd46 Upgrade Android support library to version 28 in RN
a746f3b6c Fix Android OSS CI
5ebe84c70 Removed method call to RCTRootView::setReactPreferredFocusedView as ... (#21596)
f66e8ebf5 Fixes #issue18098 SectionList scrollToLocation (#21577)
01f178031 Expose static methods to manipulate the StatusBar stack imperatively (#21206)
638d672ab Added groupCollapsed polyfill (#21457)
47e77682d Update EventEmitter.js (#23047)
ec488dcf6 AndroidViewPagers.js (#22995)
f2ab0ebdb RCTProgressView (#23077)
7e82e45e9 RCTSlider (#23048)
bf27799ba ProgressBarAndroid (#23068)
6c18069a2 RCTPicker (#22996)
1af390be1 Update references to the CLI (#23052)
a3620799e Fix OSS CI
1dfde49d0 fix windows build (#23082)
e011c4c0e Fixes 'Invalid render range' crash (#22847)
9f64ba5b0 improve current bug report process (#23078)
d55558e13 Fix isBatchActive of RCTCxxBridge (#22785)
be51dbc21 @allow-large-files [flow] Bump xplat/js to 0.91 and remove unused suppressions
1f912b9f3 Android TextInput: Fix updating of style props (#22994)
3144299b5 RCTInputAccessoryView (#23050)
6a3d9c06c Fix Picker.onValueChange on Android sometimes not fired due to race condition (#22821)
2191c9ed5 remove unused suppressions in xplat
a828db691 AndroidDrawerLayout (#23036)
b864b6cf3 AndroidSwipeRefreshLayout (#23039)
707622ac8 Refactor FabricBinding class
4802cffa1 Remove FabricBinder interface
b2459cc01 Fix [FB4A] DialogModule.showNewAlert
b0db2d71b Updated React DevTools to ^3.6.0
007e00fa7 RCTModalHostView (#23030)
68b0d4d51 Use RCTBridgeDelegate in the new project template (#23031)
7debc4da7 remove syncrhronization from FabricSoLoader.staticInit
2c7895706 @allow-large-files Deploy Flow v0.90 to xplat/js
cf85d0e4d Add HTTP cache by default (like iOS) (#18348)
091edd2ef Fabric: Clear separation between `commmit` and `tryCommit`
8d83d5f8e Fabric: Unifying retain/release logic in EventTarget
7d630b92d Fabric: Lock-free events 5/n: New implementation of `toggleEventEmitters` (which does not rely on mutations)
cdb983d33 Fabric: Lock-free events 4/n: Added an assert in EventTarget
97f9e4082 Fabric: Lock-free events 3/n: EventEmitter::DispatchMutex is not recursive mutex anymore
b1814b37a Fabric: Lock-free events 2/n: Reimagining of EventTarget
bea80b227 Fabric: Lock-free events 1/n: Removing WeakEventTarget trick from EventEmitter
9f71a8f26 Fabric: `ShadowTree::getRootShadowNode` was removed
84cf65730 Fabric: `ShadowTree::completeByReplacingShadowNode` was moved to RootShadowNode
c937300f5 Fabric: Layout-related methods were removed from ShadowTree
5a58ca414 Fabric: New non-blocking treading model for ShadowTree
8f9ca2b9a Fabric: Even more systraces
aa19fa02e Add a way to selectively enable TurboModules
c93edb5ff Apply thumbTintColor to Sliders on iOS (#22177)
378892bc0 RCTSegmentedControl (#23000)
3a70bf16e ToolbarAndroid (#23009)
5f3afb9fe #22990 add RCTDatePickerNativeComponent types (#23013)
d0ba9ce71 RCTMaskedView (#23001)
462cb1094 AndroidDropdownPicker and AndroidDialogPicker (#22999)
35823ec41 RCTTabBarItem (#23004)
28230939c RCTSafeAreaView (#23006)
eb171d272 AndroidCheckBox (#23003)
b421b5f4b Open source Fabric android
cfbb2278a guard against INF values in CompactValue
27d8824b4 Make JSCExecutorFactory accessible from outside
a93db4915 Removing warning for Pointer is missing a nullability type specifier … (#17872)
3cfe8d59b Reflow comments
53a28ee18 Fix URLs to CSS spec in comments
35e7fdd79 feat: expose AnimatedEvent (#22984)
7d881c1d8 RNTester: Add `allowFontScaling` example to Android (#22991)
0db0d263a Android Text: Fix `letterSpacing` rendering when `fontSize` changes (#22993)
e6057095a Android TextInput: Support `allowFontScaling` on placeholder (#22992)
63038500a Flesh out the URL polyfill a bit more (#22901)
e3ff15052 Remove unused files and code for old JSC and gcc build (#23014)
1fde677cf Remove duplicated `OnGlobalLayoutListener` to improve performance (#22849)
db5528ffa Use Generated Switch Schema
c93f68398 - Create individual RCTSnapshotNativeComponent JS fil… (#23012)
9ed36b77e Fix for #22891: change type for iOS accessiblityActions from NSString to NSArray<NSString*> (#22892)
5dd9d72ec Fix ReactAndroid bundle issue (#22799)
c3bbce449 - Fix failing to bundle in Release build with ndenv of anyenv by supporting anyenv (#22875)
728a35fcf fix incorrect type which makes animated gifs not loop forever on device (#22987)
3654b9edb Differentiate swipe and tap events (#22916)
bb9d01393 Dispatch event names consistent with current system
8f1003fb9 Set up buck to generate native code for rncore
b98964ba3 bump android gradle plugin to 3.3.0 (#22988)
2a479a695 remove deprecated utilities
7fbccdea2 Updated RedBox screen (#22242)
abfd563b4 Copy bundled resources and js in Android App Bundle builds (#21738)
19d04a312 iOS: Clear `Linking.getInitialURL` during bridge reload (#22659)
f76164f88 Added WebView deprecation warning (#22980)
991e83f56 fix: use `require.resolve` in `jest-preset` (#22972)
1bdb25090 Android Text: More robust logic for handling inherited text props (#22917)
e6f7d6942 Move Android TurboModules to github
8a8a11b77 fix validate-android-test-env.sh (#22961)
73434e6cb Fixing T38936345 -Opening creative tools from home or creation flow shows a red screen
64de0c0ae bump okhttp to 3.12.1 (#22877)
ca70e8e46 Improve ScrollView docs and types
adc1a95a3 Reuse ViewManagerRegistry between UIManagerModule and FabricUIManager
cb14b0630 Fabric: More systraces for Diffing and Commit phase
7bf6f2c23 Fabric: Layout/Yoga related systrace sections
7d7941100 imp: Add templates to rn package (#22952)
7ef671658 Change buck to take path to schema instead of fixture name
62264b7ce bump buck to 2019.01.10.01 (#22960)
700c71367 Bump to Android Build Tools 28.0.3, Gradle 4.10.2, Gradle Plugin 3.2.1
7406276a5 Remove enum count macros
1feda5e5c Revert D13597449: [Yoga][cleanup] Remove enum count macros
c458242d8 Reformat xplat build files according to new formatting rules.
768c1ba64 remove envinfo from dependency. (#22870)
5d1b27b01 Fix RNTester Camera Example
6c501eb66 Fix status bar default on Android
630e9faf7 Fix permissions regression in RCTCameraRollManager
5c0b9071e Remove PlatformOS from RN
a1dc92e6f Fix Flow type for onAccessibilityEscape
09795b633 Don't glob over single files
35a136801 Remove enum count macros
0265ee199 Fix autoFocus
f40a04ae3 Remove $FlowFixMe on View
93fa4efe0 Implement callback method
e6eff1f54 Fix RNTester Snapshot and Integration tests missing polyfills
2f32fea79 Remove LayoutStyle, ShadowStyle, TransformStyle in favor of just ViewStyleProp
65194534f Using ENUM_BITFIELDS_NOT_SUPPORTED for enum bitfields
f6f8b092f Android TextInput: Improve application of styles for `value` prop (#22461)
2a1faec1c Remove repetition in `YGEnums.h`
3e2471015 Apply clang-format rules
db87c2544 Re-land D13583442: [RN] Moved TurboModule iOS core to github
8e9ce92f5 Un-revert D13513777: Replace ALAssets* with PHPhoto* in RCTCameraRoll
b5e6ae0fc Unify native props
00905ab8f Fix rerender count on RNTester blue tab (#22876)
8c23b1804 Revert D13583442: [RN] Moved TurboModule iOS core to github
3d12ad5b1 workaround to prevent NPE in ReactViewGroup.dispatchProvideStructure
9380ec0d2 Fix 'global reference table overflow' error in Fabric
a3df28624 Move TurboModuleRegistry (JS) to github
f2fccbb32 Moved TurboModule iOS core to github
ac3979594 Fixing ActionSheetIOS position after rotation on tablet (#22738)
7de2f77d2 Fix expose originalConsole issue (#22844)
2b883abc0 Codemod ImageStyleProp
44a289cf2 Switch Text style to TextStyleProp
dc114260d Integrate Fabric rendering system with ReactChoreographer
117dcd9c5 Fix error message in NativeViewHierarchy
dd209bb78 Fix crash for web socket in some race conditions (#22439)
2c3f807ac Fix no shadow warnings (#22190)
bd32234e6 Add flow types RNTester examples (#22829)
34ee8250b Add filtering to e2e tests (#22828)
9db005063 Fix Jest mocks
3fae38842 Fix CircleCI build error (#22822)
386c2ec6f Added filtering to RNTester example screens (#22777)
3407a7495 ReactViewGroup.dispatchDraw NullPointerException handling
f3e5cce47 Use new JavaScriptCore from npm (#22231)
1d0404c4e Making JSI_EXPORT macro definition conditional (#22561)
5957c8b37 Fix dispatching of events when EventDispatcher is not initialized
acc2ed248 Moved TurboModule C++ core to github
b748e83fb android: worked around onTouchEvent exception
0b1f74712 Fix DatePickerAndroid flow errors
60f3b53ce Flow strict in DatePickerAndroid.android.js, DatePickerAndroid.ios.js (#22106)
19d69f9c2 RN: Workaround HorizontalMeasurementProvider Crash
79cc1468b Fix race condition in Fabric Scheduler
608670ebe iOS: guard against bad RCTModuleData instance
010e3302b Refactor ScrollResponder Mixin removal
221e2fe40 Remove mixins from ScrollView (#22374)
94456ed3d TextInput: Remove use of legacy context API (#22220)
193615a15 Revert D13513777: Replace ALAssets* with PHPhoto* in RCTCameraRoll
8ce9b4762 Replace ALAssets* with PHPhoto* in RCTCameraRoll
34ea65e3d tighter ContextContainer semantics
a3b348eac clean up surface register / start
089dba384 expose contextContainer as application API
fa31e44e1 Fix test ci reporter (#22749)
f88ce8262 Upgrade metro packages on React Native
86d0611c5 test_ios → ✅: Update iOS Snapshots, remove tvOS tests, disable failing tests (#22720)
a3c6e1da1 Open source the Codegen!
4d9f02f56 Do not use glob for static paths.
8e79a74bc Add reset logic for RN perf counters
d7025d222 Remove ActivityIndicator from ScrollView snapshot tests (#22729)
c1c2a5bce Increase idle timeout for react app tests
5d06c7495 Replace our local types by flow-typed (#20320)
60ff2799a Fix Skylint warnings in rn_defs.bzl.
97eb53d14 Update RCTFormatError to support segment ids
ae121690e Update JSStackTrace to support segment ids
0407d8c8f Update RNTester snapshots
bb09866cb Fix failing Switch E2E tests (#22698)
1bd66d9aa RCTSurface: Calling `start` is now required to start the Surface
d8fcb7f16 Use bitfields for `YGLayout` and `YGNode`
ac94e54f5 Switch storage in `YGStyle` to `CompactValue`
375311091 Decouple from storage type in `YGStyle`
c3caca921 Make TextInput event prop types less strict (#22673)
d16221760 Rearrange PR Template (#22683)
63ebbd6bf add basic signature in template (#22665)
871b763c0 Fix RNTesterUnitTests failure (#22658)
24f8d4d3d Deploy v0.89
ac30f64ae Fix E2E warnings (#22621)
0eeb94e94 Remove cast from `detail::Values` to `std::array<YGValue`
dac59586e Encapsulate arrays of `YGValue` within `YGStyle`
94dd6025d Introduce `CompactValue`
f5cb4b68e Remove metro dependency from react native
54a6e1ad3 Surface: fixed up surface stage value check
e7cf870e3 Fix textDecorationLine property
d0485b2f0 Don't use `default` in exhaustive switch
a816c0321 Don't pass `std::string` by pointer
206705892 Use bitfields for enum members of `YGStyle`
bb1b80b76 Remove templates for setting/getting style properties
05d90c301 `YGNodeBoundAxisWithinMinAndMax` accepts `YGFloatOptional`
3e3972628 Remove unnecessary `static` keyword
41c326ee9 Get rid of `static_cast` in `YGResolveValue`
a56b67fa9 Inline `YGFloatOptional` completely
688b3195c Pass `YGFloatOptional` by value, not reference
ada483158 Eliminate `YGFloatOptional::getValue()`
110c1c260 Remove `YGUnwrapFloatOptional`
f90c2fb3f Store `YGFloatOptional` in 32 bits
2d6a10028 Add tests for `YGFloatOptional`
568472231 Make equality operator for `YGValue` inlineable
b5c66a3fb Move out `YGValue`
6f70d4c0a Roll back `-ffast-math`
96e4a7267 Add definations for ReadableArray and WritableArray
1decf879f Back out "[yoga][PR] Fix aspect ratio when stretching with main axis margin"
4ed334427 Update react-test-renderer to support hooks
1a499f43b Enable removeClippedSubviews on Android only for improved scrolling performance
dc52cc5a8 Add defination for ReadableMap interface
c9dc1c68a Create metro-react-native-babel-transformer package
3bef4bddb Measure responder region on first state transition
f8bc32abb AutoFormat ReactWebViewManager
d1b90ee9e Allow to toggle Android WebView HardwareAcceleration from JS
aaa4a38fb Upgrade to Flow v0.88.0
448a66528 Update CompositeReactPackage.java (#21421)
ba9c208cd Support additional UIBarStyle's in RCTConvert (#20102)
f59d79cab Fix #20991 - use name from app.json if available (#20992)
0314fca63 Use relative path for SCRIPTDIR (#22598)
aeaeac88f Disables StateListAnimator for React Slider Android 6 and 7
39b689034 Fix crash when removing root nodes
291867947 iOS: ignore extra modules during bridge start up if it's marked for TurboModule
33fb70f6b Remove persistence from RNTester app (#22596)
794d2264f Allow 'userInfo' for native promise.reject + add native error stack support (#20940)
5194495e9 Propagate exit code in test_objc (#22562)
f8e13afb2 Remove react-native-cli
63a6bb763 Remove remaining references to local-cli
eb413bc9e Remove "babel-core" and other babel 6 modules.
9cd6ae2f4 Updated Button e2e tests to look up elements via testID (#22593)
f14edd8a0 Fix ListViewMock unique key error (#14894)
6a483495c added utfsequence to react-native exports (#20955)
ddc3471f8 set blob as default XMLHttpRequest header response type if supported (#22063)
6cc6f8f48 Revert D13402177: [react-native][PR] Map textContentType strings to Objective-C constants
077386a23 Map textContentType strings to Objective-C constants (#22579)
1bc704d4c Add Touchable E2E tests (#22570)
ee6b0d665 Fix aspect ratio when stretching with main axis margin (#834)
c8047bfe6 Fix flow types
167d7861c Don't crash on second resolve or reject in PromiseImpl. (#20303)
3592122af Delete unused code in console.js (#20860)
fb16af794 Detox debug build (#22572)
78132a0ab Fix weird `createAnimatedComponent` babel/flow bug
b0c43717a Update README.md (#20867)
af3570c63 Make jest react-native preset to use typescript files (#22217)
7fb02889d Buildify xplat build files.
9fdbf6029 Add e2e tests, bug fixes for testIDs (#22537)
cf0dd8ba7 Templates: Use default title, labels (#22560)
fe10dfc72 fix windows ci
90f582ffb Back out Stack D13119110..D13236159
69c8aa64e Fix NPE when opening Google Search Assist when a RN Dialog is displayed
896bb8a21 Move react-native template
9d3f598c2 Remove references to `local-cli`
cd43fb800 Remove local-cli
d2318c403 Remove var from Network/__tests__/XMLHttpRequest-test.js (#22195)
f6d3a6167 default hitSlop values to 0 (#22281)
cbe7d41f3 Remove trailing slash from origin header if no port is specified (#22290)
de6cdc442 Rename RCTImageCacheDelegate -> RCTImageCache in code comment (#22406)
e8a6cb5e1 Android: Adding sendIntent on Linking module (#22302)
cc4211c72 Restore TouchableHighlight and TouchableOpacity behaviour on TV platforms (#21478)
c090758c1 Fix build error for Android projects that use `apply plugin: "com.android.library"` (#22312)
2831d9ef6 Extend reason message for `RCTFatalException` (#22532)
983ddc78d Move middleware files into react-native-internal-cli
168ac8d83 Use `findPlugins` from `react-native-local-cli`
2e5e9fa88 Move asset related modules into `metro-buck`
ee7c70230 Accessibility Escape
900f2df35 Adds links to the README for roadmap, releases, RFCs. Fixes the help link (#22548)
a2ef5b85d Use main.jsbundle in iOS template for production build (#22531)
8f6521aac Don't pass `std::string` by pointer
32d5da2eb Use bitfields for enum members of `YGStyle`
32bc724fb Remove templates for setting/getting style properties
f9c575e35 `YGNodeBoundAxisWithinMinAndMax` accepts `YGFloatOptional`
94ab9b429 inline `YGUnwrapFloatOptional`
517d07ddc Remove unnecessary `static` keyword
fa171b4fe Get rid of `static_cast` in `YGResolveValue`
ceb660242 Inline `YGFloatOptional` completely
a7757f6e5 Pass `YGFloatOptional` by value, not reference
4157a49d8 Eliminate `YGFloatOptional::getValue()`
cb7a9b205 Store `YGFloatOptional` in 32 bits
e1c651340 Make equality operator for `YGValue` inlineable
c37826a93 Move out `YGValue`
57a38263b Roll back `-ffast-math`
deb2a9456 Add Flow types for `Platform.select` [5/5]
060bd73e4 Fix `Platform.select` related flow errors [3/N]
844e11967 Fix dispatch of OnLayout event for first render
c5b80062e Fix ActivityIndicator snapshot test, add toMatchShallowSnapshot
3f0f25f73 Back out "Check for thread consistency in JSCRuntime"
01d7aad54 Guard calls to debug features in fabric test
4f9a3bc8f xplat: pass through config object to fabric UIManager layer
3b6f229eb xplat: added ReactNativeConfig to access runtime specific config values
44878ea9b Fix code analysis bot failure to post lint warnings on pull requests
4dea677b4 Add detox tests for Switch (#22470)
1fe947d95 Record thread cpu time for native modules thread
3f55e87d6 Merge appveyor.yml with .appveyor/config.yml (#22529)
9d00d4d5b Bump Android SDK to 28, Build Tools to 28.0.2, Gradle to 4.7, Gradle Plugin to 3.2.0 (#21632)
c45d290b0 Fixed for supporting mediaPlaybackRequiresUserAction under iOS 10. (#22208)
9facd8189 Flow ViewPropTypes (#22504)
c3b3eb7f7 Fix bug in comparison logic of object property (#22348)
198eb0269 Fix ListEmptyComponent is rendered upside down when using inverted flag. (#21496)
7e4f92bc1 Flow TouchableWithoutFeedback (#22479)
87b653393 Duration cannot be less then 10ms (#21858)
f77aa4eb4 Avoid using `-[UITextView setAttributedString:]` while user is typing (#19809)
04af674c3 Bump RN OSS iOS tests to iOS SDK 12.1, Xcode 10.1
424d4458d Delete dead code
99c370959 Don't create the JSCRuntime until createJSExecutor() is called.
bdb084e8a Check for thread consistency in JSCRuntime
512676c65 Enable ci for windows (#22028)
96ce6f953 Bump ws package to 1.1.5 due to vulnerability issues (#21769)
073ad6a03 React sync for revisions 3ff2c7c...6bf5e85
ff6a53de2 Make type of RefreshControl.onRefresh less strict (#22376)
2330843fa Add API for instrumentation to learn the starting wall time of bg threads
9e0b79114 Pass Circle CI branch information to Coveralls (#22489)
4148976a8 Use `invariant` instead of `fbjs/lib/invariant`
cb6eb0377 Extract out CLI (#22337)
0ef1bc392 Move ToastAndroid to APIs, not Components
de759b949 Fixes animated gifs incorrectly looping/not stopping on last frame (#21999)
69e9c9d37 Add Coveralls to package.json [1/2] (#21017)
0f3be77b7 fix possible NPE in StatusBarModule
3749da131 Make RNTester build and pass again (#22468)
003dbaa3d Accept node arguments when iOS app is built (#22423)
757518edb Fabric: `ShadowTreeRegistry::get` was renamed to `ShadowTreeRegistry::visit`
d150cbc29 Fabric: Using RW-like shared lock in ShadowTreeRegistry
3c50d04cf Cleanup measure function
a2ead1c7b Decouple JSBundleLoader from CatalystInstanceImpl
668341a29 Ensure RCTImageCache's DateFormatter is only allocated once
fe97458b0 Add more information in ending Marker Tags
8d68a3e9f Upgrade metro in RN
ea734dcfb Adjust yearless format for MIT license
dac29e839 fixup xcode project
ef2084c6b 0.87.0 in xplat/js
585f7b916 Summary: Calling -[UIScrollView setContentOffset] with NaN values can cause a crash. That's not clear why exactly the computation returns NaN sometime, but the implemented sanitizing should help to detect this problem during development (and this also prevents the app from crashing).
d6d31a4b6 JSBigString: Explicitly include unistd.h (#22330)
c293f29f5 Fix rename legacy component lifecycles (#22125)
e81adb99f DeltaClient: split DeltaBundle's modules into added and modified
51d983bfa flow-typed: Define minimist
4355b2df1 JS: Upgrade to `chalk@^2.4.1`
c30c803b8 Fabric: Migrating TouchEventEmitter to JSI-based payload
847e6fdd9 Fabric: Migrating ScrollViewEventEmitter to JSI-based payload
610dac446 Fabric: Migrating ViewEventEmitter to JSI-based payload
eeaf0096b Fabric: Migrating SwitchEventEmitter to JSI-based payload
dea8773c1 Fabric: `ValueFactory` and `EventEmitter::dispatchEvent` based on that
f4da8769a Fabric: Coupling `Tag` inside `TargetEventEmitter`
106de1201 Fabric: Fixed incorrect systrace marker in UIManagerBinding::dispatchEvent
7197aa026 Fabric: Using ShadowView instad of ShadowNode inside AttributedString
6c3b05f34 Fabric: std::hash for ShadowView
62173a156 Introducing `fabric/mounting` module
28c3981f7 Fabric: UIManagerBinding::setNativeProps
142dd7673 Fabric: UIManager::setNativeProps
f42d2b9e3 Fabric: `ShadowTree::completeByReplacingShadowNode`
d594d5a4e Fabric: `UIManagerBinding::getRelativeLayoutMetrics`
7b2e3f815 Small cleanup of TextInputExample
23845fb15 Flow strict in Picker.js, PickerIOS.ios.js, PickerAndroid.android.js (#22128)
db43aa8fc Implement getConstants()
ada708906 Revert D13105396
7030d9598 Fix unmangled visibility in rn_defs
706888df3 Use Changelog instead of Release Notes for danger bot (#22395)
00681c366 Fix TouchEvents on text after state changes
d3f3bfa2a Added `persistentScrollbar` prop in ScrollView component (#22300)
0c8db08f5 Switch: Improve Accessibility
2ae559a2a eslint: Disable jasmine env and only enable jest env for test files
18f3de9dc Allow init of Native Module before bridge is initialized [2/N]
fd78eee11 Fix text alpha bug
53da58583 Fix: Add displayName to ActivityIndicator (#22417)
b5571cd5f Create a recursive free with cleanup function
e61a14e71 Fabric: RCTWeakEventEmitterWrapper, NSAttributedString and co.
0ec1d21c2 Fabric: Fixed a retain cycle between ParagraphShadowNode, LocalData and AttributedString
215a0f0f2 Fabric: Proper implementation -[RCTParagraphComponentView prepareForRecycle]`
ffd240917 Fabric: Proper implementation of -[RCTViewComponentView prepareForRecycle]
7fe3f9015 Back out "Add bounce method to TouchableBounce"
922e196ed jest: make regex for tests stricter
ffa903625 jest: rename tests to follow the new convention
fed8b39c3 Sort build file loads.
f000cf07c calling markDirtyAndPropogate when setting isReferenceBaseline value
1f8b46a2f Clean up EventEmitter
cfef04e76 Remove fbjs/lib/emptyFunction from react-native
2de01cb54 Inline `extractSingleTouch` from fbjs
f37792667 Remove isNode call from Map polyfill
dc8246d56 Stop using Promise from fbjs
287934dba Fix Xcode 10 builds (broken by folly upgrade) (#22394)
a68604879 Fix cookies not being sent after a redirected response (#22178)
c68e69cb6 Fabric: Proper handling of memory pressure event in RCTComponentViewRegistry
cd5f0bd95 Fabric: Stopping creating ShadowView instances for non-View ShadowNodes
e581977b5 Introducing RCTComponentViewFactory
eef3df86f Fabric: Introducing `-[RCTComponentViewProtocol componentHandle]`
89f647d52 Redefine hashcode for AttributedString
f34179582 Add caching of spannable text objects
3be2816ae Remove max and min font size from serialization of text attribute
5be17c01a Fix re-measure of text
eec9e4a2f Expose hash as part of text localdata
3b4d6d5ef Add systrace to calculation of Yoga layout() in Fabric
10ce6c3e1 Refactor types used during yoga meassure calls
0357d0de6 Ensure thread safety in the exeuction of RuntimeExecutor
f2894e58c Data types for marker API
c3dea894b Back out "[react-native][PR] [flow-strict] Flow strict StatusBar"
4514041b4 - Resolve two gradle deprecation warnings (#22360)
3355c5246 Bump metro version in React Native
98546e9b1 Use real flow types from metro

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2610)