### PR TITLE
Fix Sample/Index layout, set Tag to Name in debug

### DIFF
--- a/change/react-native-windows-2019-08-07-12-42-49-andrewh-DebuggingFixes.json
+++ b/change/react-native-windows-2019-08-07-12-42-49-andrewh-DebuggingFixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Sample/index.tsx layout, set Tag as Name in debug",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "2b96e796ca606187775291a81d3f922466e69a04",
+  "date": "2019-08-07T19:42:49.563Z"
+}

--- a/packages/playground/Samples/index.tsx
+++ b/packages/playground/Samples/index.tsx
@@ -229,546 +229,539 @@ export default class Bootstrap extends React.Component<
                   acceptsKeyboardFocus: true,
                 }}
               />
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>no border</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderWidth: 4,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                  }}
-                />
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>no back</Text>
-                <View
-                  style={{
-                    borderWidth: 4,
-                    borderColor: 'black',
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                  }}
-                />
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>normal</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderColor: 'black',
-                    borderWidth: 4,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                  }}
-                />
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>no clip</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderColor: 'black',
-                    borderWidth: 4,
-                    borderTopStartRadius: 10.0,
-                    borderTopEndRadius: 15.0,
-                    borderBottomStartRadius: 20.0,
-                    borderBottomEndRadius: 25.0,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                  }}>
-                  <View
-                    style={{backgroundColor: 'green', width: 52, height: 52}}
-                  />
-                </View>
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>no clip</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderColor: 'black',
-                    borderWidth: 4,
-                    borderTopStartRadius: 10.0,
-                    borderTopEndRadius: 15.0,
-                    borderBottomStartRadius: 20.0,
-                    borderBottomEndRadius: 25.0,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                  }}>
-                  <View
-                    style={{
-                      backgroundColor: 'green',
-                      width: 30,
-                      height: 15,
-                      left: -10,
-                      top: 0,
-                    }}
-                  />
-                  <View
-                    style={{
-                      backgroundColor: 'blue',
-                      width: 15,
-                      height: 40,
-                      left: 0,
-                      top: 5,
-                    }}
-                  />
-                  <View
-                    style={{
-                      backgroundColor: 'crimson',
-                      width: 40,
-                      height: 40,
-                      left: 25,
-                      top: -50,
-                    }}
-                  />
-                </View>
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>no clip</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderColor: 'black',
-                    borderWidth: 4,
-                    borderTopStartRadius: 10.0,
-                    borderTopEndRadius: 15.0,
-                    borderBottomStartRadius: 20.0,
-                    borderBottomEndRadius: 25.0,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                    overflow: 'visible',
-                  }}>
-                  <View
-                    style={{
-                      backgroundColor: 'green',
-                      width: 30,
-                      height: 15,
-                      left: -10,
-                      top: 0,
-                    }}
-                  />
-                  <View
-                    style={{
-                      backgroundColor: 'blue',
-                      width: 15,
-                      height: 40,
-                      left: 0,
-                      top: 5,
-                    }}
-                  />
-                  <View
-                    style={{
-                      backgroundColor: 'crimson',
-                      width: 40,
-                      height: 40,
-                      left: 25,
-                      top: -50,
-                    }}
-                  />
-                </View>
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>clipped</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderColor: 'black',
-                    borderWidth: 4,
-                    borderTopStartRadius: 10.0,
-                    borderTopEndRadius: 15.0,
-                    borderBottomStartRadius: 20.0,
-                    borderBottomEndRadius: 25.0,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                    overflow: 'hidden',
-                  }}>
-                  <View
-                    style={{
-                      backgroundColor: 'green',
-                      width: 30,
-                      height: 15,
-                      left: -10,
-                      top: 0,
-                    }}
-                  />
-                  <View
-                    style={{
-                      backgroundColor: 'blue',
-                      width: 15,
-                      height: 40,
-                      left: 0,
-                      top: 5,
-                    }}
-                  />
-                  <View
-                    style={{
-                      backgroundColor: 'crimson',
-                      width: 40,
-                      height: 40,
-                      left: 25,
-                      top: -50,
-                    }}
-                  />
-                </View>
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>circle</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderRadius: 30,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                    overflow: 'hidden',
-                  }}>
-                  <View
-                    style={{backgroundColor: 'purple', width: 60, height: 60}}
-                  />
-                </View>
-              </View>
-              <View style={{flexDirection: 'column', alignItems: 'center'}}>
-                <Text>circle</Text>
-                <View
-                  style={{
-                    backgroundColor: 'orange',
-                    borderRadius: 30,
-                    width: 60,
-                    height: 60,
-                    margin: 10,
-                  }}
-                  {...{
-                    // Use weird format as work around for the fact that these props are not part of the @types/react-native yet
-                    acceptsKeyboardFocus: true,
-                  }}>
-                  <View
-                    style={{backgroundColor: 'magenta', width: 60, height: 60}}
-                  />
-                </View>
-              </View>
             </View>
