### PR TITLE
Fix remote debugger for Playground app

### DIFF
--- a/change/react-native-windows-2019-10-25-19-39-55-remoteDbg.json
+++ b/change/react-native-windows-2019-10-25-19-39-55-remoteDbg.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix remote debugger for Playground app. Now you can pass  the hostname:port of a running metro bundler instance and it will connect correctly",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "commit": "3c510d99cb0db6b1fc371c589b6e97f94d85c8b5",
+  "date": "2019-10-26T02:39:55.125Z",
+  "file": "F:\\rnw\\change\\react-native-windows-2019-10-25-19-39-55-remoteDbg.json"
+}

--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -215,15 +215,13 @@ std::shared_ptr<react::uwp::IReactInstance> HostingPane::getInstance() {
     if (params.find("debughost") != params.end()) {
       settings.DebugHost = params["debughost"];
     }
-    settings.LoggingCallback = [](facebook::react::RCTLogLevel logLevel,
-                                  const char *message) {
+    settings.LoggingCallback = [](facebook::react::RCTLogLevel logLevel, const char *message) {
       OutputDebugStringA("In LoggingCallback");
       OutputDebugStringA(message);
     };
-    settings.JsExceptionCallback =
-        [](facebook::react::JSExceptionInfo &&exceptionInfo) {
-          OutputDebugStringA("in JsExceptionCallback");
-        };
+    settings.JsExceptionCallback = [](facebook::react::JSExceptionInfo &&exceptionInfo) {
+      OutputDebugStringA("in JsExceptionCallback");
+    };
     m_instance->Start(m_instance, settings);
     m_instance->loadBundle(Microsoft::Common::Unicode::Utf16ToUtf8(m_loadedBundleFileName));
   }

--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -212,13 +212,18 @@ std::shared_ptr<react::uwp::IReactInstance> HostingPane::getInstance() {
     settings.UseWebDebugger = x_UseWebDebuggerCheckBox->IsChecked->Value;
     settings.UseLiveReload = x_UseLiveReloadCheckBox->IsChecked->Value;
     settings.EnableDeveloperMenu = true;
-    settings.LoggingCallback = [](facebook::react::RCTLogLevel logLevel, const char *message) {
+    if (params.find("debughost") != params.end()) {
+      settings.DebugHost = params["debughost"];
+    }
+    settings.LoggingCallback = [](facebook::react::RCTLogLevel logLevel,
+                                  const char *message) {
       OutputDebugStringA("In LoggingCallback");
       OutputDebugStringA(message);
     };
-    settings.JsExceptionCallback = [](facebook::react::JSExceptionInfo &&exceptionInfo) {
-      OutputDebugStringA("in JsExceptionCallback");
-    };
+    settings.JsExceptionCallback =
+        [](facebook::react::JSExceptionInfo &&exceptionInfo) {
+          OutputDebugStringA("in JsExceptionCallback");
+        };
     m_instance->Start(m_instance, settings);
     m_instance->loadBundle(Microsoft::Common::Unicode::Utf16ToUtf8(m_loadedBundleFileName));
   }

--- a/packages/playground/windows/playground/MainPage.xaml.cpp
+++ b/packages/playground/windows/playground/MainPage.xaml.cpp
@@ -16,6 +16,9 @@
 #include <Windows.ApplicationModel.Core.h>
 #include <Windows.UI.Xaml.Controls.h>
 #include <Windows.UI.Xaml.h>
+#include <string>
+#include <locale>
+#include <codecvt>
 
 using namespace Playground;
 
@@ -26,7 +29,6 @@ using namespace Windows::UI::Xaml::Controls;
 
 MainPage::MainPage() {
   InitializeComponent();
-
   // Create Commands
   m_addPaneCommand = ref new RelayCommand(
       [this](Object ^ parameter) { return x_PaneContainer->ColumnDefinitions->Size < 3; },
@@ -113,5 +115,17 @@ void MainPage::UpdatePaneCommandState() {
 
     auto removePaneCommand = dynamic_cast<RelayCommand ^>(currentPane->RemovePaneCommand);
     removePaneCommand->RaiseCanExecuteChanged();
+  }
+}
+
+std::unordered_map<std::string, std::string> params;
+
+void MainPage::OnNavigatedTo(
+    Windows::UI::Xaml::Navigation::NavigationEventArgs ^ e) {
+  Platform::String ^ args = dynamic_cast<Platform::String ^>(e->Parameter);
+  if (!(args == nullptr || args->IsEmpty())) {
+    std::wstring a{args->Data()};
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+    params["debughost"] = converter.to_bytes(a);
   }
 }

--- a/packages/playground/windows/playground/MainPage.xaml.cpp
+++ b/packages/playground/windows/playground/MainPage.xaml.cpp
@@ -16,9 +16,9 @@
 #include <Windows.ApplicationModel.Core.h>
 #include <Windows.UI.Xaml.Controls.h>
 #include <Windows.UI.Xaml.h>
-#include <string>
-#include <locale>
 #include <codecvt>
+#include <locale>
+#include <string>
 
 using namespace Playground;
 
@@ -120,8 +120,7 @@ void MainPage::UpdatePaneCommandState() {
 
 std::unordered_map<std::string, std::string> params;
 
-void MainPage::OnNavigatedTo(
-    Windows::UI::Xaml::Navigation::NavigationEventArgs ^ e) {
+void MainPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs ^ e) {
   Platform::String ^ args = dynamic_cast<Platform::String ^>(e->Parameter);
   if (!(args == nullptr || args->IsEmpty())) {
     std::wstring a{args->Data()};

--- a/packages/playground/windows/playground/MainPage.xaml.h
+++ b/packages/playground/windows/playground/MainPage.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 //
 // MainPage.xaml.h
@@ -11,7 +11,7 @@
 
 #include "HostingPane.xaml.h"
 #include "Utilities/RelayCommand.h"
-
+#include <unordered_map>
 namespace Playground {
 
 [Windows::Foundation::Metadata::WebHostHidden] public ref class MainPage sealed {
@@ -28,6 +28,9 @@ namespace Playground {
 
   RelayCommand ^ m_addPaneCommand;
   RelayCommand ^ m_removePaneCommand;
+
+  protected:
+  virtual void OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ e) override;
 };
 
 } // namespace Playground

--- a/packages/playground/windows/playground/MainPage.xaml.h
+++ b/packages/playground/windows/playground/MainPage.xaml.h
@@ -9,9 +9,9 @@
 
 #include "MainPage.g.h"
 
+#include <unordered_map>
 #include "HostingPane.xaml.h"
 #include "Utilities/RelayCommand.h"
-#include <unordered_map>
 namespace Playground {
 
 [Windows::Foundation::Metadata::WebHostHidden] public ref class MainPage sealed {
@@ -29,8 +29,8 @@ namespace Playground {
   RelayCommand ^ m_addPaneCommand;
   RelayCommand ^ m_removePaneCommand;
 
-  protected:
-  virtual void OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ e) override;
+ protected:
+  virtual void OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs ^ e) override;
 };
 
 } // namespace Playground

--- a/packages/playground/windows/playground/Package.appxmanifest
+++ b/packages/playground/windows/playground/Package.appxmanifest
@@ -24,6 +24,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer"/>
     <DeviceCapability Name="location" />
   </Capabilities>
 </Package>

--- a/packages/playground/windows/playground/pch.h
+++ b/packages/playground/windows/playground/pch.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 //
 // pch.h
@@ -11,6 +11,9 @@
 
 #include "App.xaml.h"
 #include "ViewLifetimeControl.h"
+#include <unordered_map>
+
+extern std::unordered_map<std::string, std::string> params;
 
 #undef min
 #undef max

--- a/packages/playground/windows/playground/pch.h
+++ b/packages/playground/windows/playground/pch.h
@@ -9,9 +9,9 @@
 
 #include <collection.h>
 
+#include <unordered_map>
 #include "App.xaml.h"
 #include "ViewLifetimeControl.h"
-#include <unordered_map>
 
 extern std::unordered_map<std::string, std::string> params;
 

--- a/vnext/ReactUWP/ABI/Instance_rt.cpp
+++ b/vnext/ReactUWP/ABI/Instance_rt.cpp
@@ -69,10 +69,8 @@ std::shared_ptr<::react::uwp::IReactInstance> Instance::getInstance() {
 
   if (!m_instance) {
     m_instance = ::react::uwp::CreateReactInstance(m_spModuleProvider /*moduleLoader*/);
-    ::react::uwp::ReactInstanceSettings innerSettings;
-    innerSettings.UseLiveReload = m_settings.UseLiveReload;
-    innerSettings.UseWebDebugger = m_settings.UseWebDebugger;
-    innerSettings.EnableDeveloperMenu = m_settings.EnableDeveloperMenu;
+    ::react::uwp::ReactInstanceSettings innerSettings(m_settings);
+
     m_instance->Start(m_instance, innerSettings);
     m_instance->loadBundle(std::string(m_jsBundleName));
   }

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -104,6 +104,7 @@
     <ClInclude Include="BatchingMessageQueueThread.h" />
     <ClInclude Include="CreateModules.h" />
     <ClInclude Include="CxxMessageQueue.h" />
+    <ClInclude Include="DevServerHelper.h" />
     <ClInclude Include="DevSettings.h" />
     <ClInclude Include="etw\react_native_windows.h" />
     <ClInclude Include="IDevSupportManager.h" />

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj.filters
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj.filters
@@ -221,6 +221,9 @@
     <ClInclude Include="ChakraRuntimeHolder.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DevServerHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Now you can pass  the hostname:port of a running metro bundler instance and it will connect correctly

Fixes #3534 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3535)