### PR TITLE
Update to react-native@0.59.0-microsoft.39

### DIFF
--- a/change/react-native-windows-2019-08-08-21-14-22-auto-update-versions059.0microsoft.39.json
+++ b/change/react-native-windows-2019-08-08-21-14-22-auto-update-versions059.0microsoft.39.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.39",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "e81c88ebbed87572894fe92e7880d32a8ed58baf",
+  "date": "2019-08-08T21:14:22.908Z"
+}

--- a/change/react-native-windows-extended-2019-08-08-21-14-24-auto-update-versions059.0microsoft.39.json
+++ b/change/react-native-windows-extended-2019-08-08-21-14-24-auto-update-versions059.0microsoft.39.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.39",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "7ea722153481ff5270e01ba01b8e83533e898267",
+  "date": "2019-08-08T21:14:24.019Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.39.tar.gz",
     "react-native-windows": "0.59.0-vnext.126",
     "react-native-windows-extended": "0.9.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.39.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.38 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.39 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.39.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
@@ -26,7 +26,7 @@ UwpPreparedScriptStore::UwpPreparedScriptStore(winrt::hstring uri) {
   }
 }
 
-std::unique_ptr<const facebook::jsi::Buffer>
+std::shared_ptr<const facebook::jsi::Buffer>
 UwpPreparedScriptStore::tryGetPreparedScript(
     const facebook::jsi::ScriptSignature &scriptSignature,
     const facebook::jsi::JSRuntimeSignature &runtimeSignature,
@@ -43,7 +43,7 @@ UwpPreparedScriptStore::tryGetPreparedScript(
     }
 
     auto buffer = winrt::FileIO::ReadBufferAsync(byteCodeFile).get();
-    auto bytecodeBuffer(std::make_unique<ByteCodeBuffer>(buffer.Length()));
+    auto bytecodeBuffer(std::make_shared<ByteCodeBuffer>(buffer.Length()));
     auto dataReader{winrt::Streams::DataReader::FromBuffer(buffer)};
     dataReader.ReadBytes(winrt::array_view<uint8_t>{
         &bytecodeBuffer->data()[0],

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.h
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.h
@@ -12,7 +12,7 @@ namespace uwp {
 class UwpPreparedScriptStore : public facebook::jsi::PreparedScriptStore {
  public:
   UwpPreparedScriptStore(winrt::hstring uri);
-  std::unique_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
+  std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
       const facebook::jsi::ScriptSignature &scriptSignature,
       const facebook::jsi::JSRuntimeSignature &runtimeSignature,
       const char

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.39.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.38 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.39 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.39.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
1512d0f65 Applying package update to 0.59.0-microsoft.39
0785bf81b Replace unique_ptrs in ScriptStore.h with shared_ptrs. (#132)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2908)