### PR TITLE
Fix Image OnLoad never firing

### DIFF
--- a/change/react-native-windows-2019-08-02-07-32-57-users-stecrain-fixImageOnLoad.json
+++ b/change/react-native-windows-2019-08-02-07-32-57-users-stecrain-fixImageOnLoad.json
@@ -1,0 +1,8 @@
+{
+  "comment": "fix image not firing on load.",
+  "type": "prerelease",
+  "packageName": "react-native-windows",
+  "email": "stecrain@microsoft.com",
+  "commit": "d394cb68a28a8595935188f222c837a9f7c8d6a5",
+  "date": "2019-08-02T14:32:57.828Z"
+}

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -113,6 +113,10 @@ XamlView ImageViewManager::CreateViewCore(int64_t tag) {
   return ReactImage::Create().as<winrt::Canvas>();
 }
 
+facebook::react::ShadowNode *ImageViewManager::createShadow() const {
+  return new ImageShadowNode();
+}
+
 void ImageViewManager::UpdateProperties(
     ShadowNodeBase *nodeToUpdate,
     const folly::dynamic &reactDiffMap) {

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.h
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.h
@@ -20,6 +20,7 @@ class ImageViewManager : public FrameworkElementViewManager {
 
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
   folly::dynamic GetNativeProps() const override;
+  facebook::react::ShadowNode *createShadow() const override;
   void EmitImageEvent(
       winrt::Windows::UI::Xaml::Controls::Canvas canvas,
       const char *eventName,


### PR DESCRIPTION
Fixes #2855 

I introduced this regression while fixing a memory leak in PR #2667 
Sorry about breaking it :( 
The test cases are covered by RNTester, but I didn't compare RNTester before and after my changes.

Current RNTester coverage of this will add a green checkmark when the even fires, but there isn't an indication when the even fails to fire.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2868)