### PR TITLE
(0.59-vnext-stable): Pointer events don't transfer focus to the Flyout on Open (Issue #3154)

### DIFF
--- a/change/react-native-windows-2019-09-24-14-50-43-flyout-focus-fix.json
+++ b/change/react-native-windows-2019-09-24-14-50-43-flyout-focus-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow focus transfer to Flyout on Open",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "0d9bdd9d2c7ebfca96b2f2cdc871e0ea0555f908",
+  "date": "2019-09-24T21:50:43.866Z"
+}


### PR DESCRIPTION
This fix needs to go to 0.59-vnext-stable, so that it can be picked up in our app (it's beta blocking)

See vnext PR https://github.com/microsoft/react-native-windows/pull/3192 for details.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3261)