### PR TITLE
Touchable focus event fixes

### DIFF
--- a/change/react-native-windows-2019-07-31-12-56-17-touchableFocusFixes.json
+++ b/change/react-native-windows-2019-07-31-12-56-17-touchableFocusFixes.json
@@ -1,0 +1,8 @@
+{
+  "comment": "fix onFocus/onBlur events for Touchables",
+  "type": "prerelease",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "a23c9ae02f95d7088ff1f50778127d2ab7593d0a",
+  "date": "2019-07-31T19:56:17.818Z"
+}

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.uwp.js
@@ -425,6 +425,8 @@ const TouchableHighlight = ((createReactClass({
       <View
         onKeyUp={this._onKeyUp}
         onKeyDown={this._onKeyDown}
+        onFocus={this.touchableHandleFocus}
+        onBlur={this.touchableHandleBlur}
         accessible={this.props.accessible !== false}
         accessibilityLabel={this.props.accessibilityLabel}
         accessibilityHint={this.props.accessibilityHint} // TODO(OSS Candidate ISS#2710739)

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.uwp.js
@@ -310,6 +310,8 @@ const TouchableOpacity = ((createReactClass({
       <Animated.View
         onKeyUp={this._onKeyUp}
         onKeyDown={this._onKeyDown}
+        onFocus={this.touchableHandleFocus}
+        onBlur={this.touchableHandleBlur}
         accessible={this.props.accessible !== false}
         accessibilityLabel={this.props.accessibilityLabel}
         accessibilityHint={this.props.accessibilityHint} // TODO(OSS Candidate ISS#2710739)

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.uwp.js
@@ -1,0 +1,362 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
+const React = require('React');
+const PropTypes = require('prop-types');
+const Touchable = require('Touchable');
+const View = require('View');
+
+const createReactClass = require('create-react-class');
+const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
+
+const {
+  DeprecatedAccessibilityComponentTypes,
+  DeprecatedAccessibilityRoles,
+  DeprecatedAccessibilityStates,
+  DeprecatedAccessibilityTraits,
+} = require('DeprecatedViewAccessibility');
+
+import type {SyntheticEvent, LayoutEvent, PressEvent} from 'CoreEventTypes';
+import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
+import type {
+  AccessibilityComponentType,
+  AccessibilityRole,
+  AccessibilityStates,
+  AccessibilityTraits,
+} from 'ViewAccessibility';
+
+// [TODO(macOS ISS#2323203)
+const {DraggedTypes} = require('DraggedType');
+import type {DraggedTypesType} from 'DraggedType';
+// ]TODO(macOS ISS#2323203)
+
+type TargetEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+  |}>,
+>;
+
+type BlurEvent = TargetEvent;
+type FocusEvent = TargetEvent;
+
+const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
+
+export type Props = $ReadOnly<{|
+  accessible?: ?boolean,
+  accessibilityComponentType?: ?AccessibilityComponentType,
+  accessibilityLabel?: ?Stringish,
+  accessibilityHint?: ?Stringish,
+  accessibilityIgnoresInvertColors?: ?boolean,
+  accessibilityRole?: ?AccessibilityRole,
+  accessibilityStates?: ?AccessibilityStates,
+  accessibilityTraits?: ?AccessibilityTraits,
+  children?: ?React.Node,
+  delayLongPress?: ?number,
+  delayPressIn?: ?number,
+  delayPressOut?: ?number,
+  disabled?: ?boolean,
+  hitSlop?: ?EdgeInsetsProp,
+  nativeID?: ?string,
+  onBlur?: ?(e: BlurEvent) => void,
+  onFocus?: ?(e: FocusEvent) => void,
+  onLayout?: ?(event: LayoutEvent) => mixed,
+  onLongPress?: ?(event: PressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  onAccessibilityTap?: ?Function, // TODO(OSS Candidate ISS#2710739)
+  acceptsKeyboardFocus?: ?boolean, // [TODO(macOS ISS#2323203)
+  onMouseEnter?: ?Function,
+  onMouseLeave?: ?Function,
+  onDragEnter?: ?Function,
+  onMouseLeave?: ?Function,
+  onDragEnter?: ?Function,
+  onDragLeave?: ?Function,
+  onDrop?: ?Function,
+  draggedTypes?: ?DraggedTypesType, // ]TODO(macOS ISS#2323203)
+  pressRetentionOffset?: ?EdgeInsetsProp,
+  rejectResponderTermination?: ?boolean,
+  testID?: ?string,
+|}>;
+
+/**
+ * Do not use unless you have a very good reason. All elements that
+ * respond to press should have a visual feedback when touched.
+ *
+ * TouchableWithoutFeedback supports only one child.
+ * If you wish to have several child components, wrap them in a View.
+ */
+const TouchableWithoutFeedback = ((createReactClass({
+  displayName: 'TouchableWithoutFeedback',
+  mixins: [Touchable.Mixin],
+
+  propTypes: {
+    accessible: PropTypes.bool,
+    accessibilityLabel: PropTypes.node,
+    accessibilityHint: PropTypes.string,
+    accessibilityComponentType: PropTypes.oneOf(
+      DeprecatedAccessibilityComponentTypes,
+    ),
+    accessibilityRole: PropTypes.oneOf(DeprecatedAccessibilityRoles),
+    accessibilityStates: PropTypes.arrayOf(
+      PropTypes.oneOf(DeprecatedAccessibilityStates),
+    ),
+    accessibilityTraits: PropTypes.oneOfType([
+      PropTypes.oneOf(DeprecatedAccessibilityTraits),
+      PropTypes.arrayOf(PropTypes.oneOf(DeprecatedAccessibilityTraits)),
+    ]),
+    onAccessibilityTap: PropTypes.func, // TODO(OSS Candidate ISS#2710739)
+    tabIndex: PropTypes.number, // TODO(macOS/win ISS#2323203)
+
+    /**
+     * When `accessible` is true (which is the default) this may be called when
+     * the OS-specific concept of "focus" occurs. Some platforms may not have
+     * the concept of focus.
+     */
+    onFocus: PropTypes.func,
+    /**
+     * When `accessible` is true (which is the default) this may be called when
+     * the OS-specific concept of "blur" occurs, meaning the element lost focus.
+     * Some platforms may not have the concept of blur.
+     */
+    onBlur: PropTypes.func,
+    /**
+     * If true, disable all interactions for this component.
+     */
+    disabled: PropTypes.bool,
+    /**
+     * Called when the mouse enters the touchable element
+     */
+    onMouseEnter: PropTypes.func, // TODO(macOS ISS#2323203)
+    /**
+     * Called when the mouse exits the touchable element
+     */
+    onMouseLeave: PropTypes.func, // TODO(macOS ISS#2323203)
+    /**
+     * Fired when a dragged element enters a valid drop target
+     */
+    onDragEnter: PropTypes.func, // TODO(macOS ISS#2323203)
+    /**
+     * Fired when a dragged element leaves a valid drop target
+     */
+    onDragLeave: PropTypes.func, // TODO(macOS ISS#2323203)
+    /**
+     * Fired when an element is dropped on a valid drop target
+     */
+    onDrop: PropTypes.func, // TODO(macOS ISS#2323203)
+    /**
+     * Enables Drag'n'Drop Support for certain types of dragged types
+     *
+     * Possible values for `draggedTypes` are:
+     *
+     * - `'fileUrl'`
+     *
+     * @platform macos
+     */
+    draggedTypes: PropTypes.oneOfType([
+      PropTypes.oneOf(DraggedTypes),
+      PropTypes.arrayOf(PropTypes.oneOf(DraggedTypes)),
+    ]), // TODO(macOS ISS#2323203)
+    tooltip: PropTypes.string, // TODO(macOS/win ISS#2323203)
+    /**
+     * Called when the touch is released, but not if cancelled (e.g. by a scroll
+     * that steals the responder lock).
+     */
+    onPress: PropTypes.func,
+    /**
+     * Called as soon as the touchable element is pressed and invoked even before onPress.
+     * This can be useful when making network requests.
+     */
+    onPressIn: PropTypes.func,
+    /**
+     * Called as soon as the touch is released even before onPress.
+     */
+    onPressOut: PropTypes.func,
+    /**
+     * Invoked on mount and layout changes with
+     *
+     *   `{nativeEvent: {layout: {x, y, width, height}}}`
+     */
+    onLayout: PropTypes.func,
+
+    onLongPress: PropTypes.func,
+
+    nativeID: PropTypes.string,
+    testID: PropTypes.string,
+
+    /**
+     * Delay in ms, from the start of the touch, before onPressIn is called.
+     */
+    delayPressIn: PropTypes.number,
+    /**
+     * Delay in ms, from the release of the touch, before onPressOut is called.
+     */
+    delayPressOut: PropTypes.number,
+    /**
+     * Delay in ms, from onPressIn, before onLongPress is called.
+     */
+    delayLongPress: PropTypes.number,
+    /**
+     * When the scroll view is disabled, this defines how far your touch may
+     * move off of the button, before deactivating the button. Once deactivated,
+     * try moving it back and you'll see that the button is once again
+     * reactivated! Move it back and forth several times while the scroll view
+     * is disabled. Ensure you pass in a constant to reduce memory allocations.
+     */
+    pressRetentionOffset: DeprecatedEdgeInsetsPropType,
+    /**
+     * This defines how far your touch can start away from the button. This is
+     * added to `pressRetentionOffset` when moving off of the button.
+     * ** NOTE **
+     * The touch area never extends past the parent view bounds and the Z-index
+     * of sibling views always takes precedence if a touch hits two overlapping
+     * views.
+     */
+    hitSlop: DeprecatedEdgeInsetsPropType,
+  },
+
+  getInitialState: function() {
+    return this.touchableGetInitialState();
+  },
+
+  componentDidMount: function() {
+    ensurePositiveDelayProps(this.props);
+  },
+
+  UNSAFE_componentWillReceiveProps: function(nextProps: Object) {
+    ensurePositiveDelayProps(nextProps);
+  },
+
+  /**
+   * `Touchable.Mixin` self callbacks. The mixin will invoke these if they are
+   * defined on your component.
+   */
+  touchableHandlePress: function(e: PressEvent) {
+    this.props.onPress && this.props.onPress(e);
+  },
+
+  touchableHandleActivePressIn: function(e: PressEvent) {
+    this.props.onPressIn && this.props.onPressIn(e);
+  },
+
+  touchableHandleActivePressOut: function(e: PressEvent) {
+    this.props.onPressOut && this.props.onPressOut(e);
+  },
+
+  touchableHandleLongPress: function(e: PressEvent) {
+    this.props.onLongPress && this.props.onLongPress(e);
+  },
+
+  touchableGetPressRectOffset: function(): typeof PRESS_RETENTION_OFFSET {
+    // $FlowFixMe Invalid prop usage
+    return this.props.pressRetentionOffset || PRESS_RETENTION_OFFSET;
+  },
+
+  touchableGetHitSlop: function(): ?Object {
+    return this.props.hitSlop;
+  },
+
+  touchableGetHighlightDelayMS: function(): number {
+    return this.props.delayPressIn || 0;
+  },
+
+  touchableGetLongPressDelayMS: function(): number {
+    return this.props.delayLongPress === 0
+      ? 0
+      : this.props.delayLongPress || 500;
+  },
+
+  touchableGetPressOutDelayMS: function(): number {
+    return this.props.delayPressOut || 0;
+  },
+
+  _onKeyUp: function(ev) {
+    if (
+      (ev.nativeEvent.code === 'Space' ||
+        ev.nativeEvent.code === 'Enter' ||
+        ev.nativeEvent.code === 'GamepadA') &&
+      !this.props.disabled
+    ) {
+      this.touchableHandlePress();
+    }
+  },
+
+  _onKeyDown: function(ev) {
+    if (
+      (ev.nativeEvent.code === 'Space' ||
+        ev.nativeEvent.code === 'Enter' ||
+        ev.nativeEvent.code === 'GamepadA') &&
+      !this.props.disabled
+    ) {
+      this.touchableHandleActivePressIn();
+    }
+  },
+
+  render: function(): React.Element<any> {
+    // Note(avik): remove dynamic typecast once Flow has been upgraded
+    // $FlowFixMe(>=0.41.0)
+    const child = React.Children.only(this.props.children);
+    let children = child.props.children;
+    if (Touchable.TOUCH_TARGET_DEBUG && child.type === View) {
+      children = React.Children.toArray(children);
+      children.push(
+        Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop}),
+      );
+    }
+    return (React: any).cloneElement(child, {
+      onKeyUp: this._onKeyUp,
+      onKeyDown: this._onKeyDown,
+      onFocus: this.props.onFocus,
+      onBlur: this.props.onBlur,
+      accessible: this.props.accessible !== false,
+      accessibilityLabel: this.props.accessibilityLabel,
+      accessibilityHint: this.props.accessibilityHint,
+      accessibilityComponentType: this.props.accessibilityComponentType,
+      accessibilityRole: this.props.accessibilityRole,
+      accessibilityStates: this.props.accessibilityStates,
+      accessibilityTraits: this.props.accessibilityTraits,
+      onAccessibilityTap: this.props.onAccessibilityTap, // TODO(OSS Candidate ISS#2710739)
+      acceptsKeyboardFocus:
+        (this.props.acceptsKeyboardFocus === undefined ||
+          this.props.acceptsKeyboardFocus) &&
+        !this.props.disabled, // TODO(macOS ISS#2323203)
+      enableFocusRing:
+        this.props.enableFocusRing === true && !this.props.disabled, // TODO(macOS ISS#2323203)
+      tabIndex: this.props.tabIndex, // TODO(win ISS#2323203)
+      nativeID: this.props.nativeID,
+      testID: this.props.testID,
+      onLayout: this.props.onLayout,
+      hitSlop: this.props.hitSlop,
+      onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
+      onResponderTerminationRequest: this
+        .touchableHandleResponderTerminationRequest,
+      onResponderGrant: this.touchableHandleResponderGrant,
+      onResponderMove: this.touchableHandleResponderMove,
+      onResponderRelease: this.touchableHandleResponderRelease,
+      onResponderTerminate: this.touchableHandleResponderTerminate,
+      tooltip: this.props.tooltip, // TODO(macOS/win ISS#2323203)
+      clickable:
+        this.props.clickable !== false && this.props.onPress !== undefined, // TODO(android ISS)
+      onClick: this.touchableHandlePress, // TODO(android ISS)
+      onMouseEnter: this.props.onMouseEnter, // [TODO(macOS ISS#2323203)
+      onMouseLeave: this.props.onMouseLeave, // [TODO(macOS ISS#2323203)
+      onDragEnter: this.props.onDragEnter, // [TODO(macOS ISS#2323203)
+      onDragLeave: this.props.onDragLeave, // [TODO(macOS ISS#2323203)
+      onDrop: this.props.onDrop, // [TODO(macOS ISS#2323203)
+      draggedTypes: this.props.draggedTypes, // ]TODO(macOS ISS#2323203)
+      children,
+    });
+  },
+}): any): React.ComponentType<Props>);
+
+module.exports = TouchableWithoutFeedback;

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.uwp.js
@@ -35,11 +35,6 @@ import type {
   AccessibilityTraits,
 } from 'ViewAccessibility';
 
-// [TODO(macOS ISS#2323203)
-const {DraggedTypes} = require('DraggedType');
-import type {DraggedTypesType} from 'DraggedType';
-// ]TODO(macOS ISS#2323203)
-
 type TargetEvent = SyntheticEvent<
   $ReadOnly<{|
     target: number,
@@ -83,7 +78,6 @@ export type Props = $ReadOnly<{|
   onDragEnter?: ?Function,
   onDragLeave?: ?Function,
   onDrop?: ?Function,
-  draggedTypes?: ?DraggedTypesType, // ]TODO(macOS ISS#2323203)
   pressRetentionOffset?: ?EdgeInsetsProp,
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
@@ -154,19 +148,6 @@ const TouchableWithoutFeedback = ((createReactClass({
      * Fired when an element is dropped on a valid drop target
      */
     onDrop: PropTypes.func, // TODO(macOS ISS#2323203)
-    /**
-     * Enables Drag'n'Drop Support for certain types of dragged types
-     *
-     * Possible values for `draggedTypes` are:
-     *
-     * - `'fileUrl'`
-     *
-     * @platform macos
-     */
-    draggedTypes: PropTypes.oneOfType([
-      PropTypes.oneOf(DraggedTypes),
-      PropTypes.arrayOf(PropTypes.oneOf(DraggedTypes)),
-    ]), // TODO(macOS ISS#2323203)
     tooltip: PropTypes.string, // TODO(macOS/win ISS#2323203)
     /**
      * Called when the touch is released, but not if cancelled (e.g. by a scroll
@@ -353,7 +334,6 @@ const TouchableWithoutFeedback = ((createReactClass({
       onDragEnter: this.props.onDragEnter, // [TODO(macOS ISS#2323203)
       onDragLeave: this.props.onDragLeave, // [TODO(macOS ISS#2323203)
       onDrop: this.props.onDrop, // [TODO(macOS ISS#2323203)
-      draggedTypes: this.props.draggedTypes, // ]TODO(macOS ISS#2323203)
       children,
     });
   },

--- a/vnext/src/RNTester/KeyboardFocusExample.uwp.tsx
+++ b/vnext/src/RNTester/KeyboardFocusExample.uwp.tsx
@@ -5,7 +5,15 @@
  */
 
 import * as React from 'react';
-import {View, StyleSheet, Text, TextInput} from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+} from 'react-native';
 import {
   supportKeyboard,
   IKeyboardEvent,
@@ -45,6 +53,9 @@ const styles = StyleSheet.create({
 interface IKeyboardFocusComponentState {
   selected: string;
   keyOnKeyDown: string;
+  focusMessageHighlight: string;
+  focusMessageOpacity: string;
+  focusMessageWithoutFeedback: string;
 }
 
 // tslint:disable-next-line
@@ -52,6 +63,9 @@ const pickerRef = React.createRef<any>();
 const viewWindowsRef = React.createRef<View>();
 const textInputRef = React.createRef<TextInput>();
 const textInputRef2 = React.createRef<TextInput>();
+const touchableHighlightRef = React.createRef<TouchableHighlight>();
+const touchableOpacityRef = React.createRef<TouchableOpacity>();
+const touchableWithoutFeedbackRef = React.createRef<TouchableWithoutFeedback>();
 
 // tslint:disable-next-line
 const checkBoxRef = React.createRef<any>();
@@ -65,6 +79,9 @@ class KeyboardFocusExample extends React.Component<
     this.state = {
       selected: '',
       keyOnKeyDown: 'unknown',
+      focusMessageHighlight: '',
+      focusMessageOpacity: '',
+      focusMessageWithoutFeedback: '',
     };
   }
 
@@ -75,6 +92,8 @@ class KeyboardFocusExample extends React.Component<
       'TextInput',
       'TextInput2',
       'CheckBox',
+      'TouchableHighlight',
+      'TouchableOpacity',
     ];
 
     return (
@@ -130,6 +149,38 @@ class KeyboardFocusExample extends React.Component<
           <CheckBox ref={checkBoxRef} />
           <Text>Checkbox accept focus</Text>
         </View>
+        <View>
+          <TouchableHighlight
+            ref={touchableHighlightRef}
+            onFocus={this._touchableHighlightFocus}
+            onBlur={this._touchableHighlightBlur}>
+            <View style={{width: 50, height: 50, backgroundColor: 'blue'}} />
+          </TouchableHighlight>
+          <Text>
+            Last focus event for TouchableHighlight:{' '}
+            {this.state.focusMessageHighlight}
+          </Text>
+          <TouchableOpacity
+            ref={touchableOpacityRef}
+            onFocus={this._touchableOpacityFocus}
+            onBlur={this._touchableOpacityBlur}>
+            <View style={{width: 50, height: 50, backgroundColor: 'yellow'}} />
+          </TouchableOpacity>
+          <Text>
+            Last focus event for TouchableOpacity:{' '}
+            {this.state.focusMessageOpacity}
+          </Text>
+          <TouchableWithoutFeedback
+            ref={touchableWithoutFeedbackRef}
+            onFocus={this._touchableWithoutFeedbackFocus}
+            onBlur={this._touchableWithoutFeedbackBlur}>
+            <View style={{width: 50, height: 50, backgroundColor: 'green'}} />
+          </TouchableWithoutFeedback>
+          <Text>
+            Last focus event for TouchableWithoutFeedback:{' '}
+            {this.state.focusMessageWithoutFeedback}
+          </Text>
+        </View>
       </View>
     );
   }
@@ -166,7 +217,39 @@ class KeyboardFocusExample extends React.Component<
       case 'CheckBox':
         checkBoxRef.current && checkBoxRef.current.focus();
         break;
+      case 'TouchableHighlight':
+        touchableHighlightRef.current && touchableHighlightRef.current.focus();
+        break;
+      case 'TouchableOpacity':
+        touchableOpacityRef.current && touchableOpacityRef.current.focus();
+        break;
+      case 'TouchableWithoutFeedback':
+        // TouchableWithoutFeedback doesn't have a focus method, since it doesn't have NativeMethodsMixin applied
+        break;
     }
+  };
+
+  private _touchableHighlightFocus = () => {
+    this.setState({focusMessageHighlight: 'TouchableHighlight onFocus'});
+  };
+  private _touchableHighlightBlur = () => {
+    this.setState({focusMessageHighlight: 'TouchableHighlight onBlur'});
+  };
+  private _touchableOpacityFocus = () => {
+    this.setState({focusMessageOpacity: 'TouchableOpacity onFocus'});
+  };
+  private _touchableOpacityBlur = () => {
+    this.setState({focusMessageOpacity: 'TouchableOpacity onBlur'});
+  };
+  private _touchableWithoutFeedbackFocus = () => {
+    this.setState({
+      focusMessageWithoutFeedback: 'TouchableWithoutFeedback onFocus',
+    });
+  };
+  private _touchableWithoutFeedbackBlur = () => {
+    this.setState({
+      focusMessageWithoutFeedback: 'TouchableWithoutFeedback onBlur',
+    });
   };
 }
 export const displayName = (_undefined?: string) => {};


### PR DESCRIPTION
onFocus / onBlur are not working for uwp Touchables.
To fix this I added a binding for onFocus/onBlur.  In TVos where they also have onfocus/onblur they do this a little differently in they apply a component via mixin that then enables the touchableHandleFocus/touchableHandleBlur methods to be invoked.

Also I noticed that TouchableWithoutFeedback was not forked for uwp and didn't have the keyboard space/enter/gamepad key events hooked up.  I forked from microsoft/react-native, applied those changes and this focus/blur fix.


For testing I added some example code in our KeyboardFocusExample showing focus'ing touchables (well the ones that support .focus()) and the events.  

@licanhua - In trying it out I couldn't actually focus the checkbox and some other items, if that worked before its not working now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2858)