### PR TITLE
Update GettingStarted.md (current) to update react-native init command

### DIFF
--- a/current/docs/GettingStarted.md
+++ b/current/docs/GettingStarted.md
@@ -27,7 +27,7 @@ npm install -g react-native-cli
 
 Next, [generate a React Native project](http://facebook.github.io/react-native/docs/getting-started.html#creating-a-new-application). In the directory you would like your React Native Windows project directory, run:
 ```
-react-native init <project name>
+react-native init <project name> --version 0.59.10
 ```
 Navigate into this newly created directory:
 ```


### PR DESCRIPTION
Because React-native 0.60 is released but not supported by React Native Windows, we need to manually set the version number in the command `react-native init` to use a supported version.

If the version isn't explicitly set, `react-native windows` will fail with the following error message: 

```
error Unrecognized command "windows".
info Run "react-native --help" to see a list of all available commands.
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3054)