### PR TITLE
SourceCode module should provide scriptURL when running livereload without webdebugger

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -238,6 +238,13 @@ jobs:
             /p:RNW_PKG_VERSION_STR="Private Build"
             /p:RNW_PKG_VERSION="1000,0,0,0"
 
+      - task: CmdLine@2
+        displayName: Build react-native-win32 RNTester bundle
+        inputs:
+          script: yarn bundle
+          workingDirectory: packages/react-native-win32
+        condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x64'))
+
       - task: VSTest@2
         displayName: Run Desktop Unit Tests
         timeoutInMinutes: 5 # Set smaller timeout , due to hangs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,30 +8,32 @@
     "**/dist": true
   },
   "editor.formatOnSave": true,
-  // turn off formatting for JS and JSX, we will do this via eslint
-  "[javascript]": {
-    "editor.formatOnSave": false
-  },
-  "[javascriptreact]": {
-    "editor.formatOnSave": false
-  },
-  "[typescript]": {
-    "editor.formatOnSave": false
-  },
-  "[typescriptreact]": {
-    "editor.formatOnSave": false
-  },
+  "eslint.format.enable": true,
   "eslint.packageManager": "yarn",
-  "eslint.autoFixOnSave": true,
   "eslint.enable": true,
   "eslint.validate": [
-    {"language": "javascript", "autoFix": true},
-    {"language": "javascriptreact", "autoFix": true},
-    {"language": "typescript", "autoFix": true},
-    {"language": "typescriptreact", "autoFix": true}
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
   ],
   "eslint.options": {
     "configFile": "./vnext/.eslintrc.js"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   // These should run through eslint
   "prettier.disableLanguages": [
@@ -44,5 +46,8 @@
   "clang-format.language.typescript.enable": false,
   "clang-format.assumeFilename": "${workspaceFolder}/.clang-format",
   "clang-format.executable": "${workspaceRoot}/vnext/node_modules/.bin/clang-format",
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/change/@office-iss-react-native-win32-2019-12-18-14-17-59-fixupwin32.json
+++ b/change/@office-iss-react-native-win32-2019-12-18-14-17-59-fixupwin32.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Dont checkin generated index files",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates@microsoft.com",
+  "commit": "ee0de45b4e776cd6d110b6e5fdb94bfbae1c7133",
+  "date": "2019-12-18T22:17:55.695Z"
+}

--- a/change/react-native-windows-2019-12-18-14-17-59-fixupwin32.json
+++ b/change/react-native-windows-2019-12-18-14-17-59-fixupwin32.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Provide source uri in SourceCode module when using livereload",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "ee0de45b4e776cd6d110b6e5fdb94bfbae1c7133",
+  "date": "2019-12-18T22:17:59.673Z"
+}

--- a/packages/react-native-win32/.gitignore
+++ b/packages/react-native-win32/.gitignore
@@ -1,5 +1,6 @@
 /demo
 /dist
+/index.*
 /IntegrationTests
 /jest
 /lib

--- a/packages/react-native-win32/README.md
+++ b/packages/react-native-win32/README.md
@@ -1,0 +1,9 @@
+# @office-iss/react-native-win32
+
+**Internal use only**
+
+To better support some of our open source efforts, we are publishing this @office-iss/react-native-win32 JS package that office uses on win32. This is not a package that is generally consumable by other since it requires Office's UI framework which isn't open source. But it does allow some of our other cross platform efforts to be able to open source their work where previously its been unable to if Office win32 was one of the target platforms. This will enable projects such as our cross platform component libraries to be able to be published to open source.
+
+# Running react-native on win32.
+
+We do have a solution for running react-native in a win32 app.  You can run react-native-windows on win32 using Xaml Islands.  We are working on expanding the set of supported windows versions to broaden the support of that, and provide more samples of how to do that.

--- a/packages/react-native-win32/docs/api/react-native-win32.md
+++ b/packages/react-native-win32/docs/api/react-native-win32.md
@@ -12,7 +12,7 @@ This package provides Win32 specific components and provides JS implementations 
 |  --- | --- |
 |  [ButtonWin32](./react-native-win32.buttonwin32.md) | React-native <Button> control with additional Win32-specific functionality. |
 |  [TextWin32](./react-native-win32.textwin32.md) |  |
