### PR TITLE
Initial github action workflow for CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,30 +6,7 @@ jobs:
   one:
     runs-on: ubuntu-16.04
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-        run: echo "$STRATEGY_CONTEXT"
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump runner context
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-        run: echo "$RUNNER_CONTEXT"
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJson(steps) }}
-        run: echo "$STEPS_CONTEXT"
+
 
 
   UWPPR:
@@ -53,30 +30,55 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - name: Switch to fork
-      if: ${{ matrix.UseRNFork }} == 'false'
-      run: node scripts/useUnForkedRN.js
-      working-directory: vnext
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump strategy context
+      env:
+        STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+      run: echo "$STRATEGY_CONTEXT"
+    - name: Dump matrix context
+      env:
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      run: echo "$MATRIX_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump runner context
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump steps context
+      env:
+        STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    
+    #- name: Switch to fork
+    #  if: ${{ matrix.UseRNFork }} == 'false'
+    #  run: node scripts/useUnForkedRN.js
+    #  working-directory: vnext
       
-    - name: yarn install (Using microsoft/react-native)
-      if: ${{ matrix.UseRNFork }} == 'true'
-      run: yarn install --frozen-lockfile
+    #- name: yarn install (Using microsoft/react-native)
+    #  if: ${{ matrix.UseRNFork }} == 'true'
+    #  run: yarn install --frozen-lockfile
       
       # We can't use a frozen lockfile for both the fork and non-fork, since they install different dependencies
       # We don't want to force devs to update/create two lock files on every change, so just don't freeze when
       # using the non fork version.
-    - name: yarn install (Using facebook/react-native)
-      if: ${{ matrix.UseRNFork }} == 'false'
-      run: yarn install
+    #- name: yarn install (Using facebook/react-native)
+    #  if: ${{ matrix.UseRNFork }} == 'false'
+    #  run: yarn install
       
-    - run: yarn buildci
+    #- run: yarn buildci
      
-    - name: Install SDK
-      run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
-      shell: powershell
+    #- name: Install SDK
+    #  run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
+    #  shell: powershell
         
-    - name: NuGet restore
-      run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
+    #- name: NuGet restore
+    #  run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
       
     #- name: Build ReactWindows-UWP.sln
     #  run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,19 +25,19 @@ jobs:
     - uses: actions/checkout@v1
     
     - name: Switch to fork
-      if: ${{matrix.UseRNFork}} == 'false'
+      if: ${{ matrix.UseRNFork }} == 'false'
       run: node scripts/useUnForkedRN.js
       working-directory: vnext
       
     - name: yarn install (Using microsoft/react-native)
-      if: ${{matrix.UseRNFork}} == 'true'
+      if: ${{ matrix.UseRNFork }} == 'true'
       run: yarn install --frozen-lockfile
       
       # We can't use a frozen lockfile for both the fork and non-fork, since they install different dependencies
       # We don't want to force devs to update/create two lock files on every change, so just don't freeze when
       # using the non fork version.
     - name: yarn install (Using facebook/react-native)
-      if: ${{matrix.UseRNFork}} == 'false'
+      if: ${{ matrix.UseRNFork }} == 'false'
       run: yarn install
       
     - run: yarn buildci
@@ -50,4 +50,4 @@ jobs:
       run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
       
     - name: Build ReactWindows-UWP.sln
-      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="${{matrix.BuildPlatform}}" /p:configuration="${{matrix.BuildConfiguration}}"
+      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="${{ matrix.BuildPlatform }}" /p:configuration="${{ matrix.BuildConfiguration }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,12 +3,6 @@ name: CI
 on: [check_run]
 
 jobs:
-  one:
-    runs-on: ubuntu-16.04
-    steps:
-
-
-
   UWPPR:
     name: UWP PR
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,8 +78,8 @@ jobs:
     - name: NuGet restore
       run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
       
-    - name: Build ReactWindows-UWP.sln
-      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
-      env:
-        BUILDPLATFORM: ${{ matrix.BuildPlatform }}
-        BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
+    #- name: Build ReactWindows-UWP.sln
+    #  run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+    #  env:
+    #    BUILDPLATFORM: ${{ matrix.BuildPlatform }}
+    #    BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,96 @@ jobs:
     - name: Create Playground bundle
       run: cd packages\playground && node node_modules/react-native/local-cli/cli.js bundle --entry-file Samples\index.tsx --bundle-output Playground.bundle
         
