### PR TITLE
Fix for immediate live reload

### DIFF
--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -309,6 +309,9 @@ void UwpReactInstance::Start(
           auto uwpInstance =
               std::static_pointer_cast<UwpReactInstance>(strongThis);
 
+          // Mark the instance in needs reload state
+          uwpInstance->SetAsNeedsReload();
+
           // Invoke every callback registered
           for (auto const &current : uwpInstance->m_liveReloadCallbacks)
             current.second();
@@ -414,6 +417,11 @@ LiveReloadCallbackCookie UwpReactInstance::RegisterLiveReloadCallback(
   // Add callback to map with new cookie
   LiveReloadCallbackCookie cookie = ++g_nextLiveReloadCallbackCookie;
   m_liveReloadCallbacks[cookie] = callback;
+
+  // Its possible this instance is already in a reload state, if so
+  // trigger immediate reload
+  if (NeedsReload())
+    callback();
 
   return cookie;
 }

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
@@ -172,7 +172,6 @@ void DevSupportManager::StartPollingLiveReload(
                 winrt::Windows::Web::Http::HttpStatusCode::ResetContent &&
             !cancelled) {
           onChangeCallback();
-          break;
         }
       } catch (winrt::hresult_error const &e) {
         // Continue to poll on known error conditions


### PR DESCRIPTION
There is currently a window of time between starting the instance and when a root view attaches to it, where we can miss live reload requests.  Once a request has come in, we stop polling for more reload requests and the app is stuck in a 'will never reload' state.  In practice, we hit this 100% of the time with haul when making the first request - it takes a long time where we have a blocking download in init, and we process the reload request quickly enough after that, that it comes in before we've registered for reload notifications.



I have 2 changes here, either one would fix the bug I'm seeing, I could leave either out if there is a preference:
(1) [uwpreactinstance.cpp] Mark the instance as needs reload (we already have a flag and methods, that were unused, I looked back in the history when that was added 1.5yrs ago and somewhere near then it was not actually fully hooked up).  If we hit this case where during load a live reload request came in, when registering for the reload notification we will call it immediately.

(2) [devsupportmanageruwp.cpp] Our polling for live reload would stop polling after getting the first reload request.  I removed a break; to enable us to keep polling- which matches how the win32/desktop code.  -- There is some risk here that we're trigger multiple reloads but I wasn't able to see that and win32 seems to be fine.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2749)