### PR TITLE
Source Patching Improvements

### DIFF
--- a/change/react-native-windows-2020-01-16-08-55-48-poisoned-headers.json
+++ b/change/react-native-windows-2020-01-16-08-55-48-poisoned-headers.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Source Patching Improvements",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "a1efe72497a416ee6288d0f5748e5db572a838a1",
+  "date": "2020-01-16T16:55:48.229Z"
+}

--- a/vnext/PropertySheets/PoisonUnpatchedHeaders.targets
+++ b/vnext/PropertySheets/PoisonUnpatchedHeaders.targets
@@ -20,7 +20,7 @@
 
     <PropertyGroup>
       <PoisonedHeaderContent><![CDATA[
-#error Facebook React Native headers may not be including without patches. \
+#error Facebook React Native headers may not be included without patches. \
 Ensure no React Native headers are directly or indirectly included, or import \
 "ReactPatches.targets" in your project.
       ]]></PoisonedHeaderContent>

--- a/vnext/PropertySheets/PoisonUnpatchedHeaders.targets
+++ b/vnext/PropertySheets/PoisonUnpatchedHeaders.targets
@@ -26,6 +26,7 @@ Ensure no React Native headers are directly or indirectly included, or import \
       ]]></PoisonedHeaderContent>
     </PropertyGroup>
 
+    <MakeDir Directories="@(PoisonedHeaders->'%(RootDir)\%(Directory)')" />
     <WriteLinesToFile
       File="%(PoisonedHeaders.FullPath)"
       Lines='$(PoisonedHeaderContent)'

--- a/vnext/PropertySheets/PoisonUnpatchedHeaders.targets
+++ b/vnext/PropertySheets/PoisonUnpatchedHeaders.targets
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+ Copyright (c) Microsoft Corporation. All rights reserved.
+ Licensed under the MIT License.. 
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Projects trying to include headers from ReactNativeDir will fail unless
+    source patching is enabled. This is by-design to avoid conflicts with
+    patched and unpatched headers, but leads to an unintuitive error message.
+    Ensure we give a useful message when building by dyanmically generating
+    poisoned headers when patching is disabled.
+  -->
+  <Target Name="PoisonUnpatchedHeaders" Condition="'$(PatchTargetIncluded)' != 'true'" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <ReactNativeHeaders Include="$(ReactNativePackageDir)\ReactCommon\**\*.h" />
+      <PoisonedHeaders Include="@(ReactNativeHeaders->'$(ReactNativeDir)\ReactCommon\%(RecursiveDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PoisonedHeaderContent><![CDATA[
+#error Facebook React Native headers may not be including without patches. \
+Ensure no React Native headers are directly or indirectly included, or import \
+"ReactPatches.targets" in your project.
+      ]]></PoisonedHeaderContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="%(PoisonedHeaders.FullPath)"
+      Lines='$(PoisonedHeaderContent)'
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"/>
+  </Target>
+
+</Project>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -86,4 +86,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\PoisonUnpatchedHeaders.targets" />
+
 </Project>

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -5,12 +5,19 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="EvaluatePatchReactInputsOutputs" BeforeTargets="PrepareForBuild">
+  <PropertyGroup>
+    <PatchTargetIncluded>true</PatchTargetIncluded>
+    <ReactPackageCommon>$(ReactNativePackageDir)\ReactCommon\</ReactPackageCommon>
+    <ReactCommon>$(ReactNativeDir)\ReactCommon\</ReactCommon>
+    <DeforkingPatchesCommon>$(ReactNativeWindowsDir)\DeforkingPatches\ReactCommon\</DeforkingPatchesCommon>
+  </PropertyGroup>
+
+  <Target Name="EvaluatePatchReactInputsOutputs" BeforeTargets="PrepareForBuild;PoisonUnpatchedHeaders">
     <ItemGroup>
-      <DeforkingPatchFiles Include="$(ReactNativeWindowsDir)\DeforkingPatches\**" Condition="'$(PATCH_RN)'=='true'"/>
-      <AllReactSourceFiles Include="$(ReactNativePackageDir)\**\*.cpp;$(ReactNativePackageDir)\**\*.h" />
-      <ReactSourceFiles Include="@(AllReactSourceFiles)" Condition="'$(PATCH_RN)'!='true' OR !Exists('$(ReactNativeWindowsDir)\DeforkingPatches\%(AllReactSourceFiles.RecursiveDir)%(AllReactSourceFiles.Filename)%(AllReactSourceFiles.Extension)')" />
-      <JsiReactHeaderFiles Include="$(ReactNativePackageDir)\ReactCommon\turbomodule\core\*.h" />
+      <DeforkingPatchFiles Include="$(DeforkingPatchesCommon)\**" Condition="'$(PATCH_RN)'=='true'"/>
+      <AllReactSourceFiles Include="$(ReactPackageCommon)\**\*.cpp;$(ReactPackageCommon)\**\*.h" />
+      <ReactSourceFiles Include="@(AllReactSourceFiles)" Condition="'$(PATCH_RN)'!='true' OR !Exists('$(DeforkingPatchesCommon)\%(RecursiveDir)%(Filename)%(Extension)')" />
+      <JsiReactHeaderFiles Include="$(ReactPackageCommon)\turbomodule\core\*.h" />
     </ItemGroup>
   </Target>
 
@@ -26,7 +33,7 @@
           AfterTargets="EvaluatePatchInputsOutputs"
           BeforeTargets="PrepareForBuild">
     <Copy SourceFiles="@(ReactSourceFiles)"
-          DestinationFiles="@(ReactSourceFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(ReactSourceFiles->'$(ReactCommon)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
@@ -34,7 +41,7 @@
           AfterTargets="EvaluatePatchInputsOutputs"
           BeforeTargets="PrepareForBuild">
     <Copy SourceFiles="@(DeforkingPatchFiles)"
-          DestinationFiles="@(DeforkingPatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+          DestinationFiles="@(DeforkingPatchFiles->'$(ReactCommon)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
@@ -42,7 +49,7 @@
           AfterTargets="EvaluatePatchInputsOutputs"
           BeforeTargets="PrepareForBuild">
     <Copy SourceFiles="@(JsiReactHeaderFiles)"
-          DestinationFiles="@(JsiReactHeaderFiles->'$(ReactNativeDir)\ReactCommon\jsireact\%(Filename)%(Extension)')"
+          DestinationFiles="@(JsiReactHeaderFiles->'$(ReactCommon)\jsireact\%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 


### PR DESCRIPTION
Projects that rely on including headers from ReactNativeDir, but do not patch
React Native source will get a confusing error message today. Use dynamically
generated poisoned headers to cause a more sane build break if this is
attempted.

We additionally modify the existing patching logic to only copy ReactCommon.
This lowers intermediate build output overhead from about 14MB per project to
under 2MB, and reduces log spam.

Validated:
- We see the error message in Playground if we do not include the patch target
- We can build Playground when patching is present
- We can switch between the two and the build will pick up the change
- The Playground project and Desktop solution still build

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3892)