### PR TITLE
Use boost::numeric_cast.

### DIFF
--- a/change/react-native-windows-2019-11-18-14-25-18-boost-numeric-cast.json
+++ b/change/react-native-windows-2019-11-18-14-25-18-boost-numeric-cast.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use boost::numeric_cast.",
+  "packageName": "react-native-windows",
+  "email": "yicyao@microsoft.com",
+  "commit": "75f8da4c6b63d2d4dc432ac1d555cb8e140d3a20",
+  "date": "2019-11-18T22:25:18.395Z"
+}

--- a/vnext/Common/Common.vcxproj
+++ b/vnext/Common/Common.vcxproj
@@ -78,13 +78,23 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="Unicode.cpp"/>
+    <ClCompile Include="Unicode.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Unicode.h"/>
-    <ClInclude Include="Utilities.h"/>
+    <ClInclude Include="Unicode.h" />
+    <ClInclude Include="Utilities.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/vnext/Common/Common.vcxproj.filters
+++ b/vnext/Common/Common.vcxproj.filters
@@ -21,4 +21,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/vnext/Common/packages.config
+++ b/vnext/Common/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.68.0.0" targetFramework="native" />
+</packages>

--- a/vnext/Common/unicode.cpp
+++ b/vnext/Common/unicode.cpp
@@ -8,6 +8,8 @@
 
 #include "stringapiset.h"
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <cassert>
 #include <cstring>
 #include <exception>
@@ -26,13 +28,7 @@ std::wstring Utf8ToUtf16(const char *utf8, size_t utf8Len) {
     return utf16;
   }
 
-  // Extra parentheses needed here to prevent expanding max as a
-  // Windows-specific preprocessor macro.
-  if (utf8Len > static_cast<size_t>((std::numeric_limits<int>::max)())) {
-    throw std::overflow_error("Length of input string to Utf8ToUtf16() must fit into an int.");
-  }
-
-  const int utf8Length = static_cast<int>(utf8Len);
+  const int utf8Length = boost::numeric_cast<int>(utf8Len);
 
   // We do not specify MB_ERR_INVALID_CHARS here, which means that invalid UTF-8
   // characters are replaced with U+FFFD.
@@ -107,13 +103,7 @@ std::string Utf16ToUtf8(const wchar_t *utf16, size_t utf16Len) {
     return utf8;
   }
 
-  // Extra parentheses needed here to prevent expanding max as a
-  // Windows-specific preprocessor macro.
-  if (utf16Len > static_cast<size_t>((std::numeric_limits<int>::max)())) {
-    throw std::overflow_error("Length of input string to Utf16ToUtf8() must fit into an int.");
-  }
-
-  const int utf16Length = static_cast<int>(utf16Len);
+  const int utf16Length = boost::numeric_cast<int>(utf16Len);
 
   // We do not specify WC_ERR_INVALID_CHARS here, which means that invalid
   // UTF-16 characters are replaced with U+FFFD.

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -37,6 +37,7 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -48,14 +49,14 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-	  <PreprocessorDefinitions Condition="'$(CHAKRACOREUWP)'=='true'">CHAKRACORE_UWP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(CHAKRACOREUWP)'=='true'">CHAKRACORE_UWP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- /Zc:strictStrings enforces the standard C++ const qualifications for
       string literals. It prevents code like
         wchar_t* str = L"hello";
       from compiling. -->
       <AdditionalOptions>%(AdditionalOptions) /Zc:strictStrings</AdditionalOptions>
-	  <AdditionalIncludeDirectories Condition="'$(CHAKRACOREUWP)'=='true'">$(ChakraCoreInclude);$(ChakraCoreDebugInclude);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(CHAKRACOREUWP)'=='true'">$(ChakraCoreInclude);$(ChakraCoreDebugInclude);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies Condition="'$(CHAKRACOREUWP)'=='true'">ChakraCore.Debugger.Protocol.lib;ChakraCore.Debugger.ProtocolHandler.lib;ChakraCore.Debugger.Service.lib;ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -89,5 +90,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\boost.1.68.0.0\build\boost.targets'))" />
   </Target>
 </Project>

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -37,7 +37,6 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -81,15 +80,16 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" Condition="'$(CHAKRACOREUWP)'!='true'">
-    <Import Project="..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
+    <Import Project="..\..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets" Condition="Exists('..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets')" />
+    <Import Project="..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild" Condition="'$(CHAKRACOREUWP)'!='true'">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
-    <Error Condition="!Exists('..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\ChakraCore.Debugger.0.0.0.42\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
   </Target>
 </Project>

--- a/vnext/JSI/Desktop/packages.config
+++ b/vnext/JSI/Desktop/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.42" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
 </packages>

--- a/vnext/JSI/Shared/ChakraRuntime.cpp
+++ b/vnext/JSI/Shared/ChakraRuntime.cpp
@@ -10,6 +10,8 @@
 #include <ScriptStore.h>
 #include <cxxreact/MessageQueueThread.h>
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <cstring>
 #include <limits>
 #include <mutex>
