### PR TITLE
implement keyboard code

### DIFF
--- a/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
+++ b/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
@@ -16,6 +16,7 @@ static constexpr auto SHIFT_KEY = "shiftKey";
 static constexpr auto EVENT_PHASE = "handledEventPhase";
 static constexpr auto KEY = "key";
 static constexpr auto TARGET = "target";
+static constexpr auto CODE = "code";
 
 using namespace react::uwp;
 
@@ -37,14 +38,14 @@ struct json_type_traits<react::uwp::HandledKeyboardEvent> {
         event.ctrlKey = propertyValue.asBool();
       else if (propertyName == META_KEY)
         event.metaKey = propertyValue.asBool();
-      else if (propertyName == KEY)
-        event.key = propertyValue.asString();
+      else if (propertyName == CODE)
+        event.code = propertyValue.asString();
       else if (propertyName == EVENT_PHASE)
         event.handledEventPhase = asEnum<HandledEventPhase>(propertyValue);
     }
 
     // To simplify the implementaion, key from JS is converted to upper case.
-    toUpperInplace(event.key);
+    toUpperInplace(event.code);
     return event;
   }
 };
@@ -60,7 +61,7 @@ std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(
 static folly::dynamic ToEventData(ReactKeyboardEvent event) {
   return folly::dynamic::object(TARGET, event.target)(ALT_KEY, event.altKey)(
       CTRL_KEY, event.ctrlKey)(KEY, event.key)(META_KEY, event.metaKey)(
-      SHIFT_KEY, event.shiftKey);
+      SHIFT_KEY, event.shiftKey)(CODE, event.code);
 }
 
 KeyboardEventBaseHandler::KeyboardEventBaseHandler(
@@ -225,7 +226,7 @@ bool HandledKeyboardEventHandler::ShouldMarkKeyboardHandled(
     std::vector<HandledKeyboardEvent> const &handledEvents,
     HandledKeyboardEvent currentEvent) {
   for (auto const &event : handledEvents) {
-    if (event.key == currentEvent.key &&
+    if (event.code == currentEvent.code &&
         (event.altKey == currentEvent.altKey) &&
         (event.ctrlKey == currentEvent.ctrlKey) &&
         (event.shiftKey == currentEvent.shiftKey) &&
@@ -277,6 +278,8 @@ void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
         UpdateModifiedKeyStatusTo(event);
         event.key = KeyboardHelper::FromVirtualKey(
             args.Key(), event.shiftKey, event.capLocked);
+        event.code = KeyboardHelper::CodeFromVirtualKey(args.OriginalKey());
+
         instance->DispatchEvent(event.target, eventName, ToEventData(event));
       }
     }
@@ -289,8 +292,7 @@ HandledKeyboardEvent KeyboardHelper::CreateKeyboardEvent(
   HandledKeyboardEvent event;
   event.handledEventPhase = phase;
   UpdateModifiedKeyStatusTo(event);
-  event.key = KeyboardHelper::FromVirtualKey(
-      args.Key(), event.shiftKey, event.capLocked);
+  event.code = KeyboardHelper::CodeFromVirtualKey(args.OriginalKey());
 
   return event;
 }
@@ -298,7 +300,7 @@ HandledKeyboardEvent KeyboardHelper::CreateKeyboardEvent(
 // Should align to
 // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
 static const std::vector<std::pair<winrt::VirtualKey, std::string>>
-    g_virtualKeyToString{
+    g_virtualKeyToKey{
         // Modifier keys
         {winrt::VirtualKey::LeftMenu, "Alt"},
         {winrt::VirtualKey::RightMenu, "Alt"},
@@ -394,38 +396,313 @@ static const std::vector<std::pair<winrt::VirtualKey, std::string>>
         {winrt::VirtualKey::Subtract, "Subtract"},
         {winrt::VirtualKey::Separator, "Separator"},
 
-        {winrt::VirtualKey::Number0, "0"},
-        {winrt::VirtualKey::Number1, "1"},
-        {winrt::VirtualKey::Number2, "2"},
-        {winrt::VirtualKey::Number3, "3"},
-        {winrt::VirtualKey::Number4, "4"},
-        {winrt::VirtualKey::Number5, "5"},
-        {winrt::VirtualKey::Number6, "6"},
-        {winrt::VirtualKey::Number7, "7"},
-        {winrt::VirtualKey::Number8, "8"},
-        {winrt::VirtualKey::Number9, "9"},
+        {winrt::VirtualKey::NumberPad0, "0"},
+        {winrt::VirtualKey::NumberPad1, "1"},
+        {winrt::VirtualKey::NumberPad2, "2"},
+        {winrt::VirtualKey::NumberPad3, "3"},
+        {winrt::VirtualKey::NumberPad4, "4"},
+        {winrt::VirtualKey::NumberPad5, "5"},
+        {winrt::VirtualKey::NumberPad6, "6"},
+        {winrt::VirtualKey::NumberPad7, "7"},
+        {winrt::VirtualKey::NumberPad8, "8"},
+        {winrt::VirtualKey::NumberPad9, "9"},
         //
     };
+
+// Convert enum to its underlying type
+template <typename E>
+constexpr auto to_underlying(E e) noexcept {
+  return static_cast<std::underlying_type_t<E>>(e);
+}
+
+// Align to https://www.w3.org/TR/uievents-code/
+// VirtualKey mapping is from
+// https://docs.microsoft.com/en-us/uwp/api/Windows.System.VirtualKey Other
+// codes are from
+// https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes All
+// codes are listed except alpha and numbers. For the unsupported code, they are
+// all commented and they key is 'to_underlying(winrt::VirtualKey::None)' For
+// example, IntlBackslash is not sent to user:
+// //{to_underlying(winrt::VirtualKey::None), "IntlBackslash"},
+static const std::vector<std::pair<int, std::string>> g_virtualKeyToCode{
+    // writing system keys in the Alphanumeric section
+    {192, "Backquote"},
+    {220, "Backslash"},
+    {to_underlying(winrt::VirtualKey::Back), "Backspace"},
+    {219, "BracketLeft"},
+    {221, "BracketRight"},
+    {192, "BracketLeft"},
+    {188, "Comma"},
+    {187, "Equal"},
+    //{to_underlying(winrt::VirtualKey::None), "IntlBackslash"},
+    //{to_underlying(winrt::VirtualKey::None), "IntlRo"},
+    //{to_underlying(winrt::VirtualKey::None), "IntlYen"},
+    {189, "Minus"},
+    {190, "Period"},
+    {222, "Quote"},
+    {186, "Semicolon"},
+    {191, "Slash"},
+
+    // Functional Keys
+    {to_underlying(winrt::VirtualKey::LeftMenu), "AltLeft"},
+    {to_underlying(winrt::VirtualKey::RightMenu), "AltRight"},
+    {to_underlying(winrt::VirtualKey::CapitalLock), "CapsLock"},
+    {to_underlying(winrt::VirtualKey::Menu), "ContextMenu"},
+    {to_underlying(winrt::VirtualKey::LeftControl), "ControlLeft"},
+    {to_underlying(winrt::VirtualKey::RightControl), "ControlRight"},
+    {to_underlying(winrt::VirtualKey::Enter), "Enter"},
+    {to_underlying(winrt::VirtualKey::LeftWindows), "MetaLeft"},
+    {to_underlying(winrt::VirtualKey::RightWindows), "MetaRight"},
+    {to_underlying(winrt::VirtualKey::LeftShift), "ShiftLeft"},
+    {to_underlying(winrt::VirtualKey::RightShift), "ShiftRight"},
+    {to_underlying(winrt::VirtualKey::Space), "Space"},
+    {to_underlying(winrt::VirtualKey::Tab), "Tab"},
+
+    // List of code values for functional keys found on Japanese and Korean
+    // keyboards.
+    {to_underlying(winrt::VirtualKey::Convert), "Convert"},
+    {to_underlying(winrt::VirtualKey::Kana), "KanaMode"},
+    {to_underlying(winrt::VirtualKey::Hangul), "Lang1"},
+    {to_underlying(winrt::VirtualKey::Hanja), "Lang2"},
+    //{to_underlying(winrt::VirtualKey::None), "Lang3"},
+    //{to_underlying(winrt::VirtualKey::None), "Lang4"},
+    //{to_underlying(winrt::VirtualKey::None), "Lang5"},
+    {to_underlying(winrt::VirtualKey::NonConvert), "NonConvert"},
+
+    // Control Pad Section
+    {to_underlying(winrt::VirtualKey::Delete), "Delete"},
+    {to_underlying(winrt::VirtualKey::End), "End"},
+    {to_underlying(winrt::VirtualKey::Help), "Help"},
+    {to_underlying(winrt::VirtualKey::Home), "Home"},
+    {to_underlying(winrt::VirtualKey::Insert), "Insert"},
+    {to_underlying(winrt::VirtualKey::PageDown), "PageDown"},
+    {to_underlying(winrt::VirtualKey::PageUp), "PageUp"},
+
+    // Arrow Pad Section
+    {to_underlying(winrt::VirtualKey::Down), "ArrowDown"},
+    {to_underlying(winrt::VirtualKey::Left), "ArrowLeft"},
+    {to_underlying(winrt::VirtualKey::Right), "ArrowRight"},
+    {to_underlying(winrt::VirtualKey::Up), "ArrowUp"},
+
+    // Numpad Section
+    {to_underlying(winrt::VirtualKey::NumberKeyLock), "NumLock"},
+    {to_underlying(winrt::VirtualKey::NumberPad0), "Numpad0"},
+    {to_underlying(winrt::VirtualKey::NumberPad1), "Numpad1"},
+    {to_underlying(winrt::VirtualKey::NumberPad2), "Numpad2"},
+    {to_underlying(winrt::VirtualKey::NumberPad3), "Numpad3"},
+    {to_underlying(winrt::VirtualKey::NumberPad4), "Numpad4"},
+    {to_underlying(winrt::VirtualKey::NumberPad5), "Numpad5"},
+    {to_underlying(winrt::VirtualKey::NumberPad6), "Numpad6"},
+    {to_underlying(winrt::VirtualKey::NumberPad7), "Numpad7"},
+    {to_underlying(winrt::VirtualKey::NumberPad8), "Numpad8"},
+    {to_underlying(winrt::VirtualKey::NumberPad9), "Numpad9"},
+    {to_underlying(winrt::VirtualKey::Add), "NumpadAdd"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadBackspace"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadClear"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadClearEntry"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadComma"},
+    {to_underlying(winrt::VirtualKey::Decimal), "NumpadDecimal"},
+    {to_underlying(winrt::VirtualKey::Divide), "NumpadDivide"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadEnter"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadEqual"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadHash"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryAdd"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryClear"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryRecall"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryStore"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadMemorySubtract"},
+    {to_underlying(winrt::VirtualKey::Multiply), "NumpadMultiply"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadParenLeft"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadParenRight"},
+    //{to_underlying(winrt::VirtualKey::None), "NumpadStar"},
+    {to_underlying(winrt::VirtualKey::Subtract), "NumpadSubtract"},
+
+    // Function Section
+    {to_underlying(winrt::VirtualKey::Escape), "Escape"},
+    {to_underlying(winrt::VirtualKey::F1), "F1"},
+    {to_underlying(winrt::VirtualKey::F2), "F2"},
+    {to_underlying(winrt::VirtualKey::F3), "F3"},
+    {to_underlying(winrt::VirtualKey::F4), "F4"},
+    {to_underlying(winrt::VirtualKey::F5), "F5"},
+    {to_underlying(winrt::VirtualKey::F6), "F6"},
+    {to_underlying(winrt::VirtualKey::F7), "F7"},
+    {to_underlying(winrt::VirtualKey::F8), "F8"},
+    {to_underlying(winrt::VirtualKey::F9), "F9"},
+    {to_underlying(winrt::VirtualKey::F10), "F10"},
+    {to_underlying(winrt::VirtualKey::F11), "F11"},
+    {to_underlying(winrt::VirtualKey::F12), "F12"},
+    {to_underlying(winrt::VirtualKey::F13), "F13"},
+    {to_underlying(winrt::VirtualKey::F14), "F14"},
+    {to_underlying(winrt::VirtualKey::F15), "F15"},
+    {to_underlying(winrt::VirtualKey::F16), "F16"},
+    {to_underlying(winrt::VirtualKey::F17), "F17"},
+    {to_underlying(winrt::VirtualKey::F18), "F18"},
+    {to_underlying(winrt::VirtualKey::F19), "F19"},
+    {to_underlying(winrt::VirtualKey::F20), "F20"},
+    {to_underlying(winrt::VirtualKey::F21), "F21"},
+    {to_underlying(winrt::VirtualKey::F22), "F22"},
+    {to_underlying(winrt::VirtualKey::F23), "F23"},
+    {to_underlying(winrt::VirtualKey::F24), "F24"},
+    //{to_underlying(winrt::VirtualKey::None), "Fn"},
+    //{to_underlying(winrt::VirtualKey::None), "FnLock"},
+    {to_underlying(winrt::VirtualKey::Print), "PrintScreen"},
+    {to_underlying(winrt::VirtualKey::Scroll), "ScrollLock"},
+    {to_underlying(winrt::VirtualKey::Pause), "Pause"},
+
+    //// Media Keys
+    {to_underlying(winrt::VirtualKey::GoBack), "BrowserBack"},
+    {to_underlying(winrt::VirtualKey::Favorites), "BrowserFavorites"},
+    {to_underlying(winrt::VirtualKey::GoForward), "BrowserForward"},
+    {to_underlying(winrt::VirtualKey::GoHome), "BrowserHome"},
+    {to_underlying(winrt::VirtualKey::Refresh), "BrowserRefresh"},
+    {to_underlying(winrt::VirtualKey::Search), "BrowserSearch"},
+    {to_underlying(winrt::VirtualKey::Stop), "BrowserStop"},
+    //{to_underlying(winrt::VirtualKey::None), "Eject"},
+    {182, "LaunchApp1"},
+    {183, "LaunchApp2"},
+    {180, "LaunchMail"},
+    {179, "MediaPlayPause"},
+    {181, "MediaSelect"},
+    {178, "MediaStop"},
+    {176, "MediaTrackNext"},
+    {177, "MediaTrackPrevious"},
+    //{to_underlying(winrt::VirtualKey::None), "Power"},
+    {to_underlying(winrt::VirtualKey::Sleep), "Sleep"},
+    {174, "AudioVolumeDown"},
+    {173, "AudioVolumeMute"},
+    {175, "AudioVolumeUp"},
+    //{to_underlying(winrt::VirtualKey::None), "WakeUp"},
+
+    ////List of code values for legacy modifier keys.
+    //{to_underlying(winrt::VirtualKey::None), "Hyper"},
+    //{to_underlying(winrt::VirtualKey::None), "Super"},
+    //{to_underlying(winrt::VirtualKey::None), "Turbo"},
+
+    ////List of code values for legacy process control keys.
+    //{to_underlying(winrt::VirtualKey::None), "Abort"},
+    //{to_underlying(winrt::VirtualKey::None), "Resume"},
+    //{to_underlying(winrt::VirtualKey::None), "Suspend"},
+
+    ////List of code values for legacy editing keys.
+    //{to_underlying(winrt::VirtualKey::None), "Again"},
+    //{to_underlying(winrt::VirtualKey::None), "Copy"},
+    //{to_underlying(winrt::VirtualKey::None), "Cut"},
+    //{to_underlying(winrt::VirtualKey::None), "Find"},
+    //{to_underlying(winrt::VirtualKey::None), "Open"},
+    //{to_underlying(winrt::VirtualKey::None), "Paste"},
+    //{to_underlying(winrt::VirtualKey::None), "Props"},
+    {to_underlying(winrt::VirtualKey::Select), "Select"},
+    //{to_underlying(winrt::VirtualKey::None), "Undo"},
+
+    // The following keys may be found on non-standard international keyboards.
+    //{to_underlying(winrt::VirtualKey::None), "Hiragana"},
+    //{to_underlying(winrt::VirtualKey::None), "Katakana"},
+    //{to_underlying(winrt::VirtualKey::None), "Undo"},
+
+    // Xbox Gamepad
+    {to_underlying(winrt::VirtualKey::GamepadA), "GamepadA"},
+    {to_underlying(winrt::VirtualKey::GamepadB), "GamepadB"},
+    {to_underlying(winrt::VirtualKey::GamepadX), "GamepadX"},
+    {to_underlying(winrt::VirtualKey::GamepadY), "GamepadY"},
+    {to_underlying(winrt::VirtualKey::GamepadRightShoulder),
+     "GamepadRightShoulder"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftShoulder),
+     "GamepadLeftShoulder"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftTrigger),
+     "GamepadLeftTrigger"},
+    {to_underlying(winrt::VirtualKey::GamepadRightTrigger),
+     "GamepadRightTrigger"},
+    {to_underlying(winrt::VirtualKey::GamepadDPadUp), "GamepadDPadUp"},
+    {to_underlying(winrt::VirtualKey::GamepadDPadDown), "GamepadDPadDown"},
+    {to_underlying(winrt::VirtualKey::GamepadDPadLeft), "GamepadDPadLeft"},
+    {to_underlying(winrt::VirtualKey::GamepadDPadRight), "GamepadDPadRight"},
+    {to_underlying(winrt::VirtualKey::GamepadMenu), "GamepadMenu"},
+    {to_underlying(winrt::VirtualKey::GamepadView), "GamepadView"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickButton),
+     "GamepadLeftThumbstickButton"},
+    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickButton),
+     "GamepadRightThumbstickButton"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickUp),
+     "GamepadLeftThumbstickUp"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickDown),
+     "GamepadLeftThumbstickDown"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickRight),
+     "GamepadLeftThumbstickRight"},
+    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickLeft),
+     "GamepadLeftThumbstickLeft"},
+    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickUp),
+     "GamepadRightThumbstickUp"},
+    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickDown),
+     "GamepadRightThumbstickDown"},
+    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickRight),
+     "GamepadRightThumbstickRight"},
+    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickLeft),
+     "GamepadRightThumbstickLeft"}};
+
+template <typename T>
+static const std::string GetOrUnidentified(
+    winrt::Windows::System::VirtualKey virtualKey,
+    std::vector<std::pair<T, std::string>> const &vector) {
+  for (auto const &pair : vector) {
+    if (static_cast<int>(pair.first) == static_cast<int>(virtualKey))
+      return pair.second;
+  }
+  return "Unidentified";
+}
 
 std::string KeyboardHelper::FromVirtualKey(
     winrt::VirtualKey virtualKey,
     bool shiftDown,
     bool capLocked) {
-  char key = static_cast<char>(virtualKey);
+  int key = static_cast<int>(virtualKey);
 
-  if (!isalnum(key)) {
-    for (auto const &pair : g_virtualKeyToString) {
-      if (pair.first == virtualKey)
-        return pair.second;
-    }
-    return "Unidentified";
+  if (!isupper(key) && !isdigit(key)) {
+    return GetOrUnidentified(virtualKey, g_virtualKeyToKey);
   }
 
   // Customer never receives a-z
   // https://docs.microsoft.com/en-us/uwp/api/windows.system.virtualkey
   // Virtual Keys for 0-9 and A-Z, they're just aligned to their ASCII
   // representation (in uppercase, for the alphabet VKs)
-  return std::string(1, key);
+  return std::string(1, static_cast<char>(key));
+}
+
+inline winrt::VirtualKey GetLeftOrRightModifiedKey(
+    winrt::CoreWindow const &coreWindow,
+    winrt::VirtualKey leftKey,
+    winrt::VirtualKey rightKey) {
+  return IsModifiedKeyPressed(coreWindow, leftKey) ? leftKey : rightKey;
+}
+
+std::string KeyboardHelper::CodeFromVirtualKey(winrt::VirtualKey virtualKey) {
+  int key = static_cast<int>(virtualKey);
+
+  if (isdigit(key)) {
+    return "Digit" + std::string(1, static_cast<char>(key));
+  } else if (isupper(key)) {
+    return "Key" + std::string(1, static_cast<char>(key));
+  } else {
+    // Override the virtual key if it's modified key of Control, Shift or Menu
+    auto const &coreWindow = winrt::CoreWindow::GetForCurrentThread();
+    if (virtualKey == winrt::VirtualKey::Control) {
+      virtualKey = GetLeftOrRightModifiedKey(
+          coreWindow,
+          winrt::VirtualKey::LeftControl,
+          winrt::VirtualKey::RightControl);
+    } else if (virtualKey == winrt::VirtualKey::Shift) {
+      virtualKey = GetLeftOrRightModifiedKey(
+          coreWindow,
+          winrt::VirtualKey::LeftShift,
+          winrt::VirtualKey::RightShift);
+    } else if (virtualKey == winrt::VirtualKey::Menu) {
+      virtualKey = GetLeftOrRightModifiedKey(
+          coreWindow,
+          winrt::VirtualKey::LeftMenu,
+          winrt::VirtualKey::RightMenu);
+    }
+  }
+
+  return GetOrUnidentified(virtualKey, g_virtualKeyToCode);
 }
 
 } // namespace uwp

