### PR TITLE
Call StartAnimation on m_scaleCombined for ScaleX / ScaleY animations

### DIFF
--- a/change/react-native-windows-2020-01-03-14-45-45-fix-subchannel-animation-reference.json
+++ b/change/react-native-windows-2020-01-03-14-45-45-fix-subchannel-animation-reference.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Call StartAnimatiom on m_scaleCombined for ScaleX / ScaleY animations",
+  "packageName": "react-native-windows",
+  "email": "thshea@microsoft.com",
+  "commit": "0a4543017e3778a5436828340c675bbb13600a6a",
+  "date": "2020-01-03T22:45:45.183Z",
+  "file": "D:\\projects\\react-native-windows\\change\\react-native-windows-2020-01-03-14-45-45-fix-subchannel-animation-reference.json"
+}

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -110,10 +110,10 @@ void PropsAnimatedNode::StartAnimations() {
           uiElement.StartAnimation(m_translationCombined);
         } else if (anim.second.Target() == L"Scale.X") {
           m_subchannelPropertySet.StartAnimation(L"ScaleX", anim.second);
-          uiElement.StartAnimation(m_translationCombined);
+          uiElement.StartAnimation(m_scaleCombined);
         } else if (anim.second.Target() == L"Scale.Y") {
           m_subchannelPropertySet.StartAnimation(L"ScaleY", anim.second);
-          uiElement.StartAnimation(m_translationCombined);
+          uiElement.StartAnimation(m_scaleCombined);
         } else {
           uiElement.StartAnimation(anim.second);
         }


### PR DESCRIPTION
Fixes #3493 

A copy/paste error meant that the wrong animation was being started for scaleX and scaleY animations.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3829)