### PR TITLE
Header Refactoring Around jsireact to Unblock ms/rn

### DIFF
--- a/change/@office-iss-react-native-win32-2020-01-07-20-46-51-defork.json
+++ b/change/@office-iss-react-native-win32-2020-01-07-20-46-51-defork.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Header Refactoring Around jsireact to Unblock ms/rn",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "nick@nickgerleman.com",
+  "commit": "442b022fd07a7d1712cdada56604b134df0b386f",
+  "date": "2020-01-08T04:46:22.670Z"
+}

--- a/change/react-native-windows-2020-01-07-13-47-46-defork.json
+++ b/change/react-native-windows-2020-01-07-13-47-46-defork.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Remove Unneeded OSS_RN Special Path",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "b912ff74d48ca8157c8006cf1391bf0178937679",
+  "date": "2020-01-07T21:47:46.478Z"
+}

--- a/change/react-native-windows-2020-01-07-20-46-51-defork.json
+++ b/change/react-native-windows-2020-01-07-20-46-51-defork.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Header Refactoring Around jsireact to Unblock ms/rn",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "442b022fd07a7d1712cdada56604b134df0b386f",
+  "date": "2020-01-08T04:46:51.192Z"
+}

--- a/change/react-native-windows-extended-2020-01-07-20-46-51-defork.json
+++ b/change/react-native-windows-extended-2020-01-07-20-46-51-defork.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Header Refactoring Around jsireact to Unblock ms/rn",
+  "packageName": "react-native-windows-extended",
+  "email": "nick@nickgerleman.com",
+  "commit": "442b022fd07a7d1712cdada56604b134df0b386f",
+  "date": "2020-01-08T04:46:34.258Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "react-native-windows": "0.60.0-vnext.109",
     "react-native-windows-extended": "0.60.63",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "react-native-windows": "0.60.0-vnext.109",
     "react-native-windows-extended": "0.60.63",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "react-native-windows": "0.60.0-vnext.109",
     "react-native-windows-extended": "0.60.63",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/react-native-win32/.gitignore
+++ b/packages/react-native-win32/.gitignore
@@ -10,3 +10,4 @@
 /RNTester
 /RNTester.*
 /temp
+/WorkingHeaders

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -42,6 +42,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "@office-iss/rex-win32": "0.0.30",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -52,12 +53,11 @@
     "flow-bin": "^0.98.0",
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
     "react": "16.8.6",
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/.gitignore
+++ b/vnext/.gitignore
@@ -85,3 +85,4 @@ temp
 /coverage
 /third-party
 /packages/
+/WorkingHeaders/

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -65,7 +65,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeDir)\ReactCommon\jscallinvoker;$(ReactNativeDir)\ReactCommon\jsiexecutor;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeDir)\ReactCommon\jscallinvoker;$(ReactNativeDir)\ReactCommon\jsiexecutor;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\WorkingHeaders;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(ENABLE_NATIVE_SYSTRACE_TO_ETW)'=='true' AND '$(OSS_RN)' != 'true'">ENABLE_NATIVE_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)'=='true' AND '$(OSS_RN)' != 'true'">ENABLE_JS_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>_WIN32;_CRT_SECURE_NO_WARNINGS;FOLLY_NO_CONFIG;NOMINMAX;RN_EXPORT=;JSI_EXPORT=;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -153,8 +153,6 @@
     <ClCompile Include="$(YogaDir)\yoga\YGStyle.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGValue.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\Yoga.cpp" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(OSS_RN)'!='true'">
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jscallinvoker\jsireact\BridgeJSCallInvoker.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jscallinvoker\jsireact\JSCallInvoker.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\LongLivedObject.h" />
@@ -162,8 +160,6 @@
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\TurboModule.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\TurboModuleBinding.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\TurboModuleUtils.h" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(OSS_RN)'!='true'">
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jscallinvoker\jsireact\BridgeJSCallInvoker.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\LongLivedObject.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\TurboCxxModule.cpp" />

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -57,7 +57,7 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <ItemDefinitionGroup Condition="'$(OSS_RN)'=='true'">
     <ClCompile>
-      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -52,13 +52,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10839,10 +10839,9 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz":
-  version "0.60.0-microsoft.31"
-  uid "26b4041e78b54517e3494beb6478bc7ee0a3a726"
-  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz#26b4041e78b54517e3494beb6478bc7ee0a3a726"
+"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz":
+  version "0.60.0-microsoft.36"
+  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz#542ba6c44c0676940eda1ef5cd3987f213e5e741"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10839,9 +10839,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz":
-  version "0.60.0-microsoft.36"
-  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.36.tar.gz#542ba6c44c0676940eda1ef5cd3987f213e5e741"
+"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz":
+  version "0.60.0-microsoft.35"
+  uid "0ee1c6fd13eea3a9c885bd6d8de64bfb7d008a9a"
+  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz#0ee1c6fd13eea3a9c885bd6d8de64bfb7d008a9a"
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/generator" "^7.4.0"


### PR DESCRIPTION
1. Do some refactoring of copyRNLibraries.js to make it a bit less messy, and to allow some more flexibility.
2. Tell copyRNLibraries.js to copy a few headers to a jsireact folder to mimic BUCK build logic
3. Configure MSBuild to look in newly added WorkingHeaders directory
4. Add WorkingHeaders to gitignore
5. Update Microsoft RN version
6. Remove conditional compilation of JSI files on non-OSS RN, which we should no longer need

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3848)