### PR TITLE
Fix occasional text clipping

### DIFF
--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -24,6 +24,9 @@ namespace react { namespace uwp {
 
 float GetConstrainedResult(float constrainTo, float measuredSize, YGMeasureMode measureMode)
 {
+  // Round up to workaround truncation inside yoga
+  measuredSize = ceil(measuredSize);
+
   if (measureMode == YGMeasureMode::YGMeasureModeExactly)
     return constrainTo;
   if (measureMode == YGMeasureMode::YGMeasureModeAtMost)


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/issues/2660

I didn't track down the exact problem, but especially with centered content/text we're seeing truncated values getting used to calculate layout that cause unwanted truncation.  Rounding up in measure fixes these

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2701)