### PR TITLE
Update to react-native@0.59.0-microsoft.43

### DIFF
--- a/change/react-native-windows-2019-08-13-00-47-14-auto-update-versions059.0microsoft.43.json
+++ b/change/react-native-windows-2019-08-13-00-47-14-auto-update-versions059.0microsoft.43.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.43",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "de0e7ae1f8bf55738f01daeea2eb6e490b2fcbbd",
+  "date": "2019-08-13T00:47:14.334Z"
+}

--- a/change/react-native-windows-extended-2019-08-13-00-47-16-auto-update-versions059.0microsoft.43.json
+++ b/change/react-native-windows-extended-2019-08-13-00-47-16-auto-update-versions059.0microsoft.43.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.43",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "f5dfae49beb8cc69a0e0853155227a9ecaa2296c",
+  "date": "2019-08-13T00:47:16.260Z"
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
     "react-native-windows": "0.59.0-vnext.138",
     "react-native-windows-extended": "0.12.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.42 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -58,12 +58,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
     "typescript": "3.5.1"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.42 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
c7c4e265c Applying package update to 0.59.0-microsoft.43
bb62f8a00 Reduce differences between our folly and facebook folly (#138)
adc492dd8 Remove some final uses of uwp (#137)
bed45253b remove accessibility props that are no longer valid. (#136)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2924)