### PR TITLE
Update to react-native@0.59.0-microsoft.52

### DIFF
--- a/change/react-native-windows-2019-08-22-23-33-43-auto-update-versions059.0microsoft.52.json
+++ b/change/react-native-windows-2019-08-22-23-33-43-auto-update-versions059.0microsoft.52.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.52",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "c584cbb8f463e630f3b39d79caa286f1523341e8",
+  "date": "2019-08-22T23:33:43.203Z"
+}

--- a/change/react-native-windows-extended-2019-08-22-23-33-45-auto-update-versions059.0microsoft.52.json
+++ b/change/react-native-windows-extended-2019-08-22-23-33-45-auto-update-versions059.0microsoft.52.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.52",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "275d84512c3587797afdfcc07cb6195217882735",
+  "date": "2019-08-22T23:33:45.066Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.52.tar.gz",
     "react-native-windows": "0.59.0-vnext.150",
     "react-native-windows-extended": "0.14.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.52.tar.gz",
     "react-native-windows": "0.59.0-vnext.150",
     "react-native-windows-extended": "0.14.1",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.52.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.52 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.52.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.52.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.49 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.49.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.52 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.52.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
26cda8ce6 Applying package update to 0.59.0-microsoft.52
5d18bcfc9 update publish
10c354660 Merge branch 'publish-temp-1566514209740'
42b25dadb Applying package update to 0.59.0-microsoft.51
ae79f2ceb publish update
afa7883ac Publish update
1edc2fa85 Applying package update to 0.59.0-microsoft.50
2e4b85050 Move publish to github actions (#147)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2987)