### PR TITLE
Support keyboardType for TextInput

### DIFF
--- a/change/react-native-windows-2019-09-17-09-54-48-didarnw2.json
+++ b/change/react-native-windows-2019-09-17-09-54-48-didarnw2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Support keyboardType for TextInput",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "50a6c2367b4dd144376360362f625a19784be123",
+  "date": "2019-09-17T16:54:48.457Z"
+}

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -43,6 +43,11 @@ export default class Bootstrap extends React.Component<{}, any> {
         />
         <TextInput
           style={styles.input}
+          keyboardType="number-pad"
+          placeholder={'number-pad keyboardType'}
+        />
+        <TextInput
+          style={styles.input}
           placeholder={this.state.passwordHidden ? 'Password' : 'Text'}
           autoCapitalize="none"
           secureTextEntry={this.state.passwordHidden}
@@ -52,6 +57,7 @@ export default class Bootstrap extends React.Component<{}, any> {
           value={this.state.text}
           selectionColor="red"
           maxLength={10}
+          keyboardType="numeric"
         />
         <Button
           title={

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -572,8 +572,9 @@ void TextInputViewManager::TransferInputScope(
     XamlView oldView,
     XamlView newView,
     const bool copyToPasswordBox) {
-  // transfer input scope, only common keyboardType between secureTextEntry on/off is numeric,
-  // so only need to transfer input scope "Number" <=> "NumericPin", everything else leave it as default.
+  // transfer input scope, only common keyboardType between secureTextEntry
+  // on/off is numeric, so only need to transfer input scope "Number" <=>
+  // "NumericPin", everything else leave it as default.
   winrt::InputScope inputScope;
   if (copyToPasswordBox) {
     inputScope = oldView.try_as<winrt::TextBox>().InputScope();
@@ -584,8 +585,10 @@ void TextInputViewManager::TransferInputScope(
   if (inputScope != nullptr) {
     auto nameValue = inputScope.Names().GetAt(0).NameValue();
 
-    if ((nameValue == winrt::InputScopeNameValue::Number && copyToPasswordBox) ||
-        (nameValue == winrt::InputScopeNameValue::NumericPin && !copyToPasswordBox)) {
+    if ((nameValue == winrt::InputScopeNameValue::Number &&
+         copyToPasswordBox) ||
+        (nameValue == winrt::InputScopeNameValue::NumericPin &&
+         !copyToPasswordBox)) {
       auto newScope = winrt::InputScope();
       auto scopeName = winrt::InputScopeName(
           copyToPasswordBox ? winrt::InputScopeNameValue::NumericPin
@@ -646,7 +649,7 @@ void TextInputViewManager::TransferProperties(
           winrt::TextBox::SelectionHighlightColorProperty());
       newView.as<winrt::TextBox>().Text(
           oldView.as<winrt::PasswordBox>().Password());
-      }
+    }
 
     TransferInputScope(oldView, newView, copyToPasswordBox);
     // Set focus if current control has focus

--- a/vnext/ReactUWP/Views/TextInputViewManager.h
+++ b/vnext/ReactUWP/Views/TextInputViewManager.h
@@ -25,6 +25,12 @@ class TextInputViewManager : public ControlViewManager {
  protected:
   XamlView CreateViewCore(int64_t tag) override;
   friend class TextInputShadowNode;
+
+ private:
+  void TransferInputScope(
+      XamlView oldView,
+      XamlView newView,
+      const bool copyToPasswordBox);
 };
 
 } // namespace uwp


### PR DESCRIPTION
For #3080:

Map keyboardType to inputscope of TextBox and PasswordBox respectively.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3164)