### PR TITLE
Update to react-native@0.59.0-microsoft.7

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,10 +66,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.59.0-microsoft.6"
+    "react-native": "0.59.0-microsoft.7"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.6 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.6.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.7 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.7.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4895,9 +4895,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.6.tar.gz":
-  version "0.59.0-microsoft.6"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.6.tar.gz#c0e204a31032183347674f624ecaecfaa8bd0d31"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.7.tar.gz":
+  version "0.59.0-microsoft.7"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.7.tar.gz#46558143f49c8c82da1282d6211d8635ba8ae171"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
fb8100d0a Applying package update to 0.59.0-microsoft.7
ceb544d1e Updating RNTester bundle for RN59 (#95)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2685)