### PR TITLE
Add ChakraCore to JSIEngineOverride.

### DIFF
--- a/change/react-native-windows-2019-08-19-14-08-46-EditJSIEngineOverride.json
+++ b/change/react-native-windows-2019-08-19-14-08-46-EditJSIEngineOverride.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add ChakraCore to JSIEngineOverride.",
+  "packageName": "react-native-windows",
+  "email": "yicyao@microsoft.com",
+  "commit": "f136c3e3ee4557df3fe8fe3b203e02f13b971a5e",
+  "date": "2019-08-19T21:08:46.591Z"
+}

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -37,9 +37,10 @@ struct JSExceptionInfo {
 enum class JSIEngineOverride : int32_t {
   Default = 0, // No JSI, will use the legacy ExecutorFactory
   Chakra = 1, // Use the JSIExecutorFactory with ChakraRuntime
-  Hermes = 2, // Use the JSIExecutorFactory with Hermes
-  V8 = 3, // Use the JSIExecutorFactory with V8
-  V8Lite = 4, // Use the JSIExecutorFactory with V8Lite
+  ChakraCore = 2, // Use the JSIExecutorFactory with ChakraCoreRuntime
+  Hermes = 3, // Use the JSIExecutorFactory with Hermes
+  V8 = 4, // Use the JSIExecutorFactory with V8
+  V8Lite = 5, // Use the JSIExecutorFactory with V8Lite
 
   Last = V8Lite
 };

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -447,6 +447,7 @@ InstanceImpl::InstanceImpl(
           assert(false); // Hermes is not available in this build, fallthrough
 #endif
         case JSIEngineOverride::Chakra:
+        case JSIEngineOverride::ChakraCore:
         default: // TODO: Add other engines once supported
           m_devSettings->jsiRuntimeHolder =
               std::make_shared<ChakraJSIRuntimeHolder>(


### PR DESCRIPTION
Currently, whether Chakra or ChakraCore is used for ChakraJsiRuntime is controlled by a compiled time flag. We will be separating them into two separated Runtimes. Add another value to JSIEngineOverride to prepare for this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2955)