--- a/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
+++ b/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
@@ -44,8 +44,6 @@ struct json_type_traits<react::uwp::HandledKeyboardEvent> {
         event.handledEventPhase = asEnum<HandledEventPhase>(propertyValue);
     }
 
-    // To simplify the implementaion, key from JS is converted to upper case.
-    toUpperInplace(event.code);
     return event;
   }
 };

--- a/vnext/ReactWindows-UWP.sln
+++ b/vnext/ReactWindows-UWP.sln
@@ -99,6 +99,7 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Chakra\Chakra.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
+		Shared\Shared.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
 		Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/vnext/include/ReactUWP/Views/KeyboardEventHandler.h
+++ b/vnext/include/ReactUWP/Views/KeyboardEventHandler.h
@@ -41,11 +41,12 @@ struct ModifiedKeyState {
 struct ReactKeyboardEvent : ModifiedKeyState {
   int64_t target{0};
   std::string key{};
+  std::string code{};
 };
 
 struct HandledKeyboardEvent : ModifiedKeyState {
   HandledEventPhase handledEventPhase{HandledEventPhase::Bubbling};
-  std::string key{};
+  std::string code{};
 };
 
 typedef std::function<
@@ -158,6 +159,7 @@ struct KeyboardHelper {
       winrt::KeyRoutedEventArgs const &args);
   static std::string
   FromVirtualKey(winrt::VirtualKey key, bool shiftDown, bool capLocked);
+  static std::string CodeFromVirtualKey(winrt::VirtualKey key);
 };
 } // namespace uwp
 } // namespace react

