### PR TITLE
Remove Trivial Paths for OSS_RN

### DIFF
--- a/vnext/Chakra/ChakraExecutor.cpp
+++ b/vnext/Chakra/ChakraExecutor.cpp
@@ -499,9 +499,6 @@ void ChakraExecutor::loadApplicationScript(std::unique_ptr<const JSBigString> sc
 
   ChakraString jsSourceURL(sourceURL.c_str());
 
-#if defined(OSS_RN)
-  evaluateScript(std::move(script), jsSourceURL);
-#else
   auto bundleMetadata = folly::get_ptr(m_instanceArgs.BundleUrlMetadataMap, sourceURL);
 
   // when debugging is enabled, don't use bytecode caching because ChakraCore
@@ -512,7 +509,6 @@ void ChakraExecutor::loadApplicationScript(std::unique_ptr<const JSBigString> sc
     evaluateScriptWithBytecode(
         std::move(script), bundleMetadata->version, jsSourceURL, std::string(bundleMetadata->bytecodeFilename));
   }
-#endif
 
 #if !defined(USE_EDGEMODE_JSRT)
   if (needToRedirectConsoleToDebugger) {

--- a/vnext/stubs/unistd.h
+++ b/vnext/stubs/unistd.h
@@ -1,6 +1,0 @@
-// react-native includes unistd.h, which isn't available in windows.
-// This shouldn't be needed after
-// https://github.com/facebook/react-native/pull/25107 is merged
-#if !defined(OSS_RN)
-#error This stub should not be used unless building against the non-microsoft version of react-native
-#endif


### PR DESCRIPTION
Remove a stub no longer needed and remove an instance management path we
no longer need to avoid after moving to using ChakraMetadataMap

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3835)