### PR TITLE
Add React Native Source Patching Infrastructure

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <ReactNativeWindowsDir>$(MSBuildThisFileDirectory)\vnext\</ReactNativeWindowsDir>
-    <ReactNativeDir>$(MSBuildThisFileDirectory)\node_modules\react-native\</ReactNativeDir>
+    <ReactNativePackageDir>$(MSBuildThisFileDirectory)\node_modules\react-native\</ReactNativePackageDir>
   </PropertyGroup>
 
 </Project>

--- a/change/react-native-windows-2020-01-14-00-16-18-defork.json
+++ b/change/react-native-windows-2020-01-14-00-16-18-defork.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add React Native Source Patching Infrastructure",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "8a144129746ab7057827a0ff7839475029a11c0b",
+  "date": "2020-01-14T08:16:18.761Z"
+}

--- a/change/react-native-windows-extended-2020-01-14-00-16-18-defork.json
+++ b/change/react-native-windows-extended-2020-01-14-00-16-18-defork.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add React Native Source Patching Infrastructure",
+  "packageName": "react-native-windows-extended",
+  "email": "nick@nickgerleman.com",
+  "commit": "8a144129746ab7057827a0ff7839475029a11c0b",
+  "date": "2020-01-14T08:16:09.396Z"
+}

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -53,6 +53,7 @@
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">

--- a/packages/react-native-windows-extended/windows/react-native-windows-extended.vcxproj
+++ b/packages/react-native-windows-extended/windows/react-native-windows-extended.vcxproj
@@ -54,6 +54,7 @@
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Common/Common.vcxproj
+++ b/vnext/Common/Common.vcxproj
@@ -42,6 +42,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/DeforkingPatches/README.md
+++ b/vnext/DeforkingPatches/README.md
@@ -1,0 +1,5 @@
+### React Native Deforking Patches
+
+This directory contains source copies of React Native code derived from microsoft/react-native.
+This is a staging measure to let us move off of the fork. Files should not be added here or edited
+apart from the purpose of removing differences from upstream react-native.

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -37,6 +37,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -32,6 +32,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared" />

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -31,6 +31,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
@@ -31,6 +31,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared" />

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -30,6 +30,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -36,6 +36,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -5,8 +5,6 @@
     Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')))"
     Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <Import Project="$(MSBuildThisFileDirectory)\PropertySheets\ReactPackageDirectories.props" />
-
   <PropertyGroup>
     <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
 
@@ -28,5 +26,7 @@
 
     <GeneratedFilesDir>$(IntDir)Generated Files\</GeneratedFilesDir>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)\PropertySheets\ReactPackageDirectories.props" />
 
 </Project>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -283,7 +283,4 @@
     <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
   </Target>
   -->
-  <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
-  </Target>
 </Project>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -261,14 +261,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
   </Target>
-  <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
-  </Target>
-  <Target Name="DownloadFollyIfNotUseMicrosoftReactNative" BeforeTargets="PrepareForBuild">
+  <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
     <Warning Text="Folly required to build without microsoft/react-native. - Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" />
     <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" SourceUrl="https://github.com/facebook/folly/archive/v2019.09.30.00.zip" DestinationFolder="$(FollyDir)..\.follyzip" />
   </Target>
-  <Target Name="UnzipFollyIfNotUseMicrosoftReactNative" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFollyIfNotUseMicrosoftReactNative">
+  <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
     <Warning Text="Folly required to build without microsoft/react-native. - Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
     <!-- Using ContinueOnError due to https://github.com/Microsoft/msbuild/issues/3884, unzip seems to have completed dispite errors -->
     <Unzip Condition="!Exists('$(FollyDir)')" ContinueOnError="true" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
@@ -278,7 +275,7 @@
   </ItemGroup>
   <!-- Reenable this task if we need to temporarily replace any folly files for fixes, while we wait for PRs to land in folly -->
   <!--
-  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFollyIfNotUseMicrosoftReactNative">
+  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
     <Warning Text="Copying @(TemporaryFollyPatchFiles) to @(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
   </Target>

--- a/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
+++ b/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
@@ -38,6 +38,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- We cannot include Warnings.props here because Google Test only builds at warning level 3. -->
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -30,6 +30,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj
@@ -42,6 +42,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -61,6 +61,7 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared" />

--- a/vnext/PropertySheets/ReactPackageDirectories.props
+++ b/vnext/PropertySheets/ReactPackageDirectories.props
@@ -19,6 +19,7 @@
     <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)\ReactCommon\yoga</YogaDir>
   </PropertyGroup>
 