--- a/vnext/src/Libraries/Components/Keyboard/KeyboardExtProps.ts
+++ b/vnext/src/Libraries/Components/Keyboard/KeyboardExtProps.ts
@@ -26,6 +26,7 @@ export interface INativeKeyboardEvent {
   metaKey: boolean;
   shiftKey: boolean;
   key: string;
+  code: string;
   eventPhase: EventPhase;
 }
 
@@ -34,7 +35,7 @@ export interface IHandledKeyboardEvent {
   ctrlKey?: boolean;
   metaKey?: boolean;
   shiftKey?: boolean;
-  key: string;
+  code: string;
   handledEventPhase?: HandledEventPhase;
 }
 

--- a/vnext/src/RNTester/KeyboardExtensionExample.uwp.tsx
+++ b/vnext/src/RNTester/KeyboardExtensionExample.uwp.tsx
@@ -45,13 +45,17 @@ interface IKeyboardableComponentState {
   lastKeyUp: string | null;
   lastKeyDownCapture: string | null;
   lastKeyUpCapture: string | null;
+  lastKeyDownCode: string | null;
+  lastKeyUpCode: string | null;
+  lastKeyDownCaptureCode: string | null;
+  lastKeyUpCaptureCode: string | null;
 }
 
 const handledNativeKeyboardEvents: IHandledKeyboardEvent[] = [
-  {key: 'a', handledEventPhase: HandledEventPhase.Capturing},
-  {key: 'b'},
-  {key: 'c', handledEventPhase: HandledEventPhase.Bubbling},
-  {key: 'Tab', handledEventPhase: HandledEventPhase.Capturing},
+  {code: 'KeyA', handledEventPhase: HandledEventPhase.Capturing},
+  {code: 'KeyB'},
+  {code: 'Digit1', handledEventPhase: HandledEventPhase.Bubbling},
+  {code: 'Tab', handledEventPhase: HandledEventPhase.Capturing},
 ];
 
 class ViewWindowsKeyboardExample extends React.Component<
