### PR TITLE
Users/ngbu/fix webview for chakracore master

### DIFF
--- a/change/react-native-windows-2019-09-30-16-10-31-users-ngbu-fix_webview_for_chakracore_master.json
+++ b/change/react-native-windows-2019-09-30-16-10-31-users-ngbu-fix_webview_for_chakracore_master.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "fix webview",
+  "packageName": "react-native-windows",
+  "email": "ngbu@microsoft.com",
+  "commit": "12bceff146ddff6f07655833bbbc0f784be76bfc",
+  "date": "2019-09-30T23:10:31.828Z"
+}

--- a/vnext/ReactUWP/Views/WebViewManager.cpp
+++ b/vnext/ReactUWP/Views/WebViewManager.cpp
@@ -37,7 +37,11 @@ const char *WebViewManager::GetName() const {
 }
 
 XamlView WebViewManager::CreateViewCore(int64_t tag) {
+#ifdef CHAKRACORE_UWP
+  return winrt::WebView(winrt::WebViewExecutionMode::SeparateProcess);
+#else
   return winrt::WebView();
+#endif
 }
 
 void WebViewManager::UpdateProperties(


### PR DESCRIPTION
WebView throws exception when using ChakraCore because it uses Chakra by system default due to Edge using Chakra. Changed the WebView constructor to use SeparateProcess when using ChakraCore to avoid the exception.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3293)