### PR TITLE
Apply dynamic patch for WebDriverIO in pipeline and print appium.txt when test fail

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -19,6 +19,12 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - task: PowerShell@2
+        displayName: 'Remove WebDriverIO Workaround'
+        inputs:
+          targetType: 'inline'
+          script: '((Get-Content -path packages/E2ETest/package.json -Raw) -replace ".*webdriver.git.*","") | Set-Content -Path packages/E2ETest/package.json'
+
       - task: CmdLine@2
         displayName: Install react-native-cli
         inputs:
@@ -46,6 +52,12 @@ jobs:
           script: yarn install
         condition: and(succeeded(), eq('${{ parameters.UseRNFork }}', 'false'))
 
+      - task: PowerShell@2
+        displayName: 'Patch WebDriverIO'
+        inputs:
+          targetType: 'inline'
+          script: '((Get-Content -path node_modules/webdriver/build/utils.js -Raw) -replace "if \(!body .*","if (!body) {") | Set-Content -Path node_modules/webdriver/build/utils.js'
+      
       - template: stop-packagers.yml
 
       - task: CmdLine@2
@@ -93,3 +105,24 @@ jobs:
           testResultsFormat: 'JUnit'
           testResultsFiles: 'packages/E2ETest/reports/*.log'
         condition: succeededOrFailed()
+
+      - task: PowerShell@2
+        displayName: 'Show package.json'
+        inputs:
+          targetType: 'inline'
+          script: 'Get-Content packages/E2ETest/package.json | foreach {Write-Output $_}'
+        condition: failed()
+
+      - task: PowerShell@2
+        displayName: 'Show node_modules/webdriver/build/utils.js'
+        inputs:
+          targetType: 'inline'
+          script: 'Get-Content node_modules/webdriver/build/utils.js | foreach {Write-Output $_}'
+        condition: failed()
+
+      - task: PowerShell@2
+        displayName: 'Show appium log'
+        inputs:
+          targetType: 'inline'
+          script: 'Get-Content packages/E2ETest/reports/appium.txt | foreach {Write-Output $_}'
+        condition: failed()


### PR DESCRIPTION
For unknown reason, Instead of webdriver.git in package.json, the standard webdriver in WebDriverIO is used, and it cause the test fail on PR #3282. 
This fix removes the workaround before 'yanr install', then apply the workaround dynamic. So it would only have one copy of webdriver.

Also print Appium.txt when test failed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3294)