### PR TITLE
Include additional jsi headers in nuget

### DIFF
--- a/change/react-native-windows-2019-08-04-21-55-43-morejsi.json
+++ b/change/react-native-windows-2019-08-04-21-55-43-morejsi.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Include additional jsi headers in nuget",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "cb05d87a6468b75ef9a356a18408ab5f54d43671",
+  "date": "2019-08-05T04:55:43.503Z"
+}

--- a/vnext/ReactUwp.nuspec
+++ b/vnext/ReactUwp.nuspec
@@ -13,7 +13,7 @@
   </metadata>
   <files>
     <file src="inc\cxxreact\*" target="inc\cxxreact"/>
-    <file src="inc\jsi\*" target="inc\jsi"/>
+    <file src="inc\jsi\**\*.*" target="inc\jsi"/>
     <file src="inc\Yoga\*.*" target="inc\Yoga"/>
     <file src="inc\folly\**\*.*" target="inc" />
     <file src="inc\stubs\**\*.*" target="inc" />

--- a/vnext/ReactWin32.nuspec
+++ b/vnext/ReactWin32.nuspec
@@ -18,7 +18,7 @@
     <file src="target\x64\Ship\React.Windows.Desktop.DLL\react-native-win32.*" target="lib\ship\x64" exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
 
     <file src="inc\cxxreact\*" target="inc\cxxreact"/>
-    <file src="inc\jsi\*" target="inc\jsi"/>
+    <file src="inc\jsi\**\*.*" target="inc\jsi"/>
     <file src="inc\Yoga\*.*" target="inc\Yoga"/>
     <file src="inc\folly\**\*.*" target="inc" />
     <file src="inc\stubs\**\*.*" target="inc" />

--- a/vnext/layoutFilesForNuget.bat
+++ b/vnext/layoutFilesForNuget.bat
@@ -45,10 +45,6 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 %COPYCMD%  %RNROOT%\ReactCommon\cxxreact\NativeModule.h                   %DESTROOT%\inc\cxxreact
 %COPYCMD%  %RNROOT%\ReactCommon\cxxreact\PlatformBundleInfo.h             %DESTROOT%\inc\cxxreact
 
-%COPYCMD%  %RNROOT%\ReactCommon\jsi\jsi.h                                 %DESTROOT%\inc\jsi
-%COPYCMD%  %RNROOT%\ReactCommon\jsi\jsi-inl.h                             %DESTROOT%\inc\jsi
-%COPYCMD%  %RNROOT%\ReactCommon\jsi\ScriptStore.h                         %DESTROOT%\inc\jsi
-%COPYCMD%  %RNROOT%\ReactCommon\jsi\V8Runtime.h                           %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\Chakra\ChakraCoreDebugger.h                          %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\Chakra\ChakraJsiRuntimeArgs.h                        %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\Chakra\ChakraJsiRuntimeFactory.h                     %DESTROOT%\inc\jsi
@@ -56,6 +52,7 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 %COPYCMD%  %RNROOT%\ReactCommon\Yoga\Yoga\*.h                             %DESTROOT%\inc\yoga
 
 %COPYCMD%  %RNROOT%\Folly                                                 %DESTROOT%\inc\Folly
+%COPYCMD%  %RNROOT%\ReactCommon\jsi                                       %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\stubs                                                %DESTROOT%\inc\stubs
 %COPYCMD%  %SRCROOT%\Desktop\*.h                                          %DESTROOT%\inc\ReactWin32
 %COPYCMD%  %SRCROOT%\ReactWindowsCore\*.h                                 %DESTROOT%\inc\ReactWindowsCore


### PR DESCRIPTION
Latest sync of react-native, includes more jsi headers, which should be included as part of the nuget.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2884)