### PR TITLE
Device info update

### DIFF
--- a/change/react-native-windows-2019-10-03-09-55-39-deviceInfoUpdate.json
+++ b/change/react-native-windows-2019-10-03-09-55-39-deviceInfoUpdate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Connect DeviceInfo dimensions with root element",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "aab2b80b68fb5a98822013729cd38cb72b473d91",
+  "date": "2019-10-03T16:55:39.278Z"
+}

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -52,7 +52,6 @@
 #include <Modules/AppStateModuleUwp.h>
 #include <Modules/AppThemeModuleUwp.h>
 #include <Modules/ClipboardModule.h>
-#include <Modules/DeviceInfoModule.h>
 #include <Modules/ImageViewManagerModule.h>
 #include <Modules/LinkingManagerModule.h>
 #include <Modules/LocationObserverModule.h>
@@ -294,7 +293,7 @@ void UwpReactInstance::Start(
           m_uiDispatcher);
 
   // Objects that must be created on the UI thread
-  std::shared_ptr<DeviceInfo> deviceInfo = std::make_shared<DeviceInfo>();
+  m_deviceInfo = std::make_shared<DeviceInfo>(spThis);
   std::shared_ptr<facebook::react::AppState> appstate =
       std::make_shared<react::uwp::AppState>(spThis);
   std::shared_ptr<react::windows::AppTheme> appTheme =
