### PR TITLE
Update to react-native@0.59.0-microsoft.72

### DIFF
--- a/change/react-native-windows-2019-09-02-20-05-46-auto-update-versions059.0microsoft.72.json
+++ b/change/react-native-windows-2019-09-02-20-05-46-auto-update-versions059.0microsoft.72.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.72",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "ecff6489449ca142e78dd9a03b587109d088c029",
+  "date": "2019-09-02T20:05:46.200Z"
+}

--- a/change/react-native-windows-extended-2019-09-02-20-05-47-auto-update-versions059.0microsoft.72.json
+++ b/change/react-native-windows-extended-2019-09-02-20-05-47-auto-update-versions059.0microsoft.72.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.72",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "c6356265a5252f6e2622db871b805e9a3db57de0",
+  "date": "2019-09-02T20:05:47.939Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz",
     "react-native-windows": "0.59.0-vnext.168",
     "react-native-windows-extended": "0.15.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz",
     "react-native-windows": "0.59.0-vnext.168",
     "react-native-windows-extended": "0.15.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz",
     "react-native-windows": "0.59.0-vnext.168",
     "react-native-windows-extended": "0.15.0",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.71 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.72 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.71 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.72 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.72.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
aa695884d Applying package update to 0.59.0-microsoft.72 ***NO_CI***
5eea8000c Fix regression caused by PR https://github.com/microsoft/react-native/pull/146. (#152)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3055)