### PR TITLE
Adaptive cards compat

### DIFF
--- a/vnext/ReactUWP/Modules/ImageViewManagerModule.cpp
+++ b/vnext/ReactUWP/Modules/ImageViewManagerModule.cpp
@@ -18,7 +18,6 @@
 
 #include "unicode.h"
 
-
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage
 #pragma optimize("", off)

--- a/vnext/ReactUWP/Modules/ImageViewManagerModule.cpp
+++ b/vnext/ReactUWP/Modules/ImageViewManagerModule.cpp
@@ -16,12 +16,16 @@
 
 #include <Views/Image/ReactImage.h>
 
+#include "unicode.h"
+
+
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage
 #pragma optimize("", off)
 #endif
 
 namespace winrt {
+using namespace Windows::Foundation;
 using namespace Windows::Storage::Streams;
 using namespace Windows::UI::Xaml::Media::Imaging;
 } // namespace winrt
@@ -60,17 +64,26 @@ class ImageViewManagerModule::ImageViewManagerModuleImpl {
 };
 
 winrt::fire_and_forget GetImageSizeAsync(
-    std::string uri,
+    std::string uriString,
     facebook::xplat::module::CxxModule::Callback successCallback,
     facebook::xplat::module::CxxModule::Callback errorCallback) {
   bool succeeded{false};
 
   try {
     ImageSource source;
-    source.uri = uri;
+    source.uri = uriString;
 
-    winrt::InMemoryRandomAccessStream memoryStream{
-        co_await react::uwp::GetImageStreamAsync(source)};
+    winrt::Uri uri{facebook::react::unicode::utf8ToUtf16(uriString)};
+    winrt::hstring scheme{uri.SchemeName()};
+    bool needsDownload = (scheme == L"http") || (scheme == L"https");
+    bool inlineData = scheme == L"data";
+
+    winrt::InMemoryRandomAccessStream memoryStream;
+    if (needsDownload) {
+      memoryStream = co_await GetImageStreamAsync(source);
+    } else if (inlineData) {
+      memoryStream = co_await GetImageInlineDataAsync(source);
+    }
 
     winrt::BitmapImage bitmap;
     if (memoryStream) {

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -239,6 +239,8 @@ static float NumberOrDefault(const folly::dynamic &value, float defaultValue) {
     result = static_cast<float>(value.asDouble());
   else if (value.isNull())
     result = defaultValue;
+  else if (value.isString())
+    result = std::stof(value.getString());
   else
     assert(false);
 

--- a/vnext/ReactUWP/Views/WebViewManager.cpp
+++ b/vnext/ReactUWP/Views/WebViewManager.cpp
@@ -54,6 +54,10 @@ void WebViewManager::setSource(XamlView viewToUpdate, const WebSource &source) {
     return;
   auto view = viewToUpdate.as<winrt::WebView>();
 
+  // non-uri sources not yet supported
+  if (source.uri.length() == 0)
+    return;
+
   auto uriString = source.uri;
   if (source.packagerAsset && uriString.find("assets") == 0)
     uriString.replace(0, 6, "ms-appx://");


### PR DESCRIPTION
This fixes a few things I ran into trying out the samples in microsoft/react-native-adaptivecards and microsoft/AdaptiveCards/source/community/react-native  with vnext.

* providing numbers as strings for some flex properties
* requesting ImageSize on inline image data was crashing as we tried to download with that as a uri
* use of webview source:html and no uri would throw unrecoverable exception.  fail more gracefully

fixes https://github.com/microsoft/react-native-windows/issues/2836

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2819)