### PR TITLE
Update to react-native@0.59.0-microsoft.51

### DIFF
--- a/change/react-native-windows-2019-08-22-22-58-19-auto-update-versions059.0microsoft.51.json
+++ b/change/react-native-windows-2019-08-22-22-58-19-auto-update-versions059.0microsoft.51.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.51",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "7c183fa2649344c98f9b0480904d219197377ca5",
+  "date": "2019-08-22T22:58:19.689Z"
+}

--- a/change/react-native-windows-extended-2019-08-22-22-58-21-auto-update-versions059.0microsoft.51.json
+++ b/change/react-native-windows-extended-2019-08-22-22-58-21-auto-update-versions059.0microsoft.51.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.51",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "95c32e8b0f028d788787c743a48af3c4d8529d1a",
+  "date": "2019-08-22T22:58:21.644Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.51.tar.gz",
     "react-native-windows": "0.59.0-vnext.150",
     "react-native-windows-extended": "0.14.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.51.tar.gz",
     "react-native-windows": "0.59.0-vnext.150",
     "react-native-windows-extended": "0.14.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.51.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.51 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.51.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.51.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.51 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.51.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
42b25dadb Applying package update to 0.59.0-microsoft.51
afa7883ac Publish update
1edc2fa85 Applying package update to 0.59.0-microsoft.50
2e4b85050 Move publish to github actions (#147)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2984)