### PR TITLE
Update to react-native@0.59.0-microsoft.16

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,11 +59,11 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "0.59.0-microsoft.15",
+    "react-native": "0.59.0-microsoft.16",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.15.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz"
   }
 }

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -5191,9 +5191,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.15.tar.gz":
-  version "0.59.0-microsoft.15"
-  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.15.tar.gz#1f3037aac186e8f2de5677772176c4e75117e9c7"
+"react-native@https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz":
+  version "0.59.0-microsoft.16"
+  resolved "https://github.com/Microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz#bf47c0c2cd52674aa8d7b5c3d57b679d2ff808a1"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
7f1b95247 Applying package update to 0.59.0-microsoft.16
05c907ed6 Rojain/fix59 (#109)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2769)