+    # todo work out how to specify working-directory for run command
     - name: Create RNTester bundle
     #  if: ${{ matrix.UseRNFork }} == 'true'
       run: cd vnext && node ../node_modules/react-native/local-cli/cli.js bundle --entry-file .\RNTester.js --bundle-output RNTester.windows.bundle --platform windows
         
+
+  CliInit:
+    name: Verify react-native init
+
+    runs-on: windows-2016
+
+    steps:
+      - uses: actions/checkout@v1
+            
+      - name: yarn install (local react-native-windows)
+        run: yarn install --frozen-lockfile
+      
+    # todo work out how to specify working-directory for run command
+      - name: yarn build (local react-native-windows)
+        run: cd vnext && yarn build
+
+    # yarn ends up copying the whole node_modules folder when doing an install of a file package
+    # Delete node_modules, so that resolution is more like when installing from a published npm package
+      - name: Remove node_modules
+        run: cd vnext && rd /S /Q node_modules
+
+      - name:Install react-native cli
+        run: npm install -g react-native-cli
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+
+
+
+
+
+     # - task: CmdLine@2
+     #   displayName: Init new project
+     #   inputs:
+     #     script: react-native init testcli --version 0.59.10
+     #     workingDirectory: $(Agent.BuildDirectory)
+
+     # - task: CmdLine@2
+     #   displayName: Install rnpm-plugin-windows
+     #   inputs:
+     #     script: yarn add rnpm-plugin-windows@file:$(Build.SourcesDirectory)\current\local-cli\rnpm\windows
+     #     workingDirectory: $(Agent.BuildDirectory)\testcli
+        
+     # - task: CmdLine@2
+     #   displayName: Apply windows template
+     #   inputs:
+     #     script: react-native windows --template vnext --windowsVersion file:$(Build.SourcesDirectory)\vnext
+     #     workingDirectory: $(Agent.BuildDirectory)\testcli
+
+     # - template: templates/install-SDK.yml
+
+     # - task: NuGetCommand@2
+     #   displayName: NuGet restore
+     #   inputs:
+     #     command: restore
+     #     restoreSolution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
+
+     # - task: MSBuild@1
+     #   displayName: MSBuild - Build the project
+     #   inputs:
+     #     solution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
+     #     msbuildVersion: '15.0' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+     #     msbuildArchitecture: 'x86' # Optional. Options: x86, x64
+     #     platform: x64 # Optional
+     #     configuration: Debug # Optional
+     #     restoreNugetPackages: true
+     #     msbuildArguments: '/p:PreferredToolArchitecture=x64' # Optional
+     #     clean: true # Optional
+
+     # - task: CmdLine@2
+     #   displayName: Create bundle
+     #   inputs:
+     #     script: react-native bundle --entry-file App.windows.js platform uwp --bundle-output test.bundle
+     #     workingDirectory: $(Agent.BuildDirectory)\testcli

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,6 @@ jobs:
     
     strategy:
       matrix:
-        BuildConfiguration: [Debug, Release]
-        BuildPlatform: [x64, x86, arm]
-        UseRNFork: [true]
         include:
         - BuildConfiguration: Debug
           BuildPlatform: x64

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,9 +16,6 @@ jobs:
         include:
         - BuildConfiguration: Debug
           BuildPlatform: x86
-          UseRNFork: true
-        - BuildConfiguration: Debug
-          BuildPlatform: x86
           UseRNFork: false
     
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -133,7 +133,14 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
         run: echo "%JOB_CONTEXT%"
-
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "%RUNNER_CONTEXT%"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "%STEPS_CONTEXT%"
 
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,35 @@ name: CI
 on: [check_run]
 
 jobs:
+  one:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+
+
   UWPPR:
     name: UWP PR
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [check_suite]
+on: [push]
 
 jobs:
   UWPPR:
@@ -60,6 +60,9 @@ jobs:
       
     - name: Setup Nuget.exe
       uses: warrenbuckley/Setup-Nuget@v1
+      
+    - name: Setup MSBuild.exe
+      uses: warrenbuckley/Setup-MSBuild@v1
         
     - name: NuGet restore
       run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,15 +8,15 @@ jobs:
 
     runs-on: windows-2016
     
