### PR TITLE
Update flyout container background color to transparent

### DIFF
--- a/change/react-native-windows-2019-07-30-22-39-57-flyout_background_fix.json
+++ b/change/react-native-windows-2019-07-30-22-39-57-flyout_background_fix.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Update flyout container background color to transparent",
+  "type": "none",
+  "packageName": "react-native-windows",
+  "email": "askhetan@microsoft.com",
+  "commit": "b27d7ef1eeb5c66abac0f6d5a6b9edcc5639d361",
+  "date": "2019-07-31T05:39:57.061Z"
+}

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -82,7 +82,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   void updateProperties(const folly::dynamic &&props) override;
   winrt::Flyout GetFlyout();
   void AdjustDefaultFlyoutStyle(float maxWidth, float maxHeight);
-  
+
   bool IsWindowed() override {
     return true;
   }
@@ -342,13 +342,16 @@ void FlyoutShadowNode::SetTargetFrameworkElement() {
   }
 }
 
-void FlyoutShadowNode::AdjustDefaultFlyoutStyle(float maxWidth, float maxHeight) {
+void FlyoutShadowNode::AdjustDefaultFlyoutStyle(
+    float maxWidth,
+    float maxHeight) {
   winrt::Style flyoutStyle(
       {L"Windows.UI.Xaml.Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
   flyoutStyle.Setters().Append(winrt::Setter(
       winrt::FrameworkElement::MaxWidthProperty(), winrt::box_value(maxWidth)));
   flyoutStyle.Setters().Append(winrt::Setter(
-      winrt::FrameworkElement::MaxHeightProperty(), winrt::box_value(maxHeight)));
+      winrt::FrameworkElement::MaxHeightProperty(),
+      winrt::box_value(maxHeight)));
   flyoutStyle.Setters().Append(
       winrt::Setter(winrt::Control::PaddingProperty(), winrt::box_value(0)));
   flyoutStyle.Setters().Append(winrt::Setter(


### PR DESCRIPTION
- If the flyout's child element has border radius, the flyout container is visible at the corners with a default background color (shade of grey). Fixing that by setting the background color to transparent by default.
- Also, refactored the presenter code to reuse it in SetLayoutProps for full placement mode.
- Tested this change in the playground app.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2851)