### PR TITLE
Fix Login E2E test failure

### DIFF
--- a/change/react-native-windows-2019-09-10-10-21-46-SecureEntryTestFix.json
+++ b/change/react-native-windows-2019-09-10-10-21-46-SecureEntryTestFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Login E2E test failure",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "a2e2a331820e7b5e61dba3d82807c5f36cbd6b3e",
+  "date": "2019-09-10T17:21:46.908Z"
+}

--- a/packages/E2ETest/wdio/pages/LoginPage.ts
+++ b/packages/E2ETest/wdio/pages/LoginPage.ts
@@ -22,7 +22,7 @@ class LoginPage extends BasePage {
     this._password.setValue(password);
   }
 
-  apendPassword(password: string) {
+  appendPassword(password: string) {
     this._password.addValue('End');
     this._password.addValue(password);
   }

--- a/packages/E2ETest/wdio/test/login.spec.ts
+++ b/packages/E2ETest/wdio/test/login.spec.ts
@@ -41,7 +41,7 @@ describe('LoginTest', () => {
   it('Login Success with secureTextEntry off then on', () => {
     LoginPage.setLoginInfo('username', 'pass');
     LoginPage.toggleShowPassword();
-    LoginPage.apendPassword('word');
+    LoginPage.appendPassword('word');
     LoginPage.submitForm();
     assert.equal(LoginPage.getLoginResult(), 'Success');
   });
@@ -49,7 +49,7 @@ describe('LoginTest', () => {
   it('Login Success with secureTextEntry on then off', () => {
     LoginPage.setLoginInfo('username', 'pass');
     LoginPage.toggleShowPassword();
-    LoginPage.apendPassword('word');
+    LoginPage.appendPassword('word');
     LoginPage.submitForm();
     assert.equal(LoginPage.getLoginResult(), 'Success');
   });

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -37,6 +37,7 @@ void ControlViewManager::TransferProperties(
   TransferProperty(oldView, newView, winrt::Control::PaddingProperty());
   TransferProperty(oldView, newView, winrt::Control::ForegroundProperty());
   TransferProperty(oldView, newView, winrt::Control::TabIndexProperty());
+  __super::TransferProperties(oldView, newView);
 }
 
 void ControlViewManager::UpdateProperties(

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -37,7 +37,7 @@ void ControlViewManager::TransferProperties(
   TransferProperty(oldView, newView, winrt::Control::PaddingProperty());
   TransferProperty(oldView, newView, winrt::Control::ForegroundProperty());
   TransferProperty(oldView, newView, winrt::Control::TabIndexProperty());
-  __super::TransferProperties(oldView, newView);
+  Super::TransferProperties(oldView, newView);
 }
 
 void ControlViewManager::UpdateProperties(


### PR DESCRIPTION
The test failure is caused by Automation properties not transferred between TextBox and PasswordBox when switching secureTextEntry on/off. The TransferProperties() virutal function should be called from TextInputViewManager class, then ControlViewManager class then FrameworkElementViewManager Class. When I addressed the last PR comment, a mistake was made so the call ended at ControlViewManager and the automation properties are not transferred (by FrameworkElementViewManager ). 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3108)