### PR TITLE
Update to react-native@0.60.0-microsoft.16

### DIFF
--- a/change/react-native-windows-2019-11-06-04-25-44-auto-update-versions060.0microsoft.16.json
+++ b/change/react-native-windows-2019-11-06-04-25-44-auto-update-versions060.0microsoft.16.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.16",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "706fd405d978414e4c31ea3886412b2c74ecb526",
+  "date": "2019-11-06T04:25:44.276Z"
+}

--- a/change/react-native-windows-extended-2019-11-06-04-25-46-auto-update-versions060.0microsoft.16.json
+++ b/change/react-native-windows-extended-2019-11-06-04-25-46-auto-update-versions060.0microsoft.16.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.16",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "d897496ecec7dd785e26d0bba8d0685cd54045f5",
+  "date": "2019-11-06T04:25:46.013Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react-native-windows": "0.60.0-vnext.63",
     "react-native-windows-extended": "0.60.15",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react-native-windows": "0.60.0-vnext.63",
     "react-native-windows-extended": "0.60.15",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react-native-windows": "0.60.0-vnext.63",
     "react-native-windows-extended": "0.60.15",
     "rnpm-plugin-windows": "^0.3.7"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -47,13 +47,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.15 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.15.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
925a76d68 Applying package update to 0.60.0-microsoft.16 ***NO_CI***
9bba27f2b Remove bytecodeFileName and scriptVersion/bundleVersion parameters (#187)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3605)