### PR TITLE
Reduce changes needed for uwp in fork

### DIFF
--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,11 +55,11 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.17.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.17 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.17.tar.gz"
   }
 }

--- a/vnext/src/Libraries/Components/Button.uwp.js
+++ b/vnext/src/Libraries/Components/Button.uwp.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('React');
+const StyleSheet = require('StyleSheet');
+const Text = require('Text');
+const TouchableHighlight = require('TouchableHighlight'); // [TODO(windows ISS)
+const View = require('View');
+
+const invariant = require('invariant');
+
+import type {PressEvent} from 'CoreEventTypes';
+
+type ButtonProps = $ReadOnly<{|
+  /**
+   * Text to display inside the button
+   */
+  title: string,
+
+  /**
+   * Handler to be called when the user taps the button
+   */
+  onPress: (event?: PressEvent) => mixed,
+
+  /**
+   * Color of the text (iOS), or background color of the button (Android)
+   */
+  color?: ?string,
+
+  /**
+   * TV preferred focus (see documentation for the View component).
+   */
+  hasTVPreferredFocus?: ?boolean,
+
+  /**
+   * Text to display for blindness accessibility features
+   */
+  accessibilityLabel?: ?string,
+  /**
+   * Hint text to display blindness accessibility features
+   */
+  accessibilityHint?: ?string, // TODO(OSS Candidate ISS#2710739)
+  /**
+   * If true, disable all interactions for this component.
+   */
+  disabled?: ?boolean,
+
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  testID?: ?string,
+|}>;
+
+class Button extends React.Component<ButtonProps> {
+  render() {
+    const {
+      accessibilityLabel,
+      accessibilityHint,
+      color,
+      onPress,
+      title,
+      hasTVPreferredFocus,
+      disabled,
+      testID,
+    } = this.props;
+    const buttonStyles = [styles.button];
+    const textStyles = [styles.text];
+    if (color) {
+      buttonStyles.push({backgroundColor: color});
+    }
+    const accessibilityStates = [];
+    if (disabled) {
+      buttonStyles.push(styles.buttonDisabled);
+      textStyles.push(styles.textDisabled);
+      accessibilityStates.push('disabled');
+    }
+    invariant(
+      typeof title === 'string',
+      'The title prop of a Button must be a string',
+    );
+    const formattedTitle = title;
+    return (
+      <TouchableHighlight
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+        accessibilityRole="button"
+        accessibilityStates={accessibilityStates}
+        hasTVPreferredFocus={hasTVPreferredFocus}
+        testID={testID}
+        disabled={disabled}
+        onPress={onPress}>
+        <View style={buttonStyles}>
+          <Text style={textStyles} disabled={disabled}>
+            {formattedTitle}
+          </Text>
+        </View>
+      </TouchableHighlight>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#2196F3',
+    borderRadius: 2,
+  },
+  text: {
+    textAlign: 'center',
+    padding: 8,
+    color: 'white',
+    fontWeight: '500',
+  },
+  buttonDisabled: {
+    backgroundColor: '#dfdfdf',
+  },
+  textDisabled: {
+    color: '#a1a1a1',
+  },
+});
+
+module.exports = Button;

--- a/vnext/src/Libraries/Components/Button.windesktop.js
+++ b/vnext/src/Libraries/Components/Button.windesktop.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/vnext/src/Libraries/Components/ScrollView/ScrollView.windesktop.js
+++ b/vnext/src/Libraries/Components/ScrollView/ScrollView.windesktop.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windesktop.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windesktop.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/vnext/src/Libraries/YellowBox/UI/YellowBoxList.windesktop.js
+++ b/vnext/src/Libraries/YellowBox/UI/YellowBoxList.windesktop.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/vnext/yarn.lock
+++ b/vnext/yarn.lock
@@ -5191,9 +5191,9 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz":
-  version "0.59.0-microsoft.16"
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.16.tar.gz#bf47c0c2cd52674aa8d7b5c3d57b679d2ff808a1"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.17.tar.gz":
+  version "0.59.0-microsoft.17"
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.17.tar.gz#74acdba3594c0a309792883f54baaa3d5da14e75"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Button was modified in MS/RN for uwp.  That change should be in RNW so that it works without MS/RN.
Also added stubs for various components for windesktop.

These changes will allow removal of some changes in the MS/RN fork, for further alignment with RN.

https://github.com/microsoft/react-native/pull/111 - This is the PR that will remove changes in the MS/RN fork

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2774)