### PR TITLE
clang-format: add rule for pch.h and generated files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,13 +44,18 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ForEachMacros:   [ FOR_EACH_RANGE, FOR_EACH, ]
+IncludeBlocks: Preserve
 IncludeCategories:
-  - Regex:           '^<.*\.h(pp)?>'
+  - Regex:           'pch.h'
+    Priority:        -1
+  - Regex:           '.*\.g\..*'
     Priority:        1
-  - Regex:           '^<.*'
+  - Regex:           '^<.*\.h(pp)?>'
     Priority:        2
-  - Regex:           '.*'
+  - Regex:           '^<.*'
     Priority:        3
+  - Regex:           '.*'
+    Priority:        4
 IndentCaseLabels: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false

--- a/vnext/Universal.UnitTests/App.xaml.cpp
+++ b/vnext/Universal.UnitTests/App.xaml.cpp
@@ -5,8 +5,8 @@
 // Implementation of the App class.
 //
 
-#include "MainPage.xaml.h"
 #include "pch.h"
+#include "MainPage.xaml.h"
 
 using namespace ReactUWPUnitTests;
 

--- a/vnext/Universal.UnitTests/MainPage.xaml.cpp
+++ b/vnext/Universal.UnitTests/MainPage.xaml.cpp
@@ -5,8 +5,8 @@
 // Implementation of the MainPage class.
 //
 
-#include "MainPage.xaml.h"
 #include "pch.h"
+#include "MainPage.xaml.h"
 
 using namespace ReactUWPUnitTests;
 using namespace Platform;

--- a/vnext/Universal.UnitTests/Tests/StringConversionTests_Universal.cpp
+++ b/vnext/Universal.UnitTests/Tests/StringConversionTests_Universal.cpp
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#include "pch.h"
 #include <../Chakra/Utf8DebugExtensions.h>
 #include <CppUnitTest.h>
 #include <string>
 #include <vector>
-#include "pch.h"
 
 using namespace facebook::react;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;


### PR DESCRIPTION
This makes it so pch.h is always at the top and cppwinrt generated files get moved to below the "main" header.

File: Foo.cpp
```cpp
#include pch.h
#include Foo.h
#include Foo.g.cpp
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2767)