### PR TITLE
Fix RTL hit test bug

### DIFF
--- a/change/react-native-windows-2019-08-08-12-17-05-hit-test-bug.json
+++ b/change/react-native-windows-2019-08-08-12-17-05-hit-test-bug.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix hit-testing bug",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "commit": "c29be1a6030585716c40280d10f963f3c3acd8b0",
+  "date": "2019-08-08T19:17:05.480Z"
+}

--- a/vnext/ReactUWP/Views/TouchEventHandler.cpp
+++ b/vnext/ReactUWP/Views/TouchEventHandler.cpp
@@ -459,7 +459,7 @@ std::set<int64_t> TouchEventHandler::GetTagsAtPoint(
   winrt::UIElement root(m_xamlView.as<winrt::UIElement>());
 
   winrt::Point point = e.GetCurrentPoint(root).Position();
-  auto transform = root.TransformToVisual(winrt::Window::Current().Content());
+  auto transform = root.TransformToVisual(nullptr);
   point = transform.TransformPoint(point);
 
   auto elements =

--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,11 +3087,6 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@3, core-js@^3.0.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
-  integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -3101,6 +3096,11 @@ core-js@^2.2.2, core-js@^2.4.1:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
+core-js@^3.0.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
+  integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -7595,10 +7595,10 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz":
-  version "0.59.0-microsoft.35"
-  uid "8ac2b34168e9f6113acc77a1323ba779e6a3f074"
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.35.tar.gz#8ac2b34168e9f6113acc77a1323ba779e6a3f074"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz":
+  version "0.59.0-microsoft.38"
+  uid "0cfaae1930485d53800e3891000263dbc1b78df3"
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz#0cfaae1930485d53800e3891000263dbc1b78df3"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Fix for #2903 

Hit-testing is incorrect when FlowDirection is set to RTL on the root of the XAML tree. 
 
This is due to us using TransformToVisual incorrectly - it should be TransformToVisual(nullptr) to transform to Window coordinates.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2906)