### PR TITLE
Implement AccessibilityActions

### DIFF
--- a/change/react-native-windows-2019-10-21-16-17-09-action.json
+++ b/change/react-native-windows-2019-10-21-16-17-09-action.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Implement accessibilityAction",
+  "packageName": "react-native-windows",
+  "email": "licanhua@live.com",
+  "commit": "e931062bbaef57538e8e7ea06c6f1fb929f7b024",
+  "date": "2019-10-21T23:17:08.915Z",
+  "file": "F:\\repo\\react-native-windows\\change\\react-native-windows-2019-10-21-16-17-09-action.json"
+}

--- a/packages/E2ETest/app/AccessibilityTestPage.tsx
+++ b/packages/E2ETest/app/AccessibilityTestPage.tsx
@@ -1,15 +1,59 @@
-import { View, Text } from 'react-native'
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { View, Text, ViewProps } from 'react-native'
 import React, { useState } from 'react';
+
+// MyView is a workaround. Currently in typescript, accessibilityAction doesn't allow name to be any string.
+const MyView = (props: any) => (<View {...props as ViewProps} />);
 
 export function AccessibilityTestPage() {
     const [pressedCountNested, setPressedCountNested] = useState(0);
     const [pressedCount, setPressedCount] = useState(0);
+    const [accessibilityAction, setAccessibilityAction] = useState('');
+
     return (
         <View>
-            <Text accessible={true} accessibilityLiveRegion="polite" style={{fontWeight: "bold"}}>
-                I'm bold
-                <Text style={{color: 'red'}} onPress={() => setPressedCountNested(pressedCountNested + 1)} accessible={true} accessibilityLiveRegion="polite">Pressed {pressedCountNested} times</Text>
-            </Text>
-            <Text style={{color: 'green'}} onPress={() => setPressedCount(pressedCount + 1)} accessible={true} accessibilityLiveRegion="polite">Pressed {pressedCount} times</Text>
+            <View>
+                <Text accessible={true} accessibilityLiveRegion="polite" style={{ fontWeight: "bold" }}>
+                    I'm bold
+                <Text style={{ color: 'red' }} onPress={() => setPressedCountNested(pressedCountNested + 1)} accessible={true} accessibilityLiveRegion="polite">Pressed {pressedCountNested} times</Text>
+                </Text>
+                <Text style={{ color: 'green' }} onPress={() => setPressedCount(pressedCount + 1)} accessible={true} accessibilityLiveRegion="polite">Pressed {pressedCount} times</Text>
+            </View>
+            <View>
+                <MyView
+                    accessible={true}
+                    accessibilityLabel='AccessibilityAction'
+                    accessibilityRole='CheckBox'
+                    accessibilityStates={['checked', 'expanded']}
+                    accessibilityActions={[
+                        { name: 'toggle', label: 'toggle' },
+                        { name: 'invoke', label: 'invoke' },
+                        { name: 'expand', label: 'expand' },
+                        { name: 'collapse', label: 'collapseIt' },
+                    ]}
+                    onAccessibilityAction={(event: { nativeEvent: { actionName: any; }; }) => {
+                        switch (event.nativeEvent.actionName) {
+                            case 'toggle':
+                                setAccessibilityAction('toggle action success');
+                                break;
+                            case 'invoke':
+                                setAccessibilityAction('invoke action success');
+                                break;
+                            case 'expand':
+                                setAccessibilityAction('expand action success');
+                                break;
+                            case 'collapseIt':
+                                setAccessibilityAction('collapseIt action success');
+                                break;
+                        }
+                    }}
+                >
+                    <Text>accessibilityAction:{accessibilityAction}</Text>
+                </MyView>
+            </View>
         </View>)
 }

--- a/vnext/ReactUWP/ABI/idl/AccessibilityAction.idl
+++ b/vnext/ReactUWP/ABI/idl/AccessibilityAction.idl
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Note: This is just a workaround should be removed in the future.
+// Currently there are two folders which hold idl files: ABI/idl and Views/cppwinrt
+// ABI/idl is compiled by MidlRT target, but Views/cppwinrt is built by buildcppwinrt.
+// Views/cppwinrt is not merged into ReactUWP.Winmd, but ABI/idl is merged.
+// so it hits without this file: Exception thrown at 0x7646EF12 (KernelBase.dll) in ReactUWPTestApp.exe: WinRT originate error - 0x80131522 : 'System.TypeLoadException: Could not find Windows Runtime type 'react.uwp.AccessibilityAction'
+// This file has the same 'struct AccessibilityAction'  in Views/cppwinrt/AccessibilityAction.idl.
+
+import "inspectable.idl";
+
+namespace react.uwp
+{
+  [version(1)]
+    
+  struct AccessibilityAction {		
+      String Name;
+      String Label;
+  };
+}

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -421,6 +421,7 @@
     <MidlRT Include="ABI\idl\Module.idl" />
     <MidlRT Include="ABI\idl\Instance.idl" />
     <MidlRT Include="ABI\idl\ReactControl.idl" />
+    <MidlRT Include="ABI\idl\AccessibilityAction.idl" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Version.rc">

--- a/vnext/ReactUWP/Views/DynamicAutomationPeer.cpp
+++ b/vnext/ReactUWP/Views/DynamicAutomationPeer.cpp
@@ -152,6 +152,8 @@ winrt::hstring DynamicAutomationPeer::GetItemStatusCore() const {
 // IInvokeProvider
 
 void DynamicAutomationPeer::Invoke() const {
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"invoke");
+
   if (auto const &invokeHandler = GetAccessibilityInvokeEventHandler()) {
     invokeHandler();
   }
@@ -183,15 +185,15 @@ winrt::IRawElementProviderSimple DynamicAutomationPeer::SelectionContainer() con
 }
 
 void DynamicAutomationPeer::AddToSelection() const {
-  // Right now RN does not have "selection" events, so this is a no-op
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"addToSelection");
 }
 
 void DynamicAutomationPeer::RemoveFromSelection() const {
-  // Right now RN does not have "selection" events, so this is a no-op
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"removeFromSelection");
 }
 
 void DynamicAutomationPeer::Select() const {
-  // Right now RN does not have "selection" events, so this is a no-op
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"select");
 }
 
 // IToggleProvider
