### PR TITLE
Add AppTheme module

### DIFF
--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
@@ -50,7 +50,7 @@ const std::string AppTheme::getCurrentTheme()
   return m_currentTheme == winrt::ApplicationTheme::Light ? AppTheme::light : AppTheme::dark;
 }
 
-void AppTheme::fireEvent(std::string const& eventName, folly::dynamic const& eventData)
+void AppTheme::fireEvent(std::string const& eventName, folly::dynamic&& eventData)
 {
   if (auto instance = m_wkReactInstance.lock())
   {

--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "AppThemeModuleUwp.h"
+
+#include <Utils\ValueUtils.h>
+
+#if _MSC_VER <= 1913
+// VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage
+#pragma optimize( "", off )
+#endif
+
+namespace winrt {
+  using namespace Windows::UI::Xaml;
+}
+
+namespace react { namespace uwp {
+
+//
+// AppTheme
+//
+
+AppTheme::AppTheme(const std::shared_ptr<IReactInstance>& reactInstance, const std::shared_ptr<facebook::react::MessageQueueThread>& defaultQueueThread) : react::windows::AppTheme()
+  , m_wkReactInstance(reactInstance)
+  , m_queueThread(defaultQueueThread)
+{
+  m_currentTheme = winrt::Application::Current().RequestedTheme();
+
+  m_colorValuesChangedRevoker = m_uiSettings.ColorValuesChanged(winrt::auto_revoke,
+    [this](const auto&, const auto&) {
+
+      m_queueThread->runOnQueue([this]() {
+        if (m_currentTheme != winrt::Application::Current().RequestedTheme() && !m_accessibilitySettings.HighContrast())
+        {
+          m_currentTheme = winrt::Application::Current().RequestedTheme();
+
+          folly::dynamic eventData = folly::dynamic::object("currentTheme", getCurrentTheme());
+
+          fireEvent("appThemeChanged", std::move(eventData));
+        }
+        });
+    });
+}
+
+AppTheme::~AppTheme() = default;
+
+const std::string AppTheme::getCurrentTheme()
+{
+  return m_currentTheme == winrt::ApplicationTheme::Light ? "light" : "dark";
+}
+
+void AppTheme::fireEvent(std::string const& eventName, folly::dynamic const& eventData)
+{
+  if (auto instance = m_wkReactInstance.lock())
+  {
+    instance->CallJsFunction("RCTDeviceEventEmitter", "emit", folly::dynamic::array(eventName, std::move(eventData)));
+  }
+}
+
+} } // namespace react::uwp

--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
@@ -39,15 +39,15 @@ AppTheme::AppTheme(const std::shared_ptr<IReactInstance>& reactInstance, const s
 
           fireEvent("appThemeChanged", std::move(eventData));
         }
-        });
-    });
+      });
+  });
 }
 
 AppTheme::~AppTheme() = default;
 
 const std::string AppTheme::getCurrentTheme()
 {
-  return m_currentTheme == winrt::ApplicationTheme::Light ? "light" : "dark";
+  return m_currentTheme == winrt::ApplicationTheme::Light ? AppTheme::light : AppTheme::dark;
 }
 
 void AppTheme::fireEvent(std::string const& eventName, folly::dynamic const& eventData)

--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.h
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Modules/AppThemeModule.h>
+
+#include <winrt/Windows.UI.ViewManagement.h>
+
+#include <cxxreact/MessageQueueThread.h>
+
+#include <IReactInstance.h>
+
+namespace react { namespace uwp {
+
+class AppTheme : public react::windows::AppTheme
+{
+public:
+  AppTheme(const std::shared_ptr<IReactInstance>& reactInstance, const std::shared_ptr<facebook::react::MessageQueueThread>& defaultQueueThread);
+  virtual ~AppTheme();
+
+  const std::string getCurrentTheme() override;
+
+private:
+  void fireEvent(std::string const& eventName, folly::dynamic const& eventData);
+
+  std::weak_ptr<IReactInstance> m_wkReactInstance;
+  std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
+  winrt::Windows::UI::Xaml::ApplicationTheme m_currentTheme{ winrt::Windows::UI::Xaml::ApplicationTheme::Light };
+
+  winrt::Windows::UI::ViewManagement::AccessibilitySettings m_accessibilitySettings{ };
+  winrt::Windows::UI::ViewManagement::UISettings m_uiSettings{ };
+  winrt::Windows::UI::ViewManagement::UISettings::ColorValuesChanged_revoker m_colorValuesChangedRevoker{ };
+};
+
+} } // namespace react::uwp

