### PR TITLE
restore accidental delete

### DIFF
--- a/change/react-native-windows-2019-08-15-18-57-52-master.json
+++ b/change/react-native-windows-2019-08-15-18-57-52-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "restore accidental deletion",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "commit": "3b9f508518f7a3ea39c379c6ab8c4b31e571b499",
+  "date": "2019-08-16T01:57:52.030Z"
+}

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -1016,6 +1016,12 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
   if (shadowNode == nullptr)
     return;
 
+  if (shadowNode->IsExternalLayoutDirty()) {
+    YGNodeRef yogaNode = GetYogaNode(tag);
+    if (yogaNode)
+      shadowNode->DoExtraLayoutPrep(yogaNode);
+  }
+
   for (int64_t child : shadowNode->m_children) {
     UpdateExtraLayout(child);
   }


### PR DESCRIPTION
This change:
https://github.com/microsoft/react-native-windows/pull/2859
accidentally deleted a bit of code that runs DoExtraLayoutPrep().

This change restores that bit of code.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2942)