### PR TITLE
CalculatedAnimation

### DIFF
--- a/change/react-native-windows-2019-10-21-18-46-29-calculatedanimation.json
+++ b/change/react-native-windows-2019-10-21-18-46-29-calculatedanimation.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Create Calculated Animation which allows for animations that don't follow Bezier curves",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "commit": "3785eabdd6fad1417602b4ad78f4f46ab6b4a985",
+  "date": "2019-10-22T01:46:28.972Z",
+  "file": "F:\\rnw\\change\\react-native-windows-2019-10-21-18-46-29-calculatedanimation.json"
+}

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -27,8 +27,7 @@ CalculatedAnimationDriver::MakeAnimation(const folly::dynamic &config) {
     double time = 0;
     while (!done) {
       time += 1.0f / 60.0f;
-      auto [currentValue, currentVelocity] =
-          GetValueAndVelocityForTime(time);
+      auto [currentValue, currentVelocity] = GetValueAndVelocityForTime(time);
       keyFrames.push_back(currentValue);
       if (IsAnimationDone(currentValue, currentVelocity)) {
         done = true;

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <math.h>
+#include "CalculatedAnimationDriver.h"
+
+namespace react {
+namespace uwp {
+
+std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch>
+CalculatedAnimationDriver::MakeAnimation(const folly::dynamic &config) {
+  const auto [scopedBatch, animation, easingFunction] = []() {
+    const auto compositor = winrt::Window::Current().Compositor();
+    return std::make_tuple(
+        compositor.CreateScopedBatch(
+            winrt::CompositionBatchTypes::AllAnimations),
+        compositor.CreateScalarKeyFrameAnimation(),
+        compositor.CreateLinearEasingFunction());
+  }();
+
+  m_startValue = GetAnimatedValue()->Value();
+  std::vector<float> keyFrames = [this]() {
+    std::vector<float> keyFrames;
+    bool done = false;
+    double time = 0;
+    while (!done) {
+      time += 1.0f / 60.0f;
+      auto [currentValue, currentVelocity] =
+          GetValueAndVelocityForTime(time);
+      keyFrames.push_back(currentValue);
+      if (IsAnimationDone(currentValue, currentVelocity)) {
+        done = true;
+      }
+    }
+    return keyFrames;
+  }();
+
+  std::chrono::milliseconds duration(
+      static_cast<int>(keyFrames.size() / 60.0f * 1000.0f));
+  animation.Duration(duration);
+  auto normalizedProgress = 0.0f;
+  // We are animating the values offset property which should start at 0.
+  animation.InsertKeyFrame(normalizedProgress, 0.0f, easingFunction);
+  for (const auto keyFrame : keyFrames) {
+    normalizedProgress =
+        std::min(normalizedProgress + 1.0f / keyFrames.size(), 1.0f);
+    animation.InsertKeyFrame(
+        normalizedProgress,
+        keyFrame - static_cast<float>(m_startValue),
+        easingFunction);
+  }
+
+  if (m_iterations == -1) {
+    animation.IterationBehavior(winrt::AnimationIterationBehavior::Forever);
+  } else {
+    animation.IterationCount(static_cast<int32_t>(m_iterations));
+    animation.IterationBehavior(winrt::AnimationIterationBehavior::Count);
+  }
+
+  return std::make_tuple(animation, scopedBatch);
+}
+
+} // namespace uwp
+} // namespace react

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include <folly/dynamic.h>
+#include "AnimatedNode.h"
+#include "AnimationDriver.h"
+#include <utility>
+
+namespace react {
+namespace uwp {
+class CalculatedAnimationDriver : public AnimationDriver {
+ public:
+   using AnimationDriver::AnimationDriver;
+
+  std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch>
+  MakeAnimation(const folly::dynamic &config) override;
+
+ protected:
+  virtual std::tuple<float, double> GetValueAndVelocityForTime(
+      double time) = 0;
+
+  virtual bool IsAnimationDone(double currentValue, double currentVelocity) = 0;
+  double m_startValue{0};
+};
+} // namespace uwp
+} // namespace react

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.h
@@ -3,22 +3,21 @@
 
 #pragma once
 #include <folly/dynamic.h>
+#include <utility>
 #include "AnimatedNode.h"
 #include "AnimationDriver.h"
-#include <utility>
 
 namespace react {
 namespace uwp {
 class CalculatedAnimationDriver : public AnimationDriver {
  public:
-   using AnimationDriver::AnimationDriver;
+  using AnimationDriver::AnimationDriver;
 
   std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch>
   MakeAnimation(const folly::dynamic &config) override;
 
  protected:
-  virtual std::tuple<float, double> GetValueAndVelocityForTime(
-      double time) = 0;
+  virtual std::tuple<float, double> GetValueAndVelocityForTime(double time) = 0;
 
   virtual bool IsAnimationDone(double currentValue, double currentVelocity) = 0;
   double m_startValue{0};

--- a/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.cpp
@@ -14,51 +14,30 @@ DecayAnimationDriver::DecayAnimationDriver(
     const Callback &endCallback,
     const folly::dynamic &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : AnimationDriver(id, animatedValueTag, endCallback, config, manager) {
+    : CalculatedAnimationDriver(
+          id,
+          animatedValueTag,
+          endCallback,
+          config,
+          manager) {
   m_deceleration =
       config.find(s_decelerationName).dereference().second.asDouble();
   assert(m_deceleration > 0);
   m_velocity = config.find(s_velocityName).dereference().second.asDouble();
 }
 
-std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch>
-DecayAnimationDriver::MakeAnimation(const folly::dynamic &config) {
-  const auto [scopedBatch, animation] = []() {
-    const auto compositor = winrt::Window::Current().Compositor();
-    return std::make_tuple(
-        compositor.CreateScopedBatch(
-            winrt::CompositionBatchTypes::AllAnimations),
-        compositor.CreateScalarKeyFrameAnimation());
-  }();
+std::tuple<float, double> DecayAnimationDriver::GetValueAndVelocityForTime(
+    double time) {
+  const auto value = m_startValue +
+      m_velocity / (1 - m_deceleration) *
+          (1 - std::exp(-(1 - m_deceleration) * (1000*time)));
+  return std::make_tuple(static_cast<float>(value), 42.0f); // we don't need the velocity
+}
 
-  std::chrono::milliseconds duration(
-      static_cast<int>(m_velocity / -m_deceleration * 1000));
-  animation.Duration(duration);
-
-  const auto compositor = winrt::Window::Current().Compositor();
-  animation.SetScalarParameter(
-      s_velocityParameterName, static_cast<float>(m_velocity));
-  animation.SetScalarParameter(
-      s_decelerationParameterName, static_cast<float>(m_deceleration));
-  animation.SetScalarParameter(
-      s_durationName, static_cast<float>(m_velocity / -m_deceleration) * 1000);
-  // Offset = (Velocity*time) + (0.5*Acceleration*Time^2)
-  animation.InsertExpressionKeyFrame(
-      1.0f,
-      static_cast<winrt::hstring>(L"(") + s_durationName + L" * " +
-          s_velocityParameterName + L") + (0.5 * " +
-          s_decelerationParameterName + L" * " + s_durationName + L" * " +
-          s_durationName + L")",
-      compositor.CreateCubicBezierEasingFunction({0, 1}, {0, 1}));
-
-  if (m_iterations == -1) {
-    animation.IterationBehavior(winrt::AnimationIterationBehavior::Forever);
-  } else {
-    animation.IterationCount(static_cast<int32_t>(m_iterations));
-    animation.IterationBehavior(winrt::AnimationIterationBehavior::Count);
-  }
-
-  return std::make_tuple(animation, scopedBatch);
+bool DecayAnimationDriver::IsAnimationDone(
+    double currentValue,
+    double currentVelocity) {
+  return (std::abs(ToValue() - currentValue) < 0.1);
 }
 
 double DecayAnimationDriver::ToValue() {
@@ -72,9 +51,7 @@ double DecayAnimationDriver::ToValue() {
     return 0.0;
   }();
 
-  auto const duration = m_velocity / -m_deceleration;
-  return startValue + m_velocity * duration +
-      (0.5 * -m_deceleration * duration * duration);
+  return m_startValue + m_velocity / (1 - m_deceleration);
 }
 
 } // namespace uwp

--- a/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.cpp
@@ -30,8 +30,9 @@ std::tuple<float, double> DecayAnimationDriver::GetValueAndVelocityForTime(
     double time) {
   const auto value = m_startValue +
       m_velocity / (1 - m_deceleration) *
-          (1 - std::exp(-(1 - m_deceleration) * (1000*time)));
-  return std::make_tuple(static_cast<float>(value), 42.0f); // we don't need the velocity
+          (1 - std::exp(-(1 - m_deceleration) * (1000 * time)));
+  return std::make_tuple(
+      static_cast<float>(value), 42.0f); // we don't need the velocity
 }
 
 bool DecayAnimationDriver::IsAnimationDone(

--- a/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.cpp
@@ -32,7 +32,8 @@ std::tuple<float, double> DecayAnimationDriver::GetValueAndVelocityForTime(
       m_velocity / (1 - m_deceleration) *
           (1 - std::exp(-(1 - m_deceleration) * (1000 * time)));
   return std::make_tuple(
-      static_cast<float>(value), 42.0f); // we don't need the velocity
+      static_cast<float>(value),
+      42.0f); // we don't need the velocity, so set it to a dummy value
 }
 
 bool DecayAnimationDriver::IsAnimationDone(

--- a/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.h
@@ -4,11 +4,11 @@
 #pragma once
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
-#include "AnimationDriver.h"
+#include "CalculatedAnimationDriver.h"
 
 namespace react {
 namespace uwp {
-class DecayAnimationDriver : public AnimationDriver {
+class DecayAnimationDriver : public CalculatedAnimationDriver {
  public:
   DecayAnimationDriver(
       int64_t id,
@@ -17,10 +17,12 @@ class DecayAnimationDriver : public AnimationDriver {
       const folly::dynamic &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
-  std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch>
-  MakeAnimation(const folly::dynamic &config) override;
-
   double ToValue() override;
+
+ protected:
+  std::tuple<float, double> GetValueAndVelocityForTime(
+      double time) override;
+  bool IsAnimationDone(double currentValue, double currentVelocity) override;
 
  private:
   double m_velocity{0};

--- a/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/DecayAnimationDriver.h
@@ -20,8 +20,7 @@ class DecayAnimationDriver : public CalculatedAnimationDriver {
   double ToValue() override;
 
  protected:
-  std::tuple<float, double> GetValueAndVelocityForTime(
-      double time) override;
+  std::tuple<float, double> GetValueAndVelocityForTime(double time) override;
   bool IsAnimationDone(double currentValue, double currentVelocity) override;
 
  private:

--- a/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.cpp
@@ -17,7 +17,12 @@ SpringAnimationDriver::SpringAnimationDriver(
     const std::shared_ptr<NativeAnimatedNodeManager> &manager,
     const folly::dynamic &dynamicToValues)
     : m_dynamicToValues(dynamicToValues),
-      CalculatedAnimationDriver(id, animatedValueTag, endCallback, config, manager) {
+      CalculatedAnimationDriver(
+          id,
+          animatedValueTag,
+          endCallback,
+          config,
+          manager) {
   m_springStiffness = config.find(s_springStiffnessParameterName)
                           .dereference()
                           .second.asDouble();
@@ -107,8 +112,7 @@ bool SpringAnimationDriver::IsAtRest(
        m_springStiffness == 0);
 }
 
-bool SpringAnimationDriver::IsOvershooting(
-    double currentValue) {
+bool SpringAnimationDriver::IsOvershooting(double currentValue) {
   return m_springStiffness > 0 &&
       ((m_startValue < m_endValue && currentValue > m_endValue) ||
        (m_startValue > m_endValue && currentValue < m_endValue));

--- a/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.h
@@ -5,11 +5,11 @@
 #pragma once
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
-#include "AnimationDriver.h"
+#include "CalculatedAnimationDriver.h"
 
 namespace react {
 namespace uwp {
-class SpringAnimationDriver : public AnimationDriver {
+class SpringAnimationDriver : public CalculatedAnimationDriver {
  public:
   SpringAnimationDriver(
       int64_t id,
@@ -19,18 +19,17 @@ class SpringAnimationDriver : public AnimationDriver {
       const std::shared_ptr<NativeAnimatedNodeManager> &manager,
       const folly::dynamic &dynamicToValues = folly::dynamic::array());
 
-  std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch>
-  MakeAnimation(const folly::dynamic &config) override;
-
   double ToValue() override;
 
- private:
+ protected:
   std::tuple<float, double> GetValueAndVelocityForTime(
-      double time,
-      double startValue);
+      double time) override;
+  bool IsAnimationDone(double currentValue, double currentVelocity) override;
+
+ private:
   bool
   IsAtRest(double currentVelocity, double currentPosition, double endValue);
-  bool IsOvershooting(double currentValue, double startValue);
+  bool IsOvershooting(double currentValue);
 
   double m_springStiffness{0};
   double m_springDamping{0};

--- a/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/SpringAnimationDriver.h
@@ -22,8 +22,7 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
   double ToValue() override;
 
  protected:
-  std::tuple<float, double> GetValueAndVelocityForTime(
-      double time) override;
+  std::tuple<float, double> GetValueAndVelocityForTime(double time) override;
   bool IsAnimationDone(double currentValue, double currentVelocity) override;
 
  private:

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -164,6 +164,7 @@
     <ClInclude Include="ABI\Instance_rt.h" />
     <ClInclude Include="ABI\ReactControl_rt.h" />
     <ClInclude Include="Base\UwpReactInstance.h" />
+    <ClInclude Include="Modules\Animated\CalculatedAnimationDriver.h" />
     <ClInclude Include="Modules\Animated\SpringAnimationDriver.h" />
     <ClInclude Include="Modules\Animated\TrackingAnimatedNode.h" />
     <ClInclude Include="Threading\BatchingUIMessageQueueThread.h" />
@@ -271,6 +272,7 @@
     <ClCompile Include="ABI\ReactControl_rt.cpp" />
     <ClCompile Include="Base\InstanceFactory.cpp" />
     <ClCompile Include="Base\UwpReactInstance.cpp" />
+    <ClCompile Include="Modules\Animated\CalculatedAnimationDriver.cpp" />
     <ClCompile Include="Modules\Animated\SpringAnimationDriver.cpp" />
     <ClCompile Include="Modules\Animated\TrackingAnimatedNode.cpp" />
     <ClCompile Include="Threading\BatchingUIMessageQueueThread.cpp" />
@@ -405,7 +407,7 @@
     <ProjectReference Include="..\JSI\Universal\JSI.Universal.vcxproj" Condition="'$(OSS_RN)' != 'true' AND '$(CHAKRACOREUWP)'!='true'">
       <Project>{a62d504a-16b8-41d2-9f19-e2e86019e5e4}</Project>
     </ProjectReference>
-	<ProjectReference Include="..\JSI\Desktop\JSI.Desktop.vcxproj" Condition="'$(OSS_RN)' != 'true' AND '$(CHAKRACOREUWP)'=='true'">
+    <ProjectReference Include="..\JSI\Desktop\JSI.Desktop.vcxproj" Condition="'$(OSS_RN)' != 'true' AND '$(CHAKRACOREUWP)'=='true'">
       <Project>{17DD1B17-3094-40DD-9373-AC2497932ECA}</Project>
     </ProjectReference>
     <ProjectReference Include="..\ReactCommon\ReactCommon.vcxproj">


### PR DESCRIPTION
This reimplements Decay animations and creates a base class CalculatedAnimation that factors the logic that used to be in SpringAnimation so that it can be used by DecayAnimation. The formula for decay animation was wrong; in reality a decay animation has an exponential decay. This animation cannot be expressed as a cubic bezier curve so instead we use keyframes like Spring animation does (which has a neg-exponential component too). This addresses #3481 (and #3477 )

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3482)