### PR TITLE
Do not eat exceptions in DevSupportManager::GetJavaScriptFromServer

### DIFF
--- a/change/react-native-windows-2019-11-07-15-51-09-master.json
+++ b/change/react-native-windows-2019-11-07-15-51-09-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Do not eat exceptions in DevSupportManager::GetJavaScriptFromServer",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "3a2b9ba1261a52af4bd192a2d1121cd5962c2077",
+  "date": "2019-11-07T23:51:09.763Z"
+}

--- a/vnext/Desktop/DevSupportManager.cpp
+++ b/vnext/Desktop/DevSupportManager.cpp
@@ -56,34 +56,30 @@ string DevSupportManager::GetJavaScriptFromServer(
   auto bundleUrl =
       DevServerHelper::get_BundleUrl(debugHost, jsBundleName, platform /*platform*/, "true" /*dev*/, "false" /*hot*/);
 
-  try {
-    Url url(bundleUrl);
-    auto const resolveResult = m_resolver.resolve(url.host, url.port);
-    tcp::socket socket{m_context};
-    connect(socket, resolveResult);
+  Url url(bundleUrl);
+  auto const resolveResult = m_resolver.resolve(url.host, url.port);
+  tcp::socket socket{m_context};
+  connect(socket, resolveResult);
 
-    request<string_body> request{verb::get, url.Target(), 11};
-    request.set(field::host, url.host);
-    request.set(field::user_agent, BOOST_BEAST_VERSION_STRING);
+  request<string_body> request{verb::get, url.Target(), 11};
+  request.set(field::host, url.host);
+  request.set(field::user_agent, BOOST_BEAST_VERSION_STRING);
 
-    write(socket, request);
+  write(socket, request);
 
-    flat_buffer buffer;
-    response<string_body> response;
+  flat_buffer buffer;
+  response<string_body> response;
 
-    parser<false, string_body> p{std::move(response)};
-    p.body_limit(25 * 1024 * 1024); // 25MB (boost default of 1MB is too small for dev bundles)
+  parser<false, string_body> p{std::move(response)};
+  p.body_limit(25 * 1024 * 1024); // 25MB (boost default of 1MB is too small for dev bundles)
 
-    read(socket, buffer, p.base());
-    response = p.release();
-    std::stringstream jsStringStream;
-    jsStringStream << response.body();
-    // TODO: Check if UTF-8 processing is required.
+  read(socket, buffer, p.base());
+  response = p.release();
+  std::stringstream jsStringStream;
+  jsStringStream << response.body();
+  // TODO: Check if UTF-8 processing is required.
 
-    return jsStringStream.str();
-  } catch (const std::exception &e) {
-    return e.what();
-  }
+  return jsStringStream.str();
 }
 
 void DevSupportManager::StartPollingLiveReload(const string &debugHost, std::function<void()> onChangeCallback) {


### PR DESCRIPTION
This function will currently catch all exceptions and return their message as valid Javascript. This causes havock later. E.g. running RNTester tests without a server will fail, with an Executor being told to load the JS string "Connection refused". We should throw as early as possible instead of propagating the error to a later hard-to-debug point.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3616)