### PR TITLE
fix timing crash in ReactImage

### DIFF
--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -74,7 +74,7 @@ winrt::fire_and_forget ReactImage::Source(ImageSource source) {
   try {
     m_imageSource = source;
     // get weak reference before any co_await calls
-    auto weak_this = get_weak();
+    auto weak_this{get_weak()};
 
     winrt::InMemoryRandomAccessStream memoryStream;
     if (needsDownload) {

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -73,6 +73,8 @@ winrt::fire_and_forget ReactImage::Source(ImageSource source) {
 
   try {
     m_imageSource = source;
+    // get weak reference before any co_await calls
+    auto weak_this = get_weak();
 
     winrt::InMemoryRandomAccessStream memoryStream;
     if (needsDownload) {
@@ -92,7 +94,7 @@ winrt::fire_and_forget ReactImage::Source(ImageSource source) {
 
       m_surfaceLoadedRevoker = surface.LoadCompleted(
           winrt::auto_revoke,
-          [weak_this{get_weak()}, surface](
+          [weak_this = std::move(weak_this), surface](
               winrt::LoadedImageSurface const & /*sender*/,
               winrt::LoadedImageSourceLoadCompletedEventArgs const &args) {
             if (auto strong_this{weak_this.get()}) {

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -94,7 +94,7 @@ winrt::fire_and_forget ReactImage::Source(ImageSource source) {
 
       m_surfaceLoadedRevoker = surface.LoadCompleted(
           winrt::auto_revoke,
-          [weak_this = std::move(weak_this), surface](
+          [weak_this, surface](
               winrt::LoadedImageSurface const & /*sender*/,
               winrt::LoadedImageSourceLoadCompletedEventArgs const &args) {
             if (auto strong_this{weak_this.get()}) {


### PR DESCRIPTION
this change:
https://github.com/microsoft/react-native-windows/commit/08aaf1895e95873fe7a755d2d60d1928bb3777a4#diff-123785e2fea604498e13edd8bfd21628 from @Thristhart 

introduced a weak reference with the LoadCompleted event.  The problem is it gets the weak ref from a background thead after the download and the reactImage instance may have been freed already. 

This moves getting the weakptr to before any switch to a coroutine thread happens

--
Scenario wise we are hitting this when going to a screen with a bunch of images being downloaded, if you navigate away so all those Image elements are destructed, we crash in a weakref dtor with invalid heap free stuff happening

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2820)