### PR TITLE
Flyout container size fix for full view

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -371,8 +371,7 @@ void FlyoutViewManager::SetLayoutProps(
     float height) {
   auto *pFlyoutShadowNode = static_cast<FlyoutShadowNode *>(&nodeToUpdate);
 
-  if (pFlyoutShadowNode->GetFlyout()) {
-    auto flyout = pFlyoutShadowNode->GetFlyout();
+  if (auto flyout = pFlyoutShadowNode->GetFlyout()) {
 
     if (winrt::FlyoutPlacementMode::Full == flyout.Placement()) {
       winrt::Style flyoutStyle({L"Windows.UI.Xaml.Controls.FlyoutPresenter",

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -372,7 +372,6 @@ void FlyoutViewManager::SetLayoutProps(
   auto *pFlyoutShadowNode = static_cast<FlyoutShadowNode *>(&nodeToUpdate);
 
   if (auto flyout = pFlyoutShadowNode->GetFlyout()) {
-
     if (winrt::FlyoutPlacementMode::Full == flyout.Placement()) {
       winrt::Style flyoutStyle({L"Windows.UI.Xaml.Controls.FlyoutPresenter",
                                 winrt::TypeKind::Metadata});


### PR DESCRIPTION
Issue: The Flyout container doesn't resize correctly in the "Full" placement view. 

![image](https://user-images.githubusercontent.com/7191088/60847709-89c4fc80-a198-11e9-8788-ae69386207f5.png)


Fix: Set the correct width and height when the layout happens.

![image](https://user-images.githubusercontent.com/7191088/60847795-ecb69380-a198-11e9-9630-931096084448.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2742)