### PR TITLE
Allow windowsbrush: color syntax to use non-SolidColor brushes

### DIFF
--- a/change/react-native-windows-2019-08-27-12-05-40-enable-windowsbrush-nonsolidcolor.json
+++ b/change/react-native-windows-2019-08-27-12-05-40-enable-windowsbrush-nonsolidcolor.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow windowsbrush: color syntax to use non-SolidColor brushes",
+  "packageName": "react-native-windows",
+  "email": "thshea@microsoft.com",
+  "commit": "1f35ddd032b48531ee572ca9d56850d46ce6025f",
+  "date": "2019-08-27T19:05:40.749Z"
+}

--- a/vnext/ReactUWP/Utils/ValueUtils.cpp
+++ b/vnext/ReactUWP/Utils/ValueUtils.cpp
@@ -50,6 +50,59 @@ struct ColorComp {
   }
 };
 
+winrt::Windows::UI::Xaml::Media::Brush BrushFromColorObject(
+    const folly::dynamic &d) {
+  winrt::hstring resourceName{
+      winrt::to_hstring(d.find("windowsbrush")->second.asString())};
+
+  thread_local static std::
+      map<winrt::hstring, winrt::weak_ref<winrt::SolidColorBrush>>
+          accentColorMap = {{L"SystemAccentColor", {nullptr}},
+                            {L"SystemAccentColorLight1", {nullptr}},
+                            {L"SystemAccentColorLight2", {nullptr}},
+                            {L"SystemAccentColorLight3", {nullptr}},
+                            {L"SystemAccentColorDark1", {nullptr}},
+                            {L"SystemAccentColorDark2", {nullptr}},
+                            {L"SystemAccentColorDark3", {nullptr}},
+                            {L"SystemListAccentLowColor", {nullptr}},
+                            {L"SystemListAccentMediumColor", {nullptr}},
+                            {L"SystemListAccentHighColor", {nullptr}}};
+
+  if (accentColorMap.find(resourceName) != accentColorMap.end()) {
+    if (auto brush = accentColorMap.at(resourceName).get()) {
+      return brush;
+    }
+
+    winrt::hstring xamlString =
+        L"<ResourceDictionary"
+        L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
+        L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+        L"  <SolidColorBrush"
+        L"      x:Key='" +
+        resourceName +
+        L"'"
+        L"      Color='{ThemeResource " +
+        resourceName +
+        "}' />"
+        L"</ResourceDictionary>";
+
+    auto dictionary{winrt::unbox_value<winrt::ResourceDictionary>(
+        winrt::Markup::XamlReader::Load(xamlString))};
+
+    auto brush{winrt::unbox_value<winrt::SolidColorBrush>(
+        dictionary.Lookup(winrt::box_value(resourceName)))};
+
+    accentColorMap[resourceName] = winrt::make_weak(brush);
+
+    return brush;
+  }
+
+  winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(
+      winrt::box_value(resourceName))};
+
+  return winrt::unbox_value<winrt::Brush>(resource);
+}
+
 REACTWINDOWS_API_(winrt::Color) ColorFrom(const folly::dynamic &d) {
   UINT argb = static_cast<UINT>(d.asInt());
   return winrt::ColorHelper::FromArgb(
@@ -62,58 +115,7 @@ REACTWINDOWS_API_(winrt::Color) ColorFrom(const folly::dynamic &d) {
 REACTWINDOWS_API_(winrt::SolidColorBrush)
 SolidColorBrushFrom(const folly::dynamic &d) {
   if (d.isObject()) {
-    winrt::hstring resourceName{
-        winrt::to_hstring(d.find("windowsbrush")->second.asString())};
-
-    thread_local static std::
-        map<winrt::hstring, winrt::weak_ref<winrt::SolidColorBrush>>
-            accentColorMap = {{L"SystemAccentColor", {nullptr}},
-                              {L"SystemAccentColorLight1", {nullptr}},
-                              {L"SystemAccentColorLight2", {nullptr}},
-                              {L"SystemAccentColorLight3", {nullptr}},
-                              {L"SystemAccentColorDark1", {nullptr}},
-                              {L"SystemAccentColorDark2", {nullptr}},
-                              {L"SystemAccentColorDark3", {nullptr}},
-                              {L"SystemListAccentLowColor", {nullptr}},
-                              {L"SystemListAccentMediumColor", {nullptr}},
-                              {L"SystemListAccentHighColor", {nullptr}}};
-
-    if (accentColorMap.find(resourceName) != accentColorMap.end()) {
-      if (auto brush = accentColorMap.at(resourceName).get()) {
-        return brush;
-      }
-
-      winrt::hstring xamlString =
-          L"<ResourceDictionary"
-          L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
-          L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
-          L"  <SolidColorBrush"
-          L"      x:Key='" +
-          resourceName +
-          L"'"
-          L"      Color='{ThemeResource " +
-          resourceName +
-          "}' />"
-          L"</ResourceDictionary>";
-
-      auto dictionary{winrt::unbox_value<winrt::ResourceDictionary>(
-          winrt::Markup::XamlReader::Load(xamlString))};
-
-      auto brush{winrt::unbox_value<winrt::SolidColorBrush>(
-          dictionary.Lookup(winrt::box_value(resourceName)))};
-
-      accentColorMap[resourceName] = winrt::make_weak(brush);
-
-      return brush;
-    }
-
-    winrt::IInspectable resource{
-        winrt::Application::Current().Resources().Lookup(
-            winrt::box_value(resourceName))};
-
-    if (resource) {
-      winrt::unbox_value<winrt::SolidColorBrush>(resource);
-    }
+    return BrushFromColorObject(d).as<winrt::SolidColorBrush>();
   }
 
   thread_local static std::
@@ -133,6 +135,10 @@ SolidColorBrushFrom(const folly::dynamic &d) {
 }
 
 REACTWINDOWS_API_(winrt::Brush) BrushFrom(const folly::dynamic &d) {
+  if (d.isObject()) {
+    return BrushFromColorObject(d);
+  }
+
   return SolidColorBrushFrom(d);
 }
 

--- a/vnext/include/ReactUWP/Utils/ValueUtils.h
+++ b/vnext/include/ReactUWP/Utils/ValueUtils.h
@@ -18,6 +18,9 @@ struct dynamic;
 namespace react {
 namespace uwp {
 
+winrt::Windows::UI::Xaml::Media::Brush BrushFromColorObject(
+    const folly::dynamic &d);
+
 REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const folly::dynamic &d);
 REACTWINDOWS_API_(winrt::Windows::UI::Xaml::Media::Brush)
 BrushFrom(const folly::dynamic &d);


### PR DESCRIPTION
The existing windowsbrush syntax (added by #2705) lets react look up and use XAML `SolidColorBrush` resources as colors and background colors. This PR refactors this to enable any brush resources, like `LinearGradientBrush` or `AcrylicBrush`.

This is accomplished by pulling the resource lookup logic into a function that returns `Brush` rather than `SolidColorBrush`, and casting that brush to `SolidColorBrush` in the scenarios where only SolidColor is allowed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3013)