### PR TITLE
Fix UT script assemblies defaults.

### DIFF
--- a/change/react-native-windows-2019-10-07-19-41-01-fixutassemblies.json
+++ b/change/react-native-windows-2019-10-07-19-41-01-fixutassemblies.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fix UT script assemblies defaults.",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "commit": "39c8a70f7db96c6e17345a40c8ca9faba420be1d",
+  "date": "2019-10-08T02:41:01.161Z",
+  "file": "D:\\Extra\\react\\windows\\dev\\change\\react-native-windows-2019-10-07-19-41-01-fixutassemblies.json"
+}

--- a/vnext/Scripts/IntegrationTests.ps1
+++ b/vnext/Scripts/IntegrationTests.ps1
@@ -24,8 +24,8 @@ param (
 
 	[System.IO.FileInfo[]] $Assemblies =
 	(
-		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
-		"React.Windows.Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.dll"
+		("$(Split-Path $PSScriptRoot)\target\$Platform\$Configuration\" +
+		"React.Windows.Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.dll")
 	),
 
 	[switch] $NoRun,

--- a/vnext/Scripts/UnitTest.ps1
+++ b/vnext/Scripts/UnitTest.ps1
@@ -16,11 +16,11 @@ param (
 
 	[System.IO.FileInfo[]] $Assemblies =
 	(
-		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
-		"React.Windows.Desktop.UnitTests\React.Windows.Desktop.UnitTests.dll",
+		("$(Split-Path $PSScriptRoot)\target\$Platform\$Configuration\" +
+		"React.Windows.Desktop.UnitTests\React.Windows.Desktop.UnitTests.dll"),
 
-		"$PSScriptRoot\..\target\$Platform\$Configuration\" +
-		"JSI.Desktop.UnitTests\JSI.Desktop.UnitTests.exe"
+		("$(Split-Path $PSScriptRoot)\target\$Platform\$Configuration\" +
+		"JSI.Desktop.UnitTests\JSI.Desktop.UnitTests.exe")
 	),
 
 	[System.IO.FileInfo] $VsTest = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"


### PR DESCRIPTION
Avoid string array parsing conflicts in UnitTests.ps1 by explicitly grouping Assemblies argument concatenation between parentheses.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3355)