### PR TITLE
Update to react-native@0.59.0-microsoft.35

### DIFF
--- a/change/react-native-windows-2019-08-06-00-52-28-auto-update-versions059.0microsoft.35.json
+++ b/change/react-native-windows-2019-08-06-00-52-28-auto-update-versions059.0microsoft.35.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.35",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "d0a4a3560dfecf5804cc41f76c136836e263c96f",
+  "date": "2019-08-06T00:52:28.136Z"
+}

--- a/change/react-native-windows-extended-2019-08-06-00-52-29-auto-update-versions059.0microsoft.35.json
+++ b/change/react-native-windows-extended-2019-08-06-00-52-29-auto-update-versions059.0microsoft.35.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.35",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "c71c0b35ea8bdc4610a397c159af1ba04222facc",
+  "date": "2019-08-06T00:52:29.154Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz",
     "react-native-windows": "0.59.0-vnext.119",
     "react-native-windows-extended": "0.5.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.34 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.34 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.34.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
44a997235 Applying package update to 0.59.0-microsoft.35
928a60f4f Stop defining UIView and UIScrollView on macOS for Xcode 11 compatibility (#127)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2890)