### PR TITLE
Fix Layout-Headers on CI machines

### DIFF
--- a/change/react-native-windows-2020-01-15-20-42-29-master.json
+++ b/change/react-native-windows-2020-01-15-20-42-29-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix Layout-Headers on CI machines",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "bc33f50c50fbed7fef86a94624d50379ec518996",
+  "date": "2020-01-16T04:42:29.828Z"
+}

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -5,14 +5,26 @@ param(
 	[string] $SourceRoot = ($PSScriptRoot | Split-Path | Split-Path | Split-Path),
 	[string] $TargetRoot = "$SourceRoot\vnext\target",
 	[System.IO.DirectoryInfo] $ReactWindowsRoot = "$SourceRoot\vnext",
-	[System.IO.DirectoryInfo] $ReactNativeRoot = "$SourceRoot\vnext\build\" + @(gci "$ReactWindowsRoot\build\" react-native-patched -Recurse -Directory -Name)[0],
+	[System.IO.DirectoryInfo] $ReactNativeRoot,
 	[string] $FollyVersion = '2019.09.30.00',
 	[System.IO.DirectoryInfo] $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}",
 	[string[]] $Extensions = ('h', 'hpp', 'def')
 )
 
+if (!$ReactNativeRoot) {
+    $intermediateBuildDir =  if ($env:BaseIntDir) { $env:BaseIntDir } else { "$SourceRoot\vnext\build\" }
+    $relativeRnDir = @(gci $intermediateBuildDir react-native-patched -Recurse -Directory -Name)[0]
+
+    if (!$relativeRnDir) {
+        throw "Cannot find patched React Native Directory (has a project been built?)"
+    }
+
+    $ReactNativeRoot = $intermediateBuildDir + $relativeRnDir
+}
+
 Write-Host "Source root: [$SourceRoot]"
 Write-Host "Destination root: [$TargetRoot]"
+Write-Host "React Native root: [$ReactNativeRoot]"
 
 $patterns = $Extensions| ForEach-Object {"*.$_"}
 


### PR DESCRIPTION
CI machines pass an environment variable as a custom build property to
MSBuild in order to change intermediate build directory. Rely on this
environment variable if set.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3887)