### PR TITLE
Set a default 3D perspective

### DIFF
--- a/change/react-native-windows-2019-10-28-17-52-55-user-asklar-perspective.json
+++ b/change/react-native-windows-2019-10-28-17-52-55-user-asklar-perspective.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Set a default 3D perspective",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "commit": "8090b808b6696fe6d2323b260c88ec90ceedf2c8",
+  "date": "2019-10-29T00:52:55.621Z"
+}

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -23,6 +23,7 @@
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Media.Media3D.h>
 #include <winrt/Windows.UI.Xaml.h>
 
 namespace react {
@@ -339,6 +340,10 @@ void ReactControl::PrepareXamlRootView(XamlView const &rootView) {
     children.Clear();
 
     auto newRootView = winrt::Grid();
+    auto perspectiveTransform3D = winrt::Windows::UI::Xaml::Media::Media3D::PerspectiveTransform3D();
+    perspectiveTransform3D.Depth(850);
+    winrt::Windows::UI::Xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
+    newRootView.Transform3D(t3d);
     children.Append(newRootView);
     m_xamlRootView = newRootView;
   } else

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -340,6 +340,9 @@ void ReactControl::PrepareXamlRootView(XamlView const &rootView) {
     children.Clear();
 
     auto newRootView = winrt::Grid();
+    // Xaml's default projection in 3D is orthographic (all lines are parallel)
+    // However React Native's default projection is a one-point perspective.
+    // Set a default perspective projection on the main control to mimic this.
     auto perspectiveTransform3D = winrt::Windows::UI::Xaml::Media::Media3D::PerspectiveTransform3D();
     perspectiveTransform3D.Depth(850);
     winrt::Windows::UI::Xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -22,8 +22,8 @@
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Media.Media3D.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
 
 namespace react {


### PR DESCRIPTION
We need to set a perspective to match React Native's perspective, otherwise we get an orthographic projection

Fixes #3093 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3551)