### PR TITLE
Flyout shadow fix2

### DIFF
--- a/change/react-native-windows-2019-08-15-13-06-30-flyout-shadow-fix2.json
+++ b/change/react-native-windows-2019-08-15-13-06-30-flyout-shadow-fix2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Improved fix for overlapping XAML theme shadows on Flyouts",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "98aea907b03f8b75d57924352a0e015a24a97d79",
+  "date": "2019-08-15T20:06:30.738Z"
+}

--- a/change/react-native-windows-extended-2019-08-15-13-06-30-flyout-shadow-fix2.json
+++ b/change/react-native-windows-extended-2019-08-15-13-06-30-flyout-shadow-fix2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Improved fix for overlapping XAML theme shadows on Flyouts",
+  "packageName": "react-native-windows-extended",
+  "email": "kenander@microsoft.com",
+  "commit": "98aea907b03f8b75d57924352a0e015a24a97d79",
+  "date": "2019-08-15T20:06:05.010Z"
+}

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -90,6 +90,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
  private:
   void SetTargetFrameworkElement();
   winrt::Popup GetFlyoutParentPopup() const;
+  winrt::FlyoutPresenter GetFlyoutPresenter() const;
 
   winrt::FrameworkElement m_targetElement = nullptr;
   winrt::Flyout m_flyout = nullptr;
@@ -101,6 +102,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   bool m_isFlyoutShowOptionsSupported = false;
   winrt::FlyoutShowOptions m_showOptions = nullptr;
   static thread_local std::int32_t s_cOpenFlyouts;
+  std::int32_t m_elevation = 0;
 
   std::unique_ptr<TouchEventHandler> m_touchEventHanadler;
   std::unique_ptr<PreviewKeyboardEventHandlerOnRoot>
@@ -109,6 +111,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   winrt::Flyout::Closing_revoker m_flyoutClosingRevoker{};
   winrt::Flyout::Closed_revoker m_flyoutClosedRevoker{};
   int64_t m_tokenContentPropertyChangeCallback;
+  winrt::Flyout::Opened_revoker m_flyoutOpenedRevoker{};
 };
 
 thread_local std::int32_t FlyoutShadowNode::s_cOpenFlyouts = 0;
@@ -194,6 +197,26 @@ void FlyoutShadowNode::createView() {
             }
           });
 
+  // When multiple flyouts are overlapping, XAML's theme shadows don't render
+  // properly. As a workaround we enable a z-index translation based on an 
+  // elevation derived from the count of open flyouts. We apply this
+  // translation on open of the flyout.
+  // (Translation is only supported on RS5+)
+  if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
+    m_flyoutOpenedRevoker =
+        m_flyout.Opened(winrt::auto_revoke, [=](auto &&, auto &&) {
+          auto instance = wkinstance.lock();
+
+          if (!m_updating && instance != nullptr && m_elevation > 0) {
+            if (auto flyoutPresenter = GetFlyoutPresenter()) {
+              winrt::Numerics::float3 translation{
+                  0, 0, (float)32 * m_elevation};
+              flyoutPresenter.Translation(translation);
+            }
+          }
+        });
+  }
+  
   // Set XamlRoot on the Flyout to handle XamlIsland/AppWindow scenarios.
   if (auto flyoutBase6 = m_flyout.try_as<winrt::IFlyoutBase6>()) {
     if (auto instance = wkinstance.lock()) {
@@ -293,6 +316,7 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic &&props) {
   if (updateIsOpen) {
     if (m_isOpen) {
       s_cOpenFlyouts += 1;
+      m_elevation = s_cOpenFlyouts - 1;
       AdjustDefaultFlyoutStyle(50000, 50000);
       if (m_isFlyoutShowOptionsSupported) {
         m_flyout.ShowAt(m_targetElement, m_showOptions);
@@ -362,21 +386,6 @@ void FlyoutShadowNode::AdjustDefaultFlyoutStyle(
   flyoutStyle.Setters().Append(winrt::Setter(
       winrt::Control::BackgroundProperty(),
       winrt::box_value<winrt::SolidColorBrush>(winrt::Colors::Transparent())));
-
-  // When multiple flyouts are overlapping, XAML's theme shadows don't render
-  // properly. As a workaround (temporary) we disable shadows when multiple
-  // flyouts are open.
-  if (s_cOpenFlyouts > 1) {
-    static bool isDisableShadowsSupported =
-        winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
-            L"Windows.UI.Xaml.Controls.FlyoutPresenter",
-            L"IsDefaultShadowEnabled");
-    if (isDisableShadowsSupported) {
-      flyoutStyle.Setters().Append(winrt::Setter(
-          winrt::FlyoutPresenter::IsDefaultShadowEnabledProperty(),
-          winrt::box_value(false)));
-    }
-  }
   m_flyout.FlyoutPresenterStyle(flyoutStyle);
 }
 
@@ -390,9 +399,27 @@ winrt::Popup FlyoutShadowNode::GetFlyoutParentPopup() const {
   return nullptr;
 }
 
+winrt::FlyoutPresenter FlyoutShadowNode::GetFlyoutPresenter() const {
+  if (m_flyout == nullptr || m_flyout.Content() == nullptr)
+    return nullptr;
+
+  auto parent = winrt::VisualTreeHelper::GetParent(m_flyout.Content());
+  if (parent == nullptr)
+    return nullptr;
+
+  auto scope = parent.try_as<winrt::FlyoutPresenter>();
+  while (parent != nullptr && scope == nullptr) {
+    parent = winrt::VisualTreeHelper::GetParent(parent);
+    scope = parent.try_as<winrt::FlyoutPresenter>();
+  }
+
+  return scope;
+}
+
 FlyoutViewManager::FlyoutViewManager(
     const std::shared_ptr<IReactInstance> &reactInstance)
-    : Super(reactInstance) {}
+    : Super(reactInstance) {
+}
 
 const char *FlyoutViewManager::GetName() const {
   return "RCTFlyout";

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -198,7 +198,7 @@ void FlyoutShadowNode::createView() {
           });
 
   // When multiple flyouts are overlapping, XAML's theme shadows don't render
-  // properly. As a workaround we enable a z-index translation based on an 
+  // properly. As a workaround we enable a z-index translation based on an
   // elevation derived from the count of open flyouts. We apply this
   // translation on open of the flyout.
   // (Translation is only supported on RS5+)
@@ -216,7 +216,7 @@ void FlyoutShadowNode::createView() {
           }
         });
   }
-  
+
   // Set XamlRoot on the Flyout to handle XamlIsland/AppWindow scenarios.
   if (auto flyoutBase6 = m_flyout.try_as<winrt::IFlyoutBase6>()) {
     if (auto instance = wkinstance.lock()) {
@@ -418,8 +418,7 @@ winrt::FlyoutPresenter FlyoutShadowNode::GetFlyoutPresenter() const {
 
 FlyoutViewManager::FlyoutViewManager(
     const std::shared_ptr<IReactInstance> &reactInstance)
-    : Super(reactInstance) {
-}
+    : Super(reactInstance) {}
 
 const char *FlyoutViewManager::GetName() const {
   return "RCTFlyout";


### PR DESCRIPTION
This is an improved fix for the overlapping shadow rendering problem previously fixed by  
https://github.com/microsoft/react-native-windows/pull/2733

Rather than disabling the theme shadows completely once multiple flyouts are open, we instead apply an elevation translation to the FlyoutPresenter derived from the count of open flyouts. This allows the theme shadows to remain in their original state while no longer exhibiting the weird background.
(WI: 3485699)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2933)