### PR TITLE
Update SampleModuleCpp library to show how to override module name

### DIFF
--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -20,7 +20,6 @@ namespace SampleLibraryCpp {
 
 REACT_MODULE(SampleModuleCppImpl, L"SampleModuleCpp");
 struct SampleModuleCppImpl {
-
 #pragma region Constants
 
   REACT_CONSTANT(NumberConstant);

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -16,9 +16,9 @@ namespace SampleLibraryCpp {
 
 // Sample REACT_MODULE
 
-REACT_MODULE(SampleModuleCpp);
-struct SampleModuleCpp {
-  const std::string Name = "SampleModuleCpp";
+REACT_MODULE(SampleModuleCppImpl /*moduleClass*/, L"SampleModuleCpp" /*moduleName*/);
+struct SampleModuleCppImpl {
+  const std::string ClassName = "SampleModuleCppImpl";
 
 #pragma region Constants
 
@@ -40,23 +40,23 @@ struct SampleModuleCpp {
 
   REACT_METHOD(VoidMethod);
   void VoidMethod() noexcept {
-    DebugWriteLine(Name, "VoidMethod");
+    DebugWriteLine(ClassName, "VoidMethod");
   }
 
   REACT_METHOD(VoidMethodWithArgs);
   void VoidMethodWithArgs(double arg) noexcept {
-    DebugWriteLine(Name, "VoidMethodWithArgs", arg);
+    DebugWriteLine(ClassName, "VoidMethodWithArgs", arg);
   }
 
   REACT_METHOD(ReturnMethod);
   double ReturnMethod() noexcept {
-    DebugWriteLine(Name, "ReturnMethod");
+    DebugWriteLine(ClassName, "ReturnMethod");
     return M_PI;
   }
 
   REACT_METHOD(ReturnMethodWithArgs);
   double ReturnMethodWithArgs(double arg) noexcept {
-    DebugWriteLine(Name, "ReturnMethodWithArgs", arg);
+    DebugWriteLine(ClassName, "ReturnMethodWithArgs", arg);
     return M_PI;
   }
 
@@ -66,19 +66,19 @@ struct SampleModuleCpp {
 
   REACT_METHOD(ExplicitCallbackMethod);
   void ExplicitCallbackMethod(std::function<void(double)> &&callback) noexcept {
-    DebugWriteLine(Name, "ExplicitCallbackMethod");
+    DebugWriteLine(ClassName, "ExplicitCallbackMethod");
     callback(M_PI);
   }
 
   REACT_METHOD(ExplicitCallbackMethodWithArgs);
   void ExplicitCallbackMethodWithArgs(double arg, std::function<void(double)> &&callback) noexcept {
-    DebugWriteLine(Name, "ExplicitCallbackMethodWithArgs", arg);
+    DebugWriteLine(ClassName, "ExplicitCallbackMethodWithArgs", arg);
     callback(M_PI);
   }
 
   REACT_METHOD(ExplicitPromiseMethod);
   void ExplicitPromiseMethod(winrt::Microsoft::ReactNative::ReactPromise<double> &&result) noexcept {
-    DebugWriteLine(Name, "ExplicitPromiseMethod");
+    DebugWriteLine(ClassName, "ExplicitPromiseMethod");
     try {
       result.Resolve(M_PI);
     } catch (const std::exception &ex) {
@@ -90,7 +90,7 @@ struct SampleModuleCpp {
   void ExplicitPromiseMethodWithArgs(
       double arg,
       winrt::Microsoft::ReactNative::ReactPromise<double> &&result) noexcept {
-    DebugWriteLine(Name, "ExplicitPromiseMethodWithArgs", arg);
+    DebugWriteLine(ClassName, "ExplicitPromiseMethodWithArgs", arg);
     try {
       result.Resolve(M_PI);
     } catch (const std::exception &ex) {
@@ -104,13 +104,13 @@ struct SampleModuleCpp {
 
   REACT_SYNC_METHOD(SyncReturnMethod);
   double SyncReturnMethod() noexcept {
-    DebugWriteLine(Name, "SyncReturnMethod");
+    DebugWriteLine(ClassName, "SyncReturnMethod");
     return M_PI;
   }
 
   REACT_SYNC_METHOD(SyncReturnMethodWithArgs);
   double SyncReturnMethodWithArgs(double arg) noexcept {
-    DebugWriteLine(Name, "SyncReturnMethodWithArgs", arg);
+    DebugWriteLine(ClassName, "SyncReturnMethodWithArgs", arg);
     return M_PI;
   }
 
@@ -124,7 +124,7 @@ struct SampleModuleCpp {
 #pragma endregion
 
  public:
-  SampleModuleCpp() {
+  SampleModuleCppImpl() {
     m_timer = winrt::Windows::System::Threading::ThreadPoolTimer::CreatePeriodicTimer(
         [this](const winrt::Windows::System::Threading::ThreadPoolTimer) noexcept {
           if (TimedEvent) {
@@ -134,7 +134,7 @@ struct SampleModuleCpp {
         std::chrono::milliseconds(TimedEventIntervalMS));
   }
 
-  ~SampleModuleCpp() {
+  ~SampleModuleCppImpl() {
     if (m_timer) {
       m_timer.Cancel();
     }

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -12,13 +12,14 @@
 #include "DebugHelpers.h"
 #include "NativeModules.h"
 
+#define DEBUG_OUTPUT(...) DebugWriteLine("SampleModuleCppImpl", ##__VA_ARGS__);
+
 namespace SampleLibraryCpp {
 
 // Sample REACT_MODULE
 
-REACT_MODULE(SampleModuleCppImpl /*moduleClass*/, L"SampleModuleCpp" /*moduleName*/);
+REACT_MODULE(SampleModuleCppImpl, L"SampleModuleCpp");
 struct SampleModuleCppImpl {
-  const std::string ClassName = "SampleModuleCppImpl";
 
 #pragma region Constants
 
@@ -40,23 +41,23 @@ struct SampleModuleCppImpl {
 
   REACT_METHOD(VoidMethod);
   void VoidMethod() noexcept {
-    DebugWriteLine(ClassName, "VoidMethod");
+    DEBUG_OUTPUT("VoidMethod");
   }
 
   REACT_METHOD(VoidMethodWithArgs);
   void VoidMethodWithArgs(double arg) noexcept {
-    DebugWriteLine(ClassName, "VoidMethodWithArgs", arg);
+    DEBUG_OUTPUT("VoidMethodWithArgs", arg);
   }
 
   REACT_METHOD(ReturnMethod);
   double ReturnMethod() noexcept {
-    DebugWriteLine(ClassName, "ReturnMethod");
+    DEBUG_OUTPUT("ReturnMethod");
     return M_PI;
   }
 
   REACT_METHOD(ReturnMethodWithArgs);
   double ReturnMethodWithArgs(double arg) noexcept {
-    DebugWriteLine(ClassName, "ReturnMethodWithArgs", arg);
+    DEBUG_OUTPUT("ReturnMethodWithArgs", arg);
     return M_PI;
   }
 
@@ -66,19 +67,19 @@ struct SampleModuleCppImpl {
 
   REACT_METHOD(ExplicitCallbackMethod);
   void ExplicitCallbackMethod(std::function<void(double)> &&callback) noexcept {
-    DebugWriteLine(ClassName, "ExplicitCallbackMethod");
+    DEBUG_OUTPUT("ExplicitCallbackMethod");
     callback(M_PI);
   }
 
   REACT_METHOD(ExplicitCallbackMethodWithArgs);
   void ExplicitCallbackMethodWithArgs(double arg, std::function<void(double)> &&callback) noexcept {
-    DebugWriteLine(ClassName, "ExplicitCallbackMethodWithArgs", arg);
+    DEBUG_OUTPUT("ExplicitCallbackMethodWithArgs", arg);
     callback(M_PI);
   }
 
   REACT_METHOD(ExplicitPromiseMethod);
   void ExplicitPromiseMethod(winrt::Microsoft::ReactNative::ReactPromise<double> &&result) noexcept {
-    DebugWriteLine(ClassName, "ExplicitPromiseMethod");
+    DEBUG_OUTPUT("ExplicitPromiseMethod");
     try {
       result.Resolve(M_PI);
     } catch (const std::exception &ex) {
@@ -90,7 +91,7 @@ struct SampleModuleCppImpl {
   void ExplicitPromiseMethodWithArgs(
       double arg,
       winrt::Microsoft::ReactNative::ReactPromise<double> &&result) noexcept {
-    DebugWriteLine(ClassName, "ExplicitPromiseMethodWithArgs", arg);
+    DEBUG_OUTPUT("ExplicitPromiseMethodWithArgs", arg);
     try {
       result.Resolve(M_PI);
     } catch (const std::exception &ex) {
@@ -104,13 +105,13 @@ struct SampleModuleCppImpl {
 
   REACT_SYNC_METHOD(SyncReturnMethod);
   double SyncReturnMethod() noexcept {
-    DebugWriteLine(ClassName, "SyncReturnMethod");
+    DEBUG_OUTPUT("SyncReturnMethod");
     return M_PI;
   }
 
   REACT_SYNC_METHOD(SyncReturnMethodWithArgs);
   double SyncReturnMethodWithArgs(double arg) noexcept {
-    DebugWriteLine(ClassName, "SyncReturnMethodWithArgs", arg);
+    DEBUG_OUTPUT("SyncReturnMethodWithArgs", arg);
     return M_PI;
   }
 


### PR DESCRIPTION
The Name property in the current Cpp sample library is kind of misleading: people would think that is the way to override the native module name. 
Update the sample to show the correct way to override: through the second parameter of REACT_MODULE.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3833)