### PR TITLE
Fix onPress not firing for Touchable* keyboard events

### DIFF
--- a/change/react-native-windows-2019-09-10-14-48-28-fix-touchable-onkeyup-press.json
+++ b/change/react-native-windows-2019-09-10-14-48-28-fix-touchable-onkeyup-press.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix onPress not firing for Touchable* keyboard events",
+  "packageName": "react-native-windows",
+  "email": "thshea@microsoft.com",
+  "commit": "c434599726f09784d09dc10eed239a806de0a627",
+  "date": "2019-09-10T21:48:28.230Z"
+}

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -405,6 +405,7 @@ const TouchableHighlight = ((createReactClass({
       !this.props.disabled
     ) {
       this.touchableHandleActivePressOut(ev);
+      this.touchableHandlePress(ev);
     }
   },
 

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
@@ -291,6 +291,7 @@ const TouchableOpacity = ((createReactClass({
       !this.props.disabled
     ) {
       this.touchableHandleActivePressOut(ev);
+      this.touchableHandlePress(ev);
     }
   },
 

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -273,6 +273,7 @@ const TouchableWithoutFeedback = ((createReactClass({
       !this.props.disabled
     ) {
       this.touchableHandleActivePressOut(ev);
+      this.touchableHandlePress(ev);
     }
   },
 


### PR DESCRIPTION
As of v140, there were duplicate `onPress` events firing for keyboard/controller presses on Touchable*s. 

#2968 removed the native `onPress`, but unfortunately #3042 and #3049 removed the JS ones (not realizing that the native ones had already been removed.)

This PR brings back the JS `onPress` calls.

Verified using the Playground app and RNTester.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3114)