-            <Text style={{marginTop: 5}}>Border Tests:</Text>
-            <View style={{flexDirection: 'row'}}>
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderTopStartRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderTopEndRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderBottomStartRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderBottomEndRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderRadius: 10.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderRadius: 10.0,
-                  borderTopStartRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderRadius: 10.0,
-                  borderTopEndRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderRadius: 10.0,
-                  borderBottomStartRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-              <View
-                style={{
-                  borderColor: 'red',
-                  borderWidth: 1,
-                  borderRadius: 10.0,
-                  borderBottomEndRadius: 5.0,
-                  width: 40,
-                  height: 40,
-                  margin: 4,
-                }}
-              />
-            </View>
-            <Text style={{margin: 5, marginTop: 10}}>Position Tests:</Text>
-            <View
-              style={{width: 500, height: 100, backgroundColor: 'lightblue'}}>
-              <View
-                style={{
-                  backgroundColor: 'blue',
-                  width: 100,
-                  height: 40,
-                  position: 'absolute',
-                  left: '50%',
-                }}
-              />
-              <View
-                style={{
-                  backgroundColor: 'red',
-                  width: 100,
-                  height: 40,
-                  position: 'absolute',
-                  top: '25%',
-                }}
-              />
-              <View
-                style={{
-                  backgroundColor: 'green',
-                  width: 100,
-                  height: 40,
-                  position: 'absolute',
-                  bottom: '5%',
-                }}
-              />
-              <View
-                style={{
-                  backgroundColor: 'yellow',
-                  width: 100,
-                  height: 40,
-                  position: 'absolute',
-                  right: '50%',
-                }}
-              />
-              <View
-                style={{
-                  backgroundColor: 'aqua',
-                  width: '50%',
-                  height: 40,
-                  position: 'absolute',
-                  left: 20,
-                  top: 30,
-                }}
-              />
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>no border</Text>
               <View
                 style={{
                   backgroundColor: 'orange',
-                  width: 50,
-                  height: 50,
-                  position: 'absolute',
-                  right: 10,
-                  bottom: 10,
+                  borderWidth: 4,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
                 }}
               />
             </View>
