### PR TITLE
Update to react-native@0.60.0-microsoft.10

### DIFF
--- a/change/react-native-windows-2019-10-23-18-49-27-auto-update-versions060.0microsoft.10.json
+++ b/change/react-native-windows-2019-10-23-18-49-27-auto-update-versions060.0microsoft.10.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.10",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "ef6d0b507b2431fbf4def073a261bfbc9926d153",
+  "date": "2019-10-23T18:49:27.712Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-2019-10-23-18-49-27-auto-update-versions060.0microsoft.10.json"
+}

--- a/change/react-native-windows-extended-2019-10-23-18-49-29-auto-update-versions060.0microsoft.10.json
+++ b/change/react-native-windows-extended-2019-10-23-18-49-29-auto-update-versions060.0microsoft.10.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.10",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "b552fdd3a4c0667e5ae21e036e3778cc1c5c417d",
+  "date": "2019-10-23T18:49:29.355Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-extended-2019-10-23-18-49-29-auto-update-versions060.0microsoft.10.json"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz",
     "react-native-windows": "0.60.0-vnext.41",
     "react-native-windows-extended": "0.60.9",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz",
     "react-native-windows": "0.60.0-vnext.41",
     "react-native-windows-extended": "0.60.9",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz",
     "react-native-windows": "0.60.0-vnext.41",
     "react-native-windows-extended": "0.60.9",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.9 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.10 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -46,13 +46,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.9 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.9.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.10 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.10.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
1f2edb5ce Applying package update to 0.60.0-microsoft.10 ***NO_CI***
d7cf27236 Publish fix
41baf57bb Fix publish
ba1b2e9a9 Add support for registering custom fonts by family+weight (#179)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3504)