### PR TITLE
Update to react-native@0.59.0-microsoft.8

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,10 +66,10 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^4",
     "typescript": "3.5.1",
-    "react-native": "0.59.0-microsoft.7"
+    "react-native": "0.59.0-microsoft.8"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.7 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.7.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.8 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.8.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -4895,9 +4895,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.7.tar.gz":
-  version "0.59.0-microsoft.7"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.7.tar.gz#46558143f49c8c82da1282d6211d8635ba8ae171"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.8.tar.gz":
+  version "0.59.0-microsoft.8"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.8.tar.gz#fa26f69c22c3971619936f16d11cd09dae9b09f2"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
ea965d655 Applying package update to 0.59.0-microsoft.8
d0c0bb191 Nanava/configurejs (#96)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2711)