### PR TITLE
Update to react-native@0.60.0-microsoft.27

### DIFF
--- a/change/react-native-windows-2019-12-05-23-45-43-auto-update-versions060.0microsoft.27.json
+++ b/change/react-native-windows-2019-12-05-23-45-43-auto-update-versions060.0microsoft.27.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.27",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "192cd073dc0c64201d63408a80c8e8696764c232",
+  "date": "2019-12-05T23:45:43.952Z"
+}

--- a/change/react-native-windows-extended-2019-12-05-23-45-45-auto-update-versions060.0microsoft.27.json
+++ b/change/react-native-windows-extended-2019-12-05-23-45-45-auto-update-versions060.0microsoft.27.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.27",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "6df962db4800baf639898c046eb281eea3d62b03",
+  "date": "2019-12-05T23:45:45.667Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz",
     "react-native-windows": "0.60.0-vnext.87",
     "react-native-windows-extended": "0.60.35",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz",
     "react-native-windows": "0.60.0-vnext.87",
     "react-native-windows-extended": "0.60.35",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz",
     "react-native-windows": "0.60.0-vnext.87",
     "react-native-windows-extended": "0.60.35",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.26 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.27 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,13 +48,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.26 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.26.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.27 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.27.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
95c7e0fd9 Applying package update to 0.60.0-microsoft.27 ***NO_CI***
39ce8a726 Use $buildNumber$ token for NuGet (#198)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3727)