-
-            <View
-              style={{flexDirection: 'row', alignItems: 'center', padding: 10}}>
-              <Picker
-                style={{width: 100}}
-                selectedValue={this.state.pickerSelectedValue}
-                onValueChange={this.pickerValueChange}
-                accessibilityLabel="test picker"
-                testID="pickerID">
-                <Picker.Item label="item 1" color="blue" value="key0" />
-                <Picker.Item label="item 2" value="key1" />
-              </Picker>
-              <Text style={{margin: 6}}>
-                selectedIndex: {this.state.pickerSelectedIndex} selectedValue:{' '}
-                {this.state.pickerSelectedValue}
-              </Text>
-              <Button
-                title="Clear selection"
-                onPress={this.pickerClearSelection}
-              />
-            </View>
-
-            <View style={{alignItems: 'center', padding: 10}}>
-              <Text>Test Popup: </Text>
-              <PopupButton />
-            </View>
-
-            <View style={{backgroundColor: 'blue', marginTop: 15}}>
-              <Image
-                style={{width: 50, height: 50}}
-                source={{
-                  uri:
-                    'http://facebook.github.io/react-native/img/header_logo.png',
-                }}
-                onLoadStart={() => {
-                  console.log('image onLoadStart!');
-                }}
-                onLoad={() => {
-                  console.log('image onLoad!');
-                }}
-                onLoadEnd={() => {
-                  console.log('image onLoadEnd!');
-                }}
-                onError={() => {
-                  console.log('image onError!');
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>no back</Text>
+              <View
+                style={{
+                  borderWidth: 4,
+                  borderColor: 'black',
+                  width: 60,
+                  height: 60,
+                  margin: 10,
                 }}
               />
             </View>
-            <View style={{backgroundColor: 'yellow', marginTop: 15}}>
-              <Image
-                style={{width: 66, height: 58}}
-                source={{
-                  width: 66,
-                  height: 58,
-                  uri:
-                    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==',
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>normal</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderColor: 'black',
+                  borderWidth: 4,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
                 }}
               />
             </View>
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>no clip</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderColor: 'black',
+                  borderWidth: 4,
+                  borderTopStartRadius: 10.0,
+                  borderTopEndRadius: 15.0,
+                  borderBottomStartRadius: 20.0,
+                  borderBottomEndRadius: 25.0,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
+                }}>
+                <View
+                  style={{backgroundColor: 'green', width: 52, height: 52}}
+                />
+              </View>
+            </View>
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>no clip</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderColor: 'black',
+                  borderWidth: 4,
+                  borderTopStartRadius: 10.0,
+                  borderTopEndRadius: 15.0,
+                  borderBottomStartRadius: 20.0,
+                  borderBottomEndRadius: 25.0,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
+                }}>
+                <View
+                  style={{
+                    backgroundColor: 'green',
+                    width: 30,
+                    height: 15,
+                    left: -10,
+                    top: 0,
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: 'blue',
+                    width: 15,
+                    height: 40,
+                    left: 0,
+                    top: 5,
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: 'crimson',
+                    width: 40,
+                    height: 40,
+                    left: 25,
+                    top: -50,
+                  }}
+                />
+              </View>
+            </View>
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>no clip</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderColor: 'black',
+                  borderWidth: 4,
+                  borderTopStartRadius: 10.0,
+                  borderTopEndRadius: 15.0,
+                  borderBottomStartRadius: 20.0,
+                  borderBottomEndRadius: 25.0,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
+                  overflow: 'visible',
+                }}>
+                <View
+                  style={{
+                    backgroundColor: 'green',
+                    width: 30,
+                    height: 15,
+                    left: -10,
+                    top: 0,
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: 'blue',
+                    width: 15,
+                    height: 40,
+                    left: 0,
+                    top: 5,
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: 'crimson',
+                    width: 40,
+                    height: 40,
+                    left: 25,
+                    top: -50,
+                  }}
+                />
+              </View>
+            </View>
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>clipped</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderColor: 'black',
+                  borderWidth: 4,
+                  borderTopStartRadius: 10.0,
+                  borderTopEndRadius: 15.0,
+                  borderBottomStartRadius: 20.0,
+                  borderBottomEndRadius: 25.0,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
+                  overflow: 'hidden',
+                }}>
+                <View
+                  style={{
+                    backgroundColor: 'green',
+                    width: 30,
+                    height: 15,
+                    left: -10,
+                    top: 0,
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: 'blue',
+                    width: 15,
+                    height: 40,
+                    left: 0,
+                    top: 5,
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: 'crimson',
+                    width: 40,
+                    height: 40,
+                    left: 25,
+                    top: -50,
+                  }}
+                />
+              </View>
+            </View>
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>circle</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderRadius: 30,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
+                  overflow: 'hidden',
+                }}>
+                <View
+                  style={{backgroundColor: 'purple', width: 60, height: 60}}
+                />
+              </View>
+            </View>
+            <View style={{flexDirection: 'column', alignItems: 'center'}}>
+              <Text>circle</Text>
+              <View
+                style={{
+                  backgroundColor: 'orange',
+                  borderRadius: 30,
+                  width: 60,
+                  height: 60,
+                  margin: 10,
+                }}
+                {...{
+                  // Use weird format as work around for the fact that these props are not part of the @types/react-native yet
+                  acceptsKeyboardFocus: true,
+                }}>
+                <View
+                  style={{backgroundColor: 'magenta', width: 60, height: 60}}
+                />
+              </View>
+            </View>
+          </View>
+          <Text style={{marginTop: 5}}>Border Tests:</Text>
+          <View style={{flexDirection: 'row'}}>
             <View
               style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                marginTop: 15,
