### PR TITLE
Add react-native-windows to blacklistRE in playground

### DIFF
--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -50,6 +50,11 @@ module.exports = {
           .resolve(rnwePath, 'node_modules/react-native')
           .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
       ),
+      new RegExp(
+        `${path
+          .resolve(__dirname, 'node_modules/react-native-windows')
+          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+      ),
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
         `${path


### PR DESCRIPTION
This will stop the metro bundler from crashing when building the playground app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3012)