### PR TITLE
Revert "Support ScrollView keyboardDismissMode"

### DIFF
--- a/change/react-native-windows-2019-11-22-11-19-51-revert-3665-keyboardDismissMode.json
+++ b/change/react-native-windows-2019-11-22-11-19-51-revert-3665-keyboardDismissMode.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Revert \"Support ScrollView keyboardDismissMode (#3665)\"",
+  "packageName": "react-native-windows",
+  "email": "licanhua@live.com",
+  "commit": "29b555d211354f308d9d93319669552d56a46ad2",
+  "date": "2019-11-22T19:19:50.910Z"
+}

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -58,37 +58,12 @@ bool IsAPIContractVxAvailable() {
   return isAPIContractVxAvailable;
 }
 
-bool IsAPIContractV5Available() {
-  return IsAPIContractVxAvailable<5>();
-}
-
 bool IsAPIContractV6Available() {
   return IsAPIContractVxAvailable<6>();
-}
-
-bool IsAPIContractV7Available() {
-  return IsAPIContractVxAvailable<7>();
-}
-
-bool IsAPIContractV8Available() {
-  return IsAPIContractVxAvailable<8>();
-}
-
-bool IsRS3OrHigher() {
-  return IsAPIContractV5Available();
 }
 
 bool IsRS4OrHigher() {
   return IsAPIContractV6Available();
 }
-
-bool IsRS5OrHigher() {
-  return IsAPIContractV7Available();
-}
-
-bool Is19H1OrHigher() {
-  return IsAPIContractV8Available();
-}
-
 } // namespace uwp
 }; // namespace react

