### PR TITLE
View focus fixes, remove click fallback

### DIFF
--- a/change/react-native-windows-2019-08-20-14-12-15-ViewFocusClickFixes.json
+++ b/change/react-native-windows-2019-08-20-14-12-15-ViewFocusClickFixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Only send focus/blur from OriginalSource, remove Click event for enter/space",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "bb3ed51419101c4de0d51016cad3fd8703a0bb0e",
+  "date": "2019-08-20T21:12:15.173Z"
+}

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -175,29 +175,22 @@ class ViewShadowNode : public ShadowNodeBase {
         winrt::make<winrt::react::uwp::implementation::ViewControl>();
 
     m_contentControlGotFocusRevoker =
-        contentControl.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
-          DispatchEvent(
-              "topFocus", std::move(folly::dynamic::object("target", m_tag)));
+        contentControl.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&args) {
+          if (args.OriginalSource().try_as<winrt::UIElement>() ==
+              contentControl.as<winrt::UIElement>()) {
+            auto tag = m_tag;
+            DispatchEvent(
+                "topFocus", std::move(folly::dynamic::object("target", tag)));
+          }
         });
 
     m_contentControlLostFocusRevoker =
-        contentControl.LostFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
-          DispatchEvent(
-              "topBlur", std::move(folly::dynamic::object("target", m_tag)));
-        });
-
-    // FUTURE: The space/enter handler can be removed in August 2019, still here
-    // to enable transitioning to new events if native code is updated before JS
-    m_contentControlKeyDownRevoker = contentControl.KeyDown(
-        winrt::auto_revoke, [=](auto &&, winrt::KeyRoutedEventArgs const &e) {
-          if (e.Key() == winrt::VirtualKey::Enter ||
-              e.Key() == winrt::VirtualKey::Space) {
-            if (OnClick()) {
-              DispatchEvent(
-                  "topClick",
-                  std::move(folly::dynamic::object("target", m_tag)));
-              e.Handled(true);
-            }
+        contentControl.LostFocus(winrt::auto_revoke, [=](auto &&, auto &&args) {
+          if (args.OriginalSource().try_as<winrt::UIElement>() ==
+              contentControl.as<winrt::UIElement>()) {
+            auto tag = m_tag;
+            DispatchEvent(
+                "topBlur", std::move(folly::dynamic::object("target", tag)));
           }
         });
 
@@ -220,7 +213,6 @@ class ViewShadowNode : public ShadowNodeBase {
 
   winrt::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
   winrt::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};
-  winrt::ContentControl::KeyDown_revoker m_contentControlKeyDownRevoker{};
 };
 
 // ViewPanel uses a ViewBackground property, not Background, so need to


### PR DESCRIPTION
2 changes:
1. our Focus, Blur events are firing extra times when you have nested touchables.  
That makes it hard to track what has focus.  I added code to check if we're the originalsource for the focus/lostfocus event and only then dispatch the event to js.
On the JS side focus/blur events bubble so for this nested case we still need to look at the target of the event or use stopPropagation but at least its possible to tell what the actual target is now

2. remove the temporary code I had added back for space/enter handling.  We've now updated all the js components to have the keyboard event based touchable press logic.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2968)