### PR TITLE
Include JSI even when building against OSS RN

### DIFF
--- a/change/react-native-windows-2019-10-28-14-38-36-jsiwithoss.json
+++ b/change/react-native-windows-2019-10-28-14-38-36-jsiwithoss.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Move closer to allowing JSI with OSS RN",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "80801ec6ff3272320e1d150483d3422ec9690b8f",
+  "date": "2019-10-28T21:38:36.295Z"
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "lerna run build --stream",
     "buildci": "lerna run build --stream -- --ci",
-    "change": "node ./node_modules/beachball/bin/beachball.js change",
+    "change": "beachball change",
     "clean": "lerna run clean --stream",
     "format": "node packages/scripts/formatFiles.js -i -style=file -assume-filename=../.clang-format",
     "format:verify": "node packages/scripts/formatFiles.js -i -style=file -assume-filename=../.clang-format -verify"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lerna": "^3.16.1"
   },
   "resolutions": {
-    "**/eslint-plugin-react": "^7.14.1"
+    "**/eslint-plugin-react": "^7.14.1",
+    "**/react-native": "^0.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lerna": "^3.16.1"
   },
   "resolutions": {
-    "**/eslint-plugin-react": "^7.14.1",
-    "**/react-native": "^0.60.0"
+    "**/eslint-plugin-react": "^7.14.1"
   }
 }

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -143,11 +143,11 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\JSCRuntime.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\jsi.cpp" Condition="'$(OSS_RN)' != 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\JSIDynamic.cpp" Condition="'$(OSS_RN)' != 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\jsilib-windows.cpp" Condition="'$(OSS_RN)' != 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSIExecutor.cpp" Condition="'$(OSS_RN)' != 'true'" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSINativeModules.cpp" Condition="'$(OSS_RN)' != 'true'" />
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\jsi.cpp"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\JSIDynamic.cpp"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\jsilib-windows.cpp"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSIExecutor.cpp"/>
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSINativeModules.cpp"/>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>

--- a/vnext/Scripts/useUnForkedRN.js
+++ b/vnext/Scripts/useUnForkedRN.js
@@ -15,8 +15,9 @@ const rnVersion = pkgJson.peerDependencies['react-native'].split(' ')[0];
 const rootPkgJsonPath = path.resolve(__dirname, '../../package.json');
 const rootPkgJson = require(rootPkgJsonPath);
 
-rootPkgJson.resolutions = {
-  '**/react-native': rnVersion,
-};
+if (!rootPkgJson.resolutions) {
+  rootPkgJson.resolutions = {};
+}
+rootPkgJson.resolutions['**/react-native'] = rnVersion;
 
 fs.writeFileSync(rootPkgJsonPath, JSON.stringify(rootPkgJson, null, 2) + '\n');

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -12,6 +12,7 @@
   "typings": "Libraries/react-native/typings-index.d.ts",
   "scripts": {
     "build": "just-scripts build",
+    "change": "beachball change",
     "clean": "just-scripts clean",
     "start": "react-native start",
     "lint": "just-scripts eslint",


### PR DESCRIPTION
There is more to do here, but we should try to get rid of all the OSS_RN #defines, and get alignment between the fork and non-fork -- at which point we can stop using the fork altogether.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3546)