### PR TITLE
Workaround to avoid WinAppDriver error: 'Failed to locate opened application window with appId'

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -71,8 +71,13 @@ jobs:
       - task: CmdLine@2
         displayName: run-windows
         inputs:
-          script:  react-native run-windows --no-launch --no-packager --arch ${{ parameters.BuildPlatform }} --release --bundle --logging --force
+          script:  react-native run-windows --no-packager --arch ${{ parameters.BuildPlatform }} --release --bundle --logging --force
           workingDirectory: packages/E2ETest
+
+      # Wait for app to launch. A workaround to avoid WinAppDriver error: Failed to locate opened application window with appId
+      - task: Delay@1
+        inputs:
+          delayForMinutes: '1'
 
       - task: CmdLine@2
         displayName: run test

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -75,9 +75,12 @@ jobs:
           workingDirectory: packages/E2ETest
 
       # Wait for app to launch. A workaround to avoid WinAppDriver error: Failed to locate opened application window with appId
-      - task: Delay@1
+      - task: PowerShell@2
+        displayName: Wait for app to launch
         inputs:
-          delayForMinutes: '1'
+          targetType: inline # filePath | inline
+          script: |
+            Start-Sleep -Seconds 30
 
       - task: CmdLine@2
         displayName: run test

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -89,3 +89,4 @@ jobs:
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'packages/E2ETest/reports/*.log'
+        condition: succeededOrFailed()


### PR DESCRIPTION
Sometime WinAppDriver failed to launch the app, and it failed with `Original error: Failed to locate opened application window with appId: ReactUWPTestApp_kc2bncckyf4ap!App, and processId: 4120`
ms:waitForAppLaunch may help with this problem but the official WinAppDriver is not shipped yet.

This change workaround the problem by making the app launched before WinAppDriver created the new session.