### PR TITLE
Adding RNW accessibility extensions to RNW ViewProps

### DIFF
--- a/change/react-native-windows-2019-08-06-15-37-15-issue2894.json
+++ b/change/react-native-windows-2019-08-06-15-37-15-issue2894.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Adding accessibilityPosInSet and accessibilitySizeOfSet props to ViewWindows, #2894",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "commit": "ea705d4d7b9bdd0a9ac618d1db273b17f1c47536",
+  "date": "2019-08-06T22:37:15.757Z"
+}

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.uwp.js
@@ -432,6 +432,8 @@ const TouchableHighlight = ((createReactClass({
         accessibilityHint={this.props.accessibilityHint} // TODO(OSS Candidate ISS#2710739)
         accessibilityRole={this.props.accessibilityRole}
         accessibilityStates={this.props.accessibilityStates}
+        accessibilityPosInSet={this.props.accessibilityPosInSet} // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+        accessibilitySetSize={this.props.accessibilitySetSize} // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
         onAccessibilityTap={this.props.onAccessibilityTap} // TODO(OSS Candidate ISS#2710739)
         acceptsKeyboardFocus={
           (this.props.acceptsKeyboardFocus === undefined ||

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.uwp.js
@@ -317,6 +317,8 @@ const TouchableOpacity = ((createReactClass({
         accessibilityHint={this.props.accessibilityHint} // TODO(OSS Candidate ISS#2710739)
         accessibilityRole={this.props.accessibilityRole}
         accessibilityStates={this.props.accessibilityStates}
+        accessibilityPosInSet={this.props.accessibilityPosInSet} // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+        accessibilitySetSize={this.props.accessibilitySetSize} // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
         onAccessibilityTap={this.props.onAccessibilityTap} // TODO(OSS Candidate ISS#2710739)
         acceptsKeyboardFocus={
           (this.props.acceptsKeyboardFocus === undefined ||

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.uwp.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.uwp.js
@@ -55,6 +55,8 @@ export type Props = $ReadOnly<{|
   accessibilityRole?: ?AccessibilityRole,
   accessibilityStates?: ?AccessibilityStates,
   accessibilityTraits?: ?AccessibilityTraits,
+  accessibilityPosInSet?: ?number, // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+  accessibilitySetSize?: ?number, // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
   children?: ?React.Node,
   delayLongPress?: ?number,
   delayPressIn?: ?number,
@@ -109,6 +111,8 @@ const TouchableWithoutFeedback = ((createReactClass({
       PropTypes.oneOf(DeprecatedAccessibilityTraits),
       PropTypes.arrayOf(PropTypes.oneOf(DeprecatedAccessibilityTraits)),
     ]),
+    accessibilityPosInSet: PropTypes.number, // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+    accessibilitySetSize: PropTypes.number, // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
     onAccessibilityTap: PropTypes.func, // TODO(OSS Candidate ISS#2710739)
     tabIndex: PropTypes.number, // TODO(macOS/win ISS#2323203)
 
@@ -306,6 +310,10 @@ const TouchableWithoutFeedback = ((createReactClass({
       accessibilityRole: this.props.accessibilityRole,
       accessibilityStates: this.props.accessibilityStates,
       accessibilityTraits: this.props.accessibilityTraits,
+
+      accessibilityPosInSet: this.props.accessibilityPosInSet, // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+      accessibilitySetSize: this.props.accessibilitySetSize, // https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+
       onAccessibilityTap: this.props.onAccessibilityTap, // TODO(OSS Candidate ISS#2710739)
       acceptsKeyboardFocus:
         (this.props.acceptsKeyboardFocus === undefined ||

--- a/vnext/src/Libraries/Components/View/ViewWindowsProps.ts
+++ b/vnext/src/Libraries/Components/View/ViewWindowsProps.ts
@@ -11,4 +11,18 @@ export interface IViewWindowsProps extends IKeyboardProps, ViewProps {
   acceptsKeyboardFocus?: boolean;
   // tslint:disable-next-line:no-any
   children?: any;
+
+  /**
+   * Indicates to accessibility services that the UI Component is within a set and has the given numbered position.
+   *
+   * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+   */
+  accessibilityPosInSet?: number;
+
+  /**
+   * Indicates to accessibility services that the UI Component is within a set with the given size.
+   *
+   * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+   */
+  accessibilitySetSize?: number;
 }

--- a/vnext/src/RNTester/AccessibilityExample.tsx
+++ b/vnext/src/RNTester/AccessibilityExample.tsx
@@ -458,6 +458,29 @@ class AccessibilityListExamples extends React.Component {
             keyExtractor={(item, index) => index.toString()}
           />
         </View>
+        <View
+          //@ts-ignore
+          accessibilityRole="list">
+          <Text>The following does the same, but with Touchables.</Text>
+          <FlatList
+            data={items}
+            renderItem={item => (
+              <TouchableHighlight
+                style={{
+                  width: 100,
+                  height: 50,
+                  backgroundColor: 'lightskyblue',
+                }}
+                //@ts-ignore
+                accessibilityRole="listitem"
+                accessibilitySetSize={items.length}
+                accessibilityPosInSet={item.index + 1}>
+                <Text>Touchable {item.index + 1}</Text>
+              </TouchableHighlight>
+            )}
+            keyExtractor={(item, index) => index.toString()}
+          />
+        </View>
       </View>
     );
   }


### PR DESCRIPTION
* Adding accessibilityPosInSet and accessibilitySizeOfSet props to ViewWindows and Touchables, #2894

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2895)