### PR TITLE
Updated packages/microsoft-reactnative-sampleapps to build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ jobs:
   # we are using with facebook/react-native instead of microsoft/react-native
   UWPPublicRN:
     name: vnext with facebook/react-native
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     timeout-minutes: 45
     steps:
@@ -38,25 +39,37 @@ jobs:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
 
-      - name: NuGet restore
+      - name: NuGet restore ReactWindows-UWP.sln
         run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory vnext/packages/ -Verbosity Detailed -NonInteractive
 
       - name: Build ReactWindows-UWP.sln
         run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug"
 
-      - name: NuGet restore
+      - name: NuGet restore Playground.sln
         run: nuget.exe restore packages/playground/windows/Playground.sln -Verbosity Detailed -NonInteractive
 
-      - name: Build ReactWindows-UWP.sln
+      - name: Build Playground.sln
         run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
 
       # todo work out how to specify working-directory for run command
       - name: Create Playground bundle
         run: cd packages\playground && node node_modules/react-native/local-cli/cli.js bundle --entry-file Samples\index.tsx --bundle-output Playground.bundle
 
+      # todo Switch to VS2019 so we can build this
+      # - name: NuGet restore SampleApps.sln
+      #  run: nuget.exe restore packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln -Verbosity Detailed -NonInteractive
+
+      #- name: Build SampleApps.sln
+      #  run: msbuild packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+
+      # todo work out how to specify working-directory for run command
+      - name: Create SampleApp bundle
+      run: cd packages\microsoft-reactnative-sampleapps && node node_modules/react-native/local-cli/cli.js bundle --entry-file index.windows.js --bundle-output SampleApp.bundle
+
   # This job verifies the basic UWP projects
   UWPPR:
     name: vnext ReactWindows-UWP.sln
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     timeout-minutes: 45
     # Can't appear to enable matrix right now:
@@ -86,7 +99,7 @@ jobs:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
 
-      - name: NuGet restore
+      - name: NuGet restore ReactWindows-UWP.sln
         run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory vnext/packages/ -Verbosity Detailed -NonInteractive
 
       - name: Build ReactWindows-UWP.sln
@@ -95,10 +108,10 @@ jobs:
           BUILDPLATFORM: ${{ matrix.BuildPlatform }}
           BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
 
-      - name: NuGet restore
+      - name: NuGet restore Playground.sln
         run: nuget.exe restore packages/playground/windows/Playground.sln -Verbosity Detailed -NonInteractive
 
-      - name: Build ReactWindows-UWP.sln
+      - name: Build Playground.sln
         run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
         env:
           BUILDPLATFORM: ${{ matrix.BuildPlatform }}
@@ -108,6 +121,20 @@ jobs:
       - name: Create Playground bundle
         run: cd packages\playground && node node_modules/react-native/local-cli/cli.js bundle --entry-file Samples\index.tsx --bundle-output Playground.bundle
 
+      # todo Switch to VS2019 so we can build this
+      #- name: NuGet restore SampleApps.sln
+      #  run: nuget.exe restore packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln -Verbosity Detailed -NonInteractive
+
+      #- name: Build SampleApps.sln
+      #  run: msbuild packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+      #  env:
+      #    BUILDPLATFORM: ${{ matrix.BuildPlatform }}
+      #    BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
+
+      # todo work out how to specify working-directory for run command
+      - name: Create SampleApp bundle
+        run: cd packages\microsoft-reactnative-sampleapps && node node_modules/react-native/local-cli/cli.js bundle --entry-file index.windows.js --bundle-output SampleApp.bundle
+
       # todo work out how to specify working-directory for run command
       - name: Create RNTester bundle
         #  if: ${{ matrix.UseRNFork }} == 'true'
@@ -116,6 +143,7 @@ jobs:
   # This job verifies creating a new react-native app, installing react-native-windows, applying the vnext template, and building it
   CliInit:
     name: Verify react-native init
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     timeout-minutes: 30
     steps:
@@ -156,20 +184,21 @@ jobs:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
 
-      - name: NuGet restore
+      - name: NuGet restore testcli.sln
         run: nuget restore ${{ runner.temp }}\testcli\windows\testcli.sln
 
-      - name: Build ReactWindows-UWP.sln
+      - name: Build testcli.sln
         run: msbuild ${{ runner.temp }}\testcli\windows\testcli.sln /nologo /nr:false /p:PreferredToolArchitecture=x86 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
         env:
           BUILDPLATFORM: x64
           BUILDCONFIGURATION: Debug
 
-      - name: Create bundle
+      - name: Create bundle testcli.sln
         run: cd ${{ runner.temp }}\testcli && react-native bundle --entry-file App.windows.js platform uwp --bundle-output test.bundle
 
   RNWFormatting:
     name: Verify change files + formatting
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     timeout-minutes: 10
     steps:
