### PR TITLE
Added NuGet.config for Playground.

### DIFF
--- a/vnext/Playground/NuGet.Config
+++ b/vnext/Playground/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
Solves the packages relative path issue when running sample apps from `ReactWindows.sln` or `Playground\Playground.sln`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2695)