### PR TITLE
Update to react-native@0.60.0-microsoft.12

### DIFF
--- a/change/react-native-windows-2019-10-25-19-47-32-auto-update-versions060.0microsoft.12.json
+++ b/change/react-native-windows-2019-10-25-19-47-32-auto-update-versions060.0microsoft.12.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.12",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "44da446020182a3f5ab3d0a499a909e61d11c52d",
+  "date": "2019-10-25T19:47:32.271Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-2019-10-25-19-47-32-auto-update-versions060.0microsoft.12.json"
+}

--- a/change/react-native-windows-extended-2019-10-25-19-47-34-auto-update-versions060.0microsoft.12.json
+++ b/change/react-native-windows-extended-2019-10-25-19-47-34-auto-update-versions060.0microsoft.12.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.12",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "5e0084f19a518d04caf2568cba716ea881aea30d",
+  "date": "2019-10-25T19:47:33.986Z",
+  "file": "D:\\a\\1\\s\\change\\react-native-windows-extended-2019-10-25-19-47-34-auto-update-versions060.0microsoft.12.json"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
     "react-native-windows": "0.60.0-vnext.45",
     "react-native-windows-extended": "0.60.10",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
     "react-native-windows": "0.60.0-vnext.45",
     "react-native-windows-extended": "0.60.10",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
     "react-native-windows": "0.60.0-vnext.45",
     "react-native-windows-extended": "0.60.10",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.11 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.12 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -46,13 +46,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.11 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.11.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.12 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
b5e80390a Applying package update to 0.60.0-microsoft.12 ***NO_CI***
932a2b80c Copy over ios/mac header files that polyester references to fix the 0.60 merg… (#181)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3526)