### PR TITLE
Fix excessive toggles on the Switch component

### DIFF
--- a/change/react-native-windows-2019-08-07-11-10-11-switch_shimmy_fix.json
+++ b/change/react-native-windows-2019-08-07-11-10-11-switch_shimmy_fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix switch shimmy issue",
+  "packageName": "react-native-windows",
+  "email": "ruaraki@microsoft.com",
+  "commit": "693b2ed5fdeb73cfae4b558bf804544227d149fb",
+  "date": "2019-08-07T18:10:11.178Z"
+}

--- a/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
+++ b/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+'use strict';
+
+import * as React from 'react';
+import {StyleSheet, requireNativeComponent} from 'react-native';
+import {ISwitchProps, ISwitchChangeEvent} from './SwitchProps';
+
+const styles = StyleSheet.create({
+  rctSwitch: {height: 31, width: 51},
+});
+
+const RCTSwitch = requireNativeComponent('RCTSwitch');
+
+/**
+ * A visual toggle between two mutually exclusive states.
+ *
+ * This is a controlled component that requires an `onValueChange` callback that
+ * updates the `value` prop in order for the component to reflect user actions.
+ * If the `value` prop is not updated, the component will continue to render the
+ * supplied `value` prop instead of the expected result of any user actions.
+ *
+ * @keyword switch
+ * @keyword toggle
+ */
+class Switch extends React.Component<ISwitchProps> {
+  // tslint:disable-next-line:no-any
+  private _rctSwitch: any;
+
+  public constructor(props: ISwitchProps) {
+    super(props);
+    this._rctSwitch = React.createRef();
+  }
+
+  public render(): JSX.Element {
+    const props = {...this.props};
+    props.onResponderTerminationRequest = () => false;
+    props.onStartShouldSetResponder = () => true;
+    props.style = [styles.rctSwitch, this.props.style];
+    props.value = this.props.value === true;
+    props.accessibilityRole = this.props.accessibilityRole
+      ? this.props.accessibilityRole
+      : 'button';
+
+    return (
+      <RCTSwitch {...props} onChange={this._onChange} ref={this._setRef} />
+    );
+  }
+
+  private _setRef = (switchRef: Switch /*RCTSwitch*/) => {
+    this._rctSwitch = switchRef;
+  };
+
+  private _onChange = (event: ISwitchChangeEvent) => {
+    if (this._rctSwitch) {
+      // Force value of native switch in order to control it.
+      const value = this.props.value === true;
+      this._rctSwitch.setNativeProps({value});
+    }
+
+    this.props.onChange && this.props.onChange(event);
+    this.props.onValueChange &&
+      this.props.onValueChange(event.nativeEvent.value);
+  };
+}
+
+module.exports = Switch;

--- a/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
+++ b/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
@@ -29,10 +29,12 @@ const RCTSwitch = requireNativeComponent('RCTSwitch');
 class Switch extends React.Component<ISwitchProps> {
   // tslint:disable-next-line:no-any
   private _rctSwitch: any;
+  private _lastNativeValue: boolean;
 
   public constructor(props: ISwitchProps) {
     super(props);
     this._rctSwitch = React.createRef();
+    this._lastNativeValue = false;
   }
 
   public render(): JSX.Element {
@@ -50,20 +52,28 @@ class Switch extends React.Component<ISwitchProps> {
     );
   }
 
+  componentDidUpdate = () => {
+    // This is necessary in case native updates the switch and JS decides
+    // that the update should be ignored and we should stick with the value
+    // that we have in JS.
+    const value = this.props.value === true;
+
+    if (this._lastNativeValue !== value && this._rctSwitch) {
+      this._rctSwitch.setNativeProps({value});
+    }
+  };
+
   private _setRef = (switchRef: Switch /*RCTSwitch*/) => {
     this._rctSwitch = switchRef;
   };
 
   private _onChange = (event: ISwitchChangeEvent) => {
-    if (this._rctSwitch) {
-      // Force value of native switch in order to control it.
-      const value = this.props.value === true;
-      this._rctSwitch.setNativeProps({value});
-    }
-
     this.props.onChange && this.props.onChange(event);
     this.props.onValueChange &&
       this.props.onValueChange(event.nativeEvent.value);
+
+    this._lastNativeValue = event.nativeEvent.value;
+    this.forceUpdate();
   };
 }
 

