### PR TITLE
Move bytecodeFileName setting to ChakraExecutorFactory

### DIFF
--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -495,12 +495,7 @@ void ChakraExecutor::loadApplicationScript(
 #if !defined(OSS_RN)
     uint64_t scriptVersion,
 #endif
-    std::string sourceURL
-#if !defined(OSS_RN)
-    ,
-    std::string &&bytecodeFileName
-#endif
-) {
+    std::string sourceURL) {
   SystraceSection s("ChakraExecutor::loadApplicationScript", "sourceURL", sourceURL);
 
   JSContextHolder ctx(m_context);
@@ -515,14 +510,15 @@ void ChakraExecutor::loadApplicationScript(
   // when debugging is enabled, don't use bytecode caching because ChakraCore
   // doesn't support it.
 #if !defined(OSS_RN)
-  if (bytecodeFileName.empty() || m_instanceArgs.EnableDebugging)
+  if (m_instanceArgs.BytecodeFileName.empty() || m_instanceArgs.EnableDebugging)
 #endif
   {
     evaluateScript(std::move(script), jsSourceURL);
   }
 #if !defined(OSS_RN)
   else {
-    evaluateScriptWithBytecode(std::move(script), scriptVersion, jsSourceURL, std::move(bytecodeFileName));
+    evaluateScriptWithBytecode(
+        std::move(script), scriptVersion, jsSourceURL, std::string(m_instanceArgs.BytecodeFileName));
   }
 #endif
 

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -72,12 +72,7 @@ class ChakraExecutor : public JSExecutor {
 #if !defined(OSS_RN)
       uint64_t scriptVersion,
 #endif
-      std::string sourceURL
-#if !defined(OSS_RN)
-      ,
-      std::string &&bytecodeFileName
-#endif
-      ) override;
+      std::string sourceURL) override;
 
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
 

--- a/vnext/Chakra/ChakraHelpers.cpp
+++ b/vnext/Chakra/ChakraHelpers.cpp
@@ -122,7 +122,7 @@ class ChakraVersionInfo {
 
 class BytecodePrefix {
  public:
-  static std::pair<bool, BytecodePrefix> getBytecodePrefix(JsValueRef scriptFileName, uint64_t bundleVersion) noexcept {
+  static std::pair<bool, BytecodePrefix> getBytecodePrefix(uint64_t bundleVersion) noexcept {
     std::pair<bool, BytecodePrefix> result{false, BytecodePrefix{bundleVersion}};
     result.first = result.second.m_chakraVersionInfo.initialize();
     return result;
@@ -418,7 +418,7 @@ JsValueRef evaluateScriptWithBytecode(
   // code right now.
   return evaluateScript(std::move(script), scriptFileName);
 #else
-  auto bytecodePrefixOptional = BytecodePrefix::getBytecodePrefix(scriptFileName, scriptVersion);
+  auto bytecodePrefixOptional = BytecodePrefix::getBytecodePrefix(scriptVersion);
   if (!bytecodePrefixOptional.first) {
     return evaluateScript(std::move(script), scriptFileName);
   }

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -70,6 +70,11 @@ struct ChakraInstanceArgs {
    * @brief Dispatcher for notifications about JS engine memory consumption.
    */
   std::shared_ptr<MemoryTracker> MemoryTracker;
+
+  /**
+   * @brief Where to cache and load bytecode
+   */
+  std::string BytecodeFileName;
 };
 
 } // namespace react

--- a/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
@@ -71,12 +71,7 @@ TEST_METHOD(LoadApplicationScriptSucceeds) {
 #if !defined(OSS_RN)
       0,
 #endif
-      ""
-#if !defined(OSS_RN)
-      ,
-      ""
-#endif
-  );
+      "");
 
   jsQueue->quitSynchronous();
 
@@ -102,12 +97,7 @@ TEST_METHOD(LoadApplicationScriptHandles404) {
 #if !defined(OSS_RN)
       0,
 #endif
-      ""
-#if !defined(OSS_RN)
-      ,
-      ""
-#endif
-  );
+      "");
 
   jsThread->quitSynchronous();
 
@@ -133,12 +123,7 @@ TEST_METHOD(LoadApplicationScriptHandlesNonExistingBundle) {
 #if !defined(OSS_RN)
       0,
 #endif
-      ""
-#if !defined(OSS_RN)
-      ,
-      ""
-#endif
-  );
+      "");
 
   jsThread->quitSynchronous();
 

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -41,12 +41,7 @@ void WebSocketJSExecutor::loadApplicationScript(
 #if !defined(OSS_RN)
     uint64_t /*scriptVersion*/,
 #endif
-    string /*sourceURL*/
-#if !defined(OSS_RN)
-    ,
-    string && /*bytecodeFileName*/
-#endif
-) {
+    string /*sourceURL*/) {
   int requestId = ++m_requestId;
   promise<string> requestPromise;
   {

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.h
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.h
@@ -35,12 +35,7 @@ class WebSocketJSExecutor : public JSExecutor {
 #if !defined(OSS_RN)
       uint64_t scriptVersion,
 #endif
-      std::string sourceURL
-#if !defined(OSS_RN)
-      ,
-      std::string &&bytecodeFileName
-#endif
-      ) override;
+      std::string sourceURL) override;
   void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments) override;

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
@@ -84,8 +84,7 @@ SandboxJSExecutor::~SandboxJSExecutor() {}
 void SandboxJSExecutor::loadApplicationScript(
     std::unique_ptr<const JSBigString> script,
     uint64_t /*scriptVersion*/,
-    std::string sourceURL,
-    std::string && /*bytecodeFileName*/) {
+    std::string sourceURL) {
   auto requestId = GetNextRequestId();
   task_completion_event<void> callback;
   m_callbacks.emplace(requestId, callback);

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.h
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.h
@@ -73,8 +73,7 @@ class SandboxJSExecutor : public JSExecutor {
   virtual void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
       uint64_t scriptVersion,
-      std::string sourceURL,
-      std::string &&bytecodeFileName) override;
+      std::string sourceURL) override;
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   virtual void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments)


### PR DESCRIPTION
We currently determine bytecodeFileName when creating InstanceImpl, determined by the passed in DevSettings. This change makes it so that we pass the bytecodeFilename as an InstanceArg to the ChakraExecutorFactory instead of passing it through public JSInstance and JSExecutor APIs.

This change is dependent on https://github.com/microsoft/react-native/pull/183

Haven't tested this end-to-end yet (having issues doing it locally). Will get that sorted out before merging either PR, since we cannot rely on CI until we check in the RN change.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3571)