### PR TITLE
Add callstack to the error message when a JS error occurs.

### DIFF
--- a/change/react-native-windows-2020-01-29-12-59-19-kinhln-chakra-error.json
+++ b/change/react-native-windows-2020-01-29-12-59-19-kinhln-chakra-error.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Add callstack to the error message when a JS error occurs.",
+  "packageName": "react-native-windows",
+  "email": "kinhln@microsoft.com",
+  "commit": "cd10882748a53fe4eb0550eb45b60f9f482c0a8d",
+  "dependentChangeType": "patch",
+  "date": "2020-01-29T20:59:19.502Z"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -15,6 +15,7 @@
 #include "Unicode.h"
 
 #include "Chakra/ChakraExecutor.h"
+#include "Chakra/ChakraHelpers.h"
 #include "Chakra/ChakraUtils.h"
 #include "JSI/Shared/RuntimeHolder.h"
 
@@ -579,6 +580,10 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       m_innerInstance->loadScriptFromString(std::move(bundleString), jsBundleRelativePath, synchronously);
 #endif
 
+#if defined(_CHAKRACORE_H_)
+    } catch (const facebook::react::ChakraJSException &e) {
+      m_devSettings->errorCallback(std::string{e.what()} + "\r\n" + e.getStack());
+#endif
     } catch (std::exception &e) {
       m_devSettings->errorCallback(e.what());
     }


### PR DESCRIPTION
When there is a JS error, it's useful to see the callstack in the native host app. I'm appending the callstack to the default error message when reporting the error to the host app. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3980)