### PR TITLE
Remove v8 related files from ReactCommon.vcxproj.

### DIFF
--- a/change/react-native-windows-2019-09-25-14-28-07-remove-v8-from-rncommon.json
+++ b/change/react-native-windows-2019-09-25-14-28-07-remove-v8-from-rncommon.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Remove v8 related files from ReactCommon.vcxproj.",
+  "packageName": "react-native-windows",
+  "email": "yicyao@microsoft.com",
+  "commit": "0d0de897ea568ffa189941d3680e4f3d89e544cc",
+  "date": "2019-09-25T21:28:07.427Z"
+}

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -156,9 +156,6 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Platform.cpp" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_shared.cpp" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\V8Runtime_win.cpp" Condition="'$(Platform)' != 'arm' AND '$(USE_V8)' == 'true'" />
     <ClCompile Include="$(YogaDir)\yoga\log.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\Utils.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGConfig.cpp" />


### PR DESCRIPTION
We removed v8.h from the v8jsi nuget. Hence we need to remove the v8 related files from ReactCommon.vcxproj to ensure that things build when USE_V8 is defined.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3251)