### PR TITLE
Update to react-native@0.59.0-microsoft.77

### DIFF
--- a/change/react-native-windows-2019-09-11-17-37-20-auto-update-versions059.0microsoft.77.json
+++ b/change/react-native-windows-2019-09-11-17-37-20-auto-update-versions059.0microsoft.77.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.77",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "fc6c0e7e4155b2602ec7bc07baf9ba3dc1cb41cd",
+  "date": "2019-09-11T17:37:20.282Z"
+}

--- a/change/react-native-windows-extended-2019-09-11-17-37-22-auto-update-versions059.0microsoft.77.json
+++ b/change/react-native-windows-extended-2019-09-11-17-37-22-auto-update-versions059.0microsoft.77.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.77",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "3901b66e638bddcc31a0010b177bd1fa025cc6eb",
+  "date": "2019-09-11T17:37:22.336Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz",
     "react-native-windows": "0.59.0-vnext.178",
     "react-native-windows-extended": "0.15.3",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz",
     "react-native-windows": "0.59.0-vnext.178",
     "react-native-windows-extended": "0.15.3",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz",
     "react-native-windows": "0.59.0-vnext.178",
     "react-native-windows-extended": "0.15.3",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.74 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.77 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.74 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.74.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.77 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
54fa12764 Applying package update to 0.59.0-microsoft.77 ***NO_CI***
e4bc81bf0 Trigger RNW's update RN build on publish
2ac75400c Move publishing back to Azure Dev Ops ***NO_CI*** (#158)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3130)