-    strategy:
-      matrix:
-        include:
-        - BuildConfiguration: Debug
-          BuildPlatform: x64
-          UseRNFork: true
-        - BuildConfiguration: Debug
-          BuildPlatform: x86
-          UseRNFork: true
+    #strategy:
+    #  matrix:
+    #    include:
+    #    - BuildConfiguration: Debug
+    #      BuildPlatform: x64
+    #      UseRNFork: true
+    #    - BuildConfiguration: Debug
+    #      BuildPlatform: x86
+    #      UseRNFork: true
     #    - BuildConfiguration: Debug
     #      BuildPlatform: arm
     #      UseRNFork: true
@@ -70,7 +70,25 @@ jobs:
     - name: Build ReactWindows-UWP.sln
       run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
       env:
-        BUILDPLATFORM: ${{ matrix.BuildPlatform }}
-        BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
-    #    BUILDPLATFORM: x64
-    #    BUILDCONFIGURATION: Debug
+        BUILDPLATFORM: x64
+        BUILDCONFIGURATION: Debug
+    #    BUILDPLATFORM: ${{ matrix.BuildPlatform }}
+    #    BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
+
+    - name: NuGet restore
+      run: nuget.exe restore packages/playground/windows/Playground.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
+      
+    - name: Build ReactWindows-UWP.sln
+      run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+      env:
+        BUILDPLATFORM: x64
+        BUILDCONFIGURATION: Debug
+        
+    # todo work out how to specify working-directory for run command
+    - name: Create Playground bundle
+      run: cd packages\playground && node node_modules/react-native/local-cli/cli.js bundle --entry-file Samples\index.tsx --bundle-output Playground.bundle
+        
+    - name: Create RNTester bundle
+    #  if: ${{ matrix.UseRNFork }} == 'true'
+      run: cd vnext && node ../node_modules/react-native/local-cli/cli.js bundle --entry-file .\RNTester.js --bundle-output RNTester.windows.bundle --platform windows
+        

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,67 +8,42 @@ jobs:
 
     runs-on: windows-2016
     
-    strategy:
-      matrix:
-        include:
-        - BuildConfiguration: Debug
-          BuildPlatform: x64
-          UseRNFork: true
-        - BuildConfiguration: Debug
-          BuildPlatform: x86
-          UseRNFork: true
-        - BuildConfiguration: Debug
-          BuildPlatform: arm
-          UseRNFork: true
-        - BuildConfiguration: Release
-          BuildPlatform: x64
-          UseRNFork: true
-        - BuildConfiguration: Release
-          BuildPlatform: x86
-          UseRNFork: true
-        - BuildConfiguration: Release
-          BuildPlatform: arm
-          UseRNFork: true
-        - BuildConfiguration: Debug
-          BuildPlatform: x86
-          UseRNFork: false
+    # strategy:
+    #  matrix:
+    #    include:
+    #    - BuildConfiguration: Debug
+    #      BuildPlatform: x64
+    #      UseRNFork: true
+    #    - BuildConfiguration: Debug
+    #      BuildPlatform: x86
+    #      UseRNFork: true
+    #    - BuildConfiguration: Debug
+    #      BuildPlatform: arm
+    #      UseRNFork: true
+    #    - BuildConfiguration: Release
+    #      BuildPlatform: x64
+    #      UseRNFork: true
+    #    - BuildConfiguration: Release
+    #      BuildPlatform: x86
+    #      UseRNFork: true
+    #    - BuildConfiguration: Release
+    #      BuildPlatform: arm
+    #      UseRNFork: true
+    #    - BuildConfiguration: Debug
+    #      BuildPlatform: x86
+    #      UseRNFork: false
     
     steps:
     - uses: actions/checkout@v1
-    
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Dump strategy context
-      env:
-        STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-      run: echo "$STRATEGY_CONTEXT"
-    - name: Dump matrix context
-      env:
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      run: echo "$MATRIX_CONTEXT"
-    - name: Dump job context
-      env:
-        JOB_CONTEXT: ${{ toJson(job) }}
-      run: echo "$JOB_CONTEXT"
-    - name: Dump runner context
-      env:
-        RUNNER_CONTEXT: ${{ toJson(runner) }}
-      run: echo "$RUNNER_CONTEXT"
-    - name: Dump steps context
-      env:
-        STEPS_CONTEXT: ${{ toJson(steps) }}
-      run: echo "$STEPS_CONTEXT"
-    
+
     #- name: Switch to fork
     #  if: ${{ matrix.UseRNFork }} == 'false'
     #  run: node scripts/useUnForkedRN.js
     #  working-directory: vnext
       
