### PR TITLE
Changed deploy output to use StdOut

### DIFF
--- a/change/react-native-windows-2019-08-30-22-07-10-user-savatia-vscode-debugging.json
+++ b/change/react-native-windows-2019-08-30-22-07-10-user-savatia-vscode-debugging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Changed deploy output to use StdOut",
+  "packageName": "react-native-windows",
+  "email": "brkeyonz@microsoft.com",
+  "commit": "605b956702639c1bc26998549a708a43334fe139",
+  "date": "2019-08-31T05:07:10.315Z"
+}

--- a/vnext/local-cli/runWindows/utils/commandWithProgress.js
+++ b/vnext/local-cli/runWindows/utils/commandWithProgress.js
@@ -33,6 +33,11 @@ function newSpinner(text) {
   if (process.env.WT_SESSION) {
     options.spinner = spinners.dots;
   }
+
+  // By default, ora process.stderr as the output stream, however,the VS Code debugger
+  // Uses stdout to match success patterns
+  options.stream = process.stdout;
+
   return ora(options).start();
 }
 


### PR DESCRIPTION
By default, ora uses [process.stderr](https://github.com/sindresorhus/ora#stream) as the output stream, however,the VS Code debugger uses [stdout](https://github.com/microsoft/vscode-react-native/blob/13a9942728c2e3d62b3a5353d0a74b05cd2c8919/src/common/outputVerifier.ts#L32) to match success patterns. Hence the output is never verified and the debugger fails to start (#2875).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3053)