### PR TITLE
Don't call NormalizeDirectory on YogaDir and ReactNativeDir

### DIFF
--- a/change/react-native-windows-2020-01-22-14-20-29-fix-reactpackagedirs.json
+++ b/change/react-native-windows-2020-01-22-14-20-29-fix-reactpackagedirs.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Don't normalize ReactNativeDir and YogaDir; it's unneeded and it breaks on my machine for some reason",
+  "packageName": "react-native-windows",
+  "email": "hpratt@microsoft.com",
+  "commit": "a0443e733802c36571309a44e55eccc9be4ef95a",
+  "dependentChangeType": "patch",
+  "date": "2020-01-22T22:20:29.198Z"
+}

--- a/vnext/PropertySheets/ReactPackageDirectories.props
+++ b/vnext/PropertySheets/ReactPackageDirectories.props
@@ -36,8 +36,6 @@
     <!-- Normalize the directory names -->
     <ReactNativeWindowsDir>$([MSBuild]::NormalizeDirectory($(ReactNativeWindowsDir)))</ReactNativeWindowsDir>
     <ReactNativePackageDir>$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)))</ReactNativePackageDir>
-    <ReactNativeDir>$([MSBuild]::NormalizeDirectory($(ReactNativeDir)))</ReactNativeDir>
-    <YogaDir>$([MSBuild]::NormalizeDirectory($(YogaDir)))</YogaDir>
     <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
   </PropertyGroup>
 


### PR DESCRIPTION
For whatever reason, on my machine, when `$([MSBuild]::NormalizeDirectory()` is called on these relative paths, it normalizes them using `%system32%` as the root. Weird.

I'm reasonably sure there's no need to call `NormalizeDirectory()`; my local builds definitely work fine without it. Guess we'll see what the PR CI loops do!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3935)