### PR TITLE
Native Module/View Manager Docs

### DIFF
--- a/vnext/docs/NativeModules.md
+++ b/vnext/docs/NativeModules.md
@@ -1,36 +1,41 @@
 # Native Modules and React Native Windows
 
-*This documentation is very much a work in progress, however you can see the current state of working code in the [packages/microsoft-reactnative-sampleapps](../../packages/microsoft-reactnative-sampleapps)*
+*Both this documentation and the underlying code is a work in progress. You can see the current state of working code here: [packages/microsoft-reactnative-sampleapps](../../packages/microsoft-reactnative-sampleapps)*
 
-React Native can interop with your own custom native code from within your JavaScript app code. There are two main scenarios for developers: *Native Modules* and *View Managers*.
+Sometimes an app needs access to a platform API that React Native doesn't have a corresponding module for yet. Maybe you want to reuse some existing .NET code without having to reimplement it in JavaScript, or write some high performance, multi-threaded code for image processing, a database, or any number of advanced extensions.
 
-Native Modules are for exposing general purpose native code to JS.
+React Native was designed such that it is possible for you to write real native code and have access to the full power of the platform. This is a more advanced feature and we don't expect it to be part of the usual development process, however it is essential that it exists. If React Native doesn't support a native feature that you need, you should be able to build it yourself.
 
-View Managers are for exposing new native XAML controls as React Native Components to use within JSX.
+>NOTE: If you are building a widget that has a UI component, check out the [Native UI Component guide](./ViewManagers.md).
 
-## Native Modules
+## Overview 
 
-Native modules contain (or wrap) native code which can then be exposed to JS. To accomplish this in RNW, at a high level you must:
+Native modules contain (or wrap) native code which can then be exposed to JS. To accomplish this in React Native for Windows vNext, at a high level you must:
 
-1. Author a class that calls your native code. There are no requirements that the class is inherited from a specific class or interface.
-2. Add custom attributes to your class:
-   1. `ReactModule` for the class.
-   2. `ReactMethod` or `ReactSyncMethod` for asynchronous or synchronous methods.
-   3. `ReactConstant` for fields or properties that represent constants.
-   4. `ReactConstantProvider` for methods that provide a set of constants.
-   5. `ReactEvent` for fields or properties that represent events.
-3. Register your new native module in a ReactNative package. A package is a public class that implements `IReactPackageProvider` interface.
-4. Add the package to your React Native application.
-5. In JavaScript code:
-   1. Read native module constants.
-   2. Subscribe to the native module events.
-   3. Invoke the native module methods. 
+1. Author your native module, which is the class that calls your native code.
+   1. Add custom attributes to the class. These attributes allow you to define methods, properties, constants, and events that can be referenced from JavaScript.
+1. Register your native module. Note that native modules defined within your app are automatically registered.
+   1. Add the package to your React Native application.
+1. Use your native module from your JavaScript code.
 
-As an alternative to using classes with attributes, we can add native module definitions directly in the React package.
+React Native for Windows supports authoring native modules in both C# and C++. Examples of both are provided below. 
 
-### Sample Native Module using Microsoft.ReactNative.Managed (recommended)
+> NOTE: If you are unable to use the reflection-based annotation approach, you can define native modules directly using the ABI. This is outlined in the [Writing Native Modules without using Attributes](./NativeModulesAdvanced.md) document. 
 
-#### 1. Authoring your Native Module
+## Sample Native Module (C#)
+
+### Attributes
+| Attribute | Use |
+|--|--|
+| `ReactModule` | Specifies the class is a native module. |
+| `ReactMethod` | Specifies an asynchronous method. |
+| `ReactSyncMethod` | Specifies a synchronous method. |
+| `ReactConstant` | Specifies a field or property that represents a constant. |
+| `ReactConstantProvider` | Specifies a method that provides a set of constants. |
+| `ReactEvent` | Specifies a field or property that represents an event. |
+
+
+### 1. Authoring your Native Module
 
 Here is a sample native module written in C# called `FancyMath`. It is a simple class that defines two numerical constants and a method 'add'.
 
