### PR TITLE
 Update Folly Build Logic

### DIFF
--- a/change/react-native-windows-2020-01-22-16-03-11-follywarnings.json
+++ b/change/react-native-windows-2020-01-22-16-03-11-follywarnings.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Update Folly Build Logic",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "76f4e8fe3171188db922bb94c8b3b778d0db5f5e",
+  "dependentChangeType": "patch",
+  "date": "2020-01-23T00:03:11.046Z"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -270,12 +270,12 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
   </Target>
   <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
-    <Warning Text="Folly required to build without microsoft/react-native. - Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" />
+    <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" />
     <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" SourceUrl="https://github.com/facebook/folly/archive/v2019.09.30.00.zip" DestinationFolder="$(FollyDir)..\.follyzip" />
   </Target>
   <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
-    <Warning Text="Folly required to build without microsoft/react-native. - Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
-    <!-- Using ContinueOnError due to https://github.com/Microsoft/msbuild/issues/3884, unzip seems to have completed dispite errors -->
+    <Message Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
+    <!-- Using ContinueOnError due to https://github.com/Microsoft/msbuild/issues/3884, https://github.com/microsoft/msbuild/pull/4935, We will still succeed, and this will be fixed in a newer version of MSBuild  -->
     <Unzip Condition="!Exists('$(FollyDir)')" ContinueOnError="true" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
   </Target>
   <ItemGroup>
@@ -284,7 +284,6 @@
   <!-- Reenable this task if we need to temporarily replace any folly files for fixes, while we wait for PRs to land in folly -->
   <!--
   <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
-    <Warning Text="Copying @(TemporaryFollyPatchFiles) to @(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
   </Target>
   -->

--- a/vnext/FollyWin32/FollyWin32.vcxproj
+++ b/vnext/FollyWin32/FollyWin32.vcxproj
@@ -61,7 +61,9 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('$(FollyDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />
-  </Target>
+
+  <!-- Make sure we've downloaded Folly -->
+  <ItemGroup>
+    <ProjectReference Include="..\Folly\Folly.vcxproj" Project="{A990658C-CE31-4BCC-976F-0FC6B1AF693D}" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
We always donwload Folly. Do not show a warning when doing so, and do
not reference microsoft/react-native which will be retired soon. Ensure
we download Folly before building FollyWin32, since we do not have that
explicit dependency right now.

Tested by building FollyWin32 after removing the node_modules .folly
directory. We still get all the warnings from unzipping, which we will
have to live with until upgrading our tooling to a newer MSBuild.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3932)