### PR TITLE
Scroll viewer layoutbug

### DIFF
--- a/change/react-native-windows-2019-07-31-16-18-01-ScrollViewerLayoutbug.json
+++ b/change/react-native-windows-2019-07-31-16-18-01-ScrollViewerLayoutbug.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Moving picker fix",
+  "type": "prerelease",
+  "packageName": "react-native-windows",
+  "email": "decrowle@microsoft.com",
+  "commit": "8455d973a19be1d5e9bfee6329099d5657c64826",
+  "date": "2019-07-31T23:18:01.700Z"
+}

--- a/change/react-native-windows-extended-2019-08-02-13-57-41-ScrollViewerLayoutbug.json
+++ b/change/react-native-windows-extended-2019-08-02-13-57-41-ScrollViewerLayoutbug.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Clear m_needsForceLayout between calls to DoLayout",
+  "type": "patch",
+  "packageName": "react-native-windows-extended",
+  "email": "decrowle@microsoft.com",
+  "commit": "a783433937d1558283ba587db05b76ab0981a34c",
+  "date": "2019-08-02T20:57:41.153Z"
+}

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1027,7 +1027,7 @@ void NativeUIManager::DoLayout() {
   for (const int64_t tag : extraLayoutNodes) {
     ShadowNodeBase &node =
         static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-    auto element = node.GetView().try_as<winrt::FrameworkElement>();
+    auto element = node.GetView().as<winrt::FrameworkElement>();
     element.UpdateLayout();
   }
   // Values need to be cleared from the vector before next call to DoLayout.

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1025,7 +1025,8 @@ void NativeUIManager::DoLayout() {
   // Process vector of controls needing extra layout here.
   const auto controlNodes = m_controlNodes;
   for (const int64_t tag : controlNodes) {
-    ShadowNodeBase &node = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
+    ShadowNodeBase &node =
+        static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
     if (node.needsForceLayout()) {
       auto control = node.GetView().try_as<winrt::Control>();
       control.UpdateLayout();

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1013,10 +1013,7 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
 
   auto comboBox = shadowNode->GetView().try_as<winrt::ComboBox>();
   if (comboBox != nullptr) {
-    YGNodeRef yogaNode = GetYogaNode(tag);
-    if (yogaNode) {
-      comboBox.UpdateLayout();
-    }
+    comboBox.UpdateLayout();
   }
 
   for (int64_t child : shadowNode->m_children) {

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1031,6 +1031,8 @@ void NativeUIManager::DoLayout() {
       control.UpdateLayout();
     }
   }
+  // Values need to be cleared from the vector before next call to DoLayout.
+  m_controlNodes.clear();
   auto &rootTags = m_host->GetAllRootTags();
   for (int64_t rootTag : rootTags) {
     UpdateExtraLayout(rootTag);

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1011,14 +1011,17 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
   if (shadowNode == nullptr)
     return;
 
-  if (shadowNode->IsExternalLayoutDirty()) {
+  auto comboBox = shadowNode->GetView().try_as<winrt::ComboBox>();
+  if (comboBox != nullptr) {
     YGNodeRef yogaNode = GetYogaNode(tag);
-    if (yogaNode)
-      shadowNode->DoExtraLayoutPrep(yogaNode);
+    if (yogaNode) {
+      comboBox.UpdateLayout();
+    }
   }
 
-  for (int64_t child : shadowNode->m_children)
+  for (int64_t child : shadowNode->m_children) {
     UpdateExtraLayout(child);
+  }
 }
 
 void NativeUIManager::DoLayout() {

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1011,8 +1011,6 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
   if (shadowNode == nullptr)
     return;
 
-  // This should now be generalized to identifying any control in a list of problematic elements.
-
   auto control = shadowNode->GetView().try_as<winrt::Control>();
   if (control != nullptr) {
     control.UpdateLayout();

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -902,7 +902,7 @@ void NativeUIManager::CreateView(
 
   if (pViewManager->RequiresYogaNode()) {
     // Generate list of controls that need to have layout rerun on them.
-    if (const auto control = node.GetView().try_as<winrt::Control>()) {
+    if (const auto control = node.GetView().try_as<winrt::Control>() && node.NeedsForceLayout()) {
       m_controlNodes.push_back(node.m_tag);
     }
 
@@ -1027,10 +1027,8 @@ void NativeUIManager::DoLayout() {
   for (const int64_t tag : controlNodes) {
     ShadowNodeBase &node =
         static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-    if (node.needsForceLayout()) {
-      auto control = node.GetView().try_as<winrt::Control>();
-      control.UpdateLayout();
-    }
+    auto control = node.GetView().try_as<winrt::FrameworkElement>();
+    control.UpdateLayout();
   }
   // Values need to be cleared from the vector before next call to DoLayout.
   m_controlNodes.clear();

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -903,7 +903,7 @@ void NativeUIManager::CreateView(
   if (pViewManager->RequiresYogaNode()) {
     // Generate list of RN controls that need to have layout rerun on them.
     if (node.NeedsForceLayout()) {
-      m_controlNodes.push_back(node.m_tag);
+      m_extraLayoutNodes.push_back(node.m_tag);
     }
 
     auto result = m_tagsToYogaNodes.emplace(node.m_tag, make_yoga_node());
@@ -1022,16 +1022,16 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
 }
 
 void NativeUIManager::DoLayout() {
-  // Process vector of controls needing extra layout here.
-  const auto controlNodes = m_controlNodes;
-  for (const int64_t tag : controlNodes) {
+  // Process vector of RN controls needing extra layout here.
+  const auto extraLayoutNodes = m_extraLayoutNodes;
+  for (const int64_t tag : extraLayoutNodes) {
     ShadowNodeBase &node =
         static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
     auto element = node.GetView().try_as<winrt::FrameworkElement>();
     element.UpdateLayout();
   }
   // Values need to be cleared from the vector before next call to DoLayout.
-  m_controlNodes.clear();
+  m_extraLayoutNodes.clear();
   auto &rootTags = m_host->GetAllRootTags();
   for (int64_t rootTag : rootTags) {
     UpdateExtraLayout(rootTag);

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1011,9 +1011,11 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
   if (shadowNode == nullptr)
     return;
 
-  auto comboBox = shadowNode->GetView().try_as<winrt::ComboBox>();
-  if (comboBox != nullptr) {
-    comboBox.UpdateLayout();
+  // This should now be generalized to identifying any control in a list of problematic elements.
+
+  auto control = shadowNode->GetView().try_as<winrt::Control>();
+  if (control != nullptr) {
+    control.UpdateLayout();
   }
 
   for (int64_t child : shadowNode->m_children) {

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -901,8 +901,8 @@ void NativeUIManager::CreateView(
   auto *pViewManager = node.GetViewManager();
 
   if (pViewManager->RequiresYogaNode()) {
-    // Generate list of controls that need to have layout rerun on them.
-    if (const auto control = node.GetView().try_as<winrt::Control>() && node.NeedsForceLayout()) {
+    // Generate list of RN controls that need to have layout rerun on them.
+    if (node.NeedsForceLayout()) {
       m_controlNodes.push_back(node.m_tag);
     }
 
@@ -1027,8 +1027,8 @@ void NativeUIManager::DoLayout() {
   for (const int64_t tag : controlNodes) {
     ShadowNodeBase &node =
         static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-    auto control = node.GetView().try_as<winrt::FrameworkElement>();
-    control.UpdateLayout();
+    auto element = node.GetView().try_as<winrt::FrameworkElement>();
+    element.UpdateLayout();
   }
   // Values need to be cleared from the vector before next call to DoLayout.
   m_controlNodes.clear();

--- a/vnext/ReactUWP/Modules/NativeUIManager.h
+++ b/vnext/ReactUWP/Modules/NativeUIManager.h
@@ -105,7 +105,7 @@ class NativeUIManager : public facebook::react::INativeUIManager {
   std::vector<winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker>
       m_sizeChangedVector;
   std::vector<std::function<void()>> m_batchCompletedCallbacks;
-  std::vector<int64_t> m_controlNodes;
+  std::vector<int64_t> m_extraLayoutNodes;
 
   std::map<int64_t, std::weak_ptr<IXamlReactControl>> m_tagsToXamlReactControl;
 };

--- a/vnext/ReactUWP/Modules/NativeUIManager.h
+++ b/vnext/ReactUWP/Modules/NativeUIManager.h
@@ -105,6 +105,7 @@ class NativeUIManager : public facebook::react::INativeUIManager {
   std::vector<winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker>
       m_sizeChangedVector;
   std::vector<std::function<void()>> m_batchCompletedCallbacks;
+  std::vector<int64_t> m_controlNodes;
 
   std::map<int64_t, std::weak_ptr<IXamlReactControl>> m_tagsToXamlReactControl;
 };

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -24,7 +24,7 @@ class PickerShadowNode : public ShadowNodeBase {
   PickerShadowNode();
   void createView() override;
   void updateProperties(const folly::dynamic &&props) override;
-  bool needsForceLayout() override;
+  bool NeedsForceLayout() override;
 
  private:
   void RepopulateItems();

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -170,7 +170,7 @@ void PickerShadowNode::RepopulateItems() {
   instance.DispatchEvent(tag, "topChange", std::move(eventData));
 }
 
-bool PickerShadowNode::needsForceLayout() {
+bool PickerShadowNode::NeedsForceLayout() {
   return true;
 }
 

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -24,6 +24,7 @@ class PickerShadowNode : public ShadowNodeBase {
   PickerShadowNode();
   void createView() override;
   void updateProperties(const folly::dynamic &&props) override;
+  bool needsForceLayout() override;
 
  private:
   void RepopulateItems();
@@ -167,6 +168,10 @@ void PickerShadowNode::RepopulateItems() {
       folly::dynamic::object("target", tag)("value", std::move(value))(
           "itemIndex", selectedIndex)("text", std::move(text));
   instance.DispatchEvent(tag, "topChange", std::move(eventData));
+}
+
+bool PickerShadowNode::needsForceLayout() {
+  return true;
 }
 
 PickerViewManager::PickerViewManager(

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -24,10 +24,6 @@ class PickerShadowNode : public ShadowNodeBase {
   PickerShadowNode();
   void createView() override;
   void updateProperties(const folly::dynamic &&props) override;
-  bool IsExternalLayoutDirty() const override {
-    return m_hasNewItems;
-  }
-  void DoExtraLayoutPrep(YGNodeRef yogaNode) override;
 
  private:
   void RepopulateItems();
@@ -40,7 +36,6 @@ class PickerShadowNode : public ShadowNodeBase {
 
   folly::dynamic m_items;
   int32_t m_selectedIndex = -1;
-  bool m_hasNewItems = false;
 
   // FUTURE: remove when we can require RS5+
   bool m_isEditableComboboxSupported;
@@ -53,16 +48,6 @@ PickerShadowNode::PickerShadowNode() : Super() {
   m_isEditableComboboxSupported =
       winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
           L"Windows.UI.Xaml.Controls.ComboBox", L"IsEditableProperty");
-}
-
-void PickerShadowNode::DoExtraLayoutPrep(YGNodeRef yogaNode) {
-  if (!m_hasNewItems)
-    return;
-
-  m_hasNewItems = false;
-
-  auto comboBox = GetView().try_as<winrt::ComboBox>();
-  comboBox.UpdateLayout();
 }
 
 void PickerShadowNode::createView() {
@@ -167,7 +152,6 @@ void PickerShadowNode::RepopulateItems() {
 
       comboBoxItems.Append(comboboxItem);
     }
-    m_hasNewItems = true;
   }
   if (m_selectedIndex < static_cast<int32_t>(m_items.size()))
     combobox.SelectedIndex(m_selectedIndex);

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -31,6 +31,10 @@ void ShadowNodeBase::createView() {
   m_view = GetViewManager()->CreateView(this->m_tag);
 }
 
+bool ShadowNodeBase::needsForceLayout() {
+  return false;
+}
+
 void ShadowNodeBase::dispatchCommand(
     int64_t commandId,
     const folly::dynamic &commandArgs) {

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -31,7 +31,7 @@ void ShadowNodeBase::createView() {
   m_view = GetViewManager()->CreateView(this->m_tag);
 }
 
-bool ShadowNodeBase::needsForceLayout() {
+bool ShadowNodeBase::NeedsForceLayout() {
   return false;
 }
 

--- a/vnext/include/ReactUWP/Views/ShadowNodeBase.h
+++ b/vnext/include/ReactUWP/Views/ShadowNodeBase.h
@@ -74,7 +74,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
   virtual void AddView(ShadowNode &child, int64_t index) override;
   virtual void RemoveChildAt(int64_t indexToRemove) override;
   virtual void createView() override;
-  virtual bool needsForceLayout();
+  virtual bool NeedsForceLayout();
 
   virtual void updateProperties(const folly::dynamic &&props) override;
 

--- a/vnext/include/ReactUWP/Views/ShadowNodeBase.h
+++ b/vnext/include/ReactUWP/Views/ShadowNodeBase.h
@@ -74,6 +74,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
   virtual void AddView(ShadowNode &child, int64_t index) override;
   virtual void RemoveChildAt(int64_t indexToRemove) override;
   virtual void createView() override;
+  virtual bool needsForceLayout();
 
   virtual void updateProperties(const folly::dynamic &&props) override;
 


### PR DESCRIPTION
Moving the spot fix introduced by https://github.com/microsoft/react-native-windows/pull/2584 to NativeUIManager's UpdateExtraLayout method so that it can be applied to any control introduced to the tree in case similar bugs would be introduced by controls other than ScrollViewer/Picker. UpdateLayout will now be run on controls at the time that DoLayout is called from onBatchComplete. This should allow the controls to evaluate their final size before the rest of the layout is finished. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2859)