### PR TITLE
Port Important Changes in master to 0.59

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -21,6 +21,10 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+
       - task: CmdLine@2
         displayName: Install react-native-cli
         inputs:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -79,6 +79,10 @@ stages:
             clean: false
             submodules: false
 
+          - task: UseNode@1
+            inputs:
+              version: "10.x"
+
           - template: templates/build-rnw.yml
             parameters:
               useRnFork: $(UseRNFork)
@@ -186,6 +190,10 @@ stages:
             clean: false
             submodules: false
 
+          - task: UseNode@1
+            inputs:
+              version: "10.x"
+
           - task: VisualStudioTestPlatformInstaller@1
             inputs:
               testPlatformVersion: 16.3.0
@@ -196,8 +204,7 @@ stages:
               project: vnext/ReactWindows-Desktop.sln
               platformToolset: v141
               vsComponents: $(VsComponents)
-              msbuildArguments:
-                /p:RNW_PKG_VERSION_STR="Private Build"
+              msbuildArguments: /p:RNW_PKG_VERSION_STR="Private Build"
                 /p:RNW_PKG_VERSION="1000,0,0,0"
 
           - task: VSTest@2
@@ -262,6 +269,10 @@ stages:
             lfs: false # whether to download Git-LFS files
             submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
             persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+          - task: UseNode@1
+            inputs:
+              version: "10.x"
 
           # First do a build of the local package, since we point the cli at the local files, it needs to be pre-built
           - task: CmdLine@2
@@ -413,6 +424,10 @@ stages:
             lfs: false # whether to download Git-LFS files
             submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
             persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+          - task: UseNode@1
+            inputs:
+              version: "10.x"
 
           - task: PowerShell@2
             displayName: Download Winium

--- a/change/react-native-windows-2019-12-03-13-48-52-enable-cfg-0.59.json
+++ b/change/react-native-windows-2019-12-03-13-48-52-enable-cfg-0.59.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enable CFG for release builds by default.",
+  "packageName": "react-native-windows",
+  "email": "yicyao@microsoft.com",
+  "commit": "9c1a5ae479f500b4039e50ce82c32a6003ba983c",
+  "date": "2019-12-03T21:48:52.291Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -43,6 +43,7 @@
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;BOOST_SYSTEM_SOURCE;BOOST_ERROR_CODE_HEADER_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ControlFlowGuard Condition="'$(Configuration)' != 'Debug'">Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
- Enable CFG by default for 0.59 release builds.

- react-native-cli does not work with node 12 right now. In master, we downgrade to node 10 before running PR tasks. This PR changes the 0.59 branch to match master's behavior.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3719)