### PR TITLE
Update to react-native@0.59.0-microsoft.3

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,10 +66,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.59.0-microsoft.2"
+    "react-native": "0.59.0-microsoft.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "0.59.0-microsoft.2 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz"
+    "react-native": "0.59.0-microsoft.3 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.3.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4895,9 +4895,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz":
-  version "0.59.0-microsoft.2"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz#cc414b6055f976dac88ef5ca2c8490785ff16525"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.3.tar.gz":
+  version "0.59.0-microsoft.3"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.3.tar.gz#d673cbe7999ce452d38c336a1a414b22d531ef59"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
fbd42ab84 Applying package update to 0.59.0-microsoft.3
b86c177c7 Update cmake logic for latest yoga files.

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2626)