### PR TITLE
Update to react-native@0.59.0-microsoft.38

### DIFF
--- a/change/react-native-windows-2019-08-07-15-50-50-auto-update-versions059.0microsoft.38.json
+++ b/change/react-native-windows-2019-08-07-15-50-50-auto-update-versions059.0microsoft.38.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.38",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "e0790b61ebbd68578b7ffaa971f4b5b3ea0a58e8",
+  "date": "2019-08-07T15:50:50.397Z"
+}

--- a/change/react-native-windows-extended-2019-08-07-15-50-51-auto-update-versions059.0microsoft.38.json
+++ b/change/react-native-windows-extended-2019-08-07-15-50-51-auto-update-versions059.0microsoft.38.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.38",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "6ad6afe25ad265cc6799617f730d3d6b7cd47c45",
+  "date": "2019-08-07T15:50:51.362Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
     "react-native-windows": "0.59.0-vnext.123",
     "react-native-windows-extended": "0.8.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.38 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.37.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.38 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
2c52bb06e Applying package update to 0.59.0-microsoft.38
917be36bb Update cmake build for jsi file moves (#130)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2898)