### PR TITLE
(Forward port) Extend overlapping Flyout shadow fix to Popups

### DIFF
--- a/change/react-native-windows-2019-10-15-17-00-10-popup-shadow-fix.json
+++ b/change/react-native-windows-2019-10-15-17-00-10-popup-shadow-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Extend flyout shadow fix to Popups",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "2e896420694fe6b89d3a0a46450b9ea6c887b058",
+  "date": "2019-10-16T00:00:10.032Z",
+  "file": "F:\\react-native-windows\\change\\react-native-windows-2019-10-15-17-00-10-popup-shadow-fix.json"
+}

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -6,6 +6,11 @@
 #include <Modules/NativeUIManager.h>
 #include "Helpers.h"
 
+namespace winrt {
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Media;
+} // namespace winrt
+
 namespace react {
 namespace uwp {
 
@@ -32,6 +37,14 @@ ReactId getViewId(
   }
   return reactId;
 };
+
+std::int32_t CountOpenPopups() {
+  // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
+  // RS6
+  winrt::Windows::Foundation::Collections::IVectorView<winrt::Popup> popups =
+      winrt::VisualTreeHelper::GetOpenPopups(winrt::Window::Current());
+  return (int32_t)popups.Size();
+}
 
 } // namespace uwp
 }; // namespace react

