### PR TITLE
Fix CI out of disk space issues, issue #3908

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -17,6 +17,8 @@ jobs:
       vmImage: windows-2019
     variables: 
       VsComponents: Microsoft.VisualStudio.Component.VC.v141.x86.x64,Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141
+      BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir
+      runCodesignValidationInjection: false
       VmImage: windows-2019
 
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -17,7 +17,6 @@ jobs:
       vmImage: windows-2019
     variables: 
       VsComponents: Microsoft.VisualStudio.Component.VC.v141.x86.x64,Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141
-      BaseIntDir: $(BUILD_SOURCESDIRECTORY)\vnext\build
       VmImage: windows-2019
 
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/variables/vs2017.yml
+++ b/.ado/variables/vs2017.yml
@@ -3,3 +3,4 @@ variables:
   MSBuildVersion: 15.0
   GoogleTestAdapterPath: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\drknwe51.xnq'
   BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:
+  runCodesignValidationInjection: false

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -3,4 +3,4 @@ variables:
   VsComponents: Microsoft.VisualStudio.Component.VC.v141.x86.x64,Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141
   MSBuildVersion: 16.0
   GoogleTestAdapterPath: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\pemwd5jw.szc'
-  BaseIntDir: $(BUILD_SOURCESDIRECTORY)\vnext\build
+  BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -4,3 +4,4 @@ variables:
   MSBuildVersion: 16.0
   GoogleTestAdapterPath: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\pemwd5jw.szc'
   BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:
+  runCodesignValidationInjection: false


### PR DESCRIPTION
* Updating VS2019 VMs config to match VS2017 VM config for build output
* Setting runCodesignValidationInjection: false

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3923)