### PR TITLE
Conditionalize the flyout shadow rendering fix to existence of property

### DIFF
--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -304,9 +304,14 @@ void FlyoutShadowNode::AdjustDefaultFlyoutStyle() {
   // properly. As a workaround (temporary) we disable shadows when multiple
   // flyouts are open.
   if (s_cOpenFlyouts > 1) {
-    flyoutStyle.Setters().Append(winrt::Setter(
-        winrt::FlyoutPresenter::IsDefaultShadowEnabledProperty(),
-        winrt::box_value(false)));
+    static bool isDisableShadowsSupported =
+      winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
+        L"Windows.UI.Xaml.Controls.FlyoutPresenter", L"IsDefaultShadowEnabled");
+  	  if (isDisableShadowsSupported) {
+        flyoutStyle.Setters().Append(winrt::Setter(
+          winrt::FlyoutPresenter::IsDefaultShadowEnabledProperty(),
+          winrt::box_value(false)));
+      }
   }
   m_flyout.FlyoutPresenterStyle(flyoutStyle);
 }

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -305,13 +305,14 @@ void FlyoutShadowNode::AdjustDefaultFlyoutStyle() {
   // flyouts are open.
   if (s_cOpenFlyouts > 1) {
     static bool isDisableShadowsSupported =
-      winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
-        L"Windows.UI.Xaml.Controls.FlyoutPresenter", L"IsDefaultShadowEnabled");
-  	  if (isDisableShadowsSupported) {
-        flyoutStyle.Setters().Append(winrt::Setter(
+        winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
+            L"Windows.UI.Xaml.Controls.FlyoutPresenter",
+            L"IsDefaultShadowEnabled");
+    if (isDisableShadowsSupported) {
+      flyoutStyle.Setters().Append(winrt::Setter(
           winrt::FlyoutPresenter::IsDefaultShadowEnabledProperty(),
           winrt::box_value(false)));
-      }
+    }
   }
   m_flyout.FlyoutPresenterStyle(flyoutStyle);
 }


### PR DESCRIPTION
The FlyoutPresenter property, IsDefaultShadowEnabled, is only available on 19h1.  My previous workaround for the flyout shadow rendering problem wasn't conditionalized for that. This change adds a check for the existence of that property before allowing the workaround. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2750)