### PR TITLE
Update to react-native@0.59.0-microsoft.48

### DIFF
--- a/change/react-native-windows-2019-08-22-17-24-23-auto-update-versions059.0microsoft.48.json
+++ b/change/react-native-windows-2019-08-22-17-24-23-auto-update-versions059.0microsoft.48.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.48",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "1d7ec140f5b635dbf4c89dbb5ddb4d4e99afee0b",
+  "date": "2019-08-22T17:24:23.202Z"
+}

--- a/change/react-native-windows-extended-2019-08-22-17-24-25-auto-update-versions059.0microsoft.48.json
+++ b/change/react-native-windows-extended-2019-08-22-17-24-25-auto-update-versions059.0microsoft.48.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.48",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "6d1282526e378f0c382292610a4ecaab43d6fa03",
+  "date": "2019-08-22T17:24:25.130Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.48.tar.gz",
     "react-native-windows": "0.59.0-vnext.149",
     "react-native-windows-extended": "0.14.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.48.tar.gz",
     "react-native-windows": "0.59.0-vnext.149",
     "react-native-windows-extended": "0.14.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.48.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.48 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.48.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.48.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.43.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.48 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.48.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
00f196d64 Applying package update to 0.59.0-microsoft.48
dec6d4602 Update main.workflow
a59a4ebff Applying package update to 0.59.0-microsoft.47
5bff60fe0 ios 13 semantic and dynamic color support (#105)
03af69f29 Applying package update to 0.59.0-microsoft.46
0ecf30e5e Update main.workflow
df7a3068d Start github actions ci (#141)
87cef595f Reverting back to gnustl (#144)
49cb1d8f1 Applying package update to 0.59.0-microsoft.45
102128eec Using libcpp to build RN (#143)
3483c5ea2 Applying package update to 0.59.0-microsoft.44
af1d32124 Start publishing fb60merge

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2979)