### PR TITLE
Update to react-native@0.59.0-microsoft.50

### DIFF
--- a/change/react-native-windows-2019-08-22-22-31-28-auto-update-versions059.0microsoft.50.json
+++ b/change/react-native-windows-2019-08-22-22-31-28-auto-update-versions059.0microsoft.50.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.50",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "982ca58fc2177db7bac38ba15a43f9dd9b8e5d4c",
+  "date": "2019-08-22T22:31:28.850Z"
+}

--- a/change/react-native-windows-extended-2019-08-22-22-31-30-auto-update-versions059.0microsoft.50.json
+++ b/change/react-native-windows-extended-2019-08-22-22-31-30-auto-update-versions059.0microsoft.50.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.50",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "980ab3cbb6c14a7bb1812c251e98b2bb3f114d0f",
+  "date": "2019-08-22T22:31:30.696Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.50.tar.gz",
     "react-native-windows": "0.59.0-vnext.150",
     "react-native-windows-extended": "0.14.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.50.tar.gz",
     "react-native-windows": "0.59.0-vnext.150",
     "react-native-windows-extended": "0.14.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.50.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.50 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.50.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.50.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.50 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.50.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
1edc2fa85 Applying package update to 0.59.0-microsoft.50
2e4b85050 Move publish to github actions (#147)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2983)