### PR TITLE
Update DeviceInfo for getting size from the root element

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -1,7 +1,7 @@
 #
 parameters:
   name: ''
-  pool:
+  pool: ''
   BuildPlatform: 'x86' # ARM, x86, x64
   UseRNFork: true
 
@@ -71,25 +71,31 @@ jobs:
       - task: CmdLine@2
         displayName: run-windows
         inputs:
-          script:  react-native run-windows --no-packager --arch ${{ parameters.BuildPlatform }} --release --bundle --logging --force
+          script:  react-native run-windows --no-launch --no-packager --arch ${{ parameters.BuildPlatform }} --release --bundle --logging --force
           workingDirectory: packages/E2ETest
 
-      # Wait for app to launch. A workaround to avoid WinAppDriver error: Failed to locate opened application window with appId
-      - task: PowerShell@2
-        displayName: Wait for app to launch
+      - task: CopyFiles@2
+        displayName: Copy NuGet artifacts
         inputs:
-          targetType: inline # filePath | inline
-          script: |
-            Start-Sleep -Seconds 30
+          SourceFolder: packages\E2ETest\windows\ReactUWPTestApp\AppPackages
+          TargetFolder: $(Build.ArtifactStagingDirectory)\MyAppPackages
+          Contents: |
+            *
+
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish Artifact: ReactWindows"
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)
+          ArtifactName: "ReactWindows"
+
 
       - task: CmdLine@2
         displayName: run test
         inputs:
           script: yarn run test
           workingDirectory: packages/E2ETest
-
+          
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'packages/E2ETest/reports/*.log'
-        condition: succeededOrFailed()

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -80,8 +80,7 @@ jobs:
           SourceFolder: packages\E2ETest\windows\ReactUWPTestApp\AppPackages
           TargetFolder: $(Build.ArtifactStagingDirectory)\MyAppPackages
           Contents: |
-            *
-
+            ReactUWPTestApp_1.0.0.0_x64_ReleaseBundle_Test\**
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: ReactWindows"
         inputs:

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -1,7 +1,7 @@
 #
 parameters:
   name: ''
-  pool: ''
+  pool:
   BuildPlatform: 'x86' # ARM, x86, x64
   UseRNFork: true
 
@@ -18,6 +18,12 @@ jobs:
         lfs: false # whether to download Git-LFS files
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+      - task: PowerShell@2
+        displayName: 'Remove WebDriverIO Workaround'
+        inputs:
+          targetType: 'inline'
+          script: '((Get-Content -path packages/E2ETest/package.json -Raw) -replace ".*webdriver.git.*","") | Set-Content -Path packages/E2ETest/package.json'
 
       - task: CmdLine@2
         displayName: Install react-native-cli
@@ -46,6 +52,12 @@ jobs:
           script: yarn install
         condition: and(succeeded(), eq('${{ parameters.UseRNFork }}', 'false'))
 
+      - task: PowerShell@2
+        displayName: 'Patch WebDriverIO'
+        inputs:
+          targetType: 'inline'
+          script: '((Get-Content -path node_modules/webdriver/build/utils.js -Raw) -replace "if \(!body .*","if (!body) {") | Set-Content -Path node_modules/webdriver/build/utils.js'
+      
       - template: stop-packagers.yml
 
       - task: CmdLine@2
@@ -71,35 +83,46 @@ jobs:
       - task: CmdLine@2
         displayName: run-windows
         inputs:
-          script:  react-native run-windows --no-launch --no-packager --arch ${{ parameters.BuildPlatform }} --release --bundle --logging --force
+          script:  react-native run-windows --no-packager --arch ${{ parameters.BuildPlatform }} --release --bundle --logging --force
           workingDirectory: packages/E2ETest
 
-      - task: CopyFiles@2
-        displayName: Copy NuGet artifacts
-        inputs:
-          SourceFolder: packages\E2ETest\windows\ReactUWPTestApp\AppPackages
-          TargetFolder: $(Build.ArtifactStagingDirectory)\MyAppPackages
-          Contents: |
-            ReactUWPTestApp_1.0.0.0_x64_ReleaseBundle_Test\**
-      - task: PublishBuildArtifacts@1
-        displayName: "Publish Artifact: ReactWindows"
-        inputs:
-          PathtoPublish: $(Build.ArtifactStagingDirectory)
-          ArtifactName: "ReactWindows"
-
+      # Wait for app to launch. A workaround to avoid WinAppDriver error: Failed to locate opened application window with appId
       - task: PowerShell@2
