### PR TITLE
Move bytecodeFilename and scriptVersion Determination to the Executor

### DIFF
--- a/change/react-native-windows-2019-11-06-04-25-44-auto-update-versions060.0microsoft.16.json
+++ b/change/react-native-windows-2019-11-06-04-25-44-auto-update-versions060.0microsoft.16.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.16",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "706fd405d978414e4c31ea3886412b2c74ecb526",
+  "date": "2019-11-06T04:25:44.276Z"
+}

--- a/change/react-native-windows-extended-2019-11-06-04-25-46-auto-update-versions060.0microsoft.16.json
+++ b/change/react-native-windows-extended-2019-11-06-04-25-46-auto-update-versions060.0microsoft.16.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.16",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "d897496ecec7dd785e26d0bba8d0685cd54045f5",
+  "date": "2019-11-06T04:25:46.013Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react-native-windows": "0.60.0-vnext.63",
     "react-native-windows-extended": "0.60.15",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react-native-windows": "0.60.0-vnext.63",
     "react-native-windows-extended": "0.60.15",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react-native-windows": "0.60.0-vnext.63",
     "react-native-windows-extended": "0.60.15",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -495,12 +495,7 @@ void ChakraExecutor::loadApplicationScript(
 #if !defined(OSS_RN)
     uint64_t scriptVersion,
 #endif
-    std::string sourceURL
-#if !defined(OSS_RN)
-    ,
-    std::string &&bytecodeFileName
-#endif
-) {
+    std::string sourceURL) {
   SystraceSection s("ChakraExecutor::loadApplicationScript", "sourceURL", sourceURL);
 
   JSContextHolder ctx(m_context);
@@ -515,14 +510,15 @@ void ChakraExecutor::loadApplicationScript(
   // when debugging is enabled, don't use bytecode caching because ChakraCore
   // doesn't support it.
 #if !defined(OSS_RN)
-  if (bytecodeFileName.empty() || m_instanceArgs.EnableDebugging)
+  if (m_instanceArgs.BytecodeFileName.empty() || m_instanceArgs.EnableDebugging)
 #endif
   {
     evaluateScript(std::move(script), jsSourceURL);
   }
 #if !defined(OSS_RN)
   else {
-    evaluateScriptWithBytecode(std::move(script), scriptVersion, jsSourceURL, std::move(bytecodeFileName));
+    evaluateScriptWithBytecode(
+        std::move(script), scriptVersion, jsSourceURL, std::string(m_instanceArgs.BytecodeFileName));
   }
 #endif
 

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -72,12 +72,7 @@ class ChakraExecutor : public JSExecutor {
 #if !defined(OSS_RN)
       uint64_t scriptVersion,
 #endif
-      std::string sourceURL
-#if !defined(OSS_RN)
-      ,
-      std::string &&bytecodeFileName
-#endif
-      ) override;
+      std::string sourceURL) override;
 
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
 

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -69,9 +69,6 @@ class ChakraExecutor : public JSExecutor {
 
   virtual void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
-#if !defined(OSS_RN)
-      uint64_t scriptVersion,
-#endif
       std::string sourceURL) override;
 
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -67,9 +67,7 @@ class ChakraExecutor : public JSExecutor {
       ChakraInstanceArgs &&instanceArgs);
   ~ChakraExecutor() override;
 
-  virtual void loadApplicationScript(
-      std::unique_ptr<const JSBigString> script,
-      std::string sourceURL) override;
+  virtual void loadApplicationScript(std::unique_ptr<const JSBigString> script, std::string sourceURL) override;
 
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
 

--- a/vnext/Chakra/ChakraHelpers.cpp
+++ b/vnext/Chakra/ChakraHelpers.cpp
@@ -122,7 +122,7 @@ class ChakraVersionInfo {
 
 class BytecodePrefix {
  public:
-  static std::pair<bool, BytecodePrefix> getBytecodePrefix(JsValueRef scriptFileName, uint64_t bundleVersion) noexcept {
+  static std::pair<bool, BytecodePrefix> getBytecodePrefix(uint64_t bundleVersion) noexcept {
     std::pair<bool, BytecodePrefix> result{false, BytecodePrefix{bundleVersion}};
     result.first = result.second.m_chakraVersionInfo.initialize();
     return result;
@@ -418,7 +418,7 @@ JsValueRef evaluateScriptWithBytecode(
   // code right now.
   return evaluateScript(std::move(script), scriptFileName);
 #else
-  auto bytecodePrefixOptional = BytecodePrefix::getBytecodePrefix(scriptFileName, scriptVersion);
+  auto bytecodePrefixOptional = BytecodePrefix::getBytecodePrefix(scriptVersion);
   if (!bytecodePrefixOptional.first) {
     return evaluateScript(std::move(script), scriptFileName);
   }

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -70,6 +70,11 @@ struct ChakraInstanceArgs {
    * @brief Dispatcher for notifications about JS engine memory consumption.
    */
   std::shared_ptr<MemoryTracker> MemoryTracker;
+
+  /**
+   * @brief Where to cache and load bytecode
+   */
+  std::string BytecodeFileName;
 };
 
 } // namespace react

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -71,9 +71,10 @@ struct ChakraInstanceArgs {
   std::shared_ptr<MemoryTracker> MemoryTracker;
 
   /**
-   * @brief Determines the mapping between script url and cached bytecode files
+   * @brief Maps script URL to metadata needed for bytecode caching. Should be
+   * removed once we're on the JSI stack and using PreparedScriptStore.
    */
-  std::shared_ptr<ScriptBytecodeResolver> BytecodeResolver;
+  std::shared_ptr<ScriptUrlMetadataMap> ScriptMetadata;
 };
 
 } // namespace react

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -9,8 +9,7 @@
 #include <ChakraCore.h>
 #endif
 
-#include <Logging.h>
-#include <MemoryTracker.h>
+#include "DevSettings.h"
 
 namespace facebook {
 namespace react {
@@ -72,9 +71,9 @@ struct ChakraInstanceArgs {
   std::shared_ptr<MemoryTracker> MemoryTracker;
 
   /**
-   * @brief Where to cache and load bytecode
+   * @brief Determines the mapping between script url and cached bytecode files
    */
-  std::string BytecodeFileName;
+  std::shared_ptr<ScriptBytecodeResolver> BytecodeResolver;
 };
 
 } // namespace react

--- a/vnext/Chakra/ChakraInstanceArgs.h
+++ b/vnext/Chakra/ChakraInstanceArgs.h
@@ -71,10 +71,10 @@ struct ChakraInstanceArgs {
   std::shared_ptr<MemoryTracker> MemoryTracker;
 
   /**
-   * @brief Maps script URL to metadata needed for bytecode caching. Should be
-   * removed once we're on the JSI stack and using PreparedScriptStore.
+   * @brief Maps bundle URL to metadata needed for bytecode caching. Should be
+   * removed once we're on the JSI stack and using PreparedScriptStore (#3603).
    */
-  std::shared_ptr<ScriptUrlMetadataMap> ScriptMetadata;
+  ChakraBundleUrlMetadataMap BundleUrlMetadataMap;
 };
 
 } // namespace react

--- a/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
@@ -68,9 +68,6 @@ TEST_METHOD(LoadApplicationScriptSucceeds) {
       new JSBigStdString("http://localhost:8081/IntegrationTests/IntegrationTestsAppWin.bundle?platform=ios&dev=true"));
   jse->loadApplicationScript(
       std::move(bigString),
-#if !defined(OSS_RN)
-      0,
-#endif
       "");
 
   jsQueue->quitSynchronous();
@@ -94,9 +91,6 @@ TEST_METHOD(LoadApplicationScriptHandles404) {
   auto bigString = unique_ptr<JSBigString>(new JSBigStdString("http://localhost:8081/showme404"));
   jse->loadApplicationScript(
       std::move(bigString),
-#if !defined(OSS_RN)
-      0,
-#endif
       "");
 
   jsThread->quitSynchronous();
@@ -120,9 +114,6 @@ TEST_METHOD(LoadApplicationScriptHandlesNonExistingBundle) {
   auto bigString = unique_ptr<JSBigString>(new JSBigStdString("http://localhost:8081/nonexisting.bundle"));
   jse->loadApplicationScript(
       std::move(bigString),
-#if !defined(OSS_RN)
-      0,
-#endif
       "");
 
   jsThread->quitSynchronous();

--- a/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
@@ -71,12 +71,7 @@ TEST_METHOD(LoadApplicationScriptSucceeds) {
 #if !defined(OSS_RN)
       0,
 #endif
-      ""
-#if !defined(OSS_RN)
-      ,
-      ""
-#endif
-  );
+      "");
 
   jsQueue->quitSynchronous();
 
@@ -102,12 +97,7 @@ TEST_METHOD(LoadApplicationScriptHandles404) {
 #if !defined(OSS_RN)
       0,
 #endif
-      ""
-#if !defined(OSS_RN)
-      ,
-      ""
-#endif
-  );
+      "");
 
   jsThread->quitSynchronous();
 
@@ -133,12 +123,7 @@ TEST_METHOD(LoadApplicationScriptHandlesNonExistingBundle) {
 #if !defined(OSS_RN)
       0,
 #endif
-      ""
-#if !defined(OSS_RN)
-      ,
-      ""
-#endif
-  );
+      "");
 
   jsThread->quitSynchronous();
 

--- a/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
@@ -66,9 +66,7 @@ TEST_METHOD(LoadApplicationScriptSucceeds) {
   // service.
   auto bigString = unique_ptr<JSBigString>(
       new JSBigStdString("http://localhost:8081/IntegrationTests/IntegrationTestsAppWin.bundle?platform=ios&dev=true"));
-  jse->loadApplicationScript(
-      std::move(bigString),
-      "");
+  jse->loadApplicationScript(std::move(bigString), "");
 
   jsQueue->quitSynchronous();
 
@@ -89,9 +87,7 @@ TEST_METHOD(LoadApplicationScriptHandles404) {
   bool connected = jse->ConnectAsync("ws://localhost:8081/debugger-proxy?role=client", move(errorCallback)).get();
   // Point to a non-existing path.
   auto bigString = unique_ptr<JSBigString>(new JSBigStdString("http://localhost:8081/showme404"));
-  jse->loadApplicationScript(
-      std::move(bigString),
-      "");
+  jse->loadApplicationScript(std::move(bigString), "");
 
   jsThread->quitSynchronous();
 
@@ -112,9 +108,7 @@ TEST_METHOD(LoadApplicationScriptHandlesNonExistingBundle) {
   bool connected = jse->ConnectAsync("ws://localhost:8081/debugger-proxy?role=client", move(errorCallback)).get();
   // Point to a non-existing bundle.
   auto bigString = unique_ptr<JSBigString>(new JSBigStdString("http://localhost:8081/nonexisting.bundle"));
-  jse->loadApplicationScript(
-      std::move(bigString),
-      "");
+  jse->loadApplicationScript(std::move(bigString), "");
 
   jsThread->quitSynchronous();
 

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -36,9 +36,7 @@ WebSocketJSExecutor::~WebSocketJSExecutor() {}
 
 #pragma region JSExecutor members
 
-void WebSocketJSExecutor::loadApplicationScript(
-    unique_ptr<const JSBigString> script,
-    string /*sourceURL*/) {
+void WebSocketJSExecutor::loadApplicationScript(unique_ptr<const JSBigString> script, string /*sourceURL*/) {
   int requestId = ++m_requestId;
   promise<string> requestPromise;
   {

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -38,9 +38,6 @@ WebSocketJSExecutor::~WebSocketJSExecutor() {}
 
 void WebSocketJSExecutor::loadApplicationScript(
     unique_ptr<const JSBigString> script,
-#if !defined(OSS_RN)
-    uint64_t /*scriptVersion*/,
-#endif
     string /*sourceURL*/) {
   int requestId = ++m_requestId;
   promise<string> requestPromise;

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -41,12 +41,7 @@ void WebSocketJSExecutor::loadApplicationScript(
 #if !defined(OSS_RN)
     uint64_t /*scriptVersion*/,
 #endif
-    string /*sourceURL*/
-#if !defined(OSS_RN)
-    ,
-    string && /*bytecodeFileName*/
-#endif
-) {
+    string /*sourceURL*/) {
   int requestId = ++m_requestId;
   promise<string> requestPromise;
   {

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.h
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.h
@@ -30,9 +30,7 @@ class WebSocketJSExecutor : public JSExecutor {
 
 #pragma region JSExecutor members
 
-  void loadApplicationScript(
-      std::unique_ptr<const JSBigString> script,
-      std::string sourceURL) override;
+  void loadApplicationScript(std::unique_ptr<const JSBigString> script, std::string sourceURL) override;
   void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments) override;

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.h
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.h
@@ -32,9 +32,6 @@ class WebSocketJSExecutor : public JSExecutor {
 
   void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
-#if !defined(OSS_RN)
-      uint64_t scriptVersion,
-#endif
       std::string sourceURL) override;
   void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.h
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.h
@@ -35,12 +35,7 @@ class WebSocketJSExecutor : public JSExecutor {
 #if !defined(OSS_RN)
       uint64_t scriptVersion,
 #endif
-      std::string sourceURL
-#if !defined(OSS_RN)
-      ,
-      std::string &&bytecodeFileName
-#endif
-      ) override;
+      std::string sourceURL) override;
   void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments) override;

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
@@ -83,7 +83,6 @@ SandboxJSExecutor::~SandboxJSExecutor() {}
 
 void SandboxJSExecutor::loadApplicationScript(
     std::unique_ptr<const JSBigString> script,
-    uint64_t /*scriptVersion*/,
     std::string sourceURL) {
   auto requestId = GetNextRequestId();
   task_completion_event<void> callback;

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
@@ -84,8 +84,7 @@ SandboxJSExecutor::~SandboxJSExecutor() {}
 void SandboxJSExecutor::loadApplicationScript(
     std::unique_ptr<const JSBigString> script,
     uint64_t /*scriptVersion*/,
-    std::string sourceURL,
-    std::string && /*bytecodeFileName*/) {
+    std::string sourceURL) {
   auto requestId = GetNextRequestId();
   task_completion_event<void> callback;
   m_callbacks.emplace(requestId, callback);

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.cpp
@@ -81,9 +81,7 @@ SandboxJSExecutor::SandboxJSExecutor(
 
 SandboxJSExecutor::~SandboxJSExecutor() {}
 
-void SandboxJSExecutor::loadApplicationScript(
-    std::unique_ptr<const JSBigString> script,
-    std::string sourceURL) {
+void SandboxJSExecutor::loadApplicationScript(std::unique_ptr<const JSBigString> script, std::string sourceURL) {
   auto requestId = GetNextRequestId();
   task_completion_event<void> callback;
   m_callbacks.emplace(requestId, callback);

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.h
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.h
@@ -70,9 +70,7 @@ class SandboxJSExecutor : public JSExecutor {
   SandboxJSExecutor(std::shared_ptr<ExecutorDelegate> delegate, std::shared_ptr<MessageQueueThread> messageQueueThread);
   ~SandboxJSExecutor() override;
 
-  virtual void loadApplicationScript(
-      std::unique_ptr<const JSBigString> script,
-      std::string sourceURL) override;
+  virtual void loadApplicationScript(std::unique_ptr<const JSBigString> script, std::string sourceURL) override;
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   virtual void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments)

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.h
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.h
@@ -72,7 +72,6 @@ class SandboxJSExecutor : public JSExecutor {
 
   virtual void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
-      uint64_t scriptVersion,
       std::string sourceURL) override;
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;

--- a/vnext/Desktop/Sandbox/SandboxJSExecutor.h
+++ b/vnext/Desktop/Sandbox/SandboxJSExecutor.h
@@ -73,8 +73,7 @@ class SandboxJSExecutor : public JSExecutor {
   virtual void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
       uint64_t scriptVersion,
-      std::string sourceURL,
-      std::string &&bytecodeFileName) override;
+      std::string sourceURL) override;
   virtual void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   virtual void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments)

--- a/vnext/ReactUWP/Executors/WebSocketJSExecutorUwp.cpp
+++ b/vnext/ReactUWP/Executors/WebSocketJSExecutorUwp.cpp
@@ -66,15 +66,7 @@ WebSocketJSExecutor::~WebSocketJSExecutor() {
 
 void WebSocketJSExecutor::loadApplicationScript(
     std::unique_ptr<const facebook::react::JSBigString> script,
-#if !defined(OSS_RN)
-    uint64_t /*scriptVersion*/,
-#endif
-    std::string sourceURL
-#if !defined(OSS_RN)
-    ,
-    std::string && /*bytecodeFileName*/
-#endif
-) {
+    std::string sourceURL) {
   int requestId = ++m_requestId;
 
   if (!IsRunning()) {

--- a/vnext/ReactUWP/Executors/WebSocketJSExecutorUwp.h
+++ b/vnext/ReactUWP/Executors/WebSocketJSExecutorUwp.h
@@ -37,17 +37,8 @@ class WebSocketJSExecutor : public facebook::react::JSExecutor {
       std::shared_ptr<facebook::react::MessageQueueThread> messageQueueThread);
   ~WebSocketJSExecutor() override;
 
-  virtual void loadApplicationScript(
-      std::unique_ptr<const facebook::react::JSBigString> script,
-#if !defined(OSS_RN)
-      uint64_t scriptVersion,
-#endif
-      std::string sourceURL
-#if !defined(OSS_RN)
-      ,
-      std::string &&bytecodeFileName
-#endif
-      ) override;
+  virtual void loadApplicationScript(std::unique_ptr<const facebook::react::JSBigString> script, std::string sourceURL)
+      override;
   virtual void setBundleRegistry(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry) override;
   virtual void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
   virtual void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments)

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -45,10 +45,16 @@ enum class JSIEngineOverride : int32_t {
   Last = V8Lite
 };
 
+/// Determines the bytecode file to try to use for a given script url The file
+/// is not guaranteed to exist.
+struct ScriptBytecodeResolver {
+  virtual std::string BytecodeFileNameFromScriptUrl(const std::string &scriptUrl) = 0;
+};
+
 struct DevSettings {
   bool useSandbox{false};
   bool useJITCompilation{true};
-  std::string bytecodeFileName;
+  std::shared_ptr<ScriptBytecodeResolver> bytecodeResolver;
   std::string sandboxPipeName;
   std::string debugHost;
   std::string debugBundlePath;
@@ -102,6 +108,7 @@ struct DevSettings {
   // Until the ABI story is addressed we'll use this instead of the above for
   // the purposes of selecting a JSI Runtime to use.
   JSIEngineOverride jsiEngineOverride{JSIEngineOverride::Default};
+
 };
 
 } // namespace react

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -46,12 +46,12 @@ enum class JSIEngineOverride : int32_t {
   Last = V8Lite
 };
 
-struct ScriptMetadata {
-  uint64_t scriptVersion;
+struct ChakraBundleMetadata {
+  uint64_t version;
   std::string bytecodeFilename;
 };
 
-using ScriptUrlMetadataMap = std::map<std::string, ScriptMetadata>;
+using ChakraBundleUrlMetadataMap = std::map<std::string, ChakraBundleMetadata>;
 
 struct DevSettings {
   bool useSandbox{false};
@@ -110,10 +110,10 @@ struct DevSettings {
   // the purposes of selecting a JSI Runtime to use.
   JSIEngineOverride jsiEngineOverride{JSIEngineOverride::Default};
 
-  /// Used to allow ChakraExecutor to query the instance creator for
-  /// bytecode/versioning information from scriptURL. Superseded by
-  /// PreparedScriptStore on the JSI stack, and will be removed soon.
-  std::shared_ptr<ScriptUrlMetadataMap> chakraScriptMetadata;
+  /// Optionally used by ChakraExecutor to allow bundle bytecode caching.
+  /// Superseded by PreparedScriptStore on the JSI stack, and will be removed
+  /// soon. (See #3603)
+  ChakraBundleUrlMetadataMap chakraBundleUrlMetadataMap;
 };
 
 } // namespace react

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -6,6 +6,7 @@
 #include "MemoryTracker.h"
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -45,16 +46,16 @@ enum class JSIEngineOverride : int32_t {
   Last = V8Lite
 };
 
-/// Determines the bytecode file to try to use for a given script url The file
-/// is not guaranteed to exist.
-struct ScriptBytecodeResolver {
-  virtual std::string BytecodeFileNameFromScriptUrl(const std::string &scriptUrl) = 0;
+struct ScriptMetadata {
+  uint64_t scriptVersion;
+  std::string bytecodeFilename;
 };
+
+using ScriptUrlMetadataMap = std::map<std::string, ScriptMetadata>;
 
 struct DevSettings {
   bool useSandbox{false};
   bool useJITCompilation{true};
-  std::shared_ptr<ScriptBytecodeResolver> bytecodeResolver;
   std::string sandboxPipeName;
   std::string debugHost;
   std::string debugBundlePath;
@@ -109,6 +110,10 @@ struct DevSettings {
   // the purposes of selecting a JSI Runtime to use.
   JSIEngineOverride jsiEngineOverride{JSIEngineOverride::Default};
 
+  /// Used to allow ChakraExecutor to query the instance creator for
+  /// bytecode/versioning information from scriptURL. Superseded by
+  /// PreparedScriptStore on the JSI stack, and will be removed soon.
+  std::shared_ptr<ScriptUrlMetadataMap> chakraScriptMetadata;
 };
 
 } // namespace react

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -146,33 +146,6 @@ std::string GetJSBundleFilePath(const std::string &jsBundleBasePath, const std::
 
   return jsBundleFilePath;
 }
-
-bool GetLastWriteTime(const std::string &fileName, uint64_t &result) noexcept {
-  std::wstring fileNameUtf16 = Microsoft::Common::Unicode::Utf8ToUtf16(fileName);
-
-  std::unique_ptr<void, decltype(&CloseHandle)> handle{CreateFileW(
-                                                           static_cast<LPCWSTR>(fileNameUtf16.c_str()),
-                                                           GENERIC_READ,
-                                                           FILE_SHARE_READ,
-                                                           nullptr /* lpSecurityAttributes */,
-                                                           OPEN_EXISTING,
-                                                           FILE_ATTRIBUTE_NORMAL,
-                                                           nullptr /* hTemplateFile */),
-                                                       &CloseHandle};
-
-  if (handle.get() == INVALID_HANDLE_VALUE) {
-    return false;
-  }
-
-  FILETIME lastWriteTime;
-  if (!GetFileTime(handle.get(), nullptr, nullptr, &lastWriteTime)) {
-    return false;
-  }
-
-  result =
-      static_cast<uint64_t>(lastWriteTime.dwHighDateTime) << 32 | static_cast<uint64_t>(lastWriteTime.dwLowDateTime);
-  return true;
-}
 #endif
 
 } // namespace

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -553,9 +553,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
           /*hot*/ "false");
 
       m_innerInstance->loadScriptFromString(
-          std::make_unique<const JSBigStdString>(bundleUrl),
-          bundleUrl,
-          synchronously);
+          std::make_unique<const JSBigStdString>(bundleUrl), bundleUrl, synchronously);
     } catch (std::exception &e) {
       m_devSettings->errorCallback(e.what());
       return;
@@ -568,9 +566,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       m_devSettings->errorCallback(jsBundleString);
     } else {
       m_innerInstance->loadScriptFromString(
-          std::make_unique<const JSBigStdString>(jsBundleString),
-          jsBundleRelativePath,
-          synchronously);
+          std::make_unique<const JSBigStdString>(jsBundleString), jsBundleRelativePath, synchronously);
     }
   } else {
     try {
@@ -586,10 +582,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 #else
         auto bundleString = JSBigFileString::fromPath(fullBundleFilePath);
 #endif
-        m_innerInstance->loadScriptFromString(
-            std::move(bundleString),
-            std::move(fullBundleFilePath),
-            synchronously);
+        m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(fullBundleFilePath), synchronously);
       }
 
 #else
@@ -683,9 +676,7 @@ InstanceImpl::InstanceImpl(
 
   try {
     m_innerInstance->loadScriptFromString(
-        std::make_unique<const JSBigStdString>(std::move(fullBundleFilePath)),
-        sourceUrl,
-        false /*synchronously*/);
+        std::make_unique<const JSBigStdString>(std::move(fullBundleFilePath)), sourceUrl, false /*synchronously*/);
   } catch (std::exception &e) {
     m_devSettings->errorCallback(e.what());
   }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -469,9 +469,9 @@ InstanceImpl::InstanceImpl(
       instanceArgs.DebuggerConsoleRedirection = m_devSettings->debuggerConsoleRedirection;
 
       // Disable bytecode caching with live reload as we don't make guarantees
-      // that the the bundle version will change with edits
+      // that the bundle version will change with edits
       if (m_devSettings->liveReloadCallback == nullptr) {
-        instanceArgs.ScriptMetadata = m_devSettings->chakraScriptMetadata;
+        instanceArgs.BundleUrlMetadataMap = m_devSettings->chakraBundleUrlMetadataMap;
       }
 
       if (!m_devSettings->useJITCompilation) {
@@ -662,17 +662,17 @@ InstanceImpl::InstanceImpl(
   // Load ChakraExecutor for sandbox process
   auto edf = std::make_shared<SandboxDelegateFactory>(std::move(sendNativeModuleCall));
 
-  ChakraInstanceArgs instanceArgs;
-  instanceArgs.RuntimeAttributes =
+  ChakraInstanceArgs chakraInstanceArgs;
+  chakraInstanceArgs.RuntimeAttributes =
       m_devSettings->useJITCompilation ? JsRuntimeAttributeNone : JsRuntimeAttributeDisableNativeCodeGeneration;
 
   // Disable bytecode caching with live reload as we don't make guarantees that
   // the bundle version will change with edits
   if (m_devSettings->liveReloadCallback == nullptr) {
-    instanceArgs.ScriptMetadata = m_devSettings->chakraScriptMetadata;
+    chakraInstanceArgs.BundleUrlMetadataMap = m_devSettings->chakraBundleUrlMetadataMap;
   }
 
-  auto jsef = std::make_shared<ChakraExecutorFactory>(std::move(instanceArgs));
+  auto jsef = std::make_shared<ChakraExecutorFactory>(std::move(chakraInstanceArgs));
   m_innerInstance->initializeBridge(
       std::make_unique<BridgeTestInstanceCallback>(), edf, jsef, m_jsThread, m_moduleRegistry);
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -498,7 +498,7 @@ InstanceImpl::InstanceImpl(
       // Disable bytecode caching with live reload as we don't make guarantees
       // that the the bundle version will change with edits
       if (devSettings->liveReloadCallback == nullptr) {
-        instanceArgs.BytecodeFileName = m_devSettings->bytecodeFileName;
+        instanceArgs.BytecodeResolver = m_devSettings->bytecodeResolver;
       }
 
       if (!m_devSettings->useJITCompilation) {
@@ -712,7 +712,7 @@ InstanceImpl::InstanceImpl(
   // Disable bytecode caching with live reload as we don't make guarantees that
   // the bundle version will change with edits
   if (devSettings->liveReloadCallback == nullptr) {
-    instanceArgs.BytecodeFileName = m_devSettings->bytecodeFileName;
+    instanceArgs.BytecodeResolver = m_devSettings->bytecodeResolver;
   }
 
   auto jsef = std::make_shared<ChakraExecutorFactory>(std::move(instanceArgs));

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -470,7 +470,7 @@ InstanceImpl::InstanceImpl(
 
       // Disable bytecode caching with live reload as we don't make guarantees
       // that the the bundle version will change with edits
-      if (devSettings->liveReloadCallback == nullptr) {
+      if (m_devSettings->liveReloadCallback == nullptr) {
         instanceArgs.ScriptMetadata = m_devSettings->chakraScriptMetadata;
       }
 
@@ -668,7 +668,7 @@ InstanceImpl::InstanceImpl(
 
   // Disable bytecode caching with live reload as we don't make guarantees that
   // the bundle version will change with edits
-  if (devSettings->liveReloadCallback == nullptr) {
+  if (m_devSettings->liveReloadCallback == nullptr) {
     instanceArgs.ScriptMetadata = m_devSettings->chakraScriptMetadata;
   }
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -589,18 +589,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       std::string bundlePath = m_devSettings->bundleRootPath + jsBundleRelativePath + ".bundle";
 
       auto bundleString = std::make_unique<::react::uwp::StorageFileBigString>(bundlePath);
-      m_innerInstance->loadScriptFromString(
-          std::move(bundleString),
-#if !defined(OSS_RN)
-          0 /*bundleVersion*/,
-#endif
-          jsBundleRelativePath,
-          synchronously
-#if !defined(OSS_RN)
-          ,
-          "" /*bytecodeFileName*/
-#endif
-      );
+      m_innerInstance->loadScriptFromString(std::move(bundleString), jsBundleRelativePath, synchronously);
 #endif
 
     } catch (std::exception &e) {

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -47,13 +47,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9863,10 +9863,9 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz":
-  version "0.60.0-microsoft.14"
-  uid fa964a148d696ef3913f414224695b9e34abf363
-  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.14.tar.gz#fa964a148d696ef3913f414224695b9e34abf363"
+"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz":
+  version "0.60.0-microsoft.16"
+  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz#388e9033f6ce8e5863c410e73de9b51a7709274c"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
We're going to move to a new design for bytecode caching/prepared scripts when moving to JSI. In the meantime, we can reuse most of the existing ChakraExecutor bytecode and script versioning logic. Pass this association in as a map to DevSettings instead of piping it through each call.

This is pretty quick and dirty since we plan to jettison the ChakraExecutor stack soon.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3591)