### PR TITLE
Call native animation callbacks only once

### DIFF
--- a/change/react-native-windows-2019-10-31-23-56-14-user-asklar-callbacks.json
+++ b/change/react-native-windows-2019-10-31-23-56-14-user-asklar-callbacks.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Call native animation callbacks only once",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "commit": "141e2654c5b5ed958591c4933a82d85213b56e40",
+  "date": "2019-11-01T06:56:14.460Z"
+}

--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
@@ -57,7 +57,6 @@ class AnimationDriver {
 
   int64_t m_id{0};
   int64_t m_animatedValueTag{};
-  Callback m_endCallback{};
   int64_t m_iterations{0};
   folly::dynamic m_config{};
   std::weak_ptr<NativeAnimatedNodeManager> m_manager{};
@@ -67,6 +66,13 @@ class AnimationDriver {
   // auto revoker for scopedBatch.Completed is broken, tracked by internal bug
   // #22399779
   winrt::event_token m_scopedBatchCompletedToken{};
+
+ private:
+  Callback m_endCallback{};
+  void DoCallback(bool value);
+#ifdef DEBUG
+  int m_debug_callbackAttempts{0};
+#endif // DEBUG
 };
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/ReactUWP/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -396,7 +396,7 @@ TrackingAnimatedNode *NativeAnimatedNodeManager::GetTrackingAnimatedNode(int64_t
   return nullptr;
 }
 
-void NativeAnimatedNodeManager::RevmoveActiveAnimation(int64_t tag) {
+void NativeAnimatedNodeManager::RemoveActiveAnimation(int64_t tag) {
   m_activeAnimations.erase(tag);
 }
 } // namespace uwp

--- a/vnext/ReactUWP/Modules/Animated/NativeAnimatedNodeManager.h
+++ b/vnext/ReactUWP/Modules/Animated/NativeAnimatedNodeManager.h
@@ -88,7 +88,7 @@ class NativeAnimatedNodeManager {
   StyleAnimatedNode *GetStyleAnimatedNode(int64_t tag);
   TransformAnimatedNode *GetTransformAnimatedNode(int64_t tag);
   TrackingAnimatedNode *GetTrackingAnimatedNode(int64_t tag);
-  void RevmoveActiveAnimation(int64_t tag);
+  void RemoveActiveAnimation(int64_t tag);
 
  private:
   std::unordered_map<int64_t, std::unique_ptr<ValueAnimatedNode>> m_valueNodes{};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9863,10 +9863,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz":
-  version "0.60.0-microsoft.13"
-  uid ed08bc48f6601a1ca854016767567fd30f9a6b2e
-  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.13.tar.gz#ed08bc48f6601a1ca854016767567fd30f9a6b2e"
+"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz":
+  version "0.60.0-microsoft.14"
+  uid fa964a148d696ef3913f414224695b9e34abf363
+  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz#fa964a148d696ef3913f414224695b9e34abf363"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
After enabling native animations, Outlook is running into cases where a "finished animation" callback is called more than once. Looking at the code it's pretty clear this is because when stopping an animation, we call it with completed=false, and then try to mark the animation as completed but that function call tries to call the callback again with completed=true this time.

Fixes #2981 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3574)