### PR TITLE
Disable unstable debug flavor of desktop Integration testing

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -241,6 +241,7 @@ jobs:
           collectDumpOn: onAbortOnly
           vsTestVersion: toolsInstaller
           otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
+        condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))
 
       - task: VSTest@2
         displayName: List Desktop Integration Tests


### PR DESCRIPTION
Disable debug flavor of desktop Integration testing #3519

For reference, here is a list of failed build jobs in the last few days:
https://dev.azure.com/ms/react-native-windows/_build?definitionId=210&_a=summary
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44326
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44320
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44318
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44286
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44254
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44178
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44151
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44150
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=44137


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3525)