### PR TITLE
Update to react-native@0.60.0-microsoft.32

### DIFF
--- a/change/@office-iss-react-native-win32-2019-12-20-22-24-19-auto-update-versions060.0microsoft.32.json
+++ b/change/@office-iss-react-native-win32-2019-12-20-22-24-19-auto-update-versions060.0microsoft.32.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9568e58be8a94eb71722e88ebfc981db12a90eca",
+  "date": "2019-12-20T22:24:19.779Z"
+}

--- a/change/react-native-windows-2019-12-20-22-24-19-auto-update-versions060.0microsoft.32.json
+++ b/change/react-native-windows-2019-12-20-22-24-19-auto-update-versions060.0microsoft.32.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.32",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9568e58be8a94eb71722e88ebfc981db12a90eca",
+  "date": "2019-12-20T22:24:19.826Z"
+}

--- a/change/react-native-windows-extended-2019-12-20-22-24-21-auto-update-versions060.0microsoft.32.json
+++ b/change/react-native-windows-extended-2019-12-20-22-24-21-auto-update-versions060.0microsoft.32.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.32",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "890cfe49c325d6822b96551d2e4c743958796d26",
+  "date": "2019-12-20T22:24:21.546Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "react-native-windows": "0.60.0-vnext.102",
     "react-native-windows-extended": "0.60.55",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "react-native-windows": "0.60.0-vnext.102",
     "react-native-windows-extended": "0.60.55",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "react-native-windows": "0.60.0-vnext.102",
     "react-native-windows-extended": "0.60.55",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -40,7 +40,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "@office-iss/rex-win32": "0.0.30",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -53,7 +53,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.32 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.32 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -51,13 +51,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.32 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.32.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
f1e289a68 Applying package update to 0.60.0-microsoft.32 ***NO_CI***
88d882326 [RNTester] Make iOS target work with CocoaPods again (#209)

```