### PR TITLE
more getInt fixes for JSI mode

### DIFF
--- a/vnext/Desktop.UnitTests/EmptyUIManagerModule.cpp
+++ b/vnext/Desktop.UnitTests/EmptyUIManagerModule.cpp
@@ -79,7 +79,7 @@ void EmptyUIManager::setChildren(int64_t viewTag, folly::dynamic /*ReadableMap*/
 {
   auto& parent = m_nodeRegistry->m_allNodes[viewTag];
   for (auto&& childTag : childrenTags)
-    parent->m_children.push_back(childTag.getInt());
+    parent->m_children.push_back(childTag.asInt());
 }
 
 EmptyUIManagerModule::EmptyUIManagerModule(std::unique_ptr<EmptyUIManager> sample)

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -304,7 +304,7 @@ void WebSocketJSExecutor::OnMessageReceived(const string& msg)
   auto it_end = parsed.items().end();
   if (it_parsed != it_end)
   {
-    auto replyId = it_parsed->second.getInt();
+    auto replyId = it_parsed->second.asInt();
 
     lock_guard<mutex> lock(m_lockPromises);
     auto it_promise = m_promises.find(static_cast<int>(replyId));

--- a/vnext/Desktop/Sandbox/NamedPipeEndpoint.cpp
+++ b/vnext/Desktop/Sandbox/NamedPipeEndpoint.cpp
@@ -657,7 +657,7 @@ void NamedPipeEndpoint::Impl::OnMessageReceived_Host(std::unique_ptr<std::string
     auto it_parsed = parsed.find("replyID");
     auto it_end = parsed.items().end();
     if (it_parsed != it_end) {
-      replyId = it_parsed->second.getInt();
+      replyId = it_parsed->second.asInt();
       if (m_replyHandler) {
         m_replyHandler(replyId);
       }

--- a/vnext/Desktop/Sandbox/SandboxBridge.cpp
+++ b/vnext/Desktop/Sandbox/SandboxBridge.cpp
@@ -83,10 +83,10 @@ static std::vector<MethodCall> sandboxHostParseMethodCalls(folly::dynamic&& json
     }
 
     methodCalls.emplace_back(
-      static_cast<int>(moduleIds[i].getInt()),
-      static_cast<int>(methodIds[i].getInt()),
+      static_cast<int>(moduleIds[i].asInt()),
+      static_cast<int>(methodIds[i].asInt()),
       std::move(params[i]),
-      static_cast<int>(callIds[i].getInt()));
+      static_cast<int>(callIds[i].asInt()));
   }
 
   return methodCalls;
@@ -131,7 +131,7 @@ static std::pair<std::vector<MethodCall>, std::vector<MethodCall>> sandboxParseM
         folly::to<std::string>("Did not get valid calls back from JS: %s", folly::toJson(jsonData)));
     }
     else {
-      callId = static_cast<int>(jsonData[REQUEST_CALLID].getInt());
+      callId = static_cast<int>(jsonData[REQUEST_CALLID].asInt());
     }
   }
 
@@ -144,17 +144,17 @@ static std::pair<std::vector<MethodCall>, std::vector<MethodCall>> sandboxParseM
         folly::to<std::string>("Call argument isn't an array"));
     }
 
-    auto moduleId = moduleIds[i].getInt();
+    auto moduleId = moduleIds[i].asInt();
     if (moduleId < maxInprocModuleCount) {
       inprocMethodCalls.emplace_back(
         static_cast<int>(moduleId),
-        static_cast<int>(methodIds[i].getInt()),
+        static_cast<int>(methodIds[i].asInt()),
         std::move(params[i]),
         callId);
     } else {
       remoteMethodCalls.emplace_back(
         static_cast<int>(moduleId),
-        static_cast<int>(methodIds[i].getInt()),
+        static_cast<int>(methodIds[i].asInt()),
         std::move(params[i]),
         callId);
     }

--- a/vnext/ReactUWP/Executors/WebSocketJSExecutorUwp.cpp
+++ b/vnext/ReactUWP/Executors/WebSocketJSExecutorUwp.cpp
@@ -277,7 +277,7 @@ void WebSocketJSExecutor::OnMessageReceived(const std::string& msg)
   auto it_parsed = parsed.find("replyID");
   if (it_parsed != parsed.items().end())
   {
-    int replyId = it_parsed->second.getInt();
+    int replyId = it_parsed->second.asInt();
 
     std::lock_guard<std::mutex> lock(m_lockPromises);
     auto it_promise = m_promises.find(replyId);

--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
@@ -13,7 +13,7 @@ namespace react {
       m_iterations = [iterations = config.find("iterations"), end = config.items().end()]() {
         if (iterations != end)
         {
-          return iterations.dereference().second.getInt();
+          return static_cast<int64_t>(iterations.dereference().second.asDouble());
         }
         return static_cast<int64_t>(1);
       }();

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -14,7 +14,7 @@ namespace react { namespace uwp {
   {
     for (const auto& entry : config.find("props").dereference().second.items())
     {
-      m_propMapping.insert({ entry.first.getString(), entry.second.getInt() });
+      m_propMapping.insert({ entry.first.getString(), static_cast<int64_t>(entry.second.asDouble()) });
     }
   }
 

--- a/vnext/ReactUWP/Modules/Animated/StyleAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/StyleAnimatedNode.cpp
@@ -11,7 +11,7 @@ namespace react { namespace uwp {
   {
     for (const auto& entry : config.find(s_styleName).dereference().second.items())
     {
-      m_propMapping.insert({ entry.first.getString(), entry.second.getInt() });
+      m_propMapping.insert({ entry.first.getString(), static_cast<int64_t>(entry.second.asDouble()) });
     }
   }
 


### PR DESCRIPTION
The ones I am actually blocked on are in the Animation files, that getInt() even of a whole number throws in JSI mode, since all numbers are doubles.

I searched for all getInt and fixed some others to be asInt to match how react internally handles some places that must be ints (how our sandbox stuff works)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2715)