### PR TITLE
Adding support for setting a custom root path for bundle loading

### DIFF
--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -243,20 +243,20 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance>& spThis, cons
     devSettings->jsExceptionCallback = std::move(settings.JsExceptionCallback);
     devSettings->useJITCompilation = settings.EnableJITCompilation;
     devSettings->debugHost = settings.DebugHost;
-    devSettings->useCustomRootPath = settings.UseCustomRootPath;
-    devSettings->bundleRootPath = settings.BundleRootPath;
 
     // In most cases, using the hardcoded ms-appx URI works fine, but there are certain scenarios,
     // such as in optional packaging, where the developer might need to modify the path, in which
     // case we should use the custom path instead.
-    if (devSettings->useCustomRootPath)
+    if (settings.BundleRootPath.empty())
     {
-      m_bundleRootPath = devSettings->bundleRootPath;
+      devSettings->bundleRootPath = "ms-appx:///Bundle/";
     }
     else
     {
-      m_bundleRootPath = "ms-appx:///Bundle/";
+      devSettings->bundleRootPath = settings.BundleRootPath;
     }
+
+    m_bundleRootPath = devSettings->bundleRootPath;
 
     if (settings.UseLiveReload)
     {

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -247,15 +247,7 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance>& spThis, cons
     // In most cases, using the hardcoded ms-appx URI works fine, but there are certain scenarios,
     // such as in optional packaging, where the developer might need to modify the path, in which
     // case we should use the custom path instead.
-    if (settings.BundleRootPath.empty())
-    {
-      devSettings->bundleRootPath = "ms-appx:///Bundle/";
-    }
-    else
-    {
-      devSettings->bundleRootPath = settings.BundleRootPath;
-    }
-
+    devSettings->bundleRootPath = settings.BundleRootPath.empty() ? "ms-appx:///Bundle/" : settings.BundleRootPath;
     m_bundleRootPath = devSettings->bundleRootPath;
 
     if (settings.UseLiveReload)

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -243,6 +243,20 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance>& spThis, cons
     devSettings->jsExceptionCallback = std::move(settings.JsExceptionCallback);
     devSettings->useJITCompilation = settings.EnableJITCompilation;
     devSettings->debugHost = settings.DebugHost;
+    devSettings->useCustomRootPath = settings.UseCustomRootPath;
+    devSettings->bundleRootPath = settings.BundleRootPath;
+
+    // In most cases, using the hardcoded ms-appx URI works fine, but there are certain scenarios,
+    // such as in optional packaging, where the developer might need to modify the path, in which
+    // case we should use the custom path instead.
+    if (devSettings->useCustomRootPath)
+    {
+      m_bundleRootPath = devSettings->bundleRootPath;
+    }
+    else
+    {
+      m_bundleRootPath = "ms-appx:///Bundle/";
+    }
 
     if (settings.UseLiveReload)
     {

--- a/vnext/ReactUWP/Base/UwpReactInstance.h
+++ b/vnext/ReactUWP/Base/UwpReactInstance.h
@@ -53,6 +53,7 @@ public:
   const std::string& LastErrorMessage() const noexcept override { return m_errorMessage; }
   void loadBundle(std::string&& jsBundleRelativePath) override { if (!m_isInError) m_instanceWrapper->loadBundle(std::move(jsBundleRelativePath)); };
   ExpressionAnimationStore& GetExpressionAnimationStore() override { return m_expressionAnimationStore; }
+  std::string GetBundleRootPath() const noexcept override { return m_bundleRootPath; }
 
   // Test hooks
   void SetXamlViewCreatedTestHook(std::function<void(react::uwp::XamlView)> testHook) override;
@@ -82,6 +83,8 @@ private:
   ExpressionAnimationStore m_expressionAnimationStore;
 
   std::function<void(XamlView)> m_xamlViewCreatedTestHook;
+
+  std::string m_bundleRootPath;
 };
 
 } }

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -182,7 +182,7 @@ namespace react { namespace uwp {
     auto reactImage{ canvas.as<ReactImage>() };
 
     EmitImageEvent(canvas, "topLoadStart", sources[0]);
-    reactImage->Source(sources[0]);
+    reactImage->Source(sources[0], instance->GetBundleRootPath());
   }
 
   folly::dynamic ImageViewManager::GetExportedCustomDirectEventTypeConstants() const

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -33,6 +33,8 @@ struct json_type_traits<react::uwp::ImageSource>
         source.uri = item.second.asString();
       else if (item.first == "method")
         source.method = item.second.asString();
+      else if (item.first == "bundleRootPath")
+        source.bundleRootPath = item.second.asString();
       else if (item.first == "headers")
         source.headers = item.second;
       else if (item.first == "width")
@@ -179,10 +181,12 @@ namespace react { namespace uwp {
       return;
 
     auto sources{ json_type_traits<std::vector<ImageSource>>::parseJson(data) };
+    sources[0].bundleRootPath = instance->GetBundleRootPath();
+
     auto reactImage{ canvas.as<ReactImage>() };
 
     EmitImageEvent(canvas, "topLoadStart", sources[0]);
-    reactImage->Source(sources[0], instance->GetBundleRootPath());
+    reactImage->Source(sources[0]);
   }
 
   folly::dynamic ImageViewManager::GetExportedCustomDirectEventTypeConstants() const

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -33,8 +33,6 @@ struct json_type_traits<react::uwp::ImageSource>
         source.uri = item.second.asString();
       else if (item.first == "method")
         source.method = item.second.asString();
-      else if (item.first == "bundleRootPath")
-        source.bundleRootPath = item.second.asString();
       else if (item.first == "headers")
         source.headers = item.second;
       else if (item.first == "width")

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -58,7 +58,7 @@ namespace react {
       m_onLoadEndEvent.remove(token);
     }
 
-    winrt::fire_and_forget ReactImage::Source(ImageSource source, std::string bundleRootPath)
+    winrt::fire_and_forget ReactImage::Source(ImageSource source)
     {
       std::string uriString{ source.uri };
       if (uriString.length() == 0)
@@ -70,7 +70,7 @@ namespace react {
       if (source.packagerAsset && uriString.find("file://") == 0)
       {
         
-        uriString.replace(0, 7, bundleRootPath);
+        uriString.replace(0, 7, source.bundleRootPath);
       }
 
       winrt::Uri uri{ facebook::utf8ToUtf16(uriString) };

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -58,7 +58,7 @@ namespace react {
       m_onLoadEndEvent.remove(token);
     }
 
-    winrt::fire_and_forget ReactImage::Source(ImageSource source)
+    winrt::fire_and_forget ReactImage::Source(ImageSource source, std::string bundleRootPath)
     {
       std::string uriString{ source.uri };
       if (uriString.length() == 0)
@@ -69,7 +69,8 @@ namespace react {
 
       if (source.packagerAsset && uriString.find("file://") == 0)
       {
-        uriString.replace(0, 7, "ms-appx:///Bundle/");
+        
+        uriString.replace(0, 7, bundleRootPath);
       }
 
       winrt::Uri uri{ facebook::utf8ToUtf16(uriString) };

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -69,7 +69,6 @@ namespace react {
 
       if (source.packagerAsset && uriString.find("file://") == 0)
       {
-        
         uriString.replace(0, 7, source.bundleRootPath);
       }
 

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -48,7 +48,7 @@ namespace react {
 
       // Public Properties
       ImageSource Source() { return m_imageSource; }
-      winrt::fire_and_forget Source(ImageSource source);
+      winrt::fire_and_forget Source(ImageSource source, std::string bundleRootPath);
 
       react::uwp::ResizeMode ResizeMode() { return m_brush->ResizeMode(); }
       void ResizeMode(react::uwp::ResizeMode value) { m_brush->ResizeMode(value); }

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -20,6 +20,7 @@ namespace react {
     {
       std::string uri;
       std::string method;
+      std::string bundleRootPath;
       folly::dynamic headers;
       double width = 0;
       double height = 0;
@@ -48,7 +49,7 @@ namespace react {
 
       // Public Properties
       ImageSource Source() { return m_imageSource; }
-      winrt::fire_and_forget Source(ImageSource source, std::string bundleRootPath);
+      winrt::fire_and_forget Source(ImageSource source);
 
       react::uwp::ResizeMode ResizeMode() { return m_brush->ResizeMode(); }
       void ResizeMode(react::uwp::ResizeMode value) { m_brush->ResizeMode(value); }

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -46,7 +46,6 @@ struct DevSettings
   std::function<void(JSExceptionInfo&&)> jsExceptionCallback;
 
   /// Enables the user to set a custom root path for bundle resolution
-  bool useCustomRootPath{ false }; // This option is needed in case the user wants to use a blank root path
   std::string bundleRootPath;
 
   /// Enables debugging directly in the JavaScript engine.

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -45,6 +45,10 @@ struct DevSettings
   NativeLoggingHook loggingCallback;
   std::function<void(JSExceptionInfo&&)> jsExceptionCallback;
 
+  /// Enables the user to set a custom root path for bundle resolution
+  bool useCustomRootPath{ false }; // This option is needed in case the user wants to use a blank root path
+  std::string bundleRootPath;
+
   /// Enables debugging directly in the JavaScript engine.
   bool useDirectDebugger{ false };
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -576,7 +576,17 @@ void InstanceImpl::loadBundleInternal(std::string&& jsBundleRelativePath, bool s
       }
 
 #else
-    auto bundleString = std::make_unique<::react::uwp::StorageFileBigString>("ms-appx:///Bundle/" + jsBundleRelativePath + ".bundle");
+    std::string bundlePath = "";
+    if (m_devSettings->useCustomRootPath)
+    {
+      bundlePath += m_devSettings->bundleRootPath + jsBundleRelativePath + ".bundle";
+    }
+    else
+    {
+      bundlePath += "ms-appx:///Bundle/" + jsBundleRelativePath + ".bundle";
+    }
+
+    auto bundleString = std::make_unique<::react::uwp::StorageFileBigString>(bundlePath);
     m_innerInstance->loadScriptFromString(std::move(bundleString),
 #if !defined(OSS_RN)
       0 /*bundleVersion*/,

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -576,15 +576,7 @@ void InstanceImpl::loadBundleInternal(std::string&& jsBundleRelativePath, bool s
       }
 
 #else
-    std::string bundlePath = "";
-    if (m_devSettings->useCustomRootPath)
-    {
-      bundlePath += m_devSettings->bundleRootPath + jsBundleRelativePath + ".bundle";
-    }
-    else
-    {
-      bundlePath += "ms-appx:///Bundle/" + jsBundleRelativePath + ".bundle";
-    }
+    std::string bundlePath = m_devSettings->bundleRootPath + jsBundleRelativePath + ".bundle";
 
     auto bundleString = std::make_unique<::react::uwp::StorageFileBigString>(bundlePath);
     m_innerInstance->loadScriptFromString(std::move(bundleString),

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -29,6 +29,7 @@ struct ReactInstanceSettings
   bool UseWebDebugger { false };
   bool UseLiveReload { false };
   bool UseDirectDebugger{ false };
+  bool UseCustomRootPath { false };
   bool UseJsi { true };
   bool EnableJITCompilation { true };
   bool EnableByteCodeCacheing { false };
@@ -36,6 +37,7 @@ struct ReactInstanceSettings
   std::string ByteCodeFileUri;
   std::string DebugHost;
   std::string DebugBundlePath;
+  std::string BundleRootPath;
   facebook::react::NativeLoggingHook LoggingCallback;
   std::function<void(facebook::react::JSExceptionInfo&&)> JsExceptionCallback;
 };
@@ -78,6 +80,10 @@ struct IReactInstance
   virtual const std::string& LastErrorMessage() const noexcept = 0;
 
   virtual void loadBundle(std::string&& jsBundleRelativePath) = 0;
+
+  // Returns the root path of the JS bundle. This is needed for
+  // classes that do not have access to the settings object.
+  virtual std::string GetBundleRootPath() const noexcept = 0;
 
   // Test Hooks
   virtual void SetXamlViewCreatedTestHook(std::function<void(react::uwp::XamlView)> testHook) = 0;

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -29,7 +29,6 @@ struct ReactInstanceSettings
   bool UseWebDebugger { false };
   bool UseLiveReload { false };
   bool UseDirectDebugger{ false };
-  bool UseCustomRootPath { false };
   bool UseJsi { true };
   bool EnableJITCompilation { true };
   bool EnableByteCodeCacheing { false };


### PR DESCRIPTION
Currently, RNW is configured to always load bundles using the "ms-appx:///Bundle/" URI and root path. There are some scenarios where this hardcoded value does not work; for example, when the bundle resides in an optional package, the URI needs to include the PFN.

This PR adds an option for developers to specify their own root path for bundle loading.

- DevSettings and ReactInstanceSettings now contain new fields for specifying the use of a custom path and the custom path itself.
- UwpReactInstance now contains a new helper to return the root path to classes that don't have references to DevSettings
- OInstance and ReactImage both use the custom root path when available.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2690)