--- a/vnext/ReactUWP/Utils/Helpers.h
+++ b/vnext/ReactUWP/Utils/Helpers.h
@@ -30,5 +30,6 @@ inline typename T asEnum(folly::dynamic const &obj) {
 ReactId getViewId(
     _In_ IReactInstance *instance,
     winrt::FrameworkElement const &fe);
+std::int32_t CountOpenPopups();
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -9,6 +9,7 @@
 #include "ViewPanel.h"
 
 #include <Modules/NativeUIManager.h>
+#include <Utils/Helpers.h>
 #include <Utils/PropertyHandlerUtils.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 
@@ -111,7 +112,6 @@ class FlyoutShadowNode : public ShadowNodeBase {
   float m_verticalOffset = 0;
   bool m_isFlyoutShowOptionsSupported = false;
   winrt::FlyoutShowOptions m_showOptions = nullptr;
-  static thread_local std::int32_t s_cOpenFlyouts;
 
   std::unique_ptr<TouchEventHandler> m_touchEventHanadler;
   std::unique_ptr<PreviewKeyboardEventHandlerOnRoot>
@@ -122,8 +122,6 @@ class FlyoutShadowNode : public ShadowNodeBase {
   int64_t m_tokenContentPropertyChangeCallback;
   winrt::Flyout::Opened_revoker m_flyoutOpenedRevoker{};
 };
-
-thread_local std::int32_t FlyoutShadowNode::s_cOpenFlyouts = 0;
 
 FlyoutShadowNode::~FlyoutShadowNode() {
   m_touchEventHanadler->RemoveTouchHandlers();
@@ -197,15 +195,18 @@ void FlyoutShadowNode::createView() {
 
         if (!m_updating && instance != nullptr) {
           if (auto flyoutPresenter = GetFlyoutPresenter()) {
-            // When multiple flyouts are overlapping, XAML's theme shadows
-            // don't render properly. As a workaround we enable a z-index
-            // translation based on an elevation derived from the count of
-            // open flyouts. We apply this translation on open of the flyout.
-            // (Translation is only supported on RS5+, eg. IUIElement9)
+            // When multiple flyouts/popups are overlapping, XAML's theme
+            // shadows don't render properly. As a workaround we enable a
+            // z-index translation based on an elevation derived from the count
+            // of open popups/flyouts. We apply this translation on open of the
+            // flyout. (Translation is only supported on RS5+, eg. IUIElement9)
             if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
-              winrt::Numerics::float3 translation{
-                  0, 0, (float)16 * s_cOpenFlyouts};
-              flyoutPresenter.Translation(translation);
+              auto numOpenPopups = CountOpenPopups();
+              if (numOpenPopups > 0) {
+                winrt::Numerics::float3 translation{
+                    0, 0, (float)16 * numOpenPopups};
+                flyoutPresenter.Translation(translation);
+              }
             }
 
             flyoutPresenter.AllowFocusOnInteraction(false);
@@ -256,8 +257,6 @@ void FlyoutShadowNode::onDropViewInstance() {
   if (m_isOpen) {
     m_isOpen = false;
     m_flyout.Hide();
-    s_cOpenFlyouts -= 1;
-    assert(s_cOpenFlyouts >= 0);
   }
 }
 
@@ -342,7 +341,6 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic &&props) {
 
   if (updateIsOpen) {
     if (m_isOpen) {
-      s_cOpenFlyouts += 1;
       AdjustDefaultFlyoutStyle(50000, 50000);
       if (m_isFlyoutShowOptionsSupported) {
         m_flyout.ShowAt(m_targetElement, m_showOptions);
@@ -355,8 +353,6 @@ void FlyoutShadowNode::updateProperties(const folly::dynamic &&props) {
         popup.IsLightDismissEnabled(m_isLightDismissEnabled);
     } else {
       m_flyout.Hide();
-      s_cOpenFlyouts -= 1;
-      assert(s_cOpenFlyouts >= 0);
     }
   }
 

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -8,6 +8,7 @@
 #include "TouchEventHandler.h"
 
 #include <Modules/NativeUIManager.h>
+#include <Utils/Helpers.h>
 #include <Utils/ValueUtils.h>
 #include <winrt/Windows.UI.Core.h>
 
@@ -73,8 +74,23 @@ void PopupShadowNode::createView() {
   m_popupOpenedRevoker =
       popup.Opened(winrt::auto_revoke, [=](auto &&, auto &&) {
         auto instance = wkinstance.lock();
-        if (!m_updating && instance != nullptr)
+        if (!m_updating && instance != nullptr) {
           SetAnchorPosition(popup);
+
+          // When multiple flyouts/popups are overlapping, XAML's theme shadows
+          // don't render properly. As a workaround we enable a z-index
+          // translation based on an elevation derived from the count of open
+          // popups/flyouts. We apply this translation on open of the popup.
+          // (Translation is only supported on RS5+, eg. IUIElement9)
+          if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
+            auto numOpenPopups = CountOpenPopups();
+            if (numOpenPopups > 0) {
+              winrt::Numerics::float3 translation{
+                  0, 0, (float)16 * numOpenPopups};
+              popup.Translation(translation);
+            }
+          }
+        }
       });
 }
 

--- a/vnext/src/RNTester/FlyoutExample.windows.tsx
+++ b/vnext/src/RNTester/FlyoutExample.windows.tsx
@@ -6,12 +6,13 @@
 
 import React = require('react');
 import {Button, CheckBox, Text, TextInput, View} from 'react-native';
-import {Flyout, Picker} from 'react-native-windows';
+import {Flyout, Picker, Popup} from 'react-native-windows';
 import {Placement} from '../Libraries/Components/Flyout/FlyoutProps';
 
 interface IFlyoutExampleState {
   isFlyoutVisible: boolean;
   isFlyoutTwoVisible: boolean;
+  isPopupVisible: boolean;
   buttonTitle: string;
   isLightDismissEnabled: boolean;
   isOverlayEnabled: boolean;
@@ -43,6 +44,7 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
   public state: IFlyoutExampleState = {
     isFlyoutVisible: false,
     isFlyoutTwoVisible: false,
+    isPopupVisible: false,
     buttonTitle: 'Open Flyout',
     isLightDismissEnabled: true,
     isOverlayEnabled: false,
@@ -164,6 +166,19 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
                   ref={this._setRefTwo}
                 />
               </View>
+              <View
+                style={{
+                  width: 150,
+                  marginLeft: 75,
+                  marginTop: 10,
+                }}>
+                <Button
+                  onPress={() => {
+                    this.setState({isPopupVisible: true});
+                  }}
+                  title={'Open A Popup'}
+                />
+              </View>
             </View>
           </Flyout>
         )}
@@ -179,6 +194,26 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
               <Text>{lorumIpsum}</Text>
             </View>
           </Flyout>
+        )}
+        {this.state.isPopupVisible && (
+          <Popup
+            isOpen={this.state.isPopupVisible}
+            isLightDismissEnabled={this.state.isLightDismissEnabled}
+            target={this._anchorTwo}
+            onDismiss={() => {
+              this.setState({isPopupVisible: false});
+            }}>
+            <View
+              style={{backgroundColor: 'lightblue', width: 200, height: 300}}>
+              <Text>{lorumIpsum}</Text>
+              <Button
+                onPress={() => {
+                  this.setState({isPopupVisible: false});
+                }}
+                title="Close"
+              />
+            </View>
+          </Popup>
         )}
       </View>
     );
@@ -199,6 +234,7 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
   _onFlyoutDismissed = (_isOpen: boolean) => {
     this.setState({isFlyoutVisible: false});
     this.setState({isFlyoutTwoVisible: false});
+    this.setState({isPopupVisible: false});
     this.setState({buttonTitle: 'Open Flyout'});
   };
 


### PR DESCRIPTION
This fix, https://github.com/microsoft/react-native-windows/pull/3388, was merged into 0.59-vnext-stable, but also needs to be in master.  This PR does just that.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3432)