### PR TITLE
Update to react-native@0.60.0-microsoft.9

### DIFF
--- a/change/react-native-windows-2019-10-22-00-08-35-auto-update-versions060.0microsoft.9.json
+++ b/change/react-native-windows-2019-10-22-00-08-35-auto-update-versions060.0microsoft.9.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.9",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "399ac7d57bb75dc49a4a9c8acba14301d8cb7dfc",
+  "date": "2019-10-22T00:08:35.416Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-2019-10-22-00-08-35-auto-update-versions060.0microsoft.9.json"
+}

--- a/change/react-native-windows-extended-2019-10-22-00-08-37-auto-update-versions060.0microsoft.9.json
+++ b/change/react-native-windows-extended-2019-10-22-00-08-37-auto-update-versions060.0microsoft.9.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.9",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "b594deb952d846ded6ea0c70b35dab31d738dc4d",
+  "date": "2019-10-22T00:08:37.133Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-extended-2019-10-22-00-08-37-auto-update-versions060.0microsoft.9.json"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
     "react-native-windows": "0.60.0-vnext.39",
     "react-native-windows-extended": "0.60.8",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
     "react-native-windows": "0.60.0-vnext.39",
     "react-native-windows-extended": "0.60.8",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
     "react-native-windows": "0.60.0-vnext.39",
     "react-native-windows-extended": "0.60.8",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.8 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.9 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -46,13 +46,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.8 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.8.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.9 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
295e4fa98 Applying package update to 0.60.0-microsoft.9 ***NO_CI***
4af7d60da Add back jseConfigParams changes (#178)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3479)