### PR TITLE
Update to react-native@0.60.0-microsoft.14

### DIFF
--- a/change/react-native-windows-2019-10-31-17-50-35-auto-update-versions060.0microsoft.14.json
+++ b/change/react-native-windows-2019-10-31-17-50-35-auto-update-versions060.0microsoft.14.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.14",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "2ed89834a468e9c4cb1643e497661e7b70317c98",
+  "date": "2019-10-31T17:50:34.979Z"
+}

--- a/change/react-native-windows-extended-2019-10-31-17-50-36-auto-update-versions060.0microsoft.14.json
+++ b/change/react-native-windows-extended-2019-10-31-17-50-36-auto-update-versions060.0microsoft.14.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.14",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "70d8da2a392ec7c92089a4d8c996ed89bbc4b15b",
+  "date": "2019-10-31T17:50:36.938Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
     "react-native-windows": "0.60.0-vnext.57",
     "react-native-windows-extended": "0.60.13",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
     "react-native-windows": "0.60.0-vnext.57",
     "react-native-windows-extended": "0.60.13",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
     "react-native-windows": "0.60.0-vnext.57",
     "react-native-windows-extended": "0.60.13",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.13 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.14 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -47,13 +47,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.13 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.14 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
37cb19c8c Applying package update to 0.60.0-microsoft.14 ***NO_CI***
7c119ba8f Console.assert doesn't exist in the simulator, so this will always re… (#184)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3570)