### PR TITLE
Disable default border on flyouts

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -300,8 +300,8 @@ void FlyoutShadowNode::AdjustDefaultFlyoutStyle() {
       winrt::FrameworkElement::MaxHeightProperty(), winrt::box_value(50000)));
   flyoutStyle.Setters().Append(
       winrt::Setter(winrt::Control::PaddingProperty(), winrt::box_value(0)));
-  flyoutStyle.Setters().Append(
-      winrt::Setter(winrt::Control::BorderThicknessProperty(), winrt::box_value(0)));
+  flyoutStyle.Setters().Append(winrt::Setter(
+      winrt::Control::BorderThicknessProperty(), winrt::box_value(0)));
   // When multiple flyouts are overlapping, XAML's theme shadows don't render
   // properly. As a workaround (temporary) we disable shadows when multiple
   // flyouts are open.

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -300,6 +300,8 @@ void FlyoutShadowNode::AdjustDefaultFlyoutStyle() {
       winrt::FrameworkElement::MaxHeightProperty(), winrt::box_value(50000)));
   flyoutStyle.Setters().Append(
       winrt::Setter(winrt::Control::PaddingProperty(), winrt::box_value(0)));
+  flyoutStyle.Setters().Append(
+      winrt::Setter(winrt::Control::BorderThicknessProperty(), winrt::box_value(0)));
   // When multiple flyouts are overlapping, XAML's theme shadows don't render
   // properly. As a workaround (temporary) we disable shadows when multiple
   // flyouts are open.


### PR DESCRIPTION
The FlyoutPresenter applies a theme-based default border that is inappropriate for RNFW. This change disables that default border so that the RN consumer can control their own content.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2747)