### PR TITLE
Update to react-native@0.59.0-microsoft.13

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,11 +59,11 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "0.59.0-microsoft.12",
+    "react-native": "0.59.0-microsoft.13",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.12 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.12.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.13 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.13.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -5191,9 +5191,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.12.tar.gz":
-  version "0.59.0-microsoft.12"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.12.tar.gz#d733d799bf1c90489ca680a253c0910ce18c347b"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.13.tar.gz":
+  version "0.59.0-microsoft.13"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.13.tar.gz#388e22814301aa941b079575bb0a45a48ef58f32"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
e1d0925e4 Applying package update to 0.59.0-microsoft.13
f4bf4a922 Remove bit specification from nodeType_ in YGNode.h (#104)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2751)