### PR TITLE
Update evergreen to bump all packages

### DIFF
--- a/.ado/evergreen.js
+++ b/.ado/evergreen.js
@@ -156,32 +156,22 @@ request.get('https://raw.githubusercontent.com/microsoft/react-native/master/pac
   exec(`git fetch msrn`);
   listOfChanges = execSync(`git log --pretty=oneline --abbrev-commit v${existingPkgJson.devDependencies['react-native']}..v${pkgJson.version}`).toString();
 
-  console.log(`Updating react-native to version: ${pkgJson.version}`);
-  existingPkgJson.peerDependencies['react-native'] = rnDependency;
-  existingPkgJson.devDependencies['react-native'] = pkgJson.version;
-
-  const rnwePkgJsonPath = path.resolve(__dirname, '../packages/react-native-windows-extended/package.json');
-  let rnwePkgJson = JSON.parse(fs.readFileSync(rnwePkgJsonPath, 'utf8'));
-  rnwePkgJson.peerDependencies['react-native'] = rnDependency;
-  rnwePkgJson.devDependencies['react-native'] = pkgJson.version;
 
   branchName = branchNamePrefix + sanitizeBranchName(pkgJson.version);
 
-  exec(`npm install -g yarn`);
-
   exec(`git checkout -b ${branchName} --track origin/${finalTargetBranchName}`);
   exec(`git pull`);
-  fs.writeFileSync(pkgJsonPath, JSON.stringify(existingPkgJson, null, 2));
-  fs.writeFileSync(rnwePkgJsonPath, JSON.stringify(rnwePkgJson, null, 2));
-  
-  process.chdir(path.resolve(__dirname, '../vnext'));
+
+  console.log(`Updating react-native to version: ${pkgJson.version}`);
+  execSync(`lerna exec node ${path.resolve(__dirname, 'setRNVersion.js')} ${pkgJson.version}`);
+
+  process.chdir(path.resolve(__dirname, '..'));
   
   // Run yarn install to update yarn.lock
-  exec(`${process.env.APPDATA}\\npm\\node_modules\\yarn\\bin\\yarn.cmd install`);
+  exec(`yarn install`);
 
-  exec(`git add ${path.resolve(__dirname, '../vnext/yarn.lock')}`);
-  exec(`git add ${pkgJsonPath}`);
-  exec(`git add ${rnwePkgJsonPath}`)
+  exec(`git add ${path.resolve(__dirname, '../yarn.lock')}`);
+  exec(`git add ${path.resolve(__dirname, '..')}`);
   exec(`git commit -m "Update to react-native@${pkgJson.version}"`);
   exec(`git push origin ${branchName}`);
 

--- a/.ado/evergreen.yml
+++ b/.ado/evergreen.yml
@@ -19,11 +19,10 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: CmdLine@1
-        displayName: 'Install update script requirements'
+      - task: CmdLine@2
+        displayName: yarn install
         inputs:
-          filename: npm
-          arguments: 'install request --no-save'
+          script: yarn install --frozen-lockfile
 
       - task: CmdLine@2
         displayName: Do Update

--- a/.ado/setRNVersion.js
+++ b/.ado/setRNVersion.js
@@ -1,0 +1,35 @@
+// @ts-check
+// Script to update dependencies to a specific version of react-native
+// This can be triggered using lerna to update the whole repo
+
+const path = require('path');
+const fs = require('fs');
+
+if (process.argv.length < 3) {
+  throw new Error('Need to provide react-native version as arg');
+}
+const rnVersion = process.argv[2];
+
+if (!rnVersion.match(/^\d+\.\d+.\d+-microsoft\.\d+$/)) {
+  throw new Error('Version format must be X.X.X-microsoft.X');
+}
+
+const pkgJsonPath = path.resolve(process.cwd(), 'package.json');
+
+if (!fs.existsSync(pkgJsonPath)) {
+  throw new Error('package.json not found. Needs to be run in the root folder of a packge.')
+}
+
+const pkgJson = require(pkgJsonPath);
+
+function replaceDeps(dependencies) {
+  if (dependencies && dependencies['react-native']) {
+    dependencies['react-native'] = dependencies['react-native'].replace(/0\.\d+.\d+-microsoft\.\d+/g, rnVersion);
+  }
+}
+
+replaceDeps(pkgJson.dependencies);
+replaceDeps(pkgJson.peerDependencies);
+replaceDeps(pkgJson.devDependencies);
+
+fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');


### PR DESCRIPTION
Old logic wasn't updating all packages, and hadn't been updated since the repo moved to yarn/lerna

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2881)