-        displayName: 'Patch WebDriverIO'
+        displayName: Wait for app to launch
         inputs:
-          targetType: 'inline'
-          script: '((Get-Content -path node_modules/webdriver/build/utils.js -Raw) -replace "if \(!body .*","if (!body) {") | Set-Content -Path node_modules/webdriver/build/utils.js'
+          targetType: inline # filePath | inline
+          script: |
+            Start-Sleep -Seconds 30
 
       - task: CmdLine@2
         displayName: run test
         inputs:
           script: yarn run test
           workingDirectory: packages/E2ETest
-          
+
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'packages/E2ETest/reports/*.log'
+        condition: succeededOrFailed()
+
+      - task: PowerShell@2
+        displayName: 'Show package.json'
+        inputs:
+          targetType: 'inline'
+          script: 'Get-Content packages/E2ETest/package.json | foreach {Write-Output $_}'
+        condition: failed()
+
+      - task: PowerShell@2
+        displayName: 'Show node_modules/webdriver/build/utils.js'
+        inputs:
+          targetType: 'inline'
+          script: 'Get-Content node_modules/webdriver/build/utils.js | foreach {Write-Output $_}'
+        condition: failed()
+
+      - task: PowerShell@2
+        displayName: 'Show appium log'
+        inputs:
+          targetType: 'inline'
+          script: 'Get-Content packages/E2ETest/reports/appium.txt | foreach {Write-Output $_}'
+        condition: failed()

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -87,6 +87,11 @@ jobs:
           PathtoPublish: $(Build.ArtifactStagingDirectory)
           ArtifactName: "ReactWindows"
 
+      - task: PowerShell@2
+        displayName: 'Patch WebDriverIO'
+        inputs:
+          targetType: 'inline'
+          script: '((Get-Content -path node_modules/webdriver/build/utils.js -Raw) -replace "if \(!body .*","if (!body) {") | Set-Content -Path node_modules/webdriver/build/utils.js'
 
       - task: CmdLine@2
         displayName: run test

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -444,7 +444,7 @@ stages:
           name: E2ETest
           pool:
             vmImage: $(VmImage)
-          BuildPlatform: x64
+          BuildPlatform: x86
           UseRNFork: true
 
   - stage:

--- a/change/react-native-windows-2019-09-30-12-43-36-devinfo2.json
+++ b/change/react-native-windows-2019-09-30-12-43-36-devinfo2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "DeviceInfo Update to support getting size from hosting root element",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "da7c4079c83fde547e4da18491fda4766163ada7",
+  "date": "2019-09-30T19:43:36.335Z"
+}

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -52,7 +52,6 @@
 #include <Modules/AppStateModuleUwp.h>
 #include <Modules/AppThemeModuleUwp.h>
 #include <Modules/ClipboardModule.h>
-#include <Modules/DeviceInfoModule.h>
 #include <Modules/ImageViewManagerModule.h>
 #include <Modules/LinkingManagerModule.h>
 #include <Modules/LocationObserverModule.h>
@@ -294,7 +293,7 @@ void UwpReactInstance::Start(
           m_uiDispatcher);
 
   // Objects that must be created on the UI thread
-  std::shared_ptr<DeviceInfo> deviceInfo = std::make_shared<DeviceInfo>();
+  m_deviceInfo = std::make_shared<DeviceInfo>(spThis);
   std::shared_ptr<facebook::react::AppState> appstate =
       std::make_shared<react::uwp::AppState>(spThis);
   std::shared_ptr<react::windows::AppTheme> appTheme =
