### PR TITLE
update typing, examples for AppTheme

### DIFF
--- a/change/react-native-windows-2019-08-08-19-39-16-appThemeTypingFixes.json
+++ b/change/react-native-windows-2019-08-08-19-39-16-appThemeTypingFixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "use more specific typing for currentTheme, improve examples",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "042f72c1a9c89dcd47a639be33bc08ab55379ba3",
+  "date": "2019-08-09T02:39:15.996Z"
+}

--- a/vnext/src/Libraries/AppTheme/AppTheme.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.ts
@@ -10,7 +10,7 @@ import {IHighContrastColors} from './AppThemeTypes';
 
 class AppThemeModule extends MissingNativeEventEmitterShim {
   public isAvailable = false;
-  public currentTheme = '';
+  public currentTheme: 'light' | 'dark' = 'light';
   public isHighContrast = false;
   public currentHighContrastColors = {} as IHighContrastColors;
 }

--- a/vnext/src/Libraries/AppTheme/AppTheme.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.ts
@@ -6,11 +6,11 @@
 'use strict';
 
 const MissingNativeEventEmitterShim = require('MissingNativeEventEmitterShim');
-import {IHighContrastColors} from './AppThemeTypes';
+import {AppThemeTypes, IHighContrastColors} from './AppThemeTypes';
 
 class AppThemeModule extends MissingNativeEventEmitterShim {
   public isAvailable = false;
-  public currentTheme: 'light' | 'dark' = 'light';
+  public currentTheme: AppThemeTypes = 'light';
   public isHighContrast = false;
   public currentHighContrastColors = {} as IHighContrastColors;
 }

