### PR TITLE
Support dynamic swapping TextBox/PasswordBox view for SecureTextEntry 

### DIFF
--- a/change/react-native-windows-2019-09-04-12-52-15-SecureTextEntry.json
+++ b/change/react-native-windows-2019-09-04-12-52-15-SecureTextEntry.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Support dynamic swapping TextBox/PasswordBox view for SecureTextEntry property",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "d432cbe4b3ab20ab69b5723f5356f53ed1c7d832",
+  "date": "2019-09-04T19:52:15.669Z"
+}

--- a/packages/E2ETest/app/Consts.ts
+++ b/packages/E2ETest/app/Consts.ts
@@ -19,3 +19,4 @@ export const USERNAME_ON_LOGIN = 'UserName';
 export const PASSWORD_ON_LOGIN = 'Password';
 export const SUBMIT_ON_LOGIN = 'Submit';
 export const LOGINRESULT_ON_LOGIN = 'Result';
+export const SHOWPASSWORD_ON_LOGIN = 'ShowPassword';

--- a/packages/E2ETest/app/LoginTestPage.tsx
+++ b/packages/E2ETest/app/LoginTestPage.tsx
@@ -35,7 +35,7 @@ export function LoginTestPage() {
   const [password, setPassword] = useState('');
   const [passwordHidden, setPasswordHidden] = useState(true);
 
-   onPressShowPassword = () => {
+  const onPressShowPassword = () => {
       var previousState = passwordHidden;
       setPasswordHidden(!previousState);
    }
@@ -63,7 +63,7 @@ export function LoginTestPage() {
         onChange={(text) => { setPassword(text.nativeEvent.text) }} />
 
       <Button title= {passwordHidden?"Show Password":"Hide Password"} 
-        onPress={this.onPressShowPassword} 
+        onPress={onPressShowPassword} 
         testID={SHOWPASSWORD_ON_LOGIN}/>
 
       <TouchableOpacity style={styles.buttonContainer}

--- a/packages/E2ETest/app/LoginTestPage.tsx
+++ b/packages/E2ETest/app/LoginTestPage.tsx
@@ -35,10 +35,8 @@ export function LoginTestPage() {
   const [password, setPassword] = useState('');
 
   const onPress = () => {
-    if (userName === 'username') {
-      if (password === 'password') {
-        setLoginState('Success');
-      }
+    if (userName === 'username' && password === 'password') {
+      setLoginState('Success');
     } else {
       setLoginState('Fail');
     }

--- a/packages/E2ETest/app/LoginTestPage.tsx
+++ b/packages/E2ETest/app/LoginTestPage.tsx
@@ -4,8 +4,8 @@
  */
 
 import React, { useState } from 'react';
-import { Text, TextInput, View, StyleSheet, TouchableOpacity } from 'react-native';
-import { USERNAME_ON_LOGIN, PASSWORD_ON_LOGIN, SUBMIT_ON_LOGIN, LOGINRESULT_ON_LOGIN } from './Consts';
+import { Text, TextInput, View, StyleSheet, TouchableOpacity, Button } from 'react-native';
+import { USERNAME_ON_LOGIN, PASSWORD_ON_LOGIN, SUBMIT_ON_LOGIN, LOGINRESULT_ON_LOGIN, SHOWPASSWORD_ON_LOGIN } from './Consts';
 
 const styles = StyleSheet.create({
   container: {
@@ -33,6 +33,12 @@ export function LoginTestPage() {
   const [loginState, setLoginState] = useState('');
   const [userName, setUserName] = useState('');
   const [password, setPassword] = useState('');
+  const [passwordHidden, setPasswordHidden] = useState(true);
+
+   onPressShowPassword = () => {
+      var previousState = passwordHidden;
+      setPasswordHidden(!previousState);
+   }
 
   const onPress = () => {
     if (userName === 'username' && password === 'password') {
@@ -53,8 +59,12 @@ export function LoginTestPage() {
         placeholder='Password'
         testID={PASSWORD_ON_LOGIN}
         placeholderTextColor='rgba(225,225,225,0.7)'
-        secureTextEntry 
+        secureTextEntry = {passwordHidden}
         onChange={(text) => { setPassword(text.nativeEvent.text) }} />
+
+      <Button title= {passwordHidden?"Show Password":"Hide Password"} 
+        onPress={this.onPressShowPassword} 
+        testID={SHOWPASSWORD_ON_LOGIN}/>
 
       <TouchableOpacity style={styles.buttonContainer}
         testID={SUBMIT_ON_LOGIN}

--- a/packages/E2ETest/app/LoginTestPage.tsx
+++ b/packages/E2ETest/app/LoginTestPage.tsx
@@ -32,10 +32,13 @@ const styles = StyleSheet.create({
 export function LoginTestPage() {
   const [loginState, setLoginState] = useState('');
   const [userName, setUserName] = useState('');
+  const [password, setPassword] = useState('');
 
   const onPress = () => {
     if (userName === 'username') {
-      setLoginState('Success')
+      if (password === 'password') {
+        setLoginState('Success');
+      }
     } else {
       setLoginState('Fail');
     }
@@ -52,7 +55,8 @@ export function LoginTestPage() {
         placeholder='Password'
         testID={PASSWORD_ON_LOGIN}
         placeholderTextColor='rgba(225,225,225,0.7)'
-        secureTextEntry />
+        secureTextEntry 
+        onChange={(text) => { setPassword(text.nativeEvent.text) }} />
 
       <TouchableOpacity style={styles.buttonContainer}
         testID={SUBMIT_ON_LOGIN}

--- a/packages/E2ETest/reports/appium.txt
+++ b/packages/E2ETest/reports/appium.txt
@@ -1,7 +1,7 @@
 [35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session[39m
 [35m[HTTP][39m [90m{"capabilities":{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]},"desiredCapabilities":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true}}[39m
 [debug] [35m[W3C][39m Calling AppiumDriver.createSession() with args: [{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},null,{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]}]
-[debug] [35m[BaseDriver][39m Event 'newSessionRequested' logged at 1567033255565 (16:00:55 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[BaseDriver][39m Event 'newSessionRequested' logged at 1567790334099 (10:18:54 GMT-0700 (Pacific Daylight Time))
 [35m[BaseDriver][39m The capabilities ["deviceName","app"] are not standard capabilities and should have an extension prefix
 [35m[Appium][39m Appium v1.14.1 creating new WindowsDriver (v1.6.0) session
 [35m[Appium][39m Capabilities:
@@ -18,7 +18,7 @@
 [35m[BaseDriver][39m The following capabilities were provided, but are not recognized by Appium:
 [35m[BaseDriver][39m   app
 [35m[BaseDriver][39m   experimental-w3c
-[35m[BaseDriver][39m Session created with session id: e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[BaseDriver][39m Session created with session id: e6ce83b9-5cea-453a-a2c0-9ebca89fc075
 [35m[WinAppDriver][39m You must use WinAppDriver version 1.1
 [35m[WinAppDriver][39m Verifying WinAppDriver version 1.1 is installed via comparing the checksum.
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'starting'
@@ -44,7 +44,7 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
-[debug] [35m[WD Proxy][39m Got response with status 200: {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18967"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18362"}}
 [debug] [35m[WD Proxy][39m Determined the downstream protocol as 'undefined'
 [35m[WinAppDriver][39m Status call returned 200. we're online and ready to run tests
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'online'
@@ -66,24 +66,80 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 140
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
 [debug] [35m[WD Proxy][39m Determined the downstream protocol as 'MJSONWP'
-[35m[Appium][39m New WindowsDriver session created successfully, session e0a52b64-314e-4d39-8ede-74fae06ffb15 added to master session list
-[debug] [35m[BaseDriver][39m Event 'newSessionStarted' logged at 1567033273856 (16:01:13 GMT-0700 (Pacific Daylight Time))
-[debug] [35m[MJSONWP (e0a52b64)][39m Cached the protocol value 'MJSONWP' for the new session e0a52b64-314e-4d39-8ede-74fae06ffb15
-[debug] [35m[MJSONWP (e0a52b64)][39m Responding to client with driver.createSession() result: {"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}
-[35m[HTTP][39m [37m<-- POST /wd/hub/session [39m[32m200[39m [90m18300 ms - 189[39m
+[35m[Appium][39m New WindowsDriver session created successfully, session e6ce83b9-5cea-453a-a2c0-9ebca89fc075 added to master session list
+[debug] [35m[BaseDriver][39m Event 'newSessionStarted' logged at 1567790345898 (10:19:05 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[MJSONWP (e6ce83b9)][39m Cached the protocol value 'MJSONWP' for the new session e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[debug] [35m[MJSONWP (e6ce83b9)][39m Responding to client with driver.createSession() result: {"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}
+[35m[HTTP][39m [37m<-- POST /wd/hub/session [39m[32m200[39m [90m11806 ms - 189[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at runNextTicks (internal/process/task_queues.js:58:5)
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at processImmediate (internal/timers.js:412:9)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m82 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements' to command name 'findElements'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 74
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements [39m[32m200[39m [90m38 ms - 74[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements' to command name 'findElements'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 50
@@ -93,23 +149,75 @@
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 74
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m118 ms - 153[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements [39m[32m200[39m [90m37 ms - 74[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/click] with body: {}
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements' to command name 'findElements'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements] with body: {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 101
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[{"ELEMENT":"42.791910.4.4"}]}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[{"ELEMENT":"42.791910.4.4"}]}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements [39m[32m200[39m [90m159 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m33 ms - 153[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -122,20 +230,48 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click [39m[32m200[39m [90m343 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click [39m[32m200[39m [90m298 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m87 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
@@ -150,48 +286,20 @@
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
 [35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
 [debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m181 ms - 164[39m
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m65 ms - 164[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m185 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 50
@@ -199,25 +307,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 99
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m95 ms - 153[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m31 ms - 153[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -229,20 +337,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed [39m[32m200[39m [90m13 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed [39m[32m200[39m [90m14 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInputTestPage"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 56
@@ -255,20 +363,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.11"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.11"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m130 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.11"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.11"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.11/displayed] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.11/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.11/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.11/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -280,20 +388,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed [39m[32m200[39m [90m22 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed [39m[32m200[39m [90m11 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"LoginTestPage"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"LoginTestPage"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"LoginTestPage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 52
@@ -306,20 +414,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.17"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.17"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m171 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.17"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.17"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m46 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.17/click] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.17/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.17/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.17/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -327,25 +435,53 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click [39m[32m200[39m [90m316 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click [39m[32m200[39m [90m232 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m86 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
@@ -360,48 +496,20 @@
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
 [35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
 [debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m222 ms - 164[39m
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m64 ms - 164[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m210 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 50
@@ -414,20 +522,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 99
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m144 ms - 153[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m40 ms - 153[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -439,20 +547,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed [39m[32m200[39m [90m21 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed [39m[32m200[39m [90m9 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -465,20 +573,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m132 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m36 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/displayed] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -490,20 +598,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed [39m[32m200[39m [90m28 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed [39m[32m200[39m [90m10 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -516,20 +624,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m87 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m33 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -542,20 +650,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear [39m[32m200[39m [90m60 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m54 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
 [35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 61
@@ -568,20 +676,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value [39m[32m200[39m [90m549 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m455 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -594,20 +702,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m107 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m61 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -615,25 +723,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear [39m[32m200[39m [90m17 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear [39m[32m200[39m [90m18 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value[39m
 [35m[HTTP][39m [90m{"text":"password","value":["p","a","s","s","w","o","r","d"]}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 61
@@ -641,25 +749,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value [39m[32m200[39m [90m530 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value [39m[32m200[39m [90m433 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -672,20 +780,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m131 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m56 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -698,20 +806,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click [39m[32m200[39m [90m303 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m231 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -724,20 +832,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m132 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m57 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -749,20 +857,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 81
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Success"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Success"}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text [39m[32m200[39m [90m30 ms - 81[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m17 ms - 81[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -770,25 +878,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m125 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m30 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -801,20 +909,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear [39m[32m200[39m [90m32 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m20 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
 [35m[HTTP][39m [90m{"text":"username@microsoft.com","value":["u","s","e","r","n","a","m","e","@","m","i","c","r","o","s","o","f","t",".","c","o","m"]}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value] with body: {"text":"username@microsoft.com","value":["u","s","e","r","n","a","m","e","@","m","i","c","r","o","s","o","f","t",".","c","o","m"]}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username@microsoft.com","value":["u","s","e","r","n","a","m","e","@","m","i","c","r","o","s","o","f","t",".","c","o","m"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 131
@@ -827,20 +935,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value [39m[32m200[39m [90m1384 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m988 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -853,20 +961,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m144 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m50 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -879,20 +987,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear [39m[32m200[39m [90m34 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear [39m[32m200[39m [90m19 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value[39m
 [35m[HTTP][39m [90m{"text":"password","value":["p","a","s","s","w","o","r","d"]}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 61
@@ -905,20 +1013,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value [39m[32m200[39m [90m529 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value [39m[32m200[39m [90m430 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -931,20 +1039,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m152 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m56 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -957,20 +1065,279 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click [39m[32m200[39m [90m842 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m778 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m55 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 78
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m7 ms - 78[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m37 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m19 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
+[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m429 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear [39m[32m200[39m [90m19 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value[39m
+[35m[HTTP][39m [90m{"text":"abcdefg","value":["a","b","c","d","e","f","g"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value] with body: {"text":"abcdefg","value":["a","b","c","d","e","f","g"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 56
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"abcdefg","value":["a","b","c","d","e","f","g"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value [39m[32m200[39m [90m390 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Submit"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m58 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m775 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -983,20 +1350,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m159 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m52 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text] with body: {}
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -1008,24 +1375,1165 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 78
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Fail"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Fail"}
-[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text [39m[32m200[39m [90m25 ms - 78[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m14 ms - 78[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mDELETE[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15[39m
-[35m[HTTP][39m [90m{}[39m
-[debug] [35m[MJSONWP (e0a52b64)][39m Calling AppiumDriver.deleteSession() with args: ["e0a52b64-314e-4d39-8ede-74fae06ffb15"]
-[debug] [35m[BaseDriver][39m Event 'quitSessionRequested' logged at 1567033284375 (16:01:24 GMT-0700 (Pacific Daylight Time))
-[35m[Appium][39m Removing session e0a52b64-314e-4d39-8ede-74fae06ffb15 from our master session list
-[debug] [35m[WinAppDriver][39m Deleting WinAppDriver session
-[debug] [35m[WinAppDriver][39m Deleting WinAppDriver server session
-[debug] [35m[WD Proxy][39m Matched '/' to command name 'deleteSession'
-[debug] [35m[WD Proxy][39m Proxying [DELETE /] to [DELETE http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A] with no body
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ShowPassword"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ShowPassword"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] DELETE /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 51
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m35 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click [39m[32m200[39m [90m223 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m49 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m20 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
+[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m426 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m52 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear [39m[32m200[39m [90m21 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value[39m
+[35m[HTTP][39m [90m{"text":"password","value":["p","a","s","s","w","o","r","d"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value [39m[32m200[39m [90m427 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m54 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m229 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Result"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m60 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 81
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m12 ms - 81[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m34 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m16 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
+[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m428 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m43 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear [39m[32m200[39m [90m17 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value[39m
+[35m[HTTP][39m [90m{"text":"pass","value":["p","a","s","s"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value] with body: {"text":"pass","value":["p","a","s","s"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"pass","value":["p","a","s","s"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value [39m[32m200[39m [90m265 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ShowPassword"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ShowPassword"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 51
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ShowPassword"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m56 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click [39m[32m200[39m [90m230 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value[39m
+[35m[HTTP][39m [90m{"text":"","value":[""]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value] with body: {"text":"","value":[""]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 30
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value [39m[32m200[39m [90m142 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m46 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value[39m
+[35m[HTTP][39m [90m{"text":"word","value":["w","o","r","d"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value] with body: {"text":"word","value":["w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"word","value":["w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value [39m[32m200[39m [90m259 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m222 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Result"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m59 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 81
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m8 ms - 81[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m37 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m20 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
+[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m432 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m58 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear [39m[32m200[39m [90m19 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value[39m
+[35m[HTTP][39m [90m{"text":"pass","value":["p","a","s","s"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value] with body: {"text":"pass","value":["p","a","s","s"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"pass","value":["p","a","s","s"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value [39m[32m200[39m [90m265 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ShowPassword"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ShowPassword"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 51
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m47 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click [39m[32m200[39m [90m227 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value[39m
+[35m[HTTP][39m [90m{"text":"","value":[""]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value] with body: {"text":"","value":[""]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 30
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"","value":[""]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value [39m[32m200[39m [90m139 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m45 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value[39m
+[35m[HTTP][39m [90m{"text":"word","value":["w","o","r","d"]}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value] with body: {"text":"word","value":["w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"word","value":["w","o","r","d"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value [39m[32m200[39m [90m264 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m49 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m229 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m54 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 81
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
+[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m10 ms - 81[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mDELETE[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075[39m
+[35m[HTTP][39m [90m{}[39m
+[debug] [35m[MJSONWP (e6ce83b9)][39m Calling AppiumDriver.deleteSession() with args: ["e6ce83b9-5cea-453a-a2c0-9ebca89fc075"]
+[debug] [35m[BaseDriver][39m Event 'quitSessionRequested' logged at 1567790360308 (10:19:20 GMT-0700 (Pacific Daylight Time))
+[35m[Appium][39m Removing session e6ce83b9-5cea-453a-a2c0-9ebca89fc075 from our master session list
+[debug] [35m[WinAppDriver][39m Deleting WinAppDriver session
+[debug] [35m[WinAppDriver][39m Deleting WinAppDriver server session
+[debug] [35m[WD Proxy][39m Matched '/' to command name 'deleteSession'
+[debug] [35m[WD Proxy][39m Proxying [DELETE /] to [DELETE http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16] with no body
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] DELETE /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16 HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 0
@@ -1042,799 +2550,9 @@
 [debug] [35m[WD Proxy][39m Got response with status 200: {"status":0}
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopping'
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopped'
-[debug] [35m[BaseDriver][39m Event 'quitSessionFinished' logged at 1567033284480 (16:01:24 GMT-0700 (Pacific Daylight Time))
-[debug] [35m[MJSONWP (e0a52b64)][39m Received response: null
-[debug] [35m[MJSONWP (e0a52b64)][39m But deleting session, so not returning
-[debug] [35m[MJSONWP (e0a52b64)][39m Responding to client with driver.deleteSession() result: null
-[35m[HTTP][39m [37m<-- DELETE /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15 [39m[32m200[39m [90m106 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session[39m
-[35m[HTTP][39m [90m{"capabilities":{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]},"desiredCapabilities":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true}}[39m
-[debug] [35m[W3C][39m Calling AppiumDriver.createSession() with args: [{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},null,{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]}]
-[debug] [35m[BaseDriver][39m Event 'newSessionRequested' logged at 1567033286047 (16:01:26 GMT-0700 (Pacific Daylight Time))
-[35m[BaseDriver][39m The capabilities ["deviceName","app"] are not standard capabilities and should have an extension prefix
-[35m[Appium][39m Appium v1.14.1 creating new WindowsDriver (v1.6.0) session
-[35m[Appium][39m Capabilities:
-[35m[Appium][39m   platformName: windows
-[35m[Appium][39m   deviceName: WindowsPC
-[35m[Appium][39m   app: ReactUWPTestApp_2wtq0zq3ec38a!App
-[35m[Appium][39m   winAppDriver:experimental-w3c: true
-[debug] [35m[BaseDriver][39m Creating session with MJSONWP desired capabilities: {
-[debug] [35m[BaseDriver][39m   "platformName": "windows",
-[debug] [35m[BaseDriver][39m   "deviceName": "WindowsPC",
-[debug] [35m[BaseDriver][39m   "app": "ReactUWPTestApp_2wtq0zq3ec38a!App",
-[debug] [35m[BaseDriver][39m   "experimental-w3c": true
-[debug] [35m[BaseDriver][39m }
-[35m[BaseDriver][39m The following capabilities were provided, but are not recognized by Appium:
-[35m[BaseDriver][39m   app
-[35m[BaseDriver][39m   experimental-w3c
-[35m[BaseDriver][39m Session created with session id: 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[WinAppDriver][39m You must use WinAppDriver version 1.1
-[35m[WinAppDriver][39m Verifying WinAppDriver version 1.1 is installed via comparing the checksum.
-[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'starting'
-[35m[WinAppDriver][39m Killing any old WinAppDrivers on same port, running: FOR /F "usebackq tokens=5" %a in (`netstat -nao ^| findstr /R /C:"4724 "`) do (FOR /F "usebackq" %b in (`TASKLIST /FI "PID eq %a" ^| findstr /I winappdriver.exe`) do (IF NOT %b=="" TASKKILL /F /PID %a))
-[35m[WinAppDriver][39m No old WinAppDrivers seemed to exist
-[35m[WinAppDriver][39m Spawning winappdriver with: 4724/wd/hub
-[35m[WinAppDriver][39m [STDOUT] Windows Application Driver listening for requests at: http://127.0.0.1:4724/wd/hub
-[debug] [35m[WD Proxy][39m Proxying [GET /status] to [GET http://127.0.0.1:4724/wd/hub/status] with no body
-[35m[WinAppDriver][39m [STDOUT] Press ENTER to exit.
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/status HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 147
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18967"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18967"}}
-[debug] [35m[WD Proxy][39m Determined the downstream protocol as 'undefined'
-[35m[WinAppDriver][39m Status call returned 200. we're online and ready to run tests
-[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'online'
-[debug] [35m[WD Proxy][39m Matched '/session' to command name 'createSession'
-[debug] [35m[WD Proxy][39m Proxying [POST /session] to [POST http://127.0.0.1:4724/wd/hub/session] with body: {"desiredCapabilities":{"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 141
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"desiredCapabilities":{"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 140
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
-[debug] [35m[WD Proxy][39m Determined the downstream protocol as 'MJSONWP'
-[35m[Appium][39m New WindowsDriver session created successfully, session 051a1366-6778-40ce-aa44-a3cab86a19da added to master session list
-[debug] [35m[BaseDriver][39m Event 'newSessionStarted' logged at 1567033301514 (16:01:41 GMT-0700 (Pacific Daylight Time))
-[debug] [35m[MJSONWP (051a1366)][39m Cached the protocol value 'MJSONWP' for the new session 051a1366-6778-40ce-aa44-a3cab86a19da
-[debug] [35m[MJSONWP (051a1366)][39m Responding to client with driver.createSession() result: {"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}
-[35m[HTTP][39m [37m<-- POST /wd/hub/session [39m[32m200[39m [90m15469 ms - 189[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m90 ms - 153[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click [39m[32m200[39m [90m366 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m189 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m160 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m73 ms - 153[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed [39m[32m200[39m [90m16 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInputTestPage"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 56
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInputTestPage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m141 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/displayed] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/displayed HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed [39m[32m200[39m [90m15 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInputTestPage"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 56
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInputTestPage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m128 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click [39m[32m200[39m [90m273 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m147 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m147 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m83 ms - 153[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed [39m[32m200[39m [90m7 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m76 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/displayed] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/displayed HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed [39m[32m200[39m [90m22 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m89 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear [39m[32m200[39m [90m51 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value[39m
-[35m[HTTP][39m [90m{"text":"abc","value":["a","b","c"]}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value] with body: {"text":"abc","value":["a","b","c"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 36
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"abc","value":["a","b","c"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value [39m[32m200[39m [90m242 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m105 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 77
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"abc"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"abc"}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text [39m[32m200[39m [90m24 ms - 77[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m88 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear [39m[32m200[39m [90m29 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value[39m
-[35m[HTTP][39m [90m{"text":"def","value":["d","e","f"]}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value] with body: {"text":"def","value":["d","e","f"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 36
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"def","value":["d","e","f"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value [39m[32m200[39m [90m234 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m116 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 77
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"def"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"def"}
-[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text [39m[32m200[39m [90m17 ms - 77[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mDELETE[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da[39m
-[35m[HTTP][39m [90m{}[39m
-[debug] [35m[MJSONWP (051a1366)][39m Calling AppiumDriver.deleteSession() with args: ["051a1366-6778-40ce-aa44-a3cab86a19da"]
-[debug] [35m[BaseDriver][39m Event 'quitSessionRequested' logged at 1567033307147 (16:01:47 GMT-0700 (Pacific Daylight Time))
-[35m[Appium][39m Removing session 051a1366-6778-40ce-aa44-a3cab86a19da from our master session list
-[debug] [35m[WinAppDriver][39m Deleting WinAppDriver session
-[debug] [35m[WinAppDriver][39m Deleting WinAppDriver server session
-[debug] [35m[WD Proxy][39m Matched '/' to command name 'deleteSession'
-[debug] [35m[WD Proxy][39m Proxying [DELETE /] to [DELETE http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF] with no body
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] DELETE /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 0
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 12
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"status":0}
-[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopping'
-[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopped'
-[debug] [35m[BaseDriver][39m Event 'quitSessionFinished' logged at 1567033307215 (16:01:47 GMT-0700 (Pacific Daylight Time))
-[debug] [35m[MJSONWP (051a1366)][39m Received response: null
-[debug] [35m[MJSONWP (051a1366)][39m But deleting session, so not returning
-[debug] [35m[MJSONWP (051a1366)][39m Responding to client with driver.deleteSession() result: null
-[35m[HTTP][39m [37m<-- DELETE /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da [39m[32m200[39m [90m70 ms - 76[39m
+[debug] [35m[BaseDriver][39m Event 'quitSessionFinished' logged at 1567790360361 (10:19:20 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[MJSONWP (e6ce83b9)][39m Received response: null
+[debug] [35m[MJSONWP (e6ce83b9)][39m But deleting session, so not returning
+[debug] [35m[MJSONWP (e6ce83b9)][39m Responding to client with driver.deleteSession() result: null
+[35m[HTTP][39m [37m<-- DELETE /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075 [39m[32m200[39m [90m56 ms - 76[39m
 [35m[HTTP][39m [90m[39m

--- a/packages/E2ETest/reports/appium.txt
+++ b/packages/E2ETest/reports/appium.txt
@@ -1,7 +1,7 @@
 [35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session[39m
 [35m[HTTP][39m [90m{"capabilities":{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]},"desiredCapabilities":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true}}[39m
 [debug] [35m[W3C][39m Calling AppiumDriver.createSession() with args: [{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},null,{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]}]
-[debug] [35m[BaseDriver][39m Event 'newSessionRequested' logged at 1567790334099 (10:18:54 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[BaseDriver][39m Event 'newSessionRequested' logged at 1567033255565 (16:00:55 GMT-0700 (Pacific Daylight Time))
 [35m[BaseDriver][39m The capabilities ["deviceName","app"] are not standard capabilities and should have an extension prefix
 [35m[Appium][39m Appium v1.14.1 creating new WindowsDriver (v1.6.0) session
 [35m[Appium][39m Capabilities:
@@ -18,7 +18,7 @@
 [35m[BaseDriver][39m The following capabilities were provided, but are not recognized by Appium:
 [35m[BaseDriver][39m   app
 [35m[BaseDriver][39m   experimental-w3c
-[35m[BaseDriver][39m Session created with session id: e6ce83b9-5cea-453a-a2c0-9ebca89fc075
+[35m[BaseDriver][39m Session created with session id: e0a52b64-314e-4d39-8ede-74fae06ffb15
 [35m[WinAppDriver][39m You must use WinAppDriver version 1.1
 [35m[WinAppDriver][39m Verifying WinAppDriver version 1.1 is installed via comparing the checksum.
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'starting'
@@ -44,7 +44,7 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
-[debug] [35m[WD Proxy][39m Got response with status 200: {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18362"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18967"}}
 [debug] [35m[WD Proxy][39m Determined the downstream protocol as 'undefined'
 [35m[WinAppDriver][39m Status call returned 200. we're online and ready to run tests
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'online'
@@ -66,24 +66,24 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 140
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
 [debug] [35m[WD Proxy][39m Determined the downstream protocol as 'MJSONWP'
-[35m[Appium][39m New WindowsDriver session created successfully, session e6ce83b9-5cea-453a-a2c0-9ebca89fc075 added to master session list
-[debug] [35m[BaseDriver][39m Event 'newSessionStarted' logged at 1567790345898 (10:19:05 GMT-0700 (Pacific Daylight Time))
-[debug] [35m[MJSONWP (e6ce83b9)][39m Cached the protocol value 'MJSONWP' for the new session e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[debug] [35m[MJSONWP (e6ce83b9)][39m Responding to client with driver.createSession() result: {"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}
-[35m[HTTP][39m [37m<-- POST /wd/hub/session [39m[32m200[39m [90m11806 ms - 189[39m
+[35m[Appium][39m New WindowsDriver session created successfully, session e0a52b64-314e-4d39-8ede-74fae06ffb15 added to master session list
+[debug] [35m[BaseDriver][39m Event 'newSessionStarted' logged at 1567033273856 (16:01:13 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[MJSONWP (e0a52b64)][39m Cached the protocol value 'MJSONWP' for the new session e0a52b64-314e-4d39-8ede-74fae06ffb15
+[debug] [35m[MJSONWP (e0a52b64)][39m Responding to client with driver.createSession() result: {"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}
+[35m[HTTP][39m [37m<-- POST /wd/hub/session [39m[32m200[39m [90m18300 ms - 189[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 50
@@ -92,132 +92,24 @@
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at runNextTicks (internal/process/task_queues.js:58:5)
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at processImmediate (internal/timers.js:412:9)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m82 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements' to command name 'findElements'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 74
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements [39m[32m200[39m [90m38 ms - 74[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements' to command name 'findElements'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 74
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[]}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements [39m[32m200[39m [90m37 ms - 74[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements' to command name 'findElements'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/elements HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 101
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[{"ELEMENT":"42.791910.4.4"}]}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":[{"ELEMENT":"42.791910.4.4"}]}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/elements [39m[32m200[39m [90m159 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 99
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m33 ms - 153[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m118 ms - 153[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/click] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -230,48 +122,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/click [39m[32m200[39m [90m298 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/click [39m[32m200[39m [90m343 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m87 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
@@ -286,20 +150,48 @@
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
 [35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
 [debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m65 ms - 164[39m
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m181 ms - 164[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m185 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 50
@@ -307,25 +199,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 99
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m31 ms - 153[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m95 ms - 153[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -337,20 +229,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed [39m[32m200[39m [90m14 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed [39m[32m200[39m [90m13 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInputTestPage"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 56
@@ -363,20 +255,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.11"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.11"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.11"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.11"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m130 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.11/displayed] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.11/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.11/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.11/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -388,20 +280,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.11/displayed [39m[32m200[39m [90m11 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.11/displayed [39m[32m200[39m [90m22 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"LoginTestPage"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"LoginTestPage"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"LoginTestPage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 52
@@ -414,20 +306,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.17"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.17"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m46 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.17"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.17"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m171 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.17/click] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.17/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.17/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.17/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -435,53 +327,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.17/click [39m[32m200[39m [90m232 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.17/click [39m[32m200[39m [90m316 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
-[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m86 ms - 164[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
@@ -496,20 +360,48 @@
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
 [35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
-[debug] [35m[MJSONWP (e6ce83b9)][39m     at JWProxy.proxy (D:\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
 [debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[31m500[39m [90m64 ms - 164[39m
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m222 ms - 164[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e0a52b64)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (e0a52b64)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[31m500[39m [90m210 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 50
@@ -522,20 +414,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 99
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.4"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m40 ms - 153[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m144 ms - 153[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.4/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.4/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -547,20 +439,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.4/displayed [39m[32m200[39m [90m9 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.4/displayed [39m[32m200[39m [90m21 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -573,20 +465,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m36 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m132 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed' to command name 'elementDisplayed'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/displayed] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/displayed] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/displayed HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -598,20 +490,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 76
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":true}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/displayed [39m[32m200[39m [90m10 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/displayed [39m[32m200[39m [90m28 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -624,20 +516,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m33 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m87 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -650,20 +542,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m54 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear [39m[32m200[39m [90m60 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value[39m
 [35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 61
@@ -676,20 +568,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m455 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value [39m[32m200[39m [90m549 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Password"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -702,20 +594,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m61 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m107 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -723,25 +615,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear [39m[32m200[39m [90m18 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear [39m[32m200[39m [90m17 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value[39m
 [35m[HTTP][39m [90m{"text":"password","value":["p","a","s","s","w","o","r","d"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 61
@@ -749,25 +641,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"password","value":["p","a","s","s","w","o","r","d"]}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value [39m[32m200[39m [90m433 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value [39m[32m200[39m [90m530 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Submit"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -780,20 +672,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m56 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m131 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -806,20 +698,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m231 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click [39m[32m200[39m [90m303 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Result"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -832,20 +724,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m57 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m132 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -857,20 +749,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 81
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m17 ms - 81[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Success"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Success"}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text [39m[32m200[39m [90m30 ms - 81[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -878,25 +770,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"UserName"}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m30 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m125 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -909,20 +801,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m20 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/clear [39m[32m200[39m [90m32 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value[39m
 [35m[HTTP][39m [90m{"text":"username@microsoft.com","value":["u","s","e","r","n","a","m","e","@","m","i","c","r","o","s","o","f","t",".","c","o","m"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username@microsoft.com","value":["u","s","e","r","n","a","m","e","@","m","i","c","r","o","s","o","f","t",".","c","o","m"]}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value] with body: {"text":"username@microsoft.com","value":["u","s","e","r","n","a","m","e","@","m","i","c","r","o","s","o","f","t",".","c","o","m"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.26/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 131
@@ -935,20 +827,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m988 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.26/value [39m[32m200[39m [90m1384 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Password"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 47
@@ -961,20 +853,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m50 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.30"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m144 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/clear HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -987,20 +879,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear [39m[32m200[39m [90m19 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/clear [39m[32m200[39m [90m34 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value[39m
 [35m[HTTP][39m [90m{"text":"password","value":["p","a","s","s","w","o","r","d"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.30/value HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 61
@@ -1013,20 +905,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value [39m[32m200[39m [90m430 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.30/value [39m[32m200[39m [90m529 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Submit"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -1039,20 +931,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m56 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.34"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m152 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.34/click HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 2
@@ -1065,20 +957,20 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 63
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m778 ms - 76[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.34/click [39m[32m200[39m [90m842 ms - 76[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element[39m
 [35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element] to [POST http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element] with body: {"using":"accessibility id","value":"Result"}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 45
@@ -1086,25 +978,25 @@
 [35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
 [35m[WinAppDriver][39m [STDOUT] User-Agent: appium
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Result"}
 [35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 100
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m55 ms - 155[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":{"ELEMENT":"42.595584.4.36"}}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element [39m[32m200[39m [90m159 ms - 155[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
+[35m[MJSONWP (e0a52b64)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text] to [GET http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text] with body: {}
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A/element/42.595584.4.36/text HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
@@ -1116,1424 +1008,24 @@
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 78
 [35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
 [35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m7 ms - 78[39m
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Fail"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"66EC7D7D-1ADA-4169-A9D9-77C12186654A","status":0,"value":"Fail"}
+[35m[WD Proxy][39m Replacing sessionId 66EC7D7D-1ADA-4169-A9D9-77C12186654A with e0a52b64-314e-4d39-8ede-74fae06ffb15
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15/element/42.595584.4.36/text [39m[32m200[39m [90m25 ms - 78[39m
 [35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m37 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
+[35m[HTTP][39m [37m-->[39m [37mDELETE[39m [37m/wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15[39m
 [35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m19 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
-[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m429 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.30"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/clear [39m[32m200[39m [90m19 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value[39m
-[35m[HTTP][39m [90m{"text":"abcdefg","value":["a","b","c","d","e","f","g"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value] with body: {"text":"abcdefg","value":["a","b","c","d","e","f","g"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.30/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 56
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"abcdefg","value":["a","b","c","d","e","f","g"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.30/value [39m[32m200[39m [90m390 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Submit"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m58 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m775 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m52 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 78
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Fail"}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m14 ms - 78[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ShowPassword"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ShowPassword"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 51
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m35 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click [39m[32m200[39m [90m223 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"UserName"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m49 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m20 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
-[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m426 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m52 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear [39m[32m200[39m [90m21 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value[39m
-[35m[HTTP][39m [90m{"text":"password","value":["p","a","s","s","w","o","r","d"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value] with body: {"text":"password","value":["p","a","s","s","w","o","r","d"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"password","value":["p","a","s","s","w","o","r","d"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value [39m[32m200[39m [90m427 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m54 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m229 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m60 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 81
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m12 ms - 81[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"UserName"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m34 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m16 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
-[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m428 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.44"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m43 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/clear [39m[32m200[39m [90m17 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value[39m
-[35m[HTTP][39m [90m{"text":"pass","value":["p","a","s","s"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value] with body: {"text":"pass","value":["p","a","s","s"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.44/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"pass","value":["p","a","s","s"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.44/value [39m[32m200[39m [90m265 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ShowPassword"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ShowPassword"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 51
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ShowPassword"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m56 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click [39m[32m200[39m [90m230 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value[39m
-[35m[HTTP][39m [90m{"text":"","value":[""]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value] with body: {"text":"","value":[""]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 30
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value [39m[32m200[39m [90m142 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m46 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value[39m
-[35m[HTTP][39m [90m{"text":"word","value":["w","o","r","d"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value] with body: {"text":"word","value":["w","o","r","d"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"word","value":["w","o","r","d"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value [39m[32m200[39m [90m259 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m222 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m59 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 81
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m8 ms - 81[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"UserName"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"UserName"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.26"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m37 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/clear [39m[32m200[39m [90m20 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value[39m
-[35m[HTTP][39m [90m{"text":"username","value":["u","s","e","r","n","a","m","e"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value] with body: {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.26/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 61
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"username","value":["u","s","e","r","n","a","m","e"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.26/value [39m[32m200[39m [90m432 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.49"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m58 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear' to command name 'clear'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/clear] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/clear HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/clear [39m[32m200[39m [90m19 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value[39m
-[35m[HTTP][39m [90m{"text":"pass","value":["p","a","s","s"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value] with body: {"text":"pass","value":["p","a","s","s"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.49/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"pass","value":["p","a","s","s"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.49/value [39m[32m200[39m [90m265 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"ShowPassword"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"ShowPassword"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 51
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.34"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m47 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.34/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.34/click [39m[32m200[39m [90m227 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m48 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value[39m
-[35m[HTTP][39m [90m{"text":"","value":[""]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value] with body: {"text":"","value":[""]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 30
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"","value":[""]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value [39m[32m200[39m [90m139 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Password"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 47
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"Password"}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.53"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m45 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value[39m
-[35m[HTTP][39m [90m{"text":"word","value":["w","o","r","d"]}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value' to command name 'setValue'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value] with body: {"text":"word","value":["w","o","r","d"]}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.53/value HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 41
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"text":"word","value":["w","o","r","d"]}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.53/value [39m[32m200[39m [90m264 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Submit"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Submit"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.36"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m49 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click' to command name 'click'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.36/click HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {}
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.36/click [39m[32m200[39m [90m229 ms - 76[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element[39m
-[35m[HTTP][39m [90m{"using":"accessibility id","value":"Result"}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element' to command name 'findElement'
-[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element] to [POST http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element] with body: {"using":"accessibility id","value":"Result"}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 45
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":{"ELEMENT":"42.791910.4.38"}}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- POST /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element [39m[32m200[39m [90m54 ms - 155[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text[39m
-[35m[HTTP][39m [90m{}[39m
-[35m[MJSONWP (e6ce83b9)][39m Driver proxy active, passing request on via HTTP proxy
-[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text' to command name 'getText'
-[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text] to [GET http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text] with body: {}
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16/element/42.791910.4.38/text HTTP/1.1
-[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
-[35m[WinAppDriver][39m [STDOUT] Connection: close
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
-[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
-[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
-[35m[WinAppDriver][39m [STDOUT] Content-Length: 81
-[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
-[35m[WinAppDriver][39m [STDOUT] 
-[35m[WinAppDriver][39m [STDOUT] {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"DE5F627A-ABEB-41AC-843C-35F859E98C16","status":0,"value":"Success"}
-[35m[WD Proxy][39m Replacing sessionId DE5F627A-ABEB-41AC-843C-35F859E98C16 with e6ce83b9-5cea-453a-a2c0-9ebca89fc075
-[35m[HTTP][39m [37m<-- GET /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075/element/42.791910.4.38/text [39m[32m200[39m [90m10 ms - 81[39m
-[35m[HTTP][39m [90m[39m
-[35m[HTTP][39m [37m-->[39m [37mDELETE[39m [37m/wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075[39m
-[35m[HTTP][39m [90m{}[39m
-[debug] [35m[MJSONWP (e6ce83b9)][39m Calling AppiumDriver.deleteSession() with args: ["e6ce83b9-5cea-453a-a2c0-9ebca89fc075"]
-[debug] [35m[BaseDriver][39m Event 'quitSessionRequested' logged at 1567790360308 (10:19:20 GMT-0700 (Pacific Daylight Time))
-[35m[Appium][39m Removing session e6ce83b9-5cea-453a-a2c0-9ebca89fc075 from our master session list
+[debug] [35m[MJSONWP (e0a52b64)][39m Calling AppiumDriver.deleteSession() with args: ["e0a52b64-314e-4d39-8ede-74fae06ffb15"]
+[debug] [35m[BaseDriver][39m Event 'quitSessionRequested' logged at 1567033284375 (16:01:24 GMT-0700 (Pacific Daylight Time))
+[35m[Appium][39m Removing session e0a52b64-314e-4d39-8ede-74fae06ffb15 from our master session list
 [debug] [35m[WinAppDriver][39m Deleting WinAppDriver session
 [debug] [35m[WinAppDriver][39m Deleting WinAppDriver server session
 [debug] [35m[WD Proxy][39m Matched '/' to command name 'deleteSession'
-[debug] [35m[WD Proxy][39m Proxying [DELETE /] to [DELETE http://127.0.0.1:4724/wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16] with no body
+[debug] [35m[WD Proxy][39m Proxying [DELETE /] to [DELETE http://127.0.0.1:4724/wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A] with no body
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] 
 [35m[WinAppDriver][39m [STDOUT] ==========================================
-[35m[WinAppDriver][39m [STDOUT] DELETE /wd/hub/session/DE5F627A-ABEB-41AC-843C-35F859E98C16 HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] DELETE /wd/hub/session/66EC7D7D-1ADA-4169-A9D9-77C12186654A HTTP/1.1
 [35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
 [35m[WinAppDriver][39m [STDOUT] Connection: close
 [35m[WinAppDriver][39m [STDOUT] Content-Length: 0
@@ -2550,9 +1042,799 @@
 [debug] [35m[WD Proxy][39m Got response with status 200: {"status":0}
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopping'
 [debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopped'
-[debug] [35m[BaseDriver][39m Event 'quitSessionFinished' logged at 1567790360361 (10:19:20 GMT-0700 (Pacific Daylight Time))
-[debug] [35m[MJSONWP (e6ce83b9)][39m Received response: null
-[debug] [35m[MJSONWP (e6ce83b9)][39m But deleting session, so not returning
-[debug] [35m[MJSONWP (e6ce83b9)][39m Responding to client with driver.deleteSession() result: null
-[35m[HTTP][39m [37m<-- DELETE /wd/hub/session/e6ce83b9-5cea-453a-a2c0-9ebca89fc075 [39m[32m200[39m [90m56 ms - 76[39m
+[debug] [35m[BaseDriver][39m Event 'quitSessionFinished' logged at 1567033284480 (16:01:24 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[MJSONWP (e0a52b64)][39m Received response: null
+[debug] [35m[MJSONWP (e0a52b64)][39m But deleting session, so not returning
+[debug] [35m[MJSONWP (e0a52b64)][39m Responding to client with driver.deleteSession() result: null
+[35m[HTTP][39m [37m<-- DELETE /wd/hub/session/e0a52b64-314e-4d39-8ede-74fae06ffb15 [39m[32m200[39m [90m106 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session[39m
+[35m[HTTP][39m [90m{"capabilities":{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]},"desiredCapabilities":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true}}[39m
+[debug] [35m[W3C][39m Calling AppiumDriver.createSession() with args: [{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},null,{"alwaysMatch":{"platformName":"windows","appium:deviceName":"WindowsPC","appium:app":"ReactUWPTestApp_2wtq0zq3ec38a!App","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","winAppDriver:experimental-w3c":true},"firstMatch":[{}]}]
+[debug] [35m[BaseDriver][39m Event 'newSessionRequested' logged at 1567033286047 (16:01:26 GMT-0700 (Pacific Daylight Time))
+[35m[BaseDriver][39m The capabilities ["deviceName","app"] are not standard capabilities and should have an extension prefix
+[35m[Appium][39m Appium v1.14.1 creating new WindowsDriver (v1.6.0) session
+[35m[Appium][39m Capabilities:
+[35m[Appium][39m   platformName: windows
+[35m[Appium][39m   deviceName: WindowsPC
+[35m[Appium][39m   app: ReactUWPTestApp_2wtq0zq3ec38a!App
+[35m[Appium][39m   winAppDriver:experimental-w3c: true
+[debug] [35m[BaseDriver][39m Creating session with MJSONWP desired capabilities: {
+[debug] [35m[BaseDriver][39m   "platformName": "windows",
+[debug] [35m[BaseDriver][39m   "deviceName": "WindowsPC",
+[debug] [35m[BaseDriver][39m   "app": "ReactUWPTestApp_2wtq0zq3ec38a!App",
+[debug] [35m[BaseDriver][39m   "experimental-w3c": true
+[debug] [35m[BaseDriver][39m }
+[35m[BaseDriver][39m The following capabilities were provided, but are not recognized by Appium:
+[35m[BaseDriver][39m   app
+[35m[BaseDriver][39m   experimental-w3c
+[35m[BaseDriver][39m Session created with session id: 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[WinAppDriver][39m You must use WinAppDriver version 1.1
+[35m[WinAppDriver][39m Verifying WinAppDriver version 1.1 is installed via comparing the checksum.
+[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'starting'
+[35m[WinAppDriver][39m Killing any old WinAppDrivers on same port, running: FOR /F "usebackq tokens=5" %a in (`netstat -nao ^| findstr /R /C:"4724 "`) do (FOR /F "usebackq" %b in (`TASKLIST /FI "PID eq %a" ^| findstr /I winappdriver.exe`) do (IF NOT %b=="" TASKKILL /F /PID %a))
+[35m[WinAppDriver][39m No old WinAppDrivers seemed to exist
+[35m[WinAppDriver][39m Spawning winappdriver with: 4724/wd/hub
+[35m[WinAppDriver][39m [STDOUT] Windows Application Driver listening for requests at: http://127.0.0.1:4724/wd/hub
+[debug] [35m[WD Proxy][39m Proxying [GET /status] to [GET http://127.0.0.1:4724/wd/hub/status] with no body
+[35m[WinAppDriver][39m [STDOUT] Press ENTER to exit.
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/status HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 147
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18967"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"build":{"revision":"18001","time":"Tue Sep 18 18:35:38 2018","version":"1.1.1809"},"os":{"arch":"amd64","name":"windows","version":"10.0.18967"}}
+[debug] [35m[WD Proxy][39m Determined the downstream protocol as 'undefined'
+[35m[WinAppDriver][39m Status call returned 200. we're online and ready to run tests
+[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'online'
+[debug] [35m[WD Proxy][39m Matched '/session' to command name 'createSession'
+[debug] [35m[WD Proxy][39m Proxying [POST /session] to [POST http://127.0.0.1:4724/wd/hub/session] with body: {"desiredCapabilities":{"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 141
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"desiredCapabilities":{"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 140
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"app":"ReactUWPTestApp_2wtq0zq3ec38a!App","platformName":"windows"}}
+[debug] [35m[WD Proxy][39m Determined the downstream protocol as 'MJSONWP'
+[35m[Appium][39m New WindowsDriver session created successfully, session 051a1366-6778-40ce-aa44-a3cab86a19da added to master session list
+[debug] [35m[BaseDriver][39m Event 'newSessionStarted' logged at 1567033301514 (16:01:41 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[MJSONWP (051a1366)][39m Cached the protocol value 'MJSONWP' for the new session 051a1366-6778-40ce-aa44-a3cab86a19da
+[debug] [35m[MJSONWP (051a1366)][39m Responding to client with driver.createSession() result: {"platformName":"windows","deviceName":"WindowsPC","app":"ReactUWPTestApp_2wtq0zq3ec38a!App","experimental-w3c":true}
+[35m[HTTP][39m [37m<-- POST /wd/hub/session [39m[32m200[39m [90m15469 ms - 189[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m90 ms - 153[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/click [39m[32m200[39m [90m366 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m189 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m160 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m73 ms - 153[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed [39m[32m200[39m [90m16 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInputTestPage"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 56
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInputTestPage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m141 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/displayed] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/displayed [39m[32m200[39m [90m15 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInputTestPage"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInputTestPage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 56
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInputTestPage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.11"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m128 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click' to command name 'click'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/click] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.11/click HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.11/click [39m[32m200[39m [90m273 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m147 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"ReactControlErrorMessage"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"ReactControlErrorMessage"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 404 Not Found
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 139
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[35m[WD Proxy][39m Got an unexpected response with status 404: {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m Encountered internal error running command: ProxyRequestError: Could not proxy command to remote server. Original error: 404 - {"status":7,"value":{"error":"no such element","message":"An element could not be located on the page using the given search parameters."}}
+[debug] [35m[MJSONWP (051a1366)][39m     at JWProxy.proxy (D:\repo\react-native-windows\node_modules\appium-base-driver\lib\jsonwp-proxy\proxy.js:233:13)
+[debug] [35m[W3C][39m Matched W3C error code 'no such element' to NoSuchElementError
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[31m500[39m [90m147 ms - 164[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"_HomeButton"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 50
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"_HomeButton"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 99
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.4"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m83 ms - 153[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.4/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.4/displayed [39m[32m200[39m [90m7 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m76 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed' to command name 'elementDisplayed'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/displayed] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/displayed HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 76
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":true}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/displayed [39m[32m200[39m [90m22 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m89 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear [39m[32m200[39m [90m51 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value[39m
+[35m[HTTP][39m [90m{"text":"abc","value":["a","b","c"]}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value] with body: {"text":"abc","value":["a","b","c"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 36
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"abc","value":["a","b","c"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value [39m[32m200[39m [90m242 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m105 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 77
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"abc"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"abc"}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text [39m[32m200[39m [90m24 ms - 77[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m88 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear' to command name 'clear'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/clear HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 2
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/clear [39m[32m200[39m [90m29 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value[39m
+[35m[HTTP][39m [90m{"text":"def","value":["d","e","f"]}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value' to command name 'setValue'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value] with body: {"text":"def","value":["d","e","f"]}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/value HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 36
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"text":"def","value":["d","e","f"]}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 63
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/value [39m[32m200[39m [90m234 ms - 76[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mPOST[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element[39m
+[35m[HTTP][39m [90m{"using":"accessibility id","value":"TextInput"}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element' to command name 'findElement'
+[debug] [35m[WD Proxy][39m Proxying [POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element] to [POST http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element] with body: {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] POST /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 48
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"using":"accessibility id","value":"TextInput"}
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 100
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":{"ELEMENT":"42.661406.4.26"}}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- POST /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element [39m[32m200[39m [90m116 ms - 155[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mGET[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text[39m
+[35m[HTTP][39m [90m{}[39m
+[35m[MJSONWP (051a1366)][39m Driver proxy active, passing request on via HTTP proxy
+[debug] [35m[WD Proxy][39m Matched '/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text' to command name 'getText'
+[debug] [35m[WD Proxy][39m Proxying [GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text] to [GET http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text] with body: {}
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] GET /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF/element/42.661406.4.26/text HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 77
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"def"}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"sessionId":"ED1C2548-B89A-42E6-85A1-68E80D9081DF","status":0,"value":"def"}
+[35m[WD Proxy][39m Replacing sessionId ED1C2548-B89A-42E6-85A1-68E80D9081DF with 051a1366-6778-40ce-aa44-a3cab86a19da
+[35m[HTTP][39m [37m<-- GET /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da/element/42.661406.4.26/text [39m[32m200[39m [90m17 ms - 77[39m
+[35m[HTTP][39m [90m[39m
+[35m[HTTP][39m [37m-->[39m [37mDELETE[39m [37m/wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da[39m
+[35m[HTTP][39m [90m{}[39m
+[debug] [35m[MJSONWP (051a1366)][39m Calling AppiumDriver.deleteSession() with args: ["051a1366-6778-40ce-aa44-a3cab86a19da"]
+[debug] [35m[BaseDriver][39m Event 'quitSessionRequested' logged at 1567033307147 (16:01:47 GMT-0700 (Pacific Daylight Time))
+[35m[Appium][39m Removing session 051a1366-6778-40ce-aa44-a3cab86a19da from our master session list
+[debug] [35m[WinAppDriver][39m Deleting WinAppDriver session
+[debug] [35m[WinAppDriver][39m Deleting WinAppDriver server session
+[debug] [35m[WD Proxy][39m Matched '/' to command name 'deleteSession'
+[debug] [35m[WD Proxy][39m Proxying [DELETE /] to [DELETE http://127.0.0.1:4724/wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF] with no body
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] ==========================================
+[35m[WinAppDriver][39m [STDOUT] DELETE /wd/hub/session/ED1C2548-B89A-42E6-85A1-68E80D9081DF HTTP/1.1
+[35m[WinAppDriver][39m [STDOUT] Accept: application/json, */*
+[35m[WinAppDriver][39m [STDOUT] Connection: close
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 0
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json; charset=utf-8
+[35m[WinAppDriver][39m [STDOUT] Host: 127.0.0.1:4724
+[35m[WinAppDriver][39m [STDOUT] User-Agent: appium
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] HTTP/1.1 200 OK
+[35m[WinAppDriver][39m [STDOUT] Content-Length: 12
+[35m[WinAppDriver][39m [STDOUT] Content-Type: application/json
+[35m[WinAppDriver][39m [STDOUT] 
+[35m[WinAppDriver][39m [STDOUT] {"status":0}
+[debug] [35m[WD Proxy][39m Got response with status 200: {"status":0}
+[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopping'
+[debug] [35m[WinAppDriver][39m WinAppDriver changed state to 'stopped'
+[debug] [35m[BaseDriver][39m Event 'quitSessionFinished' logged at 1567033307215 (16:01:47 GMT-0700 (Pacific Daylight Time))
+[debug] [35m[MJSONWP (051a1366)][39m Received response: null
+[debug] [35m[MJSONWP (051a1366)][39m But deleting session, so not returning
+[debug] [35m[MJSONWP (051a1366)][39m Responding to client with driver.deleteSession() result: null
+[35m[HTTP][39m [37m<-- DELETE /wd/hub/session/051a1366-6778-40ce-aa44-a3cab86a19da [39m[32m200[39m [90m70 ms - 76[39m
 [35m[HTTP][39m [90m[39m

--- a/packages/E2ETest/wdio/pages/LoginPage.ts
+++ b/packages/E2ETest/wdio/pages/LoginPage.ts
@@ -9,6 +9,7 @@ import {
   PASSWORD_ON_LOGIN,
   SUBMIT_ON_LOGIN,
   LOGINRESULT_ON_LOGIN,
+  SHOWPASSWORD_ON_LOGIN,
 } from '../../app/Consts';
 
 class LoginPage extends BasePage {
@@ -19,6 +20,15 @@ class LoginPage extends BasePage {
   setLoginInfo(userName: string, password: string) {
     this._userName.setValue(userName);
     this._password.setValue(password);
+  }
+
+  apendPassword(password: string) {
+    this._password.addValue('End');
+    this._password.addValue(password);
+  }
+
+  toggleShowPassword() {
+    this._showPassword.click();
   }
 
   submitForm() {
@@ -39,6 +49,10 @@ class LoginPage extends BasePage {
 
   private get _submit() {
     return By(SUBMIT_ON_LOGIN);
+  }
+
+  private get _showPassword() {
+    return By(SHOWPASSWORD_ON_LOGIN);
   }
 
   private get _loginResult() {

--- a/packages/E2ETest/wdio/test/login.spec.ts
+++ b/packages/E2ETest/wdio/test/login.spec.ts
@@ -24,4 +24,10 @@ describe('LoginTest', () => {
     LoginPage.submitForm();
     assert.equal(LoginPage.getLoginResult(), 'Fail');
   });
+
+  it('Login Fail', () => {
+    LoginPage.setLoginInfo('username@microsoft.com', 'abcdefg');
+    LoginPage.submitForm();
+    assert.equal(LoginPage.getLoginResult(), 'Fail');
+  });
 });

--- a/packages/E2ETest/wdio/test/login.spec.ts
+++ b/packages/E2ETest/wdio/test/login.spec.ts
@@ -30,4 +30,27 @@ describe('LoginTest', () => {
     LoginPage.submitForm();
     assert.equal(LoginPage.getLoginResult(), 'Fail');
   });
+
+  it('Login Success with secureTextEntry off', () => {
+    LoginPage.toggleShowPassword();
+    LoginPage.setLoginInfo('username', 'password');
+    LoginPage.submitForm();
+    assert.equal(LoginPage.getLoginResult(), 'Success');
+  });
+
+  it('Login Success with secureTextEntry off then on', () => {
+    LoginPage.setLoginInfo('username', 'pass');
+    LoginPage.toggleShowPassword();
+    LoginPage.apendPassword('word');
+    LoginPage.submitForm();
+    assert.equal(LoginPage.getLoginResult(), 'Success');
+  });
+
+  it('Login Success with secureTextEntry on then off', () => {
+    LoginPage.setLoginInfo('username', 'pass');
+    LoginPage.toggleShowPassword();
+    LoginPage.apendPassword('word');
+    LoginPage.submitForm();
+    assert.equal(LoginPage.getLoginResult(), 'Success');
+  });
 });

--- a/packages/E2ETest/wdio/test/login.spec.ts
+++ b/packages/E2ETest/wdio/test/login.spec.ts
@@ -26,7 +26,7 @@ describe('LoginTest', () => {
   });
 
   it('Login Fail', () => {
-    LoginPage.setLoginInfo('username@microsoft.com', 'abcdefg');
+    LoginPage.setLoginInfo('username', 'abcdefg');
     LoginPage.submitForm();
     assert.equal(LoginPage.getLoginResult(), 'Fail');
   });

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import React, {Component} from 'react';
+import {AppRegistry, Button, StyleSheet, Text, TextInput, View} from 'react-native';
+
+export default class Bootstrap extends Component {
+   state = {
+      passwordHidden: true,
+      text: ""
+   }
+
+   onPressShowPassword = () => {
+      var previousState = this.state.passwordHidden;
+      this.setState({ passwordHidden: !previousState })
+   }
+  
+   render() {
+      return (
+         <View style = {styles.container}>
+            <TextInput style = {styles.input}
+               placeholder = {"MultiLine"}
+               multiline = {true} />
+            <TextInput style = {styles.input}
+               placeholder = {"ReadOnly"}
+               editable = {false} />
+            <TextInput style = {styles.input}
+               placeholder = {"SpellChecking Disabled"}
+               spellCheck = {false} />
+            <TextInput style = {styles.input}
+               placeholder = {"PlaceHolder color blue"}
+               placeholderTextColor = "blue"/>
+            <TextInput style = {styles.input}
+               placeholder = {this.state.passwordHidden?"Password":"Text"}
+               autoCapitalize = "none"
+               secureTextEntry={this.state.passwordHidden}
+               onChangeText={(text) => {this.setState({text}); }}
+               value={this.state.text}
+               selectionColor = "red"
+               maxLength = {10} />
+            <Button style = {styles.button} title= {this.state.passwordHidden?"SecureTextEntry On":"SecureTextEntry Off"} onPress={this.onPressShowPassword}/>
+         </View>
+      )
+   }
+}
+
+const styles = StyleSheet.create({
+   container: {
+      paddingTop: 23,
+      flex: 1,
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+   },
+   input: {
+      margin: 15,
+      height: 80,
+      width: 700,
+      borderColor: '#7a42f4',
+      borderWidth: 1,
+      fontSize: 40,
+   },
+   button: {
+      margin: 15,
+      height: 25,
+      width: 75,
+   },
+});
+
+AppRegistry.registerComponent('Bootstrap', () => Bootstrap);

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -4,70 +4,84 @@
  * @format
  */
 
-import React, {Component} from 'react';
-import {AppRegistry, Button, StyleSheet, Text, TextInput, View} from 'react-native';
+import * as React from 'react';
+import {AppRegistry, Button, StyleSheet, TextInput, View} from 'react-native';
 
-export default class Bootstrap extends Component {
-   state = {
-      passwordHidden: true,
-      text: ""
-   }
+export default class Bootstrap extends React.Component<{}, any> {
+  state = {
+    passwordHidden: true,
+    text: '',
+  };
 
-   onPressShowPassword = () => {
-      var previousState = this.state.passwordHidden;
-      this.setState({ passwordHidden: !previousState })
-   }
-  
-   render() {
-      return (
-         <View style = {styles.container}>
-            <TextInput style = {styles.input}
-               placeholder = {"MultiLine"}
-               multiline = {true} />
-            <TextInput style = {styles.input}
-               placeholder = {"ReadOnly"}
-               editable = {false} />
-            <TextInput style = {styles.input}
-               placeholder = {"SpellChecking Disabled"}
-               spellCheck = {false} />
-            <TextInput style = {styles.input}
-               placeholder = {"PlaceHolder color blue"}
-               placeholderTextColor = "blue"/>
-            <TextInput style = {styles.input}
-               placeholder = {this.state.passwordHidden?"Password":"Text"}
-               autoCapitalize = "none"
-               secureTextEntry={this.state.passwordHidden}
-               onChangeText={(text) => {this.setState({text}); }}
-               value={this.state.text}
-               selectionColor = "red"
-               maxLength = {10} />
-            <Button style = {styles.button} title= {this.state.passwordHidden?"SecureTextEntry On":"SecureTextEntry Off"} onPress={this.onPressShowPassword}/>
-         </View>
-      )
-   }
+  onPressShowPassword = () => {
+    var previousState = this.state.passwordHidden;
+    this.setState({passwordHidden: !previousState});
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <TextInput
+          style={styles.input}
+          placeholder={'MultiLine'}
+          multiline={true}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder={'ReadOnly'}
+          editable={false}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder={'SpellChecking Disabled'}
+          spellCheck={false}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder={'PlaceHolder color blue'}
+          placeholderTextColor="blue"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder={this.state.passwordHidden ? 'Password' : 'Text'}
+          autoCapitalize="none"
+          secureTextEntry={this.state.passwordHidden}
+          onChangeText={text => {
+            this.setState({text});
+          }}
+          value={this.state.text}
+          selectionColor="red"
+          maxLength={10}
+        />
+        <Button
+          title={
+            this.state.passwordHidden
+              ? 'SecureTextEntry On'
+              : 'SecureTextEntry Off'
+          }
+          onPress={this.onPressShowPassword}
+        />
+      </View>
+    );
+  }
 }
 
 const styles = StyleSheet.create({
-   container: {
-      paddingTop: 23,
-      flex: 1,
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-   },
-   input: {
-      margin: 15,
-      height: 80,
-      width: 700,
-      borderColor: '#7a42f4',
-      borderWidth: 1,
-      fontSize: 40,
-   },
-   button: {
-      margin: 15,
-      height: 25,
-      width: 75,
-   },
+  container: {
+    paddingTop: 23,
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  input: {
+    margin: 15,
+    height: 80,
+    width: 700,
+    borderColor: '#7a42f4',
+    borderWidth: 1,
+    fontSize: 40,
+  },
 });
 
 AppRegistry.registerComponent('Bootstrap', () => Bootstrap);

--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -441,6 +441,7 @@ void HostingPane::InitComboBoxes() {
   m_jsFileNames->Append(L"Samples\\mouse");
   m_jsFileNames->Append(L"Samples\\simple");
   m_jsFileNames->Append(L"Samples\\text");
+  m_jsFileNames->Append(L"Samples\\textinput");
   m_jsFileNames->Append(L"Samples\\ticTacToe");
   m_jsFileNames->Append(L"Samples\\view");
 

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -20,6 +20,24 @@ folly::dynamic ControlViewManager::GetNativeProps() const {
   props.update(folly::dynamic::object("tabIndex", "number"));
   return props;
 }
+void ControlViewManager::TransferProperties(
+    XamlView oldView,
+    XamlView newView) {
+  TransferProperty(oldView, newView, winrt::Control::FontSizeProperty());
+  TransferProperty(oldView, newView, winrt::Control::FontFamilyProperty());
+  TransferProperty(oldView, newView, winrt::Control::FontWeightProperty());
+  TransferProperty(oldView, newView, winrt::Control::FontStyleProperty());
+  TransferProperty(
+      oldView, newView, winrt::Control::CharacterSpacingProperty());
+  TransferProperty(
+      oldView, newView, winrt::Control::IsTextScaleFactorEnabledProperty());
+  TransferProperty(oldView, newView, winrt::Control::BackgroundProperty());
+  TransferProperty(oldView, newView, winrt::Control::BorderBrushProperty());
+  TransferProperty(oldView, newView, winrt::Control::BorderThicknessProperty());
+  TransferProperty(oldView, newView, winrt::Control::PaddingProperty());
+  TransferProperty(oldView, newView, winrt::Control::ForegroundProperty());
+  TransferProperty(oldView, newView, winrt::Control::TabIndexProperty());
+}
 
 void ControlViewManager::UpdateProperties(
     ShadowNodeBase *nodeToUpdate,

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -48,6 +48,18 @@ void FrameworkElementViewManager::TransferProperty(
   }
 }
 
+void FrameworkElementViewManager::TransferProperty(
+    XamlView oldView,
+    XamlView newView,
+    winrt::DependencyProperty oldViewDP,
+    winrt::DependencyProperty newViewDP) {
+  auto oldValue = oldView.ReadLocalValue(oldViewDP);
+  if (oldValue != nullptr) {
+    oldView.ClearValue(oldViewDP);
+    newView.SetValue(newViewDP, oldValue);
+  }
+}
+
 void FrameworkElementViewManager::TransferProperties(
     XamlView oldView,
     XamlView newView) {

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -41,11 +41,7 @@ void FrameworkElementViewManager::TransferProperty(
     XamlView oldView,
     XamlView newView,
     winrt::DependencyProperty dp) {
-  auto oldValue = oldView.ReadLocalValue(dp);
-  if (oldValue != nullptr) {
-    oldView.ClearValue(dp);
-    newView.SetValue(dp, oldValue);
-  }
+  TransferProperty(oldView, newView, dp, dp);
 }
 
 void FrameworkElementViewManager::TransferProperty(

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -5,13 +5,13 @@
 
 #include <IReactInstance.h>
 
+#include <ReactUWP\Modules\NativeUIManager.h>
 #include <ViewManager.h>
 #include <Views/ExpressionAnimationStore.h>
 #include <Views/ShadowNodeBase.h>
 #include <Views/ViewManagerBase.h>
 #include <WindowsNumerics.h>
 #include "Views/KeyboardEventHandler.h"
-#include <ReactUWP\Modules\NativeUIManager.h>
 
 using namespace std::placeholders;
 
@@ -79,7 +79,8 @@ void ShadowNodeBase::ReplaceChild(
 void ShadowNodeBase::ReparentView(XamlView view) {
   GetViewManager()->TransferProperties(m_view, view);
   if (const auto instance = GetViewManager()->GetReactInstance().lock()) {
-    if (const auto nativeUIManager = static_cast<NativeUIManager *>(instance->NativeUIManager())){
+    if (const auto nativeUIManager =
+            static_cast<NativeUIManager *>(instance->NativeUIManager())) {
       int64_t parentTag = GetParent();
       auto host = nativeUIManager->getHost();
       auto pParentNode =

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -11,6 +11,7 @@
 #include <Views/ViewManagerBase.h>
 #include <WindowsNumerics.h>
 #include "Views/KeyboardEventHandler.h"
+#include <ReactUWP\Modules\NativeUIManager.h>
 
 using namespace std::placeholders;
 
@@ -73,6 +74,22 @@ void ShadowNodeBase::ReplaceChild(
     XamlView oldChildView,
     XamlView newChildView) {
   GetViewManager()->ReplaceChild(m_view, oldChildView, newChildView);
+}
+
+void ShadowNodeBase::ReparentView(XamlView view) {
+  GetViewManager()->TransferProperties(m_view, view);
+  if (const auto instance = GetViewManager()->GetReactInstance().lock()) {
+    if (const auto nativeUIManager = static_cast<NativeUIManager *>(instance->NativeUIManager())){
+      int64_t parentTag = GetParent();
+      auto host = nativeUIManager->getHost();
+      auto pParentNode =
+          static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(parentTag));
+      if (pParentNode != nullptr) {
+        pParentNode->ReplaceChild(m_view, view);
+      }
+    }
+  }
+  ReplaceView(view);
 }
 
 winrt::Windows::UI::Composition::CompositionPropertySet

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -69,8 +69,10 @@ class TextInputShadowNode : public ShadowNodeBase {
   }
 
  private:
+  void RegisterEvents();
   bool m_shouldClearTextOnFocus = false;
   bool m_shouldSelectTextOnFocus = false;
+  bool m_isTextBox = true;
 
   // Javascripts is running in a different thread. If the typing is very fast,
   // It's possible that two TextChanged are raised but TextInput just got the
@@ -82,19 +84,28 @@ class TextInputShadowNode : public ShadowNodeBase {
  private:
   winrt::TextBox::TextChanging_revoker m_textBoxTextChangingRevoker{};
   winrt::TextBox::TextChanged_revoker m_textBoxTextChangedRevoker{};
-  winrt::TextBox::GotFocus_revoker m_textBoxGotFocusRevoker{};
-  winrt::TextBox::LostFocus_revoker m_textBoxLostFocusRevoker{};
   winrt::TextBox::SelectionChanged_revoker m_textBoxSelectionChangedRevoker{};
-  winrt::TextBox::SizeChanged_revoker m_textBoxSizeChangedRevoker{};
+
+  winrt::PasswordBox::PasswordChanging_revoker
+      m_passwordBoxPasswordChangingRevoker{};
+  winrt::PasswordBox::PasswordChanged_revoker
+      m_passwordBoxPasswordChangedRevoker{};
+
+  winrt::TextBox::GotFocus_revoker m_controlGotFocusRevoker{};
+  winrt::TextBox::LostFocus_revoker m_controlLostFocusRevoker{};
+  winrt::Control::SizeChanged_revoker m_controlSizeChangedRevoker{};
+  winrt::Control::CharacterReceived_revoker m_controlCharacterReceivedRevoker{};
   winrt::ScrollViewer::ViewChanging_revoker m_scrollViewerViewChangingRevoker{};
-  winrt::TextBox::CharacterReceived_revoker m_textBoxCharacterReceivedRevoker{};
-  winrt::TextBox::Loaded_revoker m_textboxLoadedRevoker{};
+  winrt::Control::Loaded_revoker m_controlLoadedRevoker{};
 };
 
 void TextInputShadowNode::createView() {
   Super::createView();
+  RegisterEvents();
+}
 
-  auto textBox = GetView().as<winrt::TextBox>();
+void TextInputShadowNode::RegisterEvents() {
+  auto control = GetView().as<winrt::Control>();
   auto wkinstance = GetViewManager()->GetReactInstance();
   auto tag = m_tag;
 
@@ -110,28 +121,67 @@ void TextInputShadowNode::createView() {
   //
   // TextChanging is used to drop the Javascript response of 'A' and expect
   // another TextChanged event with correct event count.
-  m_textBoxTextChangingRevoker = textBox.TextChanging(
-      winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
+  if (m_isTextBox) {
+    m_textBoxTextChangingRevoker =
+        control.as<winrt::TextBox>().TextChanging(
+            winrt::auto_revoke,
+            [=](auto &&, auto &&) { m_nativeEventCount++; });
+  } else {
+    if (control.try_as<winrt::IPasswordBox4>()) {
+      m_passwordBoxPasswordChangingRevoker =
+          control.as<winrt::IPasswordBox4>().PasswordChanging(
+              winrt::auto_revoke,
+              [=](auto &&, auto &&) { m_nativeEventCount++; });
+    }
+  }
 
-  m_textBoxTextChangedRevoker =
-      textBox.TextChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
-        if (auto instance = wkinstance.lock()) {
-          m_nativeEventCount++;
-          folly::dynamic eventData = folly::dynamic::object("target", tag)(
-              "text", HstringToDynamic(textBox.Text()))(
-              "eventCount", m_nativeEventCount);
-          instance->DispatchEvent(
-              tag, "topTextInputChange", std::move(eventData));
+  if (m_isTextBox) {
+    auto textBox = control.as<winrt::TextBox>();
+    m_textBoxTextChangedRevoker =
+        textBox.TextChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
+          if (auto instance = wkinstance.lock()) {
+            m_nativeEventCount++;
+            folly::dynamic eventData = folly::dynamic::object("target", tag)(
+                "text", HstringToDynamic(textBox.Text()))(
+                "eventCount", m_nativeEventCount);
+            instance->DispatchEvent(
+                tag, "topTextInputChange", std::move(eventData));
+          }
+        });
+  } else {
+    auto passwordBox = control.as<winrt::PasswordBox>();
+    m_passwordBoxPasswordChangedRevoker =
+        passwordBox.PasswordChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
+          if (auto instance = wkinstance.lock()) {
+            m_nativeEventCount++;
+            folly::dynamic eventData = folly::dynamic::object("target", tag)(
+                "text", HstringToDynamic(passwordBox.Password()))(
+                "eventCount", m_nativeEventCount);
+            instance->DispatchEvent(
+                tag, "topTextInputChange", std::move(eventData));
+          }
+        });
+  }
+
+  m_controlGotFocusRevoker =
+      control.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
+        if (m_shouldClearTextOnFocus) {
+          if (m_isTextBox) {
+            control.as<winrt::TextBox>().ClearValue(
+                winrt::TextBox::TextProperty());
+          } else {
+            control.as<winrt::PasswordBox>().ClearValue(
+                winrt::PasswordBox::PasswordProperty());
+          }
         }
-      });
 
-  m_textBoxGotFocusRevoker =
-      textBox.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
-        if (m_shouldClearTextOnFocus)
-          textBox.ClearValue(winrt::TextBox::TextProperty());
-
-        if (m_shouldSelectTextOnFocus)
-          textBox.SelectAll();
+        if (m_shouldSelectTextOnFocus) {
+          if (m_isTextBox) {
+            control.as<winrt::TextBox>().SelectAll();
+          } else {
+            control.as<winrt::PasswordBox>().SelectAll();
+          }
+        }
 
         auto instance = wkinstance.lock();
         folly::dynamic eventData = folly::dynamic::object("target", tag);
@@ -140,12 +190,21 @@ void TextInputShadowNode::createView() {
               tag, "topTextInputFocus", std::move(eventData));
       });
 
-  m_textBoxLostFocusRevoker =
-      textBox.LostFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
+  m_controlLostFocusRevoker =
+      control.LostFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
         auto instance = wkinstance.lock();
         folly::dynamic eventDataBlur = folly::dynamic::object("target", tag);
-        folly::dynamic eventDataEndEditing = folly::dynamic::object(
-            "target", tag)("text", HstringToDynamic(textBox.Text()));
+        folly::dynamic eventDataEndEditing = {};
+        if (m_isTextBox) {
+          eventDataEndEditing = folly::dynamic::object("target", tag)(
+              "text",
+              HstringToDynamic(control.as<winrt::TextBox>().Text()));
+        } else {
+          eventDataEndEditing = folly::dynamic::object("target", tag)(
+              "text",
+              HstringToDynamic(
+                  control.as<winrt::PasswordBox>().Password()));
+        }
         if (!m_updating && instance != nullptr) {
           instance->DispatchEvent(
               tag, "topTextInputBlur", std::move(eventDataBlur));
@@ -154,38 +213,45 @@ void TextInputShadowNode::createView() {
         }
       });
 
-  m_textBoxSelectionChangedRevoker =
-      textBox.SelectionChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
-        auto instance = wkinstance.lock();
-        folly::dynamic selectionData =
-            folly::dynamic::object("start", textBox.SelectionStart())(
-                "end", textBox.SelectionStart() + textBox.SelectionLength());
-        folly::dynamic eventData = folly::dynamic::object("target", tag)(
-            "selection", std::move(selectionData));
-        if (!m_updating && instance != nullptr)
-          instance->DispatchEvent(
-              tag, "topTextInputSelectionChange", std::move(eventData));
-      });
-
-  m_textBoxSizeChangedRevoker = textBox.SizeChanged(
-      winrt::auto_revoke,
-      [=](auto &&, winrt::SizeChangedEventArgs const &args) {
-        if (textBox.TextWrapping() == winrt::TextWrapping::Wrap) {
+  if (m_isTextBox) {
+    auto textBox = control.as<winrt::TextBox>();
+    m_textBoxSelectionChangedRevoker =
+        textBox.SelectionChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
           auto instance = wkinstance.lock();
-          folly::dynamic contentSizeData = folly::dynamic::object(
-              "width", args.NewSize().Width)("height", args.NewSize().Height);
+          folly::dynamic selectionData =
+              folly::dynamic::object("start", textBox.SelectionStart())(
+                  "end", textBox.SelectionStart() + textBox.SelectionLength());
           folly::dynamic eventData = folly::dynamic::object("target", tag)(
-              "contentSize", std::move(contentSizeData));
+              "selection", std::move(selectionData));
           if (!m_updating && instance != nullptr)
             instance->DispatchEvent(
-                tag, "topTextInputContentSizeChange", std::move(eventData));
+                tag, "topTextInputSelectionChange", std::move(eventData));
+        });
+  }
+
+  m_controlSizeChangedRevoker = control.SizeChanged(
+      winrt::auto_revoke,
+      [=](auto &&, winrt::SizeChangedEventArgs const &args) {
+        if (m_isTextBox) {
+          if (control.as<winrt::TextBox>().TextWrapping() ==
+              winrt::TextWrapping::Wrap) {
+            auto instance = wkinstance.lock();
+            folly::dynamic contentSizeData = folly::dynamic::object(
+                "width", args.NewSize().Width)("height", args.NewSize().Height);
+            folly::dynamic eventData = folly::dynamic::object("target", tag)(
+                "contentSize", std::move(contentSizeData));
+            if (!m_updating && instance != nullptr)
+              instance->DispatchEvent(
+                  tag, "topTextInputContentSizeChange", std::move(eventData));
+          }
         }
       });
 
-  m_textboxLoadedRevoker =
-      textBox.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
-        auto textBoxView = textBox.GetTemplateChild(asHstring("ContentElement"))
-                               .as<winrt::ScrollViewer>();
+  m_controlLoadedRevoker =
+      control.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
+        auto textBoxView =
+            control.GetTemplateChild(asHstring("ContentElement"))
+                .as<winrt::ScrollViewer>();
         if (textBoxView) {
           m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(
               winrt::auto_revoke,
@@ -205,8 +271,8 @@ void TextInputShadowNode::createView() {
         }
       });
 
-  if (textBox.try_as<winrt::IUIElement7>()) {
-    m_textBoxCharacterReceivedRevoker = textBox.CharacterReceived(
+  if (control.try_as<winrt::IUIElement7>()) {
+    m_controlCharacterReceivedRevoker = control.CharacterReceived(
         winrt::auto_revoke,
         [=](auto &&, winrt::CharacterReceivedRoutedEventArgs const &args) {
           auto instance = wkinstance.lock();
@@ -232,101 +298,159 @@ void TextInputShadowNode::createView() {
 }
 void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
   m_updating = true;
-  auto textBox = GetView().as<winrt::TextBox>();
-  if (textBox == nullptr)
-    return;
+  auto control = GetView().as<winrt::Control>();
 
-  auto control = textBox.as<winrt::Control>();
   for (auto &pair : props.items()) {
     const std::string &propertyName = pair.first.getString();
     const folly::dynamic &propertyValue = pair.second;
 
+    // Applicable properties for both PasswordBoxTextBox and PasswordBox
     if (TryUpdateFontProperties(control, propertyName, propertyValue)) {
-      continue;
-    } else if (TryUpdateTextAlignment(textBox, propertyName, propertyValue)) {
       continue;
     } else if (TryUpdateCharacterSpacing(
                    control, propertyName, propertyValue)) {
       continue;
-    } else if (propertyName == "multiline") {
-      if (propertyValue.isBool())
-        textBox.TextWrapping(
-            propertyValue.asBool() ? winrt::TextWrapping::Wrap
-                                   : winrt::TextWrapping::NoWrap);
-      else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::TextBox::TextWrappingProperty());
     } else if (propertyName == "allowFontScaling") {
       if (propertyValue.isBool())
-        textBox.IsTextScaleFactorEnabled(propertyValue.asBool());
+        control.IsTextScaleFactorEnabled(propertyValue.asBool());
       else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::Control::IsTextScaleFactorEnabledProperty());
+        control.ClearValue(
+            winrt::Control::IsTextScaleFactorEnabledProperty());
     } else if (propertyName == "clearTextOnFocus") {
       if (propertyValue.isBool())
         m_shouldClearTextOnFocus = propertyValue.asBool();
-    } else if (propertyName == "editable") {
-      if (propertyValue.isBool())
-        textBox.IsReadOnly(!propertyValue.asBool());
-      else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::TextBox::IsReadOnlyProperty());
-    } else if (propertyName == "maxLength") {
-      if (propertyValue.isNumber())
-        textBox.MaxLength(static_cast<int32_t>(propertyValue.asDouble()));
-      else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::TextBox::MaxLengthProperty());
-    } else if (propertyName == "placeholder") {
-      if (propertyValue.isString())
-        textBox.PlaceholderText(asHstring(propertyValue));
-      else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::TextBox::PlaceholderTextProperty());
-    } else if (propertyName == "placeholderTextColor") {
-      if (textBox.try_as<winrt::ITextBox6>()) {
-        if (IsValidColorValue(propertyValue))
-          textBox.PlaceholderForeground(SolidColorBrushFrom(propertyValue));
-        else if (propertyValue.isNull())
-          textBox.ClearValue(winrt::TextBox::PlaceholderForegroundProperty());
-      }
-    } else if (propertyName == "scrollEnabled") {
-      if (propertyValue.isBool() &&
-          textBox.TextWrapping() == winrt::TextWrapping::Wrap) {
-        auto scrollMode = propertyValue.asBool() ? winrt::ScrollMode::Auto
-                                                 : winrt::ScrollMode::Disabled;
-        winrt::ScrollViewer::SetVerticalScrollMode(textBox, scrollMode);
-        winrt::ScrollViewer::SetHorizontalScrollMode(textBox, scrollMode);
-      }
-    } else if (propertyName == "selection") {
-      if (propertyValue.isObject()) {
-        auto selection = json_type_traits<Selection>::parseJson(propertyValue);
-
-        if (selection.isValid())
-          textBox.Select(selection.start, selection.end - selection.start);
-      }
-    } else if (propertyName == "selectionColor") {
-      if (IsValidColorValue(propertyValue))
-        textBox.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
-      else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::TextBox::SelectionHighlightColorProperty());
     } else if (propertyName == "selectTextOnFocus") {
       if (propertyValue.isBool())
         m_shouldSelectTextOnFocus = propertyValue.asBool();
-    } else if (propertyName == "spellCheck") {
-      if (propertyValue.isBool())
-        textBox.IsSpellCheckEnabled(propertyValue.asBool());
-      else if (propertyValue.isNull())
-        textBox.ClearValue(winrt::TextBox::IsSpellCheckEnabledProperty());
-    } else if (propertyName == "text") {
-      if (m_mostRecentEventCount == m_nativeEventCount) {
-        if (propertyValue.isString()) {
-          auto oldValue = textBox.Text();
-          auto newValue = asHstring(propertyValue);
-          if (oldValue != newValue) {
-            textBox.Text(newValue);
-          }
-        } else if (propertyValue.isNull())
-          textBox.ClearValue(winrt::TextBox::TextProperty());
-      }
     } else if (propertyName == "mostRecentEventCount") {
       if (propertyValue.isNumber()) {
         m_mostRecentEventCount = static_cast<uint32_t>(propertyValue.asInt());
+      }
+    } else if (propertyName == "secureTextEntry") {
+      if (propertyValue.isBool()) {
+        if (propertyValue.asBool()) {
+          if (m_isTextBox) {
+            winrt::PasswordBox pwBox;
+            ReparentView(pwBox);
+            m_isTextBox = false;
+            RegisterEvents();
+            control = pwBox.as<winrt::Control>();
+          }
+        } else {
+          if (!m_isTextBox) {
+            winrt::TextBox textBox;
+            ReparentView(textBox);
+            m_isTextBox = true;
+            RegisterEvents();
+            control = textBox.as<winrt::Control>();
+          }
+        }
+      }
+    } else {
+      if (m_isTextBox) { // Applicable properties for TextBox
+        auto textBox = control.as<winrt::TextBox>();
+        if (TryUpdateTextAlignment(textBox, propertyName, propertyValue)) {
+          continue;
+        } else if (propertyName == "multiline") {
+          if (propertyValue.isBool())
+            textBox.TextWrapping(
+                propertyValue.asBool() ? winrt::TextWrapping::Wrap
+                                       : winrt::TextWrapping::NoWrap);
+          else if (propertyValue.isNull())
+            textBox.ClearValue(winrt::TextBox::TextWrappingProperty());
+        } else if (propertyName == "editable") {
+          if (propertyValue.isBool())
+            textBox.IsReadOnly(!propertyValue.asBool());
+          else if (propertyValue.isNull())
+            textBox.ClearValue(winrt::TextBox::IsReadOnlyProperty());
+        } else if (propertyName == "maxLength") {
+          if (propertyValue.isNumber())
+            textBox.MaxLength(static_cast<int32_t>(propertyValue.asDouble()));
+          else if (propertyValue.isNull())
+            textBox.ClearValue(winrt::TextBox::MaxLengthProperty());
+        } else if (propertyName == "placeholder") {
+          if (propertyValue.isString())
+            textBox.PlaceholderText(asHstring(propertyValue));
+          else if (propertyValue.isNull())
+            textBox.ClearValue(winrt::TextBox::PlaceholderTextProperty());
+        } else if (propertyName == "placeholderTextColor") {
+          if (textBox.try_as<winrt::ITextBox6>()) {
+            if (IsValidColorValue(propertyValue))
+              textBox.PlaceholderForeground(SolidColorBrushFrom(propertyValue));
+            else if (propertyValue.isNull())
+              textBox.ClearValue(
+                  winrt::TextBox::PlaceholderForegroundProperty());
+          }
+        } else if (propertyName == "scrollEnabled") {
+          if (propertyValue.isBool() &&
+              textBox.TextWrapping() == winrt::TextWrapping::Wrap) {
+            auto scrollMode = propertyValue.asBool()
+                ? winrt::ScrollMode::Auto
+                : winrt::ScrollMode::Disabled;
+            winrt::ScrollViewer::SetVerticalScrollMode(textBox, scrollMode);
+            winrt::ScrollViewer::SetHorizontalScrollMode(textBox, scrollMode);
+          }
+        } else if (propertyName == "selection") {
+          if (propertyValue.isObject()) {
+            auto selection =
+                json_type_traits<Selection>::parseJson(propertyValue);
+
+            if (selection.isValid())
+              textBox.Select(selection.start, selection.end - selection.start);
+          }
+        } else if (propertyName == "selectionColor") {
+          if (IsValidColorValue(propertyValue))
+            textBox.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
+          else if (propertyValue.isNull())
+            textBox.ClearValue(
+                winrt::TextBox::SelectionHighlightColorProperty());
+        } else if (propertyName == "spellCheck") {
+          if (propertyValue.isBool())
+            textBox.IsSpellCheckEnabled(propertyValue.asBool());
+          else if (propertyValue.isNull())
+            textBox.ClearValue(winrt::TextBox::IsSpellCheckEnabledProperty());
+        } else if (propertyName == "text") {
+          if (m_mostRecentEventCount == m_nativeEventCount) {
+            if (propertyValue.isString()) {
+              auto oldValue = textBox.Text();
+              auto newValue = asHstring(propertyValue);
+              if (oldValue != newValue) {
+                textBox.Text(newValue);
+              }
+            } else if (propertyValue.isNull())
+              textBox.ClearValue(winrt::TextBox::TextProperty());
+          }
+        }
+      } else { // Applicable properties for PasswordBox
+        auto pwBox = control.as<winrt::PasswordBox>();
+        if (propertyName == "maxLength") {
+          if (propertyValue.isNumber())
+            pwBox.MaxLength(static_cast<int32_t>(propertyValue.asDouble()));
+          else if (propertyValue.isNull())
+            pwBox.ClearValue(winrt::PasswordBox::MaxLengthProperty());
+        } else if (propertyName == "placeholder") {
+          if (propertyValue.isString())
+            pwBox.PlaceholderText(asHstring(propertyValue));
+          else if (propertyValue.isNull())
+            pwBox.ClearValue(winrt::PasswordBox::PlaceholderTextProperty());
+        } else if (propertyName == "selectionColor") {
+          if (IsValidColorValue(propertyValue))
+            pwBox.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
+          else if (propertyValue.isNull())
+            pwBox.ClearValue(
+                winrt::PasswordBox::SelectionHighlightColorProperty());
+        } else if (propertyName == "text") {
+          if (m_mostRecentEventCount == m_nativeEventCount) {
+            if (propertyValue.isString()) {
+              auto oldValue = pwBox.Password();
+              auto newValue = asHstring(propertyValue);
+              if (oldValue != newValue) {
+                pwBox.Password(newValue);
+              }
+            } else if (propertyValue.isNull())
+              pwBox.ClearValue(winrt::PasswordBox::PasswordProperty());
+          }
+        }
       }
     }
   }
@@ -352,7 +476,8 @@ folly::dynamic TextInputViewManager::GetNativeProps() const {
       "placeholderTextColor", "Color")("scrollEnabled", "boolean")(
       "selection", "Map")("selectionColor", "Color")(
       "selectTextOnFocus", "boolean")("spellCheck", "boolean")(
-      "text", "string")("mostRecentEventCount", "int"));
+      "text", "string")("mostRecentEventCount", "int")(
+      "secureTextEntry", "boolean"));
 
   return props;
 }
@@ -393,5 +518,73 @@ YGMeasureFunc TextInputViewManager::GetYogaCustomMeasureFunc() const {
   return DefaultYogaSelfMeasureFunc;
 }
 
+void TextInputViewManager::TransferProperties(
+    XamlView oldView,
+    XamlView newView) {
+  __super::TransferProperties(oldView, newView);
+
+  bool copyToPasswordBox = oldView.try_as<winrt::TextBox>() != nullptr;
+
+  // sync common control properties
+  TransferProperty(oldView, newView, winrt::Control::FontSizeProperty());
+  TransferProperty(oldView, newView, winrt::Control::FontFamilyProperty());
+  TransferProperty(oldView, newView, winrt::Control::FontWeightProperty());
+  TransferProperty(oldView, newView, winrt::Control::FontStyleProperty());
+  TransferProperty(
+      oldView, newView, winrt::Control::CharacterSpacingProperty());
+  TransferProperty(
+      oldView, newView, winrt::Control::IsTextScaleFactorEnabledProperty());
+  TransferProperty(oldView, newView, winrt::Control::BackgroundProperty());
+  TransferProperty(oldView, newView, winrt::Control::BorderBrushProperty());
+  TransferProperty(oldView, newView, winrt::Control::BorderThicknessProperty());
+  TransferProperty(oldView, newView, winrt::Control::PaddingProperty());
+  TransferProperty(oldView, newView, winrt::Control::ForegroundProperty());
+  TransferProperty(oldView, newView, winrt::Control::TabIndexProperty());
+
+  // sync common properties between TextBox and PasswordBox
+  if (copyToPasswordBox) {
+    TransferProperty(
+        oldView,
+        newView,
+        winrt::TextBox::MaxLengthProperty(),
+        winrt::PasswordBox::MaxLengthProperty());
+    TransferProperty(
+        oldView,
+        newView,
+        winrt::TextBox::PlaceholderTextProperty(),
+        winrt::PasswordBox::PlaceholderTextProperty());
+    TransferProperty(
+        oldView,
+        newView,
+        winrt::TextBox::SelectionHighlightColorProperty(),
+        winrt::PasswordBox::SelectionHighlightColorProperty());
+    newView.as<winrt::PasswordBox>().Password(
+        oldView.as<winrt::TextBox>().Text());
+  } else {
+    TransferProperty(
+        oldView,
+        newView,
+        winrt::PasswordBox::MaxLengthProperty(),
+        winrt::TextBox::MaxLengthProperty());
+    TransferProperty(
+        oldView,
+        newView,
+        winrt::PasswordBox::PlaceholderTextProperty(),
+        winrt::TextBox::PlaceholderTextProperty());
+    TransferProperty(
+        oldView,
+        newView,
+        winrt::PasswordBox::SelectionHighlightColorProperty(),
+        winrt::TextBox::SelectionHighlightColorProperty());
+    newView.as<winrt::TextBox>().Text(
+        oldView.as<winrt::PasswordBox>().Password());
+  }
+
+  // Set focus if current control has focus
+  auto focusState = oldView.as<winrt::Control>().FocusState();
+  if (focusState != winrt::FocusState::Unfocused) {
+    newView.as<winrt::Control>().Focus(focusState);
+  }
+}
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -122,10 +122,8 @@ void TextInputShadowNode::RegisterEvents() {
   // TextChanging is used to drop the Javascript response of 'A' and expect
   // another TextChanged event with correct event count.
   if (m_isTextBox) {
-    m_textBoxTextChangingRevoker =
-        control.as<winrt::TextBox>().TextChanging(
-            winrt::auto_revoke,
-            [=](auto &&, auto &&) { m_nativeEventCount++; });
+    m_textBoxTextChangingRevoker = control.as<winrt::TextBox>().TextChanging(
+        winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
   } else {
     if (control.try_as<winrt::IPasswordBox4>()) {
       m_passwordBoxPasswordChangingRevoker =
@@ -197,13 +195,11 @@ void TextInputShadowNode::RegisterEvents() {
         folly::dynamic eventDataEndEditing = {};
         if (m_isTextBox) {
           eventDataEndEditing = folly::dynamic::object("target", tag)(
-              "text",
-              HstringToDynamic(control.as<winrt::TextBox>().Text()));
+              "text", HstringToDynamic(control.as<winrt::TextBox>().Text()));
         } else {
           eventDataEndEditing = folly::dynamic::object("target", tag)(
               "text",
-              HstringToDynamic(
-                  control.as<winrt::PasswordBox>().Password()));
+              HstringToDynamic(control.as<winrt::PasswordBox>().Password()));
         }
         if (!m_updating && instance != nullptr) {
           instance->DispatchEvent(
@@ -249,9 +245,8 @@ void TextInputShadowNode::RegisterEvents() {
 
   m_controlLoadedRevoker =
       control.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
-        auto textBoxView =
-            control.GetTemplateChild(asHstring("ContentElement"))
-                .as<winrt::ScrollViewer>();
+        auto textBoxView = control.GetTemplateChild(asHstring("ContentElement"))
+                               .as<winrt::ScrollViewer>();
         if (textBoxView) {
           m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(
               winrt::auto_revoke,
@@ -314,8 +309,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
       if (propertyValue.isBool())
         control.IsTextScaleFactorEnabled(propertyValue.asBool());
       else if (propertyValue.isNull())
-        control.ClearValue(
-            winrt::Control::IsTextScaleFactorEnabledProperty());
+        control.ClearValue(winrt::Control::IsTextScaleFactorEnabledProperty());
     } else if (propertyName == "clearTextOnFocus") {
       if (propertyValue.isBool())
         m_shouldClearTextOnFocus = propertyValue.asBool();

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -350,8 +350,10 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
     } else if (propertyName == "maxLength") {
       if (propertyValue.isNumber()) {
         control.SetValue(
-            m_isTextBox ? winrt::TextBox::MaxLengthProperty() : winrt::PasswordBox::MaxLengthProperty(),
-            winrt::PropertyValue::CreateInt32(static_cast<int32_t>(propertyValue.asDouble())));
+            m_isTextBox ? winrt::TextBox::MaxLengthProperty()
+                        : winrt::PasswordBox::MaxLengthProperty(),
+            winrt::PropertyValue::CreateInt32(
+                static_cast<int32_t>(propertyValue.asDouble())));
       } else if (propertyValue.isNull()) {
         control.ClearValue(
             m_isTextBox ? winrt::TextBox::MaxLengthProperty()
@@ -361,7 +363,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
       if (propertyValue.isString()) {
         control.SetValue(
             m_isTextBox ? winrt::TextBox::PlaceholderTextProperty()
-                : winrt::PasswordBox::PlaceholderTextProperty(),
+                        : winrt::PasswordBox::PlaceholderTextProperty(),
             winrt::PropertyValue::CreateString(asHstring(propertyValue)));
       } else if (propertyValue.isNull()) {
         control.ClearValue(
@@ -374,13 +376,12 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
             m_isTextBox ? winrt::TextBox::SelectionHighlightColorProperty()
                         : winrt::PasswordBox::SelectionHighlightColorProperty(),
             SolidColorBrushFrom(propertyValue));
-      }
-      else if (propertyValue.isNull())
+      } else if (propertyValue.isNull())
         control.ClearValue(
-            m_isTextBox ? winrt::TextBox::SelectionHighlightColorProperty()
+            m_isTextBox
+                ? winrt::TextBox::SelectionHighlightColorProperty()
                 : winrt::PasswordBox::SelectionHighlightColorProperty());
-    }
-    else {
+    } else {
       if (m_isTextBox) { // Applicable properties for TextBox
         if (TryUpdateTextAlignment(textBox, propertyName, propertyValue)) {
           continue;

--- a/vnext/ReactUWP/Views/TextInputViewManager.h
+++ b/vnext/ReactUWP/Views/TextInputViewManager.h
@@ -20,6 +20,7 @@ class TextInputViewManager : public ControlViewManager {
   facebook::react::ShadowNode *createShadow() const override;
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
+  virtual void TransferProperties(XamlView oldView, XamlView newView) override;
 
  protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/include/ReactUWP/Views/ControlViewManager.h
+++ b/vnext/include/ReactUWP/Views/ControlViewManager.h
@@ -21,6 +21,7 @@ class REACTWINDOWS_EXPORT ControlViewManager
   void UpdateProperties(
       ShadowNodeBase *nodeToUpdate,
       const folly::dynamic &reactDiffMap) override;
+  void TransferProperties(XamlView oldView, XamlView newView) override;
 };
 
 } // namespace uwp

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -36,9 +36,9 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       winrt::Windows::UI::Xaml::DependencyProperty dp);
 
   void TransferProperty(
-      XamlView oldView, 
-      XamlView newView, 
-      winrt::DependencyProperty oldViewDP, 
+      XamlView oldView,
+      XamlView newView,
+      winrt::DependencyProperty oldViewDP,
       winrt::DependencyProperty newViewDP);
 
  private:

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -27,12 +27,19 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       winrt::UIElement uielement,
       winrt::Windows::UI::Composition::CompositionPropertySet transformPS);
 
- protected:
   virtual void TransferProperties(XamlView oldView, XamlView newView) override;
+
+ protected:
   void TransferProperty(
       XamlView oldView,
       XamlView newView,
       winrt::Windows::UI::Xaml::DependencyProperty dp);
+
+  void TransferProperty(
+      XamlView oldView, 
+      XamlView newView, 
+      winrt::DependencyProperty oldViewDP, 
+      winrt::DependencyProperty newViewDP);
 
  private:
   void ApplyTransformMatrix(

--- a/vnext/include/ReactUWP/Views/ShadowNodeBase.h
+++ b/vnext/include/ReactUWP/Views/ShadowNodeBase.h
@@ -96,6 +96,8 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
 
   void ReplaceView(XamlView view);
 
+  void ReparentView(XamlView view);
+
   // Extra layout handling
   virtual bool IsExternalLayoutDirty() const {
     return false;

--- a/vnext/include/ReactUWP/Views/ViewManagerBase.h
+++ b/vnext/include/ReactUWP/Views/ViewManagerBase.h
@@ -87,9 +87,10 @@ class REACTWINDOWS_EXPORT ViewManagerBase
     return m_wkReactInstance;
   }
 
+  virtual void TransferProperties(XamlView oldView, XamlView newView);
+
  protected:
   virtual XamlView CreateViewCore(int64_t tag) = 0;
-  virtual void TransferProperties(XamlView oldView, XamlView newView);
 
  protected:
   std::weak_ptr<IReactInstance> m_wkReactInstance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10393,10 +10393,10 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz":
-  version "0.59.0-microsoft.71"
-  uid a6db762880ce9d859fa35d6b0a44b7fbaf714e0a
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz#a6db762880ce9d859fa35d6b0a44b7fbaf714e0a"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.73.tar.gz":
+  version "0.59.0-microsoft.73"
+  uid a16940dc996787a7aca7169214e55e46f71f7cfc
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.73.tar.gz#a16940dc996787a7aca7169214e55e46f71f7cfc"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
We need to be able to dynamically creating/mapping view for the TextInput shadow node on the fly, TextBox object when SecureTextEntry is false/default or to PasswordBox object when SecureTextEntry is true. Normally each ShadowNode maps 1-1 to a view object in the tree, so added support to replace and reparent the new view object. 

Also in the swapping process, the properties needs to be transffered from the old view to new view too, so extended function TransferProperties to support individual view manager specific actions: e.g. TextBox.Text <=> PasswordBox.Password.

TextInputShadowNode is also modified to know if it is working with TextBox or PasswordBox, to work with different events as well as properties.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3075)