### PR TITLE
Update to react-native@0.59.0-microsoft.36

### DIFF
--- a/change/react-native-windows-2019-08-06-15-54-50-auto-update-versions059.0microsoft.36.json
+++ b/change/react-native-windows-2019-08-06-15-54-50-auto-update-versions059.0microsoft.36.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.36",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "e73598301418d1d5b09070862b70fe9f8acc3729",
+  "date": "2019-08-06T15:54:50.158Z"
+}

--- a/change/react-native-windows-extended-2019-08-06-15-54-51-auto-update-versions059.0microsoft.36.json
+++ b/change/react-native-windows-extended-2019-08-06-15-54-51-auto-update-versions059.0microsoft.36.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.36",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "75a6e31ab6e7b89dc83cce343be7de71e8776809",
+  "date": "2019-08-06T15:54:51.253Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz",
     "react-native-windows": "0.59.0-vnext.121",
     "react-native-windows-extended": "0.6.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
f8f9d7150 Applying package update to 0.59.0-microsoft.36
4ded2e53e Rojain/c++stlrevert (#128)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2891)