-|  [TouchableWin32](./react-native-win32.touchablewin32.md) | TouchableWin32 is a 'compentantization' of the Touchable Mixin in React Native. This means that instead of implementing components such as TouchableHighlight via the mixin, they are merely implemented as wrappers around TouchableWin32, forwarding the correct set of props. Additionally, TouchableWin32 supports hover via onMouseEnter and onMouseLeave and focus/blur via onFocus/onBlur. TouchableWin32 also allows for functions as child components (that use the internal state of the touchable to conditionally render children) as well functions as styles (that use internal state to conditionally calculate styles) |
+|  [TouchableWin32](./react-native-win32.touchablewin32.md) | TouchableWin32 is a 'componentization' of the Touchable Mixin in React Native. This means that instead of implementing components such as TouchableHighlight via the mixin, they are merely implemented as wrappers around TouchableWin32, forwarding the correct set of props. Additionally, TouchableWin32 supports hover via onMouseEnter and onMouseLeave and focus/blur via onFocus/onBlur. TouchableWin32 also allows for functions as child components (that use the internal state of the touchable to conditionally render children) as well functions as styles (that use internal state to conditionally calculate styles) |
 |  [ViewWin32](./react-native-win32.viewwin32.md) |  |
 
 ## Enumerations

--- a/packages/react-native-win32/docs/api/react-native-win32.touchablewin32.md
+++ b/packages/react-native-win32/docs/api/react-native-win32.touchablewin32.md
@@ -4,7 +4,7 @@
 
 ## TouchableWin32 class
 
-TouchableWin32 is a 'compentantization' of the Touchable Mixin in React Native. This means that instead of implementing components such as TouchableHighlight via the mixin, they are merely implemented as wrappers around TouchableWin32, forwarding the correct set of props. Additionally, TouchableWin32 supports hover via onMouseEnter and onMouseLeave and focus/blur via onFocus/onBlur. TouchableWin32 also allows for functions as child components (that use the internal state of the touchable to conditionally render children) as well functions as styles (that use internal state to conditionally calculate styles)
+TouchableWin32 is a 'componentization' of the Touchable Mixin in React Native. This means that instead of implementing components such as TouchableHighlight via the mixin, they are merely implemented as wrappers around TouchableWin32, forwarding the correct set of props. Additionally, TouchableWin32 supports hover via onMouseEnter and onMouseLeave and focus/blur via onFocus/onBlur. TouchableWin32 also allows for functions as child components (that use the internal state of the touchable to conditionally render children) as well functions as styles (that use internal state to conditionally calculate styles)
 
 <b>Signature:</b>
 

--- a/packages/react-native-win32/index.d.ts
+++ b/packages/react-native-win32/index.d.ts
@@ -1,2 +1,0 @@
-declare const _default: any;
-export = _default;

--- a/packages/react-native-win32/index.js
+++ b/packages/react-native-win32/index.js
@@ -1,3 +1,0 @@
-"use strict";
-module.exports = require('./Libraries/react-native/react-native-implementation.win32');
-//# sourceMappingURL=index.js.map

--- a/packages/react-native-win32/index.js.map
+++ b/packages/react-native-win32/index.js.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["src/index.ts"],"names":[],"mappings":";AAAA,iBAAS,OAAO,CAAC,4DAA4D,CAAC,CAAC"}

