### PR TITLE
Delay setting ReactImageBrush source until image has actually loaded

### DIFF
--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -114,18 +114,6 @@ namespace react {
       }
     }
 
-    void ReactImage::LoadedImageSurfaceHandler(winrt::LoadedImageSurface const& sender, winrt::LoadedImageSourceLoadCompletedEventArgs const& args)
-    {
-      bool succeeded{ false };
-      if (args.Status() == winrt::LoadedImageSourceLoadStatus::Success)
-      {
-        m_brush->Source(sender.as<winrt::LoadedImageSurface>());
-        succeeded = true;
-      }
-
-      m_onLoadEndEvent(*this, succeeded);
-    }
-
     winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageStreamAsync(ImageSource source)
     {
       try

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -97,14 +97,16 @@ namespace react {
             winrt::LoadedImageSurface::StartLoadFromStream(memoryStream) :
             winrt::LoadedImageSurface::StartLoadFromUri(uri) };
 
-          surface.LoadCompleted([this, surface](winrt::LoadedImageSurface const& sender, winrt::LoadedImageSourceLoadCompletedEventArgs const& args) {
-            bool succeeded{ false };
-            if (args.Status() == winrt::LoadedImageSourceLoadStatus::Success) {
-              m_brush->Source(surface);
-              succeeded = true;
-            }
+          surface.LoadCompleted([weak_this{ get_weak() }, surface](winrt::LoadedImageSurface const& /*sender*/, winrt::LoadedImageSourceLoadCompletedEventArgs const& args) {
+            if (auto strong_this{ weak_this.get() }) {
+              bool succeeded{ false };
+              if (args.Status() == winrt::LoadedImageSourceLoadStatus::Success) {
+                strong_this->m_brush->Source(surface);
+                succeeded = true;
+              }
 
-            m_onLoadEndEvent(*this, succeeded);
+              strong_this->m_onLoadEndEvent(*strong_this, succeeded);
+            }
           });
         }
       }

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -97,10 +97,15 @@ namespace react {
             winrt::LoadedImageSurface::StartLoadFromStream(memoryStream) :
             winrt::LoadedImageSurface::StartLoadFromUri(uri) };
 
-          // using a lambda here to capture the surface and prevent it from freeing while the image loads
           surface.LoadCompleted([this, surface](winrt::LoadedImageSurface const& sender, winrt::LoadedImageSourceLoadCompletedEventArgs const& args) {
-			      this->LoadedImageSurfaceHandler(sender, args);
-		      });
+            bool succeeded{ false };
+            if (args.Status() == winrt::LoadedImageSourceLoadStatus::Success) {
+              m_brush->Source(surface);
+              succeeded = true;
+            }
+
+            m_onLoadEndEvent(*this, succeeded);
+          });
         }
       }
       catch (winrt::hresult_error const&)

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -97,9 +97,10 @@ namespace react {
             winrt::LoadedImageSurface::StartLoadFromStream(memoryStream) :
             winrt::LoadedImageSurface::StartLoadFromUri(uri) };
 
-          surface.LoadCompleted({ this, &ReactImage::LoadedImageSurfaceHandler });
-
-          m_brush->Source(surface);
+          // using a lambda here to capture the surface and prevent it from freeing while the image loads
+          surface.LoadCompleted([this, surface](winrt::LoadedImageSurface const& sender, winrt::LoadedImageSourceLoadCompletedEventArgs const& args) {
+			      this->LoadedImageSurfaceHandler(sender, args);
+		      });
         }
       }
       catch (winrt::hresult_error const&)


### PR DESCRIPTION
## Changes in this PR
- Remove `m_brush->Source(surface);` from `ReactImage::Source`
- Capture `surface` in a lambda passed to `LoadCompleted` in order to keep it from being destructed until being assigned to the ReactImageBrush
## Why
As it stands, switching the source of an Image between large images causes noticeable flashes while the image loads (gif at 2x slowdown to make it more obvious):

![RNW_image_switching_flashes](https://user-images.githubusercontent.com/43013/59878688-c225a780-935d-11e9-867a-379e74e8a754.gif)

This is occurring because of the time it takes to load and decode these images. If the CompositionSurfaceBrush's surface is set to a LoadedImageSurface while it's still decoding, the surface is cleared. This change makes it so that the surface isn't set until the image is already decoded, so switching is smooth:

![RNW_image_switching_noflashes](https://user-images.githubusercontent.com/43013/59878938-69a2da00-935e-11e9-9cde-5a5a5facd4ca.gif)

I'm inexperienced with both UWP and modern C++, so I'm very open to suggestions on a better way to do this. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2654)