### PR TITLE
Updated SampleApp with drop-down of available samples

### DIFF
--- a/vnext/Universal.SampleApp/HostingPane.xaml
+++ b/vnext/Universal.SampleApp/HostingPane.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="WindowsSampleApp.HostingPane"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -20,9 +20,9 @@
     <Grid Grid.Row="0">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="auto"/>
-        <ColumnDefinition Width="*" MinWidth="150"/>
+        <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="auto"/>
-        <ColumnDefinition Width="auto" MinWidth="100"/>
+        <ColumnDefinition Width="auto"/>
       </Grid.ColumnDefinitions>
 
       <TextBlock
@@ -30,22 +30,29 @@
         Margin="2,2,2,2"
         VerticalAlignment="Center"
         Text="JavaScript File (no extension):"/>
-      <TextBox x:Name="x_JavaScriptFilename"
+      <ComboBox x:Name="x_JavaScriptFilename"
         Grid.Column="1"
         Margin="2,2,2,2"
+        IsEditable="True"
+        MinWidth="250"
         VerticalAlignment="Center"
-        TextChanged="OnTextChanged_JavaScriptFilename"/>
+        HorizontalAlignment="Stretch"
+        SelectionChanged="OnSelectionChanged_JavaScriptFilename" />
 
       <TextBlock
         Grid.Column="2"
         Margin="2,2,2,2"
         VerticalAlignment="Center"
         Text="App Name:"/>
-      <TextBox
+      <ComboBox
         x:Name="x_ReactAppName"
         Grid.Column="3"
+        IsEditable="True"
         Margin="2,2,2,2"
-        VerticalAlignment="Center"/>
+        MinWidth="150"
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Center"
+        SelectionChanged="OnSelectionChanged_ReactAppName" />
     </Grid>
 
     <Grid Grid.Row="1">

--- a/vnext/Universal.SampleApp/HostingPane.xaml.h
+++ b/vnext/Universal.SampleApp/HostingPane.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 //
 // HostingPane.xaml.h
@@ -33,10 +33,15 @@ namespace WindowsSampleApp {
         Windows::UI::Xaml::Input::ICommand ^ get();
       }
 
-      private : void
-                OnTextChanged_JavaScriptFilename(
-                    Platform::Object ^ sender,
-                    Windows::UI::Xaml::Controls::TextChangedEventArgs args);
+      private
+      : void OnSelectionChanged_JavaScriptFilename(
+            Platform::Object ^ sender,
+            Windows::UI::Xaml::Controls::SelectionChangedEventArgs ^ args);
+
+ private:
+  void OnSelectionChanged_ReactAppName(
+      Platform::Object ^ sender,
+      Windows::UI::Xaml::Controls::SelectionChangedEventArgs ^ args);
   void OnLoadClicked(Platform::Object ^ sender, Platform::Object ^ args);
   void OnUnloadClicked(Platform::Object ^ sender, Platform::Object ^ args);
   void OnReloadClicked(Platform::Object ^ sender, Platform::Object ^ args);
@@ -52,6 +57,9 @@ namespace WindowsSampleApp {
   internal : std::shared_ptr<react::uwp::IReactInstance> getInstance();
   void markAsNeedsReload();
 
+  void InitComboBoxes();
+  void LoadKnownApps();
+
  private:
   std::wstring m_loadedJSComponentName;
   std::wstring m_loadedBundleFileName;
@@ -60,6 +68,9 @@ namespace WindowsSampleApp {
 
   std::shared_ptr<react::uwp::IXamlRootView> m_rootView;
   std::shared_ptr<react::uwp::IReactInstance> m_instance;
+
+  Platform::Collections::Vector<Platform::String ^> ^ m_jsFileNames;
+  Platform::Collections::Vector<Platform::String ^> ^ m_ReactAppNames;
 };
 
 } // namespace WindowsSampleApp


### PR DESCRIPTION
We have a handful of small sample apps in the repo that can be loaded by our Universal SampleApp.

In preparation for adding potentially more (and making it easier to load the existing ones) I've changed the text boxes at the top of the app to combo boxes and have added every existing sample in the repo.

The combo boxes are still editable if for whatever reason you want to manually specify a specific path.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2772)