### PR TITLE
Fix invalid regular expression error

### DIFF
--- a/change/@office-iss-react-native-win32-2020-02-15-01-31-40-patch-2.json
+++ b/change/@office-iss-react-native-win32-2020-02-15-01-31-40-patch-2.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fix Invalid Regular Expression (#3795)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "t-pesant@microsoft.com",
+  "commit": "5d51eb6cc6b9610b35ff76c8ce1d4270661b22cd",
+  "dependentChangeType": "patch",
+  "date": "2020-02-15T01:31:37.614Z"
+}

--- a/change/react-native-windows-2020-02-15-01-31-40-patch-2.json
+++ b/change/react-native-windows-2020-02-15-01-31-40-patch-2.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fix Invalid Regular Expression (#3795)",
+  "packageName": "react-native-windows",
+  "email": "t-pesant@microsoft.com",
+  "commit": "5d51eb6cc6b9610b35ff76c8ce1d4270661b22cd",
+  "dependentChangeType": "patch",
+  "date": "2020-02-15T01:31:40.076Z"
+}

--- a/packages/E2ETest/metro.config.js
+++ b/packages/E2ETest/metro.config.js
@@ -39,28 +39,26 @@ module.exports = {
     blacklistRE: blacklist([
       new RegExp(
         `${'.*E2ETest/msbuild.*'
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`
+          .replace(/[/\\\\]/g, '/')}.*`
       ), // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\E2ETest\msbuild.ProjectImports.zip' in pipeline
-      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '[/\\\\]')}.*`),
+      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '/')}.*`),
       new RegExp(
-        `${path
-          .resolve(rnwPath, 'RNTesterCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(rnwPath, 'RNTesterCopy').replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwPath, 'IntegrationTestsCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwPath, 'node_modules/react-native')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`
+          .replace(/[/\\\\]/g, '/')}.*`
       ),
       new RegExp(
         `${path
           .resolve(rnwePath, 'node_modules/react-native')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`
+          .replace(/[/\\\\]/g, '/')}.*`
       ),
       new RegExp(
         `${path
@@ -68,12 +66,12 @@ module.exports = {
             require.resolve('@react-native-community/cli/package.json'),
             '../node_modules/react-native'
           )
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`
+          .replace(/[/\\\\]/g, '/')}.*`
       ),
 
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
-        `${path.resolve(__dirname, 'windows').replace(/[/\\\\]/g, '[/\\\\]')}.*`
+        `${path.resolve(__dirname, 'windows').replace(/[/\\\\]/g, '/')}.*`
       ),
     ]),
   },

--- a/packages/microsoft-reactnative-sampleapps/metro.config.js
+++ b/packages/microsoft-reactnative-sampleapps/metro.config.js
@@ -40,29 +40,27 @@ module.exports = {
       new RegExp(
         `${'.*microsoft-reactnative-sampleapps/msbuild.*'.replace(
           /[/\\\\]/g,
-          '[/\\\\]',
+          '/',
         )}.*`,
       ), // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\E2ETest\msbuild.ProjectImports.zip' in pipeline
-      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '[/\\\\]')}.*`),
+      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '/')}.*`),
       new RegExp(
-        `${path
-          .resolve(rnwPath, 'RNTesterCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(rnwPath, 'RNTesterCopy').replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwPath, 'IntegrationTestsCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwPath, 'node_modules/react-native')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwePath, 'node_modules/react-native')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
@@ -70,13 +68,11 @@ module.exports = {
             require.resolve('@react-native-community/cli/package.json'),
             '../node_modules/react-native',
           )
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
-        `${path
-          .resolve(__dirname, 'windows')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(__dirname, 'windows').replace(/[/\\\\]/g, '/')}.*`,
       ),
     ]),
   },

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -39,26 +39,24 @@ module.exports = {
     // Since there are multiple copies of react-native, we need to ensure that metro only sees one of them
     // This should go away after RN 0.61 when haste is removed
     blacklistRE: blacklist([
-      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '[/\\\\]')}.*`),
+      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '/')}.*`),
       new RegExp(
         `${path
           .resolve(rnwPath, 'node_modules/react-native')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
-        `${path
-          .resolve(rnwPath, 'RNTesterCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(rnwPath, 'RNTesterCopy').replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwPath, 'IntegrationTestsCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwePath, 'node_modules/react-native')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
@@ -66,14 +64,12 @@ module.exports = {
             require.resolve('@react-native-community/cli/package.json'),
             '../node_modules/react-native',
           )
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
 
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
-        `${path
-          .resolve(__dirname, 'windows')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(__dirname, 'windows').replace(/[/\\\\]/g, '/')}.*`,
       ),
     ]),
   },

--- a/packages/react-native-win32/metro.config.js
+++ b/packages/react-native-win32/metro.config.js
@@ -38,14 +38,14 @@ module.exports = {
     // Since there are multiple copies of react-native, we need to ensure that metro only sees one of them
     // This should go away after RN 0.61 when haste is removed
     blacklistRE: blacklist([
-      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '[/\\\\]')}.*`),
+      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '/')}.*`),
       new RegExp(
         `${path
           .resolve(
             require.resolve('@react-native-community/cli/package.json'),
             '../node_modules/react-native',
           )
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
     ]),
   },

