### PR TITLE
Add PackageCertificatePassword to MyApp.csproj file

### DIFF
--- a/change/react-native-windows-2019-09-13-09-58-36-didatst1.json
+++ b/change/react-native-windows-2019-09-13-09-58-36-didatst1.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add PackageCertificatePassword attribute to MyApp.csproj to solve the build issue in VS2019 due to temp pfx certificate issue",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "e2729f1ed7e384e3c446aaa3a90da650fef1e5d9",
+  "date": "2019-09-13T16:58:36.097Z"
+}

--- a/vnext/local-cli/generator-windows/templates/proj/MyApp.csproj
+++ b/vnext/local-cli/generator-windows/templates/proj/MyApp.csproj
@@ -22,6 +22,7 @@
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <PackageCertificateKeyFile><%=name%>_TemporaryKey.pfx</PackageCertificateKeyFile>
     <%=certificateThumbprint%>
+    <PackageCertificatePassword>password</PackageCertificatePassword>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10394,10 +10394,10 @@ react-native-local-cli@^1.0.0-alpha.5:
     xcode "^1.0.0"
     xmldoc "^0.4.0"
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz":
-  version "0.59.0-microsoft.77"
-  uid "2124314cc3208ef83a12511e6625e544a784ef74"
-  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.77.tar.gz#2124314cc3208ef83a12511e6625e544a784ef74"
+"react-native@https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz":
+  version "0.59.0-microsoft.80"
+  uid "12724492daca024b1478fa553464fd4856265d4f"
+  resolved "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz#12724492daca024b1478fa553464fd4856265d4f"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
#2986 
According to VS2019 [post](https://developercommunity.visualstudio.com/content/problem/664223/uwp-app-doesnt-compile-in-vs-2019-162-because-of-c.html), we need to add PackageCertificatePassword attribute to csproj, in order to avoid the build issue caused by password protected temp pfx file.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3144)