+  <!-- Determine whether we are using Facebook or Microsoft RN by file presence -->
   <PropertyGroup Condition="!Exists('$(ReactNativePackageDir)\stubs\glog\logging.h')">
     <OSS_RN>true</OSS_RN>
     <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>

--- a/vnext/PropertySheets/ReactPackageDirectories.props
+++ b/vnext/PropertySheets/ReactPackageDirectories.props
@@ -13,22 +13,25 @@
 
   <PropertyGroup>
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$(MSBuildThisFileDirectory)\..\</ReactNativeWindowsDir>
-    <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativeDir>
+    <ReactNativePackageDir Condition="'$(ReactNativePackageDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativePackageDir>
+    <ReactNativeDir Condition="'$(IntDir)' != ''">$(IntDir)\react-native-patched\</ReactNativeDir>
+    <ReactNativeDir Condition="'$(IntDir)' == ''">$(BaseIntermediateOutputPath)\react-native-patched\</ReactNativeDir>
     <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)\ReactCommon\yoga</YogaDir>
   </PropertyGroup>
 
-  <PropertyGroup Condition="!Exists('$(ReactNativeDir)\stubs\glog\logging.h')">
+  <PropertyGroup Condition="!Exists('$(ReactNativePackageDir)\stubs\glog\logging.h')">
     <OSS_RN>true</OSS_RN>
-    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
+    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
   </PropertyGroup>
 
-  <PropertyGroup Condition="Exists('$(ReactNativeDir)\stubs\glog\logging.h')">
-    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
+  <PropertyGroup Condition="Exists('$(ReactNativePackageDir)\stubs\glog\logging.h')">
+    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- Normalize the directory names -->
     <ReactNativeWindowsDir>$([MSBuild]::NormalizeDirectory($(ReactNativeWindowsDir)))</ReactNativeWindowsDir>
+    <ReactNativePackageDir>$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)))</ReactNativePackageDir>
     <ReactNativeDir>$([MSBuild]::NormalizeDirectory($(ReactNativeDir)))</ReactNativeDir>
     <YogaDir>$([MSBuild]::NormalizeDirectory($(YogaDir)))</YogaDir>
     <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -12,7 +12,8 @@
     <DeforkingPatchFiles Include="$(ReactNativeWindowsDir)\DeforkingPatches\**" />
     <DeforkingPatchDesintationFiles Include="@(DeforkingPatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <JsiReactHeaderFiles Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\*.h" />
+    <!-- We use unpatched React Native as the input here since we may not have yet applied patches -->
+    <JsiReactHeaderFiles Include="$(ReactNativePackageDir)\ReactCommon\turbomodule\core\*.h" />
     <JsiReactHeaderDestinationFiles Include="@(JsiReactHeaderFiles->'$(ReactNativeDir)\ReactCommon\jsireact\%(Filename)%(Extension)')" />
 
     <PatchReactNativeInputs Include="@(ReactSourceFiles);@(DeforkingPatchFiles);@(JsiReactHeaderFiles)" />
@@ -33,13 +34,10 @@
           Inputs="@(PatchReactNativeInputs)"
           Outputs="@(PatchReactNativeOutputs)">
 
-    <Copy SourceFiles="@(ReactSourceFiles)"
-          DestinationFiles="@(ReactSourceDestinationFiles)" />
-    <Copy SourceFiles="@(DeforkingPatchFiles)"
-          DestinationFiles="@(DeforkingPatchDesintationFiles)" />
+    <Copy SourceFiles="@(ReactSourceFiles)" DestinationFiles="@(ReactSourceDestinationFiles)" />
+    <Copy SourceFiles="@(DeforkingPatchFiles)" DestinationFiles="@(DeforkingPatchDesintationFiles)" />
     <!-- Special case to recreate BUCK header exports for JSI -->
-    <Copy SourceFiles="@(JsiReactHeaderFiles)"
-          DestinationFiles="@(JsiReactHeaderDestinationFiles)"/>
+    <Copy SourceFiles="@(JsiReactHeaderFiles)" DestinationFiles="@(JsiReactHeaderDestinationFiles)"/>
 
     <ItemGroup>
       <FileWrites Include="@(PatchReactNativeOutputs)" />

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -9,20 +9,20 @@
     <ReactSourceFiles Include="$(ReactNativePackageDir)\**\*.cpp;$(ReactNativePackageDir)\**\*.h" />
     <ReactSourceDestinationFiles Include="@(ReactSourceFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <PatchFiles Include="$(ReactNativeWindowsDir)\DeforkingPatches\**" />
