### PR TITLE
Update to react-native@0.60.0-microsoft.26

### DIFF
--- a/change/react-native-windows-2019-12-05-18-09-22-auto-update-versions060.0microsoft.26.json
+++ b/change/react-native-windows-2019-12-05-18-09-22-auto-update-versions060.0microsoft.26.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.26",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "afebe17f813a568613ffcf527c8fff20dfdcab05",
+  "date": "2019-12-05T18:09:22.305Z"
+}

--- a/change/react-native-windows-extended-2019-12-05-18-09-24-auto-update-versions060.0microsoft.26.json
+++ b/change/react-native-windows-extended-2019-12-05-18-09-24-auto-update-versions060.0microsoft.26.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.26",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9369a6d9dce845949d33ea52b11c344caf3b8f62",
+  "date": "2019-12-05T18:09:24.044Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
     "react-native-windows": "0.60.0-vnext.86",
     "react-native-windows-extended": "0.60.34",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
     "react-native-windows": "0.60.0-vnext.86",
     "react-native-windows-extended": "0.60.34",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
     "react-native-windows": "0.60.0-vnext.86",
     "react-native-windows-extended": "0.60.34",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.24 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.26 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,13 +48,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.24 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.24.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.26 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
99e819f63 Applying package update to 0.60.0-microsoft.26 ***NO_CI***
b6790b6d5 Adding the new jsiinspector shared module to the nuget package exported to office (#200)
d9a25c2d0 Applying package update to 0.60.0-microsoft.25 ***NO_CI***
e4db078ce Removed geolocation targets from nuspec as they are not longer in the repo.  Added <repository type="git" url="$repoUri$" commit="$commitId$" /> which is needed to record the relevent meta data about the publish.   Removed an obsolete comment. (#197)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3725)