### PR TITLE
Support ScrollView keyboardDismissMode

### DIFF
--- a/change/react-native-windows-2019-11-15-16-31-57-keyboardDismissMode.json
+++ b/change/react-native-windows-2019-11-15-16-31-57-keyboardDismissMode.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Support keyboardDismissMode on-drag for ScrollView",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "bfbf63cc3293f15622d069778fd0283c6f84b12b",
+  "date": "2019-11-16T00:31:57.734Z"
+}

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -62,8 +62,17 @@ bool IsAPIContractV6Available() {
   return IsAPIContractVxAvailable<6>();
 }
 
+bool IsAPIContractV8Available() {
+  return IsAPIContractVxAvailable<8>();
+}
+
 bool IsRS4OrHigher() {
   return IsAPIContractV6Available();
 }
+
+bool Is19H1OrHigher() {
+  return IsAPIContractV8Available();
+}
+
 } // namespace uwp
 }; // namespace react

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -58,16 +58,32 @@ bool IsAPIContractVxAvailable() {
   return isAPIContractVxAvailable;
 }
 
+bool IsAPIContractV5Available() {
+  return IsAPIContractVxAvailable<5>();
+}
+
 bool IsAPIContractV6Available() {
   return IsAPIContractVxAvailable<6>();
+}
+
+bool IsAPIContractV7Available() {
+  return IsAPIContractVxAvailable<7>();
 }
 
 bool IsAPIContractV8Available() {
   return IsAPIContractVxAvailable<8>();
 }
 