@@ -210,6 +212,8 @@ winrt::ToggleState DynamicAutomationPeer::ToggleState() const {
 }
 
 void DynamicAutomationPeer::Toggle() const {
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"toggle");
+
   if (auto const &invokeHandler = GetAccessibilityInvokeEventHandler()) {
     invokeHandler();
   }
@@ -233,11 +237,11 @@ winrt::ExpandCollapseState DynamicAutomationPeer::ExpandCollapseState() const {
 }
 
 void DynamicAutomationPeer::Expand() const {
-  // Right now RN does not have "expand" events, so this is a no-op
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"expand");
 }
 
 void DynamicAutomationPeer::Collapse() const {
-  // Right now RN does not have "collapse" events, so this is a no-op
+  DynamicAutomationProperties::DispatchAccessibilityAction(Owner(), L"collapse");
 }
 
 // Private Methods

--- a/vnext/ReactUWP/Views/DynamicAutomationPeer.h
+++ b/vnext/ReactUWP/Views/DynamicAutomationPeer.h
@@ -70,6 +70,22 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
   bool HasAccessibilityState(winrt::react::uwp::AccessibilityStates state) const;
   bool GetAccessibilityState(winrt::react::uwp::AccessibilityStates state) const;
   winrt::react::uwp::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler() const;
+
+  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty();
+  static void SetAccessibilityActions(
+      Windows::UI::Xaml::UIElement const &element,
+      Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> const &value);
+  static Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> GetAccessibilityActions(
+      Windows::UI::Xaml::UIElement const &element);
+  static void DispatchAccessibilityAction(
+      Windows::UI::Xaml::UIElement const &element,
+      std::wstring_view const &actionName);
+  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
+  static void SetAccessibilityActionEventHandler(
+      Windows::UI::Xaml::UIElement const &element,
+      winrt::react::uwp::AccessibilityActionEventHandler const &value);
+  static winrt::react::uwp::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
+      winrt::Windows::UI::Xaml::UIElement const &element);
 };
 } // namespace winrt::react::uwp::implementation
 

--- a/vnext/ReactUWP/Views/DynamicAutomationProperties.cpp
+++ b/vnext/ReactUWP/Views/DynamicAutomationProperties.cpp
@@ -206,4 +206,69 @@ winrt::react::uwp::AccessibilityInvokeEventHandler DynamicAutomationProperties::
       element.GetValue(AccessibilityInvokeEventHandlerProperty()));
 }
 
+winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty() {
+  static winrt::DependencyProperty s_AccessibilityActionsProperty = winrt::DependencyProperty::RegisterAttached(
+      L"AccessibilityActions",
+      winrt::xaml_typename<Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction>>(),
+      dynamicAutomationTypeName,
+      winrt::PropertyMetadata(nullptr));
+
+  return s_AccessibilityActionsProperty;
+}
+
+void DynamicAutomationProperties::SetAccessibilityActions(
+    Windows::UI::Xaml::UIElement const &element,
+    Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> const &value) {
+  return element.SetValue(AccessibilityActionsProperty(), winrt::box_value(value));
+}
+
+Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction>
+DynamicAutomationProperties::GetAccessibilityActions(Windows::UI::Xaml::UIElement const &element) {
+  return winrt::unbox_value<Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction>>(
+      element.GetValue(AccessibilityActionsProperty()));
+}
+
+void DynamicAutomationProperties::DispatchAccessibilityAction(
+    Windows::UI::Xaml::UIElement const &element,
+    std::wstring_view const &actionName) {
+  if (element) {
+    auto vector = GetAccessibilityActions(element);
+    if (vector) {
+      for (uint32_t i = 0; i < vector.Size(); i++) {
+        auto item = vector.GetAt(i);
+
+        if (item.Name.operator std::wstring_view() == actionName) {
+          if (auto const &handler = GetAccessibilityActionEventHandler(element)) {
+            handler(item);
+          }
+        }
+      }
+    }
+  }
+}
+
+winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionEventHandlerProperty() {
+  static winrt::DependencyProperty s_AccessibilityActionEventHandlerProperty =
+      winrt::DependencyProperty::RegisterAttached(
+          L"AccessibilityActionEventHandler",
+          winrt::xaml_typename<winrt::react::uwp::AccessibilityActionEventHandler>(),
+          dynamicAutomationTypeName,
+          winrt::PropertyMetadata(winrt::box_value<winrt::react::uwp::AccessibilityActionEventHandler>(nullptr)));
+
+  return s_AccessibilityActionEventHandlerProperty;
+}
+
+void DynamicAutomationProperties::SetAccessibilityActionEventHandler(
+    winrt::Windows::UI::Xaml::UIElement const &element,
+    winrt::react::uwp::AccessibilityActionEventHandler const &value) {
+  element.SetValue(
+      AccessibilityActionEventHandlerProperty(),
+      winrt::box_value<winrt::react::uwp::AccessibilityActionEventHandler>(value));
+}
+
+winrt::react::uwp::AccessibilityActionEventHandler DynamicAutomationProperties::GetAccessibilityActionEventHandler(
+    winrt::Windows::UI::Xaml::UIElement const &element) {
+  return winrt::unbox_value<winrt::react::uwp::AccessibilityActionEventHandler>(
+      element.GetValue(AccessibilityActionEventHandlerProperty()));
+}
 } // namespace winrt::react::uwp::implementation

--- a/vnext/ReactUWP/Views/DynamicAutomationProperties.h
+++ b/vnext/ReactUWP/Views/DynamicAutomationProperties.h
@@ -62,6 +62,26 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
       winrt::react::uwp::AccessibilityInvokeEventHandler const &value);
   static winrt::react::uwp::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(
       winrt::Windows::UI::Xaml::UIElement const &element);