-    #- name: yarn install (Using microsoft/react-native)
+    - name: yarn install (Using microsoft/react-native)
     #  if: ${{ matrix.UseRNFork }} == 'true'
-    #  run: yarn install --frozen-lockfile
+      run: yarn install --frozen-lockfile
       
       # We can't use a frozen lockfile for both the fork and non-fork, since they install different dependencies
       # We don't want to force devs to update/create two lock files on every change, so just don't freeze when
@@ -77,17 +52,19 @@ jobs:
     #  if: ${{ matrix.UseRNFork }} == 'false'
     #  run: yarn install
       
-    #- run: yarn buildci
+    - run: yarn buildci
      
-    #- name: Install SDK
-    #  run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
-    #  shell: powershell
+    - name: Install SDK
+      run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
+      shell: powershell
         
-    #- name: NuGet restore
-    #  run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
+    - name: NuGet restore
+      run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
       
-    #- name: Build ReactWindows-UWP.sln
-    #  run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
-    #  env:
+    - name: Build ReactWindows-UWP.sln
+      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+      env:
+        BUILDPLATFORM: x64
+        BUILDCONFIGURATION: Debug
     #    BUILDPLATFORM: ${{ matrix.BuildPlatform }}
     #    BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,19 +120,19 @@ jobs:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+        run: echo "%GITHUB_CONTEXT%"
       - name: Dump strategy context
         env:
           STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-        run: echo "$STRATEGY_CONTEXT"
+        run: echo "%STRATEGY_CONTEXT%"
       - name: Dump matrix context
         env:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
+        run: echo "%MATRIX_CONTEXT%"
       - name: Dump job context
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
+        run: echo "%JOB_CONTEXT%"
 
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,49 +142,33 @@ jobs:
           STEPS_CONTEXT: ${{ toJson(steps) }}
         run: echo "%STEPS_CONTEXT%"
 
-
-
-
-     # - task: CmdLine@2
-     #   displayName: Init new project
-     #   inputs:
-     #     script: react-native init testcli --version 0.59.10
-     #     workingDirectory: $(Agent.BuildDirectory)
-
-     # - task: CmdLine@2
-     #   displayName: Install rnpm-plugin-windows
-     #   inputs:
-     #     script: yarn add rnpm-plugin-windows@file:$(Build.SourcesDirectory)\current\local-cli\rnpm\windows
-     #     workingDirectory: $(Agent.BuildDirectory)\testcli
+      - name: Init new project
+        run: cd ${{ runner.temp }} && react-native init testcli --version 0.59.10
         
-     # - task: CmdLine@2
-     #   displayName: Apply windows template
-     #   inputs:
-     #     script: react-native windows --template vnext --windowsVersion file:$(Build.SourcesDirectory)\vnext
-     #     workingDirectory: $(Agent.BuildDirectory)\testcli
+      - name: Install rnpm-plugin-windows
+        run: cd ${{ runner.temp }}\testcli && yarn add rnpm-plugin-windows@file:${{ runner.workspace }}\react-native-windows\current\local-cli\rnpm\windows
 
-     # - template: templates/install-SDK.yml
+      - name: Apply windows template
+        run: cd ${{ runner.temp }}\testcli && react-native windows --template vnext --windowsVersion file:${{ runner.workspace }}\react-native-windows\vnext
 
-     # - task: NuGetCommand@2
-     #   displayName: NuGet restore
-     #   inputs:
-     #     command: restore
-     #     restoreSolution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
+      - name: Install SDK
+        run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
+        shell: powershell
 
-     # - task: MSBuild@1
-     #   displayName: MSBuild - Build the project
-     #   inputs:
-     #     solution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
-     #     msbuildVersion: '15.0' # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-     #     msbuildArchitecture: 'x86' # Optional. Options: x86, x64
-     #     platform: x64 # Optional
-     #     configuration: Debug # Optional
-     #     restoreNugetPackages: true
-     #     msbuildArguments: '/p:PreferredToolArchitecture=x64' # Optional
-     #     clean: true # Optional
+      - name: Setup Nuget.exe
+        uses: warrenbuckley/Setup-Nuget@v1
 
