### PR TITLE
Update to react-native@0.60.0-microsoft.31

### DIFF
--- a/change/@office-iss-react-native-win32-2019-12-12-21-10-06-auto-update-versions060.0microsoft.31.json
+++ b/change/@office-iss-react-native-win32-2019-12-12-21-10-06-auto-update-versions060.0microsoft.31.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.31",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9b66731f5ee90d2ca6f4dc7d7a7692f9b6eef225",
+  "date": "2019-12-12T21:10:06.243Z"
+}

--- a/change/react-native-windows-2019-12-12-21-10-06-auto-update-versions060.0microsoft.31.json
+++ b/change/react-native-windows-2019-12-12-21-10-06-auto-update-versions060.0microsoft.31.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.31",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9b66731f5ee90d2ca6f4dc7d7a7692f9b6eef225",
+  "date": "2019-12-12T21:10:06.179Z"
+}

--- a/change/react-native-windows-extended-2019-12-12-21-10-07-auto-update-versions060.0microsoft.31.json
+++ b/change/react-native-windows-extended-2019-12-12-21-10-07-auto-update-versions060.0microsoft.31.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.31",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "c30be94651aff8617b3b38e51414be5323abbfaa",
+  "date": "2019-12-12T21:10:07.582Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "react-native-windows": "0.60.0-vnext.93",
     "react-native-windows-extended": "0.60.42",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "react-native-windows": "0.60.0-vnext.93",
     "react-native-windows-extended": "0.60.42",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "react-native-windows": "0.60.0-vnext.93",
     "react-native-windows-extended": "0.60.42",
     "rnpm-plugin-windows": "^0.3.8"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -40,7 +40,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "@office-iss/rex-win32": "0.0.30",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -53,7 +53,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,13 +48,13 @@
     "eslint": "5.1.0",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.28 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.28.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
7abd5c4cc Applying package update to 0.60.0-microsoft.31 ***NO_CI***
1f7dacc98 manually update our xcschemes to have our build action entries for dependent libraries (#207)
7fb5723a9 Applying package update to 0.60.0-microsoft.30 ***NO_CI***
45554f8ec Avoid throwing exceptions from native modules when the host activity … (#201)
a65c7af60 Adding the new jsiinspector shared module to the nuget package exported to office (#203)
0782a6eaf Applying package update to 0.60.0-microsoft.29 ***NO_CI***
9bd79f3b0 redo broken dependencies for the publish targets that sdx-platform needs to succeed (#206)
e4ffca271 Add 0.59-stable branch to PR build trigger (#202) (#204)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3769)