### PR TITLE
Add commit Id to nuget packages

### DIFF
--- a/.ado/bumpFileVersions.js
+++ b/.ado/bumpFileVersions.js
@@ -1,8 +1,0 @@
-// @ts-check
-// Just bump the local version numbers in the files...
-
-const {
-  updateVersionsInFiles,
-} = require("./versionUtils");
-
-updateVersionsInFiles();

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -37,16 +37,10 @@ jobs:
 
       - task: CmdLine@2
         displayName: Update package version
+        name: updateVersionTask
         inputs:
           script: node ../.ado/updateVersion.js
           workingDirectory: vnext
-
-      # since the above task will update the package.json, we want to ensure that we use the correct version for the nuget
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish updated package.json for nuget'
-        inputs:
-          PathtoPublish: 'vnext\package.json'
-          ArtifactName: 'UpdatedPackageJson'
 
       - task: Npm@1
         displayName: npm public publish (vnext)
@@ -61,6 +55,8 @@ jobs:
   - job: RnwNativeBuild
     displayName: React-Native-Windows Native Build
     dependsOn: RnwNpmPublish
+    variables:
+      publishCommitId: $[ dependencies.RnwNpmPublish.outputs['updateVersionTask.publishCommitId'] ]
     strategy:
       matrix:
         X64Debug:
@@ -90,13 +86,11 @@ jobs:
 
     steps:
 
-      # The RnwNpmPublish task does this too before publishing the npm package,
-      # but when each slice checks out code, its not going to have those changes
+      # Sync to point where the version numbers have been updated
     - task: CmdLine@2
-      displayName: Update version numbers to align with publishing version
       inputs:
-        script: node ../.ado/bumpFileVersions.js
-        workingDirectory: vnext
+        script: git checkout $(publishCommitId)
+
 
     - template: templates/npm-install-and-build.yml
 
@@ -115,20 +109,23 @@ jobs:
 
 
   - job: RNWNuget
-    dependsOn: RnwNativeBuild
+    dependsOn:
+      - RnwNpmPublish
+      - RnwNativeBuild
     displayName: React-Native-Windows Build and Publish Nuget
     pool:
       name: OE Standard Pool
+    variables:
+      publishCommitId: $[ dependencies.RnwNpmPublish.outputs['updateVersionTask.publishCommitId'] ]
+      npmVersion: $[ dependencies.RnwNpmPublish.outputs['updateVersionTask.npmVersion'] ]
+
     steps:
       - checkout: none #skip checking out the default repository resource
 
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download source Artifact'
-        inputs:
-          artifactName: UpdatedPackageJson
-          downloadPath: $(System.DefaultWorkingDirectory)
-
       - template: templates/prep-and-pack-nuget.yml
+        parameters:
+          publishCommitId: $(publishCommitId)
+          npmVersion: $(npmVersion)
 
       - task: NuGetCommand@2
         displayName: 'NuGet push'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -122,6 +122,11 @@ jobs:
     steps:
       - checkout: none #skip checking out the default repository resource
 
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: '>=4.6.0' 
+
       - template: templates/prep-and-pack-nuget.yml
         parameters:
           publishCommitId: $(publishCommitId)

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -59,4 +59,4 @@ steps:
       command: pack
       packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/React*.nuspec'
       packDestination: '$(System.DefaultWorkingDirectory)/NugetRoot/'
-      buildProperties: CommitId=$(publishCommitId);npmVersion=$(npmVersion)
+      buildProperties: CommitId=${{parameters.publishCommitId}};npmVersion=${{parameters.npmVersion}}

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -59,6 +59,4 @@ steps:
       command: pack
       packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/React*.nuspec'
       packDestination: '$(System.DefaultWorkingDirectory)/NugetRoot/'
-      buildProperties: CommitId=$(publishCommitId)
-      versioningScheme: byEnvVar
-      versionEnvVar: npmVersion
+      buildProperties: CommitId=$(publishCommitId);npmVersion=$(npmVersion)

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,3 +1,6 @@
+parameters:
+  publishCommitId: '0'
+  npmVersion: '0.0.1-pr'
 
 steps:
   - task: DownloadBuildArtifacts@0
@@ -50,23 +53,12 @@ steps:
         robocopy $(System.DefaultWorkingDirectory)\ReactWindows-debug-arm $(System.DefaultWorkingDirectory)\NugetRoot\target\arm\debug /E /MOVE /NP
         robocopy $(System.DefaultWorkingDirectory)\ReactWindows-ship-arm $(System.DefaultWorkingDirectory)\NugetRoot\target\arm\ship /E /MOVE /NP
 
