### PR TITLE
Update to react-native@0.60.0-microsoft.40

### DIFF
--- a/change/react-native-windows-2020-01-17-19-19-48-auto-update-versions060.0microsoft.40.json
+++ b/change/react-native-windows-2020-01-17-19-19-48-auto-update-versions060.0microsoft.40.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.40",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "21184075b75f07c7e632609eb4e9a7e71393ab14",
+  "dependentChangeType": "patch",
+  "date": "2020-01-17T19:19:48.853Z"
+}

--- a/change/react-native-windows-extended-2020-01-17-19-19-50-auto-update-versions060.0microsoft.40.json
+++ b/change/react-native-windows-extended-2020-01-17-19-19-50-auto-update-versions060.0microsoft.40.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.40",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "29a5622469ed44c6978ad01050e026d8838782b4",
+  "dependentChangeType": "patch",
+  "date": "2020-01-17T19:19:50.655Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react-native-windows": "0.60.0-vnext.115",
     "react-native-windows-extended": "0.60.67-2",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react-native-windows": "0.60.0-vnext.115",
     "react-native-windows-extended": "0.60.67-2",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react-native-windows": "0.60.0-vnext.115",
     "react-native-windows-extended": "0.60.67-2",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -42,7 +42,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "@office-iss/rex-win32": "0.0.33",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -57,7 +57,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   }

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -52,13 +52,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.35 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.35.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
495ca4dfd Applying package update to 0.60.0-microsoft.40 ***NO_CI***
f5a5da14a Getting rid of the legacy JS integration in favor of JSI with V8 impl… (#224)
e5460d377 Applying package update to 0.60.0-microsoft.39 ***NO_CI***
dca14b8de Deleting a few build files not present in the FB upstream branch (#223)
bb4503076 Applying package update to 0.60.0-microsoft.38 ***NO_CI***
e91e19f21 An essential revert of 'https://github.com/microsoft/react-native/commit/243070afe2873c09c1149ca3ede3386abb88a529#diff-8e3b74ad18aa49187acd4240321bc9b9' to bring back support for showing dialogs over standard Android activities (#222)
a978d6b20 Align dependencies with facebook 0.60 (#221)
1f67be278 Applying package update to 0.60.0-microsoft.37 ***NO_CI***
dc7c50bbd [RNTester] Remove need to update lockfile after cutting new build (#219)
7317f6781 Applying package update to 0.60.0-microsoft.36 ***NO_CI***
c20196fbd Removing forked changes that were made to support win32 (#216)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3906)