### PR TITLE
Update to react-native@0.59.0-microsoft.82

### DIFF
--- a/change/react-native-windows-2019-09-16-21-01-08-auto-update-versions059.0microsoft.82.json
+++ b/change/react-native-windows-2019-09-16-21-01-08-auto-update-versions059.0microsoft.82.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.82",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "7dbbfd3638a577c19c096b9baf2b1ff83bbba82c",
+  "date": "2019-09-16T21:01:08.179Z"
+}

--- a/change/react-native-windows-extended-2019-09-16-21-01-10-auto-update-versions059.0microsoft.82.json
+++ b/change/react-native-windows-extended-2019-09-16-21-01-10-auto-update-versions059.0microsoft.82.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.59.0-microsoft.82",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "0a76abdeaaa289544d756cfaee1075892607b81a",
+  "date": "2019-09-16T21:01:10.355Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz",
     "react-native-windows": "0.59.0-vnext.185",
     "react-native-windows-extended": "0.15.7",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz",
     "react-native-windows": "0.59.0-vnext.185",
     "react-native-windows-extended": "0.15.7",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz",
     "react-native-windows": "0.59.0-vnext.185",
     "react-native-windows-extended": "0.15.7",
     "rnpm-plugin-windows": "^0.2.11"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.3",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.80 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.82 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,13 +57,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz",
     "react": "16.8.3",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "^0.59.0 || 0.59.0-microsoft.80 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.80.tar.gz"
+    "react-native": "^0.59.0 || 0.59.0-microsoft.82 || https://github.com/microsoft/react-native/archive/v0.59.0-microsoft.82.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
c3bd68be7 Applying package update to 0.59.0-microsoft.82 ***NO_CI***
6589faa78 The Release target was missing MACOSX_DEPLOYMENT_TARGET causing it default to macOS 10.15 which when executed on os's prior to 10.15 causes the _objc_opt_new symbol to be called which is not present in the older systems' dylibs (#160)
bec5acbff Revert "Update package.json version"
0c6334f8f Update package.json version
0600fbb40 Applying package update to 0.59.0-microsoft.81 ***NO_CI***
be78aa3a0 Adding the destructor for the InspectorInterface, in order to fix the build error. (#156)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3156)