### PR TITLE
Fix crash in RS5 due to missing facade property

### DIFF
--- a/change/react-native-windows-2019-10-29-13-55-40-noRS5crash.json
+++ b/change/react-native-windows-2019-10-29-13-55-40-noRS5crash.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in RS5 due to missing facade property",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "commit": "1cd1d5fe48d2f304c5b1b4597c7a9930c76183ff",
+  "date": "2019-10-29T20:55:40.104Z",
+  "file": "F:\\rnw\\change\\react-native-windows-2019-10-29-13-55-40-noRS5crash.json"
+}

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 
+#include <ReactUWP/Views/ReactControl.h>
 #include <ReactUWP\Modules\NativeUIManager.h>
 #include <Views/ShadowNodeBase.h>
 #include "NativeAnimatedNodeManager.h"
@@ -121,6 +122,11 @@ void PropsAnimatedNode::StartAnimations() {
         if (!m_centerPointAnimation) {
           m_centerPointAnimation = winrt::Window::Current().Compositor().CreateExpressionAnimation();
           m_centerPointAnimation.Target(L"CenterPoint");
+
+          if (g_HasActualSizeProperty == TriBit::Undefined) {
+            // ActualSize works on 19H1+ only
+            g_HasActualSizeProperty = (uiElement.try_as<winrt::IUIElement10>()) ? TriBit::Set : TriBit::NotSet;
+          }
           m_centerPointAnimation.SetReferenceParameter(
               L"centerPointPropertySet", GetShadowNodeBase()->EnsureTransformPS());
           m_centerPointAnimation.Expression(L"centerPointPropertySet.center");

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -473,5 +473,6 @@ void ReactControl::ToggleInspector() {
   }
 }
 
+TriBit g_HasActualSizeProperty{TriBit::Undefined};
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/ReactControl.h
+++ b/vnext/ReactUWP/Views/ReactControl.h
@@ -25,6 +25,9 @@ using namespace Windows::UI::Xaml::Media;
 namespace react {
 namespace uwp {
 
+enum class TriBit { Undefined = -1, NotSet = 0, Set = 1 };
+extern TriBit g_HasActualSizeProperty;
+
 class ReactControl : public std::enable_shared_from_this<ReactControl>, public IXamlReactControl {
  public:
   ReactControl(IXamlRootView *parent, XamlView rootView);


### PR DESCRIPTION
Some animations are sensitive to the center point of the element (e.g. rotation, scale). We were using 0.5*ActualSize to determine the center point. However this facade property was only added in 19h1 so it Comp crashed in RS5 when trying to parse an expression animation that references ActualSize.
This change makes it so we fallback to using CenterPoint instead if ActualSize isn't available.

Fixes #2996


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3550)