### PR TITLE
Minor Fix For VS2019 Build

### DIFF
--- a/change/react-native-windows-2019-08-20-18-51-35-abitest-vs2019-build-fix.json
+++ b/change/react-native-windows-2019-08-20-18-51-35-abitest-vs2019-build-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix VS2019 build for Desktop.ABITests.",
+  "packageName": "react-native-windows",
+  "email": "yicyao@microsoft.com",
+  "commit": "5b296935b88eb24fac55688e234a9ae548a61e7a",
+  "date": "2019-08-21T01:51:35.742Z"
+}

--- a/vnext/Desktop.ABITests/NativeTraceEventTests.cpp
+++ b/vnext/Desktop.ABITests/NativeTraceEventTests.cpp
@@ -4,6 +4,7 @@
 #include <CppUnitTest.h>
 #include <winrt/facebook.react.h>
 #include <stack>
+#include <functional>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace winrt::facebook::react;

--- a/vnext/Desktop.ABITests/NativeTraceEventTests.cpp
+++ b/vnext/Desktop.ABITests/NativeTraceEventTests.cpp
@@ -3,8 +3,8 @@
 
 #include <CppUnitTest.h>
 #include <winrt/facebook.react.h>
-#include <stack>
 #include <functional>
+#include <stack>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace winrt::facebook::react;


### PR DESCRIPTION
Fix React.Windows.Desktop.ABITest.vcxproj build failure when building with VS2019.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2970)