--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.h
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.h
@@ -22,7 +22,7 @@ public:
   const std::string getCurrentTheme() override;
 
 private:
-  void fireEvent(std::string const& eventName, folly::dynamic const& eventData);
+  void fireEvent(std::string const& eventName, folly::dynamic&& eventData);
 
   std::weak_ptr<IReactInstance> m_wkReactInstance;
   std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -164,6 +164,7 @@
     <ClInclude Include="Executors\WebSocketJSExecutorUwp.h" />
     <ClInclude Include="Utils\Helpers.h" />
     <ClInclude Include="Modules\AppStateModuleUwp.h" />
+    <ClInclude Include="Modules\AppThemeModuleUwp.h" />
     <ClInclude Include="Modules\ClipboardModule.h" />
     <ClInclude Include="Modules\DeviceInfoModule.h" />
     <ClInclude Include="Modules\DevSupportManagerUwp.h" />
@@ -250,6 +251,7 @@
     <ClCompile Include="Executors\WebSocketJSExecutorUwp.cpp" />
     <ClCompile Include="Utils\Helpers.cpp" />
     <ClCompile Include="Modules\AppStateModuleUwp.cpp" />
+    <ClCompile Include="Modules\AppThemeModuleUwp.cpp" />
     <ClCompile Include="Modules\ClipboardModule.cpp" />
     <ClCompile Include="Modules\DeviceInfoModule.cpp" />
     <ClCompile Include="Modules\DevSupportManagerUwp.cpp" />

--- a/vnext/ReactUWP/ReactUWP.vcxproj.filters
+++ b/vnext/ReactUWP/ReactUWP.vcxproj.filters
@@ -197,6 +197,9 @@
     <ClCompile Include="Modules\AppStateModuleUwp.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\AppThemeModuleUwp.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
     <ClCompile Include="Views\ControlViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
@@ -212,15 +215,12 @@
     <ClCompile Include="Views\Impl\ScrollViewUWPImplementation.cpp">
       <Filter>Views\Impl</Filter>
     </ClCompile>
-    <ClCompile Include="Views\Impl\SnapPointManagingContentControl.cpp" />
+    <ClCompile Include="Views\Impl\SnapPointManagingContentControl.cpp">
+      <Filter>Views\Impl</Filter>
+    </ClCompile>
     <ClCompile Include="Views\ScrollContentViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
-    <ClCompile Include="UwpPreparedScriptStore.cpp">
-      <Filter>Utils</Filter>
-    </ClCompile>
-    <ClCompile Include="UwpScriptStore.cpp">
-      <Filter>Utils</Filter>
     <ClCompile Include="Views\Image\ImageViewManager.cpp">
       <Filter>Views\Image</Filter>
     </ClCompile>
@@ -241,6 +241,12 @@
     </ClCompile>
     <ClCompile Include="Views\KeyboardEventHandler.cpp">
       <Filter>Views</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\UwpPreparedScriptStore.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\UwpScriptStore.cpp">
+      <Filter>Utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -406,6 +412,9 @@
     <ClInclude Include="Modules\AppStateModuleUwp.h">
       <Filter>Modules</Filter>
     </ClInclude>
+    <ClInclude Include="Modules\AppThemeModuleUwp.h">
+      <Filter>Modules</Filter>
+    </ClInclude>
     <ClInclude Include="Views\DatePickerViewManager.h">
       <Filter>Views</Filter>
     </ClInclude>
@@ -442,7 +451,9 @@
     <ClInclude Include="Views\Impl\ScrollViewUWPImplementation.h">
       <Filter>Views\Impl</Filter>
     </ClInclude>
