### PR TITLE
Update to react-native@0.60.0-microsoft.29

### DIFF
--- a/change/react-native-windows-2019-12-10-01-28-12-auto-update-versions060.0microsoft.29.json
+++ b/change/react-native-windows-2019-12-10-01-28-12-auto-update-versions060.0microsoft.29.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.29",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "bfa488c8d75d6099f5b2e338b53f903a46016b88",
+  "date": "2019-12-10T01:28:12.638Z"
+}

--- a/change/react-native-windows-extended-2019-12-10-01-28-14-auto-update-versions060.0microsoft.29.json
+++ b/change/react-native-windows-extended-2019-12-10-01-28-14-auto-update-versions060.0microsoft.29.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.29",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "e8b98c05f1f51c52c73e622c540edd4c52e5eb3c",
+  "date": "2019-12-10T01:28:14.375Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz",
     "react-native-windows": "0.60.0-vnext.91",
     "react-native-windows-extended": "0.60.39",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz",
     "react-native-windows": "0.60.0-vnext.91",
     "react-native-windows-extended": "0.60.39",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz",
     "react-native-windows": "0.60.0-vnext.91",
     "react-native-windows-extended": "0.60.39",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.29 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,13 +48,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.29 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.29.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
0782a6eaf Applying package update to 0.60.0-microsoft.29 ***NO_CI***
9bd79f3b0 redo broken dependencies for the publish targets that sdx-platform needs to succeed (#206)
e4ffca271 Add 0.59-stable branch to PR build trigger (#202) (#204)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3747)