+
+  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty();
+
+  static void SetAccessibilityActions(
+      Windows::UI::Xaml::UIElement const &element,
+      Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> const &value);
+
+  static Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> GetAccessibilityActions(
+      Windows::UI::Xaml::UIElement const &element);
+
+  static void DispatchAccessibilityAction(
+      Windows::UI::Xaml::UIElement const &element,
+      std::wstring_view const &actionName);
+
+  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
+  static void SetAccessibilityActionEventHandler(
+      Windows::UI::Xaml::UIElement const &element,
+      winrt::react::uwp::AccessibilityActionEventHandler const &value);
+  static winrt::react::uwp::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
+      winrt::Windows::UI::Xaml::UIElement const &element);
 };
 
 } // namespace winrt::react::uwp::implementation

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -163,7 +163,8 @@ dynamic ViewManagerBase::GetExportedCustomDirectEventTypeConstants() const {
   folly::dynamic eventTypes = folly::dynamic::object();
   eventTypes.update(folly::dynamic::object("topLayout", folly::dynamic::object("registrationName", "onLayout"))(
       "topMouseEnter", folly::dynamic::object("registrationName", "onMouseEnter"))(
-      "topMouseLeave", folly::dynamic::object("registrationName", "onMouseLeave"))
+      "topMouseLeave", folly::dynamic::object("registrationName", "onMouseLeave"))(
+      "topAccessibilityAction", folly::dynamic::object("registrationName", "onAccessibilityAction"))
                     //    ("topMouseMove",
                     //    folly::dynamic::object("registrationName",
                     //    "onMouseMove"))

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -45,6 +45,16 @@ class ViewShadowNode : public ShadowNodeBase {
       else
         DispatchEvent("topAccessibilityTap", std::move(folly::dynamic::object("target", m_tag)));
     });
+
+    DynamicAutomationProperties::SetAccessibilityActionEventHandler(
+        panel, [=](winrt::react::uwp::AccessibilityAction const &action) {
+          folly::dynamic eventData = folly::dynamic::object("target", m_tag);
+
+          eventData.insert(
+              "actionName", action.Label.empty() ? HstringToDynamic(action.Name) : HstringToDynamic(action.Label));
+
+          DispatchEvent("topAccessibilityAction", std::move(eventData));
+        });
   }
 
   bool IsControl() {

--- a/vnext/ReactUWP/Views/cppwinrt/AccessibilityAction.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/AccessibilityAction.idl
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace react.uwp
+{
+  [version(1)]
+  struct AccessibilityAction {		
+      String Name;
+      String Label;
+  };
+}

--- a/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationPeer.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationPeer.idl
@@ -6,6 +6,10 @@
 // If you modify this file, be sure to run buildcppwinrt.cmd in this folder
 // to generate new headers
 
+#define VERSION 1.0
+
+import "AccessibilityAction.idl";
+    
 namespace react.uwp
 {
 	enum AccessibilityRoles
@@ -56,6 +60,7 @@ namespace react.uwp
 	};
 
 	delegate void AccessibilityInvokeEventHandler();
+  	delegate void AccessibilityActionEventHandler(AccessibilityAction action);
 
 	[default_interface]
 	[webhosthidden]
@@ -97,6 +102,14 @@ namespace react.uwp
 		static Windows.UI.Xaml.DependencyProperty AccessibilityInvokeEventHandlerProperty { get; };
 		static void SetAccessibilityInvokeEventHandler(Windows.UI.Xaml.UIElement element, AccessibilityInvokeEventHandler value);
 		static AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(Windows.UI.Xaml.UIElement element);
+
+		static Windows.UI.Xaml.DependencyProperty AccessibilityActionsProperty { get; };
+		static void SetAccessibilityActions(Windows.UI.Xaml.UIElement element, Windows.Foundation.Collections.IVector<AccessibilityAction> value);
+		static Windows.Foundation.Collections.IVector<AccessibilityAction> GetAccessibilityActions(Windows.UI.Xaml.UIElement element);
+
+		static Windows.UI.Xaml.DependencyProperty AccessibilityActionEventHandlerProperty { get; };
+		static void SetAccessibilityActionEventHandler(Windows.UI.Xaml.UIElement element, AccessibilityActionEventHandler value);
+		static AccessibilityActionEventHandler GetAccessibilityActionEventHandler(Windows.UI.Xaml.UIElement element);
 	}
 
 	[default_interface]

--- a/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationProperties.g.h
+++ b/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationProperties.g.h
@@ -195,6 +195,36 @@ struct WINRT_EBO DynamicAutomationPropertiesT : implements<D, Windows::Foundatio
     {
         return T::GetAccessibilityInvokeEventHandler(element);
     }
+
+    Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty()
+    {
+        return T::AccessibilityActionsProperty();
+    }
+
+    void SetAccessibilityActions(Windows::UI::Xaml::UIElement const& element, Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> const& value)
+    {
+        T::SetAccessibilityActions(element, value);
+    }
+
+    Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> GetAccessibilityActions(Windows::UI::Xaml::UIElement const& element)
+    {
+        return T::GetAccessibilityActions(element);
+    }
+
+    Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty()
+    {
+        return T::AccessibilityActionEventHandlerProperty();
+    }
+
+    void SetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityActionEventHandler const& value)
+    {
+        T::SetAccessibilityActionEventHandler(element, value);
+    }
+
+    react::uwp::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element)
+    {
+        return T::GetAccessibilityActionEventHandler(element);
+    }
 };
 
 }

--- a/vnext/ReactUWP/Views/cppwinrt/winrt/impl/react.uwp.0.h
+++ b/vnext/ReactUWP/Views/cppwinrt/winrt/impl/react.uwp.0.h
@@ -97,6 +97,8 @@ struct DynamicAutomationPeer;
 struct DynamicAutomationProperties;
 struct ViewControl;
 struct ViewPanel;
+struct AccessibilityAction;
+struct AccessibilityActionEventHandler;
 struct AccessibilityInvokeEventHandler;
 
 }
