### PR TITLE
Update to react-native@0.60.0-microsoft.30

### DIFF
--- a/change/react-native-windows-2019-12-10-15-50-18-auto-update-versions060.0microsoft.30.json
+++ b/change/react-native-windows-2019-12-10-15-50-18-auto-update-versions060.0microsoft.30.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.30",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "b8fd3f6c0cdbac22eaa16303b98360647a6df36a",
+  "date": "2019-12-10T15:50:18.943Z"
+}

--- a/change/react-native-windows-extended-2019-12-10-15-50-20-auto-update-versions060.0microsoft.30.json
+++ b/change/react-native-windows-extended-2019-12-10-15-50-20-auto-update-versions060.0microsoft.30.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.30",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "b445d301b730153101a931736e3e86dffb767ed0",
+  "date": "2019-12-10T15:50:20.556Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz",
     "react-native-windows": "0.60.0-vnext.91",
     "react-native-windows-extended": "0.60.39",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz",
     "react-native-windows": "0.60.0-vnext.91",
     "react-native-windows-extended": "0.60.39",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz",
     "react-native-windows": "0.60.0-vnext.91",
     "react-native-windows-extended": "0.60.39",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.30 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,13 +48,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.30 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.30.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
7fb5723a9 Applying package update to 0.60.0-microsoft.30 ***NO_CI***
45554f8ec Avoid throwing exceptions from native modules when the host activity … (#201)
a65c7af60 Adding the new jsiinspector shared module to the nuget package exported to office (#203)
0782a6eaf Applying package update to 0.60.0-microsoft.29 ***NO_CI***
9bd79f3b0 redo broken dependencies for the publish targets that sdx-platform needs to succeed (#206)
e4ffca271 Add 0.59-stable branch to PR build trigger (#202) (#204)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3751)