--- a/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
+++ b/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
@@ -39,6 +39,41 @@ class Switch extends React.Component<ISwitchProps> {
 
   public render(): JSX.Element {
     const props = {...this.props};
+    let _thumbColor = this.props.thumbColor;
+    let _trackColorForFalse = this.props.trackColor
+      ? this.props.trackColor.false
+      : undefined;
+    let _trackColorForTrue = this.props.trackColor
+      ? this.props.trackColor.true
+      : undefined;
+
+    if (this.props.thumbTintColor !== undefined) {
+      _thumbColor = this.props.thumbTintColor;
+      if (__DEV__) {
+        console.warn(
+          'Switch: `thumbTintColor` is deprecated, use `thumbColor` instead.',
+        );
+      }
+    }
+
+    if (this.props.tintColor !== undefined) {
+      _trackColorForFalse = this.props.tintColor;
+      if (__DEV__) {
+        console.warn(
+          'Switch: `tintColor` is deprecated, use `trackColor` instead.',
+        );
+      }
+    }
+
+    if (this.props.onTintColor !== undefined) {
+      _thumbColor = this.props.onTintColor;
+      if (__DEV__) {
+        console.warn(
+          'Switch: `onTintColor` is deprecated, use `trackColor` instead.',
+        );
+      }
+    }
+
     props.onResponderTerminationRequest = () => false;
     props.onStartShouldSetResponder = () => true;
     props.style = [styles.rctSwitch, this.props.style];
@@ -46,20 +81,12 @@ class Switch extends React.Component<ISwitchProps> {
     props.accessibilityRole = this.props.accessibilityRole
       ? this.props.accessibilityRole
       : 'button';
+    props.thumbTintColor = _thumbColor;
+    props.tintColor = _trackColorForFalse;
+    props.onTintColor = _trackColorForTrue;
 
     return (
-      <RCTSwitch
-        {...props}
-        thumbTintColor={this.props.thumbColor}
-        tintColor={
-          this.props.trackColor ? this.props.trackColor.false : undefined
-        }
-        onTintColor={
-          this.props.trackColor ? this.props.trackColor.true : undefined
-        }
-        onChange={this._onChange}
-        ref={this._setRef}
-      />
+      <RCTSwitch {...props} onChange={this._onChange} ref={this._setRef} />
     );
   }
 

--- a/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
+++ b/vnext/src/Libraries/Components/Switch/Switch.uwp.tsx
@@ -48,7 +48,18 @@ class Switch extends React.Component<ISwitchProps> {
       : 'button';
 
     return (
-      <RCTSwitch {...props} onChange={this._onChange} ref={this._setRef} />
+      <RCTSwitch
+        {...props}
+        thumbTintColor={this.props.thumbColor}
+        tintColor={
+          this.props.trackColor ? this.props.trackColor.false : undefined
+        }
+        onTintColor={
+          this.props.trackColor ? this.props.trackColor.true : undefined
+        }
+        onChange={this._onChange}
+        ref={this._setRef}
+      />
     );
   }
 

--- a/vnext/src/Libraries/Components/Switch/SwitchProps.ts
+++ b/vnext/src/Libraries/Components/Switch/SwitchProps.ts
@@ -18,6 +18,11 @@ export interface ISwitchProps extends ViewProps {
   trackColor?: ISwitchTrackColorProps;
   onChange?: (event: ISwitchChangeEvent) => void;
   onValueChange?: (value: boolean) => void;
+
+  // deprecated
+  thumbTintColor?: string;
+  tintColor?: string;
+  onTintColor?: string;
 }
 
 export interface ISwitchChangeEvent {

--- a/vnext/src/Libraries/Components/Switch/SwitchProps.ts
+++ b/vnext/src/Libraries/Components/Switch/SwitchProps.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {ViewProps} from 'react-native';
+
+export interface ISwitchTrackColorProps {
+  false?: string;
+  true?: string;
+}
+
+export interface ISwitchProps extends ViewProps {
+  disabled?: boolean;
+  value?: boolean;
+  thumbColor?: string;
+  trackColor?: ISwitchTrackColorProps;
+  onChange?: (event: ISwitchChangeEvent) => void;
+  onValueChange?: (value: boolean) => void;
+}
+
+export interface ISwitchChangeEvent {
+  nativeEvent: {
+    value: boolean;
+  };
+}

--- a/vnext/src/index.uwp.ts
+++ b/vnext/src/index.uwp.ts
@@ -10,6 +10,7 @@ export * from './Libraries/Components/Flyout/Flyout.uwp';
 export * from './Libraries/Components/Glyph/Glyph.uwp';
 export * from './Libraries/Components/Picker/PickerUWP.uwp';
 export * from './Libraries/Components/Popup/Popup.uwp';
+export * from './Libraries/Components/Switch/Switch.uwp';
 export * from './Libraries/Components/Keyboard/KeyboardExt.uwp';
 export * from './Libraries/Components/Keyboard/KeyboardExtProps';
 export * from './Libraries/Components/View/ViewWindowsProps';


### PR DESCRIPTION
If you click on a Switch component to toggle it, you can see it "shimmy" back and forth once before settling. The Switch ends up toggling three times every time it's invoked.

The Switch component is a JS-controlled component. It's designed such that only the JS should be able to dictate what value it should be set to. In theory, invoking the toggle switch XAML control directly should fire a valueChanged event to the component so that it knows that the switch was pressed, but not actually change the value on the switch itself. The RN JS layer (the layer that connects the Switch component to its native counterpart) prevented the native switch from toggling to the new value by explicitly setting the switch to this.props.value. It also forwarded the event along to the component, which then decided if it wants to set the value of the switch to the new value or not. The re-setting of the value wasn't fast enough to prevent the switch from starting to toggle, causing the shimmy.

The solution I landed on is taken from TextInput. TextInput's JS to RN layer stores _lastNativeText when it receives an onChange event, and then in componentDidUpdate, if the value of this.props.text isn't the same as _lastNativeText, it puts this.props.text back on the native textbox. Porting this to the Switch results in only one toggle happening per invoke (verified by debugger), removing the shimmy. This will result in a flicker when the JS is adamant about the Switch being a certain value, but it also shows the user some feedback that the Switch received a click, so it seems acceptable.

This solution meant I needed to make a uwp-specific Switch file. This change copied Switch.js from react native and converted it into Typescript, and then applied the change described above to the file. I exposed the deprecated color props to align with react native. I have confirmed that the recent exposure of colors on the Switch have been unaffected using RNTester.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2900)