@@ -116,6 +118,8 @@ template <> struct category<react::uwp::ViewControl>{ using type = class_categor
 template <> struct category<react::uwp::ViewPanel>{ using type = class_category; };
 template <> struct category<react::uwp::AccessibilityRoles>{ using type = enum_category; };
 template <> struct category<react::uwp::AccessibilityStates>{ using type = enum_category; };
+template <> struct category<react::uwp::AccessibilityAction>{ using type = struct_category<hstring,hstring>; };
+template <> struct category<react::uwp::AccessibilityActionEventHandler>{ using type = delegate_category; };
 template <> struct category<react::uwp::AccessibilityInvokeEventHandler>{ using type = delegate_category; };
 template <> struct name<react::uwp::IDynamicAutomationPeer>{ static constexpr auto & value{ L"react.uwp.IDynamicAutomationPeer" }; };
 template <> struct name<react::uwp::IDynamicAutomationPeerFactory>{ static constexpr auto & value{ L"react.uwp.IDynamicAutomationPeerFactory" }; };
@@ -130,14 +134,17 @@ template <> struct name<react::uwp::ViewControl>{ static constexpr auto & value{
 template <> struct name<react::uwp::ViewPanel>{ static constexpr auto & value{ L"react.uwp.ViewPanel" }; };
 template <> struct name<react::uwp::AccessibilityRoles>{ static constexpr auto & value{ L"react.uwp.AccessibilityRoles" }; };
 template <> struct name<react::uwp::AccessibilityStates>{ static constexpr auto & value{ L"react.uwp.AccessibilityStates" }; };
+template <> struct name<react::uwp::AccessibilityAction>{ static constexpr auto & value{ L"react.uwp.AccessibilityAction" }; };
+template <> struct name<react::uwp::AccessibilityActionEventHandler>{ static constexpr auto & value{ L"react.uwp.AccessibilityActionEventHandler" }; };
 template <> struct name<react::uwp::AccessibilityInvokeEventHandler>{ static constexpr auto & value{ L"react.uwp.AccessibilityInvokeEventHandler" }; };
 template <> struct guid_storage<react::uwp::IDynamicAutomationPeer>{ static constexpr guid value{ 0x96D2FA46,0xD93B,0x5EB4,{ 0x9E,0xD8,0xFC,0x60,0x2C,0xB5,0xB7,0x8F } }; };
 template <> struct guid_storage<react::uwp::IDynamicAutomationPeerFactory>{ static constexpr guid value{ 0x0F0A64B1,0xCCEF,0x54F1,{ 0xB9,0x05,0x0C,0x58,0x26,0xCB,0x6C,0xC4 } }; };
 template <> struct guid_storage<react::uwp::IDynamicAutomationProperties>{ static constexpr guid value{ 0xB70AAC96,0x549C,0x52C1,{ 0xA1,0x24,0xAE,0x0C,0xA4,0x96,0xC8,0x05 } }; };
-template <> struct guid_storage<react::uwp::IDynamicAutomationPropertiesStatics>{ static constexpr guid value{ 0x12D63F8E,0xB2E6,0x577F,{ 0x9A,0x87,0xE3,0xB5,0x46,0x03,0xFA,0x0F } }; };
+template <> struct guid_storage<react::uwp::IDynamicAutomationPropertiesStatics>{ static constexpr guid value{ 0x8BECBDA4,0xC633,0x55B5,{ 0xA8,0x1F,0x4D,0x4B,0x03,0xFA,0x89,0xF8 } }; };
 template <> struct guid_storage<react::uwp::IViewControl>{ static constexpr guid value{ 0xDD899021,0xA952,0x5F5A,{ 0xA5,0xC1,0xAC,0x9E,0x85,0x08,0x09,0xBD } }; };
 template <> struct guid_storage<react::uwp::IViewPanel>{ static constexpr guid value{ 0x46487875,0x5C11,0x5EBE,{ 0xAA,0x1A,0xC7,0xC9,0x70,0xCF,0x46,0x02 } }; };
 template <> struct guid_storage<react::uwp::IViewPanelStatics>{ static constexpr guid value{ 0xF820A53A,0x6DFD,0x53F9,{ 0xA1,0x96,0x40,0xA4,0xED,0x81,0x8B,0x80 } }; };
+template <> struct guid_storage<react::uwp::AccessibilityActionEventHandler>{ static constexpr guid value{ 0x0989B119,0x9348,0x5B3A,{ 0xA7,0x29,0x8C,0xF2,0xE5,0x01,0x6F,0x19 } }; };
 template <> struct guid_storage<react::uwp::AccessibilityInvokeEventHandler>{ static constexpr guid value{ 0xCF396F1D,0x7B41,0x5E44,{ 0xB2,0xD5,0xBA,0xB5,0x86,0xC7,0xEE,0x33 } }; };
 template <> struct default_interface<react::uwp::DynamicAutomationPeer>{ using type = react::uwp::IDynamicAutomationPeer; };
 template <> struct default_interface<react::uwp::DynamicAutomationProperties>{ using type = react::uwp::IDynamicAutomationProperties; };
@@ -186,6 +193,12 @@ template <> struct abi<react::uwp::IDynamicAutomationPropertiesStatics>{ struct 
     virtual int32_t WINRT_CALL get_AccessibilityInvokeEventHandlerProperty(void** value) noexcept = 0;
     virtual int32_t WINRT_CALL SetAccessibilityInvokeEventHandler(void* element, void* value) noexcept = 0;
     virtual int32_t WINRT_CALL GetAccessibilityInvokeEventHandler(void* element, void** result) noexcept = 0;
+    virtual int32_t WINRT_CALL get_AccessibilityActionsProperty(void** value) noexcept = 0;
+    virtual int32_t WINRT_CALL SetAccessibilityActions(void* element, void* value) noexcept = 0;
+    virtual int32_t WINRT_CALL GetAccessibilityActions(void* element, void** result) noexcept = 0;
+    virtual int32_t WINRT_CALL get_AccessibilityActionEventHandlerProperty(void** value) noexcept = 0;
+    virtual int32_t WINRT_CALL SetAccessibilityActionEventHandler(void* element, void* value) noexcept = 0;
+    virtual int32_t WINRT_CALL GetAccessibilityActionEventHandler(void* element, void** result) noexcept = 0;
 };};
 
 template <> struct abi<react::uwp::IViewControl>{ struct type : IInspectable
@@ -225,6 +238,11 @@ template <> struct abi<react::uwp::IViewPanelStatics>{ struct type : IInspectabl
     virtual int32_t WINRT_CALL get_LeftProperty(void** value) noexcept = 0;
     virtual int32_t WINRT_CALL SetLeft(void* element, double value) noexcept = 0;
     virtual int32_t WINRT_CALL GetLeft(void* element, double* result) noexcept = 0;
+};};
+
+template <> struct abi<react::uwp::AccessibilityActionEventHandler>{ struct type : IUnknown
+{
+    virtual int32_t WINRT_CALL Invoke(struct struct_react_uwp_AccessibilityAction action) noexcept = 0;
 };};
 
 template <> struct abi<react::uwp::AccessibilityInvokeEventHandler>{ struct type : IUnknown
@@ -281,6 +299,12 @@ struct consume_react_uwp_IDynamicAutomationPropertiesStatics
     Windows::UI::Xaml::DependencyProperty AccessibilityInvokeEventHandlerProperty() const;
     void SetAccessibilityInvokeEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityInvokeEventHandler const& value) const;
     react::uwp::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(Windows::UI::Xaml::UIElement const& element) const;
+    Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty() const;
+    void SetAccessibilityActions(Windows::UI::Xaml::UIElement const& element, param::vector<react::uwp::AccessibilityAction> const& value) const;
+    Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> GetAccessibilityActions(Windows::UI::Xaml::UIElement const& element) const;
+    Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty() const;
+    void SetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityActionEventHandler const& value) const;
+    react::uwp::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element) const;
 };
 template <> struct consume<react::uwp::IDynamicAutomationPropertiesStatics> { template <typename D> using type = consume_react_uwp_IDynamicAutomationPropertiesStatics<D>; };
 
