### PR TITLE
Update to react-native@0.59.0-microsoft.69

### DIFF
--- a/change/react-native-windows-2019-08-28-17-21-55-auto-update-versions059.0microsoft.69.json
+++ b/change/react-native-windows-2019-08-28-17-21-55-auto-update-versions059.0microsoft.69.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.69",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "3275a72b08ca0f567b5d64253cac79ce53f3fe0e",
+  "date": "2019-08-28T17:21:55.682Z"
+}

--- a/change/react-native-windows-extended-2019-08-28-17-21-57-auto-update-versions059.0microsoft.69.json
+++ b/change/react-native-windows-extended-2019-08-28-17-21-57-auto-update-versions059.0microsoft.69.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.69",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "521a0154c50c5a783cb139c0106ba0c51d6f3907",
+  "date": "2019-08-28T17:21:57.546Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.68.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
     "react-native-windows": "0.59.0-vnext.157",
     "react-native-windows-extended": "0.14.4",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.68.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
     "react-native-windows": "0.59.0-vnext.157",
     "react-native-windows-extended": "0.14.4",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.68.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.68 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.68.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.69 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.68.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.68 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.68.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.69 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
8d53a8ade Applying package update to 0.59.0-microsoft.69 ***NO_CI***
b769136cf Clearing the old systrace plumbing to make way for improved one (#149)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3028)