### PR TITLE
Fix text trmming issue for single line text

### DIFF
--- a/change/react-native-windows-2019-08-02-15-28-12-TextTrim.json
+++ b/change/react-native-windows-2019-08-02-15-28-12-TextTrim.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix single line text trimming issue",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "3dada0ce2e01c1455eb2f786b097429202c311b1",
+  "date": "2019-08-02T22:28:12.732Z"
+}

--- a/change/react-native-windows-extended-2019-08-02-15-28-12-TextTrim.json
+++ b/change/react-native-windows-extended-2019-08-02-15-28-12-TextTrim.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix single line text trimming issue",
+  "packageName": "react-native-windows-extended",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "3dada0ce2e01c1455eb2f786b097429202c311b1",
+  "date": "2019-08-02T22:27:44.856Z"
+}

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -114,9 +114,18 @@ void TextViewManager::UpdateProperties(
                    textBlock, propertyName, propertyValue)) {
       continue;
     } else if (propertyName == "numberOfLines") {
-      if (propertyValue.isNumber())
-        textBlock.MaxLines(static_cast<int32_t>(propertyValue.asDouble()));
-      else if (propertyValue.isNull())
+      if (propertyValue.isNumber()) {
+        auto numberLines = static_cast<int32_t>(propertyValue.asDouble());
+        if (numberLines == 1) {
+          textBlock.TextWrapping(
+              winrt::TextWrapping::NoWrap); // setting no wrap for single line
+                                            // text for better trimming
+                                            // experience
+        } else {
+          textBlock.TextWrapping(winrt::TextWrapping::Wrap);
+        }
+        textBlock.MaxLines(numberLines);
+      } else if (propertyValue.isNull())
         textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
     } else if (propertyName == "lineHeight") {
       if (propertyValue.isNumber())

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -125,8 +125,9 @@ void TextViewManager::UpdateProperties(
           textBlock.TextWrapping(winrt::TextWrapping::Wrap);
         }
         textBlock.MaxLines(numberLines);
-      } else if (propertyValue.isNull()){
-        textBlock.TextWrapping(winrt::TextWrapping::Wrap); // set wrapping back to default
+      } else if (propertyValue.isNull()) {
+        textBlock.TextWrapping(
+            winrt::TextWrapping::Wrap); // set wrapping back to default
         textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
       }
     } else if (propertyName == "lineHeight") {

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -125,8 +125,10 @@ void TextViewManager::UpdateProperties(
           textBlock.TextWrapping(winrt::TextWrapping::Wrap);
         }
         textBlock.MaxLines(numberLines);
-      } else if (propertyValue.isNull())
+      } else if (propertyValue.isNull()){
+        textBlock.TextWrapping(winrt::TextWrapping::Wrap); // set wrapping back to default
         textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
+      }
     } else if (propertyName == "lineHeight") {
       if (propertyValue.isNumber())
         textBlock.LineHeight(static_cast<int32_t>(propertyValue.asDouble()));


### PR DESCRIPTION
#2849 

The default wrapping used for TextBlock in RNW is wrapping. When numberOfLines is set to 1, we should set wrapping to none, to have proper trimming/ellipsis for single line text. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2878)