@@ -328,5 +352,13 @@ struct consume_react_uwp_IViewPanelStatics
     double GetLeft(Windows::UI::Xaml::UIElement const& element) const;
 };
 template <> struct consume<react::uwp::IViewPanelStatics> { template <typename D> using type = consume_react_uwp_IViewPanelStatics<D>; };
+
+struct struct_react_uwp_AccessibilityAction
+{
+    void* Name;
+    void* Label;
+};
+template <> struct abi<react::uwp::AccessibilityAction>{ using type = struct_react_uwp_AccessibilityAction; };
+
 
 }

--- a/vnext/ReactUWP/Views/cppwinrt/winrt/impl/react.uwp.2.h
+++ b/vnext/ReactUWP/Views/cppwinrt/winrt/impl/react.uwp.2.h
@@ -12,6 +12,17 @@
 
 WINRT_EXPORT namespace winrt::react::uwp {
 
+struct AccessibilityActionEventHandler : Windows::Foundation::IUnknown
+{
+    AccessibilityActionEventHandler(std::nullptr_t = nullptr) noexcept {}
+    template <typename L> AccessibilityActionEventHandler(L lambda);
+    template <typename F> AccessibilityActionEventHandler(F* function);
+    template <typename O, typename M> AccessibilityActionEventHandler(O* object, M method);
+    template <typename O, typename M> AccessibilityActionEventHandler(com_ptr<O>&& object, M method);
+    template <typename O, typename M> AccessibilityActionEventHandler(weak_ref<O>&& object, M method);
+    void operator()(react::uwp::AccessibilityAction const& action) const;
+};
+
 struct AccessibilityInvokeEventHandler : Windows::Foundation::IUnknown
 {
     AccessibilityInvokeEventHandler(std::nullptr_t = nullptr) noexcept {}
@@ -22,6 +33,22 @@ struct AccessibilityInvokeEventHandler : Windows::Foundation::IUnknown
     template <typename O, typename M> AccessibilityInvokeEventHandler(weak_ref<O>&& object, M method);
     void operator()() const;
 };
+
+struct AccessibilityAction
+{
+    hstring Name;
+    hstring Label;
+};
+
+inline bool operator==(AccessibilityAction const& left, AccessibilityAction const& right) noexcept
+{
+    return left.Name == right.Name && left.Label == right.Label;
+}
+
+inline bool operator!=(AccessibilityAction const& left, AccessibilityAction const& right) noexcept
+{
+    return !(left == right);
+}
 
 }
 
@@ -71,6 +98,12 @@ struct WINRT_EBO DynamicAutomationProperties :
     static Windows::UI::Xaml::DependencyProperty AccessibilityInvokeEventHandlerProperty();
     static void SetAccessibilityInvokeEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityInvokeEventHandler const& value);
     static react::uwp::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(Windows::UI::Xaml::UIElement const& element);
+    static Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty();
+    static void SetAccessibilityActions(Windows::UI::Xaml::UIElement const& element, param::vector<react::uwp::AccessibilityAction> const& value);
+    static Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> GetAccessibilityActions(Windows::UI::Xaml::UIElement const& element);
+    static Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
+    static void SetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityActionEventHandler const& value);
+    static react::uwp::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element);
 };
 
 struct WINRT_EBO ViewControl :

--- a/vnext/ReactUWP/Views/cppwinrt/winrt/react.uwp.h
+++ b/vnext/ReactUWP/Views/cppwinrt/winrt/react.uwp.h
@@ -197,6 +197,44 @@ template <typename D> react::uwp::AccessibilityInvokeEventHandler consume_react_
     return result;
 }
 