-    <ClInclude Include="Views\Impl\SnapPointManagingContentControl.h" />
+    <ClInclude Include="Views\Impl\SnapPointManagingContentControl.h">
+      <Filter>Views\Impl</Filter>
+    </ClInclude>
     <ClInclude Include="Views\ScrollContentViewManager.h">
       <Filter>Views</Filter>
     </ClInclude>
@@ -460,18 +471,6 @@
     </ClInclude>
     <ClInclude Include="Views\cppwinrt\winrt\impl\react.uwp.2.h">
       <Filter>Views\cppwinrt\winrt\impl</Filter>
-    </ClInclude>
-    <ClInclude Include="Views\cppwinrt\winrt\impl\Microsoft.UI.Composition.Effects.0.h">
-      <Filter>Views\cppwinrt\winrt\impl</Filter>
-    </ClInclude>
-    <ClInclude Include="Views\cppwinrt\winrt\impl\Microsoft.UI.Composition.Effects.1.h">
-      <Filter>Views\cppwinrt\winrt\impl</Filter>
-    </ClInclude>
-    <ClInclude Include="Views\cppwinrt\winrt\impl\Microsoft.UI.Composition.Effects.2.h">
-      <Filter>Views\cppwinrt\winrt\impl</Filter>
-    </ClInclude>
-    <ClInclude Include="Views\cppwinrt\winrt\Microsoft.UI.Composition.Effects.h">
-      <Filter>Views\cppwinrt\winrt</Filter>
     </ClInclude>
     <ClInclude Include="Views\cppwinrt\BorderEffect.g.h">
       <Filter>Views\cppwinrt</Filter>
@@ -494,19 +493,17 @@
     <ClInclude Include="Views\Image\BorderEffect.h">
       <Filter>Views\Image</Filter>
     </ClInclude>
-    <ClInclude Include="UwpPreparedScriptStore.h">
-      <Filter>Utils</Filter>
-    </ClInclude>
-          <Filter>Views</Filter>
-    </ClInclude>
     <ClInclude Include="Utils\Helpers.h">
-      <Filter>Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="UwpScriptStore.h">
       <Filter>Utils</Filter>
     </ClInclude>
     <ClInclude Include="..\include\ReactUWP\Views\KeyboardEventHandler.h">
       <Filter>Views</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\UwpPreparedScriptStore.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\UwpScriptStore.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/vnext/ReactWindowsCore/Modules/AppThemeModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/AppThemeModule.cpp
