### PR TITLE
Playground solution failed to build first time

### DIFF
--- a/.ado/setRNVersion.js
+++ b/.ado/setRNVersion.js
@@ -34,7 +34,7 @@ if (process.argv.length === 4) {
 
     // Generate change file
     const beachballPath = path.resolve(rootPath, 'node_modules/beachball/bin/beachball.js');
-    const changeType = pkgJson.name === 'react-native-windows' ? 'prerelease' : 'minor';
+    const changeType = pkgJson.name === 'react-native-windows' ? 'prerelease' : 'patch';
     const changeDescription = `"Updating react-native to version: ${rnVersion}"`;
     child_process.execSync(`node ${beachballPath} change --package ${pkgJson.name} --type ${changeType} --message ${changeDescription}`);
   }

--- a/change/react-native-windows-extended-2019-08-16-18-25-17-rnwefirst.json
+++ b/change/react-native-windows-extended-2019-08-16-18-25-17-rnwefirst.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure folly is downloaded before react-native-windows-extended builds",
+  "packageName": "react-native-windows-extended",
+  "email": "acoates@microsoft.com",
+  "commit": "95216a199075a15cf10e92522a05e1a8091b4e52",
+  "date": "2019-08-17T01:25:17.595Z"
+}

--- a/packages/react-native-windows-extended/windows/react-native-windows-extended.vcxproj
+++ b/packages/react-native-windows-extended/windows/react-native-windows-extended.vcxproj
@@ -93,6 +93,11 @@
     </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="$(ReactNativeWindowsDir)\Folly\Folly.vcxproj">
+      <Project>{a990658c-ce31-4bcc-976f-0fc6b1af693d}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>


### PR DESCRIPTION
Playground depends on `react-native-windows-extended`, which uses folly.

The first time you build, `react-native-windows-extended` fails to find some folly headers because it hasn't been downloaded yet.

The second time you build it succeeds, because the `ReactUWP` project depends on folly and that build will download the headers.

The fix is to have `react-native-windows-extended` properly declare that folly needs to be built first.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2946)