### PR TITLE
Use node10

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -23,6 +23,10 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+          
       - task: PowerShell@2
         displayName: "Remove WebDriverIO Workaround"
         inputs:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -320,6 +320,10 @@ jobs:
     pool:
       vmImage: $(VmImage)
     steps:
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+
       - template: templates/react-native-init.yml
         parameters:
           version: 0.60.6

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -65,6 +65,10 @@ jobs:
         clean: false
         submodules: false
 
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+
       - template: templates/build-rnw.yml
         parameters:
           useRnFork: $(UseRNFork)
@@ -185,6 +189,10 @@ jobs:
       - checkout: self
         clean: false
         submodules: false
+
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
 
       - task: VisualStudioTestPlatformInstaller@1
         inputs:
@@ -395,6 +403,10 @@ jobs:
         lfs: false # whether to download Git-LFS files
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
 
       - task: PowerShell@2
         displayName: Download Winium


### PR DESCRIPTION
A temporary workaround for #3611
currently the official nodejs is 12, but we have problem to work with it.
Force to use nodejs 10 in pipeline.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3627)