### PR TITLE
add more scripts to package.json in e2e

### DIFF
--- a/change/react-native-windows-2019-09-11-10-32-12-addcommand.json
+++ b/change/react-native-windows-2019-09-11-10-32-12-addcommand.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add more scripts to package.json in e2e",
+  "packageName": "react-native-windows",
+  "email": "canli@microsoft.com",
+  "commit": "53149fddb5c13244606e5e6dec6d72607f30aa35",
+  "date": "2019-09-11T17:32:12.130Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -14,8 +14,12 @@
     "e2e": "react-native run-windows --no-launch && npm run test",
     "e2ebundle": "npm run bundle && react-native run-windows --no-launch --no-packager --bundle && npm run test",
     "test": "rimraf reports/* && npm run prettier && wdio",
-    "dev": "npm run prettier && wdio --spec",
-    "bundle": "just-scripts prepareBundle && react-native bundle --platform windows --entry-file dist/app/index.js --bundle-output windows/ReactUWPTestApp/Bundle/index.windows.bundle --assets-dest windows/ReactUWPTestApp/Bundle"
+    "testspec": "npm run prettier && wdio --spec",
+    "bundle": "just-scripts prepareBundle && react-native bundle --platform windows --entry-file dist/app/index.js --bundle-output windows/ReactUWPTestApp/Bundle/index.windows.bundle --assets-dest windows/ReactUWPTestApp/Bundle",
+    "buildapp": "react-native run-windows --no-launch --no-packager --no-deploy",
+    "deployapp": "react-native run-windows --no-launch --no-packager --no-build",
+    "buildbundleapp": "npm run bundle && react-native run-windows --no-launch --no-packager --no-deploy --bundle",
+    "deploybundleapp": "react-native run-windows --no-launch --no-packager --no-build --bundle"
   },
   "dependencies": {
     "react": "16.8.3",

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -51,15 +51,19 @@ async function runWindows(config, args, options) {
 
   await deploy.startServerInNewWindow(options, verbose);
 
-  try {
-    if (options.device || options.emulator || options.target) {
-      await deploy.deployToDevice(options, verbose);
-    } else {
-      await deploy.deployToDesktop(options, verbose);
+  if (options.deploy) {
+    try {
+      if (options.device || options.emulator || options.target) {
+        await deploy.deployToDevice(options, verbose);
+      } else {
+        await deploy.deployToDesktop(options, verbose);
+      }
+    } catch (e) {
+      newError(`Failed to deploy: ${e.message}`);
+      return;
     }
-  } catch (e) {
-    newError(`Failed to deploy: ${e.message}`);
-    return;
+  } else {
+    newInfo('Deploy step is skipped');
   }
 }
 
@@ -88,6 +92,7 @@ runWindows({
  *    bundle: Boolean - Enable Bundle configuration.
  *    no-launch: Boolean - Do not launch the app after deployment
  *    no-build: Boolean - Do not build the solution
+ *    no-deploy: Boolean - Do not deploy the app
  *    force: Boolean - same as Add-AppDevPackage.ps1 Force flag
  */
 module.exports = {
@@ -154,6 +159,11 @@ module.exports = {
     {
       command: '--no-build',
       description: 'Do not build the solution',
+      default: false,
+    },
+    {
+      command: '--no-deploy',
+      description: 'Do not deploy the app',
       default: false,
     },
   ],


### PR DESCRIPTION
Fix #3021
Handy command to only build the app or only deploy the app.
```
yarn run buildapp
yarn run buildbundleapp
yarn run deployapp
yarn run deploybundleapp
yarn run test
yarn run testspec wdio\test\login.spec.ts
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3129)