### PR TITLE
Delay-load dependencies absent on Win7

### DIFF
--- a/change/react-native-windows-2019-08-02-14-43-08-missing_win7_deps.json
+++ b/change/react-native-windows-2019-08-02-14-43-08-missing_win7_deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Delay-load dependencies absent on Win7",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "cf3f5017c2cd26c36067fde73da9606e851b9474",
+  "date": "2019-08-02T21:43:07.992Z"
+}

--- a/change/react-native-windows-extended-2019-08-02-14-43-08-missing_win7_deps.json
+++ b/change/react-native-windows-extended-2019-08-02-14-43-08-missing_win7_deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delay-load dependencies absent on Win7",
+  "packageName": "react-native-windows-extended",
+  "email": "acoates@microsoft.com",
+  "commit": "cf3f5017c2cd26c36067fde73da9606e851b9474",
+  "date": "2019-08-02T21:43:00.252Z"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -42,6 +42,11 @@
   <PropertyGroup>
     <IncludePath>$(FollyDir);$(ReactNativeWindowsDir)stubs;$(MSBuildProjectDirectory);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
+    <!--
+    Prevents Microsoft.Windows.CppWinRT.props from adding WindowsApp.lib reference, see
+    WindowsApp_downleve.lib reference below.
+    -->
+    <CppWinRTLibs>false</CppWinRTLibs>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -58,6 +63,12 @@
       <SubSystem>Windows</SubSystem>
       <AdditionalOptions>-minpdbpathlen:256</AdditionalOptions>
       <AdditionalDependencies>Shlwapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!--
+      Replaces the WindowsApp.lib link reference in Microsoft.Windows.CppWinRT.props until
+      we have a better solution for handling the absence of WinRT string and error DLLs on Win7.
+      -->
+      <AdditionalDependencies>WindowsApp_downlevel.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64' AND '$(OSS_RN)'!='true'">
@@ -135,5 +146,5 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.10\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.10\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.36\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.36\build\native\ChakraCore.Debugger.targets'))" />
   </Target>
-  <Target Name="GetTargetFileName" Returns="$(OutDir)$(TargetName).dll"/>
+  <Target Name="GetTargetFileName" Returns="$(OutDir)$(TargetName).dll" />
 </Project>


### PR DESCRIPTION
The addition of a C++/WinRT-based ABI has created dependencies on DLLs that are absent on Win7, causing react-native-win32.dll load failures. This change is a short-term workaround that switches these DLLs from being eagerly- to delay-loaded, enabling use of react-native-win32.dll as long as the C++/WinRT ABI is not being used.

This change is intended to be followed by a long-term solution that should allow the use of the C++/WinRT ABI on Win7.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2867)