### PR TITLE
TextInput: Don't blur if not focused (WI: 3249010)

### DIFF
--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -448,7 +448,7 @@ void TextInputViewManager::DispatchCommand(XamlView viewToUpdate, int64_t comman
         break;
 
       // Verify that the textBox hasn't already lost focus.
-      if (focusedUIElement.try_as<winrt::DependencyObject>() != static_cast<winrt::DependencyObject>(textBox))
+      if (focusedUIElement.try_as<winrt::TextBox>() != textBox)
         break;
 
       auto content = winrt::Windows::UI::Xaml::Window::Current().Content();

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -443,6 +443,14 @@ void TextInputViewManager::DispatchCommand(XamlView viewToUpdate, int64_t comman
 
     case TextInputCommands::Blur:
     {
+      auto focusedUIElement = winrt::FocusManager::GetFocusedElement();
+      if (focusedUIElement == nullptr)
+        break;
+
+      // Verify that the textBox hasn't already lost focus.
+      if (focusedUIElement.try_as<winrt::DependencyObject>() != static_cast<winrt::DependencyObject>(textBox))
+        break;
+
       auto content = winrt::Windows::UI::Xaml::Window::Current().Content();
       if (content == nullptr)
         break;


### PR DESCRIPTION
We need to ensure that the TextInput blur command, which works by focusing on the current window Frame, does not execute if the TextBox does not currently have focus.

We were doing this in 'current', but we lost that check in the C#->CPP transition in 'vnext'.

See 
https://github.com/microsoft/react-native-windows/pull/1529

Without this check, we mess up native XAML's focus management. In the specific scenario that triggered this investigation, the extra focus change was moving the focus out of the flyout containing the TextInput that just lost focus, which then triggered XAML to dismiss the flyout even though the user had just clicked on the flyout.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2687)