--- a/packages/react-native-win32/just-task.js
+++ b/packages/react-native-win32/just-task.js
@@ -78,7 +78,9 @@ function ensureDirectoryExists(filePath) {
 }
 
 task('prepareBundle', () => {
-  ensureDirectoryExists(path.resolve(__dirname, 'dist/win32/dev'));
+  ensureDirectoryExists(
+    path.resolve(__dirname, 'dist/win32/dev/index.win32.bundle'),
+  );
 });
 
 task(

--- a/packages/react-native-win32/just-task.js
+++ b/packages/react-native-win32/just-task.js
@@ -6,6 +6,7 @@
  */
 
 const path = require('path');
+const fs = require('fs');
 const {
   task,
   copyTask,
@@ -66,6 +67,18 @@ task('clean', () => {
       path.join(process.cwd(), p),
     ),
   );
+});
+
+function ensureDirectoryExists(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    ensureDirectoryExists(dir);
+    fs.mkdirSync(dir);
+  }
+}
+
+task('prepareBundle', () => {
+  ensureDirectoryExists(path.resolve(__dirname, 'dist/win32/dev'));
 });
 
 task(

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -12,7 +12,7 @@
     "lint": "just-scripts eslint",
     "lint:fix": "eslint ./**/*.js ./**/*.ts? --fix",
     "watch": "tsc -w",
-    "bundle": "react-native bundle --platform win32 --entry-file RNTester.js --bundle-output dist/win32/dev/index.win32.bundle --assets-dest dist/win32/dev",
+    "bundle": "just-scripts prepareBundle && react-native bundle --platform win32 --entry-file RNTester.js --bundle-output dist/win32/dev/index.win32.bundle --assets-dest dist/win32/dev",
     "run-win32": "rex-win32 --bundle RNTester.win32 --component RNTesterApp --basePath ./dist/win32/dev",
     "run-win32-devmain": "rex-win32 --bundle RNTester.win32 --component RNTesterApp --basePath ./dist/win32/dev --useDevMain",
     "run-win32-dev-web": "rex-win32 --bundle RNTester.win32 --component RNTesterApp --basePath ./dist/win32/dev --useWebDebugger"

--- a/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableWin32.tsx
@@ -169,7 +169,7 @@ const LONG_PRESS_DELAY_MS = LONG_PRESS_THRESHOLD - HIGHLIGHT_DELAY_MS;
 const LONG_PRESS_ALLOWED_MOVEMENT = 10;
 
 /**
- * TouchableWin32 is a 'compentantization' of the Touchable Mixin in React Native.
+ * TouchableWin32 is a 'componentization' of the Touchable Mixin in React Native.
  * This means that instead of implementing components such as TouchableHighlight
  * via the mixin, they are merely implemented as wrappers around TouchableWin32,
  * forwarding the correct set of props. Additionally, TouchableWin32 supports hover

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -730,7 +730,7 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
 
   // TODO - Encapsulate this in a helpers, and make sure callers add it to their
   // list
-  std::string bundleUrl = m_devSettings->useWebDebugger ? DevServerHelper::get_BundleUrl(
+  std::string bundleUrl = (m_devSettings->useWebDebugger || m_devSettings._Ptr->liveReloadCallback) ? DevServerHelper::get_BundleUrl(
                                                               m_devSettings->debugHost,
                                                               m_devSettings->debugBundlePath,
                                                               m_devSettings->platformName,

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -730,13 +730,14 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
 
   // TODO - Encapsulate this in a helpers, and make sure callers add it to their
   // list
-  std::string bundleUrl = (m_devSettings->useWebDebugger || m_devSettings._Ptr->liveReloadCallback) ? DevServerHelper::get_BundleUrl(
-                                                              m_devSettings->debugHost,
-                                                              m_devSettings->debugBundlePath,
-                                                              m_devSettings->platformName,
-                                                              "true" /*dev*/,
-                                                              "false" /*hot*/)
-                                                        : std::string();
+  std::string bundleUrl = (m_devSettings->useWebDebugger || m_devSettings._Ptr->liveReloadCallback)
+      ? DevServerHelper::get_BundleUrl(
+            m_devSettings->debugHost,
+            m_devSettings->debugBundlePath,
+            m_devSettings->platformName,
+            "true" /*dev*/,
+            "false" /*hot*/)
+      : std::string();
   modules.push_back(std::make_unique<CxxNativeModule>(
       m_innerInstance,
       facebook::react::SourceCodeModule::name,

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -730,7 +730,7 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
 
   // TODO - Encapsulate this in a helpers, and make sure callers add it to their
   // list
-  std::string bundleUrl = (m_devSettings->useWebDebugger || m_devSettings._Ptr->liveReloadCallback)
+  std::string bundleUrl = (m_devSettings->useWebDebugger || m_devSettings->liveReloadCallback)
       ? DevServerHelper::get_BundleUrl(
             m_devSettings->debugHost,
             m_devSettings->debugBundlePath,


### PR DESCRIPTION
Also included a couple of minor fixes from the initial react-native-win32 checkin.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3803)