### PR TITLE
 Change windows template to not use cli wrapper

### DIFF
--- a/change/react-native-windows-2019-08-13-12-04-16-nocustomcli.json
+++ b/change/react-native-windows-2019-08-13-12-04-16-nocustomcli.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Change windows template to not use cli wrapper",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "6c3e9c7990947949d7b9bdcfa11c76833c3cc6c3",
+  "date": "2019-08-13T19:04:15.977Z"
+}

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -121,7 +121,7 @@ function installDependencies(options) {
   // Patch package.json to have proper react-native version and install
   const projectPackageJsonPath = path.join(cwd, 'package.json');
   const projectPackageJson = JSON.parse(fs.readFileSync(projectPackageJsonPath, { encoding: 'UTF8' }));
-  projectPackageJson.scripts.start = 'node node_modules/react-native-windows/Scripts/cli.js start';
+  projectPackageJson.scripts.start = 'react-native start';
   projectPackageJson.dependencies['react-native'] = reactNativeVersion;
   fs.writeFileSync(projectPackageJsonPath, JSON.stringify(projectPackageJson, null, 2));
 


### PR DESCRIPTION
The cli.js script just forwards on to normal react-native now.

So we should just have the start command match a normal non-windows project.

### Result:
`yarn start` will now just call `react-native start`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2926)