### PR TITLE
Reduce onLayoutCalls (native to JS). Move Image download setup to worker 

### DIFF
--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -124,6 +124,8 @@ namespace react {
     {
       try
       {
+        co_await winrt::resume_background();
+
         auto httpMethod{ source.method.empty() ?
           winrt::HttpMethod::Get() :
           winrt::HttpMethod{facebook::utf8ToUtf16(source.method)}

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -248,32 +248,40 @@ void ViewManagerBase::SetLayoutProps(ShadowNodeBase& nodeToUpdate, XamlView view
     // TODO: Assert
     return;
   }
-
-  // Set Position & Size Properties
-  ViewPanel::SetLeft(element, left);
-  ViewPanel::SetTop(element, top);
-
   auto fe = element.as<winrt::FrameworkElement>();
-  fe.Width(width);
-  fe.Height(height);
 
-  // Fire Events
-  if (nodeToUpdate.m_onLayout)
-  {
-    int64_t tag = GetTag(viewToUpdate);
-    folly::dynamic layout = folly::dynamic::object
+  bool changed =
+    left != ViewPanel::GetLeft(element) ||
+    top != ViewPanel::GetTop(element) ||
+    width != fe.Width() ||
+    height != fe.Height();
+
+  if (changed) {
+    // Set Position & Size Properties
+    ViewPanel::SetLeft(element, left);
+    ViewPanel::SetTop(element, top);
+
+    fe.Width(width);
+    fe.Height(height);
+
+    // Fire Events
+    if (nodeToUpdate.m_onLayout)
+    {
+      int64_t tag = GetTag(viewToUpdate);
+      folly::dynamic layout = folly::dynamic::object
       ("x", left)
-      ("y", top)
-      ("height", height)
-      ("width", width);
+        ("y", top)
+        ("height", height)
+        ("width", width);
 
-    folly::dynamic eventData = folly::dynamic::object
+      folly::dynamic eventData = folly::dynamic::object
       ("target", tag)
-      ("layout", std::move(layout));
+        ("layout", std::move(layout));
 
-    auto instance = m_wkReactInstance.lock();
-    if (instance != nullptr)
-      instance->DispatchEvent(tag, "topLayout", std::move(eventData));
+      auto instance = m_wkReactInstance.lock();
+      if (instance != nullptr)
+        instance->DispatchEvent(tag, "topLayout", std::move(eventData));
+    }
   }
 }
 


### PR DESCRIPTION
Don't set layout props if they haven't changed. (Setting them calls InvalidateArrange)
Also don't call into JS if the layout props haven't changed.

Move constructing the Image requests to worker thread.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2648)