### PR TITLE
Enable most desktop integration tests.

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -18,7 +18,7 @@ variables:
   - name: VsTestPlatformVersion
     value: 16.2.0
   - name: Desktop.IntegrationTests.Filter
-    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)
+    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&(FullyQualifiedName!~WebSocketIntegrationTest::)
   - name: GoogleTestAdapterPath
     value: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\drknwe51.xnq'
 

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -16,7 +16,7 @@ variables:
   - name: VsTestVersion
     value: 16.0
   - name: Desktop.IntegrationTests.Filter
-    value: (FullyQualifiedName~RNTesterIntegrationTests)&(Owner!=Unstable)
+    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTests)
   - name: GoogleTestAdapterPath
     value: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\drknwe51.xnq'
 

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -18,7 +18,7 @@ variables:
   - name: VsTestPlatformVersion
     value: 16.2.0
   - name: Desktop.IntegrationTests.Filter
-    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTests)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)
+    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)
   - name: GoogleTestAdapterPath
     value: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\drknwe51.xnq'
 

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -18,7 +18,7 @@ variables:
   - name: VsTestPlatformVersion
     value: 16.2.0
   - name: Desktop.IntegrationTests.Filter
-    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&(FullyQualifiedName!~WebSocketIntegrationTest::)
+    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&(FullyQualifiedName!~WebSocket)
   - name: GoogleTestAdapterPath
     value: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\drknwe51.xnq'
 

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -13,12 +13,12 @@ variables:
     value: 16.0
   - name: MSBuildArchitecture
     value: x64
+  - name: VsTestVersion
+    value: 16.0
   - name: VsTestPlatformVersion
     value: 16.2.0
-  - name: VsTestVersion
-    value: toolsInstaller
   - name: Desktop.IntegrationTests.Filter
-    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTests)
+    value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTests)&(FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)
   - name: GoogleTestAdapterPath
     value: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\drknwe51.xnq'
 
@@ -330,7 +330,7 @@ jobs:
             JSI.Desktop.UnitTests\JSI.Desktop.UnitTests.exe
           pathtoCustomTestAdapters: $(GoogleTestAdapterPath)
           searchFolder: '$(Build.SourcesDirectory)\vnext\target\$(BuildPlatform)\$(BuildConfiguration)'
-          vsTestVersion: $(VsTestVersion)
+          vsTestVersion: toolsInstaller # Use installed VSTest that implements the !~ operator.
           runTestsInIsolation: true
           platform: $(BuildPlatform)
           configuration: $(BuildConfiguration)
@@ -353,7 +353,7 @@ jobs:
           testAssemblyVer2: 'React.Windows.Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.dll' # Required when testSelector == TestAssemblies
           searchFolder: '$(Build.SourcesDirectory)\vnext\target\$(BuildPlatform)\$(BuildConfiguration)'
           testFiltercriteria: $(Desktop.IntegrationTests.Filter)
-          vsTestVersion: $(VsTestVersion)
+          vsTestVersion: toolsInstaller # Use installed VSTest that implements the !~ operator.
           runTestsInIsolation: true
           platform: $(BuildPlatform)
           configuration: $(BuildConfiguration)

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -13,8 +13,10 @@ variables:
     value: 16.0
   - name: MSBuildArchitecture
     value: x64
+  - name: VsTestPlatformVersion
+    value: 16.2.0
   - name: VsTestVersion
-    value: 16.0
+    value: toolsInstaller
   - name: Desktop.IntegrationTests.Filter
     value: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTests)
   - name: GoogleTestAdapterPath
@@ -310,6 +312,12 @@ jobs:
         parameters:
           BuildConfiguration: $(BuildConfiguration)
           BuildPlatform: $(BuildPlatform)
+
+      - task: VisualStudioTestPlatformInstaller@1
+        inputs:
+          packageFeedSelector: nugetOrg
+          versionSelector: specificVersion
+          testPlatformVersion: $(VsTestPlatformVersion)
 
       - task: VSTest@2
         displayName: Run Desktop Unit Tests

--- a/change/react-native-windows-2019-09-12-19-04-27-itfilter-enableall.json
+++ b/change/react-native-windows-2019-09-12-19-04-27-itfilter-enableall.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Enable all non-Chrome integration tests",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "commit": "e34895c8d6bf637304a8950388527540522f81ee",
+  "date": "2019-09-13T02:04:26.939Z"
+}