@@ -65,6 +69,10 @@ class ViewWindowsKeyboardExample extends React.Component<
       lastKeyUp: null,
       lastKeyDownCapture: null,
       lastKeyUpCapture: null,
+      lastKeyDownCode: null,
+      lastKeyUpCode: null,
+      lastKeyDownCaptureCode: null,
+      lastKeyUpCaptureCode: null,
     };
   }
 
@@ -80,26 +88,47 @@ class ViewWindowsKeyboardExample extends React.Component<
           keyDownEvents={handledNativeKeyboardEvents}
           keyUpEvents={handledNativeKeyboardEvents}>
           <ViewWindows style={styles.keyEnterVisualizer}>
-            <Text>OnKeyDown</Text>
+            <Text>OnKeyDown Key and Code</Text>
             <Text>
               {this.state.lastKeyDown !== null ? this.state.lastKeyDown : ' '}
             </Text>
-            <Text>OnKeyDownCapture</Text>
+            <Text>
+              {this.state.lastKeyDownCode !== null
+                ? this.state.lastKeyDownCode
+                : ' '}
+            </Text>
+            <Text>OnKeyDownCapture Key and Code</Text>
             <Text>
               {this.state.lastKeyDownCapture !== null
                 ? this.state.lastKeyDownCapture
                 : ' '}
             </Text>
