### PR TITLE
(0.59) Extend overlapping Flyout shadow fix to cover Popups

### DIFF
--- a/change/react-native-windows-2019-10-10-15-18-19-popup-shadow-fix.59.json
+++ b/change/react-native-windows-2019-10-10-15-18-19-popup-shadow-fix.59.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Extend",
+  "comment": "Extending Flyout shadow fix to support Popups",
   "packageName": "react-native-windows",
   "email": "kenander@microsoft.com",
   "commit": "938708918336b230d095b93fd185a0635459d71b",

--- a/change/react-native-windows-2019-10-10-15-18-19-popup-shadow-fix.59.json
+++ b/change/react-native-windows-2019-10-10-15-18-19-popup-shadow-fix.59.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Extend",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "938708918336b230d095b93fd185a0635459d71b",
+  "date": "2019-10-10T22:18:19.618Z"
+}

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -43,7 +43,7 @@ std::int32_t CountOpenPopups() {
   // RS6
   winrt::Windows::Foundation::Collections::IVectorView<winrt::Popup> popups =
       winrt::VisualTreeHelper::GetOpenPopups(winrt::Window::Current());
-  return (int32_t) popups.Size();
+  return (int32_t)popups.Size();
 }
 
 } // namespace uwp

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -6,6 +6,11 @@
 #include <Modules/NativeUIManager.h>
 #include "Helpers.h"
 
+namespace winrt {
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Media;
+} // namespace winrt
+
 namespace react {
 namespace uwp {
 
@@ -32,6 +37,14 @@ ReactId getViewId(
   }
   return reactId;
 };
+
+std::int32_t CountOpenPopups() {
+  // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
+  // RS6
+  winrt::Windows::Foundation::Collections::IVectorView<winrt::Popup> popups =
+      winrt::VisualTreeHelper::GetOpenPopups(winrt::Window::Current());
+  return (int32_t) popups.Size();
+}
 
 } // namespace uwp
 }; // namespace react

--- a/vnext/ReactUWP/Utils/Helpers.h
+++ b/vnext/ReactUWP/Utils/Helpers.h
@@ -30,5 +30,6 @@ inline typename T asEnum(folly::dynamic const &obj) {
 ReactId getViewId(
     _In_ IReactInstance *instance,
     winrt::FrameworkElement const &fe);
+std::int32_t CountOpenPopups();
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -201,9 +201,12 @@ void FlyoutShadowNode::createView() {
             // of open popups/flyouts. We apply this translation on open of the
             // flyout. (Translation is only supported on RS5+, eg. IUIElement9)
             if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
-              winrt::Numerics::float3 translation{
-                  0, 0, (float)16 * CountOpenPopups()};
-              flyoutPresenter.Translation(translation);
+              auto numOpenPopups = CountOpenPopups();
+              if (numOpenPopups > 0) {
+                winrt::Numerics::float3 translation{
+                    0, 0, (float)16 * numOpenPopups};
+                flyoutPresenter.Translation(translation);
+              }
             }
 
             flyoutPresenter.AllowFocusOnInteraction(false);

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -8,6 +8,7 @@
 #include "TouchEventHandler.h"
 
 #include <Modules/NativeUIManager.h>
+#include <Utils/Helpers.h>
 #include <Utils/ValueUtils.h>
 #include <winrt/Windows.UI.Core.h>
 
@@ -73,8 +74,21 @@ void PopupShadowNode::createView() {
   m_popupOpenedRevoker =
       popup.Opened(winrt::auto_revoke, [=](auto &&, auto &&) {
         auto instance = wkinstance.lock();
-        if (!m_updating && instance != nullptr)
+        if (!m_updating && instance != nullptr) {
           SetAnchorPosition(popup);
+
+          // When multiple flyouts/popups are overlapping, XAML's theme shadows
+          // don't render properly. As a workaround we enable a z-index
+          // translation based on an elevation derived from the count of open
+          // popups/flyouts. We apply this translation on open of the popup.
+          // (Translation is only supported on RS5+, eg. IUIElement9)
+          if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) { 
+            winrt::Numerics::float3 translation{
+                0, 0, (float)16 * CountOpenPopups()};
+            popup.Translation(translation);
+          }
+
+        }
       });
 }
 

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -82,12 +82,14 @@ void PopupShadowNode::createView() {
           // translation based on an elevation derived from the count of open
           // popups/flyouts. We apply this translation on open of the popup.
           // (Translation is only supported on RS5+, eg. IUIElement9)
-          if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) { 
-            winrt::Numerics::float3 translation{
-                0, 0, (float)16 * CountOpenPopups()};
-            popup.Translation(translation);
+          if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
+            auto numOpenPopups = CountOpenPopups();
+            if (numOpenPopups > 0) {
+              winrt::Numerics::float3 translation{
+                  0, 0, (float)16 * numOpenPopups};
+              popup.Translation(translation);
+            }
           }