+template <typename D> Windows::UI::Xaml::DependencyProperty consume_react_uwp_IDynamicAutomationPropertiesStatics<D>::AccessibilityActionsProperty() const
+{
+    Windows::UI::Xaml::DependencyProperty value{ nullptr };
+    check_hresult(WINRT_SHIM(react::uwp::IDynamicAutomationPropertiesStatics)->get_AccessibilityActionsProperty(put_abi(value)));
+    return value;
+}
+
+template <typename D> void consume_react_uwp_IDynamicAutomationPropertiesStatics<D>::SetAccessibilityActions(Windows::UI::Xaml::UIElement const& element, param::vector<react::uwp::AccessibilityAction> const& value) const
+{
+    check_hresult(WINRT_SHIM(react::uwp::IDynamicAutomationPropertiesStatics)->SetAccessibilityActions(get_abi(element), get_abi(value)));
+}
+
+template <typename D> Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> consume_react_uwp_IDynamicAutomationPropertiesStatics<D>::GetAccessibilityActions(Windows::UI::Xaml::UIElement const& element) const
+{
+    Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> result{ nullptr };
+    check_hresult(WINRT_SHIM(react::uwp::IDynamicAutomationPropertiesStatics)->GetAccessibilityActions(get_abi(element), put_abi(result)));
+    return result;
+}
+
+template <typename D> Windows::UI::Xaml::DependencyProperty consume_react_uwp_IDynamicAutomationPropertiesStatics<D>::AccessibilityActionEventHandlerProperty() const
+{
+    Windows::UI::Xaml::DependencyProperty value{ nullptr };
+    check_hresult(WINRT_SHIM(react::uwp::IDynamicAutomationPropertiesStatics)->get_AccessibilityActionEventHandlerProperty(put_abi(value)));
+    return value;
+}
+
+template <typename D> void consume_react_uwp_IDynamicAutomationPropertiesStatics<D>::SetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityActionEventHandler const& value) const
+{
+    check_hresult(WINRT_SHIM(react::uwp::IDynamicAutomationPropertiesStatics)->SetAccessibilityActionEventHandler(get_abi(element), get_abi(value)));
+}
+
+template <typename D> react::uwp::AccessibilityActionEventHandler consume_react_uwp_IDynamicAutomationPropertiesStatics<D>::GetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element) const
+{
+    react::uwp::AccessibilityActionEventHandler result{ nullptr };
+    check_hresult(WINRT_SHIM(react::uwp::IDynamicAutomationPropertiesStatics)->GetAccessibilityActionEventHandler(get_abi(element), put_abi(result)));
+    return result;
+}
+
 template <typename D> react::uwp::ViewPanel consume_react_uwp_IViewControl<D>::GetPanel() const
 {
     react::uwp::ViewPanel result{ nullptr };
@@ -363,6 +401,28 @@ template <typename D> double consume_react_uwp_IViewPanelStatics<D>::GetLeft(Win
     check_hresult(WINRT_SHIM(react::uwp::IViewPanelStatics)->GetLeft(get_abi(element), &result));
     return result;
 }
+
+template <> struct delegate<react::uwp::AccessibilityActionEventHandler>
+{
+    template <typename H>
+    struct type : implements_delegate<react::uwp::AccessibilityActionEventHandler, H>
+    {
+        type(H&& handler) : implements_delegate<react::uwp::AccessibilityActionEventHandler, H>(std::forward<H>(handler)) {}
+
+        int32_t WINRT_CALL Invoke(struct struct_react_uwp_AccessibilityAction action) noexcept final
+        {
+            try
+            {
+                (*this)(*reinterpret_cast<react::uwp::AccessibilityAction const*>(&action));
+                return 0;
+            }
+            catch (...)
+            {
+                return to_hresult();
+            }
+        }
+    };
+};
 
 template <> struct delegate<react::uwp::AccessibilityInvokeEventHandler>
 {
@@ -743,6 +803,82 @@ struct produce<D, react::uwp::IDynamicAutomationPropertiesStatics> : produce_bas
             typename D::abi_guard guard(this->shim());
             WINRT_ASSERT_DECLARATION(GetAccessibilityInvokeEventHandler, WINRT_WRAP(react::uwp::AccessibilityInvokeEventHandler), Windows::UI::Xaml::UIElement const&);
             *result = detach_from<react::uwp::AccessibilityInvokeEventHandler>(this->shim().GetAccessibilityInvokeEventHandler(*reinterpret_cast<Windows::UI::Xaml::UIElement const*>(&element)));
+            return 0;
+        }
+        catch (...) { return to_hresult(); }
+    }
+
+    int32_t WINRT_CALL get_AccessibilityActionsProperty(void** value) noexcept final
+    {
+        try
+        {
+            *value = nullptr;
+            typename D::abi_guard guard(this->shim());
+            WINRT_ASSERT_DECLARATION(AccessibilityActionsProperty, WINRT_WRAP(Windows::UI::Xaml::DependencyProperty));
+            *value = detach_from<Windows::UI::Xaml::DependencyProperty>(this->shim().AccessibilityActionsProperty());
+            return 0;
+        }
+        catch (...) { return to_hresult(); }
+    }
+
+    int32_t WINRT_CALL SetAccessibilityActions(void* element, void* value) noexcept final
+    {
+        try
+        {
+            typename D::abi_guard guard(this->shim());
+            WINRT_ASSERT_DECLARATION(SetAccessibilityActions, WINRT_WRAP(void), Windows::UI::Xaml::UIElement const&, Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> const&);
+            this->shim().SetAccessibilityActions(*reinterpret_cast<Windows::UI::Xaml::UIElement const*>(&element), *reinterpret_cast<Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> const*>(&value));
+            return 0;
+        }
+        catch (...) { return to_hresult(); }
+    }
+
+    int32_t WINRT_CALL GetAccessibilityActions(void* element, void** result) noexcept final
+    {
+        try
+        {
+            *result = nullptr;
+            typename D::abi_guard guard(this->shim());
+            WINRT_ASSERT_DECLARATION(GetAccessibilityActions, WINRT_WRAP(Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction>), Windows::UI::Xaml::UIElement const&);
+            *result = detach_from<Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction>>(this->shim().GetAccessibilityActions(*reinterpret_cast<Windows::UI::Xaml::UIElement const*>(&element)));
+            return 0;
+        }
+        catch (...) { return to_hresult(); }
+    }
+
+    int32_t WINRT_CALL get_AccessibilityActionEventHandlerProperty(void** value) noexcept final
+    {
+        try
+        {
+            *value = nullptr;
+            typename D::abi_guard guard(this->shim());
+            WINRT_ASSERT_DECLARATION(AccessibilityActionEventHandlerProperty, WINRT_WRAP(Windows::UI::Xaml::DependencyProperty));
+            *value = detach_from<Windows::UI::Xaml::DependencyProperty>(this->shim().AccessibilityActionEventHandlerProperty());
+            return 0;
+        }
+        catch (...) { return to_hresult(); }
+    }
+
+    int32_t WINRT_CALL SetAccessibilityActionEventHandler(void* element, void* value) noexcept final
+    {
+        try
+        {
+            typename D::abi_guard guard(this->shim());
+            WINRT_ASSERT_DECLARATION(SetAccessibilityActionEventHandler, WINRT_WRAP(void), Windows::UI::Xaml::UIElement const&, react::uwp::AccessibilityActionEventHandler const&);
+            this->shim().SetAccessibilityActionEventHandler(*reinterpret_cast<Windows::UI::Xaml::UIElement const*>(&element), *reinterpret_cast<react::uwp::AccessibilityActionEventHandler const*>(&value));
+            return 0;
+        }
+        catch (...) { return to_hresult(); }
+    }
+
+    int32_t WINRT_CALL GetAccessibilityActionEventHandler(void* element, void** result) noexcept final
+    {
+        try
+        {
+            *result = nullptr;
+            typename D::abi_guard guard(this->shim());
+            WINRT_ASSERT_DECLARATION(GetAccessibilityActionEventHandler, WINRT_WRAP(react::uwp::AccessibilityActionEventHandler), Windows::UI::Xaml::UIElement const&);
+            *result = detach_from<react::uwp::AccessibilityActionEventHandler>(this->shim().GetAccessibilityActionEventHandler(*reinterpret_cast<Windows::UI::Xaml::UIElement const*>(&element)));
             return 0;
         }
         catch (...) { return to_hresult(); }
@@ -1239,6 +1375,36 @@ inline react::uwp::AccessibilityInvokeEventHandler DynamicAutomationProperties::
     return impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.GetAccessibilityInvokeEventHandler(element); });
 }
 
