### PR TITLE
Update UwpPreparedScriptStore to use shared_ptrs

### DIFF
--- a/change/react-native-windows-2019-08-09-12-02-28-scriptstorefixes.json
+++ b/change/react-native-windows-2019-08-09-12-02-28-scriptstorefixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update UwpPreparedScriptStore to use shared_ptrs",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "commit": "3e295a75c08380a6ce80a9672f14b98da3b68078",
+  "date": "2019-08-09T19:02:28.458Z"
+}

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
@@ -26,7 +26,7 @@ UwpPreparedScriptStore::UwpPreparedScriptStore(winrt::hstring uri) {
   }
 }
 
-std::unique_ptr<const facebook::jsi::Buffer>
+std::shared_ptr<const facebook::jsi::Buffer>
 UwpPreparedScriptStore::tryGetPreparedScript(
     const facebook::jsi::ScriptSignature &scriptSignature,
     const facebook::jsi::JSRuntimeSignature &runtimeSignature,

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
@@ -43,7 +43,7 @@ UwpPreparedScriptStore::tryGetPreparedScript(
     }
 
     auto buffer = winrt::FileIO::ReadBufferAsync(byteCodeFile).get();
-    auto bytecodeBuffer(std::make_unique<ByteCodeBuffer>(buffer.Length()));
+    auto bytecodeBuffer(std::make_shared<ByteCodeBuffer>(buffer.Length()));
     auto dataReader{winrt::Streams::DataReader::FromBuffer(buffer)};
     dataReader.ReadBytes(winrt::array_view<uint8_t>{
         &bytecodeBuffer->data()[0],

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.h
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.h
@@ -12,7 +12,7 @@ namespace uwp {
 class UwpPreparedScriptStore : public facebook::jsi::PreparedScriptStore {
  public:
   UwpPreparedScriptStore(winrt::hstring uri);
-  std::unique_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
+  std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
       const facebook::jsi::ScriptSignature &scriptSignature,
       const facebook::jsi::JSRuntimeSignature &runtimeSignature,
       const char

--- a/yarn.lock
+++ b/yarn.lock
@@ -7595,10 +7595,10 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz":
-  version "0.59.0-microsoft.38"
-  uid "0cfaae1930485d53800e3891000263dbc1b78df3"
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.38.tar.gz#0cfaae1930485d53800e3891000263dbc1b78df3"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz":
+  version "0.59.0-microsoft.40"
+  uid "9842f0e4d47cbb66631536e90e124b694bcd80ce"
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz#9842f0e4d47cbb66631536e90e124b694bcd80ce"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
Fixing the break introduced by this PR: https://github.com/microsoft/react-native/pull/132

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2917)