### PR TITLE
CLI reads name from app.json if it doesn't exist in package.json

### DIFF
--- a/change/rnpm-plugin-windows-2019-12-16-13-38-43-nugetver.json
+++ b/change/rnpm-plugin-windows-2019-12-16-13-38-43-nugetver.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "CLI detect project name from app.json",
+  "packageName": "rnpm-plugin-windows",
+  "email": "licanhua@live.com",
+  "commit": "ed24ef5033bac55fb8f0db6ee727051521e4682c",
+  "date": "2019-12-16T21:38:43.643Z"
+}

--- a/current/local-cli/rnpm/windows/src/common.js
+++ b/current/local-cli/rnpm/windows/src/common.js
@@ -122,7 +122,17 @@ const getReactNativeVersion = function () {
 
 const getReactNativeAppName = function () {
   console.log('Reading application name from package.json...');
-  return JSON.parse(fs.readFileSync('package.json', 'utf8')).name;
+  let name = JSON.parse(fs.readFileSync('package.json', 'utf8')).name;
+  if (!name) {
+    if (fs.existsSync('app.json')) {
+      console.log('Reading application name from app.json...');
+      name = JSON.parse(fs.readFileSync('app.json', 'utf8')).name;
+    }
+  }
+  if (!name) {
+    console.error('Please specify name in package.json or app.json');
+  }
+  return name;
 };
 
 /**


### PR DESCRIPTION
Fix #2808

For `expo init` and `expo eject` project, name is existing in app.json other than package.json.

Example output
```
D:\repo\AwesomeProject>react-native windows --template vnext
Reading application name from package.json...
Reading application name from app.json...
Reading react-native version from node_modules...
```
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3781)