### PR TITLE
accessibility fixes for <View>

### DIFF
--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -34,7 +34,10 @@ void FrameworkElementViewManager::TransferProperty(XamlView oldView, XamlView ne
 {
   auto oldValue = oldView.ReadLocalValue(dp);
   if (oldValue != nullptr)
+  {
     newView.SetValue(dp, oldValue);
+    oldView.ClearValue(dp);
+  }
 }
 
 void FrameworkElementViewManager::TransferProperties(XamlView oldView, XamlView newView)
@@ -59,9 +62,11 @@ void FrameworkElementViewManager::TransferProperties(XamlView oldView, XamlView 
 
   // Accessibility Properties
   TransferProperty(oldView, newView, winrt::AutomationProperties::NameProperty());
+  TransferProperty(oldView, newView, winrt::AutomationProperties::HelpTextProperty());
   TransferProperty(oldView, newView, winrt::AutomationProperties::LiveSettingProperty());
   auto accessibilityView = winrt::AutomationProperties::GetAccessibilityView(oldView);
   winrt::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
+  winrt::AutomationProperties::SetAccessibilityView(oldView, winrt::Peers::AccessibilityView::Raw);
 
   auto tooltip = winrt::ToolTipService::GetToolTip(oldView);
   oldView.ClearValue(winrt::ToolTipService::ToolTipProperty());


### PR DESCRIPTION
This fixes a few issues we noticed getting People card to production where there was duplicated info in the tree, and help text not in the right place.  Fixes 3 things:

1. When transferring, clear the old properties.  In the case of View converting itself to a Control, the 'oldView' continues to exist but has been wrapped by a contentcontrol.  leaving the accessibilityname, etc meant it was set on 2 elements in the tree
2. HelpText not getting transferred
3. make the old view not accessible after transfer.  (#1 is not really necessary with this change)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2612)