### PR TITLE
Fix RNTester bundle

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -127,9 +127,9 @@ jobs:
           workingDirectory: vnext
 
       - task: CmdLine@2
-        displayName: Remove SampleApp.uwp.bundle
+        displayName: Create RNTester bundle
         inputs:
-          script: del SampleApp.uwp.bundle
+          script: node Scripts\cli.js bundle --entry-file .\RNTester.js --bundle-output RNTester.uwp.bundle --platform uwp
           workingDirectory: vnext
 
   - job: CliInit

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -175,7 +175,7 @@ jobs:
       - task: CmdLine@2
         displayName: Init new project
         inputs:
-          script: react-native init testcli
+          script: react-native init testcli --version 0.59.10
           workingDirectory: $(Agent.BuildDirectory)
 
       - task: CmdLine@2

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -131,6 +131,7 @@ jobs:
         inputs:
           script: node Scripts\cli.js bundle --entry-file .\RNTester.js --bundle-output RNTester.uwp.bundle --platform uwp
           workingDirectory: vnext
+        condition: and(succeeded(), eq(variables['UseRNFork'], 'false'))
 
   - job: CliInit
     displayName: Verify react-native init

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,7 @@
     "javascriptreact",
     "typescript",
     "typescriptreact"
-  ]
+  ],
+  "clang-format.language.javascript.enable": false,
+  "clang-format.language.typescript.enable": false
 }

--- a/vnext/docs/GettingStarted.md
+++ b/vnext/docs/GettingStarted.md
@@ -157,7 +157,7 @@ You now see your new app and Chrome should have loaded `http://localhost:8081/de
 
  Try these samples by entering the JS file name and App names below into the textboxes at the top of the application window before pressing "Load":
    - Sample: JavaScript file: `Universal.SampleApp\index.uwp` App Name: `Bootstrap`
-   - RNTester: JavaScript file: `lib\RNTester\RNTesterApp.uwp` App Name: `RNTesterApp`
+   - RNTester: JavaScript file: `RNTester\RNTesterApp.uwp` App Name: `RNTesterApp`
 
 ## Troubleshooting
 * If after running the app the packager does not update (or) app does not show React Native content - close the packager command prompt window and the app, run `yarn start` and run the app again.  Issue [#2311](https://github.com/microsoft/react-native-windows/issues/2311) is tracking a known issue on this.

--- a/vnext/docs/GettingStarted.md
+++ b/vnext/docs/GettingStarted.md
@@ -39,7 +39,7 @@ npm install -g react-native-cli
 
 Next, [generate a React Native project](http://facebook.github.io/react-native/docs/getting-started.html#creating-a-new-application). In the directory you would like your React Native Windows project directory, run:
 ```
-react-native init <project name>
+react-native init <project name> --version 0.59.10
 ```
 Navigate into this newly created directory:
 ```

