### PR TITLE
Update to latest folly - and stop using forked folly

### DIFF
--- a/change/react-native-windows-2019-08-15-11-19-01-upfolly.json
+++ b/change/react-native-windows-2019-08-15-11-19-01-upfolly.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Always use unforked version of folly + Update folly to v2019.08.12.00",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "e7555cae73f86d0b67c378eada98129726b4fe33",
+  "date": "2019-08-15T18:19:01.132Z"
+}

--- a/vnext/Desktop/msoFolly.h
+++ b/vnext/Desktop/msoFolly.h
@@ -28,6 +28,7 @@
 #undef min
 #undef OUT
 #undef IN
+#define FOLLY_MOBILE 1
 #include <folly/dynamic.h>
 #pragma pop_macro("IN")
 #pragma pop_macro("OUT")

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -248,7 +248,7 @@
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4146;4251;4800;4804;4305;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4146;4251;4800;4804;4305;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -269,15 +269,15 @@
     <Error Condition="!Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
   </Target>
   <Target Name="DownloadFollyIfNotUseMicrosoftReactNative" BeforeTargets="PrepareForBuild">
-    <Warning Text="Folly required to build without microsoft/react-native. - Downloading folly..." Condition="'$(OSS_RN)'=='true' AND !Exists('$(FollyDir)..\.follyzip\folly-2019.06.10.00.zip')" />
-    <DownloadFile Condition="'$(OSS_RN)'=='true' AND !Exists('$(FollyDir)..\.follyzip\folly-2019.06.10.00.zip')" SourceUrl="https://github.com/facebook/folly/archive/v2019.06.10.00.zip" DestinationFolder="$(FollyDir)..\.follyzip" />
+    <Warning Text="Folly required to build without microsoft/react-native. - Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.08.12.00.zip')" />
+    <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.08.12.00.zip')" SourceUrl="https://github.com/facebook/folly/archive/v2019.08.12.00.zip" DestinationFolder="$(FollyDir)..\.follyzip" />
   </Target>
   <Target Name="UnzipFollyIfNotUseMicrosoftReactNative" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFollyIfNotUseMicrosoftReactNative">
-    <Warning Text="Folly required to build without microsoft/react-native. - Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="'$(OSS_RN)'=='true' AND !Exists('$(FollyDir)folly\dynamic.h')" />
+    <Warning Text="Folly required to build without microsoft/react-native. - Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
     <!-- Using ContinueOnError due to https://github.com/Microsoft/msbuild/issues/3884, unzip seems to have completed dispite errors -->
-    <Unzip Condition="'$(OSS_RN)'=='true' AND !Exists('$(FollyDir)')" ContinueOnError="true" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.06.10.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
+    <Unzip Condition="!Exists('$(FollyDir)')" ContinueOnError="true" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.08.12.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
   </Target>
   <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
-    <Error Condition="'$(OSS_RN)'!='true' AND !Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
+    <Error Condition="!Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
   </Target>
 </Project>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -235,11 +235,6 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props"/>
-  <ItemDefinitionGroup Condition="'$(OSS_RN)'=='true'">
-    <ClCompile>
-      <DisableSpecificWarnings>4018;4244;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -248,7 +243,7 @@
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4018;4146;4251;4800;4804;4305;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4146;4244;4251;4267;4800;4804;4305;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -243,7 +243,7 @@
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4018;4146;4244;4251;4267;4800;4804;4305;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4146;4244;4251;4267;4293;4305;4800;4804;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/vnext/FollyWin32/FollyWin32.vcxproj
+++ b/vnext/FollyWin32/FollyWin32.vcxproj
@@ -55,6 +55,7 @@
       </PrecompiledHeader>
       <PreprocessorDefinitions>_HAS_AUTO_PTR_ETC=1;FOLLY_NO_CONFIG;NOMINMAX;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(FollyDir)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4293;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\ReactCommunity.Cpp.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>

--- a/vnext/PropertySheets/ReactPackageDirectories.props
+++ b/vnext/PropertySheets/ReactPackageDirectories.props
@@ -19,11 +19,11 @@
 
   <PropertyGroup Condition="!Exists('$(ReactNativeDir)\stubs\glog\logging.h')">
     <OSS_RN>true</OSS_RN>
-    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-2019.06.10.00</FollyDir>
+    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-2019.08.12.00</FollyDir>
   </PropertyGroup>
 
   <PropertyGroup Condition="Exists('$(ReactNativeDir)\stubs\glog\logging.h')">
-    <FollyDir Condition="'$(FollyDir)' == ''">$(ReactNativeDir)\folly\</FollyDir>
+    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-2019.08.12.00</FollyDir>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -5,8 +5,6 @@ EXPORTS
 ??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0TypeError@folly@@QEAA@AEBU01@@Z
 ??0TypeError@folly@@QEAA@$$QEAU01@@Z
-?asanPendingSafeInserts@detail@f14@folly@@3_KA
-?asanRehashState@detail@f14@folly@@3_KA
 ?logTaggedMarker@ReactMarker@react@facebook@@3P6AXW4ReactMarkerId@123@PEBD@ZEA
 ?get_ptr@dynamic@folly@@QEGBAPEBU12@V?$Range@PEBD@2@@Z
 ?destroy@dynamic@folly@@AEAAXXZ

--- a/vnext/layoutFilesForNuget.bat
+++ b/vnext/layoutFilesForNuget.bat
@@ -15,6 +15,7 @@ set SRCROOT=%~dp0
 :: Remove trailing \ from srcroot
 IF %SRCROOT:~-1%==\ SET SRCROOT=%SRCROOT:~0,-1%
 set RNROOT=%~dp0..\node_modules\react-native
+set FOLLYROOT=%~dp0..\node_modules\.folly\folly-2019.08.12.00
 
 echo Source root: %SRCROOT%
 echo Dest root: %DESTROOT%
@@ -51,7 +52,7 @@ mkdir %DESTROOT%\inc\ReactUWP >nul 2>&1
 
 %COPYCMD%  %RNROOT%\ReactCommon\Yoga\Yoga\*.h                             %DESTROOT%\inc\yoga
 
-%COPYCMD%  %RNROOT%\Folly                                                 %DESTROOT%\inc\Folly
+%COPYCMD%  %FOLLYROOT%                                                    %DESTROOT%\inc\Folly
 %COPYCMD%  %RNROOT%\ReactCommon\jsi                                       %DESTROOT%\inc\jsi
 %COPYCMD%  %SRCROOT%\stubs                                                %DESTROOT%\inc\stubs
 %COPYCMD%  %SRCROOT%\Desktop\*.h                                          %DESTROOT%\inc\ReactWin32

--- a/yarn.lock
+++ b/yarn.lock
@@ -7632,10 +7632,10 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz":
-  version "0.59.0-microsoft.42"
-  uid "053d931ad633c689d80ec332e4580521beee979f"
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.42.tar.gz#053d931ad633c689d80ec332e4580521beee979f"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz":
+  version "0.59.0-microsoft.43"
+  uid "1f1287774e85b2db033491bc8b245049203187ad"
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz#1f1287774e85b2db033491bc8b245049203187ad"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
There are no outstanding reasons we need a fork of folly on windows.

This removes the usage of the forked version of folly, and bumps the version to latest.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2938)