--- a/vnext/ReactUWP/Utils/Helpers.h
+++ b/vnext/ReactUWP/Utils/Helpers.h
@@ -30,9 +30,6 @@ inline typename T asEnum(folly::dynamic const &obj) {
 ReactId getViewId(_In_ IReactInstance *instance, winrt::FrameworkElement const &fe);
 std::int32_t CountOpenPopups();
 
-bool IsRS3OrHigher();
 bool IsRS4OrHigher();
-bool IsRS5OrHigher();
-bool Is19H1OrHigher();
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
+++ b/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
@@ -68,13 +68,11 @@ PreviewKeyboardEventHandler::PreviewKeyboardEventHandler(KeyboardEventCallback &
 
 void PreviewKeyboardEventHandler::hook(XamlView xamlView) {
   auto uiElement = xamlView.as<winrt::UIElement>();
-  if (uiElement.try_as<winrt::IUIElement7>()) {
-    if (m_keyDownCallback)
-      m_previewKeyDownRevoker = uiElement.PreviewKeyDown(winrt::auto_revoke, m_keyDownCallback);
+  if (m_keyDownCallback)
+    m_previewKeyDownRevoker = uiElement.PreviewKeyDown(winrt::auto_revoke, m_keyDownCallback);
 
-    if (m_keyUpCallback)
-      m_previewKeyUpRevoker = uiElement.PreviewKeyUp(winrt::auto_revoke, m_keyUpCallback);
-  }
+  if (m_keyUpCallback)
+    m_previewKeyUpRevoker = uiElement.PreviewKeyUp(winrt::auto_revoke, m_keyUpCallback);
 }
 
 void PreviewKeyboardEventHandler::unhook() {

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -203,7 +203,6 @@ void ReactControl::AttachRoot() noexcept {
 
   m_touchEventHandler->AddTouchHandlers(m_xamlRootView);
   m_previewKeyboardEventHandlerOnRoot->hook(m_xamlRootView);
-  m_SIPEventHandler->AttachView(m_xamlRootView, true /*fireKeyboradEvents*/);
 
   auto initialProps = m_initialProps;
   m_reactInstance->AttachMeasuredRootView(m_pParent, std::move(initialProps));

--- a/vnext/ReactUWP/Views/SIPEventHandler.cpp
+++ b/vnext/ReactUWP/Views/SIPEventHandler.cpp
@@ -7,7 +7,6 @@
 
 #include <Modules/NativeUIManager.h>
 
-#include <ReactUWP\Utils\Helpers.h>
 #include <winrt/Windows.ApplicationModel.Core.h>
 #include <winrt/Windows.Foundation.h>
 
@@ -21,77 +20,38 @@ namespace react {
 namespace uwp {
 
 SIPEventHandler::SIPEventHandler(const std::weak_ptr<IReactInstance> &reactInstance)
-    : m_wkReactInstance(reactInstance), m_fireKeyboradEvents(false), m_finalRect(winrt::RectHelper::Empty()){};
-
-SIPEventHandler::~SIPEventHandler() {
-  m_occlusionsChanged_revoker = {};
-}
-// keyboardDidHide and keyboardDidShow events works on >= RS3
-// TryShow and TryHide works on >= RS5
-
-void SIPEventHandler::AttachView(XamlView xamlView, bool fireKeyboardEvents) {
-  m_fireKeyboradEvents = fireKeyboardEvents;
-
-  if (!IsRS3OrHigher()) {
-    return; // CoreInputView is only supported on >= RS3.
-  }
-
-  if (Is19H1OrHigher()) {
-    // 19H1 and higher supports island scenarios
-    auto uiElement(xamlView.as<winrt::UIElement>());
-    m_coreInputView = winrt::CoreInputView::GetForUIContext(uiElement.UIContext());
-  } else {
-    m_coreInputView = winrt::CoreInputView::GetForCurrentView();
-  }
-
-  if (m_coreInputView) {
-    auto occlusions = m_coreInputView.GetCoreInputViewOcclusions();
-    m_isShowing = !IsOcclusionsEmpty(occlusions);
-    m_occlusionsChanged_revoker = m_coreInputView.OcclusionsChanged(
-        winrt::auto_revoke, [this](auto &&, const winrt::CoreInputViewOcclusionsChangedEventArgs &e) {
+    : m_wkReactInstance(reactInstance) {
+  auto coreInputView = winrt::CoreInputView::GetForCurrentView();
+  if (coreInputView) {
+    m_occlusionsChanged_revoker = coreInputView.OcclusionsChanged(
+        winrt::auto_revoke, [=](auto &&, const winrt::CoreInputViewOcclusionsChangedEventArgs &e) {
           if (!e.Handled()) {
-            bool wasShowing = m_isShowing;
-            m_isShowing = !IsOcclusionsEmpty(e.Occlusions());
-            if (wasShowing != m_isShowing && m_fireKeyboradEvents) {
-              if (!m_isShowing) {
-                folly::dynamic params = folly::dynamic::object("screenY", 0)("screenX", 0)("width", 0)("height", 0);
-                SendEvent("keyboardDidHide", std::move(params));
-              } else {
-                folly::dynamic params = folly::dynamic::object(
-                    "endCoordinates",
-                    folly::dynamic::object("screenY", m_finalRect.Y)("screenX", m_finalRect.X)(
-                        "width", m_finalRect.Width)("height", m_finalRect.Height));
-                SendEvent("keyboardDidShow", std::move(params));
+            winrt::Rect finalRect = winrt::RectHelper::Empty();
+            winrt::IVectorView<winrt::CoreInputViewOcclusion> occlusions = e.Occlusions();
+            for (uint32_t i = 0; i < occlusions.Size(); i++) {
+              winrt::CoreInputViewOcclusion occlusion = occlusions.GetAt(i);
+              if (occlusion.OcclusionKind() == winrt::CoreInputViewOcclusionKind::Docked) {
+                finalRect = winrt::RectHelper::Union(finalRect, occlusion.OccludingRect());
               }
+            }
+
+            if (winrt::RectHelper::GetIsEmpty(finalRect)) {
+              folly::dynamic params = folly::dynamic::object("screenY", 0)("screenX", 0)("width", 0)("height", 0);
+              SendEvent("keyboardDidHide", std::move(params));
+            } else {
+              folly::dynamic params = folly::dynamic::object(
+                  "endCoordinates",
+                  folly::dynamic::object("screenY", finalRect.Y)("screenX", finalRect.X)("width", finalRect.Width)(
+                      "height", finalRect.Height));
+              SendEvent("keyboardDidShow", std::move(params));
             }
           }
         });
   }
 }
-/*
-void SIPEventHandler::TryShow() {
-  if (IsRS5OrHigher() && m_coreInputView && !m_isShowing) { // CoreInputView.TryShow is only avaliable after RS5
-      m_coreInputView.TryShow();
-    }
-}
-*/
 
-void SIPEventHandler::TryHide() {
-  if (IsRS5OrHigher() && m_coreInputView && m_isShowing) { // CoreInputView.TryHide is only avaliable after RS5
-    m_coreInputView.TryHide();
-  }
-}
-
-bool SIPEventHandler::IsOcclusionsEmpty(winrt::IVectorView<winrt::CoreInputViewOcclusion> occlusions) {
-  m_finalRect = winrt::RectHelper::Empty();
-  if (occlusions) {
-    for (const auto &occlusion : occlusions) {
-      if (occlusion.OcclusionKind() == winrt::CoreInputViewOcclusionKind::Docked) {
-        m_finalRect = winrt::RectHelper::Union(m_finalRect, occlusion.OccludingRect());
-      }
-    }
-  }
-  return (winrt::RectHelper::GetIsEmpty(m_finalRect));
+SIPEventHandler::~SIPEventHandler() {
+  m_occlusionsChanged_revoker = {};
 }
 
 void SIPEventHandler::SendEvent(std::string &&eventName, folly::dynamic &&parameters) {

--- a/vnext/ReactUWP/Views/SIPEventHandler.h
+++ b/vnext/ReactUWP/Views/SIPEventHandler.h
@@ -8,7 +8,7 @@
 #include <winrt/Windows.UI.ViewManagement.Core.h>
 
 namespace winrt {
-using namespace Windows::Foundation::Collections;
+using namespace Windows::Foundation;
 using namespace Windows::UI::ViewManagement::Core;
 } // namespace winrt
 
@@ -20,23 +20,10 @@ class SIPEventHandler {
   SIPEventHandler(const std::weak_ptr<IReactInstance> &reactInstance);
   virtual ~SIPEventHandler();
 
-  bool IsSIPShowing() {
-    return m_isShowing;
-  }
-
-  void AttachView(XamlView xamlView, bool fireKeyboardEvents);
-  // void TryShow();
-  void TryHide();
-
  private:
-  bool IsOcclusionsEmpty(winrt::IVectorView<winrt::CoreInputViewOcclusion> occlusions);
   void SendEvent(std::string &&eventName, folly::dynamic &&parameters);
   std::weak_ptr<IReactInstance> m_wkReactInstance;
   winrt::CoreInputView::OcclusionsChanged_revoker m_occlusionsChanged_revoker;
-  winrt::Rect m_finalRect;
-  winrt::CoreInputView m_coreInputView{nullptr};
-  bool m_isShowing{false};
-  bool m_fireKeyboradEvents;
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -3,7 +3,6 @@
 
 #include "pch.h"
 
-#include <ReactUWP\Views\SIPEventHandler.h>
 #include <Views/ShadowNodeBase.h>
 #include "Impl/ScrollViewUWPImplementation.h"
 #include "ScrollViewManager.h"
@@ -21,7 +20,6 @@ class ScrollViewShadowNode : public ShadowNodeBase {
 
  public:
   ScrollViewShadowNode();
-  ~ScrollViewShadowNode();
   void dispatchCommand(int64_t commandId, const folly::dynamic &commandArgs) override;
   void createView() override;
   void updateProperties(const folly::dynamic &&props) override;
@@ -46,10 +44,6 @@ class ScrollViewShadowNode : public ShadowNodeBase {
   bool m_isHorizontal = false;
   bool m_isScrollingEnabled = true;
   bool m_changeViewAfterLoaded = false;
-  bool m_dismissKeyboardOnDrag = false;
-
-  std::shared_ptr<SIPEventHandler> m_SIPEventHandler;
-  void RegisterSIPEventsWhenNeeded();
 
   winrt::FrameworkElement::SizeChanged_revoker m_scrollViewerSizeChangedRevoker{};
   winrt::FrameworkElement::SizeChanged_revoker m_contentSizeChangedRevoker{};
@@ -61,10 +55,6 @@ class ScrollViewShadowNode : public ShadowNodeBase {
 };
 
 ScrollViewShadowNode::ScrollViewShadowNode() {}
-
-ScrollViewShadowNode::~ScrollViewShadowNode() {
-  m_SIPEventHandler.reset();
-}
 
 void ScrollViewShadowNode::dispatchCommand(int64_t commandId, const folly::dynamic &commandArgs) {
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
@@ -196,12 +186,6 @@ void ScrollViewShadowNode::updateProperties(const folly::dynamic &&reactDiffMap)
       if (valid) {
         ScrollViewUWPImplementation(scrollViewer).SnapToEnd(snapToEnd);
       }
-    } else if (propertyName == "keyboardDismissMode") {
-      m_dismissKeyboardOnDrag = false;
-      if (propertyValue.isString()) {
-        m_dismissKeyboardOnDrag = (propertyValue.getString() == "on-drag");
-        RegisterSIPEventsWhenNeeded();
-      }
     } else if (propertyName == "snapToAlignment") {
       const auto [valid, snapToAlignment] = getPropertyAndValidity(propertyValue, winrt::SnapPointsAlignment::Near);
       if (valid) {
@@ -252,11 +236,6 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
   m_scrollViewerDirectManipulationStartedRevoker =
       scrollViewer.DirectManipulationStarted(winrt::auto_revoke, [this](const auto &sender, const auto &) {
         m_isScrolling = true;
-
-        if (m_dismissKeyboardOnDrag && m_SIPEventHandler) {
-          m_SIPEventHandler->TryHide();
-        }
-
         const auto scrollViewer = sender.as<winrt::ScrollViewer>();
         EmitScrollEvent(
             scrollViewer,
@@ -292,8 +271,6 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
         m_isScrollingFromInertia = false;
       });
   m_controlLoadedRevoker = scrollViewer.Loaded(winrt::auto_revoke, [this](const auto &sender, const auto &) {
-    RegisterSIPEventsWhenNeeded();
-
     if (m_changeViewAfterLoaded) {
       const auto scrollViewer = sender.as<winrt::ScrollViewer>();
       scrollViewer.ChangeView(nullptr, nullptr, static_cast<float>(m_zoomFactor));
@@ -301,17 +278,6 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
     }
   });
 }
-
-void ScrollViewShadowNode::RegisterSIPEventsWhenNeeded() {
-  if (m_dismissKeyboardOnDrag) {
-    auto view = GetView();
-    if (winrt::VisualTreeHelper::GetParent(view)) {
-      auto wkinstance = GetViewManager()->GetReactInstance();
-      m_SIPEventHandler = std::make_unique<SIPEventHandler>(wkinstance);
-      m_SIPEventHandler->AttachView(GetView(), false /*fireKeyboardEvents*/);
-    }
-  }
-} // namespace uwp
 
 void ScrollViewShadowNode::EmitScrollEvent(
     const winrt::ScrollViewer &scrollViewer,
@@ -430,8 +396,7 @@ folly::dynamic ScrollViewManager::GetNativeProps() const {
   props.update(folly::dynamic::object("horizontal", "boolean")("scrollEnabled", "boolean")(
       "showsHorizontalScrollIndicator", "boolean")("showsVerticalScrollIndicator", "boolean")(
       "minimumZoomScale", "float")("maximumZoomScale", "float")("zoomScale", "float")("snapToInterval", "float")(
-      "snapToOffsets", "array")("snapToAlignment", "number")("snapToStart", "boolean")("snapToEnd", "boolean")(
-      "keyboardDismissMode", "string"));
+      "snapToOffsets", "array")("snapToAlignment", "number")("snapToStart", "boolean")("snapToEnd", "boolean"));
 
   return props;
 }


### PR DESCRIPTION
Reverts microsoft/react-native-windows#3665
It crashed in latest inside build and have problem to GetForUIContext
```
  if (Is19H1OrHigher()) {
    // 19H1 and higher supports island scenarios
    auto uiElement(xamlView.as<winrt::UIElement>());
    m_coreInputView = winrt::CoreInputView::GetForUIContext(uiElement.UIContext());
  } else {
    m_coreInputView = winrt::CoreInputView::GetForCurrentView();
  }
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3692)