+            <Text>
+              {this.state.lastKeyDownCaptureCode !== null
+                ? this.state.lastKeyDownCaptureCode
+                : ' '}
+            </Text>
           </ViewWindows>
           <ViewWindows style={styles.keyEnterVisualizer}>
-            <Text>OnKeyUp</Text>
+            <Text>OnKeyUp Key and Code</Text>
             <Text>
               {this.state.lastKeyUp !== null ? this.state.lastKeyUp : ' '}
             </Text>
-            <Text>OnKeyUpCapture</Text>
+            <Text>
+              {this.state.lastKeyUpCode !== null
+                ? this.state.lastKeyUpCode
+                : ' '}
+            </Text>
+
+            <Text>OnKeyUpCapture Key and Code</Text>
             <Text>
               {this.state.lastKeyUpCapture !== null
                 ? this.state.lastKeyUpCapture
+                : ' '}
+            </Text>
+            <Text>
+              {this.state.lastKeyUpCaptureCode !== null
+                ? this.state.lastKeyUpCaptureCode
                 : ' '}
             </Text>
           </ViewWindows>
@@ -112,16 +141,28 @@ class ViewWindowsKeyboardExample extends React.Component<
   }
 
   private _onKeyUp = (ev: IKeyboardEvent) => {
-    this.setState({lastKeyUp: ev.nativeEvent.key, lastKeyDown: null});
+    this.setState({
+      lastKeyUp: ev.nativeEvent.key,
+      lastKeyDown: null,
+      lastKeyUpCode: ev.nativeEvent.code,
+      lastKeyDownCode: null,
+    });
   };
 
   private _onKeyDown = (ev: IKeyboardEvent) => {
-    this.setState({lastKeyDown: ev.nativeEvent.key, lastKeyUp: null});
+    this.setState({
+      lastKeyDown: ev.nativeEvent.key,
+      lastKeyUp: null,
+      lastKeyDownCode: ev.nativeEvent.code,
+      lastKeyUpCode: null,
+    });
   };
   private _onKeyUpCapture = (ev: IKeyboardEvent) => {
     this.setState({
       lastKeyUpCapture: ev.nativeEvent.key,
       lastKeyDownCapture: null,
+      lastKeyUpCaptureCode: ev.nativeEvent.code,
+      lastKeyDownCaptureCode: null,
     });
   };
 
@@ -129,6 +170,8 @@ class ViewWindowsKeyboardExample extends React.Component<
     this.setState({
       lastKeyDownCapture: ev.nativeEvent.key,
       lastKeyUpCapture: null,
+      lastKeyDownCaptureCode: ev.nativeEvent.code,
+      lastKeyUpCaptureCode: null,
     });
   };
 }


### PR DESCRIPTION
Fix #2679
For the HandledKeyboardEvent, key is renamed to code.
For the native keyboard event, we raise both key and code.
the code follows [uievents-code](https://www.w3.org/TR/uievents-code/)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2734)