### PR TITLE
Image - basic svg support

### DIFF
--- a/change/react-native-windows-2020-01-07-16-17-58-image-svg.json
+++ b/change/react-native-windows-2020-01-07-16-17-58-image-svg.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Image - basic svg support",
+  "packageName": "react-native-windows",
+  "email": "mcota@microsoft.com",
+  "commit": "74e6ed91c0466fd9894aa6f0ee65bb3d4255088f",
+  "date": "2020-01-08T00:17:58.848Z"
+}

--- a/packages/playground/Samples/Microsoft-Logo.svg
+++ b/packages/playground/Samples/Microsoft-Logo.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28" fill="none"><path d="M13.125 0H0V13.125H13.125V0Z" fill="#F25022"></path><path d="M28 0H14.875V13.125H28V0Z" fill="#7FBA00"></path><path d="M13.125 14.875H0V28H13.125V14.875Z" fill="#00A4EF"></path><path d="M28 14.875H14.875V28H28V14.875Z" fill="#FFB900"></path></svg> 

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -15,6 +15,9 @@ const smallImageUri =
 const dataImageUri =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==';
 
+const svgImageUri =
+  'https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg';
+
 export default class Bootstrap extends React.Component<
   {},
   {
@@ -48,6 +51,8 @@ export default class Bootstrap extends React.Component<
       imageUri = largeImageUri;
     } else if (value === 'data') {
       imageUri = dataImageUri;
+    } else if (value === 'svg') {
+      imageUri = svgImageUri;
     }
 
     this.setState({imageUri});
@@ -78,6 +83,7 @@ export default class Bootstrap extends React.Component<
             <Picker.Item label="small" value="small" />
             <Picker.Item label="large" value="large" />
             <Picker.Item label="data" value="data" />
+            <Picker.Item label="svg" value="svg" />
           </Picker>
         </View>
         <View style={styles.rowContainer}>

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -15,8 +15,13 @@ const smallImageUri =
 const dataImageUri =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==';
 
-const svgImageUri =
-  'https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg';
+// const svgImageUri =
+//   'http://thenewcode.com/assets/images/thumbnails/homer-simpson.svg';
+
+// const svgImageUri =
+//   'https://visualstudio.microsoft.com/wp-content/uploads/2019/09/Microsoft-Account.svg';
+
+// const svgImageUri = require('../Samples/Microsoft-Logo.svg');
 
 export default class Bootstrap extends React.Component<
   {},
@@ -51,8 +56,6 @@ export default class Bootstrap extends React.Component<
       imageUri = largeImageUri;
     } else if (value === 'data') {
       imageUri = dataImageUri;
-    } else if (value === 'svg') {
-      imageUri = svgImageUri;
     }
 
     this.setState({imageUri});
@@ -102,7 +105,11 @@ export default class Bootstrap extends React.Component<
             style={
               this.state.inlcudeBorder ? styles.imageWithBorder : styles.image
             }
-            source={{uri: this.state.imageUri}}
+            source={
+              this.state.selectedSource === 'svg'
+                ? require('../Samples/Microsoft-Logo.svg')
+                : {uri: this.state.imageUri}
+            }
             resizeMode={this.state.selectedResizeMode}
           />
         </View>

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -15,14 +15,6 @@ const smallImageUri =
 const dataImageUri =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==';
 
-// const svgImageUri =
-//   'http://thenewcode.com/assets/images/thumbnails/homer-simpson.svg';
-
-// const svgImageUri =
-//   'https://visualstudio.microsoft.com/wp-content/uploads/2019/09/Microsoft-Account.svg';
-
-// const svgImageUri = require('../Samples/Microsoft-Logo.svg');
-
 export default class Bootstrap extends React.Component<
   {},
   {
@@ -33,7 +25,7 @@ export default class Bootstrap extends React.Component<
       | 'contain'
       | 'repeat'
       | undefined;
-    inlcudeBorder: boolean;
+    includeBorder: boolean;
     selectedSource: string;
     imageUri: string;
   }
@@ -41,7 +33,7 @@ export default class Bootstrap extends React.Component<
   state = {
     selectedResizeMode: 'center' as 'center',
     selectedSource: 'small',
-    inlcudeBorder: false,
+    includeBorder: false,
     imageUri: 'http://facebook.github.io/react-native/img/header_logo.png',
   };
 
@@ -93,9 +85,9 @@ export default class Bootstrap extends React.Component<
           <Text>No Border</Text>
           <Switch
             style={{marginLeft: 10}}
