### PR TITLE
Use junctions instead of symlinks on windows

### DIFF
--- a/change/react-native-windows-2019-08-08-09-42-24-usejunc.json
+++ b/change/react-native-windows-2019-08-08-09-42-24-usejunc.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Minor documentation update",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "commit": "fc5669b454531d630ad69dbe6fc2cb27706ffe43",
+  "date": "2019-08-08T16:42:24.651Z"
+}

--- a/packages/playground/postinstall.js
+++ b/packages/playground/postinstall.js
@@ -12,12 +12,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
 const link = (name, target) => {
   const p = path.join(__dirname, 'node_modules', name);
 
   if (!fs.existsSync(p)) {
-    fs.symlinkSync(target, p, 'dir');
+    fs.symlinkSync(target, p, os.platform() === 'win32' ? 'junction' : 'dir');
   }
 };
 

--- a/vnext/docs/BuildingRNW.md
+++ b/vnext/docs/BuildingRNW.md
@@ -23,6 +23,13 @@
 ## Automatic
 The playground app can be run in a completely automatic way by using `react-native run-windows`.
 
+If you haven't already, install the react-native-cli  (One time only!)
+```cmd
+npm install -g react-native-cli
+```
+
+Then 
+
 ```cmd
 cd packages\playground
 react-native run-windows


### PR DESCRIPTION
When trying to enlist in RNW on a new machine I hit an issue where windows doesn't allow users to create symlinks without elevating, which would block non-admins from being able to correctly run the playground app.

This switches to use junctions on windows machines, which are able to be created by non-admins.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2904)