-              }}>
-              <CheckBox
-                onValueChange={value => this.setState({checkBoxIsOn: value})}
-                checked={this.state.checkBoxIsOn}
-              />
-              <Text>Checkbox {this.state.checkBoxIsOn ? 'ON' : 'OFF'}</Text>
-            </View>
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                marginTop: 15,
-              }}>
-              <Switch
-                onValueChange={value => this.setState({switchIsOn: value})}
-                value={this.state.switchIsOn}
-              />
-              <Text>Switch {this.state.switchIsOn ? 'ON' : 'OFF'}</Text>
-            </View>
-            <View style={{padding: 10}}>
-              <View>
-                <TouchableHighlight
-                  style={{height: 30}}
-                  onPress={this.focusTextInputPressed}
-                  underlayColor={'transparent'}>
-                  <View
-                    style={[
-                      this.state.highlightPressed ? styles.selected : {},
-                    ]}>
-                    <Text>Click to focus textbox</Text>
-                  </View>
-                </TouchableHighlight>
-              </View>
-              <View>
-                <TouchableHighlight
-                  style={{height: 30}}
-                  onPress={this.blurTextInputPressed}
-                  underlayColor={'transparent'}>
-                  <View
-                    style={[
-                      this.state.highlightPressed ? styles.selected : {},
-                    ]}>
-                    <Text>Click to remove focus from textbox</Text>
-                  </View>
-                </TouchableHighlight>
-              </View>
-              <View>
-                <TouchableHighlight
-                  style={{height: 30}}
-                  onPress={this.clearTextInputPressed}
-                  underlayColor={'transparent'}>
-                  <View
-                    style={[
-                      this.state.highlightPressed ? styles.selected : {},
-                    ]}>
-                    <Text>Click to clear textbox</Text>
-                  </View>
-                </TouchableHighlight>
-              </View>
-              <TextInput
-                ref={this.inputRef}
-                defaultValue={'Test'}
-                placeholderTextColor={'hotpink'}
-                onChangeText={this.changeTextHandler}
-                onFocus={this.focusTextInputHandler}
-                onBlur={this.blurTextInputHandler}
-                onSelectionChange={this.selectionChangeTextInputHandler}
-                onEndEditing={this.endEditingTextInputHandler}
-                onContentSizeChange={this.contentSizeChangeTextInputHandler}
-                selectionColor={'red'}
-                clearTextOnFocus={false}
-                selectTextOnFocus={true}
-                style={{height: 30}}
-              />
-            </View>
-            <WebView
-              style={{width: 350, height: 500}}
-              source={{uri: 'https://login.live.com'}}
+                borderColor: 'red',
+                borderWidth: 1,
+                borderTopStartRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
             />