+inline Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty()
+{
+    return impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.AccessibilityActionsProperty(); });
+}
+
+inline void DynamicAutomationProperties::SetAccessibilityActions(Windows::UI::Xaml::UIElement const& element, param::vector<react::uwp::AccessibilityAction> const& value)
+{
+    impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.SetAccessibilityActions(element, value); });
+}
+
+inline Windows::Foundation::Collections::IVector<react::uwp::AccessibilityAction> DynamicAutomationProperties::GetAccessibilityActions(Windows::UI::Xaml::UIElement const& element)
+{
+    return impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.GetAccessibilityActions(element); });
+}
+
+inline Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionEventHandlerProperty()
+{
+    return impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.AccessibilityActionEventHandlerProperty(); });
+}
+
+inline void DynamicAutomationProperties::SetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element, react::uwp::AccessibilityActionEventHandler const& value)
+{
+    impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.SetAccessibilityActionEventHandler(element, value); });
+}
+
+inline react::uwp::AccessibilityActionEventHandler DynamicAutomationProperties::GetAccessibilityActionEventHandler(Windows::UI::Xaml::UIElement const& element)
+{
+    return impl::call_factory<DynamicAutomationProperties, react::uwp::IDynamicAutomationPropertiesStatics>([&](auto&& f) { return f.GetAccessibilityActionEventHandler(element); });
+}
+
 inline ViewControl::ViewControl() :
     ViewControl(impl::call_factory<ViewControl>([](auto&& f) { return f.template ActivateInstance<ViewControl>(); }))
 {}
@@ -1302,6 +1468,31 @@ inline double ViewPanel::GetLeft(Windows::UI::Xaml::UIElement const& element)
     return impl::call_factory<ViewPanel, react::uwp::IViewPanelStatics>([&](auto&& f) { return f.GetLeft(element); });
 }
 
