### PR TITLE
Update to react-native@0.60.0-microsoft.24

### DIFF
--- a/change/react-native-windows-2019-12-01-22-55-26-auto-update-versions060.0microsoft.24.json
+++ b/change/react-native-windows-2019-12-01-22-55-26-auto-update-versions060.0microsoft.24.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.24",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "a1091818524a587066df580064a426738c01df46",
+  "date": "2019-12-01T22:55:26.533Z"
+}

--- a/change/react-native-windows-extended-2019-12-01-22-55-28-auto-update-versions060.0microsoft.24.json
+++ b/change/react-native-windows-extended-2019-12-01-22-55-28-auto-update-versions060.0microsoft.24.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.24",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "227b368b47249d0cb4ac468a3a3152a18b6e296e",
+  "date": "2019-12-01T22:55:28.003Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
     "react-native-windows": "0.60.0-vnext.84",
     "react-native-windows-extended": "0.60.32",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
     "react-native-windows": "0.60.0-vnext.84",
     "react-native-windows-extended": "0.60.32",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
     "react-native-windows": "0.60.0-vnext.84",
     "react-native-windows-extended": "0.60.32",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.23 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.24 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,13 +48,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.23 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.23.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.24 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
eab20d458 Applying package update to 0.60.0-microsoft.24 ***NO_CI***
fe9ccbcbc Tomun/fixflow (#196)
3707a293f Stop beachball from publishing internally (#195)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3710)