-            <View style={{padding: 10}}>
-              <Text>Test DatePicker</Text>
-              <Text>
-                Date selected: {this.state.datePickerSelectedValue.toString()}
-              </Text>
-              <DatePicker
-                placeholderText="select start date"
-                dateFormat="longdate"
-                dayOfWeekFormat="{dayofweek.abbreviated(3)}"
-                style={{width: 300}}
-                onDateChange={this.datePickerValueChange}
-              />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderTopEndRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderBottomStartRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderBottomEndRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderRadius: 10.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderRadius: 10.0,
+                borderTopStartRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderRadius: 10.0,
+                borderTopEndRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderRadius: 10.0,
+                borderBottomStartRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+            <View
+              style={{
+                borderColor: 'red',
+                borderWidth: 1,
+                borderRadius: 10.0,
+                borderBottomEndRadius: 5.0,
+                width: 40,
+                height: 40,
+                margin: 4,
+              }}
+            />
+          </View>
+          <Text style={{margin: 5, marginTop: 10}}>Position Tests:</Text>
+          <View style={{width: 500, height: 100, backgroundColor: 'lightblue'}}>
+            <View
+              style={{
+                backgroundColor: 'blue',
+                width: 100,
+                height: 40,
+                position: 'absolute',
+                left: '50%',
+              }}
+            />
+            <View
+              style={{
+                backgroundColor: 'red',
+                width: 100,
+                height: 40,
+                position: 'absolute',
+                top: '25%',
+              }}
+            />
+            <View
+              style={{
+                backgroundColor: 'green',
+                width: 100,
+                height: 40,
+                position: 'absolute',
+                bottom: '5%',
+              }}
+            />
+            <View
+              style={{
+                backgroundColor: 'yellow',
+                width: 100,
+                height: 40,
+                position: 'absolute',
+                right: '50%',
+              }}
+            />
+            <View
+              style={{
+                backgroundColor: 'aqua',
+                width: '50%',
+                height: 40,
+                position: 'absolute',
+                left: 20,
+                top: 30,
+              }}
+            />
+            <View
+              style={{
+                backgroundColor: 'orange',
+                width: 50,
+                height: 50,
+                position: 'absolute',
+                right: 10,
+                bottom: 10,
+              }}
+            />
+          </View>
+
+          <View
+            style={{flexDirection: 'row', alignItems: 'center', padding: 10}}>
+            <Picker
+              style={{width: 100}}
+              selectedValue={this.state.pickerSelectedValue}
+              onValueChange={this.pickerValueChange}
+              accessibilityLabel="test picker"
+              testID="pickerID">
+              <Picker.Item label="item 1" color="blue" value="key0" />
+              <Picker.Item label="item 2" value="key1" />
+            </Picker>
+            <Text style={{margin: 6}}>
+              selectedIndex: {this.state.pickerSelectedIndex} selectedValue:{' '}
+              {this.state.pickerSelectedValue}
+            </Text>
+            <Button
+              title="Clear selection"
+              onPress={this.pickerClearSelection}
+            />
+          </View>
+
+          <View style={{alignItems: 'center', padding: 10}}>
+            <Text>Test Popup: </Text>
+            <PopupButton />
+          </View>
+
+          <View style={{backgroundColor: 'blue', marginTop: 15}}>
+            <Image
+              style={{width: 50, height: 50}}
+              source={{
+                uri:
+                  'http://facebook.github.io/react-native/img/header_logo.png',
+              }}
+              onLoadStart={() => {
+                console.log('image onLoadStart!');
+              }}
+              onLoad={() => {
+                console.log('image onLoad!');
+              }}
+              onLoadEnd={() => {
+                console.log('image onLoadEnd!');
+              }}
+              onError={() => {
+                console.log('image onError!');
+              }}
+            />
+          </View>
+          <View style={{backgroundColor: 'yellow', marginTop: 15}}>
+            <Image
+              style={{width: 66, height: 58}}
+              source={{
+                width: 66,
+                height: 58,
+                uri:
+                  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==',
+              }}
+            />
+          </View>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              marginTop: 15,
+            }}>
+            <CheckBox
+              onValueChange={value => this.setState({checkBoxIsOn: value})}
+              checked={this.state.checkBoxIsOn}
+            />
+            <Text>Checkbox {this.state.checkBoxIsOn ? 'ON' : 'OFF'}</Text>
+          </View>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              marginTop: 15,
+            }}>
+            <Switch
+              onValueChange={value => this.setState({switchIsOn: value})}
+              value={this.state.switchIsOn}
+            />
+            <Text>Switch {this.state.switchIsOn ? 'ON' : 'OFF'}</Text>
+          </View>
+          <View style={{padding: 10}}>
+            <View>
+              <TouchableHighlight
+                style={{height: 30}}
+                onPress={this.focusTextInputPressed}
+                underlayColor={'transparent'}>
+                <View
+                  style={[this.state.highlightPressed ? styles.selected : {}]}>
+                  <Text>Click to focus textbox</Text>
+                </View>
+              </TouchableHighlight>
             </View>
