### PR TITLE
add base64 image support

### DIFF
--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -86,17 +86,17 @@ namespace react {
         if (needsDownload)
         {
           memoryStream = co_await GetImageStreamAsync(source);
-
-          if (!memoryStream)
-          {
-            m_onLoadEndEvent(*this, false);
-          }
         }
         else if (inlineData)
         {
           memoryStream = co_await GetImageInlineDataAsync(source);
         }
 
+        if ((needsDownload || inlineData) && !memoryStream)
+        {
+          m_onLoadEndEvent(*this, false);
+        }
+        
         if (!needsDownload || memoryStream)
         {
           auto surface = needsDownload || inlineData ?

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -62,5 +62,6 @@ namespace react {
 
     // Helper functions
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> GetImageStreamAsync(ImageSource source);
+    winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> GetImageInlineDataAsync(ImageSource source);
   }
 } // namespace react::uwp

--- a/vnext/Universal.SampleApp/index.uwp.js
+++ b/vnext/Universal.SampleApp/index.uwp.js
@@ -262,6 +262,15 @@ export default class Bootstrap extends Component {
               onError={() => { console.log('image onError!'); }}
             />
           </View>
+          <View style={{ backgroundColor: 'yellow', marginTop: 15 }}>
+            <Image
+              style={{ width: 66, height: 58 }}
+              source={{ width: 66, height: 58,
+              uri:
+              "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg=="
+              }}
+              />
+          </View>
           <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 15 }}>
             <CheckBox
               onValueChange={value => this.setState({ checkBoxIsOn: value })}


### PR DESCRIPTION
Adds simple base64 image decoding support, 

based on react-native-windows current's code here:
https://github.com/microsoft/react-native-windows/blob/48a23b5181c7e91c1ec243c9556a6e81351a8927/current/ReactWindows/ReactNative.Net46/Modules/Image/BitmapImageHelpers.cs#L36

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2700)