@@ -59,25 +64,28 @@ namespace NativeModuleSample
 }
 ```
 
-First off, you see that we're making use of the `Microsoft.ReactNative.Managed` shared library, which provides the easiest (and recommended) experience for authoring native modules. Rather than providing native module meta information directly, we use reflection to discover it, and then use LINQ Expressions to build bindings at runtime.
+First off, you see that we're making use of the `Microsoft.ReactNative.Managed` shared library, which provides the easiest (and recommended) experience for authoring native modules. `Microsoft.ReactNative.Managed` provides the mechanism that discovers the native module annotations to build bindings at runtime.
 
-The `ReactModule` attribute says that the class is a ReactNative native module. It has an optional parameter for the name visible to JavaScript and the name of the event emitter. By default both these names are the same as the class name. They can be provided explicitly as the following: `[ReactModule("math", EventEmitterName = "mathEmitter")]`.
+The `ReactModule` attribute says that the class is a ReactNative native module. It has an optional parameter for the name visible to JavaScript and the name of the event emitter. By default both these names are the same as the class name. You can overwrite the name that JavaScript references or overwrite the event emitter name like this: `[ReactModule("math", EventEmitterName = "mathEmitter")]`.
 
-Then we define constants, and it's as easy as creating a public property or field and giving it a `[ReactConstant]` attribute. Here FancyMath has defined two constants: `E` and `Pi`. By default, the name exposed to JS will be the same name as the field (`E` for `E`), but you can override this by specifying an argument in the `[ReactConstant]` attribute (hence `Pi` instead of `PI`).
+The `[ReactConstant]` attribute is how you can define constants. Here FancyMath has defined two constants: `E` and `Pi`. By default, the name exposed to JS will be the same name as the field (`E` for `E`), but you can override the name like this: `[ReactConstant("Pi")]`.
 
-It's just as easy to add custom methods, by attributing a public method with `[ReactMethod]`. In FancyMath we have one method, `add`, which takes two doubles and returns their sum. Again, we've specified the optional `Name` argument in the `[ReactMethod]` attribute so in JS we call `add` instead of `Add`.
+The `[ReactMethod]` attribute is how you define methods. In FancyMath we have one method, `add`, which takes two doubles and returns their sum. As before, you can optionally customize the name like this: `[ReactMethod("add")]`.
 
-#### 2. Registering your Native Module
 
-Now, we want to register our new `FancyMath` module with React Native so we can use it from JavaScript code. To do this, first we're going to create a `FancyMathPackageProvider` which implements [Microsoft.ReactNative.IReactPackageProvider](../Microsoft.ReactNative/IReactPackageProvider.idl).
+### 2. Registering your Native Module
 
-*FancyMathPackageProvider.cs*
+> IMPORTANT NOTE: When you create a new project via the CLI, the generated `ReactNativeHost` class will automatically register all native modules defined within the app. **You will not need to manually register native modules that are defined within your app's scope, as they will be registered automatically.**
+
+Now, we want to register our new `FancyMath` module with React Native so we can use it from JavaScript code. To do this, first we're going to create a `ReactPackageProvider` which implements [Microsoft.ReactNative.IReactPackageProvider](../Microsoft.ReactNative/IReactPackageProvider.idl).
+
+*ReactPackageProvider.cs*
 ```csharp
 using Microsoft.ReactNative.Managed;
 
 namespace NativeModuleSample
 {
-  public sealed class FancyMathPackageProvider : IReactPackageProvider
+  public sealed class ReactPackageProvider : IReactPackageProvider
   {
     public void CreatePackage(IReactPackageBuilder packageBuilder)
     {
@@ -89,7 +97,7 @@ namespace NativeModuleSample
 
 Here we've implemented the `CreatePackage` method, which receives `packageBuilder` to build contents of the package. Since we use reflection to discover and bind native module, we call `AddAttributedModules` extension method to register all native modules in our assembly that have the `ReactModule` attribute.
 
-Now that we have the `FancyMathPackageProvider`, it's time to register it within our React Native host application's native code. To do that, we're going to look for the class which inherits from `Microsoft.ReactNative.ReactNativeHost`, the default of which (if you created your app using the RNW CLI) is called `MainReactNativeHost`.
+Now that we have the `ReactPackageProvider`, it's time to register it within our React Native host application's native code. To do that, we're going to look for the class which inherits from `Microsoft.ReactNative.ReactNativeHost`, the default of which (if you created your app using the React Native for Windows vNext CLI) is called `MainReactNativeHost`.
 
 *MainReactNativeHost.cs*
 ```csharp
@@ -114,7 +122,7 @@ namespace NativeModuleSample
 }
 ```
 
-#### 3. Using your Native Module in JS
+### 3. Using your Native Module in JS
 
 Now we have a Native Module which is registered with React Native Windows. How do we access it in JS? Here's a simple RN app:
 
@@ -156,159 +164,27 @@ class NativeModuleSample extends Component {
 AppRegistry.registerComponent('NativeModuleSample', () => NativeModuleSample);
 ```
 
-As you can see, to access your native modules, you need to import `NativeModules` from `react-native`. All of the native modules registered with your host application (including both the built-in ones that come with RNW in addition to the ones you've added) are available as members of `NativeModules`.
+To access your native modules, you need to import `NativeModules` from `react-native`. All of the native modules registered with your host application (including both the built-in ones that come with React Native for Windows vNext in addition to the ones you've added) are available as members of `NativeModules`.
 
 To access our `FancyMath` constants, we can simply call `NativeModules.FancyMath.E` and `NativeModules.FancyMath.Pi`.
 
 Calls to methods are a little different due to the asynchronous nature of the JS engine. If the native method returns nothing, we can simply call the method. However, in this case `FancyMath.add()` returns a value, so in addition to the two necessary parameters we also include a callback function which will be called with the result of `FancyMath.add()`. In the example above, we can see that the callback raises an Alert dialog with the result value.
 
-### Sample Native Module using just Microsoft.ReactNative (not recommended)
+## Sample Native Module (C++)
 
-Now for reference, it is possible to write directly against `INativeModule` however it is not recommended unless you know what you're doing.
+> NOTE: C++ does not have custom attributes and reflection as C#. Instead we use macros to simulate use of custom attributes and C++ templates to implement the binding. The binding is done during compilation time and there is virtually no overhead at runtime.
 
-#### 1. Authoring your Native Module
+### Attributes
+| Attribute | Use |
+|--|--|
+| `REACT_MODULE` | Specifies the class is a native module. |
+| `REACT_METHOD` | Specifies an asynchronous method. |
+| `REACT_SYNCMETHOD` | Specifies a synchronous method. |
+| `REACT_CONSTANT` | Specifies a field or property that represents a constant. |
+| `REACT_CONSTANTPROVIDER` | Specifies a method that provides a set of constants. |
+| `REACT_EVENT` | Specifies a field or property that represents an event. |
 
-Here is the same `FancyMath` native module we created above, but we do not use custom attributes and going to implement registration of its members ourselves without using reflection.
-
-*FancyMath.cs*
-```csharp
-using System;
-using Microsoft.ReactNative.Managed;
-
-namespace NativeModuleSample
-{
-  class FancyMath
-  {
-    public double E = Math.E;
-
-    public double PI = Math.PI;
-
-    public double Add(double a, double b)
-    {
-        return a + b;
-    }
-  }
-}
-```
-
-#### 2. Registering your Native Module
-
-Here's our `FancyMathPackageProvider` where we do not use Reflection to register native module members.
-
-*FancyMathPackageProvider.cs*
-```csharp
-namespace NativeModuleSample
-{
-  public sealed class FancyMathPackageProvider : IReactPackageProvider
-  {
-    public void CreatePackage(IReactPackageBuilder packageBuilder)
-    {
-      packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
-        var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
-        moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
-          writer.WritePropertyName("E");
-          writer.WriteDouble(module.E);
-          writer.WritePropertyName("Pi");
-          writer.WriteDouble(module.PI);
-        });
-        moduleBuilder.AddMethod("add", MethodReturnType.Callback,
-          (IJSValueReader inputReader,
-          IJSValueWriter outputWriter,
-          MethodResultCallback resolve,
-          MethodResultCallback reject) => {
-           inputReader.ReadNext();
-           inputReader.ReadNext();
-           inputReader.TryGetDouble(out double a);
-           inputReader.ReadNext();
-           inputReader.TryGetDouble(out double b);
-           double result = module.Add(a, b);
-           writer.WriteArrayBegin();
-           writer.WriteDouble(result);
-           writer.WriteArrayEnd();
-           resolve(writer);
-          });
-        return module;
-      });
-    }
-  }
-}
-```
-
-As you can see, it is possible to use the API directly, but the code looks a little bit more complicated. The most complexity is related to the value serialization and deserialization. We can choose using helper methods for that and then the code would look a little bit simpler:
-
-*FancyMathPackageProvider.cs*
-```csharp
-namespace NativeModuleSample
-{
-  public sealed class FancyMathPackageProvider : IReactPackageProvider
-  {
-    public void CreatePackage(IReactPackageBuilder packageBuilder)
-    {
-      packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
-        var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
-        moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
-          writer.WriteProperty("E", module.E);
-          writer.WriteProperty("Pi", module.PI);
-        });
-        moduleBuilder.AddMethod("add", MethodReturnType.Callback,
-          (IJSValueReader inputReader,
-          IJSValueWriter outputWriter,
-          MethodResultCallback resolve,
-          MethodResultCallback reject) => {
-           object[] args = inputReader.ReadArgs();
-           double result = module.Add((double)args[0], (double)args[1]);
-           writer.WriteArgs(result);
-           resolve(writer);
-          });
-        return module;
-      });
-    }
-  }
-}
-```
-
-It is possible to simplify the code even more by hiding the use of the value reader and writer interfaces:
-
-*FancyMathPackageProvider.cs*
-```csharp
-namespace NativeModuleSample
-{
-  public sealed class FancyMathPackageProvider : IReactPackageProvider
-  {
-    public void CreatePackage(IReactPackageBuilder packageBuilder)
-    {
-      packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
-        var module = new FancyMath();
-        moduleBuilder.SetName("FancyMath");
-        moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
-          ["E"] = module.E,
-          ["Pi"] = module.PI
-        });
-        moduleBuilder.AddMethod("add", MethodReturnType.Callback, (MethodCallContext callContext) => {
-          double result = module.Add((double)callContext.Args[0], (double)callContext.Args[1]);
-          callContext.resolve(result);
-        });
-        return module;
-      });
-    }
-  }
-}
-```
-
-This code looks much better, but we are getting the overhead of boxing values that involves memory allocation for each call. The code generation that we do using LINQ Expression avoids this extra overhead. Though, the initial use of reflection and code generation has some penalty too.
-From the maintenance point of view, the attributed code is much simple to support because we do not need to describe the same things in two different places.
-
-And as for the rest of the code, once we have the `IReactPackageProvider`, registering that package is the same as in the example above that uses custom attributes.
-
-#### 3. Using your Native Module in JS
-
-Consumption of your Native Module in JS is the same as in the example above.
-
-### C++ Sample Native Module
-
-#### 1. Authoring your Native Module
+### 1. Authoring your Native Module
 
 Here is a sample native module written in C++ called `FancyMath`. It is a simple class that defines two numerical constants and a method 'add'.
 
@@ -336,8 +212,6 @@ namespace NativeModuleSample
 }
 ```
 
