### PR TITLE
Skips CI build for gif/png/jpeg (#3427)

### DIFF
--- a/.ado/shouldSkipPRBuild.ps1
+++ b/.ado/shouldSkipPRBuild.ps1
@@ -5,7 +5,7 @@ function AllChangedFilesAreSkippable
 {
     Param($files)
 
-    $skipExts = @(".md")
+    $skipExts = @(".md",".gif",".png",".jpeg")
     $allFilesAreSkippable = $true
 
     foreach($file in $files)


### PR DESCRIPTION
Fixes (#3427 ) 

Whitelists .png/.gif/.jpeg file types for CI build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3632)