### PR TITLE
Fix error handling in WebSocket.connect

### DIFF
--- a/change/react-native-windows-2019-12-09-11-51-33-WebSocketConnectError.json
+++ b/change/react-native-windows-2019-12-09-11-51-33-WebSocketConnectError.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "This change correctly handles a failed WebSocket connection",
+  "packageName": "react-native-windows",
+  "email": "acampbell2@officeworks.com.au",
+  "commit": "cba52ff91293ce401c7b5db64addca9e8f859d3d",
+  "date": "2019-12-09T01:51:32.983Z"
+}

--- a/vnext/ReactUWP/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/WebSocketModuleUwp.cpp
@@ -139,10 +139,10 @@ void WebSocketModule::WebSocket::connect(
 
   winrt::Windows::Foundation::Uri uri(Microsoft::Common::Unicode::Utf8ToUtf16(url));
 
-  HRESULT hr = S_OK;
+  winrt::hresult hr = S_OK;
   try {
     auto async = Connect(socket, uri);
-    winrt::hresult hr = async.get();
+    hr = async.get();
     if (SUCCEEDED(hr)) {
       folly::dynamic params = folly::dynamic::object("id", id);
       sendEvent("websocketOpen", std::move(params));


### PR DESCRIPTION
variable hr is initialised both inside and outside the try/catch block, meaning that outside of the try/catch, hr is always S_OK -- removed duplicate variable initialisation to ensure that WebSocket.onerror is correctly called when a socket fails to connect

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3739)