### PR TITLE
Update to react-native@0.59.0-microsoft.41

### DIFF
--- a/change/react-native-windows-2019-08-10-19-34-13-auto-update-versions059.0microsoft.41.json
+++ b/change/react-native-windows-2019-08-10-19-34-13-auto-update-versions059.0microsoft.41.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.41",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "0a2407117ab0b7f28ad90d23ce1b498f0e5a47cd",
+  "date": "2019-08-10T19:34:13.165Z"
+}

--- a/change/react-native-windows-extended-2019-08-10-19-34-14-auto-update-versions059.0microsoft.41.json
+++ b/change/react-native-windows-extended-2019-08-10-19-34-14-auto-update-versions059.0microsoft.41.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.41",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "bbc886506efed9521835fd56721bac674d4dc12d",
+  "date": "2019-08-10T19:34:14.802Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz",
     "react-native-windows": "0.59.0-vnext.134",
     "react-native-windows-extended": "0.10.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.41 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.40.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.41 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
456718032 Applying package update to 0.59.0-microsoft.41
1b8721792 apple: fix timing issue crash in executeApplicationScript (#134)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2919)