### PR TITLE
Don't add asyncStorage module to nativeModules if ReactUWP is running without package identity

### DIFF
--- a/change/react-native-windows-2019-11-20-15-34-16-master.json
+++ b/change/react-native-windows-2019-11-20-15-34-16-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Merge remote-tracking branch 'upstream/master'",
+  "packageName": "react-native-windows",
+  "email": "hpratt@microsoft.com",
+  "commit": "5f3419d9ed6288ffa3dbdeb58a91db2d9734d704",
+  "date": "2019-11-20T23:34:15.986Z"
+}

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -112,7 +112,8 @@ bool HasPackageIdentity() noexcept {
     winrt::com_ptr<ABI::Windows::ApplicationModel::IPackage> dummy;
     return abiPackageStatics->get_Current(reinterpret_cast<ABI::Windows::ApplicationModel::IPackage **>(
                winrt::put_abi(dummy))) != APPMODEL_ERROR_NO_PACKAGE;
-  }();
+  }
+  ();
 
   return hasPackageIdentity;
 }
@@ -232,14 +233,11 @@ std::vector<facebook::react::NativeModuleDescription> GetModules(
       },
       messageQueue);
 
-  modules.emplace_back(
-      AlertModule::name, []() { return std::make_unique<AlertModule>(); }, messageQueue);
+  modules.emplace_back(AlertModule::name, []() { return std::make_unique<AlertModule>(); }, messageQueue);
 
-  modules.emplace_back(
-      ClipboardModule::name, []() { return std::make_unique<ClipboardModule>(); }, messageQueue);
+  modules.emplace_back(ClipboardModule::name, []() { return std::make_unique<ClipboardModule>(); }, messageQueue);
 
-  modules.emplace_back(
-      StatusBarModule::name, []() { return std::make_unique<StatusBarModule>(); }, messageQueue);
+  modules.emplace_back(StatusBarModule::name, []() { return std::make_unique<StatusBarModule>(); }, messageQueue);
 
   modules.emplace_back(
       NativeAnimatedModule::name,
@@ -509,8 +507,8 @@ const std::shared_ptr<facebook::react::MessageQueueThread> &UwpReactInstance::JS
   return m_jsThread;
 }
 
-const std::shared_ptr<facebook::react::MessageQueueThread> &UwpReactInstance::DefaultNativeMessageQueueThread()
-    const noexcept {
+const std::shared_ptr<facebook::react::MessageQueueThread> &UwpReactInstance::DefaultNativeMessageQueueThread() const
+    noexcept {
   return m_defaultNativeThread;
 }
 

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -105,11 +105,10 @@ namespace {
 bool HasPackageIdentity() noexcept {
   static const bool hasPackageIdentity = []() noexcept {
     try {
-      winrt::check_hresult(E_FAIL);
       auto package = winrt::Windows::ApplicationModel::Package::Current();
       return true;
-    } catch (...) {
-      return false;
+    } catch (const winrt::hresult_error &hresultError) {
+      return hresultError.code() != APPMODEL_ERROR_NO_PACKAGE;
     }
   }();
 

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -105,6 +105,7 @@ namespace {
 bool HasPackageIdentity() noexcept {
   static const bool hasPackageIdentity = []() noexcept {
     try {
+      winrt::check_hresult(E_FAIL);
       auto package = winrt::Windows::ApplicationModel::Package::Current();
       return true;
     } catch (...) {
@@ -253,6 +254,8 @@ std::vector<facebook::react::NativeModuleDescription> GetModules(
       },
       messageQueue);
 
+  // AsyncStorageModule doesn't work without package identity (it indirectly depends on
+  // Windows.Storage.StorageFile), so check for package identity before adding it.
   if (HasPackageIdentity()) {
     modules.emplace_back(
         "AsyncLocalStorage",


### PR DESCRIPTION
`AsyncStorageModule` uses `AsyncStorageManager`, which uses `KeyValueStorage`, which uses `StorageFileIO`, which uses `Windows.Storage.StorageFile`, which can only be used from processes with package identity (either UWP apps, or Desktop Bridge apps packaged in an MSIX).

Without this change, creating an instance of `UwpReactInstance` from a classic desktop app would cause an exception to be raised & terminate the app. With it, classic desktop apps can create an instance of `UwpReactInstance`, although `asyncStorage` won't work.

@dotnetjunky, can you please verify that, with this change, your unpackaged version of TodoFeed works correctly?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3686)