-    <PatchDestinationFiles Include="@(PatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <DeforkingPatchFiles Include="$(ReactNativeWindowsDir)\DeforkingPatches\**" />
+    <DeforkingPatchDesintationFiles Include="@(DeforkingPatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <JsiHeaderFiles Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\*.h" />
-    <JsiHeaderDestinationFiles Include="$(@JsiHeaderFiles->'$(ReactNativeDir)\ReactCommon\jsireact\%(Filename)%(Extension)')" />
+    <JsiReactHeaderFiles Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\*.h" />
+    <JsiReactHeaderDestinationFiles Include="@(JsiReactHeaderFiles->'$(ReactNativeDir)\ReactCommon\jsireact\%(Filename)%(Extension)')" />
 
-    <PatchInputs Include="@(ReactSourceFiles);@(PatchFiles);@(JsiHeaderFiles)" />
-    <PatchOutputs Include="@(ReactSourceDestinationFiles);@(PatchDestinationFiles);@(JsiHeaderDestinationFiles)" />
+    <PatchReactNativeInputs Include="@(ReactSourceFiles);@(DeforkingPatchFiles);@(JsiReactHeaderFiles)" />
+    <PatchReactNativeOutputs Include="@(ReactSourceDestinationFiles);@(DeforkingPatchDesintationFiles);@(JsiReactHeaderDestinationFiles)" />
   </ItemGroup>
 
   <!--
     Visual Studio has its own incremental build logic for simple cases that
     falls over here. Force use of MSBuild logic here. This has a minimal impact
-    on build time (~10s total to build a noop change on a six core machine).
+    on build time (~10s total to build desktop solution on a six core machine).
     -->
   <PropertyGroup>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
@@ -30,19 +30,19 @@
 
   <Target Name="PatchReactNative"
           BeforeTargets="PrepareForBuild"
-          Inputs="@(PatchInputs)"
-          Outputs="@(PatchOutputs)">
+          Inputs="@(PatchReactNativeInputs)"
+          Outputs="@(PatchReactNativeOutputs)">
 
     <Copy SourceFiles="@(ReactSourceFiles)"
-          DestinationFiles="@(ReactSourceFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(PatchFiles)"
-          DestinationFiles="@(PatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+          DestinationFiles="@(ReactSourceDestinationFiles)" />
+    <Copy SourceFiles="@(DeforkingPatchFiles)"
+          DestinationFiles="@(DeforkingPatchDesintationFiles)" />
     <!-- Special case to recreate BUCK header exports for JSI -->
-    <Copy SourceFiles="@(JsiHeaderFiles)"
-          DestinationFolder="$(ReactNativeDir)\ReactCommon\jsireact\"/>
+    <Copy SourceFiles="@(JsiReactHeaderFiles)"
+          DestinationFiles="@(JsiReactHeaderDestinationFiles)"/>
 
     <ItemGroup>
