### PR TITLE
export all unicode helper functions

### DIFF
--- a/change/react-native-windows-2019-07-24-16-36-54-unicodeExports.json
+++ b/change/react-native-windows-2019-07-24-16-36-54-unicodeExports.json
@@ -1,0 +1,8 @@
+{
+  "comment": "export unicode functions via dllexport instead of .def files, many were not being exported",
+  "type": "prerelease",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "7c4b62a0003f85bfa011d44be113a95db1346560",
+  "date": "2019-07-24T23:36:54.926Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -49,8 +49,6 @@ EXPORTS
 ?toJson@folly@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUdynamic@1@@Z
 ?typeName@dynamic@folly@@QEBAPEBDXZ
 ?updateProperties@ShadowNode@react@facebook@@UEAAX$$QEBUdynamic@folly@@@Z
-?utf16ToUtf8@unicode@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?utf8ToUtf16@unicode@react@facebook@@YA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?asFunction@Object@jsi@facebook@@QEHAA?AVFunction@23@AEAVRuntime@23@@Z
 ??1Value@jsi@facebook@@QEAA@XZ
 ??1Buffer@jsi@facebook@@UEAA@XZ

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -44,8 +44,6 @@ EXPORTS
 ?toJson@folly@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABUdynamic@1@@Z
 ?typeName@dynamic@folly@@QBEPBDXZ
 ?updateProperties@ShadowNode@react@facebook@@UAEX$$QBUdynamic@folly@@@Z
-?utf16ToUtf8@unicode@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?utf8ToUtf16@unicode@react@facebook@@YG?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@IHttpResource@React@Microsoft@@SG?AV?$unique_ptr@UIHttpResource@React@Microsoft@@U?$default_delete@UIHttpResource@React@Microsoft@@@std@@@std@@XZ
 ?Make@IWebSocket@React@Microsoft@@SG?AV?$unique_ptr@UIWebSocket@React@Microsoft@@U?$default_delete@UIWebSocket@React@Microsoft@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -45,8 +45,12 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <SDLCheck>true</SDLCheck>
+      <!--
+        BOOST_ASIO_HAS_IOCP - Force unique layout/size for boost::asio::basic_stream_socket<> subtypes.
+        REACTWINDOWS_BUILD - building with REACTWINDOWS_API as dll exports
+      -->
       <!-- See //https://stackoverflow.com/questions/42847103/stdtr1-with-visual-studio-2017. -->
-      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;GTEST_LANG_CXX11=1;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REACTWINDOWS_BUILD;BOOST_ASIO_HAS_IOCP;GTEST_LANG_CXX11=1;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190506.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190506.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -54,8 +54,9 @@
     <ClCompile>
       <!--
         BOOST_ASIO_HAS_IOCP - Force unique layout/size for boost::asio::basic_stream_socket<> subtypes.
+        REACTWINDOWS_BUILD - building with REACTWINDOWS_API as dll exports
       -->
-      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_PLATFORM=win32;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REACTWINDOWS_BUILD;BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_PLATFORM=win32;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>%(AdditionalOptions) /Zc:strictStrings /bigobj</AdditionalOptions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
+++ b/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
@@ -54,7 +54,10 @@
     <ClCompile>
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PreprocessorDefinitions>FOLLY_NO_CONFIG;RN_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        REACTWINDOWS_BUILD - building with REACTWINDOWS_API as dll exports
+      -->
+      <PreprocessorDefinitions>REACTWINDOWS_BUILD;FOLLY_NO_CONFIG;RN_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
@@ -29,10 +29,6 @@ EXPORTS
 ?callJSFunction@Instance@react@facebook@@UAAX$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QAUdynamic@folly@@@Z
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 
-?utf16ToUtf8@unicode@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?utf16ToUtf8@unicode@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
-?utf8ToUtf16@unicode@react@facebook@@YA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
-
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_K@detail@folly@@YA?AV?$Expected@_KW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -63,9 +63,6 @@ EXPORTS
 ??0ViewViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0WebViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 
-?utf16ToUtf8@unicode@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?utf16ToUtf8@unicode@react@facebook@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
-
 ?JsPointerToStringUtf8@react@facebook@@YA?AW4_JsErrorCode@@PEBD_KPEAPEAX@Z
 ?JsStringToStdStringUtf8@react@facebook@@YA?AW4_JsErrorCode@@PEAXAEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z
 

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -43,9 +43,6 @@ EXPORTS
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0WebSocketModule@uwp@react@@QAE@XZ
 
-?utf16ToUtf8@unicode@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@5@@Z
-?utf16ToUtf8@unicode@react@facebook@@YG?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV?$basic_string_view@_WU?$char_traits@_W@std@@@5@@Z
-
 ?demangle@folly@@YG?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PBD@Z
 
 mallocxWeak

--- a/vnext/ReactWindowsCore/unicode.cpp
+++ b/vnext/ReactWindowsCore/unicode.cpp
@@ -20,7 +20,7 @@ namespace unicode {
 // The implementations of the following functions heavily reference the MSDN
 // article at https://msdn.microsoft.com/en-us/magazine/mt763237.aspx.
 
-std::wstring utf8ToUtf16(const char *utf8, size_t utf8Len) {
+REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const char *utf8, size_t utf8Len) {
   std::wstring utf16{};
 
   // A small optimization.
@@ -89,21 +89,21 @@ std::wstring utf8ToUtf16(const char *utf8, size_t utf8Len) {
   return utf16;
 }
 
-std::wstring utf8ToUtf16(const char *utf8) {
+REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const char *utf8) {
   return utf8ToUtf16(utf8, strlen(utf8));
 }
 
-std::wstring utf8ToUtf16(const std::string &utf8) {
+REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const std::string &utf8) {
   return utf8ToUtf16(utf8.c_str(), utf8.length());
 }
 
 #if _HAS_CXX17
-std::wstring utf8ToUtf16(const std::string_view &utf8) {
+REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const std::string_view &utf8) {
   return utf8ToUtf16(utf8.data(), utf8.length());
 }
 #endif
 
-std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Len) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Len) {
   std::string utf8{};
 
   // A small optimization.
@@ -176,35 +176,35 @@ std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Len) {
   return utf8;
 }
 
-std::string utf16ToUtf8(const char16_t *utf16, size_t utf16Len) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const char16_t *utf16, size_t utf16Len) {
   return utf16ToUtf8(
       utilities::checkedReinterpretCast<const wchar_t *>(utf16), utf16Len);
 }
 
