### PR TITLE
Change the CLI bundle name index.bundle (vnext)

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -240,7 +240,7 @@ jobs:
       - task: CmdLine@2
         displayName: Create bundle testcli
         inputs:
-          script: react-native bundle --entry-file App.windows.js platform uwp --bundle-output test.bundle
+          script: react-native bundle --entry-file index.windows.js platform uwp --bundle-output test.bundle
           workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - job: RnwNativePRBuild

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,7 +194,7 @@ jobs:
           BUILDCONFIGURATION: Debug
 
       - name: Create bundle testcli.sln
-        run: cd ${{ runner.temp }}\testcli && react-native bundle --entry-file App.windows.js platform uwp --bundle-output test.bundle
+        run: cd ${{ runner.temp }}\testcli && react-native bundle --entry-file index.windows.js platform uwp --bundle-output test.bundle
 
   RNWFormatting:
     name: Verify change files + formatting

--- a/change/react-native-windows-2019-09-06-16-39-05-user-savatia-cli-bundle-rename.json
+++ b/change/react-native-windows-2019-09-06-16-39-05-user-savatia-cli-bundle-rename.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Change the CLI bundle name index.bundle (vnext)",
+  "packageName": "react-native-windows",
+  "email": "brkeyonz@microsoft.com",
+  "commit": "f8a82c11e642baaf36a9c3889810b3e98ee61fa4",
+  "date": "2019-09-06T23:39:05.026Z"
+}

--- a/vnext/.eslintignore
+++ b/vnext/.eslintignore
@@ -1,7 +1,7 @@
 /dist
 /lib
 /Libraries
-/local-cli/generator-windows/templates/App.windows.js
+/local-cli/generator-windows/templates/index.windows.js
 **/node_modules
 /packages
 /RNTester

--- a/vnext/Microsoft.ReactNative/ReactInstanceCreator.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceCreator.cpp
@@ -70,7 +70,7 @@ ReactInstanceCreator::getInstance() {
     if (!m_jsMainModuleName.empty()) {
       m_jsBundleFile = m_jsMainModuleName;
     } else {
-      m_jsBundleFile = "App.windows";
+      m_jsBundleFile = "index.windows";
     }
   }
 

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -87,12 +87,12 @@ function copyProjectTemplateAndReplace(
   };
 
   [
-    { from: path.join(srcPath, 'App.windows.js'), to: 'App.windows.js' },
+    { from: path.join(srcPath, 'index.windows.js'), to: 'index.windows.js' },
     { from: path.join(srcPath, projDir, 'MyApp.sln'), to: path.join(windowsDir, newProjectName + '.sln') },
     { from: path.join(srcPath, projDir, 'MyApp.csproj'), to: path.join(windowsDir, newProjectName, newProjectName + '.csproj') },
     { from: path.join(srcPath, '_gitignore'), to: path.join(windowsDir, '.gitignore') },
     { from: path.join(srcPath, 'ra_gitignore'), to: path.join(windowsDir, newProjectName, reactAssetsDir, '.gitignore') },
-    { from: path.join(srcPath, 'app.windows.bundle'), to: path.join(windowsDir, newProjectName, reactAssetsDir, 'app.windows.bundle') },
+    { from: path.join(srcPath, 'index.windows.bundle'), to: path.join(windowsDir, newProjectName, reactAssetsDir, 'index.windows.bundle') },
   ].forEach((mapping) => copyAndReplaceWithChangedCallback(mapping.from, destPath, mapping.to, templateVars));
 
   copyAndReplaceAll(path.join(srcPath, 'assets'), destPath, path.join(windowsDir, newProjectName, 'Assets'), templateVars);

--- a/vnext/local-cli/generator-windows/templates/index.windows.bundle
+++ b/vnext/local-cli/generator-windows/templates/index.windows.bundle
@@ -2,7 +2,7 @@
  * 
  * Be sure to generate this file using the CLI:
  *
- * react-native bundle --platform windows --entry-file app.windows.js 
+ * react-native bundle --platform windows --entry-file index.windows.js 
  *   --bundle-output windows\<%=name%>\ReactAssets\index.windows.bundle
  *   --assets-dest windows\<%=name%>\ReactAssets
  *

--- a/vnext/local-cli/generator-windows/templates/index.windows.js
+++ b/vnext/local-cli/generator-windows/templates/index.windows.js
@@ -20,7 +20,7 @@ class <%=name%> extends Component {
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
-          To get started, edit app.windows.js
+          To get started, edit index.windows.js
         </Text>
         <Text style={styles.instructions}>
           To show the Developer Menu, enter Ctrl+Shift+D

--- a/vnext/local-cli/generator-windows/templates/src/MainPage.xaml.cs
+++ b/vnext/local-cli/generator-windows/templates/src/MainPage.xaml.cs
@@ -23,7 +23,7 @@ namespace <%=ns%>
   /// </summary>
   public sealed partial class MainPage : Page
   {
-    const string JSFILENAME = "App.windows";
+    const string JSFILENAME = "index.windows";
     const string JSCOMPONENTNAME = "<%=name%>";
 
     public MainPage()


### PR DESCRIPTION
Changed the CLI bundle name from app.bundle to index.bundle so that VS Code can find the bundle and prewarm the cache.

Fix #2901

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3099)