### PR TITLE
Live reload fix

### DIFF
--- a/change/react-native-windows-2019-08-19-22-43-52-liveReloadQueueFix.json
+++ b/change/react-native-windows-2019-08-19-22-43-52-liveReloadQueueFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't use DefaultNativeMessageQueueThread in live reload",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "89ddedf6f1b193bfea345981e7312f8468382055",
+  "date": "2019-08-20T05:43:52.625Z"
+}

--- a/vnext/ReactUWP/Views/ReactControl.h
+++ b/vnext/ReactUWP/Views/ReactControl.h
@@ -98,6 +98,7 @@ class ReactControl : public std::enable_shared_from_this<ReactControl>,
   winrt::Grid m_developerMenuRoot{nullptr};
   winrt::Button::Click_revoker m_remoteDebugJSRevoker{};
   winrt::Button::Click_revoker m_cancelRevoker{};
+  winrt::Windows::UI::Core::CoreDispatcher m_uiDispatcher;
   winrt::CoreDispatcher::AcceleratorKeyActivated_revoker
       m_coreDispatcherAKARevoker{};
 };


### PR DESCRIPTION
The ui messagequeue now requires it only be used from the jsThread.
Live reload & instance errors queue from other threads which assert (and crash when no debugger is attached) in debug builds

Remove usage of DefaultNativeMessageQueueThread in ReactControl to avoid this, use a coredispatcher instance directly

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2958)