### PR TITLE
reduce Haul polling exceptions

### DIFF
--- a/change/react-native-windows-2019-08-23-13-55-55-HaulPollingExceptions.json
+++ b/change/react-native-windows-2019-08-23-13-55-55-HaulPollingExceptions.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "move cppwinrt less exception helper, use in DevSupportManager",
+  "packageName": "react-native-windows",
+  "email": "andrewh@microsoft.com",
+  "commit": "5df0fd5e75089b6639308d76fd60cacf33e3be5e",
+  "date": "2019-08-23T20:55:55.498Z"
+}

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
@@ -15,6 +15,7 @@
 #include "unicode.h"
 #include "utilities.h"
 
+#include <Utils/CppWinrtLessExceptions.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Web.Http.Filters.h>
 #include <winrt/Windows.Web.Http.Headers.h>
@@ -141,6 +142,12 @@ bool is_cancelled(const std::wstring &msg) {
   return false;
 }
 
+bool IsIgnorablePollHResult(HRESULT hr) {
+  // Ignored HRESULTS:
+  // WININET_E_INVALID_SERVER_RESPONSE - Haul packager returns on timeouts
+  return hr == WININET_E_INVALID_SERVER_RESPONSE;
+}
+
 std::future<winrt::Windows::Web::Http::HttpStatusCode> PollForLiveReload(
     const std::string &url) {
   winrt::Windows::Web::Http::HttpClient httpClient;
@@ -149,9 +156,27 @@ std::future<winrt::Windows::Web::Http::HttpStatusCode> PollForLiveReload(
   httpClient.DefaultRequestHeaders().Connection().TryParseAdd(L"keep-alive");
 
   winrt::Windows::Web::Http::HttpResponseMessage responseMessage;
-  responseMessage = co_await httpClient.GetAsync(
+  auto async = httpClient.GetAsync(
       uri,
       winrt::Windows::Web::Http::HttpCompletionOption::ResponseHeadersRead);
+
+#ifdef DEFAULT_CPPWINRT_EXCEPTIONS
+  responseMessage = co_await async;
+#else
+  // Avoid CppWinrt exception when the Polling, we'll
+  // specifically check some HRESULTs to not throw on
+  co_await lessthrow_await_adapter<
+      winrt::Windows::Foundation::IAsyncOperationWithProgress<
+          winrt::Windows::Web::Http::HttpResponseMessage,
+          winrt::Windows::Web::Http::HttpProgress>>{async};
+
+  HRESULT hr = async.ErrorCode();
+  if (IsIgnorablePollHResult(hr))
+    co_return winrt::Windows::Web::Http::HttpStatusCode::Ok;
+  winrt::check_hresult(hr);
+
+  responseMessage = async.GetResults();
+#endif
 
   co_return responseMessage.StatusCode();
 }
@@ -176,7 +201,7 @@ void DevSupportManager::StartPollingLiveReload(
       } catch (winrt::hresult_error const &e) {
         // Continue to poll on known error conditions
         HRESULT hr = e.code();
-        if (hr == WININET_E_INVALID_SERVER_RESPONSE)
+        if (IsIgnorablePollHResult(hr))
           continue;
 
         // Just let the live reload stop working when the connection fails,

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="Modules\Animated\SpringAnimationDriver.h" />
     <ClInclude Include="Utils\BaseScriptStoreImpl.h" Condition="'$(OSS_RN)' != 'true'" />
     <ClInclude Include="Threading\BatchingUIMessageQueueThread.h" />
+    <ClInclude Include="Utils\CppWinrtLessExceptions.h" />
     <ClInclude Include="Utils\UwpPreparedScriptStore.h" Condition="'$(OSS_RN)' != 'true'" />
     <ClInclude Include="Utils\UwpScriptStore.h" Condition="'$(OSS_RN)' != 'true'" />
     <ClInclude Include="Executors\WebSocketJSExecutorUwp.h" />

--- a/vnext/ReactUWP/ReactUWP.vcxproj.filters
+++ b/vnext/ReactUWP/ReactUWP.vcxproj.filters
@@ -642,6 +642,9 @@
     <ClInclude Include="Threading\BatchingUIMessageQueueThread.h">
       <Filter>Threading</Filter>
     </ClInclude>
+    <ClInclude Include="Utils\CppWinrtLessExceptions.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="EndPoints\dll\react-native-uwp.arm.def">

--- a/vnext/ReactUWP/Utils/CppWinrtLessExceptions.h
+++ b/vnext/ReactUWP/Utils/CppWinrtLessExceptions.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//
+// Helper file for places where the winrt API throws exceptions in 'expected' cases
+// and we want to avoid them to allow developers to have break on exceptions
+// enabled to find bugs
+//
+
+// This assumes RS5 winrtcpp SDK.  Set the define DEFAULT_CPPWINRT_EXCEPTIONS 
+// if winrtcpp internals change and break this lessthrow_await_adapter - 
+// based on await_adapter but doesn't throw from
+// await_resume for APIs that fail in normal usage.
+//
+// When we can assume Windows 10 20H1 new APIs which may exist with less throwing by
+// default (TryConnectAsync, httpClient.TryGetAsync APIs may exist then), this
+// could go away (or cppwinrt API could add nothrow accessors)
+//
+
+#include "winrt/base.h"
+
+// #define DEFAULT_CPPWINRT_EXCEPTIONS
+#ifndef DEFAULT_CPPWINRT_EXCEPTIONS
+
+// Adapted from winrt/base.h await_adapter
+template <typename Async>
+struct lessthrow_await_adapter {
+  Async const &async;
+
+  bool await_ready() const {
+    return async.Status() == winrt::Windows::Foundation::AsyncStatus::Completed;
+  }
+
+  void await_suspend(std::experimental::coroutine_handle<> handle) const {
+    auto context =
+     winrt::capture<winrt::impl::IContextCallback>(WINRT_CoGetObjectContext);
+
+    async.Completed([handle, context = std::move(context)](
+                        auto const &, winrt::Windows::Foundation::AsyncStatus) {
+      winrt::impl::com_callback_args args{};
+      args.data = handle.address();
+
+      auto callback =
+          [](winrt::impl::com_callback_args * args) noexcept->int32_t {
+        std::experimental::coroutine_handle<>::from_address(args->data)();
+        return S_OK;
+      };
+
+      winrt::check_hresult(context->ContextCallback(
+          callback,
+          &args,
+          winrt::guid_of<
+              winrt::impl::ICallbackWithNoReentrancyToApplicationSTA>(),
+          5,
+          nullptr));
+    });
+  }
+
+  void await_resume() const {
+    // Don't check for a failure result here
+    return;
+  }
+};
+#endif

--- a/vnext/ReactUWP/Utils/CppWinrtLessExceptions.h
+++ b/vnext/ReactUWP/Utils/CppWinrtLessExceptions.h
@@ -2,19 +2,19 @@
 // Licensed under the MIT License.
 
 //
-// Helper file for places where the winrt API throws exceptions in 'expected' cases
-// and we want to avoid them to allow developers to have break on exceptions
-// enabled to find bugs
+// Helper file for places where the winrt API throws exceptions in 'expected'
+// cases and we want to avoid them to allow developers to have break on
+// exceptions enabled to find bugs
 //
 
-// This assumes RS5 winrtcpp SDK.  Set the define DEFAULT_CPPWINRT_EXCEPTIONS 
-// if winrtcpp internals change and break this lessthrow_await_adapter - 
+// This assumes RS5 winrtcpp SDK.  Set the define DEFAULT_CPPWINRT_EXCEPTIONS
+// if winrtcpp internals change and break this lessthrow_await_adapter -
 // based on await_adapter but doesn't throw from
 // await_resume for APIs that fail in normal usage.
 //
-// When we can assume Windows 10 20H1 new APIs which may exist with less throwing by
-// default (TryConnectAsync, httpClient.TryGetAsync APIs may exist then), this
-// could go away (or cppwinrt API could add nothrow accessors)
+// When we can assume Windows 10 20H1 new APIs which may exist with less
+// throwing by default (TryConnectAsync, httpClient.TryGetAsync APIs may exist
+// then), this could go away (or cppwinrt API could add nothrow accessors)
 //
 
 #include "winrt/base.h"
@@ -33,7 +33,7 @@ struct lessthrow_await_adapter {
 
   void await_suspend(std::experimental::coroutine_handle<> handle) const {
     auto context =
-     winrt::capture<winrt::impl::IContextCallback>(WINRT_CoGetObjectContext);
+        winrt::capture<winrt::impl::IContextCallback>(WINRT_CoGetObjectContext);
 
     async.Completed([handle, context = std::move(context)](
                         auto const &, winrt::Windows::Foundation::AsyncStatus) {


### PR DESCRIPTION
When using haul as your packager, frequent hresult exceptions are thrown.
We had this problem before with the react devtools trying to open socket connections and failing where I put in a workaround to use cppwinrt in a slightly manual way to not throw exceptions.  Haul usage is similarly noisy and annoying.  Actually we have a check around this error condition already because live reload would stop working when we got one of these errors, which we handle specifically - now we can handle that error without an internal exception being thrown.

This moves that helper code to a header and using it in another place.  For some reason haul returns these errors where when I use metro it seems to return more valid http results.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/2992)