### PR TITLE
fix formula for loaded spring animation

### DIFF
--- a/change/react-native-windows-2019-10-21-17-23-28-loadedSpring.json
+++ b/change/react-native-windows-2019-10-21-17-23-28-loadedSpring.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "fix formula for loaded spring animation",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "commit": "0616ddefcbb6f04fc516f1bf228ba0a38ceed715",
+  "date": "2019-10-22T00:23:28.589Z",
+  "file": "F:\\rnw\\change\\react-native-windows-2019-10-21-17-23-28-loadedSpring.json"
+}

--- a/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.cpp
@@ -140,7 +140,7 @@ std::tuple<float, double> SpringAnimationDriver::GetValueAndVelocityForTime(
   } else {
     const auto envelope = std::exp(-omega0 * time);
     const auto value = static_cast<float>(
-        toValue * (v0 * (time * omega0 - 1) + time * x0 * (omega0 * omega0)));
+        toValue - envelope * (x0 + (v0 + omega0 * x0) * time));
     const auto velocity =
         envelope * (v0 * (time * omega0 - 1) + time * x0 * (omega0 * omega0));
     return std::make_tuple(value, velocity);


### PR DESCRIPTION
The spring animation isn't working when using the native module; this is because the formula for calculating the animation is wrong (probably copy pasted wrong). Fixing it here. Issue #3477 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3478)