### PR TITLE
Update GettingStarted.md - fixed yarn command

### DIFF
--- a/current/docs/GettingStarted.md
+++ b/current/docs/GettingStarted.md
@@ -24,7 +24,7 @@ npm install -g react-native-cli
 ```
 If you are using Yarn, run
 ```
-yarn add global react-native-cli
+yarn global add react-native-cli
 ```
 
 #### Initialize your project


### PR DESCRIPTION
To install a yarn package globally, the keyword `global` has to immediately follow `yarn` as per :https://yarnpkg.com/lang/en/docs/cli/global/

`yarn add global XXXX` won't install anything globally,

`yarn global add XXXX` will install the XXXX package globally, I just switched them to fix that command.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3714)