-std::string utf16ToUtf8(const wchar_t *utf16) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const wchar_t *utf16) {
   return utf16ToUtf8(utf16, wcslen(utf16));
 }
 
-std::string utf16ToUtf8(const char16_t *utf16) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const char16_t *utf16) {
   return utf16ToUtf8(utf16, std::char_traits<char16_t>::length(utf16));
 }
 
-std::string utf16ToUtf8(const std::wstring &utf16) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::wstring &utf16) {
   return utf16ToUtf8(utf16.c_str(), utf16.length());
 }
 
-std::string utf16ToUtf8(const std::u16string &utf16) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::u16string &utf16) {
   return utf16ToUtf8(
       utilities::checkedReinterpretCast<const wchar_t *>(utf16.c_str()),
       utf16.length());
 }
 
 #if _HAS_CXX17
-std::string utf16ToUtf8(const std::wstring_view &utf16) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::wstring_view &utf16) {
   return utf16ToUtf8(utf16.data(), utf16.length());
 }
 
-std::string utf16ToUtf8(const std::u16string_view &utf16) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::u16string_view &utf16) {
   return utf16ToUtf8(
       utilities::checkedReinterpretCast<const wchar_t *>(utf16.data()),
       utf16.length());

--- a/vnext/ReactWindowsCore/unicode.cpp
+++ b/vnext/ReactWindowsCore/unicode.cpp
@@ -103,7 +103,9 @@ REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const std::string_view &utf8) {
 }
 #endif
 