-C++ does not have custom attributes and reflection as C#. Instead we use macros to simulate use of custom attributes and C++ templates to implement the binding. The binding is done during compilation time and there is virtually no overhead at runtime.
-
 The `REACT_MODULE` macro-attribute says that the class is a ReactNative native module. It receives the class name as a first parameter. All other macro-attributes also receive their target as a first parameter. The `REACT_MODULE` has an optional parameter for the name visible to JavaScript and the name of the event emitter. By default both these names are the same as the class name. They can be provided explicitly as the following: `REACT_MODULE(FancyMath, "math", "mathEmitter")`.
 
 Then we define constants, and it's as easy as creating a public field and giving it a `REACT_CONSTANT` macro-attribute. Here FancyMath has defined two constants: `E` and `Pi`. By default, the name exposed to JS will be the same name as the field (`E` for `E`), but you can override this by specifying an argument in the `REACT_CONSTANT` attribute (hence `Pi` instead of `PI`).
@@ -346,31 +220,33 @@ It's just as easy to add custom methods, by attributing a public method with `RE
 
 #### 2. Registering your Native Module
 
-Now, we want to register our new `FancyMath` module with React Native so we can use it from JavaScript code. To do this, first we're going to create a `FancyMathPackageProvider` which implements [Microsoft.ReactNative.IReactPackageProvider](../Microsoft.ReactNative/IReactPackageProvider.idl).
+> IMPORTANT NOTE: **NYI** When you create a new project via the CLI, the generated `ReactNativeHost` class will automatically register all native modules defined within the app. **You will not need to manually register native modules that are defined within your app's scope, as they will be registered automatically.**
+
+Now, we want to register our new `FancyMath` module with React Native so we can use it from JavaScript code. To do this, first we're going to create a `ReactPackageProvider` which implements [Microsoft.ReactNative.IReactPackageProvider](../Microsoft.ReactNative/IReactPackageProvider.idl).
 It starts with defining an .idl file:
 
-*FancyMathPackageProvider.idl*
+*ReactPackageProvider.idl*
 ```csharp
 namespace NativeModuleSample {
 
-runtimeclass FancyMathPackageProvider : Microsoft.ReactNative.IReactPackageProvider
+runtimeclass ReactPackageProvider : Microsoft.ReactNative.IReactPackageProvider
 {
-  FancyMathPackageProvider();
+  ReactPackageProvider();
 };
 ```
 
 After that we add the .h and.cpp files:
 
