### PR TITLE
ignore Bundle folder in sampleapps

### DIFF
--- a/packages/microsoft-reactnative-sampleapps/.gitignore
+++ b/packages/microsoft-reactnative-sampleapps/.gitignore
@@ -5,3 +5,5 @@
 /windows/SampleLibraryCS/Generated Files/
 /build
 /msbuild*
+/windows/SampleAppCS/Bundle
+/windows/SampleAppCPP/Bundle


### PR DESCRIPTION
Avoid untracked Bundle folder like below
```
PS D:\repo\react-native-windows> git status
On branch gitignore
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/Bundle/
        packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/Bundle/
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3778)