### PR TITLE
Delete .pch after build on pipeline

### DIFF
--- a/change/react-native-windows-2019-12-13-11-33-23-PCHDelete.json
+++ b/change/react-native-windows-2019-12-13-11-33-23-PCHDelete.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete .PCH ",
+  "packageName": "react-native-windows",
+  "email": "licanhua@live.com",
+  "commit": "42a383343b2b7624fb05efd5253064d9102746de",
+  "date": "2019-12-13T19:33:23.242Z"
+}

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -47,4 +47,26 @@
     <Message Text="=> VCTargetsPath           [$(VCTargetsPath)]" />
   </Target>
 
+  <Target Name="_ComputePrecompToCleanUp">
+    <ItemGroup>
+      <PCHFileToClean Include="$(IntDir)\**\*.pch" />
+      <_PCHFileToCleanWithTimestamp Include="@(PCHFileToClean)" Condition="'%(Identity)' != ''">
+        <LastWriteTime>$([System.IO.File]::GetLastWriteTime('%(Identity)'))</LastWriteTime>
+      </_PCHFileToCleanWithTimestamp>
+    </ItemGroup>
+  </Target>
+  <!-- 
+    As a cppwinrt project, .pch is very big, and delete it in pipeline after build
+    Instead of outright deleting the PCHs, we want to trick the "project freshness detector" by
+    emitting empty files that look suspiciously like the PCHs it's expecting.
+    It's of utmost importance that their timestamps match up. -->
+  <Target Name="CleanUpPrecompHeaders"
+          DependsOnTargets="_ComputePrecompToCleanUp"
+          AfterTargets="AfterBuild"
+          Condition="'$(AGENT_ID)' != ''">
+    <!-- We just need to keep *ReactNativeWindows*'s PCHs because they get rebuilt more often. -->
+    <Delete Files="@(_PCHFileToCleanWithTimestamp)"/>
+    <Touch Files="@(_PCHFileToCleanWithTimestamp)" Time="%(LastWriteTime)" AlwaysCreate="true" />
+    <Message Text="PCH and Precomp object @(_PCHFileToCleanWithTimestamp) has been deleted for $(ProjectName)." />
+  </Target>
 </Project>


### PR DESCRIPTION
Will help on #3197 and fix #3620

cppwinrt generated huge .pch. This is an example to remove them from pipeline.
I didn't apply them to projects in packages. If we still see disk usage issue, we can apply it too.

ideas are from: https://github.com/microsoft/terminal/blob/a3f3cc823c786d7a217632b03f3cb9af83faeb6d/src/common.build.post.props#L42-L62


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3771)