### PR TITLE
Update to react-native@0.60.0-microsoft.36

### DIFF
--- a/change/@office-iss-react-native-win32-2020-01-07-20-40-12-auto-update-versions060.0microsoft.36.json
+++ b/change/@office-iss-react-native-win32-2020-01-07-20-40-12-auto-update-versions060.0microsoft.36.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.36",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9ddb95687c7eaf4dc8e50f1ebcbb6937889395b2",
+  "date": "2020-01-07T20:40:12.124Z"
+}

--- a/change/react-native-windows-2020-01-07-20-40-12-auto-update-versions060.0microsoft.36.json
+++ b/change/react-native-windows-2020-01-07-20-40-12-auto-update-versions060.0microsoft.36.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.36",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "9ddb95687c7eaf4dc8e50f1ebcbb6937889395b2",
+  "date": "2020-01-07T20:40:12.187Z"
+}

--- a/change/react-native-windows-extended-2020-01-07-20-40-13-auto-update-versions060.0microsoft.36.json
+++ b/change/react-native-windows-extended-2020-01-07-20-40-13-auto-update-versions060.0microsoft.36.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.36",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "bb6fd17a9fe2d7546fdae487cfe44821ba763d3c",
+  "date": "2020-01-07T20:40:13.873Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "react-native-windows": "0.60.0-vnext.108",
     "react-native-windows-extended": "0.60.62",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "react-native-windows": "0.60.0-vnext.108",
     "react-native-windows-extended": "0.60.62",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "react-native-windows": "0.60.0-vnext.108",
     "react-native-windows-extended": "0.60.62",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -51,12 +51,12 @@
     "flow-bin": "^0.98.0",
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "react": "16.8.6",
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -51,13 +51,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.36 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
7317f6781 Applying package update to 0.60.0-microsoft.36 ***NO_CI***
c20196fbd Removing forked changes that were made to support win32 (#216)
6bcb2c123 Applying package update to 0.60.0-microsoft.35 ***NO_CI***
f12841d6b fix up some minor spacing issues with the numbering indentations (#213)
ef7415f40 Applying package update to 0.60.0-microsoft.34 ***NO_CI***
fd7ee802b Fix Flow check for macos (#212)
5b3c1c0ed Applying package update to 0.60.0-microsoft.33 ***NO_CI***
e1ac1bc7b Move FB version merge documentation to the repo it's used in (#208)
f1e289a68 Applying package update to 0.60.0-microsoft.32 ***NO_CI***
88d882326 [RNTester] Make iOS target work with CocoaPods again (#209)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3840)