### PR TITLE
Update Flyout Placement Mapping For Pre-RS5

### DIFF
--- a/change/react-native-windows-2019-08-13-12-59-23-cknestri-UpdatePlacementMapping.json
+++ b/change/react-native-windows-2019-08-13-12-59-23-cknestri-UpdatePlacementMapping.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update placement mapping",
+  "packageName": "react-native-windows",
+  "email": "cknestri@microsoft.com",
+  "commit": "bb7d84a80d835eb96c3e107836ef748648e9f717",
+  "date": "2019-08-13T19:59:23.504Z"
+}

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -18,19 +18,20 @@ using namespace Windows::UI::Xaml::Interop;
 } // namespace winrt
 
 static const std::unordered_map<std::string, winrt::FlyoutPlacementMode>
-    placementModeMinVersion = {{"top", winrt::FlyoutPlacementMode::Top},
-                               {"top-edge-aligned-left", winrt::FlyoutPlacementMode::Top},
-                               {"top-edge-aligned-right", winrt::FlyoutPlacementMode::Top},
-                               {"bottom", winrt::FlyoutPlacementMode::Bottom},
-                               {"bottom-edge-aligned-left", winrt::FlyoutPlacementMode::Bottom},
-                               {"bottom-edge-aligned-right", winrt::FlyoutPlacementMode::Bottom},
-                               {"left", winrt::FlyoutPlacementMode::Left},
-                               {"left-edge-aligned-top", winrt::FlyoutPlacementMode::Left},
-                               {"left-edge-aligned-bottom", winrt::FlyoutPlacementMode::Left},
-                               {"right", winrt::FlyoutPlacementMode::Right},
-                               {"right-edge-aligned-top", winrt::FlyoutPlacementMode::Right},
-                               {"right-edge-aligned-bottom", winrt::FlyoutPlacementMode::Right},
-                               {"full", winrt::FlyoutPlacementMode::Full}};
+    placementModeMinVersion = {
+        {"top", winrt::FlyoutPlacementMode::Top},
+        {"top-edge-aligned-left", winrt::FlyoutPlacementMode::Top},
+        {"top-edge-aligned-right", winrt::FlyoutPlacementMode::Top},
+        {"bottom", winrt::FlyoutPlacementMode::Bottom},
+        {"bottom-edge-aligned-left", winrt::FlyoutPlacementMode::Bottom},
+        {"bottom-edge-aligned-right", winrt::FlyoutPlacementMode::Bottom},
+        {"left", winrt::FlyoutPlacementMode::Left},
+        {"left-edge-aligned-top", winrt::FlyoutPlacementMode::Left},
+        {"left-edge-aligned-bottom", winrt::FlyoutPlacementMode::Left},
+        {"right", winrt::FlyoutPlacementMode::Right},
+        {"right-edge-aligned-top", winrt::FlyoutPlacementMode::Right},
+        {"right-edge-aligned-bottom", winrt::FlyoutPlacementMode::Right},
+        {"full", winrt::FlyoutPlacementMode::Full}};
 
 static const std::unordered_map<std::string, winrt::FlyoutPlacementMode>
     placementModeRS5 = {{"top", winrt::FlyoutPlacementMode::Top},

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -19,9 +19,17 @@ using namespace Windows::UI::Xaml::Interop;
 
 static const std::unordered_map<std::string, winrt::FlyoutPlacementMode>
     placementModeMinVersion = {{"top", winrt::FlyoutPlacementMode::Top},
+                               {"top-edge-aligned-left", winrt::FlyoutPlacementMode::Top},
+                               {"top-edge-aligned-right", winrt::FlyoutPlacementMode::Top},
                                {"bottom", winrt::FlyoutPlacementMode::Bottom},
+                               {"bottom-edge-aligned-left", winrt::FlyoutPlacementMode::Bottom},
+                               {"bottom-edge-aligned-right", winrt::FlyoutPlacementMode::Bottom},
                                {"left", winrt::FlyoutPlacementMode::Left},
+                               {"left-edge-aligned-top", winrt::FlyoutPlacementMode::Left},
+                               {"left-edge-aligned-bottom", winrt::FlyoutPlacementMode::Left},
                                {"right", winrt::FlyoutPlacementMode::Right},
+                               {"right-edge-aligned-top", winrt::FlyoutPlacementMode::Right},
+                               {"right-edge-aligned-bottom", winrt::FlyoutPlacementMode::Right},
                                {"full", winrt::FlyoutPlacementMode::Full}};
 
 static const std::unordered_map<std::string, winrt::FlyoutPlacementMode>


### PR DESCRIPTION
The Flyout control on pre-RS5 only supports placement of "top", "bottom", "right", "left" and "full".  If the caller tries to set something not supported - like "top-edge-aligned-left" - it simply sets a default placement of "right".  This change allows us to provide a slightly better experience and simply convert the placement type to the closest primary placement position.  For example, if attempting to set "top-edge-aligned-left", it will ignore the "left" portion  of the placement and instead use "top".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2925)