### PR TITLE
Enable e2e-test-job

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -30,6 +30,27 @@ jobs:
         fetchDepth: 1 # the depth of commits to ask Git to fetch
         submodules: false
 
+      - task: PowerShell@2
+        displayName: List disksize after checkout
+        inputs:
+          targetType: inline # filePath | inline
+          script: |
+            Get-WmiObject Win32_LogicalDisk
+
+      - task: PowerShell@2
+        displayName: Delete Android SDK folder
+        inputs:
+          targetType: inline # filePath | inline
+          script: |
+            Remove-Item –path "C:\Program Files (x86)\Android\android-sdk" –recurse -force
+
+      - task: PowerShell@2
+        displayName: List disksize after deleting software on C:
+        inputs:
+          targetType: inline # filePath | inline
+          script: |
+            Get-WmiObject Win32_LogicalDisk
+            
       - template: prepare-env.yml
         parameters:
           useRnFork: ${{ parameters.UseRNFork }}

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -45,7 +45,7 @@ jobs:
             Remove-Item –path "C:\Program Files (x86)\Android\android-sdk" –recurse -force
 
       - task: PowerShell@2
-        displayName: List disksize after deleting software on C:
+        displayName: List disksize after deleting software on C
         inputs:
           targetType: inline # filePath | inline
           script: |

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -582,11 +582,11 @@ jobs:
       #    workingDirectory: current
       #  condition: and(succeeded(), or(eq(variables['BuildConfiguration'], 'DebugBundle'), eq(variables['BuildConfiguration'], 'ReleaseBundle')))
 
-#  - template: templates/e2e-test-job.yml # Template reference
-#    parameters:
-#      name: E2ETest
-#      BuildPlatform: x64
-#      UseRNFork: true
+  - template: templates/e2e-test-job.yml # Template reference
+    parameters:
+      name: E2ETest
+      BuildPlatform: x64
+      UseRNFork: true
 
   - job: RNWNugetPR
     displayName: Build and Pack Nuget


### PR DESCRIPTION
Fix #3953. This is not a perfect solution which would delete the android folder on C drive this project doesn't need, but it introduced 6 minutes more to E2E test pipeline.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3959)