### PR TITLE
Workaround folly break until folly PR lands

### DIFF
--- a/change/react-native-windows-2019-09-27-16-18-29-follypatch.json
+++ b/change/react-native-windows-2019-09-27-16-18-29-follypatch.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix build break when using latest Visual Studio compiler versions",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "1f1d803bd62b7f396c9e1978f05a43a915e38779",
+  "date": "2019-09-27T23:18:29.131Z"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -273,6 +273,13 @@
     <!-- Using ContinueOnError due to https://github.com/Microsoft/msbuild/issues/3884, unzip seems to have completed dispite errors -->
     <Unzip Condition="!Exists('$(FollyDir)')" ContinueOnError="true" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.08.12.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
   </Target>
+  <ItemGroup>
+    <TemporaryFollyPatchFiles Include="$(MSBuildThisFileDirectory)\TEMP_UntilFollyUpdate\**\*.*"/>
+  </ItemGroup>
+  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFollyIfNotUseMicrosoftReactNative">
+    <Warning Text="Copying @(TemporaryFollyPatchFiles) to @(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
+  </Target>
   <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
   </Target>

--- a/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+  *  This is file contains the changes in https://github.com/facebook/folly/pull/1234 required to build using
+  *  the latest builds of Visual Studio.  Once that PR is merged, and published we should be able to update
+  *  the version of folly we reference and remove this file.
+  */
+
+#pragma once
+
+#if defined(_WIN32) && !defined(__clang__)
+#include <assert.h>
+#include <folly/Portability.h>
+#include <intrin.h>
+#include <stdint.h>
+
+namespace folly {
+namespace portability {
+namespace detail {
+void call_flush_instruction_cache_self_pid(void* begin, size_t size);
+}
+} // namespace portability
+} // namespace folly
+
+FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char* begin, char* end) {
+  if (folly::kIsArchAmd64) {
+    // x86_64 doesn't require the instruction cache to be flushed after
+    // modification.
+  } else {
+    // Default to flushing it for everything else, such as ARM.
+    folly::portability::detail::call_flush_instruction_cache_self_pid(
+        static_cast<void*>(begin), static_cast<size_t>(end - begin));
+  }
+}
+
+#if !defined(_MSC_VER) || (_MSC_VER < 1923)
+FOLLY_ALWAYS_INLINE int __builtin_clz(unsigned int x) {
+  unsigned long index;
+  return int(_BitScanReverse(&index, (unsigned long)x) ? 31 - index : 32);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_clzl(unsigned long x) {
+  return __builtin_clz((unsigned int)x);
+}
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
+  if (x == 0) {
+    return 64;
+  }
+  unsigned int msb = (unsigned int)(x >> 32);
+  unsigned int lsb = (unsigned int)x;
+  return (msb != 0) ? __builtin_clz(msb) : 32 + __builtin_clz(lsb);
+}
+#else
+FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
+  unsigned long index;
+  return int(_BitScanReverse64(&index, x) ? 63 - index : 64);
+}
+#endif
+
+FOLLY_ALWAYS_INLINE int __builtin_ctz(unsigned int x) {
+  unsigned long index;
+  return int(_BitScanForward(&index, (unsigned long)x) ? index : 32);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_ctzl(unsigned long x) {
+  return __builtin_ctz((unsigned int)x);
+}
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
+  unsigned long index;
+  unsigned int msb = (unsigned int)(x >> 32);
+  unsigned int lsb = (unsigned int)x;
+  if (lsb != 0) {
+    return (int)(_BitScanForward(&index, lsb) ? index : 64);
+  } else {
+    return (int)(_BitScanForward(&index, msb) ? index + 32 : 64);
+  }
+}
+#else
+FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
+  unsigned long index;
+  return int(_BitScanForward64(&index, x) ? index : 64);
+}
+#endif
+#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
+
+FOLLY_ALWAYS_INLINE int __builtin_ffs(int x) {
+  unsigned long index;
+  return int(_BitScanForward(&index, (unsigned long)x) ? index + 1 : 0);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_ffsl(long x) {
+  return __builtin_ffs(int(x));
+}
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
+  int ctzll = __builtin_ctzll((unsigned long long)x);
+  return ctzll != 64 ? ctzll + 1 : 0;
+}
+#else
+FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
+  unsigned long index;
+  return int(_BitScanForward64(&index, (unsigned long long)x) ? index + 1 : 0);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_popcount(unsigned int x) {
+  return int(__popcnt(x));
+}
+
+#if !defined(_MSC_VER) || (_MSC_VER < 1923)
+FOLLY_ALWAYS_INLINE int __builtin_popcountl(unsigned long x) {
+  static_assert(sizeof(x) == 4, "");
+  return int(__popcnt(x));
+}
+#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
+#endif
+
+#if !defined(_MSC_VER) || (_MSC_VER < 1923)
+#if defined(_M_IX86)
+FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
+  return int(__popcnt((unsigned int)(x >> 32))) +
+      int(__popcnt((unsigned int)x));
+}
+#elif defined(_M_X64)
+FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
+  return int(__popcnt64(x));
+}
+#endif
+#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
+
+FOLLY_ALWAYS_INLINE void* __builtin_return_address(unsigned int frame) {
+  // I really hope frame is zero...
+  (void)frame;
+  assert(frame == 0);
+  return _ReturnAddress();
+}
+#endif

--- a/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
- /*
-  *  This is file contains the changes in https://github.com/facebook/folly/pull/1234 required to build using
-  *  the latest builds of Visual Studio.  Once that PR is merged, and published we should be able to update
-  *  the version of folly we reference and remove this file.
-  */
+/*
+ *  This is file contains the changes in
+ * https://github.com/facebook/folly/pull/1234 required to build using the
+ * latest builds of Visual Studio.  Once that PR is merged, and published we
+ * should be able to update the version of folly we reference and remove this
+ * file.
+ */
 
 #pragma once
 
@@ -31,19 +33,19 @@
 namespace folly {
 namespace portability {
 namespace detail {
-void call_flush_instruction_cache_self_pid(void* begin, size_t size);
+void call_flush_instruction_cache_self_pid(void *begin, size_t size);
 }
 } // namespace portability
 } // namespace folly
 
-FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char* begin, char* end) {
+FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char *begin, char *end) {
   if (folly::kIsArchAmd64) {
     // x86_64 doesn't require the instruction cache to be flushed after
     // modification.
   } else {
     // Default to flushing it for everything else, such as ARM.
     folly::portability::detail::call_flush_instruction_cache_self_pid(
-        static_cast<void*>(begin), static_cast<size_t>(end - begin));
+        static_cast<void *>(begin), static_cast<size_t>(end - begin));
   }
 }
 
@@ -146,7 +148,7 @@ FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
 #endif
 #endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
 
-FOLLY_ALWAYS_INLINE void* __builtin_return_address(unsigned int frame) {
+FOLLY_ALWAYS_INLINE void *__builtin_return_address(unsigned int frame) {
   // I really hope frame is zero...
   (void)frame;
   assert(frame == 0);


### PR DESCRIPTION
The latest version of MSVC breaks folly.

This PR will fix folly, at which point we can update to the latest version of folly.
https://github.com/facebook/folly/pull/1234

But until then, this allows RNW to build using the latest compiler.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3276)