### PR TITLE
Fix Focus/Blur events, bring back space/enter handling temporarily

### DIFF
--- a/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
@@ -17,6 +17,31 @@ namespace react {
 namespace uwp {
 namespace polyester {
 
+class ButtonShadowNode : public ContentControlShadowNode {
+  using Super = ContentControlShadowNode;
+
+ public:
+  ButtonShadowNode() = default;
+  void createView() override;
+
+ private:
+  winrt::Button::Click_revoker m_buttonClickRevoker{};
+};
+
+void ButtonShadowNode::createView() {
+  Super::createView();
+
+  auto button = GetView().as<winrt::Button>();
+
+  m_buttonClickRevoker =
+      button.Click(winrt::auto_revoke, [=](auto &&, auto &&) {
+        auto instance = GetViewManager()->GetReactInstance().lock();
+        folly::dynamic eventData = folly::dynamic::object("target", m_tag);
+        if (instance != nullptr)
+          instance->DispatchEvent(m_tag, "topClick", std::move(eventData));
+      });
+}
+
 ButtonViewManager::ButtonViewManager(
     const std::shared_ptr<IReactInstance> &reactInstance)
     : ContentControlViewManager(reactInstance) {}
@@ -44,16 +69,12 @@ folly::dynamic ButtonViewManager::GetExportedCustomDirectEventTypeConstants()
   return directEvents;
 }
 
+facebook::react::ShadowNode *ButtonViewManager::createShadow() const {
+  return new ButtonShadowNode();
+}
+
 XamlView ButtonViewManager::CreateViewCore(int64_t tag) {
   winrt::Button button = winrt::Button();
-  m_buttonClickRevoker =
-      button.Click(winrt::auto_revoke, [=](auto &&, auto &&) {
-        auto instance = m_wkReactInstance.lock();
-        folly::dynamic eventData = folly::dynamic::object("target", tag);
-        if (instance != nullptr)
-          instance->DispatchEvent(tag, "topClick", std::move(eventData));
-      });
-
   return button;
 }
 

--- a/vnext/ReactUWP/Polyester/ButtonViewManager.h
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.h
@@ -22,6 +22,7 @@ class ButtonViewManager : public ContentControlViewManager {
   const char *GetName() const override;
   folly::dynamic GetNativeProps() const override;
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
+  facebook::react::ShadowNode *createShadow() const override;
 
   void UpdateProperties(
       ShadowNodeBase *nodeToUpdate,
@@ -29,9 +30,6 @@ class ButtonViewManager : public ContentControlViewManager {
 
  protected:
   XamlView CreateViewCore(int64_t tag) override;
-
- private:
-  winrt::Button::Click_revoker m_buttonClickRevoker{};
 };
 
 } // namespace polyester

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
@@ -22,21 +22,6 @@ namespace react {
 namespace uwp {
 namespace polyester {
 
-class ContentControlShadowNode : public ShadowNodeBase {
-  using Super = ShadowNodeBase;
-
- public:
-  ContentControlShadowNode() = default;
-  void createView() override;
-  bool IsExternalLayoutDirty() const override {
-    return m_paddingDirty;
-  }
-  void DoExtraLayoutPrep(YGNodeRef yogaNode) override;
-
- private:
-  bool m_paddingDirty = false;
-};
-
 void ContentControlShadowNode::DoExtraLayoutPrep(YGNodeRef yogaNode) {
   if (!m_paddingDirty)
     return;

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.h
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.h
@@ -10,6 +10,11 @@ namespace react {
 namespace uwp {
 namespace polyester {
 
+//
+// ContentControlShadowNode
+// - required for subclasses of ContentControlViewManager with a custom
+// shadownode
+//
 class ContentControlShadowNode : public ShadowNodeBase {
   using Super = ShadowNodeBase;
 
@@ -25,6 +30,9 @@ class ContentControlShadowNode : public ShadowNodeBase {
   bool m_paddingDirty = false;
 };
 
+//
+// ContentControlViewManager
+//
 class ContentControlViewManager : public ControlViewManager {
   using Super = ControlViewManager;
 

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.h
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.h
@@ -4,10 +4,26 @@
 #pragma once
 
 #include <Views/ControlViewManager.h>
+#include <Views/ShadowNodeBase.h>
 
 namespace react {
 namespace uwp {
 namespace polyester {
+
+class ContentControlShadowNode : public ShadowNodeBase {
+  using Super = ShadowNodeBase;
+
+ public:
+  ContentControlShadowNode() = default;
+  void createView() override;
+  bool IsExternalLayoutDirty() const override {
+    return m_paddingDirty;
+  }
+  void DoExtraLayoutPrep(YGNodeRef yogaNode) override;
+
+ private:
+  bool m_paddingDirty = false;
+};
 
 class ContentControlViewManager : public ControlViewManager {
   using Super = ControlViewManager;

--- a/vnext/ReactUWP/Views/ViewViewManager.h
+++ b/vnext/ReactUWP/Views/ViewViewManager.h
@@ -46,17 +46,6 @@ class ViewViewManager : public FrameworkElementViewManager {
       ViewShadowNode *viewShadowNode,
       winrt::react::uwp::ViewPanel &pPanel,
       bool useControl);
-
- private:
-  void DispatchEvent(
-      int64_t viewTag,
-      std::string eventName,
-      folly::dynamic &&eventData);
-
-  XamlView CreateViewControl(int64_t tag);
-
-  winrt::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
-  winrt::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};
 };
 
 } // namespace uwp


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/issues/2783

This fixes some fallout of the auto_revoker changes recently made.  We can't use auto_revoker in a ViewManager, must be done in ShadowNode.  This moves ViewViewManager things to ViewShadowNode and ButtonViewManager to a new ButtonShadowNode.

For View - I also moved the accessibility event being registered for so all callers of DispatchEvent could be in the shadownode.

ViewShadowNode is getting pretty big as a class with all inline functions, should probably do a followup checkin that fixes that and moves the rest of the ViewViewManager into the shadownode (basically - updateproperties)


For Button - (while this control will get deleted soon, keeping it functional) it's base class was already creating a shadownode that wasn't in a header, so moved ContentControlShadowNode to a header for it to reference.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2785)