### PR TITLE
Support caretHidden for TextInput

### DIFF
--- a/change/react-native-windows-2019-10-11-10-01-03-hiddenCursor.json
+++ b/change/react-native-windows-2019-10-11-10-01-03-hiddenCursor.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Support caretHidden",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "b6255479abbc300ec48d125038bdfe1fc688b77e",
+  "date": "2019-10-11T17:01:03.246Z",
+  "file": "D:\\react-native-windows\\change\\react-native-windows-2019-10-11-10-01-03-hiddenCursor.json"
+}

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -48,6 +48,11 @@ export default class Bootstrap extends React.Component<{}, any> {
         />
         <TextInput
           style={styles.input}
+          caretHidden={true}
+          placeholder={'caretHidden'}
+        />
+        <TextInput
+          style={styles.input}
           keyboardType="number-pad"
           placeholder={'number-pad keyboardType'}
         />
@@ -86,12 +91,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   input: {
-    margin: 15,
-    height: 80,
+    margin: 5,
+    height: 40,
     width: 700,
     borderColor: '#7a42f4',
     borderWidth: 1,
-    fontSize: 40,
+    fontSize: 15,
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9868,10 +9868,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz":
-  version "0.60.0-microsoft.3"
-  uid a547be3bac4b2e499203c2536b706c6addeb2e9e
-  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.3.tar.gz#a547be3bac4b2e499203c2536b706c6addeb2e9e"
+"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz":
+  version "0.60.0-microsoft.5"
+  uid "4c3fa1679b4ad4b45bf76e117dfa936359beef2a"
+  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz#4c3fa1679b4ad4b45bf76e117dfa936359beef2a"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
#3087 
- The solution is not optimal, rather a hacking where we walk down the tree, find the caret element(shape) and make it transparent. 
- Current solution only support one way property change, meaning setting it to false. Toggle the property back to true is not supported, because the hacking solution gets complicated and XAML does not expose composition mode DestInvert(original composition mode set internally on caret) in public API.
- There is a feature request to add a public API to support caretHidden on XAML's text control, we should remove this hacking solution and use that new API when available.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3397)