### PR TITLE
Reduce React Patching Disk Space Usage

### DIFF
--- a/change/react-native-windows-2020-01-18-23-13-45-smaller-patches.json
+++ b/change/react-native-windows-2020-01-18-23-13-45-smaller-patches.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Reduce React Patching Disk Space Usage",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "e331384689c30df28286cefa73e74159357b7d48",
+  "dependentChangeType": "patch",
+  "date": "2020-01-19T07:13:45.041Z"
+}

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -5,12 +5,20 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="EvaluatePatchReactInputsOutputs" BeforeTargets="PrepareForBuild">
+  <PropertyGroup>
+    <ReactCommonSrc>$(ReactNativePackageDir)\ReactCommon\</ReactCommonSrc>
+    <ReactCommonDest>$(ReactNativeDir)\ReactCommon\</ReactCommonDest>
+    <PatchedReactCommonDest>$(ReactNativeWindowsDir)\\DeforkingPatches\ReactCommon\</PatchedReactCommonDest>
+  </PropertyGroup>
+
+  <Target Name="EvaluateReactPatchInputs" BeforeTargets="PrepareForBuild">
     <ItemGroup>
-      <DeforkingPatchFiles Include="$(ReactNativeWindowsDir)\DeforkingPatches\**" Condition="'$(PATCH_RN)'=='true'"/>
-      <AllReactSourceFiles Include="$(ReactNativePackageDir)\**\*.cpp;$(ReactNativePackageDir)\**\*.h" />
-      <ReactSourceFiles Include="@(AllReactSourceFiles)" Condition="'$(PATCH_RN)'!='true' OR !Exists('$(ReactNativeWindowsDir)\DeforkingPatches\%(AllReactSourceFiles.RecursiveDir)%(AllReactSourceFiles.Filename)%(AllReactSourceFiles.Extension)')" />
-      <JsiReactHeaderFiles Include="$(ReactNativePackageDir)\ReactCommon\turbomodule\core\*.h" />
+      <ReactCommonSrc Include="$(ReactCommonSrc)\**\*.cpp;$(ReactCommonSrc)\**\*.h" />
+      <UnpatchedReactCommonSrc Include="@(ReactCommonSrc)" Condition="'$(PATCH_RN)'!='true' OR !Exists('$(PatchedReactCommonDest)\%(RecursiveDir)%(Filename)%(Extension)')" />
+      <PatchedReactCommonSrc Include="$(PatchedReactCommonDest)\**" Condition="'$(PATCH_RN)'=='true'"/>
+
+      <!-- Special case to recreate custom header exports in Facebook BUCK logic -->
+      <JsiReactHeaderFiles Include="$(ReactCommonSrc)\turbomodule\core\*.h" />
     </ItemGroup>
   </Target>
 
@@ -25,24 +33,24 @@
   <Target Name="CopyReactSources"
           AfterTargets="EvaluatePatchInputsOutputs"
           BeforeTargets="PrepareForBuild">
-    <Copy SourceFiles="@(ReactSourceFiles)"
-          DestinationFiles="@(ReactSourceFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+    <Copy SourceFiles="@(UnpatchedReactCommonSrc)"
+          DestinationFiles="@(UnpatchedReactCommonSrc->'$(ReactCommonDest)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="CopyDeforkingPatches"
+  <Target Name="CopyPatchedReactCommonSrc"
           AfterTargets="EvaluatePatchInputsOutputs"
           BeforeTargets="PrepareForBuild">
-    <Copy SourceFiles="@(DeforkingPatchFiles)"
-          DestinationFiles="@(DeforkingPatchFiles->'$(ReactNativeDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+    <Copy SourceFiles="@(PatchedReactCommonSrc)"
+          DestinationFiles="@(PatchedReactCommonSrc->'$(ReactCommonDest)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="CopyJsiHeaders"
+  <Target Name="CopyJsiReactHeaders"
           AfterTargets="EvaluatePatchInputsOutputs"
           BeforeTargets="PrepareForBuild">
     <Copy SourceFiles="@(JsiReactHeaderFiles)"
