### PR TITLE
Clean E2E before fetching in attempt to fix disk size issues

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -118,3 +118,10 @@ jobs:
           targetType: "inline"
           script: "Get-Content packages/E2ETest/reports/appium.txt | foreach {Write-Output $_}"
         condition: failed()
+
+      - task: PowerShell@2
+        displayName: Display disksize in the end
+        inputs:
+          targetType: inline # filePath | inline
+          script: |
+            Get-WmiObject Win32_LogicalDisk 

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -25,8 +25,9 @@ jobs:
 
     steps:
       - checkout: self
-        clean: false
-        submodules: false
+        clean: true # whether to fetch clean each time
+        fetchDepth: 1 # the depth of commits to ask Git to fetch (reduces size)
+        submodules: true # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
 
       - template: prepare-env.yml
         parameters:


### PR DESCRIPTION
Lately we see that E2E CI fails due to insufficient disk space. This is just an attempt to fix it by cleaning the repo before the E2E Test starts. I am not familiar with our CI and this is just a test to see if it works. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3919)