### PR TITLE
return SolidColorBrush unboxed from resource

### DIFF
--- a/change/react-native-windows-2019-08-27-10-27-55-patch-1.json
+++ b/change/react-native-windows-2019-08-27-10-27-55-patch-1.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enable windowsbrush themeresource colors",
+  "packageName": "react-native-windows",
+  "email": "thshea@microsoft.com",
+  "commit": "07bfeda8e5c600035134168e8dd0fab4da5947c3",
+  "date": "2019-08-27T17:27:55.368Z"
+}

--- a/vnext/ReactUWP/Utils/ValueUtils.cpp
+++ b/vnext/ReactUWP/Utils/ValueUtils.cpp
@@ -112,7 +112,7 @@ SolidColorBrushFrom(const folly::dynamic &d) {
             winrt::box_value(resourceName))};
 
     if (resource) {
-      winrt::unbox_value<winrt::SolidColorBrush>(resource);
+      return winrt::unbox_value<winrt::SolidColorBrush>(resource);
     }
   }
 


### PR DESCRIPTION
The existing SolidColorBrushFrom handles windowsbrush values that refer to XAML theme resources, but doesn't actually use them. (It unboxes the resource, then doesn't do anything with it and eventually returns a transparent brush.) I assume this was unintentional and it was supposed to be returned.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3010)