### PR TITLE
Create stub StatusBarManager to avoid crash in NewAppScreen

### DIFF
--- a/change/react-native-windows-2019-09-24-14-05-30-statusbarmgr.json
+++ b/change/react-native-windows-2019-09-24-14-05-30-statusbarmgr.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Create stub StatusBarManager to avoid crash when using <StatusBar>",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "8f10f575517dcc7a3b5de86bc58748b47513dd35",
+  "date": "2019-09-24T21:05:30.338Z"
+}

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -58,6 +58,7 @@
 #include <Modules/LocationObserverModule.h>
 #include <Modules/NativeUIManager.h>
 #include <Modules/NetworkingModule.h>
+#include <Modules/StatusBarModule.h>
 #include <Modules/UIManagerModule.h>
 #include <Modules/WebSocketModuleUwp.h>
 #include <ReactUWP/Modules/I18nModule.h>
@@ -238,6 +239,11 @@ std::vector<facebook::react::NativeModuleDescription> GetModules(
   modules.emplace_back(
       ClipboardModule::name,
       []() { return std::make_unique<ClipboardModule>(); },
+      messageQueue);
+
+  modules.emplace_back(
+      StatusBarModule::name,
+      []() { return std::make_unique<StatusBarModule>(); },
       messageQueue);
 
   modules.emplace_back(

--- a/vnext/ReactUWP/Modules/StatusBarModule.cpp
+++ b/vnext/ReactUWP/Modules/StatusBarModule.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "StatusBarModule.h"
+
+namespace react {
+namespace uwp {
+
+//
+// StatusBarModule
+//
+const char *StatusBarModule::name = "StatusBarManager";
+
+StatusBarModule::~StatusBarModule() = default;
+
+std::string StatusBarModule::getName() {
+  return name;
+}
+
+std::map<std::string, folly::dynamic> StatusBarModule::getConstants() {
+  return {{"HEIGHT", 0}};
+}
+
+std::vector<facebook::xplat::module::CxxModule::Method>
+StatusBarModule::getMethods() {
+  return {};
+}
+
+} // namespace uwp
+} // namespace react

--- a/vnext/ReactUWP/Modules/StatusBarModule.h
+++ b/vnext/ReactUWP/Modules/StatusBarModule.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cxxreact/CxxModule.h>
+#include <folly/dynamic.h>
+
+namespace react {
+namespace uwp {
+
+class StatusBarModule final : public facebook::xplat::module::CxxModule {
+ public:
+  virtual ~StatusBarModule();
+
+  // CxxModule
+  std::string getName() override;
+  std::map<std::string, folly::dynamic> getConstants() override;
+  auto getMethods() -> std::vector<Method> override;
+
+  static const char *name;
+};
+
+} // namespace uwp
+} // namespace react

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -214,6 +214,7 @@
     <ClInclude Include="Modules\LocationObserverModule.h" />
     <ClInclude Include="Modules\NativeUIManager.h" />
     <ClInclude Include="Modules\NetworkingModule.h" />
+    <ClInclude Include="Modules\StatusBarModule.h" />
     <ClInclude Include="Modules\TimingModule.h" />
     <ClInclude Include="Modules\WebSocketModuleUwp.h" />
     <ClInclude Include="Pch\pch.h" />
@@ -318,6 +319,7 @@
     <ClCompile Include="Modules\LocationObserverModule.cpp" />
     <ClCompile Include="Modules\NativeUIManager.cpp" />
     <ClCompile Include="Modules\NetworkingModule.cpp" />
+    <ClCompile Include="Modules\StatusBarModule.cpp" />
     <ClCompile Include="Modules\TimingModule.cpp" />
     <ClCompile Include="Modules\WebSocketModuleUwp.cpp" />
     <ClCompile Include="Pch\pch.cpp">


### PR DESCRIPTION
StatusBar.js assume that there is a StatusBarManager native module, and that it has a HEIGHT property.

<StatusBar> is used in the NewAppScreen experience that is part of the new react-native init app, so this causes new apps to crash.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3238)