-     # - task: CmdLine@2
-     #   displayName: Create bundle
-     #   inputs:
-     #     script: react-native bundle --entry-file App.windows.js platform uwp --bundle-output test.bundle
-     #     workingDirectory: $(Agent.BuildDirectory)\testcli
+      - name: Setup MSBuild.exe
+        uses: warrenbuckley/Setup-MSBuild@v1
+
+      - name: NuGet restore
+        run: nuget restore ${{ runner.temp }}\testcli\windows\testcli.sln
+
+      - name: Build ReactWindows-UWP.sln
+        run: msbuild ${{ runner.temp }}\testcli\windows\testcli.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x86 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+        env:
+          BUILDPLATFORM: x64
+          BUILDCONFIGURATION: Debug
+          
+      - name: Create bundle
+        run: cd ${{ runner.temp }}\testcli && react-native bundle --entry-file App.windows.js platform uwp --bundle-output test.bundle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on: [check_run]
+
+jobs:
+  UWPPR:
+    name: UWP PR
+
+    runs-on: windows-2016
+    
+    strategy:
+      matrix:
+        BuildConfiguration: [Debug, Release]
+        BuildPlatform: [x64, x86, arm]
+        UseRNFork: [true]
+        include:
+        - BuildConfiguration: Debug
+          BuildPlatform: x86
+          UseRNFork: true
+        - BuildConfiguration: Debug
+          BuildPlatform: x86
+          UseRNFork: false
+    
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Switch to fork
+      if: ${{matrix.UseRNFork}} == 'false'
+      run: node scripts/useUnForkedRN.js
+      working-directory: vnext
+      
+    - name: yarn install (Using microsoft/react-native)
+      if: ${{matrix.UseRNFork}} == 'true'
+      run: yarn install --frozen-lockfile
+      
+      # We can't use a frozen lockfile for both the fork and non-fork, since they install different dependencies
+      # We don't want to force devs to update/create two lock files on every change, so just don't freeze when
+      # using the non fork version.
+    - name: yarn install (Using facebook/react-native)
+      if: ${{matrix.UseRNFork}} == 'false'
+      run: yarn install
+      
+    - name: yarn buildci
+      run: yarn buildci
+     
+    - name: Install SDK
+      run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
+        shell: powershell
+        
+    - name: NuGet restore
+      run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
+      
+    - name: Build ReactWindows-UWP.sln
+      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="${{matrix.BuildPlatform}}" /p:configuration="${{matrix.BuildConfiguration}}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,15 +8,15 @@ jobs:
 
     runs-on: windows-2016
     
-    # strategy:
-    #  matrix:
-    #    include:
-    #    - BuildConfiguration: Debug
-    #      BuildPlatform: x64
-    #      UseRNFork: true
-    #    - BuildConfiguration: Debug
-    #      BuildPlatform: x86
-    #      UseRNFork: true
+    strategy:
+      matrix:
+        include:
+        - BuildConfiguration: Debug
+          BuildPlatform: x64
+          UseRNFork: true
+        - BuildConfiguration: Debug
+          BuildPlatform: x86
+          UseRNFork: true
     #    - BuildConfiguration: Debug
     #      BuildPlatform: arm
     #      UseRNFork: true
@@ -70,7 +70,7 @@ jobs:
     - name: Build ReactWindows-UWP.sln
       run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
       env:
-        BUILDPLATFORM: x64
-        BUILDCONFIGURATION: Debug
-    #    BUILDPLATFORM: ${{ matrix.BuildPlatform }}
-    #    BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
+        BUILDPLATFORM: ${{ matrix.BuildPlatform }}
+        BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
+    #    BUILDPLATFORM: x64
+    #    BUILDCONFIGURATION: Debug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,24 @@ jobs:
         UseRNFork: [true]
         include:
         - BuildConfiguration: Debug
