### PR TITLE
Conditioning support for Flyout offsets on RS5+

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -90,7 +90,7 @@ class FlyoutShadowNode : public ShadowNodeBase
 {
   using Super = ShadowNodeBase;
 public:
-  FlyoutShadowNode();
+  FlyoutShadowNode() = default;
   virtual ~FlyoutShadowNode();
 
   void AddView(ShadowNode& child, int64_t index) override;
@@ -113,16 +113,10 @@ private:
   float m_horizontalOffset = 0;
   float m_verticalOffset = 0;
   bool m_isFlyoutShowOptionsSupported = false;
-  winrt::FlyoutShowOptions m_showOptions;
+  winrt::FlyoutShowOptions m_showOptions = nullptr;
 
   std::shared_ptr<TouchEventHandler> m_touchEventHanadler;
 };
-
-FlyoutShadowNode::FlyoutShadowNode()
-  : Super()
-{
-  m_isFlyoutShowOptionsSupported = winrt::Windows::Foundation::Metadata::ApiInformation::IsTypePresent(L"Windows.UI.Xaml.Controls.Primitives.FlyoutShowOptions");
-}
 
 FlyoutShadowNode::~FlyoutShadowNode()
 {
@@ -143,10 +137,10 @@ void FlyoutShadowNode::createView()
   Super::createView();
 
   m_flyout = winrt::Flyout();
+  m_isFlyoutShowOptionsSupported = !!(m_flyout.try_as<winrt::IFlyoutBase5>());
+
   if (m_isFlyoutShowOptionsSupported)
     m_showOptions = winrt::FlyoutShowOptions();
-  else
-    m_showOptions = nullptr;
 
   auto wkinstance = GetViewManager()->GetReactInstance();
   m_touchEventHanadler = std::make_shared<TouchEventHandler>(wkinstance);


### PR DESCRIPTION
We recently added support to Flyouts for horizontal and vertical offsets from the target element. 
However, the code relied on API's that were only introduced in RS5 (FlyoutShowOptions, and FlyoutBase::ShowAt with options). 

This change conditions the support for offsets on the existence of the FlyoutShowOptions type.
(WI: 3432947)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2629)