### PR TITLE
Update to react-native@0.60.0-microsoft.37

### DIFF
--- a/change/@office-iss-react-native-win32-2020-01-08-18-44-53-auto-update-versions060.0microsoft.37.json
+++ b/change/@office-iss-react-native-win32-2020-01-08-18-44-53-auto-update-versions060.0microsoft.37.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.37",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "2cf45311d5d2e4bfd6e65aca3207fc7adf843e7b",
+  "date": "2020-01-08T18:44:52.688Z"
+}

--- a/change/react-native-windows-2020-01-08-18-44-53-auto-update-versions060.0microsoft.37.json
+++ b/change/react-native-windows-2020-01-08-18-44-53-auto-update-versions060.0microsoft.37.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.37",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "2cf45311d5d2e4bfd6e65aca3207fc7adf843e7b",
+  "date": "2020-01-08T18:44:53.122Z"
+}

--- a/change/react-native-windows-extended-2020-01-08-18-44-54-auto-update-versions060.0microsoft.37.json
+++ b/change/react-native-windows-extended-2020-01-08-18-44-54-auto-update-versions060.0microsoft.37.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.37",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "a28a017df33c0e01b2d9db690e77d244917de220",
+  "date": "2020-01-08T18:44:54.843Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "react-native-windows": "0.60.0-vnext.109",
     "react-native-windows-extended": "0.60.63",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "react-native-windows": "0.60.0-vnext.109",
     "react-native-windows-extended": "0.60.63",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "react-native-windows": "0.60.0-vnext.109",
     "react-native-windows-extended": "0.60.63",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -52,12 +52,12 @@
     "flow-bin": "^0.98.0",
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "react": "16.8.6",
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -52,13 +52,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.31 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.31.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.37 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.37.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
1f67be278 Applying package update to 0.60.0-microsoft.37 ***NO_CI***
dc7c50bbd [RNTester] Remove need to update lockfile after cutting new build (#219)
7317f6781 Applying package update to 0.60.0-microsoft.36 ***NO_CI***
c20196fbd Removing forked changes that were made to support win32 (#216)
6bcb2c123 Applying package update to 0.60.0-microsoft.35 ***NO_CI***
f12841d6b fix up some minor spacing issues with the numbering indentations (#213)
ef7415f40 Applying package update to 0.60.0-microsoft.34 ***NO_CI***
fd7ee802b Fix Flow check for macos (#212)
5b3c1c0ed Applying package update to 0.60.0-microsoft.33 ***NO_CI***
e1ac1bc7b Move FB version merge documentation to the repo it's used in (#208)
f1e289a68 Applying package update to 0.60.0-microsoft.32 ***NO_CI***
88d882326 [RNTester] Make iOS target work with CocoaPods again (#209)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3852)