@@ -14,29 +14,21 @@ namespace react { namespace windows {
 AppTheme::AppTheme() = default;
 AppTheme::~AppTheme() = default;
 
-// TODO: real implementation
 const std::string AppTheme::getCurrentTheme()
 {
-  return "light";
+  return AppTheme::light;
 }
 
 //
 // AppThemeModule
 //
 
-/* static */ const std::string AppThemeModule::name = "RTCAppTheme";
-
 AppThemeModule::AppThemeModule(std::shared_ptr<AppTheme>&& appTheme)
   : m_appTheme(std::move(appTheme))
 {
 }
 
-std::string AppThemeModule::getName()
-{
-  return name;
-}
-
-std::map<std::string, folly::dynamic> AppThemeModule::getConstants()
+auto AppThemeModule::getConstants() -> std::map<std::string, folly::dynamic>
 {
   return {
     { "initialAppTheme", folly::dynamic { m_appTheme->getCurrentTheme() } }

--- a/vnext/ReactWindowsCore/Modules/AppThemeModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/AppThemeModule.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "AppThemeModule.h"
+
+namespace react { namespace windows {
+
+//
+// AppTheme
+//
+
+AppTheme::AppTheme() = default;
+AppTheme::~AppTheme() = default;
+
+// TODO: real implementation
+const std::string AppTheme::getCurrentTheme()
+{
+  return "light";
+}
+
+//
+// AppThemeModule
+//
+
+/* static */ const std::string AppThemeModule::name = "RTCAppTheme";
+
+AppThemeModule::AppThemeModule(std::shared_ptr<AppTheme>&& appTheme)
+  : m_appTheme(std::move(appTheme))
+{
+}
+
+std::string AppThemeModule::getName()
+{
+  return name;
+}
+
+std::map<std::string, folly::dynamic> AppThemeModule::getConstants()
+{
+  return {
+    { "initialAppTheme", folly::dynamic { m_appTheme->getCurrentTheme() } }
+  };
+}
+
+auto AppThemeModule::getMethods() -> std::vector<facebook::xplat::module::CxxModule::Method>
+{
+  return { };
+}
+
+} } // namespace react::windows

--- a/vnext/ReactWindowsCore/Modules/AppThemeModule.h
+++ b/vnext/ReactWindowsCore/Modules/AppThemeModule.h
@@ -12,6 +12,9 @@ namespace react { namespace windows {
 class AppTheme
 {
 public:
+  static inline const std::string dark = "dark";
+  static inline const std::string light = "light";
+
   AppTheme();
   virtual ~AppTheme();
 
@@ -21,14 +24,14 @@ public:
 class AppThemeModule : public facebook::xplat::module::CxxModule
 {
 public:
+  static inline const std::string name = "RTCAppTheme";
+
   AppThemeModule(std::shared_ptr<AppTheme> && appTheme);
 
-  static const std::string name;
-
   // CxxModule
-  std::string getName() override;
-  std::map<std::string, folly::dynamic> getConstants() override;
-  auto getMethods()->std::vector<Method> override;
+  std::string getName() override { return name; }
+  auto getConstants() -> std::map<std::string, folly::dynamic> override;
+  auto getMethods() -> std::vector<Method> override;
 
 private:
   std::shared_ptr<AppTheme> m_appTheme;

--- a/vnext/ReactWindowsCore/Modules/AppThemeModule.h
+++ b/vnext/ReactWindowsCore/Modules/AppThemeModule.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cxxreact/CxxModule.h>
+#include <folly/dynamic.h>
+#include <map>
+
+namespace react { namespace windows {
+
+class AppTheme
+{
+public:
+  AppTheme();
+  virtual ~AppTheme();
+
+  virtual const std::string getCurrentTheme();
+};
+
+class AppThemeModule : public facebook::xplat::module::CxxModule
+{
+public:
+  AppThemeModule(std::shared_ptr<AppTheme> && appTheme);
+
+  static const std::string name;
+
+  // CxxModule
+  std::string getName() override;
+  std::map<std::string, folly::dynamic> getConstants() override;
+  auto getMethods()->std::vector<Method> override;
+
+private:
+  std::shared_ptr<AppTheme> m_appTheme;
+};
+
+} } // namespace react::windows

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -109,6 +109,7 @@
     <ClInclude Include="Logging.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="Modules\AppStateModule.h" />
+    <ClInclude Include="Modules\AppThemeModule.h" />
     <ClInclude Include="Modules\BatchingUIManagerModule.h" />
     <ClInclude Include="Modules\ExceptionsManagerModule.h" />
     <ClInclude Include="Modules\I18nModule.h" />
@@ -130,6 +131,7 @@
     <ClCompile Include="JSBigAbiString.cpp" />
     <ClCompile Include="LayoutAnimation.cpp" />
     <ClCompile Include="Modules\AppStateModule.cpp" />
+    <ClCompile Include="Modules\AppThemeModule.cpp" />
     <ClCompile Include="Modules\BatchingUIManagerModule.cpp" />
     <ClCompile Include="Modules\ExceptionsManagerModule.cpp" />
     <ClCompile Include="Modules\I18nModule.cpp" />

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj.filters
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj.filters
@@ -41,6 +41,9 @@
     <ClCompile Include="Modules\BatchingUIManagerModule.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\AppThemeModule.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CxxMessageQueue.h" />
@@ -129,6 +132,9 @@
     <ClInclude Include="LayoutAnimation.h" />
     <ClInclude Include="utilities.h" />
     <ClInclude Include="Modules\BatchingUIManagerModule.h">
+      <Filter>Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\AppThemeModule.h">
       <Filter>Modules</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vnext/Universal.SampleApp/App.xaml
+++ b/vnext/Universal.SampleApp/App.xaml
@@ -1,8 +1,7 @@
-﻿<Application
+<Application
     x:Class="WindowsSampleApp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WindowsSampleApp"
-    RequestedTheme="Light">
+    xmlns:local="using:WindowsSampleApp">
 
 </Application>

--- a/vnext/src/Libraries/Modules/AppTheme/AppTheme.tsx
+++ b/vnext/src/Libraries/Modules/AppTheme/AppTheme.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import { NativeEventEmitter } from 'react-native';
+
+class AppThemeModule extends NativeEventEmitter  {
+  get currentTheme(): string {
+    return '';
+  }
+}
+
+export const AppTheme = new AppThemeModule();
+export default AppTheme;

--- a/vnext/src/Libraries/Modules/AppTheme/AppTheme.uwp.ts
+++ b/vnext/src/Libraries/Modules/AppTheme/AppTheme.uwp.ts
@@ -7,7 +7,7 @@ import { NativeEventEmitter } from 'react-native';
 const NativeModules = require('NativeModules');
 const ThemingNative = NativeModules.RTCAppTheme;
 
-class ThemingModule extends NativeEventEmitter  {
+class AppThemeModule extends NativeEventEmitter  {
   private _currentTheme: string;
 
   constructor() {
@@ -24,5 +24,5 @@ class ThemingModule extends NativeEventEmitter  {
   }
 }
 
-export const Theming = new ThemingModule();
-export default Theming;
+export const AppTheme = new AppThemeModule();
+export default AppTheme;

--- a/vnext/src/Libraries/Modules/AppTheme/AppTheme.uwp.ts
+++ b/vnext/src/Libraries/Modules/AppTheme/AppTheme.uwp.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import { NativeEventEmitter } from 'react-native';
+
+const NativeModules = require('NativeModules');
+const ThemingNative = NativeModules.RTCAppTheme;
+
+class ThemingModule extends NativeEventEmitter  {
+  private _currentTheme: string;
+
+  constructor() {
+    super(ThemingNative);
+
+    this._currentTheme = ThemingNative.initialAppTheme;
+    this.addListener('appThemeChanged', ({currentTheme}:{currentTheme: string}) => {
+      this._currentTheme = currentTheme;
+    });
+  }
+
+  get currentTheme(): string {
+    return this._currentTheme;
+  }
+}
+
+export const Theming = new ThemingModule();
+export default Theming;

--- a/vnext/src/index.ts
+++ b/vnext/src/index.ts
@@ -9,3 +9,4 @@ export * from './Libraries/Components/Picker/PickerUWP';
 export * from './Libraries/Components/Popup/Popup';
 export * from './Libraries/Components/Keyboard/KeyboardExt';
 export * from './Libraries/Components/Keyboard/KeyboardExtProps';
+export * from './Libraries/Modules/AppTheme/AppTheme';

--- a/vnext/src/index.uwp.ts
+++ b/vnext/src/index.uwp.ts
@@ -9,3 +9,4 @@ export * from './Libraries/Components/Picker/PickerUWP.uwp';
 export * from './Libraries/Components/Popup/Popup.uwp';
 export * from './Libraries/Components/Keyboard/KeyboardExt.uwp';
 export * from './Libraries/Components/Keyboard/KeyboardExtProps';
+export * from './Libraries/Modules/AppTheme/AppTheme.uwp';


### PR DESCRIPTION
This module exposes the app's current theme (dark/light) as a property and allows the user to subscribe to theme change events. 

Sample usage:
`import { AppTheme } from 'react-native-windows'`
```
  state = {
    currentTheme: AppTheme.currentTheme
  }

  componentDidMount() {
    AppTheme.addListener('appThemeChanged', this.onAppThemeChanged);
  }

  componentWillUnmount() {
    AppTheme.removeListener('appThemeChanged', this.onAppThemeChanged);
  }

  onAppThemeChanged = (event) => {
    const currentTheme = AppTheme.currentTheme;
    this.setState({currentTheme});
  };

  render() {
    return (
      <Button title='click me' color={this.state.currentTheme === 'dark' ? 'grey' : 'orange'}></Button>
    );
  }
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2684)