### PR TITLE
Update to react-native@0.60.0-microsoft.15

### DIFF
--- a/change/react-native-windows-2019-11-01-22-33-42-auto-update-versions060.0microsoft.15.json
+++ b/change/react-native-windows-2019-11-01-22-33-42-auto-update-versions060.0microsoft.15.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.15",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "4988e4a8effa4b9d760410f6bead68e9f3f7555a",
+  "date": "2019-11-01T22:33:41.995Z"
+}

--- a/change/react-native-windows-extended-2019-11-01-22-33-43-auto-update-versions060.0microsoft.15.json
+++ b/change/react-native-windows-extended-2019-11-01-22-33-43-auto-update-versions060.0microsoft.15.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.15",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "87802f691c664b1170a782120562999c1c32932a",
+  "date": "2019-11-01T22:33:43.529Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
     "react-native-windows": "0.60.0-vnext.60",
     "react-native-windows-extended": "0.60.14",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
     "react-native-windows": "0.60.0-vnext.60",
     "react-native-windows-extended": "0.60.14",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
     "react-native-windows": "0.60.0-vnext.60",
     "react-native-windows-extended": "0.60.14",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.14 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -47,13 +47,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.14 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
3c4fb8565 Applying package update to 0.60.0-microsoft.15 ***NO_CI***
bce68a390 Remove RuntimeHolder and ScriptStore. (#185)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3578)