### PR TITLE
Enforce correct platform toolset

### DIFF
--- a/vnext/.editorconfig
+++ b/vnext/.editorconfig
@@ -14,7 +14,7 @@ indent_size = 2
 end_of_line = crlf
 
 # Xml project files
-[*.{config,csproj,props,targets,vcxitems,vcxproj,vcxproj.filters}]
+[*.{config,csproj,njsproj,props,targets,vcxitems,vcxproj,vcxproj.filters}]
 end_of_line = crlf
 insert_final_newline = false
 

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -253,7 +253,6 @@
     <ProjectName>Folly</ProjectName>
     <RootNamespace>Folly</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>

--- a/vnext/IntegrationTestScripts/IntegrationTests.njsproj
+++ b/vnext/IntegrationTestScripts/IntegrationTests.njsproj
@@ -10,7 +10,7 @@
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">16.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
     <StartWebBrowser>False</StartWebBrowser>

--- a/vnext/Playground/Playground/Playground.csproj
+++ b/vnext/Playground/Playground/Playground.csproj
@@ -162,11 +162,11 @@
       <Name>ReactUWP</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-    <VisualStudioVersion>14.0</VisualStudioVersion>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0' ">
+    <VisualStudioVersion>16.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -3,14 +3,14 @@
 
   <PropertyGroup Label="Globals">
     <DefaultLanguage>en-US</DefaultLanguage>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <!-- Use 19H1 SDK (10.0.18362.0)  Support running on RS2+ (10.0.15063.0) -->
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <GenerateProjectSpecificOutputFolder>false</GenerateProjectSpecificOutputFolder>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/vnext/docs/GettingStarted.md
+++ b/vnext/docs/GettingStarted.md
@@ -7,11 +7,11 @@ This is a summary of setup steps needed to install and work with React Native fo
 * [Visual Studio 2019](https://www.visualstudio.com/downloads) with the following options:
   * Workloads
     * Universal Windows Platform development
-      * Enable the optional 'C++ Universal Windows Platform tools'
+      * Enable the optional `C++ (v141) Universal Windows Platform tools`
     * Desktop development with C++
   * Individual Components
     * Development activities
-      * Node.js development support
+      * Node.js development support (optional)
     * SDKs, libraries, and frameworks per your versioning needs
       * Windows 10 SDK (10.0.18362.0)
 

--- a/vnext/local-cli/generator-windows/templates/proj/MyApp.csproj
+++ b/vnext/local-cli/generator-windows/templates/proj/MyApp.csproj
@@ -165,8 +165,8 @@
       <Name>ReactUWP</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-    <VisualStudioVersion>14.0</VisualStudioVersion>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0' ">
+    <VisualStudioVersion>16.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
After commit ( 6c5ede477ea364a4c72de80f21959f3c42851082 ), The MSVC `PlatformToolset` (and thus, the compiler version) is set depending on the Visual Studio version as follows:
- v141 (compiler version 14.16.27023) for Visual Studio 2017
- v142 (compiler version 14.21.27702) for Visual Studio 2019

Continuous Integration and Deployment (CI/CD) for react-native-windows is don using the v141 toolset.

This will lead to continuous compiling and linking issues due compiler versions used to build certain dependencies, like `ChakraCore.Debugger`:
```
LINK : fatal error C1047: The object or library file 'packages\ChakraCore.Debugger.0.0.0.36\lib\x64\Release\ChakraCore.Debugger.ProtocolHandler.lib' was created with an older compiler than other objects; rebuild
```

While dependencies could be compiled with a more recent v141-based compiler version, this turns into a "cat-and-mouse", eventually recurring problem as new VS2019 versions are rolled out.

This change enforces the right version, and adds the appropriate documentation so users install the correct Visual Studio components.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2709)