@@ -186,6 +215,7 @@ jobs:
 
   CurrentPR:
     name: Current (C#) PR
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     timeout-minutes: 10
     strategy:
@@ -209,7 +239,7 @@ jobs:
       - name: Setup Nuget.exe
         uses: warrenbuckley/Setup-Nuget@v1
 
-      - name: NuGet restore
+      - name: NuGet restore ReactNative.sln
         run: nuget.exe restore current/ReactWindows/ReactNative.sln -Verbosity Detailed -NonInteractive
 
       - name: Install react-native-cli
@@ -227,7 +257,7 @@ jobs:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
 
-      - name: Build ReactWindows-UWP.sln
+      - name: Build ReactNative.sln
         run: msbuild current/ReactWindows/ReactNative.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
         env:
           BUILDPLATFORM: ${{ matrix.BuildPlatform }}
@@ -257,6 +287,7 @@ jobs:
 
   RnwNativePRBuild:
     name: vnext Windows.sln
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     timeout-minutes: 45
     strategy:
@@ -279,7 +310,7 @@ jobs:
       - name: Setup Nuget.exe
         uses: warrenbuckley/Setup-Nuget@v1
 
-      - name: NuGet restore
+      - name: NuGet restore ReactWindows.sln
         run: nuget.exe restore vnext\ReactWindows.sln -PackagesDirectory vnext/packages/ -Verbosity Detailed -NonInteractive
 
       - name: Setup MSBuild.exe
@@ -330,6 +361,7 @@ jobs:
 
   RNWNugetPR:
     name: React-Native-Windows Build and Pack Nuget
+    # todo switch to windows-2019 (to get VS 2019, but will need to remove dependency on v141 tools)
     runs-on: windows-2016
     needs: RnwNativePRBuild
     timeout-minutes: 15

--- a/change/react-native-windows-2019-08-27-14-01-02-sampleappfix.json
+++ b/change/react-native-windows-2019-08-27-14-01-02-sampleappfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed sampleapps build and updated CI",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "commit": "6c3463e5f85c02866f22195d4b65437228153158",
+  "date": "2019-08-27T21:01:02.572Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/SampleApp.vcxproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/SampleApp.vcxproj
@@ -2,7 +2,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <MinimalCoreWin>true</MinimalCoreWin>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
@@ -151,7 +151,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
+    <ProjectReference Include="..\..\..\..\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
       <Name>Microsoft.ReactNative</Name>
     </ProjectReference>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln
@@ -6,19 +6,19 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleAppCS", "SampleAppCS\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SampleAppCPP", "SampleAppCPP\SampleApp.vcxproj", "{93F7572C-64B9-4096-9EF9-6BA0EDE2B50D}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Folly", "..\..\..\node_modules\react-native-windows\Folly\Folly.vcxproj", "{A990658C-CE31-4BCC-976F-0FC6B1AF693D}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Folly", "..\..\..\vnext\Folly\Folly.vcxproj", "{A990658C-CE31-4BCC-976F-0FC6B1AF693D}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactUWP", "..\..\..\node_modules\react-native-windows\ReactUWP\ReactUWP.vcxproj", "{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactUWP", "..\..\..\vnext\ReactUWP\ReactUWP.vcxproj", "{2D5D43D9-CFFC-4C40-B4CD-02EFB4E2742B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactCommon", "..\..\..\node_modules\react-native-windows\ReactCommon\ReactCommon.vcxproj", "{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactCommon", "..\..\..\vnext\ReactCommon\ReactCommon.vcxproj", "{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}"
 	ProjectSection(ProjectDependencies) = postProject
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "..\..\..\node_modules\react-native-windows\ReactWindowsCore\ReactWindowsCore.vcxproj", "{11C084A3-A57C-4296-A679-CAC17B603144}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "..\..\..\vnext\ReactWindowsCore\ReactWindowsCore.vcxproj", "{11C084A3-A57C-4296-A679-CAC17B603144}"
 	ProjectSection(ProjectDependencies) = postProject
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
 	EndProjectSection
@@ -35,15 +35,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "PropertyS
 		PropertySheets\x86.props = PropertySheets\x86.props
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra", "..\..\..\node_modules\react-native-windows\Chakra\Chakra.vcxitems", "{C38970C0-5FBF-4D69-90D8-CBAC225AE895}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra", "..\..\..\vnext\Chakra\Chakra.vcxitems", "{C38970C0-5FBF-4D69-90D8-CBAC225AE895}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative", "..\..\..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj", "{F7D32BD0-2749-483E-9A0D-1635EF7E3136}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative", "..\..\..\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj", "{F7D32BD0-2749-483E-9A0D-1635EF7E3136}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\..\..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
-		..\..\..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
-		..\..\..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
+		..\..\..\vnext\Chakra\Chakra.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
+		..\..\..\vnext\Shared\Shared.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
+		..\..\..\vnext\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -2,8 +2,6 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190712.2\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <MinimalCoreWin>true</MinimalCoreWin>


### PR DESCRIPTION
* Updated SampleApp.sln to use `vnext` in paths, as per #2965
* Fixed SampleApp and Microsoft.ReactNative projects
* Bumped versions in package.json
* Fix existing task names in pr.xml
* Add SampleApps.sln build to pr.xml (disabled until VS2019 CI support)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3029)