### PR TITLE
update AppTheme stub for non-windows

### DIFF
--- a/vnext/src/Libraries/AppTheme/AppTheme.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.ts
@@ -5,21 +5,14 @@
  */
 'use strict';
 
-import {NativeEventEmitter} from 'react-native';
+const MissingNativeEventEmitterShim = require('MissingNativeEventEmitterShim');
 import {IHighContrastColors} from './AppThemeTypes';
 
-class AppThemeModule extends NativeEventEmitter {
-  get currentTheme(): string {
-    return '';
-  }
-
-  get isHighContrast(): boolean {
-    return false;
-  }
-
-  get currentHighContrastColorValues(): IHighContrastColors {
-    return {} as IHighContrastColors;
-  }
+class AppThemeModule extends MissingNativeEventEmitterShim {
+  public isAvailable = false;
+  public currentTheme = '';
+  public isHighContrast = false;
+  public currentHighContrastColors = {} as IHighContrastColors;
 }
 
 export const AppTheme = new AppThemeModule();


### PR DESCRIPTION
ran into errors with NativeEventEmitter in a crossplat project that was importing a react-native-windows component (but not actually hitting any code that used RNW js), but because AppTheme is included by index.ts and always constructs a global class, it is always running.

Updated based on the fallback code in AppTheme.uwp.ts

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2763)