-  - task: PowerShell@2
-    displayName: Extract version from package.json, and put it in nuspec
-    inputs:
-      targetType: inline # filePath | inline
-      script: |
-        if (Test-Path $env:SYSTEM_DEFAULTWORKINGDIRECTORY/UpdatedPackageJson/package.json) {
-          $lines = Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/UpdatedPackageJson/package.json | Where {$_ -match '^\s*"version":.*'} 
-          $npmVersion = $lines.Trim().Split()[1].Trim('",');
-        } else {
-          $npmVersion = "0.0.1-pr"
-        }
-        (Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactWin32.nuspec
-        (Get-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactUwp.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content $env:SYSTEM_DEFAULTWORKINGDIRECTORY/NugetRoot/ReactUwp.nuspec
-
   - task: NuGetCommand@2
     displayName: 'NuGet pack'
     inputs:
       command: pack
       packagesToPack: '$(System.DefaultWorkingDirectory)/NugetRoot/React*.nuspec'
       packDestination: '$(System.DefaultWorkingDirectory)/NugetRoot/'
+      buildProperties: CommitId=$(publishCommitId)
+      versioningScheme: byEnvVar
+      versionEnvVar: npmVersion

--- a/.ado/templates/vs-build.yml
+++ b/.ado/templates/vs-build.yml
@@ -14,7 +14,7 @@ steps:
       feedsToUse: config
       #vstsFeed: # Required when feedsToUse == Select
       #includeNuGetOrg: true # Required when feedsToUse == Select
-      nugetConfigPath: vnext/NuGet.config
+      nugetConfigPath: vnext/NuGet.config 
       #externalFeedCredentials: # Optional
       #noCache: false
       #disableParallelProcessing: false

--- a/.ado/updateVersion.js
+++ b/.ado/updateVersion.js
@@ -65,6 +65,11 @@ function updateVersion() {
   exec(`git push origin HEAD:${tempPublishBranch} --follow-tags --verbose`);
   exec(`git push origin tag ${tagName}`);
 
+  // Record the updated npmVersion and commitId so that later build tasks can use it (to record in the nuget for instance)
+  const publishCommitId = execSync(`git rev-list -n 1 ${tagName}`);
+  console.log(`##vso[task.setvariable variable=publishCommitId;isOutput=true]${publishCommitId}`);
+  console.log(`##vso[task.setvariable variable=npmVersion;isOutput=true]${releaseVersion}`);
+  
   exec(`git checkout ${publishBranchName}`);
   exec(`git pull origin ${publishBranchName}`);
   exec(`git merge ${tempPublishBranch} --no-edit`);

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -380,4 +380,9 @@ jobs:
     steps:
       - checkout: none #skip checking out the default repository resource
 
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: '>=4.6.0' 
+
       - template: templates/prep-and-pack-nuget.yml

--- a/vnext/ReactUwp.nuspec
+++ b/vnext/ReactUwp.nuspec
@@ -7,6 +7,10 @@
     <authors>Microsoft</authors>
     <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <repository type="git"
+      url="https://github.com/microsoft/react-native-windows.git"
+      commit="$CommitId$" />
   </metadata>
   <files>
     <file src="inc\cxxreact\*" target="inc\cxxreact"/>

--- a/vnext/ReactUwp.nuspec
+++ b/vnext/ReactUwp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>OfficeReact.Uwp</id>
-    <version>__BuildBuildNumber__</version>
+    <version>$npmVersion$</version>
     <description>Contains Windows Implementation of React-Native</description>
     <authors>Microsoft</authors>
     <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>

--- a/vnext/ReactUwp.nuspec
+++ b/vnext/ReactUwp.nuspec
@@ -7,7 +7,6 @@
     <authors>Microsoft</authors>
     <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />

--- a/vnext/ReactWin32.nuspec
+++ b/vnext/ReactWin32.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>OfficeReact.Win32</id>
-    <version>__BuildBuildNumber__</version>
+    <version>$npmVersion$</version>
     <description>Contains Windows Implementation of React-Native</description>
     <authors>Microsoft</authors>
     <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>

--- a/vnext/ReactWin32.nuspec
+++ b/vnext/ReactWin32.nuspec
@@ -7,7 +7,6 @@
     <authors>Microsoft</authors>
     <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />

--- a/vnext/ReactWin32.nuspec
+++ b/vnext/ReactWin32.nuspec
@@ -7,6 +7,10 @@
     <authors>Microsoft</authors>
     <projectUrl>https://office.visualstudio.com/ISS/_git/sdx-platform</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <repository type="git"
+      url="https://github.com/microsoft/react-native-windows.git"
+      commit="$CommitId$" />
   </metadata>
   <files>
     <file src="target\x86\Debug\React.Windows.Desktop.DLL\react-native-win32.*" target="lib\debug\x86" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -13,7 +13,7 @@
     "preinstall": "node Scripts/preInstall.js",
     "postinstall": "node Scripts/postInstall.js",
     "build": "just-scripts build",
-    "clean": "node Scripts/just.js clean",
+    "clean": "just-scripts clean",
     "start": "node Scripts/cli.js start",
     "watch": "node node_modules/@office-iss/sdx-build-tools/watch.js"
   },


### PR DESCRIPTION
Changes how some version numbers get passed around during publish, and includes the commitId and repo information inside the nuget.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2647)