### PR TITLE
Workaround for overlapping flyout shadows

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -95,14 +95,14 @@ class FlyoutShadowNode : public ShadowNodeBase {
   float m_verticalOffset = 0;
   bool m_isFlyoutShowOptionsSupported = false;
   winrt::FlyoutShowOptions m_showOptions = nullptr;
-  static std::int32_t s_cOpenFlyouts;
+  static thread_local std::int32_t s_cOpenFlyouts;
 
   std::unique_ptr<TouchEventHandler> m_touchEventHanadler;
   std::unique_ptr<PreviewKeyboardEventHandlerOnRoot>
       m_previewKeyboardEventHandlerOnRoot;
 };
 
-std::int32_t FlyoutShadowNode::s_cOpenFlyouts = 0;
+thread_local std::int32_t FlyoutShadowNode::s_cOpenFlyouts = 0;
 
 FlyoutShadowNode::~FlyoutShadowNode() {
   m_touchEventHanadler->RemoveTouchHandlers();


### PR DESCRIPTION
When multiple flyouts are overlapping, XAML shadow rendering doesn't use the right z-order.  The result is very noticeable. As a workaround for this problem, I disable theme shadows when more than 1 flyout is open.

At some point we can consider a fix that retains theme shadows in this scenario by exposing depth properties to the app, but this will be more complex for app devs for limited benefit.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2733)