+          BuildPlatform: x64
+          UseRNFork: true
+        - BuildConfiguration: Debug
+          BuildPlatform: x86
+          UseRNFork: true
+        - BuildConfiguration: Debug
+          BuildPlatform: arm
+          UseRNFork: true
+        - BuildConfiguration: Release
+          BuildPlatform: x64
+          UseRNFork: true
+        - BuildConfiguration: Release
+          BuildPlatform: x86
+          UseRNFork: true
+        - BuildConfiguration: Release
+          BuildPlatform: arm
+          UseRNFork: true
+        - BuildConfiguration: Debug
           BuildPlatform: x86
           UseRNFork: false
     

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [check_run]
+on: [check_suite]
 
 jobs:
   UWPPR:
@@ -57,6 +57,9 @@ jobs:
     - name: Install SDK
       run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
       shell: powershell
+      
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
         
     - name: NuGet restore
       run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,4 +50,7 @@ jobs:
       run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
       
     - name: Build ReactWindows-UWP.sln
-      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="${{ matrix.BuildPlatform }}" /p:configuration="${{ matrix.BuildConfiguration }}"
+      run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /t:"Clean" /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+      env:
+        BUILDPLATFORM: ${{ matrix.BuildPlatform }}
+        BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,12 +40,11 @@ jobs:
       if: ${{matrix.UseRNFork}} == 'false'
       run: yarn install
       
-    - name: yarn buildci
-      run: yarn buildci
+    - run: yarn buildci
      
     - name: Install SDK
       run: .\vnext\Scripts\Install-WindowsSdkISO.ps1 18362
-        shell: powershell
+      shell: powershell
         
     - name: NuGet restore
       run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,11 +3,15 @@ name: CI
 on: [push]
 
 jobs:
+
+  # This job verifies the basic UWP projects
   UWPPR:
     name: UWP PR
 
     runs-on: windows-2016
     
+    # Can't appear to enable matrix right now:
+    # https://github.community/t5/How-to-use-Git-and-GitHub/GitHub-Actions-Matrix-options-dont-work-as-documented/m-p/29558
     #strategy:
     #  matrix:
     #    include:
@@ -93,7 +97,7 @@ jobs:
     #  if: ${{ matrix.UseRNFork }} == 'true'
       run: cd vnext && node ../node_modules/react-native/local-cli/cli.js bundle --entry-file .\RNTester.js --bundle-output RNTester.windows.bundle --platform windows
         
-
+  # This job verifies creating a new react-native app, installing react-native-windows, applying the vnext template, and building it
   CliInit:
     name: Verify react-native init
 
@@ -105,42 +109,17 @@ jobs:
       - name: yarn install (local react-native-windows)
         run: yarn install --frozen-lockfile
       
-    # todo work out how to specify working-directory for run command
+      # todo work out how to specify working-directory for run command
       - name: yarn build (local react-native-windows)
         run: cd vnext && yarn build
 
-    # yarn ends up copying the whole node_modules folder when doing an install of a file package
-    # Delete node_modules, so that resolution is more like when installing from a published npm package
+      # yarn ends up copying the whole node_modules folder when doing an install of a file package
+      # Delete node_modules, so that resolution is more like when installing from a published npm package
       - name: Remove node_modules
         run: cd vnext && rd /S /Q node_modules
 
       - name: Install react-native cli
         run: npm install -g react-native-cli
-
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "%GITHUB_CONTEXT%"
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-        run: echo "%STRATEGY_CONTEXT%"
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "%MATRIX_CONTEXT%"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "%JOB_CONTEXT%"
-      - name: Dump runner context
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-        run: echo "%RUNNER_CONTEXT%"
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJson(steps) }}
-        run: echo "%STEPS_CONTEXT%"
 
       - name: Init new project
         run: cd ${{ runner.temp }} && react-native init testcli --version 0.59.10

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Remove node_modules
         run: cd vnext && rd /S /Q node_modules
 
-      - name:Install react-native cli
+      - name: Install react-native cli
         run: npm install -g react-native-cli
 
       - name: Dump GitHub context


### PR DESCRIPTION
Creating an initial github action workflow to be able to test if it can work for us.

This initial version tries to duplicate some of the jobs that the current azure pipeline does.  -- It doesn't fully duplicate them all yet.  I also had trouble getting the matrix strategy to work properly, so that will need to be fixed before this can be turned on for real.

After check-in, I'll want to verify that this action runs correctly on PRs from forks in addition to PRs within the repo. -- And then maybe we can start moving the official checks to this, and deprecate the azure dev ops definition.