### PR TITLE
Add InjectBundleContent target

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -40,13 +40,7 @@ jobs:
           command: restore
           restoreSolution: packages/E2ETest/windows/ReactUWPTestApp.sln
           verbosityRestore: Detailed # Options: quiet, normal, detailed
-
-      - task: CmdLine@2
-        displayName: Create bundle
-        inputs:
-          script: yarn run bundle
-          workingDirectory: packages/E2ETest
-          
+         
       - task: CmdLine@2
         displayName: run-windows
         inputs:

--- a/change/react-native-windows-2019-12-30-12-16-46-bundlecrash.json
+++ b/change/react-native-windows-2019-12-30-12-16-46-bundlecrash.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid app crash because content is not bundled for the first time",
+  "packageName": "react-native-windows",
+  "email": "licanhua@live.com",
+  "commit": "703f7d4f116abbb7d40d74681f40e9d8d0a036ce",
+  "date": "2019-12-30T20:16:46.912Z"
+}

--- a/vnext/PropertySheets/Bundle.Cpp.targets
+++ b/vnext/PropertySheets/Bundle.Cpp.targets
@@ -8,7 +8,7 @@
 
   <Target Name="InjectBundleContent" BeforeTargets="PrepareForBuild" AfterTargets="MakeBundle">
     <ItemGroup Condition="'$(UseBundle)' == 'true' and '$(BundleContent)' != '' and '$(BundleContentRoot)' != '' ">
-	    <BundleContentToBePackaged Include="$(BundleContent)" />
+      <BundleContentToBePackaged Include="$(BundleContent)" />
       <None Include="@(BundleContentToBePackaged)">
         <Link>$(BundleContentRoot)\%(RecursiveDir)%(Filename)%(Extension)</Link>
         <DeploymentContent>true</DeploymentContent>

--- a/vnext/PropertySheets/Bundle.Cpp.targets
+++ b/vnext/PropertySheets/Bundle.Cpp.targets
@@ -6,12 +6,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\Bundle.Common.targets"/>
 
-  <ItemGroup Condition="'$(UseBundle)' == 'true' and '$(BundleContent)' != '' and '$(BundleContentRoot)' != '' ">
-    <None Include="$(BundleContent)">
-      <Link>$(BundleContentRoot)\%(RecursiveDir)%(Filename)%(Extension)</Link>
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-  </ItemGroup>
+  <Target Name="InjectBundleContent" BeforeTargets="PrepareForBuild" AfterTargets="MakeBundle">
+    <ItemGroup Condition="'$(UseBundle)' == 'true' and '$(BundleContent)' != '' and '$(BundleContentRoot)' != '' ">
+	    <BundleContentToBePackaged Include="$(BundleContent)" />
+      <None Include="@(BundleContentToBePackaged)">
+        <Link>$(BundleContentRoot)\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <DeploymentContent>true</DeploymentContent>
+      </None>
+   </ItemGroup>
+  </Target>
+
   <ItemDefinitionGroup Condition=" '$(UseBundle)' == 'true' ">
     <ClCompile>
       <PreprocessorDefinitions>BUNDLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/vnext/PropertySheets/Bundle.targets
+++ b/vnext/PropertySheets/Bundle.targets
@@ -6,9 +6,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\Bundle.Common.targets"/>
 
-  <ItemGroup Condition="'$(UseBundle)' == 'true' and '$(BundleContent)' != ''">
-    <Content Include="$(BundleContent)">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <Target Name="InjectBundleContent" BeforeTargets="PrepareForBuild" AfterTargets="MakeBundle">
+    <ItemGroup Condition="'$(UseBundle)' == 'true' and '$(BundleContent)' != ''">
+      <Content Include="$(BundleContent)">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Fix #3810 
For the new project, Bundle\index.windows.bundle doesn't exist and it's not counted into `<None>` and `<Content>` when build the project.
Delay the injection until MakeBundle target is executed.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3821)