### PR TITLE
New switch props (thumbColor and trackColor), and fix bugs found in TextInputViewManager

### DIFF
--- a/change/react-native-windows-2019-08-01-15-19-17-switchprops.json
+++ b/change/react-native-windows-2019-08-01-15-19-17-switchprops.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "New switch props (thumbColor and trackColor), and fix few bugs found in TextInputViewManager",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "1ecf51ddf43de87c8a9d090bc39ceeda563aceb7",
+  "date": "2019-08-01T22:19:16.988Z"
+}

--- a/vnext/ReactUWP/Views/SwitchViewManager.cpp
+++ b/vnext/ReactUWP/Views/SwitchViewManager.cpp
@@ -52,8 +52,8 @@ void SwitchShadowNode::createView() {
           OnToggled(*instance, m_tag, toggleSwitch.IsOn());
       });
 
-  //properties can come down early before native XAML element added into tree
-  //hook up loading event which is called right at beginning of Measure
+  // properties can come down early before native XAML element added into tree
+  // hook up loading event which is called right at beginning of Measure
   m_toggleSwitchLoadingRevoker =
       toggleSwitch.Loading(winrt::auto_revoke, [=](auto &&, auto &&) {
         UpdateThumbColor();
@@ -88,7 +88,7 @@ void SwitchShadowNode::UpdateTrackColor() {
     return;
 
   folly::dynamic trackColor =
-  toggleSwitch.IsOn() ? m_onTrackColor : m_offTrackColor;
+      toggleSwitch.IsOn() ? m_onTrackColor : m_offTrackColor;
   if (IsValidColorValue(trackColor)) {
     toggleSwitch.ApplyTemplate();
     winrt::Rectangle knob =

--- a/vnext/ReactUWP/Views/SwitchViewManager.cpp
+++ b/vnext/ReactUWP/Views/SwitchViewManager.cpp
@@ -3,10 +3,17 @@
 
 #include "pch.h"
 
+#include <IReactInstance.h>
+#include <Utils/ValueUtils.h>
 #include <Views/ShadowNodeBase.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
 #include "SwitchViewManager.h"
 
-#include <IReactInstance.h>
+namespace winrt {
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Shapes;
+} // namespace winrt
 
 namespace react {
 namespace uwp {
@@ -18,11 +25,18 @@ class SwitchShadowNode : public ShadowNodeBase {
   SwitchShadowNode() = default;
   void createView() override;
   void updateProperties(const folly::dynamic &&props) override;
+  void UpdateThumbColor();
+  void UpdateTrackColor();
 
  private:
   static void OnToggled(IReactInstance &instance, int64_t tag, bool newValue);
 
   winrt::ToggleSwitch::Toggled_revoker m_toggleSwitchToggledRevoker{};
+  winrt::ToggleSwitch::Loading_revoker m_toggleSwitchLoadingRevoker{};
+
+  folly::dynamic m_thumbColor;
+  folly::dynamic m_offTrackColor;
+  folly::dynamic m_onTrackColor;
 };
 
 void SwitchShadowNode::createView() {
@@ -32,15 +46,89 @@ void SwitchShadowNode::createView() {
   auto wkinstance = GetViewManager()->GetReactInstance();
   m_toggleSwitchToggledRevoker =
       toggleSwitch.Toggled(winrt::auto_revoke, [=](auto &&, auto &&) {
+        UpdateTrackColor();
         auto instance = wkinstance.lock();
         if (!m_updating && instance != nullptr)
           OnToggled(*instance, m_tag, toggleSwitch.IsOn());
       });
+
+  //properties can come down early before native XAML element added into tree
+  //hook up loading event which is called right at beginning of Measure
+  m_toggleSwitchLoadingRevoker =
+      toggleSwitch.Loading(winrt::auto_revoke, [=](auto &&, auto &&) {
+        UpdateThumbColor();
+        UpdateTrackColor();
+      });
+}
+
+void SwitchShadowNode::UpdateThumbColor() {
+  auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();
+  if (toggleSwitch == nullptr)
+    return;
+
+  if (IsValidColorValue(m_thumbColor)) {
+    // apply template if it has not done so
+    toggleSwitch.ApplyTemplate();
+    winrt::Ellipse knobOn =
+        toggleSwitch.GetTemplateChild(asHstring("SwitchKnobOn"))
+            .as<winrt::Ellipse>();
+    if (knobOn)
+      knobOn.Fill(SolidColorBrushFrom(m_thumbColor));
+    winrt::Ellipse knobOff =
+        toggleSwitch.GetTemplateChild(asHstring("SwitchKnobOff"))
+            .as<winrt::Ellipse>();
+    if (knobOff)
+      knobOff.Fill(SolidColorBrushFrom(m_thumbColor));
+  }
+}
+
+void SwitchShadowNode::UpdateTrackColor() {
+  auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();
+  if (toggleSwitch == nullptr)
+    return;
+
+  folly::dynamic trackColor =
+  toggleSwitch.IsOn() ? m_onTrackColor : m_offTrackColor;
+  if (IsValidColorValue(trackColor)) {
+    toggleSwitch.ApplyTemplate();
+    winrt::Rectangle knob =
+        toggleSwitch.GetTemplateChild(asHstring("SwitchKnobBounds"))
+            .as<winrt::Rectangle>();
+    if (knob) {
+      knob.Fill(SolidColorBrushFrom(trackColor));
+      knob.Opacity(1);
+    }
+    winrt::Rectangle knobBorder =
+        toggleSwitch.GetTemplateChild(asHstring("OuterBorder"))
+            .as<winrt::Rectangle>();
+    if (knobBorder) {
+      knobBorder.Stroke(SolidColorBrushFrom(trackColor));
+    }
+  }
 }
 
 void SwitchShadowNode::updateProperties(const folly::dynamic &&props) {
   m_updating = true;
+
   Super::updateProperties(std::move(props));
+  for (const auto &pair : props.items()) {
+    const std::string &propertyName = pair.first.getString();
+    const folly::dynamic &propertyValue = pair.second;
+    // RN maps thumbColor to deprecated thumbTintColor,
+    // and trackColor to tintColor(not toggled state) and onTintColor( toggled
+    // state)
+    if (propertyName == "thumbTintColor") {
+      m_thumbColor = propertyValue;
+      UpdateThumbColor();
+    } else if (propertyName == "tintColor") {
+      m_offTrackColor = propertyValue;
+      UpdateTrackColor();
+    } else if (propertyName == "onTintColor") {
+      m_onTrackColor = propertyValue;
+      UpdateTrackColor();
+    }
+  }
+
   m_updating = false;
 }
 
@@ -64,8 +152,9 @@ const char *SwitchViewManager::GetName() const {
 folly::dynamic SwitchViewManager::GetNativeProps() const {
   auto props = Super::GetNativeProps();
 
-  props.update(
-      folly::dynamic::object("value", "boolean")("disabled", "boolean"));
+  props.update(folly::dynamic::object("value", "boolean")(
+      "disabled", "boolean")("thumbTintColor", "Color")("tintColor", "Color")(
+      "onTintColor", "Color"));
 
   return props;
 }
@@ -105,7 +194,6 @@ void SwitchViewManager::UpdateProperties(
         toggleSwitch.ClearValue(winrt::ToggleSwitch::IsOnProperty());
     }
   }
-
   Super::UpdateProperties(nodeToUpdate, reactDiffMap);
 }
 

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -184,40 +184,41 @@ void TextInputShadowNode::createView() {
 
   m_textboxLoadedRevoker =
       textBox.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
-    auto textBoxView = textBox.GetTemplateChild(asHstring("ContentElement"))
-                           .as<winrt::ScrollViewer>();
-    if (textBoxView) {
-      m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(
-          winrt::auto_revoke,
-          [=](auto &&, winrt::ScrollViewerViewChangingEventArgs const &args) {
-            auto instance = wkinstance.lock();
-            if (!m_updating && instance != nullptr) {
-              folly::dynamic offsetData = folly::dynamic::object(
-                  "x", args.FinalView().HorizontalOffset())(
-                  "y", args.FinalView().VerticalOffset());
-              folly::dynamic eventData = folly::dynamic::object("target", tag)(
-                  "contentOffset", std::move(offsetData));
-              instance->DispatchEvent(
-                  tag, "topTextInputOnScroll", std::move(eventData));
-            }
-          });
-      }
-  });
+        auto textBoxView = textBox.GetTemplateChild(asHstring("ContentElement"))
+                               .as<winrt::ScrollViewer>();
+        if (textBoxView) {
+          m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(
+              winrt::auto_revoke,
+              [=](auto &&,
+                  winrt::ScrollViewerViewChangingEventArgs const &args) {
+                auto instance = wkinstance.lock();
+                if (!m_updating && instance != nullptr) {
+                  folly::dynamic offsetData = folly::dynamic::object(
+                      "x", args.FinalView().HorizontalOffset())(
+                      "y", args.FinalView().VerticalOffset());
+                  folly::dynamic eventData = folly::dynamic::object(
+                      "target", tag)("contentOffset", std::move(offsetData));
+                  instance->DispatchEvent(
+                      tag, "topTextInputOnScroll", std::move(eventData));
+                }
+              });
+        }
+      });
 
   if (textBox.try_as<winrt::IUIElement7>()) {
     m_textBoxCharacterReceivedRevoker = textBox.CharacterReceived(
-      winrt::auto_revoke,
-      [=](auto &&, winrt::CharacterReceivedRoutedEventArgs const &args) {
-        auto instance = wkinstance.lock();
-        std::string key;
-        wchar_t s[2] = L" ";
-        s[0] = args.Character();
-        key = facebook::react::unicode::utf16ToUtf8(s, 1);
+        winrt::auto_revoke,
+        [=](auto &&, winrt::CharacterReceivedRoutedEventArgs const &args) {
+          auto instance = wkinstance.lock();
+          std::string key;
+          wchar_t s[2] = L" ";
+          s[0] = args.Character();
+          key = facebook::react::unicode::utf16ToUtf8(s, 1);
 
-        if (key.compare("\r") == 0) {
-          key = "Enter";
-        } else if (key.compare("\b") == 0) {
-          key = "Backspace";
+          if (key.compare("\r") == 0) {
+            key = "Enter";
+          } else if (key.compare("\b") == 0) {
+            key = "Backspace";
           }
 
           if (!m_updating && instance != nullptr) {


### PR DESCRIPTION
#2140 
- Adding support for thumbColor and trackColor to switch: since XAML does not have corresponding color brush properties on ToggleSwitch control, we have to be creative: find the child shapes and change the fill color in the code. I choose the timing of Loading event fired to do so, this happens right after ToggleSwitch added to the tree and measure called for the first time. 

- Also found two bugs in TextInputViewManager while playing with it as learning examples, the PlaceHolderTextColor was not applied correctly due to casting the object to ITextBlock6 instead of ITextBox6. (typo?).  Second issue is that the ViewChanging event was hooked up at wrong time, during view creation the template has not been applied and GetTemplateChild will return null, so fix it by moving the event hookup code to Loaded event.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2864)