### PR TITLE
Don't hardcode the path to v141 platform toolset

### DIFF
--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -3,5 +3,10 @@ $installationPath = . $installerPath\vswhere.exe -latest -property installationP
 
 $p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config .\vsconfig" -Wait 
 $p.WaitForExit()
-Sleep 30
+while (!(Test-Path .\vsconfig))
+{
+    Sleep 5
+    Write-Host "Waiting for vsconfig file..."
+}
+
 gc .\vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,8 +1,14 @@
+$dir = $env:temp
+if ($env:Agent_TempDirectory -ne $null)
+{
+    $dir = $env:Agent_TempDirectory
+}
+Write-Output "hello" |  Out-File $dir\foobar.txt
 $installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
 $installationPath = . $installerPath\vswhere.exe -latest -property installationPath
-$vsconfig = "$env:temp\vsconfig"
+$vsconfig = "$dir\vsconfig"
 Write-Host "VSConfig will be at $vsconfig"
-$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
+$p = Start-Process -PassThru $installerPath\vs_installer.exe -RedirectStandardError $dir\err -RedirectStandardOutput $dir\out -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
 $p.WaitForExit()
 $x = [Datetime]::Now.AddSeconds(60)
 while (!(Test-Path $vsconfig) -and ([datetime]::Now -lt $x))
@@ -11,4 +17,6 @@ while (!(Test-Path $vsconfig) -and ([datetime]::Now -lt $x))
     Write-Host "Waiting for vsconfig file..."
 }
 
+gc $dir\err
+gc $dir\out
 gc $vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,7 +1,9 @@
 $installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
 $installationPath = . $installerPath\vswhere.exe -latest -property installationPath
 
-$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $env:temp\vsconfig" -Wait
+$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $env:temp\vsconfig" -Wait -RedirectStandardOutput $env:temp\out -RedirectStandardError $env:temp\err
 $p.WaitForExit()
 Sleep 30
+gc $env:temp\out
+gc $env:temp\err
 gc $env:temp\vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -5,7 +5,7 @@ Write-Host "VSConfig will be at $vsconfig"
 $p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
 $p.WaitForExit()
 $x = [Datetime]::Now.AddSeconds(60)
