### PR TITLE
Update to react-native@0.59.0-microsoft.37

### DIFF
--- a/change/react-native-windows-2019-08-06-20-37-26-auto-update-versions059.0microsoft.37.json
+++ b/change/react-native-windows-2019-08-06-20-37-26-auto-update-versions059.0microsoft.37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.37",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "220e4e5d6549a1a240fb9ffb87b6e468280f661b",
+  "date": "2019-08-06T20:37:26.554Z"
+}

--- a/change/react-native-windows-extended-2019-08-06-20-37-27-auto-update-versions059.0microsoft.37.json
+++ b/change/react-native-windows-extended-2019-08-06-20-37-27-auto-update-versions059.0microsoft.37.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.37",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "b3d9dfb3fc1fcf1fba79f3789799c9cc0cc860e5",
+  "date": "2019-08-06T20:37:27.603Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz",
     "react-native-windows": "0.59.0-vnext.122",
     "react-native-windows-extended": "0.7.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.36.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
c4c1adf15 Applying package update to 0.59.0-microsoft.37
2a08f2d64 Ensure npm tar file is included in final build artifact

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2893)