### PR TITLE
check if testapp is running

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -94,6 +94,12 @@ jobs:
           script: |
             Start-Sleep -Seconds 30
 
+      - task: PowerShell@2
+        displayName: 'Check TestApp'
+        inputs:
+          targetType: 'inline'
+          script: 'if ((Get-Process React*) -eq $Null) { echo "TestApp is not running"; exit 1}'
+
       - task: CmdLine@2
         displayName: run test
         inputs:


### PR DESCRIPTION
We didn't have good way to catch the crashes in build machine. Here I check if TestApp is running before starting E2E testing. Provide 'TestApp is not running' when test app is not running like crashed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3298)