-while (!(Test-Path .\vsconfig) -and ([datetime]::Now -lt $x))
+while (!(Test-Path $vsconfig) -and ([datetime]::Now -lt $x))
 {
     Sleep 5
     Write-Host "Waiting for vsconfig file..."

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,3 +1,4 @@
 $p = Start-Process -PassThru 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -ArgumentList "export --installpath `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise`" --quiet --config $env:temp\vsconfig"
 $p.WaitForExit()
+Sleep 30
 gc $env:temp\vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,4 +1,7 @@
-$p = Start-Process -PassThru 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -ArgumentList "export --installpath `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise`" --quiet --config $env:temp\vsconfig"
+$installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
+$installationPath = . $installerPath\vswhere.exe -latest -property installationPath
+
+$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $env:temp\vsconfig" -Wait
 $p.WaitForExit()
 Sleep 30
 gc $env:temp\vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,9 +1,11 @@
 $installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
 $installationPath = . $installerPath\vswhere.exe -latest -property installationPath
-
-$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config .\vsconfig" -Wait 
+$vsconfig = "$env:temp\vsconfig"
+Write-Host "VSConfig will be at $vsconfig"
+$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
 $p.WaitForExit()
-while (!(Test-Path .\vsconfig))
+$x = [Datetime]::Now.AddSeconds(60)
+while (!(Test-Path .\vsconfig) -and ([datetime]::Now -lt $x))
 {
     Sleep 5
     Write-Host "Waiting for vsconfig file..."

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,0 +1,3 @@
+$p = Start-Process -PassThru 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -ArgumentList "export --installpath `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise`" --quiet --config $env:temp\vsconfig"
+$p.WaitForExit()
+gc $env:temp\vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -1,9 +1,7 @@
 $installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
 $installationPath = . $installerPath\vswhere.exe -latest -property installationPath
 
-$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config $env:temp\vsconfig" -Wait -RedirectStandardOutput $env:temp\out -RedirectStandardError $env:temp\err
+$p = Start-Process -PassThru $installerPath\vs_installer.exe -ArgumentList "export --installpath `"$installationPath`" --quiet --config .\vsconfig" -Wait 
 $p.WaitForExit()
 Sleep 30
-gc $env:temp\out
-gc $env:temp\err
-gc $env:temp\vsconfig
+gc .\vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -3,12 +3,14 @@ if ($env:Agent_TempDirectory -ne $null)
 {
     $dir = $env:Agent_TempDirectory
 }
-Write-Output "hello" |  Out-File $dir\foobar.txt
+
 $installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
 $installationPath = . $installerPath\vswhere.exe -latest -property installationPath
 $vsconfig = "$dir\vsconfig"
 Write-Host "VSConfig will be at $vsconfig"
-$p = Start-Process -PassThru $installerPath\vs_installershell.exe -RedirectStandardError $dir\err -RedirectStandardOutput $dir\out -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
+
+Invoke-WebRequest -Uri 'https://download.visualstudio.microsoft.com/download/pr/c4fef23e-cc45-4836-9544-70e213134bc8/1ee5717e9a1e05015756dff77eb27d554a79a6db91f2716d836df368381af9a1/vs_Enterprise.exe' -OutFile $dir\vs_enterprise.exe
+$p = Start-Process -PassThru $dir\vs_enterprise.exe -RedirectStandardError $dir\err -RedirectStandardOutput $dir\out -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
 $p.WaitForExit()
 $x = [Datetime]::Now.AddSeconds(60)
 while (!(Test-Path $vsconfig) -and ([datetime]::Now -lt $x))

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -8,7 +8,7 @@ $installerPath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\'
 $installationPath = . $installerPath\vswhere.exe -latest -property installationPath
 $vsconfig = "$dir\vsconfig"
 Write-Host "VSConfig will be at $vsconfig"
-$p = Start-Process -PassThru $installerPath\vs_installer.exe -RedirectStandardError $dir\err -RedirectStandardOutput $dir\out -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
+$p = Start-Process -PassThru $installerPath\vs_installershell.exe -RedirectStandardError $dir\err -RedirectStandardOutput $dir\out -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
 $p.WaitForExit()
 $x = [Datetime]::Now.AddSeconds(60)
 while (!(Test-Path $vsconfig) -and ([datetime]::Now -lt $x))
@@ -17,6 +17,6 @@ while (!(Test-Path $vsconfig) -and ([datetime]::Now -lt $x))
     Write-Host "Waiting for vsconfig file..."
 }
 
-gc $dir\err
-gc $dir\out
-gc $vsconfig
+Get-Content $dir\err
+Get-Content $dir\out
+Get-Content $vsconfig

--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -11,4 +11,4 @@ while (!(Test-Path .\vsconfig) -and ([datetime]::Now -lt $x))
     Write-Host "Waiting for vsconfig file..."
 }
 
-gc .\vsconfig
+gc $vsconfig

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -37,7 +37,7 @@ jobs:
       - task: CmdLine@2
         displayName: VS Component list
         inputs:
-          script: "\"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe\" export --installpath \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\" --quiet --config %temp%\\vsconfig && type %temp%\\vsconfig"
+          script: "\"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe\" export --installpath \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\" --quiet --config %temp%\\vsconfig && (timeout 30 > NUL) && type %temp%\\vsconfig"
 
       - task: CmdLine@2
         displayName: Modify package.json to use unforked RN

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -24,6 +24,12 @@ jobs:
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
       - task: PowerShell@2
+        displayName: VS Component list
+        inputs:
+          targetType: filePath
+          filePath: $(Build.SourcesDirectory)/.ado/VSComponentList.ps1
+
+      - task: PowerShell@2
         displayName: "Remove WebDriverIO Workaround"
         inputs:
           targetType: "inline"
@@ -33,11 +39,6 @@ jobs:
         displayName: Install react-native-cli
         inputs:
           script: npm install -g react-native-cli
-
-      - task: CmdLine@2
-        displayName: VS Component list
-        inputs:
-          script: "\"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe\" export --installpath \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\" --quiet --config %temp%\\vsconfig && (timeout 30 > NUL) && type %temp%\\vsconfig"
 
       - task: CmdLine@2
         displayName: Modify package.json to use unforked RN

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -37,7 +37,7 @@ jobs:
       - task: CmdLine@2
         displayName: VS Component list
         inputs:
-          script: "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" export --installpath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet --config %temp%\vsconfig && type %temp%\vsconfig
+          script: "C:\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe" export --installpath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet --config %temp%\vsconfig && type %temp%\vsconfig
 
       - task: CmdLine@2
         displayName: Modify package.json to use unforked RN

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -35,6 +35,11 @@ jobs:
           script: npm install -g react-native-cli
 
       - task: CmdLine@2
+        displayName: VS Component list
+        inputs:
+          script: "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" export --installpath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet --config %temp%\vsconfig && type %temp%\vsconfig
+
+      - task: CmdLine@2
         displayName: Modify package.json to use unforked RN
         inputs:
           script: node scripts/useUnForkedRN.js

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -37,7 +37,7 @@ jobs:
       - task: CmdLine@2
         displayName: VS Component list
         inputs:
-          script: "C:\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe" export --installpath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet --config %temp%\\vsconfig && type %temp%\\vsconfig
+          script: &quot;C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe&quot; export --installpath &quot;C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise&quot; --quiet --config %temp%\\vsconfig && type %temp%\\vsconfig
 
       - task: CmdLine@2
         displayName: Modify package.json to use unforked RN

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -37,7 +37,7 @@ jobs:
       - task: CmdLine@2
         displayName: VS Component list
         inputs:
-          script: &quot;C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe&quot; export --installpath &quot;C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise&quot; --quiet --config %temp%\\vsconfig && type %temp%\\vsconfig
+          script: "\"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe\" export --installpath \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\" --quiet --config %temp%\\vsconfig && type %temp%\\vsconfig"
 
       - task: CmdLine@2
         displayName: Modify package.json to use unforked RN

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -37,7 +37,7 @@ jobs:
       - task: CmdLine@2
         displayName: VS Component list
         inputs:
-          script: "C:\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe" export --installpath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet --config %temp%\vsconfig && type %temp%\vsconfig
+          script: "C:\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vs_installer.exe" export --installpath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet --config %temp%\\vsconfig && type %temp%\\vsconfig
 
       - task: CmdLine@2
         displayName: Modify package.json to use unforked RN

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -24,12 +24,6 @@ jobs:
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
       - task: PowerShell@2
-        displayName: VS Component list
-        inputs:
-          targetType: filePath
-          filePath: $(Build.SourcesDirectory)/.ado/VSComponentList.ps1
-
-      - task: PowerShell@2
         displayName: "Remove WebDriverIO Workaround"
         inputs:
           targetType: "inline"

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -473,7 +473,7 @@ jobs:
         vmImage: windows-2019
       BuildPlatform: x64
       UseRNFork: true
-      vsComponents: Microsoft.VisualStudio.Component.VC.v141.x86.x64
+      vsComponents: Microsoft.VisualStudio.Component.VC.v141.x86.x64, Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141
 
   - job: RNWNugetPR
     displayName: Build and Pack Nuget

--- a/change/react-native-windows-2019-10-15-18-17-54-v141path.json
+++ b/change/react-native-windows-2019-10-15-18-17-54-v141path.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Don't hardcode the path to v141 platform toolset",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "commit": "5259e65b49ff7d0131cc7d731ca7bd3438b03776",
+  "date": "2019-10-16T01:17:54.674Z",
+  "file": "F:\\rnw\\change\\react-native-windows-2019-10-15-18-17-54-v141path.json"
+}

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -29,10 +29,10 @@ async function buildSolution(slnFile, buildType, buildArch, verbose) {
   await msBuildTools.buildProject(slnFile, buildType, buildArch, null, verbose);
 }
 
-async function nugetRestore(nugetPath, slnFile, verbose) {
+async function nugetRestore(nugetPath, slnFile, verbose, msbuildVersion) {
   const text = 'Restoring NuGets';
   const spinner = newSpinner(text);
-
+  console.log(nugetPath);
   await commandWithProgress(
     spinner,
     text,
@@ -43,6 +43,8 @@ async function nugetRestore(nugetPath, slnFile, verbose) {
       '-NonInteractive',
       '-Verbosity',
       verbose ? 'normal' : 'quiet',
+      '-MSBuildVersion',
+      msbuildVersion,
     ],
     verbose,
   );
@@ -68,7 +70,8 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
   }
   ensureNugetSpinner.succeed('Found NuGet Binary');
 
-  await nugetRestore(nugetPath, slnFile, verbose);
+  const msbuildTools = MSBuildTools.findAvailableVersion();
+  await nugetRestore(nugetPath, slnFile, verbose, msbuildTools.installationVersion);
 }
 
 function getSolutionFile(options) {

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -25,7 +25,7 @@ async function buildSolution(slnFile, buildType, buildArch, verbose) {
     );
   }
 
-  const msBuildTools = MSBuildTools.findAvailableVersion();
+  const msBuildTools = MSBuildTools.findAvailableVersion(verbose);
   await msBuildTools.buildProject(slnFile, buildType, buildArch, null, verbose);
 }
 
@@ -70,7 +70,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
   }
   ensureNugetSpinner.succeed('Found NuGet Binary');
 
-  const msbuildTools = MSBuildTools.findAvailableVersion();
+  const msbuildTools = MSBuildTools.findAvailableVersion(verbose);
   await nugetRestore(
     nugetPath,
     slnFile,

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -25,7 +25,7 @@ async function buildSolution(slnFile, buildType, buildArch, verbose) {
     );
   }
 
-  const msBuildTools = MSBuildTools.findAvailableVersion(verbose);
+  const msBuildTools = MSBuildTools.findAvailableVersion(buildArch, verbose);
   await msBuildTools.buildProject(slnFile, buildType, buildArch, null, verbose);
 }
 
@@ -70,7 +70,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
   }
   ensureNugetSpinner.succeed('Found NuGet Binary');
 
-  const msbuildTools = MSBuildTools.findAvailableVersion(verbose);
+  const msbuildTools = MSBuildTools.findAvailableVersion('x86', verbose);
   await nugetRestore(
     nugetPath,
     slnFile,

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -71,7 +71,12 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
   ensureNugetSpinner.succeed('Found NuGet Binary');
 
   const msbuildTools = MSBuildTools.findAvailableVersion();
-  await nugetRestore(nugetPath, slnFile, verbose, msbuildTools.installationVersion);
+  await nugetRestore(
+    nugetPath,
+    slnFile,
+    verbose,
+    msbuildTools.installationVersion,
+  );
 }
 
 function getSolutionFile(options) {

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -65,11 +65,17 @@ class MSBuildTools {
 
     // Set platform toolset for VS 2019
     if (this.version === '16.0') {
+      const v141path = child_process
+        .execSync('"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -requires Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141 -property installationPath')
+        .toString().split(EOL)[0]
+        + '\\MSBuild\\Microsoft\\VC\\v150\\';
+
       args.push('/p:PlatformToolset=v141');
       args.push('/p:VisualStudioVersion=16.0');
       args.push(
-        '/p:VCTargetsPath=C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Microsoft\\VC\\v150\\',
+        '/p:VCTargetsPath=' + v141path,
       );
+
     }
 
     if (config) {
@@ -84,6 +90,8 @@ class MSBuildTools {
       newError(e.message);
       return;
     }
+
+    console.log('MSBuild args: ' + args.join(' '));
 
     const progressName = 'Building Solution';
     const spinner = newSpinner(progressName);

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -5,7 +5,6 @@
  */
 // @ts-check
 'use strict';
-
 const EOL = require('os').EOL;
 const fs = require('fs');
 const path = require('path');
@@ -65,17 +64,21 @@ class MSBuildTools {
 
     // Set platform toolset for VS 2019
     if (this.version === '16.0') {
-      const v141path = child_process
-        .execSync('"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -requires Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141 -property installationPath')
-        .toString().split(EOL)[0]
-        + '\\MSBuild\\Microsoft\\VC\\v150\\';
+      const results =
+        child_process
+          .execSync(
+            '"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -requires Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141 -property installationPath',
+          )
+          .toString()
+          .split(EOL)[0] + '\\MSBuild\\Microsoft\\VC\\v150\\';
+
+      console.warn('v141Path = ' + results);
 
       args.push('/p:PlatformToolset=v141');
       args.push('/p:VisualStudioVersion=16.0');
-      args.push(
-        '/p:VCTargetsPath=' + v141path,
-      );
+      args.push('/p:VCTargetsPath=' + results);
 
+      console.warn(args.join(' '));
     }
 
     if (config) {
@@ -90,8 +93,6 @@ class MSBuildTools {
       newError(e.message);
       return;
     }
-
-    console.log('MSBuild args: ' + args.join(' '));
 
     const progressName = 'Building Solution';
     const spinner = newSpinner(progressName);

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -145,9 +145,9 @@ function VSWhere(requires, version, property) {
   }
 }
 
-function checkMSBuildVersion(version) {
+function checkMSBuildVersion(version, verbose) {
   let toolsPath = null;
-  if (process.argv.indexOf('--logging') >= 0) {
+  if (verbose) {
     console.log('Searching for MSBuild version ' + version);
   }
 
@@ -183,11 +183,13 @@ function checkMSBuildVersion(version) {
   }
 }
 
-module.exports.findAvailableVersion = function() {
+module.exports.findAvailableVersion = function(verbose) {
   const versions =
     process.env.VisualStudioVersion != null
-      ? [checkMSBuildVersion(process.env.VisualStudioVersion)]
-      : MSBUILD_VERSIONS.map(checkMSBuildVersion);
+      ? [checkMSBuildVersion(process.env.VisualStudioVersion, verbose)]
+      : MSBUILD_VERSIONS.map(function(value) {
+          return checkMSBuildVersion(value, verbose);
+        });
   const msbuildTools = versions.find(Boolean);
 
   if (!msbuildTools) {
@@ -206,9 +208,11 @@ module.exports.findAvailableVersion = function() {
   return msbuildTools;
 };
 
-module.exports.findAllAvailableVersions = function() {
+module.exports.findAllAvailableVersions = function(verbose) {
   console.log(chalk.green('Searching for available MSBuild versions...'));
-  return MSBUILD_VERSIONS.map(checkMSBuildVersion).filter(item => !!item);
+  return MSBUILD_VERSIONS.map(function(value) {
+    return checkMSBuildVersion(value, verbose);
+  }).filter(item => !!item);
 };
 
 module.exports.getAllAvailableUAPVersions = function() {

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -122,6 +122,7 @@ function VSWhere(requires, version, property) {
     return vsPath;
   } else {
     const query = `reg query HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions\\${version} /s /v MSBuildToolsPath`;
+    let toolsPath = null;
     // Try to get the MSBuild path using registry
     try {
       const output = child_process.execSync(query).toString();
@@ -150,7 +151,8 @@ function checkMSBuildVersion(version) {
     console.log('Searching for MSBuild version ' + version);
   }
 
-  const requiresUWP = 'Microsoft.Component.MSBuild Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141';
+  const requiresUWP =
+    'Microsoft.Component.MSBuild Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141';
   const vsPath = VSWhere(requiresUWP, version, 'installationPath');
   const installationVersion = VSWhere(
     requiresUWP,


### PR DESCRIPTION
This change removes the hardcoded path to C:\Program Files (x86)\ ... where we go look for v141 tool. This addresses #3430 and #3435

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3434)