### PR TITLE
 Pointer events don't transfer focus to the Flyout on Open (Issue #3154)

### DIFF
--- a/change/react-native-windows-2019-09-24-14-50-43-flyout-focus-fix.json
+++ b/change/react-native-windows-2019-09-24-14-50-43-flyout-focus-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow focus transfer to Flyout on Open",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "0d9bdd9d2c7ebfca96b2f2cdc871e0ea0555f908",
+  "date": "2019-09-24T21:50:43.866Z"
+}


### PR DESCRIPTION
In a previous fix, we set the AllowFocusOnInteraction property to false for the Flyout and its FlyoutPresenter to prevent some undesirable flyout dismissal problems.  See [https://github.com/microsoft/react-native-windows/pull/2817](https://github.com/microsoft/react-native-windows/pull/2817)
 
Unfortunately, that fix causes the focus to not transfer into any of the Flyout child elements when activated by a mouse/touch event.  The reason for this is that XAML makes a decision on whether or not to update the Focus element upon opening the flyout. If the action is due to a mouse/touch event and the AllowFocusOnInteraction property is set false on the Flyout, then the flyout doesn't update the Focus element. 
 
_(from %SDXROOT%\onecoreuap\windows\dxaml\xcp\components\focus\inc\FocusSelection.h)_
```
FocusSelection
    {
    public:
        template<class Element>
        static bool ShouldUpdateFocus(_In_ Element* const element, _In_ const DirectUI::FocusState focusState)
        {
            return !(focusState == DirectUI::FocusState::Pointer && GetAllowFocusOnInteraction(element) == false);
        }
 
```
_Called from FlyoutBase::OnPresenterLoaded (%SDXROOT%\onecoreuap\windows\dxaml\xcp\dxaml\lib\FlyoutBase_partial.cpp)._
 
This PR contains a refinement of that original flyout dismissal workaround that resolves the focus transfer problem. The change is to delay the setting of the AllowFocusOnInteraction flag to false until after the flyout is opened. 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3192)