### PR TITLE
Updating parity of NetInfo module

### DIFF
--- a/blog/Roadmap2019.md
+++ b/blog/Roadmap2019.md
@@ -10,7 +10,7 @@ The ["current"](https://github.com/microsoft/react-native-windows/tree/master/cu
 Please continue to report issues as you encounter them, but be sure to use the [correct template](https://github.com/microsoft/react-native-windows/issues/new?assignees=rozele&labels=.NET&template=DOTNET.md) for issues related to the existing `react-native-windows` package.
 
 ## vnext
-The ["vnext"](https://github.com/microsoft/react-native-windows/tree/master/vnext) subdirectory holds the newer, high performance implementation for `react-native-windows` written in C++ to better align with the shared C++ react-native core as it evolves. This is the new architecture where all the ongoing feature investments are being made at this time. You can read more about this effort [here](vnext/README.md). 
+The ["vnext"](https://github.com/microsoft/react-native-windows/tree/master/vnext) subdirectory holds the newer, high performance implementation for `react-native-windows` written in C++ to better align with the shared C++ react-native core as it evolves. This is the new architecture where all the ongoing feature investments are being made at this time. You can read more about this effort [here](/vnext/README.md). 
 
 Our intent is to provide a compatibility layer for vnext that will support existing apps, view managers, and native modules written in C# with minimal breaking changes.
 

--- a/vnext/docs/ParityStatus.md
+++ b/vnext/docs/ParityStatus.md
@@ -42,7 +42,7 @@ These set of components and modules are not part of [React Native Lean Core](htt
 
 ### Components
 
-|Component| vnext Status | Issues | Current Status |
+|Component| `vnext` version Status | `vnext` Issues remaining | `current` version Status |
 |:-|:-|:-|:-|
 |Modal|Not Started|*nothing logged*|Partial (Beta)|
 |Navigator|Not Started|*nothing logged*|**Complete**|
@@ -54,13 +54,13 @@ These set of components and modules are not part of [React Native Lean Core](htt
 
 ### Modules
 
-|Module| vnext Status | Issues | Current Status|
+|Module| `vnext` version Status | `vnext` Issues remaining | `current` version Status|
 |:-|:-|:-|:-|
 |AsyncStorage|Partial|[2271](https://github.com/microsoft/react-native-windows/issues/2271)|**Complete**|
 |BackAndroid|Partial|*nothing logged*|Partial|
 |Clipboard|**Complete**|-|**Complete**|
 |Geolocation|**Complete**|-|**Complete**|
-|NetInfo|Not Started|*nothing logged*|Partial|
+|NetInfo|Not Started|*nothing logged*|**Complete**|
 |AppRegistry|Not Started|*nothing logged*|**Complete**|
 |NativeMethodsMixin|Not Started|*nothing logged*|**Complete**|
 |PixelRatio|Not Started|*nothing logged*|**Complete**|


### PR DESCRIPTION
NetInfo module has been updated to support react native windows - current version as of [v3.2.0](https://github.com/react-native-community/react-native-netinfo/releases/tag/v3.2.0). Marking that column for "current version status" as completed.

Also updated broken link in roadmap blog

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2816)