### PR TITLE
Remove OSS_RN Specialization in unistd.h Stub

### DIFF
--- a/change/react-native-windows-2020-01-21-11-30-55-stubs.json
+++ b/change/react-native-windows-2020-01-21-11-30-55-stubs.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Remove OSS_RN Specialization in unistd.h Stub",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "e77ad6640e5c76b31acc508fa8ed2a6c75640085",
+  "dependentChangeType": "patch",
+  "date": "2020-01-21T19:30:55.735Z"
+}

--- a/vnext/stubs/unistd.h
+++ b/vnext/stubs/unistd.h
@@ -1,6 +1,1 @@
 // react-native includes unistd.h, which isn't available in windows.
-// This shouldn't be needed after
-// https://github.com/facebook/react-native/pull/25107 is merged
-#if !defined(OSS_RN)
-#error This stub should not be used unless building against the non-microsoft version of react-native
-#endif


### PR DESCRIPTION
We're going to remove the OSS_RN preprocessor definition. In the world
of building against facebook/react-native we will always need this stub
for now. Remove the OSS_RN check, along with a comment which isn't
accurate. (We build multiple files including unistd.h still).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3921)