### PR TITLE
Update to react-native@0.60.0-microsoft.4

### DIFF
--- a/change/react-native-windows-2019-10-08-04-18-47-auto-update-versions060.0microsoft.4.json
+++ b/change/react-native-windows-2019-10-08-04-18-47-auto-update-versions060.0microsoft.4.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.4",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "5dc6641f239d401efc327dd047d7a1694f7c2a22",
+  "date": "2019-10-08T04:18:47.885Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-2019-10-08-04-18-47-auto-update-versions060.0microsoft.4.json"
+}

--- a/change/react-native-windows-extended-2019-10-08-04-18-49-auto-update-versions060.0microsoft.4.json
+++ b/change/react-native-windows-extended-2019-10-08-04-18-49-auto-update-versions060.0microsoft.4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.4",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "e83cd760e835e6d0e22f928f59730d4303ac3c9a",
+  "date": "2019-10-08T04:18:49.766Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-extended-2019-10-08-04-18-49-auto-update-versions060.0microsoft.4.json"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz",
     "react-native-windows": "0.60.0-vnext.20",
     "react-native-windows-extended": "0.60.4",
     "rnpm-plugin-windows": "^0.3.5"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz",
     "react-native-windows": "0.60.0-vnext.20",
     "react-native-windows-extended": "0.60.4",
     "rnpm-plugin-windows": "^0.3.5"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz",
     "react-native-windows": "0.60.0-vnext.20",
     "react-native-windows-extended": "0.60.4",
     "rnpm-plugin-windows": "^0.3.5"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.3 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.4 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -46,13 +46,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.3 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.4 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.4.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
25fab075e Applying package update to 0.60.0-microsoft.4 ***NO_CI***
7316be1e6 Remove merge conflict artifacts (#170)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3356)