### PR TITLE
Added image sample and fixed a couple bugs

### DIFF
--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -93,10 +93,8 @@ namespace react {
 
         if (!needsDownload || memoryStream)
         {
-          // Height and Width are required for network images, so we can set the desiredMaxSize of the surface.
-          // TODO: Set desiredMaxSize for static images if height/width have been set.
           auto surface{ needsDownload ?
-            winrt::LoadedImageSurface::StartLoadFromStream(memoryStream, m_brush->AvailableSize()) :
+            winrt::LoadedImageSurface::StartLoadFromStream(memoryStream) :
             winrt::LoadedImageSurface::StartLoadFromUri(uri) };
 
           surface.LoadCompleted({ this, &ReactImage::LoadedImageSurfaceHandler });

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -93,8 +93,10 @@ namespace react {
 
         if (!needsDownload || memoryStream)
         {
+          // Height and Width are required for network images, so we can set the desiredMaxSize of the surface.
+          // TODO: Set desiredMaxSize for static images if height/width have been set.
           auto surface{ needsDownload ?
-            winrt::LoadedImageSurface::StartLoadFromStream(memoryStream) :
+            winrt::LoadedImageSurface::StartLoadFromStream(memoryStream, m_brush->AvailableSize()) :
             winrt::LoadedImageSurface::StartLoadFromUri(uri) };
 
           surface.LoadCompleted({ this, &ReactImage::LoadedImageSurfaceHandler });

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -61,7 +61,16 @@ namespace react {
     {
       if (m_loadedImageSurface != value)
       {
+        bool updateSurface{ m_loadedImageSurface };
+
         m_loadedImageSurface = value;
+
+        if (updateSurface)
+        {
+          winrt::CompositionSurfaceBrush surfaceBrush{ GetOrCreateSurfaceBrush() };
+          surfaceBrush.Surface(m_loadedImageSurface);
+        }
+
         UpdateCompositionBrush();
       }
     }
@@ -85,6 +94,17 @@ namespace react {
         // and anytime we switch between Surface and Effect brushes (to/from ResizeMode::Repeat)
         if (CompositionBrush() != compositionBrush)
         {
+          if (ResizeMode() == ResizeMode::Repeat)
+          {
+            surfaceBrush.HorizontalAlignmentRatio(0.0f);
+            surfaceBrush.VerticalAlignmentRatio(0.0f);
+          }
+          else
+          {
+            surfaceBrush.HorizontalAlignmentRatio(0.5f);
+            surfaceBrush.VerticalAlignmentRatio(0.5f);
+          }
+
           CompositionBrush(compositionBrush);
         }
       }
@@ -177,9 +197,6 @@ namespace react {
 
         winrt::CompositionEffectFactory effectFactory{ winrt::Window::Current().Compositor().CreateEffectFactory(borderEffect) };
         m_effectBrush = effectFactory.CreateBrush();
-
-        surfaceBrush.HorizontalAlignmentRatio(0.0f);
-        surfaceBrush.VerticalAlignmentRatio(0.0f);
 
         m_effectBrush.SetSourceParameter(L"source", surfaceBrush);
       }

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -110,22 +110,17 @@ namespace react {
       }
     }
 
-    bool ReactImageBrush::IsImageLargerThanView()
+    bool ReactImageBrush::IsImageSmallerThanView()
     {
       if (m_loadedImageSurface)
       {
         auto surface{ GetOrCreateSurfaceBrush().Surface().as<winrt::LoadedImageSurface>() };
         winrt::Size dipsSize{ surface.DecodedSize() };
 
-        return (dipsSize.Height > AvailableSize().Height) || (dipsSize.Width > AvailableSize().Width);
+        return (dipsSize.Height < AvailableSize().Height) && (dipsSize.Width < AvailableSize().Width);
       }
 
       return false;
-    }
-
-    bool ReactImageBrush::UsingSurfaceBrush()
-    {
-      return CompositionBrush().try_as<winrt::CompositionSurfaceBrush>() != nullptr;
     }
 
     winrt::CompositionStretch ReactImageBrush::ResizeModeToStretch()
@@ -134,10 +129,6 @@ namespace react {
 
       switch (ResizeMode())
       {
-      case ResizeMode::Center:
-        stretch = IsImageLargerThanView() ? winrt::CompositionStretch::Uniform : winrt::CompositionStretch::None;
-        break;
-
       case ResizeMode::Contain:
         stretch = winrt::CompositionStretch::Uniform;
         break;
@@ -150,8 +141,9 @@ namespace react {
         stretch = winrt::CompositionStretch::Fill;
         break;
 
+      case ResizeMode::Center:
       case ResizeMode::Repeat:
-        stretch = IsImageLargerThanView() ? winrt::CompositionStretch::Uniform : winrt::CompositionStretch::None;
+        stretch = IsImageSmallerThanView() ? winrt::CompositionStretch::None : winrt::CompositionStretch::Uniform;
         break;
       }
 

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.h
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.h
@@ -45,8 +45,7 @@ namespace react {
 
     private:
       void UpdateCompositionBrush();
-      bool IsImageLargerThanView();
-      bool UsingSurfaceBrush();
+      bool IsImageSmallerThanView();
       winrt::Windows::UI::Composition::CompositionStretch ResizeModeToStretch();
       winrt::Windows::UI::Composition::CompositionSurfaceBrush GetOrCreateSurfaceBrush();
       winrt::Windows::UI::Composition::CompositionEffectBrush GetOrCreateEffectBrush(winrt::Windows::UI::Composition::CompositionSurfaceBrush const& surfaceBrush);

--- a/vnext/Universal.SampleApp/React.Windows.Universal.SampleApp.vcxproj
+++ b/vnext/Universal.SampleApp/React.Windows.Universal.SampleApp.vcxproj
@@ -116,6 +116,7 @@
     <None Include="Bundle\Universal.SampleApp\index.uwp.bundle">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <None Include="image.uwp.js" />
     <None Include="index.uwp.js" />
     <None Include="packages.config" />
     <None Include="React.Windows.Universal.SampleApp_TemporaryKey.pfx" />

--- a/vnext/Universal.SampleApp/React.Windows.Universal.SampleApp.vcxproj.filters
+++ b/vnext/Universal.SampleApp/React.Windows.Universal.SampleApp.vcxproj.filters
@@ -78,6 +78,7 @@
     <None Include="Bundle\Universal.SampleApp\index.uwp.bundle">
       <Filter>Bundle\Universal.SampleApp</Filter>
     </None>
+    <None Include="image.uwp.js" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="MainPage.xaml" />

--- a/vnext/Universal.SampleApp/image.uwp.js
+++ b/vnext/Universal.SampleApp/image.uwp.js
@@ -1,0 +1,94 @@
+/**
+ * Sample React Native App
+ * https://github.com/facebook/react-native
+ * @flow
+ */
+
+import React, { Component } from 'react';
+import { Picker } from 'react-native-windows';
+import {
+  AppRegistry,
+  Image,
+  View,
+  Text,
+  Switch,
+  StyleSheet
+} from 'react-native';
+
+const largeImageUri = 'https://cdn.freebiesupply.com/logos/large/2x/react-logo-png-transparent.png';
+const smallImageUri = 'http://facebook.github.io/react-native/img/header_logo.png';
+
+export default class Bootstrap extends Component {
+  state = {
+    selectedResizeMode: 'center',
+    useLargeImage: false,
+    imageUrl: 'http://facebook.github.io/react-native/img/header_logo.png'
+  };
+
+  switchImageUrl = () => {
+    const useLargeImage = !this.state.useLargeImage;
+    this.setState({ useLargeImage });
+
+    const imageUrl = useLargeImage ? largeImageUri : smallImageUri;
+    this.setState({ imageUrl });
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <View styles={styles.rowContainer}>
+          <View style={styles.rowContainer}>
+            <Text style={styles.title} >ResizeMode</Text>
+            <Picker style={{ width: 125 }} selectedValue={this.state.selectedResizeMode} onValueChange={value => this.setState({ selectedResizeMode: value })}>
+              <Picker.Item label="cover" value="cover" />
+              <Picker.Item label="contain" value="contain" />
+              <Picker.Item label="stretch" value="stretch" />
+              <Picker.Item label="center" value="center" />
+              <Picker.Item label="repeat" value="repeat" />
+            </Picker>
+          </View>
+          <View style={styles.rowContainer}>
+            <Text style={styles.title}>Image Size</Text>
+            <Text style={{ marginRight: 5 }}>Small</Text>
+            <Switch value={this.state.useLargeImage} onValueChange={this.switchImageUrl}/>
+            <Text style={{ marginRight: 5 }}>Large</Text>
+          </View>
+        </View>
+        <View style={styles.imageContainer}>
+          <Image style={styles.image} source={{ uri: this.state.imageUrl }} resizeMode={this.state.selectedResizeMode}/>
+        </View>
+        
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 5
+  },
+  rowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  imageContainer: {
+    marginTop: 5,
+    backgroundColor: 'orange',
+    height: '50%',
+    width: '75%'
+  },
+  image: {
+    height: '100%',
+    width: '100%'
+  },
+  title: {
+    fontWeight: 'bold',
+    margin: 5,
+    width: 80
+  }
+});
+
+AppRegistry.registerComponent('Bootstrap', () => Bootstrap);


### PR DESCRIPTION
- Added a sample that sets an Image's resizeMode from the selected Picker value
- Fixed an issue where images weren't centered after switching back from 'repeat'
- Fixed an issue where the image wasn't updating when switching the source.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2649)