### PR TITLE
Build fix for linking with react native windows

### DIFF
--- a/change/react-native-windows-2019-08-20-08-01-26-users-stecrain-fixLinkBuild.json
+++ b/change/react-native-windows-2019-08-20-08-01-26-users-stecrain-fixLinkBuild.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix building for consumers without hermes",
+  "type": "prerelease",
+  "packageName": "react-native-windows",
+  "email": "stecrain@microsoft.com",
+  "commit": "c6836b9e4e7289ebacae7dd5cd25270397fd269c",
+  "date": "2019-08-20T15:01:26.025Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <USE_HERMES>false</USE_HERMES>
+    <USE_HERMES Condition="'$(USE_HERMES)' == ''">false</USE_HERMES>
   </PropertyGroup>
 
   <ImportGroup Label="Defaults">

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <USE_HERMES Condition="'$(USE_HERMES)' == ''">false</USE_HERMES>
+    <USE_HERMES>false</USE_HERMES>
   </PropertyGroup>
 
   <ImportGroup Label="Defaults">

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props')" />
+  <Import Project="$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props" Condition="Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -172,7 +172,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.targets'))" />
+    <Error Condition="'$(USE_HERMES)' == 'true' AND !Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.props'))" />
+    <Error Condition="'$(USE_HERMES)' == 'true' AND !Exists('$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.0\build\native\ReactNative.Hermes.Windows.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
Small fixup to not error when USE_HERMES='false' and hermes nuget is not present.

Also allow Setting USE_HERMES through environment variable or msbuild command line param

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2957)