-      <FileWrites Include="@(PatchOutputs)" />
+      <FileWrites Include="@(PatchReactNativeOutputs)" />
     </ItemGroup>
 
   </Target>

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+ Copyright (c) Microsoft Corporation. All rights reserved.
+ Licensed under the MIT License.. 
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <ReactSourceFiles Include="$(ReactNativePackageDir)\**\*.cpp;$(ReactNativePackageDir)\**\*.h" />
+    <ReactSourceDestinationFiles Include="@(ReactSourceFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <PatchFiles Include="$(ReactNativeWindowsDir)\DeforkingPatches\**" />
+    <PatchDestinationFiles Include="@(PatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <JsiHeaderFiles Include="$(ReactNativeDir)\ReactCommon\turbomodule\core\*.h" />
+    <JsiHeaderDestinationFiles Include="$(@JsiHeaderFiles->'$(ReactNativeDir)\ReactCommon\jsireact\%(Filename)%(Extension)')" />
+
+    <PatchInputs Include="@(ReactSourceFiles);@(PatchFiles);@(JsiHeaderFiles)" />
+    <PatchOutputs Include="@(ReactSourceDestinationFiles);@(PatchDestinationFiles);@(JsiHeaderDestinationFiles)" />
+  </ItemGroup>
+
+  <!--
+    Visual Studio has its own incremental build logic for simple cases that
+    falls over here. Force use of MSBuild logic here. This has a minimal impact
+    on build time (~10s total to build a noop change on a six core machine).
+    -->
+  <PropertyGroup>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
+  </PropertyGroup>
+
+  <Target Name="PatchReactNative"
+          BeforeTargets="PrepareForBuild"
+          Inputs="@(PatchInputs)"
+          Outputs="@(PatchOutputs)">
+
+    <Copy SourceFiles="@(ReactSourceFiles)"
+          DestinationFiles="@(ReactSourceFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(PatchFiles)"
+          DestinationFiles="@(PatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <!-- Special case to recreate BUCK header exports for JSI -->
+    <Copy SourceFiles="@(JsiHeaderFiles)"
+          DestinationFolder="$(ReactNativeDir)\ReactCommon\jsireact\"/>
+
+    <ItemGroup>
+      <FileWrites Include="@(PatchOutputs)" />
+    </ItemGroup>
+
+  </Target>
+</Project>

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -66,7 +66,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeDir)\ReactCommon\jscallinvoker;$(ReactNativeDir)\ReactCommon\jsiexecutor;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\WorkingHeaders;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeDir)\ReactCommon\jscallinvoker;$(ReactNativeDir)\ReactCommon\jsiexecutor;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(ENABLE_NATIVE_SYSTRACE_TO_ETW)'=='true' AND '$(OSS_RN)' != 'true'">ENABLE_NATIVE_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)'=='true' AND '$(OSS_RN)' != 'true'">ENABLE_JS_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>_WIN32;_CRT_SECURE_NO_WARNINGS;FOLLY_NO_CONFIG;NOMINMAX;RN_EXPORT=;JSI_EXPORT=;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -43,6 +43,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -177,7 +178,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
   </Target>
   <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('$(ReactNativeDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
+    <Error Condition="!Exists('$(ReactNativePackageDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
     <Error Condition="!Exists('$(YogaDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
   </Target>
 </Project>

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -51,6 +51,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
@@ -42,6 +42,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Warnings.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -5,7 +5,7 @@ param(
 	[string] $TargetRoot = "$SourceRoot\vnext\target",
 	[string] $SourceRoot = ($PSScriptRoot | Split-Path | Split-Path | Split-Path),
 	[System.IO.DirectoryInfo] $ReactWindowsRoot = "$SourceRoot\vnext",
-	[System.IO.DirectoryInfo] $ReactNativeRoot = "$SourceRoot\node_modules\react-native",
+	[System.IO.DirectoryInfo] $ReactNativeRoot = "$SourceRoot\vnext\build\" + @(gci "$ReactWindowsRoot\build\" react-native-patched -Recurse -Directory -Name)[0],
 	[string] $FollyVersion = '2019.09.30.00',
 	[System.IO.DirectoryInfo] $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}",
 	[string[]] $Extensions = ('h', 'hpp', 'def')

--- a/vnext/Scripts/copyRNLibraries.js
+++ b/vnext/Scripts/copyRNLibraries.js
@@ -109,10 +109,6 @@ exports.copyRNLibraries = baseDir => {
       src: 'RNTester',
       dest: 'RNTester',
     },
-    {
-      src: 'ReactCommon/turbomodule/core',
-      dest: 'WorkingHeaders/jsireact',
-    },
   ]);
 
   copyDirectories(baseDir, baseDir, [

--- a/vnext/Universal.IntegrationTests/React.Windows.Universal.IntegrationTests.vcxproj
+++ b/vnext/Universal.IntegrationTests/React.Windows.Universal.IntegrationTests.vcxproj
@@ -34,6 +34,7 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">

--- a/vnext/Universal.UnitTests/React.Windows.Universal.UnitTests.vcxproj
+++ b/vnext/Universal.UnitTests/React.Windows.Universal.UnitTests.vcxproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>

--- a/vnext/V8Inspector/V8Inspector.vcxproj
+++ b/vnext/V8Inspector/V8Inspector.vcxproj
@@ -53,6 +53,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPatches.targets" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">


### PR DESCRIPTION
As part of the efforts to move off of microsoft/react-native, we're aiming to
consume facebook/react-native directly and then apply a set of Windows specific
patches. This change gives us a mechanism to do this patching.

We opt to fully modify React Native sources instead of manipulating
files/includes with build logic. This helps with header resolution and keeps
the rest of the build mostly unaware of the patching. Patching is done in the
projects intermediate output directory. This has a number of benefits but has
the unfortunate property that we will do patching separately for each vcxproj,
and have copies of patched react native for each. Some of this overhead is
mitigated by only copying C++ source files. Avoiding this would likely mean
outputting to a non-build directory or making larger changes to build
structure.

We move jsireact header logic here as well, so we can remove the root
WorkingHeaders directory.

Validated that files in DeforkingPatches will overwrite source and that we
still compile files including jsireact after removing an existing
WorkingHeaders directory. Tested that changing patches leads to a correct
imcremental rebuild.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3871)