### PR TITLE
StopAnimation fixes

### DIFF
--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
@@ -66,10 +66,10 @@ void AnimationDriver::StopAnimation() {
     animatedValue->PropertySet().StopAnimation(ValueAnimatedNode::s_offsetName);
     animatedValue->RemoveActiveAnimation(m_id);
 
-    if (m_scopedBatch)
-    {
-      m_endCallback(
-        std::vector<folly::dynamic>{folly::dynamic::object("finished", false)});
+    if (m_scopedBatch) {
+      if (m_endCallback)
+        m_endCallback(std::vector<folly::dynamic>{
+            folly::dynamic::object("finished", false)});
       m_scopedBatch.Completed(m_scopedBatchCompletedToken);
       m_scopedBatch = nullptr;
     }

--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.cpp
@@ -64,8 +64,15 @@ void AnimationDriver::StartAnimation() {
 void AnimationDriver::StopAnimation() {
   if (const auto animatedValue = GetAnimatedValue()) {
     animatedValue->PropertySet().StopAnimation(ValueAnimatedNode::s_offsetName);
-    m_endCallback(
+    animatedValue->RemoveActiveAnimation(m_id);
+
+    if (m_scopedBatch)
+    {
+      m_endCallback(
         std::vector<folly::dynamic>{folly::dynamic::object("finished", false)});
+      m_scopedBatch.Completed(m_scopedBatchCompletedToken);
+      m_scopedBatch = nullptr;
+    }
   }
 }
 


### PR DESCRIPTION
When StopAnimation runs instead of full completion, 2 things were happening -

1) the RemoveActiveAnimation wasn't happening in this path
2) we would endCallback, but then often the endCallback would be called a second time if the animation completed.  If you call the same callback twice the js side throws on the second one.  Added code to unregister the completion token.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2776)