### PR TITLE
Update rex-win32 to fix boot of RNTester

### DIFF
--- a/change/@office-iss-react-native-win32-2020-01-13-11-32-57-updaterex.json
+++ b/change/@office-iss-react-native-win32-2020-01-13-11-32-57-updaterex.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update rex-win32 to fix boot of RNTester",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates@microsoft.com",
+  "commit": "edc0c937e419fbc12fd9f1d102271756d2bd859b",
+  "date": "2020-01-13T19:32:57.525Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
-    "@office-iss/rex-win32": "0.0.30",
+    "@office-iss/rex-win32": "0.0.33",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
     "@types/node": "^12.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2833,10 +2833,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@office-iss/rex-win32@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.0.30.tgz#3ffe94f3cf07bae1c6ccb702d60413553a695841"
-  integrity sha512-SNiC+iv2uPdOLiyqNXBMbqED3Nbfsv8JIy1vZt3YAGUhdqgmXaiGgd4n+CQrplxskqV27dPI1xNMNv9puDbyng==
+"@office-iss/rex-win32@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.0.33.tgz#960ed52275c827df58aede4819d39927bdf2ae70"
+  integrity sha512-Eh4orZ3F4P03IJAn509H7rXPcA8/6iXIEJbBTrNdO0RK6gVIRQ/5GVVPg3BA3QrFN7GDJeXOqjN1/9daV4O8ag==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"
@@ -10841,7 +10841,6 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
 
 "react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz":
   version "0.60.0-microsoft.35"
-  uid "0ee1c6fd13eea3a9c885bd6d8de64bfb7d008a9a"
   resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz#0ee1c6fd13eea3a9c885bd6d8de64bfb7d008a9a"
   dependencies:
     "@babel/core" "^7.4.0"


### PR DESCRIPTION
Updates rex-win32 to a version that doesn't crash running RNTester.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3869)