+            <View>
+              <TouchableHighlight
+                style={{height: 30}}
+                onPress={this.blurTextInputPressed}
+                underlayColor={'transparent'}>
+                <View
+                  style={[this.state.highlightPressed ? styles.selected : {}]}>
+                  <Text>Click to remove focus from textbox</Text>
+                </View>
+              </TouchableHighlight>
+            </View>
+            <View>
+              <TouchableHighlight
+                style={{height: 30}}
+                onPress={this.clearTextInputPressed}
+                underlayColor={'transparent'}>
+                <View
+                  style={[this.state.highlightPressed ? styles.selected : {}]}>
+                  <Text>Click to clear textbox</Text>
+                </View>
+              </TouchableHighlight>
+            </View>
+            <TextInput
+              ref={this.inputRef}
+              defaultValue={'Test'}
+              placeholderTextColor={'hotpink'}
+              onChangeText={this.changeTextHandler}
+              onFocus={this.focusTextInputHandler}
+              onBlur={this.blurTextInputHandler}
+              onSelectionChange={this.selectionChangeTextInputHandler}
+              onEndEditing={this.endEditingTextInputHandler}
+              onContentSizeChange={this.contentSizeChangeTextInputHandler}
+              selectionColor={'red'}
+              clearTextOnFocus={false}
+              selectTextOnFocus={true}
+              style={{height: 30}}
+            />
+          </View>
+          <WebView
+            style={{width: 350, height: 500}}
+            source={{uri: 'https://login.live.com'}}
+          />
+          <View style={{padding: 10}}>
+            <Text>Test DatePicker</Text>
+            <Text>
+              Date selected: {this.state.datePickerSelectedValue.toString()}
+            </Text>
+            <DatePicker
+              placeholderText="select start date"
+              dateFormat="longdate"
+              dayOfWeekFormat="{dayofweek.abbreviated(3)}"
+              style={{width: 300}}
+              onDateChange={this.datePickerValueChange}
+            />
           </View>
         </View>
       </ScrollView>

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -201,7 +201,7 @@ XamlView ViewManagerBase::CreateView(int64_t tag) {
 #ifdef DEBUG
   auto element = view.try_as<winrt::FrameworkElement>();
   if (element) {
-    element.Name(std::to_wstring(tag));
+    element.Name(L"<reacttag>: " + std::to_wstring(tag));
   }
 #endif
 

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -196,6 +196,15 @@ XamlView ViewManagerBase::CreateView(int64_t tag) {
   // Set the tag if the element type supports it
   SetTag(view, tag);
 
+  // In Debug, set the element name to the tag for convienent
+  // searching within VisualStudio's Live Visual Tree pane
+#ifdef DEBUG
+  auto element = view.try_as<winrt::FrameworkElement>();
+  if (element) {
+    element.Name(std::to_wstring(tag));
+  }
+#endif
+
   auto instance = m_wkReactInstance.lock();
   if (instance != nullptr)
     instance->CallXamlViewCreatedTestHook(view);


### PR DESCRIPTION
2 minor changes:

1. In playground/Samples/Index . when it was ported to TS the view hierarchy was broken slightly so things are being stacked into columns instead of rows, so you can't see all the UI and some things are just broken.

2. in debug set the Tag as the Name
Not sure if this is useful to others, but I keep debugging things our app and I know the Tag id and want to look it up with the live visual tree.  For example the last case, I was seeing something getting focused unexpectedly and then focus was immediately moved somewhere else.  I couldn't see or know what the focused thing was other than knowing its ID via messagespy events.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2902)