### PR TITLE
Patch for run-windows command

### DIFF
--- a/current/local-cli/runWindows/runWindows.js
+++ b/current/local-cli/runWindows/runWindows.js
@@ -4,9 +4,9 @@ const chalk = require('chalk');
 const build = require('./utils/build');
 const deploy = require('./utils/deploy');
 
-function runWindows(config, args, options) {
+function runWindows(argv, config, options) {
   // Fix up options
-  options.root = options.root || process.cwd();
+  options.root = options.root || config.root || process.cwd();
 
   const slnFile = build.getSolutionFile(options);
   if (!slnFile) {
@@ -31,7 +31,7 @@ function runWindows(config, args, options) {
     return;
   }
 
-  return deploy.startServerInNewWindow(options)
+  return deploy.startServerInNewWindow(options, config.reactNativePath)
     .then(() => {
       if (options.device || options.emulator || options.target) {
         return deploy.deployToDevice(options);
@@ -64,6 +64,7 @@ runWindows({
  *    proxy: Boolean - Run using remote JS proxy
  *    verbose: Boolean - Enables logging
  *    no-packager: Boolean - Do not launch packager while building
+ *    port: Integer - port number that should be used by the packager
  */
 module.exports = {
   name: 'run-windows',
@@ -98,5 +99,9 @@ module.exports = {
   }, {
     command: '--no-packager',
     description: 'Do not launch packager while building'
+  }, {
+    command: '--port [number]',
+    default: process.env.RCT_METRO_PORT || 8081,
+    parse: val => Number(val)
   }]
 };

--- a/current/local-cli/runWindows/utils/deploy.js
+++ b/current/local-cli/runWindows/utils/deploy.js
@@ -108,33 +108,82 @@ function deployToDesktop(options) {
   });
 }
 
-function startServerInNewWindow(options) {
+function startServerInNewWindow(options, reactNativePath) {
   return new Promise(resolve => {
     if (options.packager) {
-      http.get('http://localhost:8081/status', res => {
+      http.get(`http://localhost:${options.port}/status`, res => {
         if (res.statusCode === 200) {
           console.log(chalk.green('React-Native Server already started'));
         } else {
           console.log(chalk.red('React-Native Server not responding'));
         }
         resolve();
-      }).on('error', () => resolve(launchServer(options)));
+      }).on('error', () => resolve(launchServer(options.port, reactNativePath)));
     } else {
       resolve();
     }
   });
 }
 
-function launchServer(options) {
-  console.log(chalk.green('Starting the React-Native Server'));
-  const launchPackagerScript = path.join('node_modules/react-native/scripts/launchPackager.bat');
-  const opts = {
-    cwd: options.root,
-    detached: true,
-    stdio: options.verbose ? 'inherit' : 'ignore'
-  };
+function launchServer(port, reactNativePath)
+{
+  /**
+   * Set up OS-specific filenames and commands
+   */
+  const scriptFile = 'launchPackager.bat';
+  const packagerEnvFilename = '.packager.bat';
+  const portExportContent = `set RCT_METRO_PORT=${port}`;
 
-  return Promise.resolve(spawn('cmd.exe', ['/C', 'start', launchPackagerScript], opts));
+  /**
+   * Quick & temporary fix for packager crashing on Windows due to using removed --projectRoot flag
+   * in script. So we just replace the contents of the script with the fixed version. This should be
+   * removed when PR #25517 on RN Repo gets approved and a new RN version is released.
+   */
+  const launchPackagerScriptContent = `:: Copyright (c) Facebook, Inc. and its affiliates.
+  ::
+  :: This source code is licensed under the MIT license found in the
+  :: LICENSE file in the root directory of this source tree.
+  @echo off
+  title Metro Bundler
+  call .packager.bat
+  cd ../../../
+  node "%~dp0..\\cli.js" start
+  pause
+  exit`;
+
+  /**
+   * Set up the `.packager.bat` file to ensure the packager starts on the right port.
+   */
+  const launchPackagerScript = path.join(
+    reactNativePath,
+    `scripts/${scriptFile}`,
+  );
+
+  /**
+   * Set up the `launchpackager.bat` file.
+   * It lives next to `.packager.bat`
+   */
+  const scriptsDir = path.dirname(launchPackagerScript);
+  const packagerEnvFile = path.join(scriptsDir, packagerEnvFilename);
+  const procConfig = {cwd: scriptsDir};
+
+  /**
+   * Ensure we overwrite file by passing the `w` flag
+   */
+  fs.writeFileSync(packagerEnvFile, portExportContent, {
+    encoding: 'utf8',
+    flag: 'w',
+  });
+
+  procConfig.detached = true;
+  procConfig.stdio = 'ignore';
+  //Temporary fix for #484. See comment on line 254
+  fs.writeFileSync(launchPackagerScript, launchPackagerScriptContent, {
+    encoding: 'utf8',
+    flag: 'w',
+  });
+
+  return Promise.resolve(spawn('cmd.exe', ['/C', launchPackagerScript], procConfig));
 }
 
 module.exports = {

--- a/current/local-cli/runWpf/runWpf.js
+++ b/current/local-cli/runWpf/runWpf.js
@@ -4,9 +4,9 @@ const chalk = require('chalk');
 const build = require('./utils/build');
 const deploy = require('./utils/deploy');
 
-function runWpf(config, args, options) {
+function runWpf(argv, config, options) {
   // Fix up options
-  options.root = options.root || process.cwd();
+  options.root = options.root || config.root || process.cwd();
 
   const slnFile = build.getSolutionFile(options);
   if (!slnFile) {
@@ -31,7 +31,7 @@ function runWpf(config, args, options) {
     return;
   }
 
-  return deploy.startServerInNewWindow(options)
+  return deploy.startServerInNewWindow(options, config.reactNativePath)
     .then(() => {
       return deploy.deployToDesktop(options);
     })
@@ -82,5 +82,9 @@ module.exports = {
   }, {
     command: '--no-packager',
     description: 'Do not launch packager while building'
+  }, {
+    command: '--port [number]',
+    default: process.env.RCT_METRO_PORT || 8081,
+    parse: val => Number(val)
   }]
 };

--- a/current/local-cli/runWpf/utils/deploy.js
+++ b/current/local-cli/runWpf/utils/deploy.js
@@ -2,7 +2,6 @@
 
 const child_process = require('child_process');
 const spawn = child_process.spawn;
-const http = require('http');
 const path = require('path');
 const chalk = require('chalk');
 
@@ -17,21 +16,82 @@ function deployToDesktop(options) {
 
 }
 
-function startServerInNewWindow(options) {
+function startServerInNewWindow(options, reactNativePath) {
   return new Promise(resolve => {
     if (options.packager) {
-      http.get('http://localhost:8081/status', res => {
+      http.get(`http://localhost:${options.port}/status`, res => {
         if (res.statusCode === 200) {
           console.log(chalk.green('React-Native Server already started'));
         } else {
           console.log(chalk.red('React-Native Server not responding'));
         }
         resolve();
-      }).on('error', () => resolve(launchServer(options)));
+      }).on('error', () => resolve(launchServer(options.port, reactNativePath)));
     } else {
       resolve();
     }
   });
+}
+
+function launchServer(port, reactNativePath)
+{
+  /**
+   * Set up OS-specific filenames and commands
+   */
+  const scriptFile = 'launchPackager.bat';
+  const packagerEnvFilename = '.packager.bat';
+  const portExportContent = `set RCT_METRO_PORT=${port}`;
+
+  /**
+   * Quick & temporary fix for packager crashing on Windows due to using removed --projectRoot flag
+   * in script. So we just replace the contents of the script with the fixed version. This should be
+   * removed when PR #25517 on RN Repo gets approved and a new RN version is released.
+   */
+  const launchPackagerScriptContent = `:: Copyright (c) Facebook, Inc. and its affiliates.
+  ::
+  :: This source code is licensed under the MIT license found in the
+  :: LICENSE file in the root directory of this source tree.
+  @echo off
+  title Metro Bundler
+  call .packager.bat
+  cd ../../../
+  node "%~dp0..\\cli.js" start
+  pause
+  exit`;
+
+  /**
+   * Set up the `.packager.bat` file to ensure the packager starts on the right port.
+   */
+  const launchPackagerScript = path.join(
+    reactNativePath,
+    `scripts/${scriptFile}`,
+  );
+
+  /**
+   * Set up the `launchpackager.bat` file.
+   * It lives next to `.packager.bat`
+   */
+  const scriptsDir = path.dirname(launchPackagerScript);
+  const packagerEnvFile = path.join(scriptsDir, packagerEnvFilename);
+  const procConfig = {cwd: scriptsDir};
+
+  /**
+   * Ensure we overwrite file by passing the `w` flag
+   */
+  fs.writeFileSync(packagerEnvFile, portExportContent, {
+    encoding: 'utf8',
+    flag: 'w',
+  });
+
+  procConfig.detached = true;
+  procConfig.stdio = 'ignore';
+  //Temporary fix for #484. See comment on line 254
+  fs.writeFileSync(launchPackagerScript, launchPackagerScriptContent, {
+    encoding: 'utf8',
+    flag: 'w',
+  });
+
+  return Promise.resolve(spawn('cmd.exe', ['/C', launchPackagerScript], procConfig));
 }
 
 function launchServer(options) {


### PR DESCRIPTION
There is currently a problem with packager.bat for starting the react-native server. This change addresses that issue until targeting a version with react-native PR #25517.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2794)