### PR TITLE
Fix issue with using getInt instead of asDouble for JSI

### DIFF
--- a/change/react-native-windows-2019-09-05-14-52-58-a11yAsDouble.json
+++ b/change/react-native-windows-2019-09-05-14-52-58-a11yAsDouble.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix issue with using getInt instead of asDouble for JSI",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "commit": "dccdb9de931860f8152e4480ceff6dddc82f91c5",
+  "date": "2019-09-05T21:52:58.772Z"
+}

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -335,7 +335,7 @@ void FrameworkElementViewManager::UpdateProperties(
         AnnounceLiveRegionChangedIfNeeded(element);
       } else if (propertyName == "accessibilityPosInSet") {
         if (propertyValue.isNumber()) {
-          auto value = static_cast<int>(propertyValue.getInt());
+          auto value = static_cast<int>(propertyValue.asDouble());
           auto boxedValue =
               winrt::Windows::Foundation::PropertyValue::CreateInt32(value);
 
@@ -347,7 +347,7 @@ void FrameworkElementViewManager::UpdateProperties(
         }
       } else if (propertyName == "accessibilitySetSize") {
         if (propertyValue.isNumber()) {
-          auto value = static_cast<int>(propertyValue.getInt());
+          auto value = static_cast<int>(propertyValue.asDouble());
           auto boxedValue =
               winrt::Windows::Foundation::PropertyValue::CreateInt32(value);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10393,10 +10393,10 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz":
-  version "0.59.0-microsoft.71"
-  uid a6db762880ce9d859fa35d6b0a44b7fbaf714e0a
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.71.tar.gz#a6db762880ce9d859fa35d6b0a44b7fbaf714e0a"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.73.tar.gz":
+  version "0.59.0-microsoft.73"
+  uid a16940dc996787a7aca7169214e55e46f71f7cfc
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.73.tar.gz#a16940dc996787a7aca7169214e55e46f71f7cfc"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
JSI makes all dynamic numbers doubles, so we can't use getInt - we have to asDouble and cast it to int.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3094)