### PR TITLE
Update to react-native@0.59.0-microsoft.40

### DIFF
--- a/change/react-native-windows-2019-08-09-05-59-55-auto-update-versions059.0microsoft.40.json
+++ b/change/react-native-windows-2019-08-09-05-59-55-auto-update-versions059.0microsoft.40.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.40",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "3b4a0f3fb87bf853a28904f98f934f0f68d6ed2a",
+  "date": "2019-08-09T05:59:55.555Z"
+}

--- a/change/react-native-windows-extended-2019-08-09-05-59-56-auto-update-versions059.0microsoft.40.json
+++ b/change/react-native-windows-extended-2019-08-09-05-59-56-auto-update-versions059.0microsoft.40.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.40",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "8936ee1519492000f358ac29b12adf4efd3a7108",
+  "date": "2019-08-09T05:59:56.588Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz",
     "react-native-windows": "0.59.0-vnext.130",
     "react-native-windows-extended": "0.9.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.38 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.38 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
2c2ac65b9 Applying package update to 0.59.0-microsoft.40
50dd558c7 Rojain/droidnuget (#135)
1512d0f65 Applying package update to 0.59.0-microsoft.39
0785bf81b Replace unique_ptrs in ScriptStore.h with shared_ptrs. (#132)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2911)