### PR TITLE
Update CreateStringResponseBody symbol in test DLL.

### DIFF
--- a/change/react-native-windows-2019-09-05-02-38-17-HEAD.json
+++ b/change/react-native-windows-2019-09-05-02-38-17-HEAD.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update CreateStringResponseBody symbol in test DLL.",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "commit": "8f3abfb5959005c841eef1420043f79e8bcc9d62",
+  "date": "2019-09-05T09:38:17.176Z"
+}

--- a/change/react-native-windows-extended-2019-09-04-17-03-52-testdll-def-CreateStringResponseBody.json
+++ b/change/react-native-windows-extended-2019-09-04-17-03-52-testdll-def-CreateStringResponseBody.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update CreateStringResponseBody symbol in test DLL.",
+  "packageName": "react-native-windows-extended",
+  "email": "julio@rochsquadron.net",
+  "commit": "8f3abfb5959005c841eef1420043f79e8bcc9d62",
+  "date": "2019-09-05T00:03:52.026Z"
+}

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x64.def
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x64.def
@@ -22,3 +22,6 @@ EXPORTS
 ?Stop@HttpServer@Test@React@Microsoft@@QEAAXXZ
 ?SetOnResponseSent@HttpServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXXZ@std@@@Z
 ?SetOnGet@HttpServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6A?AU?$message@$0A@U?$basic_dynamic_body@V?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@AEBU?$message@$00U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@234@@Z@std@@@Z
+
+; Free functions
+?CreateStringResponseBody@Test@React@Microsoft@@YA?AV?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x86.def
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x86.def
@@ -22,3 +22,6 @@ EXPORTS
 ?Stop@HttpServer@Test@React@Microsoft@@QAEXXZ
 ?SetOnResponseSent@HttpServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXXZ@std@@@Z
 ?SetOnGet@HttpServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6G?AU?$message@$0A@U?$basic_dynamic_body@V?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@ABU?$message@$00U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@234@@Z@std@@@Z
+
+; Free functions
+?CreateStringResponseBody@Test@React@Microsoft@@YG?AV?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z


### PR DESCRIPTION
DEF files for Desktop test DLL missed symbol for helper function `Microsoft::React::Test::CreateStringResponseBody`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3090)