### PR TITLE
Fix ViewPanel layout issue when outer border exists

### DIFF
--- a/change/react-native-windows-2019-11-14-09-55-26-sticky.json
+++ b/change/react-native-windows-2019-11-14-09-55-26-sticky.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix layout children position issue when outer border exists",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "b7c19aa75cefb535fe5f9a9f4000995ede1354e8",
+  "date": "2019-11-14T17:55:26.783Z"
+}

--- a/packages/playground/Samples/view.tsx
+++ b/packages/playground/Samples/view.tsx
@@ -17,7 +17,6 @@ export default class Bootstrap extends React.Component<
     alignSelfCenter: boolean;
     largeBorder: boolean;
     largePadding: boolean;
-
   }
 > {
   constructor(props: {}) {
@@ -38,41 +37,41 @@ export default class Bootstrap extends React.Component<
       noBorder: {
         width: 200,
         margin: 20,
-        padding: this.state.largePadding? 15 : 0,
+        padding: this.state.largePadding ? 15 : 0,
         backgroundColor: 'orange',
       },
       innerBorder: {
         width: 200,
         margin: 20,
-        padding: this.state.largePadding? 15 : 0,
+        padding: this.state.largePadding ? 15 : 0,
         backgroundColor: 'lime',
         borderColor: 'navy',
-        borderWidth: this.state.largeBorder? 20 : 1,
+        borderWidth: this.state.largeBorder ? 20 : 1,
       },
       outerBorder: {
         width: 200,
         margin: 20,
-        padding: this.state.largePadding? 15 : 0,
+        padding: this.state.largePadding ? 15 : 0,
         backgroundColor: 'pink',
         borderColor: 'crimson',
-        borderWidth: this.state.largeBorder? 20 : 1,
+        borderWidth: this.state.largeBorder ? 20 : 1,
         borderRadius: 10,
       },
       radial: {
         width: 200,
         margin: 20,
-        padding: this.state.largePadding? 15 : 0,
+        padding: this.state.largePadding ? 15 : 0,
         backgroundColor: 'magenta',
         borderRadius: 10,
-        borderWidth: this.state.largeBorder? 20 : 1,
+        borderWidth: this.state.largeBorder ? 20 : 1,
       },
       child: {
         backgroundColor: 'yellow',
-        alignSelf: this.state.alignSelfCenter? 'center' : 'flex-start',
+        alignSelf: this.state.alignSelfCenter ? 'center' : 'flex-start',
         width: 100,
         height: 50,
-        fontSize:20,
-      }
+        fontSize: 20,
+      },
     });
 
     return (
@@ -127,7 +126,8 @@ export default class Bootstrap extends React.Component<
           <Text>largeBorder</Text>
         </View>
 
-        <View style={{flexDirection: 'row', alignSelf: 'flex-start', width:100}}>
+        <View
+          style={{flexDirection: 'row', alignSelf: 'flex-start', width: 100}}>
           <CheckBox
             onValueChange={value => this.setState({alignSelfCenter: value})}
             value={this.state.alignSelfCenter}
@@ -135,7 +135,8 @@ export default class Bootstrap extends React.Component<
           <Text>alignCenter</Text>
         </View>
 
-        <View style={{flexDirection: 'row', alignSelf: 'flex-start', width:100}}>
+        <View
+          style={{flexDirection: 'row', alignSelf: 'flex-start', width: 100}}>
           <CheckBox
             onValueChange={value => this.setState({largePadding: value})}
             value={this.state.largePadding}

--- a/packages/playground/Samples/view.tsx
+++ b/packages/playground/Samples/view.tsx
@@ -14,8 +14,10 @@ export default class Bootstrap extends React.Component<
     hasStyle: boolean;
     hasBorder: boolean;
     radius: boolean;
-    padding: number;
-    margin: number;
+    alignSelfCenter: boolean;
+    largeBorder: boolean;
+    largePadding: boolean;
+
   }
 > {
   constructor(props: {}) {
@@ -25,39 +27,52 @@ export default class Bootstrap extends React.Component<
       hasStyle: true,
       hasBorder: true,
       radius: true,
-      padding: 0,
-      margin: 0,
+      alignSelfCenter: true,
+      largeBorder: true,
+      largePadding: true,
     };
   }
 
   render() {
     const styles = StyleSheet.create({
       noBorder: {
+        width: 200,
         margin: 20,
-        padding: 15,
+        padding: this.state.largePadding? 15 : 0,
         backgroundColor: 'orange',
       },
       innerBorder: {
+        width: 200,
         margin: 20,
-        padding: 15,
+        padding: this.state.largePadding? 15 : 0,
         backgroundColor: 'lime',
         borderColor: 'navy',
-        borderWidth: 1,
+        borderWidth: this.state.largeBorder? 20 : 1,
       },
       outerBorder: {
+        width: 200,
         margin: 20,
-        padding: 15,
+        padding: this.state.largePadding? 15 : 0,
         backgroundColor: 'pink',
         borderColor: 'crimson',
-        borderWidth: 1,
+        borderWidth: this.state.largeBorder? 20 : 1,
         borderRadius: 10,
       },
       radial: {
+        width: 200,
         margin: 20,
-        padding: 15,
+        padding: this.state.largePadding? 15 : 0,
         backgroundColor: 'magenta',
         borderRadius: 10,
+        borderWidth: this.state.largeBorder? 20 : 1,
       },
+      child: {
+        backgroundColor: 'yellow',
+        alignSelf: this.state.alignSelfCenter? 'center' : 'flex-start',
+        width: 100,
+        height: 50,
+        fontSize:20,
+      }
     });
 
     return (
@@ -104,6 +119,30 @@ export default class Bootstrap extends React.Component<
           <Text>hasRadius</Text>
         </View>
 
+        <View style={{flexDirection: 'row', alignSelf: 'flex-start'}}>
+          <CheckBox
+            onValueChange={value => this.setState({largeBorder: value})}
+            value={this.state.largeBorder}
+          />
+          <Text>largeBorder</Text>
+        </View>
+
+        <View style={{flexDirection: 'row', alignSelf: 'flex-start', width:100}}>
+          <CheckBox
+            onValueChange={value => this.setState({alignSelfCenter: value})}
+            value={this.state.alignSelfCenter}
+          />
+          <Text>alignCenter</Text>
+        </View>
+
+        <View style={{flexDirection: 'row', alignSelf: 'flex-start', width:100}}>
+          <CheckBox
+            onValueChange={value => this.setState({largePadding: value})}
+            value={this.state.largePadding}
+          />
+          <Text>largePadding</Text>
+        </View>
+
         <View
           style={{
             flex: 1,
@@ -130,7 +169,7 @@ export default class Bootstrap extends React.Component<
               // Use weird format as work around for the fact that these props are not part of the @types/react-native yet
               acceptsKeyboardFocus: true,
             }}>
-            <Text>The text!</Text>
+            <Text style={styles.child}>The Text</Text>
           </View>
         </View>
       </View>

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -339,9 +339,7 @@ winrt::Border ViewPanel::GetOuterBorder() {
 }
 
 void ViewPanel::UpdateClip(winrt::Size &finalSize) {
-  // When an outer Border is used it will handle the clipping, otherwise this
-  // panel must do so
-  if (!m_hasOuterBorder && ClipChildren()) {
+  if (ClipChildren()) {
     winrt::RectangleGeometry clipGeometry;
     clipGeometry.Rect(winrt::Rect(0, 0, static_cast<float>(finalSize.Width), static_cast<float>(finalSize.Height)));
 

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -141,7 +141,7 @@ winrt::Size ViewPanel::MeasureOverride(winrt::Size availableSize) {
 winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
   // Sometimes we create outerBorder(i.e. when CornerRadius is true) instead of innerBorder,
   // Yoga has no notion of outerBorder when calculating the child's position, so we
-  // need to make adujustments in arrange for outerborder's thickness.
+  // need to make adujustment in arrange for outerborder's thickness.
   float outerBorderLeft = 0;
   float outerBorderTop = 0;
   if (auto outerBorder = GetOuterBorder()) {
@@ -176,10 +176,11 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
     childWidth = std::max<double>(0.0f, childWidth);
     childHeight = std::max<double>(0.0f, childHeight);
 
-    float adjustedLeft = (float)ViewPanel::GetLeft(child) - outerBorderLeft;
-    float adjustedTop = (float)ViewPanel::GetTop(child) - outerBorderTop;
+    float adjustedLeft = static_cast<float>(ViewPanel::GetLeft(child)) - outerBorderLeft;
+    float adjustedTop = static_cast<float>(ViewPanel::GetTop(child)) - outerBorderTop;
 
-    child.Arrange(winrt::Rect(adjustedLeft, adjustedTop, (float)childWidth, (float)childHeight));
+    child.Arrange(
+        winrt::Rect(adjustedLeft, adjustedTop, static_cast<float>(childWidth), static_cast<float>(childHeight)));
   }
 
   UpdateClip(finalSize);


### PR DESCRIPTION
#3549 
#3488 
#3661 

RNW implementation of ViewPanel sometimes create outer border instead of using the inner border, for example when round corner border is requested. This is causing noticeable layout issue especially when border size is large. RN's yoga layout sets the Top/Left for each children, but Yoga has no notion of outer border(in its view, border is always part of the view instead of parent of view), and its placement logic includes the border size. So we need to compensate the outer border size when ViewPanel is arranging its children, by deducting the border size from the Top and Left.

When testing, I also found children clipping issue when outer border is present, so fix that too.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3660)