### PR TITLE
Use full pdbs in debug

### DIFF
--- a/vnext/PropertySheets/DynamicLibrary/Debug.props
+++ b/vnext/PropertySheets/DynamicLibrary/Debug.props
@@ -11,6 +11,10 @@
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
+    <Link>
+      <FullProgramDatabaseFile>DebugFull</FullProgramDatabaseFile>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+    </Link>
   </ItemDefinitionGroup>
 
 </Project>


### PR DESCRIPTION
Debug dlls in the nuget package are not debuggable right now

this sets the full debug flags that we have in ship

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2717)