### PR TITLE
Asking for 'react-native run-windows --logging' for build error

### DIFF
--- a/.github/ISSUE_TEMPLATE/react-native-windows--vnext--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/react-native-windows--vnext--bug-report.md
@@ -73,6 +73,12 @@ Then, specify:
 
 (Write what happened. Add screenshots!)
 
+### react-native run-windows --logging
+
+<!--
+  If you see build failure on `react-native run-windows`, please try again with 'react-native run-windows --logging' and provide the output.
+-->
+
 ### Reproducible Demo
 
 <!--


### PR DESCRIPTION
Customer reported the build error of `react-native run-windows`, but most of time, it's not enough for troubleshooting. asking for it in bug template.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3961)