+template <typename L> AccessibilityActionEventHandler::AccessibilityActionEventHandler(L handler) :
+    AccessibilityActionEventHandler(impl::make_delegate<AccessibilityActionEventHandler>(std::forward<L>(handler)))
+{}
+
+template <typename F> AccessibilityActionEventHandler::AccessibilityActionEventHandler(F* handler) :
+    AccessibilityActionEventHandler([=](auto&&... args) { return handler(args...); })
+{}
+
+template <typename O, typename M> AccessibilityActionEventHandler::AccessibilityActionEventHandler(O* object, M method) :
+    AccessibilityActionEventHandler([=](auto&&... args) { return ((*object).*(method))(args...); })
+{}
+
+template <typename O, typename M> AccessibilityActionEventHandler::AccessibilityActionEventHandler(com_ptr<O>&& object, M method) :
+    AccessibilityActionEventHandler([o = std::move(object), method](auto&&... args) { return ((*o).*(method))(args...); })
+{}
+
+template <typename O, typename M> AccessibilityActionEventHandler::AccessibilityActionEventHandler(weak_ref<O>&& object, M method) :
+    AccessibilityActionEventHandler([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
+{}
+
+inline void AccessibilityActionEventHandler::operator()(react::uwp::AccessibilityAction const& action) const
+{
+    check_hresult((*(impl::abi_t<AccessibilityActionEventHandler>**)this)->Invoke(get_abi(action)));
+}
+
 template <typename L> AccessibilityInvokeEventHandler::AccessibilityInvokeEventHandler(L handler) :
     AccessibilityInvokeEventHandler(impl::make_delegate<AccessibilityInvokeEventHandler>(std::forward<L>(handler)))
 {}
@@ -1333,6 +1524,40 @@ namespace winrt::impl {
 
 struct property_react_uwp_IDynamicAutomationPropertiesStatics
 { struct named {
+    struct AccessibilityActionEventHandlerProperty
+    {
+        struct name { static constexpr std::wstring_view value{ L"AccessibilityActionEventHandlerProperty"sv }; };
+        using property_type = winrt::Windows::UI::Xaml::DependencyProperty;
+        using target_type = winrt::react::uwp::IDynamicAutomationPropertiesStatics;
+
+        using is_readable = std::true_type;
+        using is_writable = std::false_type;
+        using is_static = std::false_type;
+        struct getter
+        {
+            auto operator()(target_type const& target) const
+            {
+                return target.AccessibilityActionEventHandlerProperty();
+            }
+        };
+    };
+    struct AccessibilityActionsProperty
+    {
+        struct name { static constexpr std::wstring_view value{ L"AccessibilityActionsProperty"sv }; };
+        using property_type = winrt::Windows::UI::Xaml::DependencyProperty;
+        using target_type = winrt::react::uwp::IDynamicAutomationPropertiesStatics;
+
+        using is_readable = std::true_type;
+        using is_writable = std::false_type;
+        using is_static = std::false_type;
+        struct getter
+        {
+            auto operator()(target_type const& target) const
+            {
+                return target.AccessibilityActionsProperty();
+            }
+        };
+    };
     struct AccessibilityInvokeEventHandlerProperty
     {
         struct name { static constexpr std::wstring_view value{ L"AccessibilityInvokeEventHandlerProperty"sv }; };
@@ -1486,7 +1711,7 @@ struct property_react_uwp_IDynamicAutomationPropertiesStatics
             }
         };
     };};
-    struct list { using type = impl::typelist<named::AccessibilityInvokeEventHandlerProperty, named::AccessibilityRoleProperty, named::AccessibilityStateBusyProperty, named::AccessibilityStateCheckedProperty, named::AccessibilityStateCollapsedProperty, named::AccessibilityStateDisabledProperty, named::AccessibilityStateExpandedProperty, named::AccessibilityStateSelectedProperty, named::AccessibilityStateUncheckedProperty>; };
+    struct list { using type = impl::typelist<named::AccessibilityActionEventHandlerProperty, named::AccessibilityActionsProperty, named::AccessibilityInvokeEventHandlerProperty, named::AccessibilityRoleProperty, named::AccessibilityStateBusyProperty, named::AccessibilityStateCheckedProperty, named::AccessibilityStateCollapsedProperty, named::AccessibilityStateDisabledProperty, named::AccessibilityStateExpandedProperty, named::AccessibilityStateSelectedProperty, named::AccessibilityStateUncheckedProperty>; };
 };
 
 struct property_react_uwp_IViewPanel
@@ -1852,6 +2077,40 @@ struct property_react_uwp_DynamicAutomationPeer
 
 struct property_react_uwp_DynamicAutomationProperties
 { struct named {
+    struct AccessibilityActionEventHandlerProperty
+    {
+        struct name { static constexpr std::wstring_view value{ L"AccessibilityActionEventHandlerProperty"sv }; };
+        using property_type = winrt::Windows::UI::Xaml::DependencyProperty;
+        using target_type = winrt::react::uwp::DynamicAutomationProperties;
+
+        using is_readable = std::true_type;
+        using is_writable = std::false_type;
+        using is_static = std::true_type;
+        struct getter
+        {
+            auto operator()() const
+            {
+                return target_type::AccessibilityActionEventHandlerProperty();
+            }
+        };
+    };
+    struct AccessibilityActionsProperty
+    {
+        struct name { static constexpr std::wstring_view value{ L"AccessibilityActionsProperty"sv }; };
+        using property_type = winrt::Windows::UI::Xaml::DependencyProperty;
+        using target_type = winrt::react::uwp::DynamicAutomationProperties;
+
+        using is_readable = std::true_type;
+        using is_writable = std::false_type;
+        using is_static = std::true_type;
+        struct getter
+        {
+            auto operator()() const
+            {
+                return target_type::AccessibilityActionsProperty();
+            }
+        };
+    };
     struct AccessibilityInvokeEventHandlerProperty
     {
         struct name { static constexpr std::wstring_view value{ L"AccessibilityInvokeEventHandlerProperty"sv }; };
@@ -2005,7 +2264,7 @@ struct property_react_uwp_DynamicAutomationProperties
             }
         };
     };};
-    struct list { using type = impl::typelist<named::AccessibilityInvokeEventHandlerProperty, named::AccessibilityRoleProperty, named::AccessibilityStateBusyProperty, named::AccessibilityStateCheckedProperty, named::AccessibilityStateCollapsedProperty, named::AccessibilityStateDisabledProperty, named::AccessibilityStateExpandedProperty, named::AccessibilityStateSelectedProperty, named::AccessibilityStateUncheckedProperty>; };
+    struct list { using type = impl::typelist<named::AccessibilityActionEventHandlerProperty, named::AccessibilityActionsProperty, named::AccessibilityInvokeEventHandlerProperty, named::AccessibilityRoleProperty, named::AccessibilityStateBusyProperty, named::AccessibilityStateCheckedProperty, named::AccessibilityStateCollapsedProperty, named::AccessibilityStateDisabledProperty, named::AccessibilityStateExpandedProperty, named::AccessibilityStateSelectedProperty, named::AccessibilityStateUncheckedProperty>; };
 };
 
 struct property_react_uwp_ViewPanel


### PR DESCRIPTION
fix #2765

add new AccessibilityActions: invoke, addToSelection, removeFromSelection, select, toggle, expand and collapse.

The following tasks are not in the scope of this PR, but they are related.
1. I did the test manually. Expect automation when #3473 is delivered.
2. The typescript for AccessiblityAction is not ready yet, and expect it be delivered in #3474
3. I applied a workaround in ABI/idl/AccessibilityAction, and it should be removed when implementing #2455

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3475)