### PR TITLE
Users/ngbu/fix webview for chakracore

### DIFF
--- a/change/react-native-windows-2019-09-30-16-11-38-users-ngbu-fix_webview_for_chakracore.json
+++ b/change/react-native-windows-2019-09-30-16-11-38-users-ngbu-fix_webview_for_chakracore.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "fix webview",
+  "packageName": "react-native-windows",
+  "email": "ngbu@microsoft.com",
+  "commit": "4de39a3d187b27fd246c4007b23da39a5e5a9138",
+  "date": "2019-09-30T23:11:38.750Z"
+}

--- a/change/react-native-windows-extended-2019-09-30-16-11-38-users-ngbu-fix_webview_for_chakracore.json
+++ b/change/react-native-windows-extended-2019-09-30-16-11-38-users-ngbu-fix_webview_for_chakracore.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "fix webview",
+  "packageName": "react-native-windows-extended",
+  "email": "ngbu@microsoft.com",
+  "commit": "4de39a3d187b27fd246c4007b23da39a5e5a9138",
+  "date": "2019-09-30T23:11:33.897Z"
+}

--- a/vnext/ReactUWP/Views/WebViewManager.cpp
+++ b/vnext/ReactUWP/Views/WebViewManager.cpp
@@ -37,7 +37,11 @@ const char *WebViewManager::GetName() const {
 }
 
 XamlView WebViewManager::CreateViewCore(int64_t tag) {
+#ifdef CHAKRACORE_UWP
+  return winrt::WebView(winrt::WebViewExecutionMode::SeparateProcess);
+#else
   return winrt::WebView();
+#endif
 }
 
 void WebViewManager::UpdateProperties(


### PR DESCRIPTION
WebView throws exception when using ChakraCore because it uses Chakra by system default due to Edge using Chakra. Changed the WebView constructor to use SeparateProcess when using ChakraCore to avoid the exception.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3292)