### PR TITLE
Align rnw-extended version number with rnw

### DIFF
--- a/change/react-native-windows-extended-2019-10-01-16-16-58-rnw-extended-version.json
+++ b/change/react-native-windows-extended-2019-10-01-16-16-58-rnw-extended-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Align rnw-extended version number with rnw",
+  "packageName": "react-native-windows-extended",
+  "email": "email not defined",
+  "commit": "b5b1638ed39829de47539477a239dcec8ee6469f",
+  "date": "2019-10-01T23:16:58.516Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -25,7 +25,7 @@
     "react": "16.8.6",
     "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft-fb60merge.13.tar.gz",
     "react-native-windows": "0.60.0-vnext.16",
-    "react-native-windows-extended": "0.61.1",
+    "react-native-windows-extended": "0.60.2",
     "rnpm-plugin-windows": "^0.3.5"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -15,7 +15,7 @@
     "react": "16.8.6",
     "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft-fb60merge.13.tar.gz",
     "react-native-windows": "0.60.0-vnext.16",
-    "react-native-windows-extended": "0.61.1",
+    "react-native-windows-extended": "0.60.2",
     "rnpm-plugin-windows": "^0.3.5"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,7 +15,7 @@
     "react": "16.8.6",
     "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft-fb60merge.13.tar.gz",
     "react-native-windows": "0.60.0-vnext.16",
-    "react-native-windows-extended": "0.61.1",
+    "react-native-windows-extended": "0.60.2",
     "rnpm-plugin-windows": "^0.3.5"
   },
   "devDependencies": {

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows-extended",
-  "version": "0.61.1",
+  "version": "0.60.2",
   "description": "Additional react-native-windows components that are not part of RN lean-core.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This commit accidentally bumped the react-native-windows-extended version to 0.61. 
https://github.com/microsoft/react-native-windows/commit/79285030542fe4164b699299142c87e48ec6f5eb#diff-ce8da290799a236b6b3e17528c87cca9

Changing it back to 0.60 so it matches react-native-windows. When we move to react-native 0.61, we will need to manually change react-native-windows-extended to 0.61.1 as 0.61 has already been published. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3300)