### PR TITLE
Update to react-native@0.59.0-microsoft.2

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,10 +66,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.59.0-microsoft.1"
+    "react-native": "0.59.0-microsoft.2"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.1 || https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.1.tar.gz"
+    "react-native": "0.59.0-microsoft.2 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4650,9 +4650,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.1.tar.gz":
-  version "0.59.0-microsoft.1"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.1.tar.gz#e865f34cc8dcf1f0acdd4a2b7bb59db6d9469b9f"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz":
+  version "0.59.0-microsoft.2"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz#cc414b6055f976dac88ef5ca2c8490785ff16525"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
506d07191 Applying package update to 0.59.0-microsoft.2
77f2be40a Adding logging support for droid and logging failure message (#87)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2619)