### PR TITLE
reduce build flavors for RNWUniversalPR 

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -26,23 +26,23 @@ jobs:
     condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
     strategy:
       matrix:
-        X64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x64
-          UseRNFork: true
-          LayoutHeaders: true
-        X64Release:
-          BuildConfiguration: Release
-          BuildPlatform: x64
-          UseRNFork: true
-        ArmDebug:
-          BuildConfiguration: Debug
-          BuildPlatform: arm
-          UseRNFork: true
-        X86Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-          UseRNFork: true
+        #X64Debug:
+        #  BuildConfiguration: Debug
+        #  BuildPlatform: x64
+        #  UseRNFork: true
+        #  LayoutHeaders: true
+        #X64Release:
+        #  BuildConfiguration: Release
+        #  BuildPlatform: x64
+        #  UseRNFork: true
+        #ArmDebug:
+        #  BuildConfiguration: Debug
+        #  BuildPlatform: arm
+        #  UseRNFork: true
+        #X86Debug:
+        #  BuildConfiguration: Debug
+        #  BuildPlatform: x86
+        #  UseRNFork: true
         X86Release:
           BuildConfiguration: Release
           BuildPlatform: x86
@@ -182,12 +182,12 @@ jobs:
         X64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
-        X86Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-        X64Release:
-          BuildConfiguration: Release
-          BuildPlatform: x64
+        #X86Debug:
+        #  BuildConfiguration: Debug
+        #  BuildPlatform: x86
+        #X64Release:
+        #  BuildConfiguration: Release
+        #  BuildPlatform: x64
         X86Release:
           BuildConfiguration: Release
           BuildPlatform: x86
@@ -560,5 +560,13 @@ jobs:
       - task: NuGetToolInstaller@0
         inputs:
           versionSpec: ">=4.6.0"
+
+      # Exclude ReactUWP from nuget because we didn't build all the flavours.
+      - task: PowerShell@2
+        displayName: Download Winium
+        inputs:
+          targetType: inline # filePath | inline
+          script: |
+            ((Get-Content -path vnext\Scripts\ReactUwp.nuspec -Raw) -replace ".*ReactUWP\React.UWP.*","") | Set-Content -Path vnext\Scripts\ReactUwp.nuspec
 
       - template: templates/prep-and-pack-nuget.yml

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -182,12 +182,12 @@ jobs:
         X64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
-        #X86Debug:
-        #  BuildConfiguration: Debug
-        #  BuildPlatform: x86
-        #X64Release:
-        #  BuildConfiguration: Release
-        #  BuildPlatform: x64
+        X86Debug:
+          BuildConfiguration: Debug
+          BuildPlatform: x86
+        X64Release:
+          BuildConfiguration: Release
+          BuildPlatform: x64
         X86Release:
           BuildConfiguration: Release
           BuildPlatform: x86

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -563,7 +563,7 @@ jobs:
 
       # Exclude ReactUWP from nuget because we didn't build all the flavours.
       - task: PowerShell@2
-        displayName: Download Winium
+        displayName: Exclude ReactUWP from ReactUwp.nuspec
         inputs:
           targetType: inline # filePath | inline
           script: |

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -567,6 +567,6 @@ jobs:
         inputs:
           targetType: inline # filePath | inline
           script: |
-            ((Get-Content -path vnext\Scripts\ReactUwp.nuspec -Raw) -replace ".*ReactUWP\React.UWP.*","") | Set-Content -Path vnext\Scripts\ReactUwp.nuspec
+            ((Get-Content -path vnext\Scripts\ReactUwp.nuspec -Raw) -replace ".*ReactUWP\\React.UWP.*","") | Set-Content -Path vnext\Scripts\ReactUwp.nuspec
 
       - template: templates/prep-and-pack-nuget.yml


### PR DESCRIPTION
Currently we have more than 20 parallel jobs, This will help to reduce the number of parallel jobs.
We don't need to build all the flavors for RNWUniversalPR because publish pipeline will redo anything.
This change exclude React.UWP from the nuspec in PR pipeline, and it still be able to catch the bugs which is caused by missing files which nuget required.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3773)