### PR TITLE
Run-windows fails on x86 machines

### DIFF
--- a/change/react-native-windows-2019-10-24-17-13-17-x86runwindows.json
+++ b/change/react-native-windows-2019-10-24-17-13-17-x86runwindows.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "make run-windows work on x86 machines",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "commit": "280c71dbe5b34e13bb5012d35446324e1df1b039",
+  "date": "2019-10-25T00:13:17.214Z",
+  "file": "F:\\rnw\\change\\react-native-windows-2019-10-24-17-13-17-x86runwindows.json"
+}

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -100,7 +100,7 @@ class MSBuildTools {
 function VSWhere(requires, version, property) {
   // This path is maintained and VS has promised to keep it valid.
   const vsWherePath = path.join(
-    process.env['ProgramFiles(x86)'],
+    process.env['ProgramFiles(x86)'] || process.env.ProgramFiles,
     '/Microsoft Visual Studio/Installer/vswhere.exe',
   );
 


### PR DESCRIPTION
Fixes #3516 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3520)