--- a/vnext/src/Libraries/AppTheme/AppTheme.uwp.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.uwp.ts
@@ -14,7 +14,7 @@ const NativeAppTheme = NativeModules.RTCAppTheme;
 class AppThemeModule extends NativeEventEmitter {
   public isAvailable: boolean;
   private _isHighContrast: boolean;
-  private _currentTheme: string;
+  private _currentTheme: 'light' | 'dark';
   private _highContrastColors: IHighContrastColors;
 
   constructor() {
@@ -34,13 +34,13 @@ class AppThemeModule extends NativeEventEmitter {
     this._currentTheme = NativeAppTheme.initialAppTheme;
     this.addListener(
       'appThemeChanged',
-      ({currentTheme}: {currentTheme: string}) => {
+      ({currentTheme}: {currentTheme: 'light' | 'dark'}) => {
         this._currentTheme = currentTheme;
       },
     );
   }
 
-  get currentTheme(): string {
+  get currentTheme(): 'light' | 'dark' {
     return this._currentTheme;
   }
 

--- a/vnext/src/Libraries/AppTheme/AppTheme.uwp.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.uwp.ts
@@ -7,14 +7,18 @@
 
 import {NativeEventEmitter, NativeModules} from 'react-native';
 const MissingNativeEventEmitterShim = require('MissingNativeEventEmitterShim');
-import {IHighContrastColors, IHighContrastChangedEvent} from './AppThemeTypes';
+import {
+  AppThemeTypes,
+  IHighContrastColors,
+  IHighContrastChangedEvent,
+} from './AppThemeTypes';
 
 const NativeAppTheme = NativeModules.RTCAppTheme;
 
 class AppThemeModule extends NativeEventEmitter {
   public isAvailable: boolean;
   private _isHighContrast: boolean;
-  private _currentTheme: 'light' | 'dark';
+  private _currentTheme: AppThemeTypes;
   private _highContrastColors: IHighContrastColors;
 
   constructor() {
@@ -34,13 +38,13 @@ class AppThemeModule extends NativeEventEmitter {
     this._currentTheme = NativeAppTheme.initialAppTheme;
     this.addListener(
       'appThemeChanged',
-      ({currentTheme}: {currentTheme: 'light' | 'dark'}) => {
+      ({currentTheme}: {currentTheme: AppThemeTypes}) => {
         this._currentTheme = currentTheme;
       },
     );
   }
 
-  get currentTheme(): 'light' | 'dark' {
+  get currentTheme(): AppThemeTypes {
     return this._currentTheme;
   }
 

--- a/vnext/src/Libraries/AppTheme/AppThemeTypes.ts
+++ b/vnext/src/Libraries/AppTheme/AppThemeTypes.ts
@@ -16,7 +16,7 @@ export interface IHighContrastColors {
 }
 
 export interface IAppThemeChangedEvent {
-  currentTheme: string;
+  currentTheme: 'light' | 'dark';
 }
 
 export interface IHighContrastChangedEvent {

--- a/vnext/src/Libraries/AppTheme/AppThemeTypes.ts
+++ b/vnext/src/Libraries/AppTheme/AppThemeTypes.ts
@@ -15,8 +15,10 @@ export interface IHighContrastColors {
   WindowTextColor: string;
 }
 
+export type AppThemeTypes = 'light' | 'dark';
+
 export interface IAppThemeChangedEvent {
-  currentTheme: 'light' | 'dark';
+  currentTheme: AppThemeTypes;
 }
 
 export interface IHighContrastChangedEvent {

--- a/vnext/src/RNTester/AccessibilityExample.tsx
+++ b/vnext/src/RNTester/AccessibilityExample.tsx
@@ -12,8 +12,11 @@ import {
   View,
   StyleSheet,
 } from 'react-native';
-import {AppTheme} from '../index.uwp';
-import {IAppThemeChangedEvent} from 'src/Libraries/AppTheme/AppThemeTypes';
+import {
+  AppTheme,
+  IAppThemeChangedEvent,
+  IHighContrastChangedEvent,
+} from '../index.uwp';
 
 class AccessibilityBaseExample extends React.Component {
   public render() {
@@ -54,15 +57,15 @@ class HighContrastExample extends React.Component {
   }
 
   // TODO: Make args props
-  onHighContrastChanged = (_event: IAppThemeChangedEvent) => {
+  onHighContrastChanged = (event: IHighContrastChangedEvent) => {
     this.setState({
-      isHighContrast: AppTheme.isHighContrast,
-      highContrastColorValues: AppTheme.currentHighContrastColors,
+      isHighContrast: event.isHighContrast,
+      highContrastColorValues: event.highContrastColors,
     });
   };
 
-  onAppThemeChanged = (_event: any) => {
-    this.setState({currentTheme: AppTheme.currentTheme});
+  onAppThemeChanged = (event: IAppThemeChangedEvent) => {
+    this.setState({currentTheme: event.currentTheme});
   };
 
   public render() {

--- a/vnext/src/RNTester/ThemingExample.uwp.tsx
+++ b/vnext/src/RNTester/ThemingExample.uwp.tsx
@@ -6,7 +6,7 @@
 
 import React = require('react');
 import {Text, View, Button} from 'react-native';
-import {AppTheme} from '../index.uwp';
+import {AppTheme, IAppThemeChangedEvent} from '../index.uwp';
 
 class ThemeExample extends React.Component {
   state = {
@@ -21,8 +21,8 @@ class ThemeExample extends React.Component {
     AppTheme.removeListener('appThemeChanged', this.onAppThemeChanged);
   }
 
-  onAppThemeChanged = (_event: any) => {
-    const currentTheme = AppTheme.currentTheme;
+  onAppThemeChanged = (event: IAppThemeChangedEvent) => {
+    const currentTheme = event.currentTheme;
     this.setState({currentTheme});
   };
 


### PR DESCRIPTION
some small changes around AppTheme I noticed while integrating it into our app.

currentTheme exposed as a string, updated that the type will always be 'light' or 'dark'.
fixed the examples to take the right types/don't use any.  It was unclear if we want the examples to read the apptheme or read the event props - are we guaranteed the apptheme getter will have been notified first so that is safe?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2910)