### PR TITLE
Fix Layout-Headers for Publish Try 2

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -47,6 +47,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: x86
           UseRNFork: true
+          LayoutHeaders: true
         ArmRelease:
           BuildConfiguration: Release
           BuildPlatform: arm

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -47,7 +47,6 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: x86
           UseRNFork: true
-          LayoutHeaders: true
         ArmRelease:
           BuildConfiguration: Release
           BuildPlatform: arm

--- a/change/react-native-windows-2020-01-15-22-58-18-master.json
+++ b/change/react-native-windows-2020-01-15-22-58-18-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix Layout-Headers for Publish Try 2",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "46f4396665eea22b8d2342dd4a8e64f420c499be",
+  "date": "2020-01-16T06:58:18.186Z"
+}

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -12,14 +12,14 @@ param(
 )
 
 if (!$ReactNativeRoot) {
-    $intermediateBuildDir =  if ($env:BaseIntDir) { $env:BaseIntDir } else { "$SourceRoot\vnext\build" }
+    $intermediateBuildDir = if ($env:BaseIntDir) { $env:BaseIntDir } else { "$SourceRoot\vnext\build" }
     $relativeRnDir = @(gci $intermediateBuildDir react-native-patched -Recurse -Directory -Name)[0]
 
     if (!$relativeRnDir) {
         throw "Cannot find patched React Native Directory (has a project been built?)"
     }
 
-    $ReactNativeRoot = $intermediateBuildDir + "\" + $relativeRnDir
+    $ReactNativeRoot = Join-Path $intermediateBuildDir $relativeRnDir
 }
 
 Write-Host "Source root: [$SourceRoot]"

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -12,14 +12,14 @@ param(
 )
 
 if (!$ReactNativeRoot) {
-    $intermediateBuildDir =  if ($env:BaseIntDir) { $env:BaseIntDir } else { "$SourceRoot\vnext\build\" }
+    $intermediateBuildDir =  if ($env:BaseIntDir) { $env:BaseIntDir } else { "$SourceRoot\vnext\build" }
     $relativeRnDir = @(gci $intermediateBuildDir react-native-patched -Recurse -Directory -Name)[0]
 
     if (!$relativeRnDir) {
         throw "Cannot find patched React Native Directory (has a project been built?)"
     }
 
-    $ReactNativeRoot = $intermediateBuildDir + $relativeRnDir
+    $ReactNativeRoot = $intermediateBuildDir + "\" + $relativeRnDir
 }
 
 Write-Host "Source root: [$SourceRoot]"


### PR DESCRIPTION
Continue from #3887

Add a missing directory separator that wasn't in the env variable. ~Add
LayoutHeaders to a build flavor in the PR matrix so we can find this
earlier.~ (see update below)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3888)