### PR TITLE
Flyout shadow fix

### DIFF
--- a/change/react-native-windows-2019-09-11-12-49-37-flyout-shadow-fix-4.json
+++ b/change/react-native-windows-2019-09-11-12-49-37-flyout-shadow-fix-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Refined logic for handling Flyout shadows",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "2cfeb8701abbf97377a585932e1859a4af4b276c",
+  "date": "2019-09-11T19:49:37.756Z"
+}

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -252,6 +252,7 @@ void FlyoutShadowNode::onDropViewInstance() {
     m_isOpen = false;
     m_flyout.Hide();
     s_cOpenFlyouts -= 1;
+    assert(s_cOpenFlyouts >= 0);
   }
 }
 
@@ -350,6 +351,7 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic &&props) {
     } else {
       m_flyout.Hide();
       s_cOpenFlyouts -= 1;
+      assert(s_cOpenFlyouts >= 0);
     }
   }
 


### PR DESCRIPTION
In the last episode of the flyout shadow fix, the fix for the following bug, 
_"Flyout shadows cause an incorrect background color where Flyouts overlap."_
(#3022), did not get into RNW correctly. (See #2933 for original issue)

I mistakenly closed my branch before the fix was completed even though everything was all good to go! In any case, since then, we discovered that the existing tracking of open flyouts was not completely correct. This updated fix resolves that issue (by only updating the counter and 'hiding' the flyout when the flyout state _actually_ changes).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3131)