### PR TITLE
Update to react-native@0.59.0-microsoft.42

### DIFF
--- a/change/react-native-windows-2019-08-12-18-55-52-auto-update-versions059.0microsoft.42.json
+++ b/change/react-native-windows-2019-08-12-18-55-52-auto-update-versions059.0microsoft.42.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.42",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "273785b7bacea929236c77210ad102455b8d17b5",
+  "date": "2019-08-12T18:55:52.386Z"
+}

--- a/change/react-native-windows-extended-2019-08-12-18-55-54-auto-update-versions059.0microsoft.42.json
+++ b/change/react-native-windows-extended-2019-08-12-18-55-54-auto-update-versions059.0microsoft.42.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.42",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "c25f5033cd967947742bc8f9f76a21a270b25568",
+  "date": "2019-08-12T18:55:54.362Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz",
     "react-native-windows": "0.59.0-vnext.135",
     "react-native-windows-extended": "0.11.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.41 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.42 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -55,12 +55,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.41 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.41.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.42 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
349719e51 Applying package update to 0.59.0-microsoft.42
d414abf04 Changing the signature of this method to match its counterpart on Fac… (#133)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2923)