### PR TITLE
Animation crash fix

### DIFF
--- a/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.cpp
@@ -88,7 +88,8 @@ void ValueAnimatedNode::RemoveActiveAnimation(int64_t animationTag) {
   if (!m_activeAnimations.size()) {
     if (const auto manager = m_manager.lock()) {
       for (const auto &props : m_dependentPropsNodes) {
-        manager->GetPropsAnimatedNode(props)->DisposeCompletedAnimation(Tag());
+        if (const auto propsNode = manager->GetPropsAnimatedNode(props))
+          propsNode->DisposeCompletedAnimation(Tag());
       }
     }
   }


### PR DESCRIPTION
add nullcheck

I checked all the other Get*AnimatedNode functions and everything else is already checking

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2766)