### PR TITLE
Updates logic for `wpf` command to install correct dependency

### DIFF
--- a/change/rnpm-plugin-windows-2019-09-24-09-54-53-issue3102.json
+++ b/change/rnpm-plugin-windows-2019-09-24-09-54-53-issue3102.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updates logic for `wpf` command to install correct dependency",
+  "packageName": "rnpm-plugin-windows",
+  "email": "erozell@outlook.com",
+  "commit": "2325263a2cd4bd66ae7f78f2fa01650aee280345",
+  "date": "2019-09-24T13:54:53.668Z"
+}

--- a/current/local-cli/rnpm/windows/src/wpf.js
+++ b/current/local-cli/rnpm/windows/src/wpf.js
@@ -19,12 +19,16 @@ const REACT_NATIVE_WPF_GENERATE_PATH = function() {
   );
 };
 
-module.exports = function windows(config, args, options) {
+module.exports = function (config, args, options) {
   const name = args[0] ? args[0] : Common.getReactNativeAppName();
   const ns = options.namespace ? options.namespace : name;
   const version = options.windowsVersion ? options.windowsVersion : Common.getReactNativeVersion();
 
-  return Common.getInstallPackage(version)
+  // If the template is not set, look for a stable or 'rc' version
+  const template = options.template ? options.template : 'rc';
+  const ignoreStable = !!options.template;
+
+  return Common.getInstallPackage(version, template, ignoreStable)
     .then(rnwPackage => {
       console.log(`Installing ${rnwPackage}...`);
       const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';
@@ -34,6 +38,6 @@ module.exports = function windows(config, args, options) {
       console.log(chalk.green(`${rnwPackage} successfully installed.`));
 
       const generateWPF = require(REACT_NATIVE_WPF_GENERATE_PATH());
-      generateWPF(process.cwd(), name, ns);
+      generateWPF(process.cwd(), name, ns, options);
     }).catch(error => console.error(chalk.red(error.message)));
 };


### PR DESCRIPTION
A recent change to the `windows` command (4ff550e) specified the correct pre-release tag to install from (i.e., "rc" or stable) when running `react-native windows`. This change introduces the same logic for the `wpf` command.

Fixes #3102