### PR TITLE
Linking module fixes

### DIFF
--- a/vnext/ReactUWP/Modules/LinkingManagerModule.cpp
+++ b/vnext/ReactUWP/Modules/LinkingManagerModule.cpp
@@ -35,11 +35,15 @@ static winrt::fire_and_forget openURLAsync(winrt::Windows::Foundation::Uri uri, 
   }
   else
   {
-    error({});
+    error({
+      folly::dynamic::object
+      ("code", 1)
+      ("message", "Unable to open URL:" + facebook::react::unicode::utf16ToUtf8(uri.DisplayUri()))
+    });
   }
 }
 
-static winrt::fire_and_forget canOpenURLAsync(winrt::Windows::Foundation::Uri uri, Callback success, Callback error)
+static winrt::fire_and_forget canOpenURLAsync(winrt::Windows::Foundation::Uri uri, Callback success, Callback /*error*/)
 {
   winrt::Windows::System::LaunchQuerySupportStatus status = co_await winrt::Windows::System::Launcher::QueryUriSupportAsync(uri, winrt::Windows::System::LaunchQuerySupportType::Uri);
   if (status == winrt::Windows::System::LaunchQuerySupportStatus::Available)
@@ -48,7 +52,7 @@ static winrt::fire_and_forget canOpenURLAsync(winrt::Windows::Foundation::Uri ur
   }
   else
   {
-    error({});
+    success({ false });
   }
 }
 


### PR DESCRIPTION
1. canOpenurl should succeed with false when you can't, instead of erroring (which was actually generating a js error)
2. in openUrl, call the error callback properly, error callbacks that are promises must contain code and message or the js side throws exceptions on expected data in the error

(I couldn't actually get openUrl to fail without adding additional local changes for launcher options, so maybe the error path can't actually be hit)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2688)