### PR TITLE
Workaround for flyout centering problem

### DIFF
--- a/change/react-native-windows-2019-11-11-12-58-16-flyout-centering-workaround.2.json
+++ b/change/react-native-windows-2019-11-11-12-58-16-flyout-centering-workaround.2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Workaround for flyout centering problem",
+  "packageName": "react-native-windows",
+  "email": "kenander@microsoft.com",
+  "commit": "b0defe86c05d88310fb66663be45dd925d3b3207",
+  "date": "2019-11-11T20:58:16.583Z"
+}

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -122,6 +122,11 @@ void FlyoutShadowNode::AddView(ShadowNode &child, int64_t index) {
 
   if (m_flyout != nullptr) {
     m_flyout.Content(childView.as<winrt::UIElement>());
+    if (winrt::FlyoutPlacementMode::Full == m_flyout.Placement()) {
+      if (auto fe = m_flyout.Content().try_as<winrt::FrameworkElement>()) {
+        AdjustDefaultFlyoutStyle((float)fe.Width(), (float)fe.Height());
+      }
+    }
   }
 }
 

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -123,6 +123,12 @@ void FlyoutShadowNode::AddView(ShadowNode &child, int64_t index) {
   if (m_flyout != nullptr) {
     m_flyout.Content(childView.as<winrt::UIElement>());
     if (winrt::FlyoutPlacementMode::Full == m_flyout.Placement()) {
+      // When using FlyoutPlacementMode::Full on a Flyout with an embedded
+      // Picker, the flyout is not centered correctly. Below is a temporary
+      // workaround that resolves the problem for flyouts with fixed size
+      // content by adjusting the flyout presenter max size settings prior to
+      // layout. This will unblock those scenarios while the work on a more
+      // exhaustive fix proceeds.  Tracked by Issue #2969
       if (auto fe = m_flyout.Content().try_as<winrt::FrameworkElement>()) {
         AdjustDefaultFlyoutStyle((float)fe.Width(), (float)fe.Height());
       }


### PR DESCRIPTION
When using FlyoutPlacementMode::Full on a Flyout with an embedded Picker, the flyout is not centered correctly.  This issue is described in https://github.com/microsoft/react-native-windows/issues/2969.

This PR resolves the problem for flyouts with fixed size content by adjusting the flyout presenter max size settings (FlyoutShadowNode::AdjustDefaultFlyoutStyle) to match the content prior to layout (eg prior to the call to FlyoutViewManager::SetLayoutProps). 

This will unblock those scenarios while the work on a more exhaustive fix proceeds.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3640)