### PR TITLE
Update to react-native@0.59.0-microsoft.4

### DIFF
--- a/.ado/evergreen.js
+++ b/.ado/evergreen.js
@@ -138,7 +138,7 @@ request.get('https://raw.githubusercontent.com/microsoft/react-native/master/pac
 
   let existingPkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
 
-  const rnDependency = `${pkgJson.version} || https://github.com/microsoft/react-native/archive/v${pkgJson.version}.tar.gz`;
+  const rnDependency = `^${pkgJson.version.slice(0, pkgJson.version.indexOf('-'))} || ${pkgJson.version} || https://github.com/microsoft/react-native/archive/v${pkgJson.version}.tar.gz`;
 
   if (existingPkgJson.peerDependencies['react-native'] === rnDependency) {
     console.log(`Already at latest react-native version: ${pkgJson.version}.`);

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,10 +66,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.59.0-microsoft.2"
+    "react-native": "0.59.0-microsoft.4"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "0.59.0-microsoft.2 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz"
+    "react-native": "0.59.0-microsoft.4 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.4.tar.gz"
   }
 }

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "0.59.0-microsoft.4 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.4.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.4 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.4.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4895,9 +4895,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz":
-  version "0.59.0-microsoft.2"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.2.tar.gz#cc414b6055f976dac88ef5ca2c8490785ff16525"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.4.tar.gz":
+  version "0.59.0-microsoft.4"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.4.tar.gz#1776b512acd24257a3c1a64aaf7983ca30e37237"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
f88b82e24 Applying package update to 0.59.0-microsoft.4
881a64175 Merge branch 'publish-temp-1560803506372'
eb1617de0 Remove references to RCTTabBar from CMake definitions
fbd42ab84 Applying package update to 0.59.0-microsoft.3
b86c177c7 Update cmake logic for latest yoga files.

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2628)