### PR TITLE
Update to react-native@0.60.0-microsoft.20

### DIFF
--- a/change/react-native-windows-2019-11-12-01-54-17-auto-update-versions060.0microsoft.20.json
+++ b/change/react-native-windows-2019-11-12-01-54-17-auto-update-versions060.0microsoft.20.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.20",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "1799d42f737fc5fb31978c60a22a8dfd8c390719",
+  "date": "2019-11-12T01:54:17.575Z"
+}

--- a/change/react-native-windows-extended-2019-11-12-01-54-19-auto-update-versions060.0microsoft.20.json
+++ b/change/react-native-windows-extended-2019-11-12-01-54-19-auto-update-versions060.0microsoft.20.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.20",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9adc8fa2bd113420f8551508203492295e26c236",
+  "date": "2019-11-12T01:54:19.150Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz",
     "react-native-windows": "0.60.0-vnext.69",
     "react-native-windows-extended": "0.60.17",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz",
     "react-native-windows": "0.60.0-vnext.69",
     "react-native-windows-extended": "0.60.17",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz",
     "react-native-windows": "0.60.0-vnext.69",
     "react-native-windows-extended": "0.60.17",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.20 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -47,13 +47,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.16 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.16.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.20 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.20.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
c164770cd Applying package update to 0.60.0-microsoft.20 ***NO_CI***
dac509cd7 Add a mac test plan to improve our confidence in fixes going into RN moving forward. Check for safe memory usage and concurrency problems (#190)
c610b2e93 Applying package update to 0.60.0-microsoft.19 ***NO_CI***
b917a64fe Enable mac yml tests (#189)
03e2b9974 Applying package update to 0.60.0-microsoft.18 ***NO_CI***
1694a6fa8 Preparing work for adding JSI and TurboModule to ReactCommon in Microsoft/react-native-windows (#191)
55c5835fe Applying package update to 0.60.0-microsoft.17 ***NO_CI***
ea7767a21 Add memory management and concurrency tests plans to our fork of Reac… (#186)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3645)