+bool IsRS3OrHigher() {
+  return IsAPIContractV5Available();
+}
+
 bool IsRS4OrHigher() {
   return IsAPIContractV6Available();
+}
+
+bool IsRS5OrHigher() {
+  return IsAPIContractV7Available();
 }
 
 bool Is19H1OrHigher() {

--- a/vnext/ReactUWP/Utils/Helpers.h
+++ b/vnext/ReactUWP/Utils/Helpers.h
@@ -31,5 +31,6 @@ ReactId getViewId(_In_ IReactInstance *instance, winrt::FrameworkElement const &
 std::int32_t CountOpenPopups();
 
 bool IsRS4OrHigher();
+bool Is19H1OrHigher();
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Utils/Helpers.h
+++ b/vnext/ReactUWP/Utils/Helpers.h
@@ -30,7 +30,9 @@ inline typename T asEnum(folly::dynamic const &obj) {
 ReactId getViewId(_In_ IReactInstance *instance, winrt::FrameworkElement const &fe);
 std::int32_t CountOpenPopups();
 
+bool IsRS3OrHigher();
 bool IsRS4OrHigher();
+bool IsRS5OrHigher();
 bool Is19H1OrHigher();
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
+++ b/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
@@ -68,11 +68,13 @@ PreviewKeyboardEventHandler::PreviewKeyboardEventHandler(KeyboardEventCallback &
 
 void PreviewKeyboardEventHandler::hook(XamlView xamlView) {
   auto uiElement = xamlView.as<winrt::UIElement>();
-  if (m_keyDownCallback)
-    m_previewKeyDownRevoker = uiElement.PreviewKeyDown(winrt::auto_revoke, m_keyDownCallback);
+  if (uiElement.try_as<winrt::IUIElement7>()) {
+    if (m_keyDownCallback)
+      m_previewKeyDownRevoker = uiElement.PreviewKeyDown(winrt::auto_revoke, m_keyDownCallback);
 
-  if (m_keyUpCallback)
-    m_previewKeyUpRevoker = uiElement.PreviewKeyUp(winrt::auto_revoke, m_keyUpCallback);
+    if (m_keyUpCallback)
+      m_previewKeyUpRevoker = uiElement.PreviewKeyUp(winrt::auto_revoke, m_keyUpCallback);
+  }
 }
 
 void PreviewKeyboardEventHandler::unhook() {

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -203,6 +203,7 @@ void ReactControl::AttachRoot() noexcept {
 
   m_touchEventHandler->AddTouchHandlers(m_xamlRootView);
   m_previewKeyboardEventHandlerOnRoot->hook(m_xamlRootView);
+  m_SIPEventHandler->AttachView(m_xamlRootView, true /*fireKeyboradEvents*/);
 
   auto initialProps = m_initialProps;
   m_reactInstance->AttachMeasuredRootView(m_pParent, std::move(initialProps));

--- a/vnext/ReactUWP/Views/SIPEventHandler.cpp
+++ b/vnext/ReactUWP/Views/SIPEventHandler.cpp
@@ -68,32 +68,24 @@ void SIPEventHandler::AttachView(XamlView xamlView, bool fireKeyboardEvents) {
         });
   }
 }
-
-bool SIPEventHandler::TryShow() {
-  if (IsRS5OrHigher() && m_coreInputView) {
-    if (!m_isShowing) { // CoreInputView.TryShow is only avaliable after RS5
-      return m_coreInputView.TryShow();
+/*
+void SIPEventHandler::TryShow() {
+  if (IsRS5OrHigher() && m_coreInputView && !m_isShowing) { // CoreInputView.TryShow is only avaliable after RS5
+      m_coreInputView.TryShow();
     }
-    return true;
-  }
-  return false;
 }
+*/
 
-bool SIPEventHandler::TryHide() {
-  if (IsRS5OrHigher() && m_coreInputView) {
-    if (m_isShowing) { // CoreInputView.TryHide is only avaliable after RS5
-      return m_coreInputView.TryHide();
-    }
-    return true;
+void SIPEventHandler::TryHide() {
+  if (IsRS5OrHigher() && m_coreInputView && m_isShowing) { // CoreInputView.TryHide is only avaliable after RS5
+    m_coreInputView.TryHide();
   }
-  return false;
 }
 
 bool SIPEventHandler::IsOcclusionsEmpty(winrt::IVectorView<winrt::CoreInputViewOcclusion> occlusions) {
   m_finalRect = winrt::RectHelper::Empty();
   if (occlusions) {
-    for (uint32_t i = 0; i < occlusions.Size(); i++) {
-      winrt::CoreInputViewOcclusion occlusion = occlusions.GetAt(i);
+    for (const auto &occlusion : occlusions) {
       if (occlusion.OcclusionKind() == winrt::CoreInputViewOcclusionKind::Docked) {
         m_finalRect = winrt::RectHelper::Union(m_finalRect, occlusion.OccludingRect());
       }

--- a/vnext/ReactUWP/Views/SIPEventHandler.h
+++ b/vnext/ReactUWP/Views/SIPEventHandler.h
@@ -25,8 +25,8 @@ class SIPEventHandler {
   }
 
   void AttachView(XamlView xamlView, bool fireKeyboardEvents);
-  bool TryShow();
-  bool TryHide();
+  // void TryShow();
+  void TryHide();
 
  private:
   bool IsOcclusionsEmpty(winrt::IVectorView<winrt::CoreInputViewOcclusion> occlusions);

--- a/vnext/ReactUWP/Views/SIPEventHandler.h
+++ b/vnext/ReactUWP/Views/SIPEventHandler.h
@@ -34,8 +34,8 @@ class SIPEventHandler {
   std::weak_ptr<IReactInstance> m_wkReactInstance;
   winrt::CoreInputView::OcclusionsChanged_revoker m_occlusionsChanged_revoker;
   winrt::Rect m_finalRect;
-  winrt::CoreInputView m_coreInputView = nullptr;
-  bool m_isShowing = false;
+  winrt::CoreInputView m_coreInputView{nullptr};
+  bool m_isShowing{false};
   bool m_fireKeyboradEvents;
 };
 

--- a/vnext/ReactUWP/Views/SIPEventHandler.h
+++ b/vnext/ReactUWP/Views/SIPEventHandler.h
@@ -8,7 +8,7 @@
 #include <winrt/Windows.UI.ViewManagement.Core.h>
 
 namespace winrt {
-using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
 using namespace Windows::UI::ViewManagement::Core;
 } // namespace winrt
 
@@ -20,10 +20,23 @@ class SIPEventHandler {
   SIPEventHandler(const std::weak_ptr<IReactInstance> &reactInstance);
   virtual ~SIPEventHandler();
 
+  bool IsSIPShowing() {
+    return m_isShowing;
+  }
+
+  void AttachView(XamlView xamlView, bool fireKeyboardEvents);
+  bool TryShow();
+  bool TryHide();
+
  private:
+  bool IsOcclusionsEmpty(winrt::IVectorView<winrt::CoreInputViewOcclusion> occlusions);
   void SendEvent(std::string &&eventName, folly::dynamic &&parameters);
   std::weak_ptr<IReactInstance> m_wkReactInstance;
   winrt::CoreInputView::OcclusionsChanged_revoker m_occlusionsChanged_revoker;
+  winrt::Rect m_finalRect;
+  winrt::CoreInputView m_coreInputView = nullptr;
+  bool m_isShowing = false;
+  bool m_fireKeyboradEvents;
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 
+#include <ReactUWP\Views\SIPEventHandler.h>
 #include <Views/ShadowNodeBase.h>
 #include "Impl/ScrollViewUWPImplementation.h"
 #include "ScrollViewManager.h"
@@ -20,6 +21,7 @@ class ScrollViewShadowNode : public ShadowNodeBase {
 
  public:
   ScrollViewShadowNode();
+  ~ScrollViewShadowNode();
   void dispatchCommand(int64_t commandId, const folly::dynamic &commandArgs) override;
   void createView() override;
   void updateProperties(const folly::dynamic &&props) override;
@@ -44,6 +46,10 @@ class ScrollViewShadowNode : public ShadowNodeBase {
   bool m_isHorizontal = false;
   bool m_isScrollingEnabled = true;
   bool m_changeViewAfterLoaded = false;
+  bool m_dismissKeyboardOnDrag = false;
+
+  std::shared_ptr<SIPEventHandler> m_SIPEventHandler;
+  void RegisterSIPEventsWhenNeeded();
 
   winrt::FrameworkElement::SizeChanged_revoker m_scrollViewerSizeChangedRevoker{};
   winrt::FrameworkElement::SizeChanged_revoker m_contentSizeChangedRevoker{};
@@ -55,6 +61,10 @@ class ScrollViewShadowNode : public ShadowNodeBase {
 };
 
 ScrollViewShadowNode::ScrollViewShadowNode() {}
+
+ScrollViewShadowNode::~ScrollViewShadowNode() {
+  m_SIPEventHandler.reset();
+}
 
 void ScrollViewShadowNode::dispatchCommand(int64_t commandId, const folly::dynamic &commandArgs) {
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
@@ -186,6 +196,12 @@ void ScrollViewShadowNode::updateProperties(const folly::dynamic &&reactDiffMap)
       if (valid) {
         ScrollViewUWPImplementation(scrollViewer).SnapToEnd(snapToEnd);
       }
+    } else if (propertyName == "keyboardDismissMode") {
+      m_dismissKeyboardOnDrag = false;
+      if (propertyValue.isString()) {
+        m_dismissKeyboardOnDrag = (propertyValue.getString() == "on-drag");
+        RegisterSIPEventsWhenNeeded();
+      }
     } else if (propertyName == "snapToAlignment") {
       const auto [valid, snapToAlignment] = getPropertyAndValidity(propertyValue, winrt::SnapPointsAlignment::Near);
       if (valid) {
@@ -236,6 +252,13 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
   m_scrollViewerDirectManipulationStartedRevoker =
       scrollViewer.DirectManipulationStarted(winrt::auto_revoke, [this](const auto &sender, const auto &) {
         m_isScrolling = true;
+
+        if (m_dismissKeyboardOnDrag) {
+          if (m_SIPEventHandler) {
+            m_SIPEventHandler->TryHide();
+          }
+        }
+
         const auto scrollViewer = sender.as<winrt::ScrollViewer>();
         EmitScrollEvent(
             scrollViewer,
@@ -271,6 +294,8 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
         m_isScrollingFromInertia = false;
       });
   m_controlLoadedRevoker = scrollViewer.Loaded(winrt::auto_revoke, [this](const auto &sender, const auto &) {
+    RegisterSIPEventsWhenNeeded();
+
     if (m_changeViewAfterLoaded) {
       const auto scrollViewer = sender.as<winrt::ScrollViewer>();
       scrollViewer.ChangeView(nullptr, nullptr, static_cast<float>(m_zoomFactor));
@@ -278,6 +303,17 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
     }
   });
 }
+
+void ScrollViewShadowNode::RegisterSIPEventsWhenNeeded() {
+  if (m_dismissKeyboardOnDrag) {
+    auto view = GetView();
+    if (winrt::VisualTreeHelper::GetParent(view) != nullptr) {
+      auto wkinstance = GetViewManager()->GetReactInstance();
+      m_SIPEventHandler = std::make_unique<SIPEventHandler>(wkinstance);
+      m_SIPEventHandler->AttachView(GetView(), false /*fireKeyboardEvents*/);
+    }
+  }
+} // namespace uwp
 
 void ScrollViewShadowNode::EmitScrollEvent(
     const winrt::ScrollViewer &scrollViewer,
@@ -396,7 +432,8 @@ folly::dynamic ScrollViewManager::GetNativeProps() const {
   props.update(folly::dynamic::object("horizontal", "boolean")("scrollEnabled", "boolean")(
       "showsHorizontalScrollIndicator", "boolean")("showsVerticalScrollIndicator", "boolean")(
       "minimumZoomScale", "float")("maximumZoomScale", "float")("zoomScale", "float")("snapToInterval", "float")(
-      "snapToOffsets", "array")("snapToAlignment", "number")("snapToStart", "boolean")("snapToEnd", "boolean"));
+      "snapToOffsets", "array")("snapToAlignment", "number")("snapToStart", "boolean")("snapToEnd", "boolean")(
+      "keyboardDismissMode", "string"));
 
   return props;
 }

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -253,10 +253,8 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
       scrollViewer.DirectManipulationStarted(winrt::auto_revoke, [this](const auto &sender, const auto &) {
         m_isScrolling = true;
 
-        if (m_dismissKeyboardOnDrag) {
-          if (m_SIPEventHandler) {
-            m_SIPEventHandler->TryHide();
-          }
+        if (m_dismissKeyboardOnDrag && m_SIPEventHandler) {
+          m_SIPEventHandler->TryHide();
         }
 
         const auto scrollViewer = sender.as<winrt::ScrollViewer>();
@@ -307,7 +305,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
 void ScrollViewShadowNode::RegisterSIPEventsWhenNeeded() {
   if (m_dismissKeyboardOnDrag) {
     auto view = GetView();
-    if (winrt::VisualTreeHelper::GetParent(view) != nullptr) {
+    if (winrt::VisualTreeHelper::GetParent(view)) {
       auto wkinstance = GetViewManager()->GetReactInstance();
       m_SIPEventHandler = std::make_unique<SIPEventHandler>(wkinstance);
       m_SIPEventHandler->AttachView(GetView(), false /*fireKeyboardEvents*/);


### PR DESCRIPTION
#3068 

-Hook up property keyboardDismissMode in ScrollViewManager.
-When manipulation starts and if keyboardDismissMode is on-drag, issue TryHide though SIP event handler.
- Some tweak to SIP Event Handler code to be able to share in the RNW's code base, and call GetForUIContext instead of GetForCurrentView on newer build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3665)