-          DestinationFiles="@(JsiReactHeaderFiles->'$(ReactNativeDir)\ReactCommon\jsireact\%(Filename)%(Extension)')"
+          DestinationFiles="@(JsiReactHeaderFiles->'$(ReactCommonDest)\jsireact\%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -6,19 +6,19 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ReactCommonSrc>$(ReactNativePackageDir)\ReactCommon\</ReactCommonSrc>
-    <ReactCommonDest>$(ReactNativeDir)\ReactCommon\</ReactCommonDest>
-    <PatchedReactCommonDest>$(ReactNativeWindowsDir)\\DeforkingPatches\ReactCommon\</PatchedReactCommonDest>
+    <ReactCommonSrcPath>$(ReactNativePackageDir)\ReactCommon\</ReactCommonSrcPath>
+    <ReactCommonDestPath>$(ReactNativeDir)\ReactCommon\</ReactCommonDestPath>
+    <ReactCommonPatchesPath>$(ReactNativeWindowsDir)\DeforkingPatches\ReactCommon\</ReactCommonPatchesPath>
   </PropertyGroup>
 
   <Target Name="EvaluateReactPatchInputs" BeforeTargets="PrepareForBuild">
     <ItemGroup>
-      <ReactCommonSrc Include="$(ReactCommonSrc)\**\*.cpp;$(ReactCommonSrc)\**\*.h" />
-      <UnpatchedReactCommonSrc Include="@(ReactCommonSrc)" Condition="'$(PATCH_RN)'!='true' OR !Exists('$(PatchedReactCommonDest)\%(RecursiveDir)%(Filename)%(Extension)')" />
-      <PatchedReactCommonSrc Include="$(PatchedReactCommonDest)\**" Condition="'$(PATCH_RN)'=='true'"/>
-
+      <DeforkingPatchFiles Include="$(ReactCommonPatchesPath)\**" Condition="'$(PATCH_RN)'=='true'"/>
+      <ReactCommonSrcFiles Include="$(ReactCommonSrcPath)\**\*.cpp;$(ReactCommonSrcPath)\**\*.h" />
+      <UnpatchedReactCommonSrcFiles Include="@(ReactCommonSrcFiles)" Condition="'$(PATCH_RN)'!='true' OR !Exists('$(ReactCommonPatchesPath)\%(RecursiveDir)%(Filename)%(Extension)')" />
+      
       <!-- Special case to recreate custom header exports in Facebook BUCK logic -->
-      <JsiReactHeaderFiles Include="$(ReactCommonSrc)\turbomodule\core\*.h" />
+      <JsiReactHeaderFiles Include="$(ReactCommonSrcPath)\turbomodule\core\*.h" />
     </ItemGroup>
   </Target>
 
@@ -30,27 +30,27 @@
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
-  <Target Name="CopyReactSources"
-          AfterTargets="EvaluatePatchInputsOutputs"
+  <Target Name="CopyUnpatchedReactSources"
+          AfterTargets="EvaluateReactPatchInputs"
           BeforeTargets="PrepareForBuild">
-    <Copy SourceFiles="@(UnpatchedReactCommonSrc)"
-          DestinationFiles="@(UnpatchedReactCommonSrc->'$(ReactCommonDest)\%(RecursiveDir)%(Filename)%(Extension)')"
+    <Copy SourceFiles="@(UnpatchedReactCommonSrcFiles)"
+          DestinationFiles="@(UnpatchedReactCommonSrcFiles->'$(ReactCommonDestPath)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="CopyPatchedReactCommonSrc"
-          AfterTargets="EvaluatePatchInputsOutputs"
+  <Target Name="CopyDeforkingPatches"
+          AfterTargets="EvaluateReactPatchInputs"
           BeforeTargets="PrepareForBuild">
-    <Copy SourceFiles="@(PatchedReactCommonSrc)"
-          DestinationFiles="@(PatchedReactCommonSrc->'$(ReactCommonDest)\%(RecursiveDir)%(Filename)%(Extension)')"
+    <Copy SourceFiles="@(DeforkingPatchFiles)"
+          DestinationFiles="@(DeforkingPatchFiles->'$(ReactCommonDestPath)\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CopyJsiReactHeaders"
-          AfterTargets="EvaluatePatchInputsOutputs"
+          AfterTargets="EvaluateReactPatchInputs"
           BeforeTargets="PrepareForBuild">
     <Copy SourceFiles="@(JsiReactHeaderFiles)"
-          DestinationFiles="@(JsiReactHeaderFiles->'$(ReactCommonDest)\jsireact\%(Filename)%(Extension)')"
+          DestinationFiles="@(JsiReactHeaderFiles->'$(ReactCommonDestPath)\jsireact\%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 


### PR DESCRIPTION
Only copy and patch ReactCommon, since that's the directory we currently build. This reduces disk space overhead for projects from 14MB to
under 2. This should save ~200MB of outputs for a full build.

Additionally rename some properties, which were using names which are no
longer accurate or may be confusing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3911)