### PR TITLE
Update to react-native@0.60.0-microsoft.13

### DIFF
--- a/change/react-native-windows-2019-10-26-01-48-30-auto-update-versions060.0microsoft.13.json
+++ b/change/react-native-windows-2019-10-26-01-48-30-auto-update-versions060.0microsoft.13.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.13",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "d4b0d7291715673659e8490ef5ba8c1d65f26e56",
+  "date": "2019-10-26T01:48:30.205Z"
+}

--- a/change/react-native-windows-extended-2019-10-26-01-48-32-auto-update-versions060.0microsoft.13.json
+++ b/change/react-native-windows-extended-2019-10-26-01-48-32-auto-update-versions060.0microsoft.13.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.13",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "1198d7f7dc40aceca81fa7c75e44eb1107922ccb",
+  "date": "2019-10-26T01:48:32.069Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
     "react-native-windows": "0.60.0-vnext.48",
     "react-native-windows-extended": "0.60.12",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
     "react-native-windows": "0.60.0-vnext.48",
     "react-native-windows-extended": "0.60.12",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
     "react-native-windows": "0.60.0-vnext.48",
     "react-native-windows-extended": "0.60.12",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.12 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.13 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -46,13 +46,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.12 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.12.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.13 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
4e1e54177 Applying package update to 0.60.0-microsoft.13 ***NO_CI***
0c567f65b align with ios here and copy these to the same location on mac (#182)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3533)