### PR TITLE
add error handling in NetworkingModule

### DIFF
--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -91,12 +91,12 @@ std::future<void> SendRequestAsync(
   networking->AddRequest(requestId, completion);
 
   winrt::Windows::Web::Http::HttpResponseMessage response = co_await completion;
-
-  networking->OnResponseReceived(requestId, response);
+  if (response != nullptr)
+    networking->OnResponseReceived(requestId, response);
 
   // NotYetImplemented: useIncrementalUpdates
 
-  if (response.Content() != nullptr)
+  if (response != nullptr && response.Content() != nullptr)
   {
     winrt::Windows::Storage::Streams::IInputStream inputStream = co_await response.Content().ReadAsInputStreamAsync();
     auto reader = winrt::Windows::Storage::Streams::DataReader(inputStream);
@@ -129,7 +129,7 @@ std::future<void> SendRequestAsync(
   }
   else
   {
-    networking->OnRequestError(requestId, "No response content", false/*isTimeout*/);
+    networking->OnRequestError(requestId, response == nullptr ? "request failed" : "No response content", false/*isTimeout*/);
   }
 
   networking->RemoveRequest(requestId);


### PR DESCRIPTION
We had a brief period of time today with an invalid cert on a server we connect to.
When that happened we were crashing in NetworkingModule - the response was null in this case instead of having some error code.

I tried to see what happens with no network at all, but it doesn't get this far (may be another bug that the timeout is too long) and was fine

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2714)