--- a/vnext/local-cli/generator-windows/templates/metro.config.js
+++ b/vnext/local-cli/generator-windows/templates/metro.config.js
@@ -28,14 +28,12 @@ module.exports = {
     // This should go in RN 0.61 when haste is removed
     blacklistRE: blacklist([
       new RegExp(
-        `${(path.resolve(rnPath) + path.sep).replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${(path.resolve(rnPath) + path.sep).replace(/[/\\\\]/g, '/')}.*`,
       ),
 
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
-        `${path
-          .resolve(__dirname, 'windows')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(__dirname, 'windows').replace(/[/\\\\]/g, '/')}.*`,
       ),
     ]),
   },

--- a/vnext/metro.config.js
+++ b/vnext/metro.config.js
@@ -30,16 +30,14 @@ module.exports = {
     // Since there are multiple copies of react-native, we need to ensure that metro only sees one of them
     // This should go away after RN 0.61 when haste is removed
     blacklistRE: blacklist([
-      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '[/\\\\]')}.*`),
+      new RegExp(`${path.resolve(rnPath).replace(/[/\\\\]/g, '/')}.*`),
       new RegExp(
-        `${path
-          .resolve(rnwPath, 'RNTesterCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+        `${path.resolve(rnwPath, 'RNTesterCopy').replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
           .resolve(rnwPath, 'IntegrationTestsCopy')
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
       new RegExp(
         `${path
@@ -47,7 +45,7 @@ module.exports = {
             require.resolve('@react-native-community/cli/package.json'),
             '../node_modules/react-native',
           )
-          .replace(/[/\\\\]/g, '[/\\\\]')}.*`,
+          .replace(/[/\\\\]/g, '/')}.*`,
       ),
     ]),
     hasteImplModulePath: path.resolve(__dirname, 'jest/hasteImpl.js'),


### PR DESCRIPTION
Facebook Metro has a bug facebook/metro#498 that replaces any `/` with the system path separator on blacklist. So expressions like `[/\\]` become `[\\\]` on Windows and an invalid regular expression error in thrown when building some React Native for Windows projects.

To really fix that we need:
- facebook/metro#498 to get merged
- a new version of Facebook Metro to be released
- a new PR to be created updating Metro version on React Native CLI
- the second PR to get merged
- a new version of React Native CLI to be released
- another PR on this repository updating React Native CLI version
- the final PR to get merged
- a new version of React Native for Windows to be released

This long path will occasionally happen, but it will take time. To fix this problem early on React Native for Windows, I propose a workaround that replaces expressions like `[/\\]` with just `/` as Facebook Metro will already replace `/` with the correct path separator on each OS.

Another problem is that the version of React Native CLI that we are using has a old version of Facebook Metro that uses `[/\\]` expressions, so a local fix here would not help unless we stop using the `blacklist` function from Metro. To solve this problem I've submitted a PR to React Native CLI react-native-community/cli#893 back-porting the Facebook Metro update to React Native CLI 2.x.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3795)