### PR TITLE
report more Networking errors to js

### DIFF
--- a/change/react-native-windows-2019-08-21-13-38-20-NetworkErrorReporting.json
+++ b/change/react-native-windows-2019-08-21-13-38-20-NetworkErrorReporting.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Improve Networking error reporting",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "507a55b4f67a37870b2b1f02e48d30e1c0db883a",
+  "date": "2019-08-21T20:38:20.759Z"
+}

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -96,7 +96,7 @@ class NetworkingModule::NetworkingHelper
 
 std::int64_t NetworkingModule::NetworkingHelper::s_lastRequestId = 0;
 
-std::future<void> SendRequestAsync(
+winrt::fire_and_forget SendRequestAsync(
     std::shared_ptr<NetworkingModule::NetworkingHelper> networking,
     winrt::Windows::Web::Http::HttpClient httpClient,
     winrt::Windows::Web::Http::HttpRequestMessage request,

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -104,53 +104,59 @@ std::future<void> SendRequestAsync(
     int64_t requestId) {
   // NotYetImplemented: set timeout
 
-  auto completion = httpClient.SendRequestAsync(request);
-  networking->AddRequest(requestId, completion);
+  try {
+    auto completion = httpClient.SendRequestAsync(request);
+    networking->AddRequest(requestId, completion);
 
-  winrt::Windows::Web::Http::HttpResponseMessage response = co_await completion;
-  if (response != nullptr)
-    networking->OnResponseReceived(requestId, response);
+    winrt::Windows::Web::Http::HttpResponseMessage response =
+        co_await completion;
+    if (response != nullptr)
+      networking->OnResponseReceived(requestId, response);
 
-  // NotYetImplemented: useIncrementalUpdates
+    // NotYetImplemented: useIncrementalUpdates
 
-  if (response != nullptr && response.Content() != nullptr) {
-    winrt::Windows::Storage::Streams::IInputStream inputStream =
-        co_await response.Content().ReadAsInputStreamAsync();
-    auto reader = winrt::Windows::Storage::Streams::DataReader(inputStream);
+    if (response != nullptr && response.Content() != nullptr) {
+      winrt::Windows::Storage::Streams::IInputStream inputStream =
+          co_await response.Content().ReadAsInputStreamAsync();
+      auto reader = winrt::Windows::Storage::Streams::DataReader(inputStream);
 
-    if (textResponse)
-      reader.UnicodeEncoding(
-          winrt::Windows::Storage::Streams::UnicodeEncoding::Utf8);
+      if (textResponse)
+        reader.UnicodeEncoding(
+            winrt::Windows::Storage::Streams::UnicodeEncoding::Utf8);
 
-    // Only support up to 10MB response sizes
-    co_await reader.LoadAsync(10000000);
-    uint32_t len = reader.UnconsumedBufferLength();
+      // Only support up to 10MB response sizes
+      co_await reader.LoadAsync(10000000);
+      uint32_t len = reader.UnconsumedBufferLength();
 
-    if (textResponse) {
-      std::vector<uint8_t> data(len);
-      reader.ReadBytes(data);
-      std::string responseData = std::string(
-          facebook::react::utilities::checkedReinterpretCast<char *>(
-              data.data()),
-          data.size());
+      if (textResponse) {
+        std::vector<uint8_t> data(len);
+        reader.ReadBytes(data);
+        std::string responseData = std::string(
+            facebook::react::utilities::checkedReinterpretCast<char *>(
+                data.data()),
+            data.size());
 
-      networking->OnDataReceived(requestId, std::move(responseData));
+        networking->OnDataReceived(requestId, std::move(responseData));
+      } else {
+        auto buffer = reader.ReadBuffer(len);
+        winrt::hstring data = winrt::Windows::Security::Cryptography::
+            CryptographicBuffer::EncodeToBase64String(buffer);
+        std::string responseData =
+            facebook::react::unicode::utf16ToUtf8(std::wstring_view(data));
+
+        networking->OnDataReceived(requestId, std::move(responseData));
+      }
+
+      networking->OnRequestSuccess(requestId);
     } else {
-      auto buffer = reader.ReadBuffer(len);
-      winrt::hstring data = winrt::Windows::Security::Cryptography::
-          CryptographicBuffer::EncodeToBase64String(buffer);
-      std::string responseData =
-          facebook::react::unicode::utf16ToUtf8(std::wstring_view(data));
-
-      networking->OnDataReceived(requestId, std::move(responseData));
+      networking->OnRequestError(
+          requestId,
+          response == nullptr ? "request failed" : "No response content",
+          false /*isTimeout*/);
     }
-
-    networking->OnRequestSuccess(requestId);
-  } else {
+  } catch (...) {
     networking->OnRequestError(
-        requestId,
-        response == nullptr ? "request failed" : "No response content",
-        false /*isTimeout*/);
+        requestId, "Unhandled exception during request", false /*isTimeout*/);
   }
 
   networking->RemoveRequest(requestId);


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/issues/2954

If an exception occurs in co_await or later, the outer catch() isn't getting anything due to the async thread continuing on.  Wrapping everything in another try / catch gets us the error.

Alternatively, making the existing call synchronous (adding .get()) also starts catching errors but we don't want to block the messagequeue

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2972)