--- a/vnext/Scripts/IntegrationTests.ps1
+++ b/vnext/Scripts/IntegrationTests.ps1
@@ -14,14 +14,15 @@ param (
 	[ValidateSet('Debug', 'Release')]
 	[string] $Configuration = 'Debug',
 
-	[string[]] $Tests,
+	[string[]] $Include,
+
+	[string[]] $Exclude,
 
 	[switch] $Preload,
 
 	[UInt32] $Delay = 10,
 
-	[ValidateScript({Test-Path $_})]
-	[string[]] $Assemblies =
+	[System.IO.FileInfo[]] $Assemblies =
 	(
 		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
 		"React.Windows.Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.dll"
@@ -31,18 +32,14 @@ param (
 
 	[switch] $List,
 
-	[ValidateScript({Test-Path $_})]
-	[string] $VsTest =	"${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\" +
+	[System.IO.FileInfo] $VsTest =	"${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\" +
 						"Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe",
 
-	[ValidateScript({Test-Path $_})]
-	[string] $ReactNativeLocation = "$($PSScriptRoot | Split-Path | Split-Path)\node_modules\react-native",
+	[System.IO.DirectoryInfo] $ReactNativeLocation = "$($PSScriptRoot | Split-Path | Split-Path)\node_modules\react-native",
 
-	[ValidateScript({Test-Path $_})]
-	[string] $NodePath = (Get-Command node.exe).Definition,
+	[System.IO.FileInfo] $NodePath = (Get-Command node.exe).Definition,
 
-	[ValidateScript({Test-Path $_})]
-	[string] $NpmPath = (Get-Command npm.cmd).Definition
+	[System.IO.FileInfo] $NpmPath = (Get-Command npm.cmd).Definition
 )
 
 # Import test server functions.
@@ -91,5 +88,13 @@ if ($NoRun) {
 	Exit
 }
 
+if ($Include.Count) {
+	$filter = "(FullyQualifiedName~" + ($Include -join ')&(FullyQualifiedName~') + ")"
+}
+
+if ($Exclude.Count) {
+	$filter += ('', '&')[$filter.Length -gt 0] + "(FullyQualifiedName!~" + ($Exclude -join ')&(FullyQualifiedName!~') + ")"
+}
+
 # Run Integration Test assemblies.
-& $VsTest $Assemblies --InIsolation --Platform:$Platform ('', "--Tests:$($Tests -join ',')")[$Tests.Count -gt 0]
+& $VsTest $Assemblies --InIsolation --Platform:$Platform ('', "--TestCaseFilter:$filter")[$filter.Length -gt 0]

--- a/vnext/Scripts/UnitTest.ps1
+++ b/vnext/Scripts/UnitTest.ps1
@@ -10,18 +10,26 @@ param (
 	[ValidateSet('Debug', 'Release')]
 	[string] $Configuration = 'Debug',
 
-	[string[]] $Tests,
+	[string[]] $Include,
 
-	[ValidateScript({Test-Path $_})]
-	[string[]] $Assemblies =
+	[string[]] $Exclude,
+
+	[System.IO.FileInfo[]] $Assemblies =
 	(
 		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
 		"React.Windows.Desktop.UnitTests\React.Windows.Desktop.UnitTests.dll"
 	),
 
-	[ValidateScript({Test-Path $_})]
-	[string] $VsTest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
+	[System.IO.FileInfo] $VsTest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 )
 
+if ($Include.Count) {
+	$filter = "(FullyQualifiedName~" + ($Include -join ')&(FullyQualifiedName~') + ")"
+}
+
+if ($Exclude.Count) {
+	$filter += ('', '&')[$filter.Length -gt 0] + "(FullyQualifiedName!~" + ($Exclude -join ')&(FullyQualifiedName!~') + ")"
+}
+
 # Run Unit Test assemblies.
-& $VsTest $Assemblies --InIsolation --Platform:$Platform ('', "--Tests:$($Tests -join ',')")[$Tests.Count -gt 0]
+& $VsTest $Assemblies --InIsolation --Platform:$Platform ('', "--TestCaseFilter:$filter")[$filter.Length -gt 0]

--- a/vnext/Scripts/UnitTest.ps1
+++ b/vnext/Scripts/UnitTest.ps1
@@ -17,7 +17,10 @@ param (
 	[System.IO.FileInfo[]] $Assemblies =
 	(
 		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
-		"React.Windows.Desktop.UnitTests\React.Windows.Desktop.UnitTests.dll"
+		"React.Windows.Desktop.UnitTests\React.Windows.Desktop.UnitTests.dll",
+
+		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
+		"JSI.Desktop.UnitTests\JSI.Desktop.UnitTests.exe"
 	),
 
 	[System.IO.FileInfo] $VsTest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"


### PR DESCRIPTION
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3134)

PR builds are run in Windows images using Visual Studio 2017.
The pre-installed VSTest lacks filtering capabilities to exclude specific tests from running.
This change installs the 2019 VSTest tool and enables most Desktop integration tests that were until now excluded.