--- a/vnext/just-task.js
+++ b/vnext/just-task.js
@@ -49,7 +49,7 @@ task('clean', () => {
 task(
   'build',
   series(
-    condition('clean', () => argv().clean),
+    condition('clean', () => true || argv().clean),
     'eslint',
     'copyFlowFiles',
     'ts',

--- a/vnext/src/RNTester/AccessibilityExample.tsx
+++ b/vnext/src/RNTester/AccessibilityExample.tsx
@@ -12,7 +12,7 @@ import {
   View,
   StyleSheet,
 } from 'react-native';
-import {AppTheme} from '../../src/index.uwp';
+import {AppTheme} from '../index.uwp';
 import {IAppThemeChangedEvent} from 'src/Libraries/AppTheme/AppThemeTypes';
 
 class AccessibilityBaseExample extends React.Component {

--- a/vnext/src/RNTester/DatePickerExample.uwp.tsx
+++ b/vnext/src/RNTester/DatePickerExample.uwp.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Text, View} from 'react-native';
-import {DatePicker, Picker, DayOfWeek} from '../../src/index.uwp';
+import {DatePicker, Picker, DayOfWeek} from '../index.uwp';
 
 interface IDatePickerExampleState {
   dateFormat:

--- a/vnext/src/RNTester/FlyoutExample.uwp.tsx
+++ b/vnext/src/RNTester/FlyoutExample.uwp.tsx
@@ -6,8 +6,8 @@
 
 import React = require('react');
 import {Button, Text, TextInput, View} from 'react-native';
-import {CheckBox, Flyout, Picker} from '../../src/index.uwp';
-import {Placement} from '../../src/Libraries/Components/Flyout/FlyoutProps';
+import {CheckBox, Flyout, Picker} from '../index.uwp';
+import {Placement} from '../Libraries/Components/Flyout/FlyoutProps';
 
 interface IFlyoutExampleState {
   isFlyoutVisible: boolean;

--- a/vnext/src/RNTester/GlyphExample.tsx
+++ b/vnext/src/RNTester/GlyphExample.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Text, View} from 'react-native';
-import {Glyph} from '../../src/index.uwp';
+import {Glyph} from '../index.uwp';
 
 class GlyphExamples extends React.Component {
   public render() {

--- a/vnext/src/RNTester/KeyboardExample.tsx
+++ b/vnext/src/RNTester/KeyboardExample.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Text, TouchableHighlight, View, ViewStyle} from 'react-native';
-import {Picker} from '../../src/index.uwp';
+import {Picker} from '../index.uwp';
 
 class TabStopExample extends React.Component {
   public render() {

--- a/vnext/src/RNTester/KeyboardExtensionExample.uwp.tsx
+++ b/vnext/src/RNTester/KeyboardExtensionExample.uwp.tsx
@@ -11,7 +11,7 @@ import {
   IHandledKeyboardEvent,
   IKeyboardEvent,
   HandledEventPhase,
-} from '../../src/index.uwp';
+} from '../index.uwp';
 
 const ViewWindows = supportKeyboard(View);
 

--- a/vnext/src/RNTester/KeyboardFocusExample.uwp.tsx
+++ b/vnext/src/RNTester/KeyboardFocusExample.uwp.tsx
@@ -12,7 +12,7 @@ import {
   CheckBox,
   ViewWindows,
   Picker,
-} from '../../src/index.uwp';
+} from '../index.uwp';
 
 // TextInput2 is used to verify supportKeyboard + focus
 const TextInput2 = supportKeyboard(TextInput);

--- a/vnext/src/RNTester/PickerUWPExample.tsx
+++ b/vnext/src/RNTester/PickerUWPExample.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Button, Text, View} from 'react-native';
-import {Picker} from '../../src/index.uwp';
+import {Picker} from '../index.uwp';
 
 interface MakesModels {
   name: string;

--- a/vnext/src/RNTester/PopupExample.uwp.tsx
+++ b/vnext/src/RNTester/PopupExample.uwp.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Button, Text, TextInput, View} from 'react-native';
-import {Popup} from '../../src/index.uwp';
+import {Popup} from '../index.uwp';
 
 interface IPopupExampleState {
   isFlyoutVisible: boolean;

--- a/vnext/src/RNTester/ThemingExample.uwp.tsx
+++ b/vnext/src/RNTester/ThemingExample.uwp.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Text, View, Button} from 'react-native';
-import {AppTheme} from '../../src/index.uwp';
+import {AppTheme} from '../index.uwp';
 
 class ThemeExample extends React.Component {
   state = {


### PR DESCRIPTION
- Update some imports to handle new file layout.
- Add test to CI loop to verify that the RNTester bundle is buildable
- Update GettingStarted doc to reflect new location of RNTester
- Updated CI loop to specify 0.59 version when doing CLI test
- Updated GettingStarted doc to let people know they need to specify 0.59 when creating a new app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2728)