### PR TITLE
Update to react-native@0.60.0-microsoft.43

### DIFF
--- a/change/react-native-windows-2020-01-24-21-13-00-auto-update-versions060.0microsoft.43.json
+++ b/change/react-native-windows-2020-01-24-21-13-00-auto-update-versions060.0microsoft.43.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.43",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "3d63180184a05ce41998f01f5e505b2eea780f5d",
+  "dependentChangeType": "patch",
+  "date": "2020-01-24T21:13:00.239Z"
+}

--- a/change/react-native-windows-extended-2020-01-24-21-13-02-auto-update-versions060.0microsoft.43.json
+++ b/change/react-native-windows-extended-2020-01-24-21-13-02-auto-update-versions060.0microsoft.43.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating react-native to version: 0.60.0-microsoft.43",
+  "packageName": "react-native-windows-extended",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "commit": "67c2b712739ca3e62b857d416615f1d7ea9e9b34",
+  "dependentChangeType": "patch",
+  "date": "2020-01-24T21:13:02.297Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "react-native-windows": "0.60.0-vnext.121",
     "react-native-windows-extended": "0.60.68-2",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "react-native-windows": "0.60.0-vnext.121",
     "react-native-windows-extended": "0.60.68-2",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "react-native-windows": "0.60.0-vnext.121",
     "react-native-windows-extended": "0.60.68-2",
     "rnpm-plugin-windows": "^0.4.0"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -42,7 +42,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "@office-iss/rex-win32": "0.0.33",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -57,7 +57,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "^0.60.0 || 0.60.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   }

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -52,13 +52,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
+    "react-native": "^0.60.0 || 0.60.0-microsoft.43 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.43.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Automatic update to latest version published from @Microsoft/react-native, includes these changes:
```
7a4f8124d Applying package update to 0.60.0-microsoft.43 ***NO_CI***
b1a11c619 Fix for building and deploying arm64e to devices (#226)
e8b564b47 Applying package update to 0.60.0-microsoft.42 ***NO_CI***
96ffd3564 Remove react-native commands from cli when installed as 'react-native-macos' (#227)
9bf2c7527 Applying package update to 0.60.0-microsoft.41 ***NO_CI***
5fb6950a2 Fixing the publish task (#225)

```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3955)