### PR TITLE
Fix Memory Leak in ViewViewManager

### DIFF
--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -102,7 +102,22 @@ public:
 
   void removeAllChildren() override
   {
-    GetViewPanel(/* removeAllChildren */ true)->Clear();
+    GetViewPanel()->Clear();
+
+    XamlView current = m_view;
+
+    if (IsControl())
+    {
+      auto control = m_view.as<winrt::ContentControl>();
+      current = control.Content().as<XamlView>();
+      control.Content(nullptr);
+    }
+
+    if (HasOuterBorder())
+    {
+      auto border = current.try_as<winrt::Border>();
+      border.Child(nullptr);
+    }
   }
 
   void ReplaceChild(XamlView oldChildView, XamlView newChildView) override
@@ -134,7 +149,7 @@ public:
     static_cast<FrameworkElementViewManager*>(GetViewManager())->RefreshTransformMatrix(this);
   }
 
-  winrt::com_ptr<ViewPanel> GetViewPanel(bool removeAllChildren = false)
+  winrt::com_ptr<ViewPanel> GetViewPanel()
   {
     XamlView current = m_view;
 
@@ -142,18 +157,12 @@ public:
     {
       auto control = m_view.as<winrt::ContentControl>();
       current = control.Content().as<XamlView>();
-      if (removeAllChildren) {
-        control.Content(nullptr);
-      }
     }
 
     if (HasOuterBorder())
     {
       auto border = current.try_as<winrt::Border>();
       current = border.Child().try_as<XamlView>();
-      if (removeAllChildren) {
-        border.Child(nullptr);
-      }
     }
 
     auto panel = current.try_as<ViewPanel>();

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -102,7 +102,7 @@ public:
 
   void removeAllChildren() override
   {
-    GetViewPanel()->Clear();
+    GetViewPanel(/* removeAllChildren */ true)->Clear();
   }
 
   void ReplaceChild(XamlView oldChildView, XamlView newChildView) override
@@ -134,7 +134,7 @@ public:
     static_cast<FrameworkElementViewManager*>(GetViewManager())->RefreshTransformMatrix(this);
   }
 
-  winrt::com_ptr<ViewPanel> GetViewPanel()
+  winrt::com_ptr<ViewPanel> GetViewPanel(bool removeAllChildren = false)
   {
     XamlView current = m_view;
 
@@ -142,12 +142,18 @@ public:
     {
       auto control = m_view.as<winrt::ContentControl>();
       current = control.Content().as<XamlView>();
+      if (removeAllChildren) {
+        control.Content(nullptr);
+      }
     }
 
     if (HasOuterBorder())
     {
       auto border = current.try_as<winrt::Border>();
       current = border.Child().try_as<XamlView>();
+      if (removeAllChildren) {
+        border.Child(nullptr);
+      }
     }
 
     auto panel = current.try_as<ViewPanel>();


### PR DESCRIPTION
I found this with windbg and !idallocs provided by the UIExtensions.

Internal to Microsoft you should be able to open windbg, attach to a running React Native Windows App and use the command !idallocs, if it does not get the ui extensions automatically for you, then you probably need to update your debuggers.

Before this fix you could see the number of Windows_UI_Xaml!CPanel objects increasing as you visit more pages. 
![image](https://user-images.githubusercontent.com/48095233/59934965-9a881b00-9401-11e9-9568-b49ad7a9edda.png)

Using the !xamlTree debugger extensions you can see that some of the panels have no children, and their parent is a border. This made the leak pretty easy to pinpoint.
![image](https://user-images.githubusercontent.com/48095233/59935087-dae79900-9401-11e9-813b-54dad7709024.png)



After this fix I am able to Go back and forth between pages (starting and ending on the same page), and see that the number of Windows_UI_Xaml!CPanel objects in the heap remains constant.
![image](https://user-images.githubusercontent.com/48095233/59936291-7b3ebd00-9404-11e9-9679-ee6b496ce4a4.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2658)