-REACTWINDOWS_EXPORT std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Len) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(
+    const wchar_t *utf16,
+    size_t utf16Len) {
   std::string utf8{};
 
   // A small optimization.
@@ -176,7 +178,9 @@ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Le
   return utf8;
 }
 
-REACTWINDOWS_EXPORT std::string utf16ToUtf8(const char16_t *utf16, size_t utf16Len) {
+REACTWINDOWS_EXPORT std::string utf16ToUtf8(
+    const char16_t *utf16,
+    size_t utf16Len) {
   return utf16ToUtf8(
       utilities::checkedReinterpretCast<const wchar_t *>(utf16), utf16Len);
 }

--- a/vnext/include/ReactWindowsCore/unicode.h
+++ b/vnext/include/ReactWindowsCore/unicode.h
@@ -9,6 +9,8 @@
 #include <string_view>
 #endif
 
+#include "ReactWindowsAPI.h"
+
 namespace facebook {
 namespace react {
 namespace unicode {
@@ -50,11 +52,11 @@ class UnicodeConversionException : public std::runtime_error {
 //
 // For (2), utf8 must be null terminated. The behavior is undefined otherwise.
 //
-/* (1) */ std::wstring utf8ToUtf16(const char *utf8, size_t utf8Len);
-/* (2) */ std::wstring utf8ToUtf16(const char *utf8);
-/* (3) */ std::wstring utf8ToUtf16(const std::string &utf8);
+/* (1) */ REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const char *utf8, size_t utf8Len);
+/* (2) */ REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const char *utf8);
+/* (3) */ REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const std::string &utf8);
 #if _HAS_CXX17
-/* (4) */ std::wstring utf8ToUtf16(const std::string_view &utf8);
+/* (4) */ REACTWINDOWS_EXPORT std::wstring utf8ToUtf16(const std::string_view &utf8);
 #endif
 
 // The following functions convert UTF-16BE strings to UTF-8 strings. Their
@@ -67,15 +69,15 @@ class UnicodeConversionException : public std::runtime_error {
 // For (3) and (4), utf16 must be null terminated. The behavior is undefined
 // otherwise.
 //
-/* (1) */ std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Len);
-/* (2) */ std::string utf16ToUtf8(const char16_t *utf16, size_t utf16Len);
-/* (3) */ std::string utf16ToUtf8(const wchar_t *utf16);
-/* (4) */ std::string utf16ToUtf8(const char16_t *utf16);
-/* (5) */ std::string utf16ToUtf8(const std::wstring &utf16);
-/* (6) */ std::string utf16ToUtf8(const std::u16string &utf16);
+/* (1) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const wchar_t *utf16, size_t utf16Len);
+/* (2) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const char16_t *utf16, size_t utf16Len);
+/* (3) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const wchar_t *utf16);
+/* (4) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const char16_t *utf16);
+/* (5) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::wstring &utf16);
+/* (6) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::u16string &utf16);
 #if _HAS_CXX17
-/* (7) */ std::string utf16ToUtf8(const std::wstring_view &utf16);
-/* (8) */ std::string utf16ToUtf8(const std::u16string_view &utf16);
+/* (7) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::wstring_view &utf16);
+/* (8) */ REACTWINDOWS_EXPORT std::string utf16ToUtf8(const std::u16string_view &utf16);
 #endif
 
 } // namespace unicode


### PR DESCRIPTION
We were exporting these functions via .def files instead of dllexport.

Update to use the macro and some vcxproj changes for desktop to reduce warnings about duplicate functions in unit/integration tests.

I did not use the API_() form since that changes the calling convention, which might be fine but is slightly annoying for copy in a dll ABI compat

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2825)