-            value={this.state.inlcudeBorder}
+            value={this.state.includeBorder}
             onValueChange={(value: boolean) =>
-              this.setState({inlcudeBorder: value})
+              this.setState({includeBorder: value})
             }
           />
           <Text>Round Border</Text>
@@ -103,7 +95,7 @@ export default class Bootstrap extends React.Component<
         <View style={styles.imageContainer}>
           <Image
             style={
-              this.state.inlcudeBorder ? styles.imageWithBorder : styles.image
+              this.state.includeBorder ? styles.imageWithBorder : styles.image
             }
             source={
               this.state.selectedSource === 'svg'

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -82,8 +82,7 @@ winrt::Stretch ReactImage::ResizeModeToStretch(react::uwp::ResizeMode value) {
       // That is handled by the shouldUseCompositionBrush/switchBrushes code path.
       assert(value != ResizeMode::Repeat);
 
-      if (m_imageSource.sourceType != ImageSourceType::Svg &&
-          (m_imageSource.height < ActualHeight() && m_imageSource.width < ActualWidth())) {
+      if (m_imageSource.height < ActualHeight() && m_imageSource.width < ActualWidth()) {
         return winrt::Stretch::None;
       } else {
         return winrt::Stretch::Uniform;
@@ -238,15 +237,10 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
           svgImageSource = winrt::SvgImageSource{};
 
           strong_this->m_svgImageSourceOpenedRevoker = svgImageSource.Opened(
-              winrt::auto_revoke, [weak_this, fireLoadEndEvent](const auto &sender, const auto &) {
-                if (auto strong_this{weak_this.get()}) {
-                  auto svg{sender.try_as<winrt::SvgImageSource>()};
-                  // strong_this->m_imageSource.height = svg.RasterizePixelHeight();
-                  // strong_this->m_imageSource.width = svg.RasterizePixelWidth();
-
-                  if (fireLoadEndEvent) {
-                    strong_this->m_onLoadEndEvent(*strong_this, true);
-                  }
+              winrt::auto_revoke, [weak_this, fireLoadEndEvent](const auto &, const auto &) {
+                auto strong_this{weak_this.get()};
+                if (strong_this && fireLoadEndEvent) {
+                  strong_this->m_onLoadEndEvent(*strong_this, true);
                 }
               });
 

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -236,8 +236,8 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         if (!svgImageSource) {
           svgImageSource = winrt::SvgImageSource{};
 
-          strong_this->m_svgImageSourceOpenedRevoker = svgImageSource.Opened(
-              winrt::auto_revoke, [weak_this, fireLoadEndEvent](const auto &, const auto &) {
+          strong_this->m_svgImageSourceOpenedRevoker =
+              svgImageSource.Opened(winrt::auto_revoke, [weak_this, fireLoadEndEvent](const auto &, const auto &) {
                 auto strong_this{weak_this.get()};
                 if (strong_this && fireLoadEndEvent) {
                   strong_this->m_onLoadEndEvent(*strong_this, true);

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -17,7 +17,7 @@
 namespace react {
 namespace uwp {
 
-enum class ImageSourceType { Uri = 0, Download = 1, InlineData = 2 };
+enum class ImageSourceType { Uri = 0, Download = 1, InlineData = 2, Svg = 3 };
 
 struct ReactImageSource {
   std::string uri;
@@ -73,6 +73,8 @@ struct ReactImage : winrt::Windows::UI::Xaml::Controls::GridT<ReactImage> {
   winrt::Windows::UI::Xaml::Media::Imaging::BitmapImage::ImageOpened_revoker m_bitmapImageOpened;
   winrt::Windows::UI::Xaml::Media::ImageBrush::ImageOpened_revoker m_imageBrushOpenedRevoker;
   winrt::Windows::UI::Xaml::Media::ImageBrush::ImageFailed_revoker m_imageBrushFailedRevoker;
+  winrt::Windows::UI::Xaml::Media::Imaging::SvgImageSource::Opened_revoker m_svgImageSourceOpenedRevoker;
+  winrt::Windows::UI::Xaml::Media::Imaging::SvgImageSource::OpenFailed_revoker m_svgImageSourceOpenFailedRevoker;
 };
 
 // Helper functions


### PR DESCRIPTION
#3573 

See here for the svg properties supported:
https://docs.microsoft.com/en-us/windows/win32/direct2d/svg-support

We don't currently have a good way to get the width and height off of the svg file, so for now you will need to set those through the Image's style. For the same reason, resizeMode is also not currently supported when using an svg as source. 





###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3845)