### PR TITLE
fix Animated shutdown crash

### DIFF
--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
@@ -19,6 +19,12 @@ namespace react {
       }();
     }
 
+    AnimationDriver::~AnimationDriver()
+    {
+      if (m_scopedBatch)
+        m_scopedBatch.Completed(m_scopedBatchCompletedToken);
+    }
+
     void AnimationDriver::StartAnimation()
     {
       const auto [animation, scopedBatch] = MakeAnimation(m_config);
@@ -32,7 +38,7 @@ namespace react {
       }
       scopedBatch.End();
 
-      scopedBatch.Completed([endCallback = m_endCallback, animatedValue, id = m_id](auto sender, auto)
+      m_scopedBatchCompletedToken = scopedBatch.Completed([endCallback = m_endCallback, animatedValue, id = m_id](auto sender, auto)
       {
         if (endCallback)
         {
@@ -45,6 +51,7 @@ namespace react {
       });
 
       m_animation = animation;
+      m_scopedBatch = scopedBatch;
     }
 
     void AnimationDriver::StopAnimation()

--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
@@ -14,6 +14,7 @@ namespace react { namespace uwp {
   {
   public:
     AnimationDriver(int64_t id, int64_t animatedValueTag, const Callback& endCallback, const folly::dynamic& config, const std::shared_ptr<NativeAnimatedNodeManager>& manager);
+    virtual ~AnimationDriver();
     void StartAnimation();
     void StopAnimation();
 
@@ -35,6 +36,7 @@ namespace react { namespace uwp {
     std::weak_ptr<NativeAnimatedNodeManager> m_manager{};
 
     winrt::Windows::UI::Composition::CompositionAnimation m_animation{ nullptr };
+    winrt::Windows::UI::Composition::CompositionScopedBatch m_scopedBatch{ nullptr };
     //auto revoker for scopedBatch.Completed is broken, tracked by internal bug #22399779
     winrt::event_token m_scopedBatchCompletedToken{};
   };

--- a/vnext/ReactUWP/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/ReactUWP/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -39,57 +39,57 @@ namespace react {
       {
         case AnimatedNodeType::Style:
         {
-          m_styleNodes.emplace(tag, std::make_unique<StyleAnimatedNode>(StyleAnimatedNode(tag, config, manager)));
+          m_styleNodes.emplace(tag, std::make_unique<StyleAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Value:
         {
-          m_valueNodes.emplace(tag, std::make_unique<ValueAnimatedNode>(ValueAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<ValueAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Props:
         {
-          m_propsNodes.emplace(tag, std::make_unique<PropsAnimatedNode>(PropsAnimatedNode(tag, config, instance, manager)));
+          m_propsNodes.emplace(tag, std::make_unique<PropsAnimatedNode>(tag, config, instance, manager));
           break;
         }
         case AnimatedNodeType::Interpolation:
         {
-          m_valueNodes.emplace(tag, std::make_unique<InterpolationAnimatedNode>(InterpolationAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<InterpolationAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Addition:
         {
-          m_valueNodes.emplace(tag, std::make_unique<AdditionAnimatedNode>(AdditionAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<AdditionAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Subtraction:
         {
-          m_valueNodes.emplace(tag, std::make_unique<SubtractionAnimatedNode>(SubtractionAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<SubtractionAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Division:
         {
-          m_valueNodes.emplace(tag, std::make_unique<DivisionAnimatedNode>(DivisionAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<DivisionAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Multiplication:
         {
-          m_valueNodes.emplace(tag, std::make_unique<MultiplicationAnimatedNode>(MultiplicationAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<MultiplicationAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Modulus:
         {
-          m_valueNodes.emplace(tag, std::make_unique<ModulusAnimatedNode>(ModulusAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<ModulusAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Diffclamp:
         {
-          m_valueNodes.emplace(tag, std::make_unique<DiffClampAnimatedNode>(DiffClampAnimatedNode(tag, config, manager)));
+          m_valueNodes.emplace(tag, std::make_unique<DiffClampAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Transform:
         {
-          m_transformNodes.emplace(tag, std::make_unique<TransformAnimatedNode>(TransformAnimatedNode(tag, config, manager)));
+          m_transformNodes.emplace(tag, std::make_unique<TransformAnimatedNode>(tag, config, manager));
           break;
         }
         case AnimatedNodeType::Tracking:
@@ -147,10 +147,10 @@ namespace react {
       switch (AnimationTypeFromString(animationConfig.find("type").dereference().second.getString()))
       {
       case AnimationType::Decay:
-        m_activeAnimations.emplace(animationId, std::make_unique<DecayAnimationDriver>(DecayAnimationDriver(animationId, animatedNodeTag, endCallback, animationConfig, manager)));
+        m_activeAnimations.emplace(animationId, std::make_unique<DecayAnimationDriver>(animationId, animatedNodeTag, endCallback, animationConfig, manager));
         break;
       case AnimationType::Frames:
-        m_activeAnimations.emplace(animationId, std::make_unique<FrameAnimationDriver>(FrameAnimationDriver(animationId, animatedNodeTag, endCallback, animationConfig, manager)));
+        m_activeAnimations.emplace(animationId, std::make_unique<FrameAnimationDriver>(animationId, animatedNodeTag, endCallback, animationConfig, manager));
         break;
       case AnimationType::Spring:
         //TODO: implement spring animations tracked by issue #2681
@@ -214,12 +214,12 @@ namespace react {
       const auto key = std::make_tuple(viewTag, eventName);
       if (m_eventDrivers.count(key))
       {
-        m_eventDrivers.at(key).emplace_back(std::make_unique<EventAnimationDriver>(EventAnimationDriver(pathList, valueNodeTag, manager)));
+        m_eventDrivers.at(key).emplace_back(std::make_unique<EventAnimationDriver>(pathList, valueNodeTag, manager));
       }
       else
       {
         auto vector = std::vector<std::unique_ptr<EventAnimationDriver>>{};
-        vector.emplace_back(std::make_unique<EventAnimationDriver>(EventAnimationDriver(pathList, valueNodeTag, manager)));
+        vector.emplace_back(std::make_unique<EventAnimationDriver>(pathList, valueNodeTag, manager));
         m_eventDrivers.insert({ key, std::move(vector) });
       }
     }


### PR DESCRIPTION
If animation manager manually shuts down / drops animations before they complete, we currently crash in the Completed notification looking at freed memory.  We have some things in a flyout animating that get manually shut down as the flyout closes that are crashing with animated now existing (I think before just some debug message was being shown about animated not being implemented)

This probably was working before we removed the shared_ptr types that would keep some stuff alive.

Fix - manually revoke (since the auto revoker was noted as not working)

Also fix make_unique code in animated to not do an extra copy.  Discovered when I tested auto_revoker it wouldn't compile because there is no copyctor for auto_revoker.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2707)