### PR TITLE
Update to react-native@0.60.0-microsoft.6

### DIFF
--- a/change/react-native-windows-2019-10-14-21-12-27-auto-update-versions060.0microsoft.6.json
+++ b/change/react-native-windows-2019-10-14-21-12-27-auto-update-versions060.0microsoft.6.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.6",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "fbf62c69471f704ad6cf35c3a3b74eda4539c76e",
+  "date": "2019-10-14T21:12:27.543Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-2019-10-14-21-12-27-auto-update-versions060.0microsoft.6.json"
+}

--- a/change/react-native-windows-extended-2019-10-14-21-12-29-auto-update-versions060.0microsoft.6.json
+++ b/change/react-native-windows-extended-2019-10-14-21-12-29-auto-update-versions060.0microsoft.6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.6",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "3038c79de6fd30530eb341fb4195c36a88f96f9c",
+  "date": "2019-10-14T21:12:29.337Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-extended-2019-10-14-21-12-29-auto-update-versions060.0microsoft.6.json"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz",
     "react-native-windows": "0.60.0-vnext.27",
     "react-native-windows-extended": "0.60.5",
     "rnpm-plugin-windows": "^0.3.5"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz",
     "react-native-windows": "0.60.0-vnext.27",
     "react-native-windows-extended": "0.60.5",
     "rnpm-plugin-windows": "^0.3.5"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz",
     "react-native-windows": "0.60.0-vnext.27",
     "react-native-windows-extended": "0.60.5",
     "rnpm-plugin-windows": "^0.3.5"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.5 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.6 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -46,13 +46,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.5 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.5.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.6 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.6.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
ae7549cc2 Applying package update to 0.60.0-microsoft.6 ***NO_CI***
93b3e6e75 Use $buildNumber$ token for NuGet (#172)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3408)