### PR TITLE
Update to react-native@0.60.0-microsoft.23

### DIFF
--- a/change/react-native-windows-2019-11-21-00-39-16-auto-update-versions060.0microsoft.23.json
+++ b/change/react-native-windows-2019-11-21-00-39-16-auto-update-versions060.0microsoft.23.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.23",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "d8bf979e514d4f546e740c979c816d311a7d896f",
+  "date": "2019-11-21T00:39:16.825Z"
+}

--- a/change/react-native-windows-extended-2019-11-21-00-39-18-auto-update-versions060.0microsoft.23.json
+++ b/change/react-native-windows-extended-2019-11-21-00-39-18-auto-update-versions060.0microsoft.23.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.23",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "bb9ecc2e30716aea89919b3adc69cb0580387bf1",
+  "date": "2019-11-21T00:39:18.538Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
     "react-native-windows": "0.60.0-vnext.74",
     "react-native-windows-extended": "0.60.22",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
     "react-native-windows": "0.60.0-vnext.74",
     "react-native-windows-extended": "0.60.22",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
     "react-native-windows": "0.60.0-vnext.74",
     "react-native-windows-extended": "0.60.22",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.22 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.23 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -47,13 +47,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.22 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.22.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.23 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
66f182eec Applying package update to 0.60.0-microsoft.23 ***NO_CI***
4d057af9c Revert an RTL change we made that FB fixed at a lower level, making this obsolete. This file now aligns with what FB has in their repo (#194)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3688)