### PR TITLE
Use neutral exit code with ***NO_CI***

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Skip NO CI
         if: contains( github.event.head_commit.message, '***NO_CI***')
-        run: exit 123
+        run: exit 78
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: No publish loop
         if: contains( github.event.head_commit.message, '***NO_CI***')
-        run: exit 123
+        run: exit 78
 
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
We're failing workflows when bumping up package versions to prevent the normal CI loop from run. We can use exit code 78 instead for a "neutral exit status". 
https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses

It still stops the rest of the workflow from executing, but we don't get all the redness from failures.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3026)