### PR TITLE
Update to react-native@0.59.0-microsoft.34

### DIFF
--- a/change/react-native-windows-2019-08-05-11-48-15-auto-update-versions059.0microsoft.34.json
+++ b/change/react-native-windows-2019-08-05-11-48-15-auto-update-versions059.0microsoft.34.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.34",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "fbe67a429145e08afb446b9fb901e13f22a0cc0f",
+  "date": "2019-08-05T11:48:15.377Z"
+}

--- a/change/react-native-windows-extended-2019-08-05-11-48-16-auto-update-versions059.0microsoft.34.json
+++ b/change/react-native-windows-extended-2019-08-05-11-48-16-auto-update-versions059.0microsoft.34.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.34",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "f3416579d1f50e7c66e96a662acd3bb8ebca6bfc",
+  "date": "2019-08-05T11:48:16.489Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.33.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz",
     "react-native-windows": "0.59.0-vnext.118",
     "react-native-windows-extended": "0.4.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.33.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.33 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.33.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.34 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.33.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.33 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.33.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.34 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
10db60ebd Applying package update to 0.59.0-microsoft.34
15101b6f5 Fixing folly related build failures (#125)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2885)