### PR TITLE
Disable dynmaic_casting to BatchingMessageQueueThread on Win32

### DIFF
--- a/change/react-native-windows-2019-08-21-15-13-45-DisableBatchingMessageQueueThread.json
+++ b/change/react-native-windows-2019-08-21-15-13-45-DisableBatchingMessageQueueThread.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Disable BatchingMessageQueueThread on win32.",
+  "packageName": "react-native-windows",
+  "email": "yicyao@microsoft.com",
+  "commit": "ce46ec516491f57991e3e7791a1a7fa0ca1e4735",
+  "date": "2019-08-21T22:13:45.101Z"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -235,12 +235,14 @@ struct BridgeUIBatchInstanceCallback : public InstanceCallback {
         if (uiManager != nullptr)
           uiManager->onBatchComplete();
       });
+#ifdef WINRT
       facebook::react::BatchingMessageQueueThread *batchingUIThread =
           dynamic_cast<facebook::react::BatchingMessageQueueThread *>(
               uithread.get());
       if (batchingUIThread != nullptr) {
         batchingUIThread->onBatchComplete();
       }
+#endif
     }
   }
   void incrementPendingJSCalls() override {}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -236,6 +236,9 @@ struct BridgeUIBatchInstanceCallback : public InstanceCallback {
           uiManager->onBatchComplete();
       });
 #ifdef WINRT
+      // react-native-win32.dll need to interface with dlls that are compiled
+      // without RTTI, which means that dynamic_casting will crash. For now, we
+      // disable the optimization based on BatchingMessageQueueThread for Win32.
       facebook::react::BatchingMessageQueueThread *batchingUIThread =
           dynamic_cast<facebook::react::BatchingMessageQueueThread *>(
               uithread.get());


### PR DESCRIPTION
Commit 0280b5e74c1cfae3487bb1c6cb64b45213805860 adds a use of dynmaic_cast (to a BatchingMessageQueue) in OInstance.cpp. We cannot use dynamic_cast on Win32. While we figure out the long term solution, let's use a macro guard to disable said code for Win32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2973)