@@ -307,7 +306,6 @@ void UwpReactInstance::Start(
       m_initThread);
   m_initThread->runOnQueueSync([this,
                                 spThis,
-                                deviceInfo,
                                 settings,
                                 i18nInfo = std::move(i18nInfo),
                                 appstate = std::move(appstate),
@@ -368,7 +366,7 @@ void UwpReactInstance::Start(
         GetModules(
             m_uiManager,
             m_batchingNativeThread,
-            deviceInfo,
+            m_deviceInfo,
             devSettings,
             std::move(i18nInfo),
             std::move(appstate),
@@ -449,11 +447,17 @@ void UwpReactInstance::Start(
 void UwpReactInstance::AttachMeasuredRootView(
     IXamlRootView *pRootView,
     folly::dynamic &&initProps) {
-  if (!IsInError())
+  if (!IsInError()) {
     m_instanceWrapper->AttachMeasuredRootView(pRootView, std::move(initProps));
+    auto rootView = pRootView->GetXamlView().try_as<winrt::FrameworkElement>();
+    if (rootView) {
+      m_deviceInfo->attachRoot(rootView);
+    }
+  }
 }
 
 void UwpReactInstance::DetachRootView(IXamlRootView *pRootView) {
+  m_deviceInfo->detachRoot();
   m_instanceWrapper->DetachRootView(pRootView);
 }
 

--- a/vnext/ReactUWP/Base/UwpReactInstance.h
+++ b/vnext/ReactUWP/Base/UwpReactInstance.h
@@ -5,6 +5,7 @@
 
 #include <IReactInstance.h>
 
+#include <Modules/DeviceInfoModule.h>
 #include <Threading/WorkerMessageQueueThread.h>
 #include <Views/ExpressionAnimationStore.h>
 
@@ -135,6 +136,7 @@ class UwpReactInstance
 
   std::string m_bundleRootPath;
   ReactInstanceSettings m_reactInstanceSettings;
+  std::shared_ptr<DeviceInfo> m_deviceInfo;
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x64.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QEAA@$$QEAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0DeviceInfoModule@uwp@react@@QEAA@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QEAA@AEBV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QEAA@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x86.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QAE@$$QAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QAE@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QEAA@$$QEAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0DeviceInfoModule@uwp@react@@QEAA@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QEAA@AEBV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QEAA@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QAE@$$QAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QAE@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86sdx.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86sdx.def
@@ -7,6 +7,7 @@ EXPORTS
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??0AppState@react@facebook@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@UIReactContext@oReactNative@@@std@@@Z
 ??0ModuleProvider@windows@react@@QAE@$$QAU012@@Z
 ??0ModuleProvider@windows@react@@QAE@PBD$$QAV?$function@$$A6A?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@XZ@std@@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
@@ -13,6 +13,10 @@ namespace uwp {
 //
 // DeviceInfo
 //
+DeviceInfo::DeviceInfo(const std::shared_ptr<IReactInstance> &reactInstance)
+    : m_wkReactInstance(reactInstance) {
+  update();
+}
 
 void DeviceInfo::update() {
   auto displayInfo = winrt::Windows::Graphics::Display::DisplayInformation::
@@ -21,7 +25,6 @@ void DeviceInfo::update() {
 
   auto const &window = winrt::Windows::UI::Xaml::Window::Current().CoreWindow();
 
-  // TODO: get parent element (not window) size
   m_dimensions = folly::dynamic::object(
       "windowPhysicalPixels",
       folly::dynamic::object("width", window.Bounds().Width)(
@@ -35,6 +38,38 @@ void DeviceInfo::update() {
           "scale", static_cast<int>(displayInfo.ResolutionScale()) / 100)(
           "fontScale", uiSettings.TextScaleFactor())(
           "densityDpi", displayInfo.LogicalDpi()));
+}
+
+void DeviceInfo::updateRootElementSize(float width, float height) {
+  m_dimensions["windowPhysicalPixels"]["width"] = width;
+  m_dimensions["windowPhysicalPixels"]["height"] = height;
+  fireEvent();
+}
+
+void DeviceInfo::fireEvent() {
+  auto instance = m_wkReactInstance.lock();
+  if (instance) {
+    instance->CallJsFunction(
+        "RCTDeviceEventEmitter",
+        "emit",
+        folly::dynamic::array(
+            "didUpdateDimensions", std::move(GetDimensionsConstants())));
+  }
+}
+
+void DeviceInfo::attachRoot(
+    winrt::Windows::UI::Xaml::FrameworkElement rootElement) {
+  m_rootElement = rootElement;
+  m_sizeChangedRevoker =
+      m_rootElement.SizeChanged(winrt::auto_revoke, [&](auto &&, auto &&) {
+        auto size = m_rootElement.ActualSize();
+        updateRootElementSize(size.x, size.y);
+      });
+}
+
+void DeviceInfo::detachRoot() {
+  m_rootElement = nullptr;
+  m_sizeChangedRevoker = {};
 }
 
 //

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.h
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <IReactInstance.h>
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
+#include <winrt/Windows.UI.Xaml.h>
 #include <memory>
 #include <vector>
 
@@ -14,17 +16,23 @@ namespace uwp {
 // TODO: Emit event to react when dimensions change.
 class DeviceInfo {
  public:
-  DeviceInfo() {
-    update();
-  }
+  DeviceInfo(const std::shared_ptr<IReactInstance> &reactInstance);
 
   folly::dynamic GetDimensionsConstants() {
     return m_dimensions;
   }
   void update();
+  void updateRootElementSize(float width, float height);
+  void attachRoot(const winrt::Windows::UI::Xaml::FrameworkElement rootElement);
+  void detachRoot();
 
  private:
+  void fireEvent();
   folly::dynamic m_dimensions;
+  winrt::Windows::UI::Xaml::FrameworkElement m_rootElement{nullptr};
+  winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker
+      m_sizeChangedRevoker;
+  std::weak_ptr<IReactInstance> m_wkReactInstance;
 };
 
 class DeviceInfoModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Universal.UnitTests/Tests/CreateModulesTests.cpp
+++ b/vnext/Universal.UnitTests/Tests/CreateModulesTests.cpp
@@ -37,8 +37,10 @@ TEST_METHOD(CreateModules_DevSupportManager) {
 }
 
 TEST_METHOD(CreateModules_DeviceInfoModule) {
-  auto deviceInfoModule =
-      std::make_unique<DeviceInfoModule>(std::make_unique<DeviceInfo>());
+  auto reactInstance = react::uwp::CreateReactInstance(nullptr);
+  Assert::IsFalse(reactInstance == nullptr);
+  auto deviceInfoModule = std::make_unique<DeviceInfoModule>(
+      std::make_unique<DeviceInfo>(reactInstance));
 
   Assert::IsFalse(deviceInfoModule == nullptr);
 }

--- a/vnext/src/Libraries/Utilities/Dimensions.windows.js
+++ b/vnext/src/Libraries/Utilities/Dimensions.windows.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const EventEmitter = require('EventEmitter');
+const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+
+const invariant = require('invariant');
+
+const eventEmitter = new EventEmitter();
+let dimensionsInitialized = false;
+const dimensions = {};
+class Dimensions {
+  /**
+   * This should only be called from native code by sending the
+   * didUpdateDimensions event.
+   *
+   * @param {object} dims Simple string-keyed object of dimensions to set
+   */
+  static set(dims: {[key: string]: any}): void {
+    // We calculate the window dimensions in JS so that we don't encounter loss of
+    // precision in transferring the dimensions (which could be non-integers) over
+    // the bridge.
+    if (dims && dims.windowPhysicalPixels) {
+      // parse/stringify => Clone hack
+      dims = JSON.parse(JSON.stringify(dims));
+
+      const windowPhysicalPixels = dims.windowPhysicalPixels;
+      dims.window = {
+        width: windowPhysicalPixels.width / windowPhysicalPixels.scale,
+        height: windowPhysicalPixels.height / windowPhysicalPixels.scale,
+        scale: windowPhysicalPixels.scale,
+        fontScale: windowPhysicalPixels.fontScale,
+      };
+      // Screen and window dimensions are different on windows
+      const screenPhysicalPixels = dims.screenPhysicalPixels;
+      dims.screen = {
+        width: screenPhysicalPixels.width / screenPhysicalPixels.scale,
+        height: screenPhysicalPixels.height / screenPhysicalPixels.scale,
+        scale: screenPhysicalPixels.scale,
+        fontScale: screenPhysicalPixels.fontScale,
+      };
+
+      // delete so no callers rely on this existing
+      delete dims.screenPhysicalPixels;
+      // delete so no callers rely on this existing
+      delete dims.windowPhysicalPixels;
+    }
+
+    Object.assign(dimensions, dims);
+    if (dimensionsInitialized) {
+      // Don't fire 'change' the first time the dimensions are set.
+      eventEmitter.emit('change', {
+        window: dimensions.window,
+        screen: dimensions.screen,
+      });
+    } else {
+      dimensionsInitialized = true;
+    }
+  }
+
+  /**
+   * Initial dimensions are set before `runApplication` is called so they should
+   * be available before any other require's are run, but may be updated later.
+   *
+   * Note: Although dimensions are available immediately, they may change (e.g
+   * due to device rotation) so any rendering logic or styles that depend on
+   * these constants should try to call this function on every render, rather
+   * than caching the value (for example, using inline styles rather than
+   * setting a value in a `StyleSheet`).
+   *
+   * Example: `var {height, width} = Dimensions.get('window');`
+   *
+   * @param {string} dim Name of dimension as defined when calling `set`.
+   * @returns {Object?} Value for the dimension.
+   */
+  static get(dim: string): Object {
+    invariant(dimensions[dim], 'No dimension set for key ' + dim);
+    return dimensions[dim];
+  }
+
+  /**
+   * Add an event handler. Supported events:
+   *
+   * - `change`: Fires when a property within the `Dimensions` object changes. The argument
+   *   to the event handler is an object with `window` and `screen` properties whose values
+   *   are the same as the return values of `Dimensions.get('window')` and
+   *   `Dimensions.get('screen')`, respectively.
+   */
+  static addEventListener(type: string, handler: Function) {
+    invariant(
+      type === 'change',
+      'Trying to subscribe to unknown event: "%s"',
+      type,
+    );
+    eventEmitter.addListener(type, handler);
+  }
+
+  /**
+   * Remove an event handler.
+   */
+  static removeEventListener(type: string, handler: Function) {
+    invariant(
+      type === 'change',
+      'Trying to remove listener for unknown event: "%s"',
+      type,
+    );
+    eventEmitter.removeListener(type, handler);
+  }
+}
+
+let dims: ?{[key: string]: any} =
+  global.nativeExtensions &&
+  global.nativeExtensions.DeviceInfo &&
+  global.nativeExtensions.DeviceInfo.Dimensions;
+let nativeExtensionsEnabled = true;
+if (!dims) {
+  const DeviceInfo = require('DeviceInfo');
+  dims = DeviceInfo.Dimensions;
+  nativeExtensionsEnabled = false;
+}
+
+invariant(
+  dims,
+  'Either DeviceInfo native extension or DeviceInfo Native Module must be registered',
+);
+Dimensions.set(dims);
+if (!nativeExtensionsEnabled) {
+  RCTDeviceEventEmitter.addListener('didUpdateDimensions', function(update) {
+    Dimensions.set(update);
+  });
+}
+
+module.exports = Dimensions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10421,10 +10421,10 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rnpm-plugin-windows@^0.2.13:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.2.13.tgz#c4e31607ea7fe7ce4279050a65319f33d42f33db"
-  integrity sha512-j0yQVIxhp3hlfaEhh+FhvDpA86iNI1C+1rr4Vuj7B3ijKnfbYQo5uImI0NB9JN+Hi9iPdXRihFJ4m7n4A1Pqaw==
+rnpm-plugin-windows@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.3.0.tgz#59f5e53a88d8d249146683c09ef367cd09734ed1"
+  integrity sha512-vpeMGqyTVOGDQfEQE64zqbsYWkSsKoNoFQiDu9SF1RXzsMYcn68zOzjnLbNjV58gBlO2dj3RSspLSEXX7IqC6w==
   dependencies:
     chalk "^1.1.3"
     extract-zip "^1.6.7"


### PR DESCRIPTION
#2470 

- Currently DeviceInfo is reporting CoreWindow's bounds for the window dimension, this update change it and hook up with the root element's size instead. 
- When root element size changes, we should fire event to app to update the dimensions. This functionality is also added in this change. I tested with the RNTester;s Dimensions.jst and the update events worked fine.
- Additionally, the screen dimension reported was overwritten with window dimension in React Native, this is apple's behavior. We should adopt Android's behavior(user whatever reported by the native module) instead, so I also add a dimensions.windows.js for RNW.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3282)