-
         }
       });
 }

--- a/vnext/src/RNTester/FlyoutExample.windows.tsx
+++ b/vnext/src/RNTester/FlyoutExample.windows.tsx
@@ -173,7 +173,9 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
                   marginTop: 10,
                 }}>
                 <Button
-                  onPress={() => {this.setState({isPopupVisible: true})}}
+                  onPress={() => {
+                    this.setState({isPopupVisible: true});
+                  }}
                   title={'Open A Popup'}
                 />
               </View>
@@ -198,11 +200,18 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
             isOpen={this.state.isPopupVisible}
             isLightDismissEnabled={this.state.isLightDismissEnabled}
             target={this._anchorTwo}
-            onDismiss={() => {this.setState({isPopupVisible: false})}}>
+            onDismiss={() => {
+              this.setState({isPopupVisible: false});
+            }}>
             <View
               style={{backgroundColor: 'lightblue', width: 200, height: 300}}>
               <Text>{lorumIpsum}</Text>
-              <Button onPress={() => {this.setState({isPopupVisible: false})}} title="Close" />
+              <Button
+                onPress={() => {
+                  this.setState({isPopupVisible: false});
+                }}
+                title="Close"
+              />
             </View>
           </Popup>
         )}

--- a/vnext/src/RNTester/FlyoutExample.windows.tsx
+++ b/vnext/src/RNTester/FlyoutExample.windows.tsx
@@ -6,12 +6,13 @@
 
 import React = require('react');
 import {Button, Text, TextInput, View} from 'react-native';
-import {CheckBox, Flyout, Picker} from '../index.windows';
+import {CheckBox, Flyout, Picker, Popup} from '../index.windows';
 import {Placement} from '../Libraries/Components/Flyout/FlyoutProps';
 
 interface IFlyoutExampleState {
   isFlyoutVisible: boolean;
   isFlyoutTwoVisible: boolean;
+  isPopupVisible: boolean;
   buttonTitle: string;
   isLightDismissEnabled: boolean;
   isOverlayEnabled: boolean;
@@ -43,6 +44,7 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
   public state: IFlyoutExampleState = {
     isFlyoutVisible: false,
     isFlyoutTwoVisible: false,
+    isPopupVisible: false,
     buttonTitle: 'Open Flyout',
     isLightDismissEnabled: true,
     isOverlayEnabled: false,
@@ -164,6 +166,17 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
                   ref={this._setRefTwo}
                 />
               </View>
+              <View
+                style={{
+                  width: 150,
+                  marginLeft: 75,
+                  marginTop: 10,
+                }}>
+                <Button
+                  onPress={() => {this.setState({isPopupVisible: true})}}
+                  title={'Open A Popup'}
+                />
+              </View>
             </View>
           </Flyout>
         )}
@@ -179,6 +192,19 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
               <Text>{lorumIpsum}</Text>
             </View>
           </Flyout>
+        )}
+        {this.state.isPopupVisible && (
+          <Popup
+            isOpen={this.state.isPopupVisible}
+            isLightDismissEnabled={this.state.isLightDismissEnabled}
+            target={this._anchorTwo}
+            onDismiss={() => {this.setState({isPopupVisible: false})}}>
+            <View
+              style={{backgroundColor: 'lightblue', width: 200, height: 300}}>
+              <Text>{lorumIpsum}</Text>
+              <Button onPress={() => {this.setState({isPopupVisible: false})}} title="Close" />
+            </View>
+          </Popup>
         )}
       </View>
     );
@@ -199,6 +225,7 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
   _onFlyoutDismissed = (_isOpen: boolean) => {
     this.setState({isFlyoutVisible: false});
     this.setState({isFlyoutTwoVisible: false});
+    this.setState({isPopupVisible: false});
     this.setState({buttonTitle: 'Open Flyout'});
   };
 


### PR DESCRIPTION
The overlapping Flyout shadow problem (https://github.com/microsoft/react-native-windows/pull/2733) also occurs with Popups. 

This is occuring in our app now when we integrated a component using a Popup into one of our Flyouts (See image below).

This means that we need to have the Flyout shadow fix extended to include Popups.
This PR does that by adding the Translation workaround from the FlyoutShadowNode to the PopupShadowNode and changes the tracking of open flyouts from the manual tracking code to a utility function using the XAML VisualTreeHelper::GetOpenPopups.

The PR also adds an embedded Popup to the RNTester app's Flyout example for more complexity.

![image](https://user-images.githubusercontent.com/5695388/66603406-fd442480-eb60-11e9-962b-cd799d95f30b.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3388)