### PR TITLE
Update to react-native@0.59.0-microsoft.70

### DIFF
--- a/change/react-native-windows-2019-08-28-21-28-43-auto-update-versions059.0microsoft.70.json
+++ b/change/react-native-windows-2019-08-28-21-28-43-auto-update-versions059.0microsoft.70.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.70",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "dac10f703bd6d597ed5effcbb4dd61bc42d7cc81",
+  "date": "2019-08-28T21:28:43.809Z"
+}

--- a/change/react-native-windows-extended-2019-08-28-21-28-45-auto-update-versions059.0microsoft.70.json
+++ b/change/react-native-windows-extended-2019-08-28-21-28-45-auto-update-versions059.0microsoft.70.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.70",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "5f6a82445caf6fa7ee49aed5db607c5aa48b73ee",
+  "date": "2019-08-28T21:28:45.950Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.70.tar.gz",
     "react-native-windows": "0.59.0-vnext.159",
     "react-native-windows-extended": "0.14.5",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.70.tar.gz",
     "react-native-windows": "0.59.0-vnext.159",
     "react-native-windows-extended": "0.14.5",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.70.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.69 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.70 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.70.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.70.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.69 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.69.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.70 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.70.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
d740554be Applying package update to 0.59.0-microsoft.70 ***NO_CI***
73a8a7e6d fix yellow box style in win32 (#150)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3031)