-*FancyMathPackageProvider.h*
+*ReactPackageProvider.h*
 ```cpp
 #pragma once
-#include "FancyMathPackageProvider.g.h"
+#include "ReactPackageProvider.g.h"
 
 namespace winrt::NativeModuleSample::implementation {
 
-struct FancyMathPackageProvider : FancyMathPackageProviderT<FancyMathPackageProvider>
+struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider>
 {
-  FancyMathPackageProvider() = default;
+  ReactPackageProvider() = default;
   void CreatePackage(Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder);
 };
 
@@ -378,20 +254,20 @@ struct FancyMathPackageProvider : FancyMathPackageProviderT<FancyMathPackageProv
 
 namespace winrt::NativeModuleSample::factory_implementation {
 
-struct FancyMathPackageProvider : FancyMathPackageProviderT<
-                                     FancyMathPackageProvider,
-                                     implementation::FancyMathPackageProvider>
+struct ReactPackageProvider : ReactPackageProviderT<
+                                     ReactPackageProvider,
+                                     implementation::ReactPackageProvider>
 {
 };
 
 } // namespace winrt::NativeModuleSample::factory_implementation
 ```
 
-*FancyMathPackageProvider.cpp*
+*ReactPackageProvider.cpp*
 ```cpp
 #include "pch.h"
-#include "FancyMathPackageProvider.h"
-#include "FancyMathPackageProvider.g.cpp"
+#include "ReactPackageProvider.h"
+#include "ReactPackageProvider.g.cpp"
 #include "FancyMath.h"
 
 using namespace winrt::Microsoft::ReactNative;
@@ -399,7 +275,7 @@ using namespace Microsoft::ReactNative;
 
 namespace winrt::NativeModuleSample::implementation {
 
-void FancyMathPackageProvider::CreatePackage(IReactPackageBuilder const& packageBuilder)
+void ReactPackageProvider::CreatePackage(IReactPackageBuilder const& packageBuilder)
 {
   AddAttributedModules(packageBuilder);
 }
@@ -410,7 +286,7 @@ void FancyMathPackageProvider::CreatePackage(IReactPackageBuilder const& package
 
 Here we've implemented the `CreatePackage` method, which receives `packageBuilder` to build contents of the package. Since we use macros and templates to discover and bind native module, we call `AddAttributedModules` function to register all native modules in our DLL that have the `REACT_MODULE` macro-attribute.
 
-Now that we have the `FancyMathPackageProvider`, it's time to register it within our React Native host application's native code. To do that, we're going to look for the class which inherits from `Microsoft.ReactNative.ReactNativeHost`, the default of which (if you created your app using the RNW CLI) is called `MainReactNativeHost`.
+Now that we have the `ReactPackageProvider`, it's time to register it within our React Native host application's native code. To do that, we're going to look for the class which inherits from `Microsoft.ReactNative.ReactNativeHost`, the default of which (if you created your app using the React Native for Windows vNext CLI) is called `MainReactNativeHost`.
 
 *MainReactNativeHost.h*
 ```cpp
@@ -423,14 +299,14 @@ namespace NativeModuleSample
     IVectorView<IReactPackageProvider> PackageProviders()
     {
       auto packages = single_threaded_vector<IReactPackageProvider>({
-        make<FancyMathPackageProvider>()
+        make<ReactPackageProvider>()
       });
     return packages.GetView();
   };
 }
 ```
 
-#### 3. Using your Native Module in JS
+### 3. Using your Native Module in JS
 
 Now we have a Native Module which is registered with React Native Windows. How do we access it in JS? Here's a simple RN app:
 
@@ -472,238 +348,8 @@ class NativeModuleSample extends Component {
 AppRegistry.registerComponent('NativeModuleSample', () => NativeModuleSample);
 ```
 