@@ -449,10 +451,8 @@ facebook::jsi::Value ChakraRuntime::lockWeakObject(const facebook::jsi::WeakObje
 }
 
 facebook::jsi::Array ChakraRuntime::createArray(size_t length) {
-  assert(length <= (std::numeric_limits<unsigned int>::max)());
-
   JsValueRef result = JS_INVALID_REFERENCE;
-  VerifyJsErrorElseThrow(JsCreateArray(static_cast<unsigned int>(length), &result));
+  VerifyJsErrorElseThrow(JsCreateArray(boost::numeric_cast<unsigned int>(length), &result));
   return MakePointer<facebook::jsi::Object>(result).asArray(*this);
 }
 
@@ -493,19 +493,16 @@ uint8_t *ChakraRuntime::data(const facebook::jsi::ArrayBuffer &arrBuf) {
 
 facebook::jsi::Value ChakraRuntime::getValueAtIndex(const facebook::jsi::Array &arr, size_t index) {
   assert(isArray(arr));
-  assert(index <= static_cast<size_t>((std::numeric_limits<int>::max)()));
-
   JsValueRef result = JS_INVALID_REFERENCE;
-  VerifyJsErrorElseThrow(JsGetIndexedProperty(GetChakraObjectRef(arr), ToJsNumber(static_cast<int>(index)), &result));
+  VerifyJsErrorElseThrow(
+      JsGetIndexedProperty(GetChakraObjectRef(arr), ToJsNumber(boost::numeric_cast<int>(index)), &result));
   return ToJsiValue(ChakraObjectRef(result));
 }
 
 void ChakraRuntime::setValueAtIndexImpl(facebook::jsi::Array &arr, size_t index, const facebook::jsi::Value &value) {
   assert(isArray(arr));
-  assert(index <= static_cast<size_t>((std::numeric_limits<int>::max)()));
-
-  VerifyJsErrorElseThrow(
-      JsSetIndexedProperty(GetChakraObjectRef(arr), ToJsNumber(static_cast<int>(index)), ToChakraObjectRef(value)));
+  VerifyJsErrorElseThrow(JsSetIndexedProperty(
+      GetChakraObjectRef(arr), ToJsNumber(boost::numeric_cast<int>(index)), ToChakraObjectRef(value)));
 }
 
 facebook::jsi::Function ChakraRuntime::createFunctionFromHostFunction(
@@ -560,11 +557,13 @@ facebook::jsi::Value ChakraRuntime::call(
   std::vector<ChakraObjectRef> argRefs = ToChakraObjectRefs(args, count);
 
   std::vector<JsValueRef> argsWithThis = ConstructJsFunctionArguments(thisRef, argRefs);
-  assert(argsWithThis.size() <= (std::numeric_limits<unsigned short>::max)());
 
   JsValueRef result;
   VerifyJsErrorElseThrow(JsCallFunction(
-      GetChakraObjectRef(func), argsWithThis.data(), static_cast<unsigned short>(argsWithThis.size()), &result));
+      GetChakraObjectRef(func),
+      argsWithThis.data(),
+      boost::numeric_cast<unsigned short>(argsWithThis.size()),
+      &result));
   return ToJsiValue(ChakraObjectRef(result));
 }
 
@@ -576,11 +575,13 @@ ChakraRuntime::callAsConstructor(const facebook::jsi::Function &func, const face
   std::vector<ChakraObjectRef> argRefs = ToChakraObjectRefs(args, count);
 
   std::vector<JsValueRef> argsWithThis = ConstructJsFunctionArguments(undefinedRef, argRefs);
-  assert(argsWithThis.size() <= (std::numeric_limits<unsigned short>::max)());
 
   JsValueRef result;
   VerifyJsErrorElseThrow(JsConstructObject(
-      GetChakraObjectRef(func), argsWithThis.data(), static_cast<unsigned short>(argsWithThis.size()), &result));
+      GetChakraObjectRef(func),
+      argsWithThis.data(),
+      boost::numeric_cast<unsigned short>(argsWithThis.size()),
+      &result));
   return ToJsiValue(ChakraObjectRef(result));
 }
 

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj
@@ -82,14 +82,24 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp" Condition="'$(OSS_RN)' != 'true'"/>
+    <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp" Condition="'$(OSS_RN)' != 'true'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Common.vcxproj">
       <Project>{fca38f3c-7c73-4c47-be4e-32f77fa8538d}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\boost.1.68.0.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj.filters
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj.filters
@@ -13,4 +13,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/vnext/JSI/Universal/packages.config
+++ b/vnext/JSI/Universal/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.68.0.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
There a various places where we check for overflow before using static_cast to perform an integer conversion. Since we already depend on boost, we should just use boost::numeric_cast for this. This PR performs said change.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3676)