### PR TITLE
Fix calling onPress twice in touchableHighlight and touchableWithoutFeedback

### DIFF
--- a/change/react-native-windows-2019-08-30-11-04-44-users-ngbu-fix_touchable_doubleClick.json
+++ b/change/react-native-windows-2019-08-30-11-04-44-users-ngbu-fix_touchable_doubleClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix double onPress issue in touchableOpacity (#3042)",
+  "packageName": "react-native-windows",
+  "email": "ngbu@microsoft.com",
+  "commit": "ba368131fb6bccfe02092cbe4cc90f9abf99d214",
+  "date": "2019-08-30T18:04:44.063Z"
+}

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -404,7 +404,7 @@ const TouchableHighlight = ((createReactClass({
         ev.nativeEvent.code === 'GamepadA') &&
       !this.props.disabled
     ) {
-      this.touchableHandlePress();
+      this.touchableHandleActivePressOut(ev);
     }
   },
 
@@ -415,7 +415,7 @@ const TouchableHighlight = ((createReactClass({
         ev.nativeEvent.code === 'GamepadA') &&
       !this.props.disabled
     ) {
-      this.touchableHandleActivePressIn();
+      this.touchableHandleActivePressIn(ev);
     }
   },
 

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -272,7 +272,7 @@ const TouchableWithoutFeedback = ((createReactClass({
         ev.nativeEvent.code === 'GamepadA') &&
       !this.props.disabled
     ) {
-      this.touchableHandlePress();
+      this.touchableHandleActivePressOut(ev);
     }
   },
 
@@ -283,7 +283,7 @@ const TouchableWithoutFeedback = ((createReactClass({
         ev.nativeEvent.code === 'GamepadA') &&
       !this.props.disabled
     ) {
-      this.touchableHandleActivePressIn();
+      this.touchableHandleActivePressIn(ev);
     }
   },
 


### PR DESCRIPTION
Similar to PR: #3042 , Fix calling onPress twice in touchableHighlight and touchableWithoutFeedback.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3049)