### PR TITLE
Update to react-native@0.59.0-microsoft.12

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -70,11 +70,11 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "0.59.0-microsoft.11",
+    "react-native": "0.59.0-microsoft.12",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.11 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.11.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.12 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.12.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -5177,9 +5177,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.11.tar.gz":
-  version "0.59.0-microsoft.11"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.11.tar.gz#43e1b45f58d78d4c7785cc9bc57c539c52bfd6d4"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.12.tar.gz":
+  version "0.59.0-microsoft.12"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.12.tar.gz#d733d799bf1c90489ca680a253c0910ce18c347b"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
29798b2af Applying package update to 0.59.0-microsoft.12
2556f0ed5 Rojain/executorflowfix (#103)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2736)