### PR TITLE
Fix double onPress issue in touchableOpacity

### DIFF
--- a/change/react-native-windows-2019-08-29-17-25-49-users-ngbu-fix_touchableOpacity_doubleclick.json
+++ b/change/react-native-windows-2019-08-29-17-25-49-users-ngbu-fix_touchableOpacity_doubleclick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "fix double onpress issue",
+  "packageName": "react-native-windows",
+  "email": "ngbu@microsoft.com",
+  "commit": "af7dcea1b513568858c546682870fdce3ac0c67b",
+  "date": "2019-08-30T00:25:49.730Z"
+}

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
@@ -210,7 +210,7 @@ const TouchableOpacity = ((createReactClass({
    * defined on your component.
    */
   touchableHandleActivePressIn: function(e: PressEvent) {
-    if (e.dispatchConfig.registrationName === 'onResponderGrant') {
+    if (e && e.dispatchConfig.registrationName === 'onResponderGrant') {
       this._opacityActive(0);
     } else {
       this._opacityActive(150);
@@ -290,7 +290,7 @@ const TouchableOpacity = ((createReactClass({
         ev.nativeEvent.code === 'GamepadA') &&
       !this.props.disabled
     ) {
-      this.touchableHandlePress();
+      this.touchableHandleActivePressOut(ev);
     }
   },
 
@@ -301,7 +301,7 @@ const TouchableOpacity = ((createReactClass({
         ev.nativeEvent.code === 'GamepadA') &&
       !this.props.disabled
     ) {
-      this.touchableHandleActivePressIn();
+      this.touchableHandleActivePressIn(ev);
     }
   },
 


### PR DESCRIPTION
onPress event was being called twice due to onKeyUp calling `touchableHandlePress()` instead of `touchableHandlePressOut()`.

With these changes, onKeyUp and onKeyDown events will call the corresponding `touchableHandleActivePressOut` and `touchableHandleActivePressIn` event handlers and also pass the PressEvent value. 

Previously, the onPress event would be fired twice every time a touchableOpacity element was pressed because the onKeyUp event was calling the onClick event handler `touchableHandleActivePress`, which happens to call the passed in onPress event handler.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3042)