### PR TITLE
Fix memory leaks in ReactImage

### DIFF
--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -91,14 +91,12 @@ namespace react { namespace uwp {
       ShadowNodeBase::createView();
       auto reactImage{ m_view.as<ReactImage>() };
 
-      m_onLoadEndToken = reactImage->OnLoadEnd([imageViewManager{ static_cast<ImageViewManager*>(GetViewManager()) }, weak_reactImage{ reactImage->get_weak() }](const auto&, const bool& succeeded)
+      m_onLoadEndToken = reactImage->OnLoadEnd([imageViewManager{ static_cast<ImageViewManager*>(GetViewManager()) }, reactImage ](const auto&, const bool& succeeded)
       {
-        if (auto strong_reactImage{ weak_reactImage.get() }) {
-          ImageSource source{ strong_reactImage->Source() };
+        ImageSource source{ reactImage->Source() };
 
-          imageViewManager->EmitImageEvent(strong_reactImage.as<winrt::Canvas>(), succeeded ? "topLoad" : "topError", source);
-          imageViewManager->EmitImageEvent(strong_reactImage.as<winrt::Canvas>(), "topLoadEnd", source);
-        }
+        imageViewManager->EmitImageEvent(reactImage.as<winrt::Canvas>(), succeeded ? "topLoad" : "topError", source);
+        imageViewManager->EmitImageEvent(reactImage.as<winrt::Canvas>(), "topLoadEnd", source);
       });
     }
 

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -96,12 +96,14 @@ namespace react { namespace uwp {
   {
     auto reactImage{ ReactImage::Create() };
 
-    reactImage->OnLoadEnd([this, reactImage](const auto&, const bool& succeeded)
+    reactImage->OnLoadEnd([this, weak_reactImage{ reactImage->get_weak() }](const auto&, const bool& succeeded)
     {
-        ImageSource source{ reactImage->Source() };
+      if (auto strong_reactImage{ weak_reactImage.get() }) {
+        ImageSource source{ strong_reactImage->Source() };
 
-        EmitImageEvent(m_wkReactInstance.lock(), reactImage.as<winrt::Canvas>(), succeeded ? "topLoad" : "topError", source);
-        EmitImageEvent(m_wkReactInstance.lock(), reactImage.as<winrt::Canvas>(), "topLoadEnd", source);
+        EmitImageEvent(m_wkReactInstance.lock(), strong_reactImage.as<winrt::Canvas>(), succeeded ? "topLoad" : "topError", source);
+        EmitImageEvent(m_wkReactInstance.lock(), strong_reactImage.as<winrt::Canvas>(), "topLoadEnd", source);
+      }
     });
 
     return reactImage.as<winrt::Canvas>();

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -82,6 +82,36 @@ struct json_type_traits<react::uwp::ResizeMode>
 
 namespace react { namespace uwp {
 
+  class ImageShadowNode : public ShadowNodeBase {
+  public:
+    ImageShadowNode() = default;
+
+    void createView() override
+    {
+      ShadowNodeBase::createView();
+      auto reactImage{ m_view.as<ReactImage>() };
+
+      m_onLoadEndToken = reactImage->OnLoadEnd([imageViewManager{ static_cast<ImageViewManager*>(GetViewManager()) }, weak_reactImage{ reactImage->get_weak() }](const auto&, const bool& succeeded)
+      {
+        if (auto strong_reactImage{ weak_reactImage.get() }) {
+          ImageSource source{ strong_reactImage->Source() };
+
+          imageViewManager->EmitImageEvent(strong_reactImage.as<winrt::Canvas>(), succeeded ? "topLoad" : "topError", source);
+          imageViewManager->EmitImageEvent(strong_reactImage.as<winrt::Canvas>(), "topLoadEnd", source);
+        }
+      });
+    }
+
+    void onDropViewInstance() override
+    {
+      auto reactImage{ m_view.as<ReactImage>() };
+      reactImage->OnLoadEnd(m_onLoadEndToken);
+    }
+
+  private:
+    winrt::event_token m_onLoadEndToken;
+  };
+
   ImageViewManager::ImageViewManager(const std::shared_ptr<IReactInstance>& reactInstance)
     : Super(reactInstance)
   {
@@ -94,19 +124,7 @@ namespace react { namespace uwp {
 
   XamlView ImageViewManager::CreateViewCore(int64_t tag)
   {
-    auto reactImage{ ReactImage::Create() };
-
-    reactImage->OnLoadEnd([this, weak_reactImage{ reactImage->get_weak() }](const auto&, const bool& succeeded)
-    {
-      if (auto strong_reactImage{ weak_reactImage.get() }) {
-        ImageSource source{ strong_reactImage->Source() };
-
-        EmitImageEvent(m_wkReactInstance.lock(), strong_reactImage.as<winrt::Canvas>(), succeeded ? "topLoad" : "topError", source);
-        EmitImageEvent(m_wkReactInstance.lock(), strong_reactImage.as<winrt::Canvas>(), "topLoadEnd", source);
-      }
-    });
-
-    return reactImage.as<winrt::Canvas>();
+    return ReactImage::Create().as<winrt::Canvas>();
   }
 
   void ImageViewManager::UpdateProperties(ShadowNodeBase* nodeToUpdate, const folly::dynamic& reactDiffMap)
@@ -138,8 +156,9 @@ namespace react { namespace uwp {
     Super::UpdateProperties(nodeToUpdate, reactDiffMap);
   }
 
-  void EmitImageEvent(const std::shared_ptr<react::uwp::IReactInstance>& reactInstance, winrt::Canvas canvas, const char* eventName, ImageSource& source)
+  void ImageViewManager::EmitImageEvent(winrt::Canvas canvas, const char* eventName, ImageSource& source)
   {
+    auto reactInstance{ m_wkReactInstance.lock() };
     if (reactInstance == nullptr)
       return;
 
@@ -164,7 +183,7 @@ namespace react { namespace uwp {
     auto sources{ json_type_traits<std::vector<ImageSource>>::parseJson(data) };
     auto reactImage{ canvas.as<ReactImage>() };
 
-    EmitImageEvent(instance, canvas, "topLoadStart", sources[0]);
+    EmitImageEvent(canvas, "topLoadStart", sources[0]);
     reactImage->Source(sources[0]);
   }
 

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.h
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <Views/FrameworkElementViewManager.h>
+#include "ReactImage.h"
 
 namespace react { namespace uwp {
 
@@ -16,6 +17,7 @@ namespace react { namespace uwp {
 
     folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
     folly::dynamic GetNativeProps() const override;
+    void EmitImageEvent(winrt::Windows::UI::Xaml::Controls::Canvas canvas, const char* eventName, ImageSource& source);
 
   protected:
     XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -35,11 +35,6 @@ namespace react {
       this->Background(m_brush.as<winrt::XamlCompositionBrushBase>());
     }
 
-    ReactImage::~ReactImage()
-    {
-      m_surface = nullptr;
-    }
-
     /*static*/ winrt::com_ptr<ReactImage> ReactImage::Create()
     {
       return winrt::make_self<ReactImage>();
@@ -98,15 +93,15 @@ namespace react {
 
         if (!needsDownload || memoryStream)
         {
-          m_surface = needsDownload ?
+          auto surface = needsDownload ?
             winrt::LoadedImageSurface::StartLoadFromStream(memoryStream) :
             winrt::LoadedImageSurface::StartLoadFromUri(uri);
 
-          m_surfaceLoadedRevoker = m_surface.LoadCompleted(winrt::auto_revoke, [weak_this{ get_weak() }](winrt::LoadedImageSurface const& /*sender*/, winrt::LoadedImageSourceLoadCompletedEventArgs const& args) {
+          m_surfaceLoadedRevoker = surface.LoadCompleted(winrt::auto_revoke, [weak_this{ get_weak() }, surface](winrt::LoadedImageSurface const& /*sender*/, winrt::LoadedImageSourceLoadCompletedEventArgs const& args) {
             if (auto strong_this{ weak_this.get() }) {
               bool succeeded{ false };
               if (args.Status() == winrt::LoadedImageSourceLoadStatus::Success) {
-                strong_this->m_brush->Source(strong_this->m_surface);
+                strong_this->m_brush->Source(surface);
                 succeeded = true;
               }
               strong_this->m_onLoadEndEvent(*strong_this, succeeded);

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -33,7 +33,6 @@ namespace react {
     private:
       // Constructors
       ReactImage();
-      ~ReactImage();
 
     public:
       static winrt::com_ptr<ReactImage> Create();
@@ -58,7 +57,6 @@ namespace react {
       ImageSource m_imageSource;
       winrt::com_ptr<ReactImageBrush> m_brush;
       winrt::event<winrt::Windows::Foundation::EventHandler<bool>> m_onLoadEndEvent;
-      winrt::Windows::UI::Xaml::Media::LoadedImageSurface m_surface{ nullptr };
       winrt::Windows::UI::Xaml::Media::LoadedImageSurface::LoadCompleted_revoker m_surfaceLoadedRevoker;
     };
 

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -33,6 +33,7 @@ namespace react {
     private:
       // Constructors
       ReactImage();
+      ~ReactImage();
 
     public:
       static winrt::com_ptr<ReactImage> Create();
@@ -54,13 +55,11 @@ namespace react {
       void ResizeMode(react::uwp::ResizeMode value) { m_brush->ResizeMode(value); }
 
     private:
-      void LoadedImageSurfaceHandler(
-        winrt::Windows::UI::Xaml::Media::LoadedImageSurface const& sender,
-        winrt::Windows::UI::Xaml::Media::LoadedImageSourceLoadCompletedEventArgs const& args);
-
       ImageSource m_imageSource;
       winrt::com_ptr<ReactImageBrush> m_brush;
       winrt::event<winrt::Windows::Foundation::EventHandler<bool>> m_onLoadEndEvent;
+      winrt::Windows::UI::Xaml::Media::LoadedImageSurface m_surface{ nullptr };
+      winrt::Windows::UI::Xaml::Media::LoadedImageSurface::LoadCompleted_revoker m_surfaceLoadedRevoker;
     };
 
     // Helper functions


### PR DESCRIPTION
This addresses two separate (but similar) memory leaks.

1. Reference Cycle Between CLoadedImageSurface and the LoadedEvent Handler.
This is addressed by using an auto-revoker.

Before this change you could observe the number of CLoadedImage objects increasing on the heap.
![image](https://user-images.githubusercontent.com/48095233/60035023-b6d5c300-9660-11e9-8be6-7c311570951b.png)

With !find you could see that the Handler is keeping the Surface.
![image](https://user-images.githubusercontent.com/48095233/60035087-e258ad80-9660-11e9-89bc-715c0dabeb52.png)


2. ReferenceCycle between ImageViewManager and ReactImage caused by the OnLoadEnd event.
This can be solved by un-registering the event handler from the ShadowNode.

You can see the number of ReactImages on the heap continuing to grow.
![image](https://user-images.githubusercontent.com/48095233/60035594-0a94dc00-9662-11e9-924d-38d439a9cebd.png)

Looking at what references the Image you can see it is the handler.
![image](https://user-images.githubusercontent.com/48095233/60035632-2c8e5e80-9662-11e9-91e6-724eac3121f6.png)


After these changes you can see the number of ReactImage objects and CLoadedImageSurface objects remains constant while navigating between pages (start and end on the same page)

![image](https://user-images.githubusercontent.com/48095233/60036285-bbe84180-9663-11e9-8cfd-66617af5f9ba.png)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2667)