-As you can see, to access your native modules, you need to import `NativeModules` from `react-native`. All of the native modules registered with your host application (including both the built-in ones that come with RNW in addition to the ones you've added) are available as members of `NativeModules`.
+As you can see, to access your native modules, you need to import `NativeModules` from `react-native`. All of the native modules registered with your host application (including both the built-in ones that come with React Native for Windows vNext in addition to the ones you've added) are available as members of `NativeModules`.
 
 To access our `FancyMath` constants, we can simply call `NativeModules.FancyMath.E` and `NativeModules.FancyMath.Pi`.
 
 Calls to methods are a little different due to the asynchronous nature of the JS engine. If the native method returns nothing, we can simply call the method. However, in this case `FancyMath.add()` returns a value, so in addition to the two necessary parameters we also include a callback function which will be called with the result of `FancyMath.add()`. In the example above, we can see that the callback raises an Alert dialog with the result value.
-
-## View Managers
-
-View Managers are a form of specialized native modules which expose native UI controls as React Native Components. In RNW, this means you have access to the world of rich XAML controls. Similarly to authoring native modules, at a high level you must:
-
-1. Author a Windows Runtime Class which implements [Microsoft.ReactNative.IViewManager](../Microsoft.ReactNative/IViewManager.idl) and understands how to interact with the native UI.
-2. Register your new `IViewManager` within the native code of your React Native host application.
-3. Reference the new Component within your React Native JSX code.
-
-*Open Questions:*
-
-* Do we need to expose (custom) shadow nodes?
-* Do we need to create JS wrappers so the Component can be referenced (at all, or more naturally) in JSX?
-* Do we ever want to support non-FrameworkElement views?
-* How do XAML controls fire events into RN?
-
-### Sample View Manager using Microsoft.ReactNative.Managed (recommended)
-
-#### 1. Authoring your View Manager 
-
-Here is a sample view manager written in C# called `CircleViewManager`.
-
-*FancyMath.cs*
-```csharp
-using System;
-
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Shapes;
-
-using Microsoft.ReactNative;
-using Microsoft.ReactNative.Managed;
-
-namespace ViewManagerSample
-{
-    public sealed class CircleViewManager : IManagedViewManager
-    {
-        public string Name => "Circle";
-
-        public FrameworkElement CreateView() => new Ellipse();
-
-        [ViewManagerPropertySetter(Name = "radius")]
-        public static void SetRadius(Ellipse circle, double? value)
-        {
-            if (value.HasValue)
-            {
-                circle.Width = value.Value * 2.0;
-                circle.Height = value.Value * 2.0;
-            }
-            else
-            {
-                circle.ClearValue(FrameworkElement.WidthProperty);
-                circle.ClearValue(FrameworkElement.HeightProperty);
-            }
-        }
-    }
-}
-```
-
-As with native modules, we're making use of the `Microsoft.ReactNative.Managed` library, which provides the easiest (and recommended) experience for authoring view managers. Rather than implement the `IViewManager` interface directly with our class, we're implementing [IManagedViewManager](../Microsoft.ReactNative.Managed/ManagedViewManager.cs), which will be passsed as a parameter to the `ManagedViewManager` helper class.
-
-To fulfill `IManagedViewManager`, we only have to implement two things: the `Name` property getter and the `CreateView()` method.
-
-The `Name` string specifies the name of the React Native Component that you will use in JSX, and that this view manager know how to work with. In this case, we're creating a new Component called "Circle".
-
-The `CreateView()` method returns the XAML control (anything derived from `FrameworkElement`) that will be added to the native UI tree when React Native asks for a "Circle". In this case, we return a new `Windows.UI.Xaml.Shapes.Ellipse`.
-
-Now we need to define some properties that are unique to our Circle component. We don't need to specify every possible property (most properties common to all `FrameworkElement`s will already be taken care of) so we just need to focus on the ones that are unique to Circle.
-
-In this case, we want a `radius` property, so we need to create a public method attributed with a `[ViewManagerPropertySetter]` attribute. We specify `Name` argument set to `radius` which let's React Native know, when an app wants to set the `radius` property on a Circle component, this is the mehtod to call.
-
-All property setter methods should take two parameters - an instance of the native XAML control, and the value of the property being set. This value will come from React Native. As you can see, our `SetRadius()` method follows a simple pattern: it takes nullable double - if there is a value, we set the width and height of the Ellipse to 2x that value. If that value is null, we clear the width and height of the Ellipse.
-
-#### 2. Registering your View Manager
-
-As with native modules, we want to register our new `CircleViewManager` module with React Native so we can actually use it. To do this, first we're going to create a `CircleViewManagerPackage` which implements `Microsoft.ReactNative.IReactPackage`.
-
-*CircleViewManagerPackage.cs*
-```csharp
-using System;
-using System.Collections.Generic;
-
-using Microsoft.ReactNative;
-using Microsoft.ReactNative.Managed;
-
-namespace ViewManagerSample
-{
-    public sealed class CircleViewManagerPackage : IReactPackage
-    {
-        /*
-            Other Code
-        */
-
-        public IReadOnlyList<IViewManager> CreateViewManagers(ReactContext reactContext)
-        {
-            return new List<IViewManager>() {
-                new ManagedViewManager(new CircleViewManager()),
-            };
-        }
-    }
-}
-```
-
-Here we've implemented the `CreateViewManagers` method, which returns a read-only collection of `IViewManager` instances. We're only going have oneview manager in this package, and as previously mentioned, we're going to use the `ManagedViewManager` adapter class provided by `Microsoft.ReactNative.Managed`.
-
-`ManagedViewManager` implements `IViewManager` by reflecting over an `IManagedViewManager` which uses the `[ViewManagerPropertySetter]` attributes. So in our package, we simply pass an instance of `CircleViewManager` into `ManagedViewManager`.
-
-Now that we have a `CircleViewManagerPackage`, it's time to actually register it within our React Native host application's native code. To do that, we're going to look for the class which inherits from `Microsoft.ReactNative.ReactNativeHost`, the default of which (if you created your app using the RNW CLI) is called `MainReactNativeHost`.
-
-*MainReactNativeHost.cs*
-```csharp
-using System.Collections.Generic;
-
-using Microsoft.ReactNative;
-
-namespace ViewManagerSample
-{
-    sealed class MainReactNativeHost : ReactNativeHost
-    {
-        /*
-            Other Code
-        */
-
-        protected override IReadOnlyList<IReactPackage> Packages
-        {
-            get
-            {
-                return new IReactPackage[] { new CircleViewManagerPackage() };
-            }
-        }
-    }
-}
-```
-
-#### 3. Using your View Manager in JSX
-
-*TODO:* Example should be able to use `<Circle>` component syntax, but need to figure out how to import the component type.
-
-### Sample View Manager using just Microsoft.ReactNative (not recommended)
-
-Now for reference, it is possible and supported to write directly against `IViewManager` however it is not recommended unless you know what you're doing.
-
-#### 1. Authoring your View Manager
-
-Here is the same `CircleViewManager` we created above, but here we write it directly against `IViewManager` without the benefit of `Microsoft.ReactNative.Managed`.
-
-*CircleViewManager.cs*
-```csharp
-using System;
-using System.Collections.Generic;
-
-using Microsoft.ReactNative;
-
-namespace ViewManagerSample
-{
-    public sealed class CircleViewManagerABI : IViewManager
-    {
-        public string Name => "CircleABI";
-
-        public FrameworkElement CreateView() => new Ellipse();
-
-        public IReadOnlyDictionary<string, string> NativeProps => _nativeProps ?? (_nativeProps = new Dictionary<string, string>(1)
-        {
-            { "radius", "number" },
-        });
-        private IReadOnlyDictionary<string, string> _nativeProps;
-
-        public void UpdateProperties(FrameworkElement view, IReadOnlyDictionary<string, object> propertyMap)
-        {
-            if (view is Ellipse circle)
-            {
-                foreach (var property in propertyMap)
-                {
-                    switch (property.Key)
-                    {
-                        case "radius":
-                            if (property.Value is double propertyValue)
-                            {
-                                circle.Width = propertyValue * 2.0;
-                                circle.Height = propertyValue * 2.0;
-                            }
-                            else if (null == property.Value)
-                            {
-                                circle.ClearValue(FrameworkElement.WidthProperty);
-                                circle.ClearValue(FrameworkElement.HeightProperty);
-                            }
-                            break;
-                    }
-                }
-            }
-        }
-    }
-}
-```
-
-As you can see, it's a little more complicated, and more "glue" code that you're responsible for.
-
-#### 2. Registering your View Manager
-
-Here's our `CircleViewManager` again, and again this time we're not depending on the `Microsoft.ReactNative.Managed` library.
-
-*FancyMathPackage.cs*
-```csharp
-using System;
-using System.Collections.Generic;
-
-using Microsoft.ReactNative;
-
-namespace ViewManagerSample
-{
-    public sealed class CircleViewManagerPackage : IReactPackage
-    {
-        /*
-            Other Code
-        */
-
-        public IReadOnlyList<IViewManager> CreateViewManagers(ReactContext reactContext)
-        {
-            return new List<IViewManager>() {
-                new CircleViewManager(),
-            };
-        }
-    }
-}
-```
-
-And as for the rest, once we have the `IReactPackage`, registering that package is the same as in the example above.
-
-#### 3. Using your View Manager in JSX
-
-Consumption of your new View in JS is the same as in the example above.

--- a/vnext/docs/NativeModulesAdvanced.md
+++ b/vnext/docs/NativeModulesAdvanced.md
@@ -1,0 +1,188 @@
+# Writing Native Modules without using Attributes 
+
+The [Native Modules](./NativeModules.md) page describes how you can author Native Modules in both C# and C++ using an attribute-based approach. The attribute-based approach makes it easy for you to author your native modules because it uses reflection to help React Native understand your native module. 
+
+In rare cases, you may need to write a native module against the ABI directly without using reflection. The high-level steps remain the same:
+1. Author your native module
+2. Register your native module
+3. Use your native module
+
+However, your app will be responsible for handling the code that the attributes would have otherwise provided. This guide will walk through those steps. 
+
+## 1. Authoring your Native Module
+
+Here is the same `FancyMath` native module, but we do not use custom attributes and going to implement registration of its members ourselves without using reflection.
+
+*FancyMath.cs*
+```csharp
+using System;
+using Microsoft.ReactNative.Managed;
+
+namespace NativeModuleSample
+{
+  class FancyMath
+  {
+    public double E = Math.E;
+
+    public double PI = Math.PI;
+
+    public double Add(double a, double b)
+    {
+        return a + b;
+    }
+  }
+}
+```
+
+## 2. Registering your Native Module
+
+Here's our `FancyMathPackageProvider` where we do not use Reflection to register native module members.
+
+*FancyMathPackageProvider.cs*
+```csharp
+namespace NativeModuleSample
+{
+  public sealed class FancyMathPackageProvider : IReactPackageProvider
+  {
+    public void CreatePackage(IReactPackageBuilder packageBuilder)
+    {
+      packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
+        var module = new FancyMath();
+        moduleBuilder.SetName("FancyMath");
+        moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
+          writer.WritePropertyName("E");
+          writer.WriteDouble(module.E);
+          writer.WritePropertyName("Pi");
+          writer.WriteDouble(module.PI);
+        });
+        moduleBuilder.AddMethod("add", MethodReturnType.Callback,
+          (IJSValueReader inputReader,
+          IJSValueWriter outputWriter,
+          MethodResultCallback resolve,
+          MethodResultCallback reject) => {
+           inputReader.ReadNext();
+           inputReader.ReadNext();
+           inputReader.TryGetDouble(out double a);
+           inputReader.ReadNext();
+           inputReader.TryGetDouble(out double b);
+           double result = module.Add(a, b);
+           writer.WriteArrayBegin();
+           writer.WriteDouble(result);
+           writer.WriteArrayEnd();
+           resolve(writer);
+          });
+        return module;
+      });
+    }
+  }
+}
+```
+
+As you can see, it is possible to use the API directly, but the code looks a little bit more complicated. The most complexity is related to the value serialization and deserialization. We can choose using helper methods for that and then the code would look a little bit simpler:
+
+*FancyMathPackageProvider.cs*
+```csharp
+namespace NativeModuleSample
+{
+  public sealed class FancyMathPackageProvider : IReactPackageProvider
+  {
+    public void CreatePackage(IReactPackageBuilder packageBuilder)
+    {
+      packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
+        var module = new FancyMath();
+        moduleBuilder.SetName("FancyMath");
+        moduleBuilder.AddConstantProvider((IJSValueWriter writer) => {
+          writer.WriteProperty("E", module.E);
+          writer.WriteProperty("Pi", module.PI);
+        });
+        moduleBuilder.AddMethod("add", MethodReturnType.Callback,
+          (IJSValueReader inputReader,
+          IJSValueWriter outputWriter,
+          MethodResultCallback resolve,
+          MethodResultCallback reject) => {
+           object[] args = inputReader.ReadArgs();
+           double result = module.Add((double)args[0], (double)args[1]);
+           writer.WriteArgs(result);
+           resolve(writer);
+          });
+        return module;
+      });
+    }
+  }
+}
+```
+
+It is possible to simplify the code even more by hiding the use of the value reader and writer interfaces:
+
+*FancyMathPackageProvider.cs*
+```csharp
+namespace NativeModuleSample
+{
+  public sealed class FancyMathPackageProvider : IReactPackageProvider
+  {
+    public void CreatePackage(IReactPackageBuilder packageBuilder)
+    {
+      packageBuilder.AddModule("FancyMath", (IReactModuleBuilder moduleBuilder) => {
+        var module = new FancyMath();
+        moduleBuilder.SetName("FancyMath");
+        moduleBuilder.AddConstantProvider(() => new Dictionary<string, object> {
+          ["E"] = module.E,
+          ["Pi"] = module.PI
+        });
+        moduleBuilder.AddMethod("add", MethodReturnType.Callback, (MethodCallContext callContext) => {
+          double result = module.Add((double)callContext.Args[0], (double)callContext.Args[1]);
+          callContext.resolve(result);
+        });
+        return module;
+      });
+    }
+  }
+}
+```
+
+This code looks much better, but we are getting the overhead of boxing values that involves memory allocation for each call. The code generation that we do using LINQ Expression avoids this extra overhead. Though, the initial use of reflection and code generation has some penalty too.
+From the maintenance point of view, the attributed code is much simple to support because we do not need to describe the same things in two different places.
+
+And as for the rest of the code, once we have the `IReactPackageProvider`, registering that package is the same as in the example above that uses custom attributes.
+
+## 3. Using your Native Module in JS
+
+Using your native module in JS is the exact same as if the native module was defined using attributes. 
+
+*NativeModuleSample.js*
+```js
+import React, { Component } from 'react';
+import {
+  AppRegistry,
+  Alert,
+  NativeModules,
+  Text,
+  View,
+} from 'react-native';
+
+class NativeModuleSample extends Component {
+  _onPressHandler() {
+    NativeModules.FancyMath.add(
+      /* arg a */ NativeModules.FancyMath.Pi,
+      /* arg b */ NativeModules.FancyMath.E,
+      /* callback */ function (result) {
+        Alert.alert(
+          'FancyMath',
+          `FancyMath says ${NativeModules.FancyMath.Pi} + ${NativeModules.FancyMath.E} = ${result}`,
+          [{ text: 'OK' }],
+          {cancelable: false});
+      });
+  }
+
+  render() {
+    return (
+      <View>
+         <Text>FancyMath says PI = {NativeModules.FancyMath.Pi}</Text>
+         <Text>FancyMath says E = {NativeModules.FancyMath.E}</Text>
+         <Button onPress={this._onPressHandler} title="Click me!"/>
+      </View>);
+  }
+}
+
+AppRegistry.registerComponent('NativeModuleSample', () => NativeModuleSample);
+```

--- a/vnext/docs/ViewManagers.md
+++ b/vnext/docs/ViewManagers.md
@@ -1,0 +1,235 @@
+# Native UI Components
+
+>**This documentation and the underlying platform code is a work in progress. You can see the current state of working code here: [packages/microsoft-reactnative-sampleapps](../../packages/microsoft-reactnative-sampleapps)**
+
+There are tons of native UI widgets out there ready to be used in the latest apps - some of them are part of the platform, others are available as third-party libraries, and still more might be in use in your very own portfolio. React Native has several of the most critical platform components already wrapped, like ScrollView and TextInput, but not all of them, and certainly not ones you might have written yourself for a previous app. Fortunately, we can wrap up these existing components for seamless integration with your React Native application.
+
+Like the [native module guide](./NativeModules.md), this too is a more advanced guide that assumes you are somewhat familiar with UWP programming. This guide will show you how to build a native UI component, walking you through the implementation of a subset of the existing ImageView component available in the core React Native library.
+
+Similarly to authoring native modules, at a high level you must:
+
+1. Author a Windows Runtime Class which implements [Microsoft.ReactNative.IViewManager](../Microsoft.ReactNative/IViewManager.idl) and understands how to interact with the native UI.
+2. Register your new `IViewManager` within the native code of your React Native host application.
+3. Reference the new Component within your React Native JSX code.
+
+*Open Questions:*
+
+* Do we need to expose (custom) shadow nodes?
+* Do we need to create JS wrappers so the Component can be referenced (at all, or more naturally) in JSX?
+* Do we ever want to support non-FrameworkElement views?
+* How do XAML controls fire events into RN?
+
+### Sample View Manager using Microsoft.ReactNative.Managed (recommended)
+
+#### 1. Authoring your View Manager 
+
+Here is a sample view manager written in C# called `CircleViewManager`.
+
+*FancyMath.cs*
+```csharp
+using System;
+
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Shapes;
+
+using Microsoft.ReactNative;
+using Microsoft.ReactNative.Managed;
+
+namespace ViewManagerSample
+{
+    public sealed class CircleViewManager : IManagedViewManager
+    {
+        public string Name => "Circle";
+
+        public FrameworkElement CreateView() => new Ellipse();
+
+        [ViewManagerPropertySetter(Name = "radius")]
+        public static void SetRadius(Ellipse circle, double? value)
+        {
+            if (value.HasValue)
+            {
+                circle.Width = value.Value * 2.0;
+                circle.Height = value.Value * 2.0;
+            }
+            else
+            {
+                circle.ClearValue(FrameworkElement.WidthProperty);
+                circle.ClearValue(FrameworkElement.HeightProperty);
+            }
+        }
+    }
+}
+```
+
+As with native modules, we're making use of the `Microsoft.ReactNative.Managed` library, which provides the easiest (and recommended) experience for authoring view managers. Rather than implement the `IViewManager` interface directly with our class, we're implementing [IManagedViewManager](../Microsoft.ReactNative.Managed/ManagedViewManager.cs), which will be passsed as a parameter to the `ManagedViewManager` helper class.
+
+To fulfill `IManagedViewManager`, we only have to implement two things: the `Name` property getter and the `CreateView()` method.
+
+The `Name` string specifies the name of the React Native Component that you will use in JSX, and that this view manager know how to work with. In this case, we're creating a new Component called "Circle".
+
+The `CreateView()` method returns the XAML control (anything derived from `FrameworkElement`) that will be added to the native UI tree when React Native asks for a "Circle". In this case, we return a new `Windows.UI.Xaml.Shapes.Ellipse`.
+
+Now we need to define some properties that are unique to our Circle component. We don't need to specify every possible property (most properties common to all `FrameworkElement`s will already be taken care of) so we just need to focus on the ones that are unique to Circle.
+
+In this case, we want a `radius` property, so we need to create a public method attributed with a `[ViewManagerPropertySetter]` attribute. We specify `Name` argument set to `radius` which let's React Native know, when an app wants to set the `radius` property on a Circle component, this is the mehtod to call.
+
+All property setter methods should take two parameters - an instance of the native XAML control, and the value of the property being set. This value will come from React Native. As you can see, our `SetRadius()` method follows a simple pattern: it takes nullable double - if there is a value, we set the width and height of the Ellipse to 2x that value. If that value is null, we clear the width and height of the Ellipse.
+
+#### 2. Registering your View Manager
+
+As with native modules, we want to register our new `CircleViewManager` module with React Native so we can actually use it. To do this, first we're going to create a `CircleViewManagerPackage` which implements `Microsoft.ReactNative.IReactPackage`.
+
+*CircleViewManagerPackage.cs*
+```csharp
+using System;
+using System.Collections.Generic;
+
+using Microsoft.ReactNative;
+using Microsoft.ReactNative.Managed;
+
+namespace ViewManagerSample
+{
+    public sealed class CircleViewManagerPackage : IReactPackage
+    {
+        /*
+            Other Code
+        */
+
+        public IReadOnlyList<IViewManager> CreateViewManagers(ReactContext reactContext)
+        {
+            return new List<IViewManager>() {
+                new ManagedViewManager(new CircleViewManager()),
+            };
+        }
+    }
+}
+```
+
+Here we've implemented the `CreateViewManagers` method, which returns a read-only collection of `IViewManager` instances. We're only going have oneview manager in this package, and as previously mentioned, we're going to use the `ManagedViewManager` adapter class provided by `Microsoft.ReactNative.Managed`.
+
+`ManagedViewManager` implements `IViewManager` by reflecting over an `IManagedViewManager` which uses the `[ViewManagerPropertySetter]` attributes. So in our package, we simply pass an instance of `CircleViewManager` into `ManagedViewManager`.
+
+Now that we have a `CircleViewManagerPackage`, it's time to actually register it within our React Native host application's native code. To do that, we're going to look for the class which inherits from `Microsoft.ReactNative.ReactNativeHost`, the default of which (if you created your app using the RNW CLI) is called `MainReactNativeHost`.
+
+*MainReactNativeHost.cs*
+```csharp
+using System.Collections.Generic;
+
+using Microsoft.ReactNative;
+
+namespace ViewManagerSample
+{
+    sealed class MainReactNativeHost : ReactNativeHost
+    {
+        /*
+            Other Code
+        */
+
+        protected override IReadOnlyList<IReactPackage> Packages
+        {
+            get
+            {
+                return new IReactPackage[] { new CircleViewManagerPackage() };
+            }
+        }
+    }
+}
+```
+
+#### 3. Using your View Manager in JSX
+
+*TODO:* Example should be able to use `<Circle>` component syntax, but need to figure out how to import the component type.
+
+### Sample View Manager using just Microsoft.ReactNative (not recommended)
+
+Now for reference, it is possible and supported to write directly against `IViewManager` however it is not recommended unless you know what you're doing.
+
+#### 1. Authoring your View Manager
+
+Here is the same `CircleViewManager` we created above, but here we write it directly against `IViewManager` without the benefit of `Microsoft.ReactNative.Managed`.
+
+*CircleViewManager.cs*
+```csharp
+using System;
+using System.Collections.Generic;
+
+using Microsoft.ReactNative;
+
+namespace ViewManagerSample
+{
+    public sealed class CircleViewManagerABI : IViewManager
+    {
+        public string Name => "CircleABI";
+
+        public FrameworkElement CreateView() => new Ellipse();
+
+        public IReadOnlyDictionary<string, string> NativeProps => _nativeProps ?? (_nativeProps = new Dictionary<string, string>(1)
+        {
+            { "radius", "number" },
+        });
+        private IReadOnlyDictionary<string, string> _nativeProps;
+
+        public void UpdateProperties(FrameworkElement view, IReadOnlyDictionary<string, object> propertyMap)
+        {
+            if (view is Ellipse circle)
+            {
+                foreach (var property in propertyMap)
+                {
+                    switch (property.Key)
+                    {
+                        case "radius":
+                            if (property.Value is double propertyValue)
+                            {
+                                circle.Width = propertyValue * 2.0;
+                                circle.Height = propertyValue * 2.0;
+                            }
+                            else if (null == property.Value)
+                            {
+                                circle.ClearValue(FrameworkElement.WidthProperty);
+                                circle.ClearValue(FrameworkElement.HeightProperty);
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+As you can see, it's a little more complicated, and more "glue" code that you're responsible for.
+
+#### 2. Registering your View Manager
+
+Here's our `CircleViewManager` again, and again this time we're not depending on the `Microsoft.ReactNative.Managed` library.
+
+*FancyMathPackage.cs*
+```csharp
+using System;
+using System.Collections.Generic;
+
+using Microsoft.ReactNative;
+
+namespace ViewManagerSample
+{
+    public sealed class CircleViewManagerPackage : IReactPackage
+    {
+        /*
+            Other Code
+        */
+
+        public IReadOnlyList<IViewManager> CreateViewManagers(ReactContext reactContext)
+        {
+            return new List<IViewManager>() {
+                new CircleViewManager(),
+            };
+        }
+    }
+}
+```
+
+And as for the rest, once we have the `IReactPackage`, registering that package is the same as in the example above.
+
+#### 3. Using your View Manager in JSX
+
+Consumption of your new View in JS is the same as in the example above.


### PR DESCRIPTION
This change modifies and expands upon the documentation for Native Modules and View Managers.

The content is broken up into three pages:
1) View Managers
2) Native Modules
3) Native Modules (advanced topics)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3472)