### PR TITLE
Mark SnapPointManagingContentControl IsTabStop = False

### DIFF
--- a/change/react-native-windows-2019-08-30-08-13-54-users-stecrain-scrollViewFocus.json
+++ b/change/react-native-windows-2019-08-30-08-13-54-users-stecrain-scrollViewFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "set IsTabStop = false for SnapPointManagingContentControl",
+  "packageName": "react-native-windows",
+  "email": "stecrain@microsoft.com",
+  "commit": "5f41be48b33e46a650877325618f77fb634ac620",
+  "date": "2019-08-30T15:13:54.060Z"
+}

--- a/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
+++ b/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
@@ -5,7 +5,9 @@
 namespace react {
 namespace uwp {
 
-SnapPointManagingContentControl::SnapPointManagingContentControl() {}
+SnapPointManagingContentControl::SnapPointManagingContentControl() {
+  IsTabStop(false);
+}
 
 /*static*/ winrt::com_ptr<SnapPointManagingContentControl>
 SnapPointManagingContentControl::Create() {


### PR DESCRIPTION
Addresses #2939

Setting IsTabStop false helps to prevent lots of strange behavior with dpad navigation on Xbox

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3047)