@@ -307,7 +306,6 @@ void UwpReactInstance::Start(
       m_initThread);
   m_initThread->runOnQueueSync([this,
                                 spThis,
-                                deviceInfo,
                                 settings,
                                 i18nInfo = std::move(i18nInfo),
                                 appstate = std::move(appstate),
@@ -368,7 +366,7 @@ void UwpReactInstance::Start(
         GetModules(
             m_uiManager,
             m_batchingNativeThread,
-            deviceInfo,
+            m_deviceInfo,
             devSettings,
             std::move(i18nInfo),
             std::move(appstate),
@@ -449,11 +447,17 @@ void UwpReactInstance::Start(
 void UwpReactInstance::AttachMeasuredRootView(
     IXamlRootView *pRootView,
     folly::dynamic &&initProps) {
-  if (!IsInError())
+  if (!IsInError()) {
     m_instanceWrapper->AttachMeasuredRootView(pRootView, std::move(initProps));
+    auto rootView = pRootView->GetXamlView().try_as<winrt::FrameworkElement>();
+    if (rootView) {
+      m_deviceInfo->attachRoot(rootView);
+    }
+  }
 }
 
 void UwpReactInstance::DetachRootView(IXamlRootView *pRootView) {
+  m_deviceInfo->detachRoot();
   m_instanceWrapper->DetachRootView(pRootView);
 }
 

--- a/vnext/ReactUWP/Base/UwpReactInstance.h
+++ b/vnext/ReactUWP/Base/UwpReactInstance.h
@@ -5,6 +5,7 @@
 
 #include <IReactInstance.h>
 
+#include <Modules/DeviceInfoModule.h>
 #include <Threading/WorkerMessageQueueThread.h>
 #include <Views/ExpressionAnimationStore.h>
 
@@ -135,6 +136,7 @@ class UwpReactInstance
 
   std::string m_bundleRootPath;
   ReactInstanceSettings m_reactInstanceSettings;
+  std::shared_ptr<DeviceInfo> m_deviceInfo;
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x64.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QEAA@$$QEAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0DeviceInfoModule@uwp@react@@QEAA@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QEAA@AEBV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QEAA@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.oss.x86.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QAE@$$QAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QAE@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QEAA@$$QEAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0DeviceInfoModule@uwp@react@@QEAA@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QEAA@AEBV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QEAA@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -9,6 +9,7 @@ EXPORTS
 ??0AppStateModule@react@facebook@@QAE@$$QAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
 ??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@@Z
 ??0NativeUIManager@uwp@react@@QAE@XZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86sdx.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86sdx.def
@@ -7,6 +7,7 @@ EXPORTS
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??0AppState@react@facebook@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
+??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0LocationObserverModule@uwp@react@@QAE@ABV?$shared_ptr@UIReactContext@oReactNative@@@std@@@Z
 ??0ModuleProvider@windows@react@@QAE@$$QAU012@@Z
 ??0ModuleProvider@windows@react@@QAE@PBD$$QAV?$function@$$A6A?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@XZ@std@@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
@@ -13,6 +13,10 @@ namespace uwp {
 //
 // DeviceInfo
 //
+DeviceInfo::DeviceInfo(const std::shared_ptr<IReactInstance> &reactInstance)
+    : m_wkReactInstance(reactInstance) {
+  update();
+}
 
 void DeviceInfo::update() {
   auto displayInfo = winrt::Windows::Graphics::Display::DisplayInformation::
@@ -21,7 +25,6 @@ void DeviceInfo::update() {
 
   auto const &window = winrt::Windows::UI::Xaml::Window::Current().CoreWindow();
 
-  // TODO: get parent element (not window) size
   m_dimensions = folly::dynamic::object(
       "windowPhysicalPixels",
       folly::dynamic::object("width", window.Bounds().Width)(
@@ -35,6 +38,40 @@ void DeviceInfo::update() {
           "scale", static_cast<int>(displayInfo.ResolutionScale()) / 100)(
           "fontScale", uiSettings.TextScaleFactor())(
           "densityDpi", displayInfo.LogicalDpi()));
+}
+
+void DeviceInfo::updateRootElementSize(float width, float height) {
+  m_dimensions["windowPhysicalPixels"]["width"] = width;
+  m_dimensions["windowPhysicalPixels"]["height"] = height;
+  fireEvent();
+}
+
+void DeviceInfo::fireEvent() {
+  auto instance = m_wkReactInstance.lock();
+  if (instance) {
+    instance->CallJsFunction(
+        "RCTDeviceEventEmitter",
+        "emit",
+        folly::dynamic::array(
+            "didUpdateDimensions", std::move(GetDimensionsConstants())));
+  }
+}
+
+void DeviceInfo::attachRoot(winrt::FrameworkElement rootElement) {
+  m_rootElement = winrt::make_weak(rootElement);
+  m_sizeChangedRevoker =
+    rootElement.SizeChanged(winrt::auto_revoke, [this](auto &&, auto &&) {
+      if (const auto root = m_rootElement.get()) {
+        updateRootElementSize(
+            static_cast<float>(root.ActualWidth()),
+            static_cast<float>(root.ActualHeight()));
+        }
+    });
+}
+
+void DeviceInfo::detachRoot() {
+  m_sizeChangedRevoker = {};
+  m_rootElement = {};
 }
 
 //

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
@@ -60,13 +60,13 @@ void DeviceInfo::fireEvent() {
 void DeviceInfo::attachRoot(winrt::FrameworkElement rootElement) {
   m_rootElement = winrt::make_weak(rootElement);
   m_sizeChangedRevoker =
-    rootElement.SizeChanged(winrt::auto_revoke, [this](auto &&, auto &&) {
-      if (const auto root = m_rootElement.get()) {
-        updateRootElementSize(
-            static_cast<float>(root.ActualWidth()),
-            static_cast<float>(root.ActualHeight()));
+      rootElement.SizeChanged(winrt::auto_revoke, [this](auto &&, auto &&) {
+        if (const auto root = m_rootElement.get()) {
+          updateRootElementSize(
+              static_cast<float>(root.ActualWidth()),
+              static_cast<float>(root.ActualHeight()));
         }
-    });
+      });
 }
 
 void DeviceInfo::detachRoot() {

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.h
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <IReactInstance.h>
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
+#include <winrt/Windows.UI.Xaml.h>
 #include <memory>
 #include <vector>
 
@@ -14,17 +16,23 @@ namespace uwp {
 // TODO: Emit event to react when dimensions change.
 class DeviceInfo {
  public:
-  DeviceInfo() {
-    update();
-  }
+  DeviceInfo(const std::shared_ptr<IReactInstance> &reactInstance);
 
   folly::dynamic GetDimensionsConstants() {
     return m_dimensions;
   }
   void update();
+  void updateRootElementSize(float width, float height);
+  void attachRoot(const winrt::Windows::UI::Xaml::FrameworkElement rootElement);
+  void detachRoot();
 
  private:
+  void fireEvent();
   folly::dynamic m_dimensions;
+  winrt::weak_ref<winrt::Windows::UI::Xaml::FrameworkElement> m_rootElement{};
+  winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker
+      m_sizeChangedRevoker;
+  std::weak_ptr<IReactInstance> m_wkReactInstance;
 };
 
 class DeviceInfoModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Universal.UnitTests/Tests/CreateModulesTests.cpp
+++ b/vnext/Universal.UnitTests/Tests/CreateModulesTests.cpp
@@ -37,8 +37,10 @@ TEST_METHOD(CreateModules_DevSupportManager) {
 }
 
 TEST_METHOD(CreateModules_DeviceInfoModule) {
-  auto deviceInfoModule =
-      std::make_unique<DeviceInfoModule>(std::make_unique<DeviceInfo>());
+  auto reactInstance = react::uwp::CreateReactInstance(nullptr);
+  Assert::IsFalse(reactInstance == nullptr);
+  auto deviceInfoModule = std::make_unique<DeviceInfoModule>(
+      std::make_unique<DeviceInfo>(reactInstance));
 
   Assert::IsFalse(deviceInfoModule == nullptr);
 }

--- a/vnext/src/Libraries/Utilities/Dimensions.windows.js
+++ b/vnext/src/Libraries/Utilities/Dimensions.windows.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const EventEmitter = require('EventEmitter');
+const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+
+const invariant = require('invariant');
+
+const eventEmitter = new EventEmitter();
+let dimensionsInitialized = false;
+const dimensions = {};
+class Dimensions {
+  /**
+   * This should only be called from native code by sending the
+   * didUpdateDimensions event.
+   *
+   * @param {object} dims Simple string-keyed object of dimensions to set
+   */
+  static set(dims: {[key: string]: any}): void {
+    // We calculate the window dimensions in JS so that we don't encounter loss of
+    // precision in transferring the dimensions (which could be non-integers) over
+    // the bridge.
+    if (dims && dims.windowPhysicalPixels) {
+      // parse/stringify => Clone hack
+      dims = JSON.parse(JSON.stringify(dims));
+
+      const windowPhysicalPixels = dims.windowPhysicalPixels;
+      dims.window = {
+        width: windowPhysicalPixels.width / windowPhysicalPixels.scale,
+        height: windowPhysicalPixels.height / windowPhysicalPixels.scale,
+        scale: windowPhysicalPixels.scale,
+        fontScale: windowPhysicalPixels.fontScale,
+      };
+      // Screen and window dimensions are different on windows
+      const screenPhysicalPixels = dims.screenPhysicalPixels;
+      dims.screen = {
+        width: screenPhysicalPixels.width / screenPhysicalPixels.scale,
+        height: screenPhysicalPixels.height / screenPhysicalPixels.scale,
+        scale: screenPhysicalPixels.scale,
+        fontScale: screenPhysicalPixels.fontScale,
+      };
+
+      // delete so no callers rely on this existing
+      delete dims.screenPhysicalPixels;
+      // delete so no callers rely on this existing
+      delete dims.windowPhysicalPixels;
+    }
+
+    Object.assign(dimensions, dims);
+    if (dimensionsInitialized) {
+      // Don't fire 'change' the first time the dimensions are set.
+      eventEmitter.emit('change', {
+        window: dimensions.window,
+        screen: dimensions.screen,
+      });
+    } else {
+      dimensionsInitialized = true;
+    }
+  }
+
+  /**
+   * Initial dimensions are set before `runApplication` is called so they should
+   * be available before any other require's are run, but may be updated later.
+   *
+   * Note: Although dimensions are available immediately, they may change (e.g
+   * due to device rotation) so any rendering logic or styles that depend on
+   * these constants should try to call this function on every render, rather
+   * than caching the value (for example, using inline styles rather than
+   * setting a value in a `StyleSheet`).
+   *
+   * Example: `var {height, width} = Dimensions.get('window');`
+   *
+   * @param {string} dim Name of dimension as defined when calling `set`.
+   * @returns {Object?} Value for the dimension.
+   */
+  static get(dim: string): Object {
+    invariant(dimensions[dim], 'No dimension set for key ' + dim);
+    return dimensions[dim];
+  }
+
+  /**
+   * Add an event handler. Supported events:
+   *
+   * - `change`: Fires when a property within the `Dimensions` object changes. The argument
+   *   to the event handler is an object with `window` and `screen` properties whose values
+   *   are the same as the return values of `Dimensions.get('window')` and
+   *   `Dimensions.get('screen')`, respectively.
+   */
+  static addEventListener(type: string, handler: Function) {
+    invariant(
+      type === 'change',
+      'Trying to subscribe to unknown event: "%s"',
+      type,
+    );
+    eventEmitter.addListener(type, handler);
+  }
+
+  /**
+   * Remove an event handler.
+   */
+  static removeEventListener(type: string, handler: Function) {
+    invariant(
+      type === 'change',
+      'Trying to remove listener for unknown event: "%s"',
+      type,
+    );
+    eventEmitter.removeListener(type, handler);
+  }
+}
+
+let dims: ?{[key: string]: any} =
+  global.nativeExtensions &&
+  global.nativeExtensions.DeviceInfo &&
+  global.nativeExtensions.DeviceInfo.Dimensions;
+let nativeExtensionsEnabled = true;
+if (!dims) {
+  const DeviceInfo = require('DeviceInfo');
+  dims = DeviceInfo.Dimensions;
+  nativeExtensionsEnabled = false;
+}
+
+invariant(
+  dims,
+  'Either DeviceInfo native extension or DeviceInfo Native Module must be registered',
+);
+Dimensions.set(dims);
+if (!nativeExtensionsEnabled) {
+  RCTDeviceEventEmitter.addListener('didUpdateDimensions', function(update) {
+    Dimensions.set(update);
+  });
+}
+
+module.exports = Dimensions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10421,10 +10421,10 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rnpm-plugin-windows@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.3.3.tgz#9a958911fc496fddffc909655a37d7554266d6ac"
-  integrity sha512-55O5BxwH1UTCYlSEBNhPPvIvMV0Thd4UfZLnORe/hV0yih2TYd1unk4GkRXKRd4jZnP6fyPj1JXM6Tksq70bRw==
+rnpm-plugin-windows@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.3.5.tgz#6c84bedda93445017ce7d6d4035b25a1e86cdaf2"
+  integrity sha512-dCqiEr6QS7/yODKdoBY0b0VzocFilZ8RZDsnIPHIXtQhpo8y1VhJYqxoQAxnE3kFLGDKYuLwgfD8bTo0P2zZcg==
   dependencies:
     chalk "^1.1.3"
     extract-zip "^1.6.7"


### PR DESCRIPTION
#2470 
- Currently DeviceInfo is reporting CoreWindow's bounds for the window dimension, this update change it and hook up with the root element's size instead.
- When root element size changes, we should fire event to app to update the dimensions. This functionality is also added in this change. I tested with the RNTester;s Dimensions.jst and the update events worked fine.
- Additionally, the screen dimension reported was overwritten with window dimension in React Native, this is apple's behavior. We should adopt Android's behavior(user whatever reported by the native module) instead, so I also add a dimensions.windows.js for RNW.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3319)