### PR TITLE
Add Overrides for AnimatedInterpolation and NativeOrDynamicColor

### DIFF
--- a/change/@office-iss-react-native-win32-2020-01-29-14-19-59-animated-interpolation.json
+++ b/change/@office-iss-react-native-win32-2020-01-29-14-19-59-animated-interpolation.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Add win32 override of AnimatedInterpolation",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "nick@nickgerleman.com",
+  "commit": "9b0fc7bcdaf03b3902fc1aa1755f44ba5fe2eb98",
+  "dependentChangeType": "patch",
+  "date": "2020-01-29T22:19:59.646Z"
+}

--- a/change/react-native-windows-2020-01-29-22-33-01-animated-interpolation.json
+++ b/change/react-native-windows-2020-01-29-22-33-01-animated-interpolation.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Add as Windows Overrides",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "1683435db9fe8ec57c835e7b5c0acb1d17190e15",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T06:33:01.821Z"
+}

--- a/packages/react-native-win32/.flowconfig
+++ b/packages/react-native-win32/.flowconfig
@@ -12,7 +12,6 @@
 <PROJECT_ROOT>/Libraries/Animated/src/nodes/AnimatedInterpolation.js
 <PROJECT_ROOT>/Libraries/Color/normalizeColor.js
 <PROJECT_ROOT>/Libraries/Color/normalizeColorObject.js
-<PROJECT_ROOT>/Libraries/Color/NativeOrDynamicColorType.js
 <PROJECT_ROOT>/Libraries/Components/SafeAreaView/SafeAreaView.js
 <PROJECT_ROOT>/Libraries/Components/StatusBar/StatusBar.js
 <PROJECT_ROOT>/Libraries/Components/TextInput/TextInput.js
@@ -34,6 +33,10 @@
 ; This example currently uses mac dynamic colors
 <PROJECT_ROOT>/RNTester/js/DarkModeExample.js
 
+; This file is present in the microsoft/react-native fork, but not upstream.
+; Blacklist it if using microsoft/react-native so we don't see duplicate
+; modules when combined with out local patch. RNW #3995
+<PROJECT_ROOT>/Libraries/Color/NativeOrDynamicColorType.js
 
 ; Ignore react-native files in node_modules since they are copied into project root
 .*/node_modules/react-native/.*

--- a/packages/react-native-win32/.flowconfig
+++ b/packages/react-native-win32/.flowconfig
@@ -9,6 +9,7 @@
 ; Ideally we'd delete the base versions of files that had .win32 overrides as part of the
 ; initRNLibraries build step
 <PROJECT_ROOT>/Libraries/Alert/Alert.js
+<PROJECT_ROOT>/Libraries/Animated/src/nodes/AnimatedInterpolation.js
 <PROJECT_ROOT>/Libraries/Color/normalizeColor.js
 <PROJECT_ROOT>/Libraries/Color/normalizeColorObject.js
 <PROJECT_ROOT>/Libraries/Color/NativeOrDynamicColorType.js

--- a/packages/react-native-win32/src/Libraries/Animated/src/nodes/AnimatedInterpolation.win32.js
+++ b/packages/react-native-win32/src/Libraries/Animated/src/nodes/AnimatedInterpolation.win32.js
@@ -1,0 +1,377 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+/* eslint no-bitwise: 0 */
+'use strict';
+
+const AnimatedNode = require('./AnimatedNode');
+const AnimatedWithChildren = require('./AnimatedWithChildren');
+const NativeAnimatedHelper = require('../NativeAnimatedHelper');
+
+const invariant = require('invariant');
+const normalizeColor = require('../../../Color/normalizeColor');
+
+type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+
+export type InterpolationConfigType = {
+  inputRange: Array<number>,
+  /* $FlowFixMe(>=0.38.0 site=react_native_fb,react_native_oss) - Flow error
+   * detected during the deployment of v0.38.0. To see the error, remove this
+   * comment and run flow
+   */
+  outputRange: Array<number> | Array<string>,
+  easing?: (input: number) => number,
+  extrapolate?: ExtrapolateType,
+  extrapolateLeft?: ExtrapolateType,
+  extrapolateRight?: ExtrapolateType,
+};
+
+const linear = t => t;
+
+/**
+ * Very handy helper to map input ranges to output ranges with an easing
+ * function and custom behavior outside of the ranges.
+ */
+function createInterpolation(
+  config: InterpolationConfigType,
+): (input: number) => number | string {
+  if (config.outputRange && typeof config.outputRange[0] === 'string') {
+    return createInterpolationFromStringOutputRange(config);
+  }
+
+  const outputRange: Array<number> = (config.outputRange: any);
+  checkInfiniteRange('outputRange', outputRange);
+
+  const inputRange = config.inputRange;
+  checkInfiniteRange('inputRange', inputRange);
+  checkValidInputRange(inputRange);
+
+  invariant(
+    inputRange.length === outputRange.length,
+    'inputRange (' +
+    inputRange.length +
+    ') and outputRange (' +
+    outputRange.length +
+    ') must have the same length',
+  );
+
+  const easing = config.easing || linear;
+
+  let extrapolateLeft: ExtrapolateType = 'extend';
+  if (config.extrapolateLeft !== undefined) {
+    extrapolateLeft = config.extrapolateLeft;
+  } else if (config.extrapolate !== undefined) {
+    extrapolateLeft = config.extrapolate;
+  }
+
+  let extrapolateRight: ExtrapolateType = 'extend';
+  if (config.extrapolateRight !== undefined) {
+    extrapolateRight = config.extrapolateRight;
+  } else if (config.extrapolate !== undefined) {
+    extrapolateRight = config.extrapolate;
+  }
+
+  return input => {
+    invariant(
+      typeof input === 'number',
+      'Cannot interpolation an input which is not a number',
+    );
+
+    const range = findRange(input, inputRange);
+    return interpolate(
+      input,
+      inputRange[range],
+      inputRange[range + 1],
+      outputRange[range],
+      outputRange[range + 1],
+      easing,
+      extrapolateLeft,
+      extrapolateRight,
+    );
+  };
+}
+
+function interpolate(
+  input: number,
+  inputMin: number,
+  inputMax: number,
+  outputMin: number,
+  outputMax: number,
+  easing: (input: number) => number,
+  extrapolateLeft: ExtrapolateType,
+  extrapolateRight: ExtrapolateType,
+) {
+  let result = input;
+
+  // Extrapolate
+  if (result < inputMin) {
+    if (extrapolateLeft === 'identity') {
+      return result;
+    } else if (extrapolateLeft === 'clamp') {
+      result = inputMin;
+    } else if (extrapolateLeft === 'extend') {
+      // noop
+    }
+  }
+
+  if (result > inputMax) {
+    if (extrapolateRight === 'identity') {
+      return result;
+    } else if (extrapolateRight === 'clamp') {
+      result = inputMax;
+    } else if (extrapolateRight === 'extend') {
+      // noop
+    }
+  }
+
+  if (outputMin === outputMax) {
+    return outputMin;
+  }
+
+  if (inputMin === inputMax) {
+    if (input <= inputMin) {
+      return outputMin;
+    }
+    return outputMax;
+  }
+
+  // Input Range
+  if (inputMin === -Infinity) {
+    result = -result;
+  } else if (inputMax === Infinity) {
+    result = result - inputMin;
+  } else {
+    result = (result - inputMin) / (inputMax - inputMin);
+  }
+
+  // Easing
+  result = easing(result);
+
+  // Output Range
+  if (outputMin === -Infinity) {
+    result = -result;
+  } else if (outputMax === Infinity) {
+    result = result + outputMin;
+  } else {
+    result = result * (outputMax - outputMin) + outputMin;
+  }
+
+  return result;
+}
+
+function colorToRgba(input: string): string {
+  let int32Color = normalizeColor(input);
+
+  // TODO RNW #3984 [
+  if (
+    int32Color === null ||
+    typeof int32Color !== 'number'
+  ) {
+    return input;
+  }
+  // ]
+
+  int32Color = int32Color || 0;
+
+  const r = (int32Color & 0xff000000) >>> 24;
+  const g = (int32Color & 0x00ff0000) >>> 16;
+  const b = (int32Color & 0x0000ff00) >>> 8;
+  const a = (int32Color & 0x000000ff) / 255;
+
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+const stringShapeRegex = /[0-9\.-]+/g;
+
+/**
+ * Supports string shapes by extracting numbers so new values can be computed,
+ * and recombines those values into new strings of the same shape.  Supports
+ * things like:
+ *
+ *   rgba(123, 42, 99, 0.36) // colors
+ *   -45deg                  // values with units
+ */
+function createInterpolationFromStringOutputRange(
+  config: InterpolationConfigType,
+): (input: number) => string {
+  let outputRange: Array<string> = (config.outputRange: any);
+  invariant(outputRange.length >= 2, 'Bad output range');
+  outputRange = outputRange.map(colorToRgba);
+  checkPattern(outputRange);
+
+  // ['rgba(0, 100, 200, 0)', 'rgba(50, 150, 250, 0.5)']
+  // ->
+  // [
+  //   [0, 50],
+  //   [100, 150],
+  //   [200, 250],
+  //   [0, 0.5],
+  // ]
+  /* $FlowFixMe(>=0.18.0): `outputRange[0].match()` can return `null`. Need to
+   * guard against this possibility.
+   */
+  const outputRanges = outputRange[0].match(stringShapeRegex).map(() => []);
+  outputRange.forEach(value => {
+    /* $FlowFixMe(>=0.18.0): `value.match()` can return `null`. Need to guard
+     * against this possibility.
+     */
+    value.match(stringShapeRegex).forEach((number, i) => {
+      outputRanges[i].push(+number);
+    });
+  });
+
+  /* $FlowFixMe(>=0.18.0): `outputRange[0].match()` can return `null`. Need to
+   * guard against this possibility.
+   */
+  const interpolations = outputRange[0]
+    .match(stringShapeRegex)
+    .map((value, i) => {
+      return createInterpolation({
+        ...config,
+        outputRange: outputRanges[i],
+      });
+    });
+
+  // rgba requires that the r,g,b are integers.... so we want to round them, but we *dont* want to
+  // round the opacity (4th column).
+  const shouldRound = isRgbOrRgba(outputRange[0]);
+
+  return input => {
+    let i = 0;
+    // 'rgba(0, 100, 200, 0)'
+    // ->
+    // 'rgba(${interpolations[0](input)}, ${interpolations[1](input)}, ...'
+    return outputRange[0].replace(stringShapeRegex, () => {
+      const val = +interpolations[i++](input);
+      const rounded =
+        shouldRound && i < 4 ? Math.round(val) : Math.round(val * 1000) / 1000;
+      return String(rounded);
+    });
+  };
+}
+
+function isRgbOrRgba(range) {
+  return typeof range === 'string' && range.startsWith('rgb');
+}
+
+function checkPattern(arr: Array<string>) {
+  const pattern = arr[0].replace(stringShapeRegex, '');
+  for (let i = 1; i < arr.length; ++i) {
+    invariant(
+      pattern === arr[i].replace(stringShapeRegex, ''),
+      'invalid pattern ' + arr[0] + ' and ' + arr[i],
+    );
+  }
+}
+
+function findRange(input: number, inputRange: Array<number>) {
+  let i;
+  for (i = 1; i < inputRange.length - 1; ++i) {
+    if (inputRange[i] >= input) {
+      break;
+    }
+  }
+  return i - 1;
+}
+
+function checkValidInputRange(arr: Array<number>) {
+  invariant(arr.length >= 2, 'inputRange must have at least 2 elements');
+  for (let i = 1; i < arr.length; ++i) {
+    invariant(
+      arr[i] >= arr[i - 1],
+      /* $FlowFixMe(>=0.13.0) - In the addition expression below this comment,
+       * one or both of the operands may be something that doesn't cleanly
+       * convert to a string, like undefined, null, and object, etc. If you really
+       * mean this implicit string conversion, you can do something like
+       * String(myThing)
+       */
+      'inputRange must be monotonically non-decreasing ' + arr,
+    );
+  }
+}
+
+function checkInfiniteRange(name: string, arr: Array<number>) {
+  invariant(arr.length >= 2, name + ' must have at least 2 elements');
+  invariant(
+    arr.length !== 2 || arr[0] !== -Infinity || arr[1] !== Infinity,
+    /* $FlowFixMe(>=0.13.0) - In the addition expression below this comment,
+     * one or both of the operands may be something that doesn't cleanly convert
+     * to a string, like undefined, null, and object, etc. If you really mean
+     * this implicit string conversion, you can do something like
+     * String(myThing)
+     */
+    name + 'cannot be ]-infinity;+infinity[ ' + arr,
+  );
+}
+
+class AnimatedInterpolation extends AnimatedWithChildren {
+  // Export for testing.
+  static __createInterpolation = createInterpolation;
+
+  _parent: AnimatedNode;
+  _config: InterpolationConfigType;
+  _interpolation: (input: number) => number | string;
+
+  constructor(parent: AnimatedNode, config: InterpolationConfigType) {
+    super();
+    this._parent = parent;
+    this._config = config;
+    this._interpolation = createInterpolation(config);
+  }
+
+  __makeNative() {
+    this._parent.__makeNative();
+    super.__makeNative();
+  }
+
+  __getValue(): number | string {
+    const parentValue: number = this._parent.__getValue();
+    invariant(
+      typeof parentValue === 'number',
+      'Cannot interpolate an input which is not a number.',
+    );
+    return this._interpolation(parentValue);
+  }
+
+  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
+    return new AnimatedInterpolation(this, config);
+  }
+
+  __attach(): void {
+    this._parent.__addChild(this);
+  }
+
+  __detach(): void {
+    this._parent.__removeChild(this);
+    super.__detach();
+  }
+
+  __transformDataType(range: Array<any>) {
+    return range.map(NativeAnimatedHelper.transformDataType);
+  }
+
+  __getNativeConfig(): any {
+    if (__DEV__) {
+      NativeAnimatedHelper.validateInterpolation(this._config);
+    }
+
+    return {
+      inputRange: this._config.inputRange,
+      // Only the `outputRange` can contain strings so we don't need to transform `inputRange` here
+      outputRange: this.__transformDataType(this._config.outputRange),
+      extrapolateLeft:
+        this._config.extrapolateLeft || this._config.extrapolate || 'extend',
+      extrapolateRight:
+        this._config.extrapolateRight || this._config.extrapolate || 'extend',
+      type: 'interpolation',
+    };
+  }
+}
+
+module.exports = AnimatedInterpolation;

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -9,6 +9,7 @@
 ; Ideally we'd delete the base versions of files that had .windows overrides as part of the
 ; initRNLibraries build step
 <PROJECT_ROOT>/Libraries/Alert/Alert.js
+<PROJECT_ROOT>/Libraries/Animated/src/nodes/AnimatedInterpolation.js
 <PROJECT_ROOT>/Libraries/AppTheme/AppTheme.js
 <PROJECT_ROOT>/Libraries/Color/normalizeColor.js
 <PROJECT_ROOT>/Libraries/Components/ActivityIndicator/ActivityIndicator.js

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -47,6 +47,10 @@
 <PROJECT_ROOT>/Libraries/StyleSheet/StyleSheetTypes.js
 <PROJECT_ROOT>/Libraries/Utilities/Dimensions.js
 
+; This file is present in the microsoft/react-native fork, but not upstream.
+; Blacklist it if using microsoft/react-native so we don't see duplicate
+; modules when combined with out local patch. RNW #3995
+<PROJECT_ROOT>/Libraries/Color/NativeOrDynamicColorType.js
 
 
 ; Ignore react-native files in node_modules since they are copied into project root

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -89,6 +89,10 @@
 ; Ignore the src folder - flow files are combined with ones from react-native into the root Libraries folder
 .*/vnext/src/.*
 
+; Ignore RN copies, which cause duplicate violations to be shown
+.*/vnext/IntegrationTestsCopy/.*
+.*/vnext/RNTesterCopy/.*
+
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
 

--- a/vnext/src/Libraries/Animated/src/nodes/AnimatedInterpolation.windows.js
+++ b/vnext/src/Libraries/Animated/src/nodes/AnimatedInterpolation.windows.js
@@ -1,0 +1,374 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+/* eslint no-bitwise: 0 */
+'use strict';
+
+const AnimatedNode = require('./AnimatedNode');
+const AnimatedWithChildren = require('./AnimatedWithChildren');
+const NativeAnimatedHelper = require('../NativeAnimatedHelper');
+
+const invariant = require('invariant');
+const normalizeColor = require('../../../Color/normalizeColor');
+
+type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+
+export type InterpolationConfigType = {
+  inputRange: Array<number>,
+  /* $FlowFixMe(>=0.38.0 site=react_native_fb,react_native_oss) - Flow error
+   * detected during the deployment of v0.38.0. To see the error, remove this
+   * comment and run flow
+   */
+  outputRange: Array<number> | Array<string>,
+  easing?: (input: number) => number,
+  extrapolate?: ExtrapolateType,
+  extrapolateLeft?: ExtrapolateType,
+  extrapolateRight?: ExtrapolateType,
+};
+
+const linear = t => t;
+
+/**
+ * Very handy helper to map input ranges to output ranges with an easing
+ * function and custom behavior outside of the ranges.
+ */
+function createInterpolation(
+  config: InterpolationConfigType,
+): (input: number) => number | string {
+  if (config.outputRange && typeof config.outputRange[0] === 'string') {
+    return createInterpolationFromStringOutputRange(config);
+  }
+
+  const outputRange: Array<number> = (config.outputRange: any);
+  checkInfiniteRange('outputRange', outputRange);
+
+  const inputRange = config.inputRange;
+  checkInfiniteRange('inputRange', inputRange);
+  checkValidInputRange(inputRange);
+
+  invariant(
+    inputRange.length === outputRange.length,
+    'inputRange (' +
+      inputRange.length +
+      ') and outputRange (' +
+      outputRange.length +
+      ') must have the same length',
+  );
+
+  const easing = config.easing || linear;
+
+  let extrapolateLeft: ExtrapolateType = 'extend';
+  if (config.extrapolateLeft !== undefined) {
+    extrapolateLeft = config.extrapolateLeft;
+  } else if (config.extrapolate !== undefined) {
+    extrapolateLeft = config.extrapolate;
+  }
+
+  let extrapolateRight: ExtrapolateType = 'extend';
+  if (config.extrapolateRight !== undefined) {
+    extrapolateRight = config.extrapolateRight;
+  } else if (config.extrapolate !== undefined) {
+    extrapolateRight = config.extrapolate;
+  }
+
+  return input => {
+    invariant(
+      typeof input === 'number',
+      'Cannot interpolation an input which is not a number',
+    );
+
+    const range = findRange(input, inputRange);
+    return interpolate(
+      input,
+      inputRange[range],
+      inputRange[range + 1],
+      outputRange[range],
+      outputRange[range + 1],
+      easing,
+      extrapolateLeft,
+      extrapolateRight,
+    );
+  };
+}
+
+function interpolate(
+  input: number,
+  inputMin: number,
+  inputMax: number,
+  outputMin: number,
+  outputMax: number,
+  easing: (input: number) => number,
+  extrapolateLeft: ExtrapolateType,
+  extrapolateRight: ExtrapolateType,
+) {
+  let result = input;
+
+  // Extrapolate
+  if (result < inputMin) {
+    if (extrapolateLeft === 'identity') {
+      return result;
+    } else if (extrapolateLeft === 'clamp') {
+      result = inputMin;
+    } else if (extrapolateLeft === 'extend') {
+      // noop
+    }
+  }
+
+  if (result > inputMax) {
+    if (extrapolateRight === 'identity') {
+      return result;
+    } else if (extrapolateRight === 'clamp') {
+      result = inputMax;
+    } else if (extrapolateRight === 'extend') {
+      // noop
+    }
+  }
+
+  if (outputMin === outputMax) {
+    return outputMin;
+  }
+
+  if (inputMin === inputMax) {
+    if (input <= inputMin) {
+      return outputMin;
+    }
+    return outputMax;
+  }
+
+  // Input Range
+  if (inputMin === -Infinity) {
+    result = -result;
+  } else if (inputMax === Infinity) {
+    result = result - inputMin;
+  } else {
+    result = (result - inputMin) / (inputMax - inputMin);
+  }
+
+  // Easing
+  result = easing(result);
+
+  // Output Range
+  if (outputMin === -Infinity) {
+    result = -result;
+  } else if (outputMax === Infinity) {
+    result = result + outputMin;
+  } else {
+    result = result * (outputMax - outputMin) + outputMin;
+  }
+
+  return result;
+}
+
+function colorToRgba(input: string): string {
+  let int32Color = normalizeColor(input);
+
+  // TODO RNW #3984 [
+  if (int32Color === null || typeof int32Color !== 'number') {
+    return input;
+  }
+  // ]
+
+  int32Color = int32Color || 0;
+
+  const r = (int32Color & 0xff000000) >>> 24;
+  const g = (int32Color & 0x00ff0000) >>> 16;
+  const b = (int32Color & 0x0000ff00) >>> 8;
+  const a = (int32Color & 0x000000ff) / 255;
+
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+const stringShapeRegex = /[0-9\.-]+/g;
+
+/**
+ * Supports string shapes by extracting numbers so new values can be computed,
+ * and recombines those values into new strings of the same shape.  Supports
+ * things like:
+ *
+ *   rgba(123, 42, 99, 0.36) // colors
+ *   -45deg                  // values with units
+ */
+function createInterpolationFromStringOutputRange(
+  config: InterpolationConfigType,
+): (input: number) => string {
+  let outputRange: Array<string> = (config.outputRange: any);
+  invariant(outputRange.length >= 2, 'Bad output range');
+  outputRange = outputRange.map(colorToRgba);
+  checkPattern(outputRange);
+
+  // ['rgba(0, 100, 200, 0)', 'rgba(50, 150, 250, 0.5)']
+  // ->
+  // [
+  //   [0, 50],
+  //   [100, 150],
+  //   [200, 250],
+  //   [0, 0.5],
+  // ]
+  /* $FlowFixMe(>=0.18.0): `outputRange[0].match()` can return `null`. Need to
+   * guard against this possibility.
+   */
+  const outputRanges = outputRange[0].match(stringShapeRegex).map(() => []);
+  outputRange.forEach(value => {
+    /* $FlowFixMe(>=0.18.0): `value.match()` can return `null`. Need to guard
+     * against this possibility.
+     */
+    value.match(stringShapeRegex).forEach((number, i) => {
+      outputRanges[i].push(+number);
+    });
+  });
+
+  /* $FlowFixMe(>=0.18.0): `outputRange[0].match()` can return `null`. Need to
+   * guard against this possibility.
+   */
+  const interpolations = outputRange[0]
+    .match(stringShapeRegex)
+    .map((value, i) => {
+      return createInterpolation({
+        ...config,
+        outputRange: outputRanges[i],
+      });
+    });
+
+  // rgba requires that the r,g,b are integers.... so we want to round them, but we *dont* want to
+  // round the opacity (4th column).
+  const shouldRound = isRgbOrRgba(outputRange[0]);
+
+  return input => {
+    let i = 0;
+    // 'rgba(0, 100, 200, 0)'
+    // ->
+    // 'rgba(${interpolations[0](input)}, ${interpolations[1](input)}, ...'
+    return outputRange[0].replace(stringShapeRegex, () => {
+      const val = +interpolations[i++](input);
+      const rounded =
+        shouldRound && i < 4 ? Math.round(val) : Math.round(val * 1000) / 1000;
+      return String(rounded);
+    });
+  };
+}
+
+function isRgbOrRgba(range) {
+  return typeof range === 'string' && range.startsWith('rgb');
+}
+
+function checkPattern(arr: Array<string>) {
+  const pattern = arr[0].replace(stringShapeRegex, '');
+  for (let i = 1; i < arr.length; ++i) {
+    invariant(
+      pattern === arr[i].replace(stringShapeRegex, ''),
+      'invalid pattern ' + arr[0] + ' and ' + arr[i],
+    );
+  }
+}
+
+function findRange(input: number, inputRange: Array<number>) {
+  let i;
+  for (i = 1; i < inputRange.length - 1; ++i) {
+    if (inputRange[i] >= input) {
+      break;
+    }
+  }
+  return i - 1;
+}
+
+function checkValidInputRange(arr: Array<number>) {
+  invariant(arr.length >= 2, 'inputRange must have at least 2 elements');
+  for (let i = 1; i < arr.length; ++i) {
+    invariant(
+      arr[i] >= arr[i - 1],
+      /* $FlowFixMe(>=0.13.0) - In the addition expression below this comment,
+       * one or both of the operands may be something that doesn't cleanly
+       * convert to a string, like undefined, null, and object, etc. If you really
+       * mean this implicit string conversion, you can do something like
+       * String(myThing)
+       */
+      'inputRange must be monotonically non-decreasing ' + arr,
+    );
+  }
+}
+
+function checkInfiniteRange(name: string, arr: Array<number>) {
+  invariant(arr.length >= 2, name + ' must have at least 2 elements');
+  invariant(
+    arr.length !== 2 || arr[0] !== -Infinity || arr[1] !== Infinity,
+    /* $FlowFixMe(>=0.13.0) - In the addition expression below this comment,
+     * one or both of the operands may be something that doesn't cleanly convert
+     * to a string, like undefined, null, and object, etc. If you really mean
+     * this implicit string conversion, you can do something like
+     * String(myThing)
+     */
+    name + 'cannot be ]-infinity;+infinity[ ' + arr,
+  );
+}
+
+class AnimatedInterpolation extends AnimatedWithChildren {
+  // Export for testing.
+  static __createInterpolation = createInterpolation;
+
+  _parent: AnimatedNode;
+  _config: InterpolationConfigType;
+  _interpolation: (input: number) => number | string;
+
+  constructor(parent: AnimatedNode, config: InterpolationConfigType) {
+    super();
+    this._parent = parent;
+    this._config = config;
+    this._interpolation = createInterpolation(config);
+  }
+
+  __makeNative() {
+    this._parent.__makeNative();
+    super.__makeNative();
+  }
+
+  __getValue(): number | string {
+    const parentValue: number = this._parent.__getValue();
+    invariant(
+      typeof parentValue === 'number',
+      'Cannot interpolate an input which is not a number.',
+    );
+    return this._interpolation(parentValue);
+  }
+
+  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
+    return new AnimatedInterpolation(this, config);
+  }
+
+  __attach(): void {
+    this._parent.__addChild(this);
+  }
+
+  __detach(): void {
+    this._parent.__removeChild(this);
+    super.__detach();
+  }
+
+  __transformDataType(range: Array<any>) {
+    return range.map(NativeAnimatedHelper.transformDataType);
+  }
+
+  __getNativeConfig(): any {
+    if (__DEV__) {
+      NativeAnimatedHelper.validateInterpolation(this._config);
+    }
+
+    return {
+      inputRange: this._config.inputRange,
+      // Only the `outputRange` can contain strings so we don't need to transform `inputRange` here
+      outputRange: this.__transformDataType(this._config.outputRange),
+      extrapolateLeft:
+        this._config.extrapolateLeft || this._config.extrapolate || 'extend',
+      extrapolateRight:
+        this._config.extrapolateRight || this._config.extrapolate || 'extend',
+      type: 'interpolation',
+    };
+  }
+}
+
+module.exports = AnimatedInterpolation;

--- a/vnext/src/Libraries/Color/NativeOrDynamicColorType.windows.js
+++ b/vnext/src/Libraries/Color/NativeOrDynamicColorType.windows.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+export type ColorStop = {
+  color: string | number | NativeOrDynamicColorType,
+  offset: number,
+};
+
+export type NativeOrDynamicColorType = {
+  gradientDirection: string,
+  colorStops: Array<ColorStop>,
+};

--- a/vnext/src/Libraries/Color/NativeOrDynamicColorType.windows.js
+++ b/vnext/src/Libraries/Color/NativeOrDynamicColorType.windows.js
@@ -8,12 +8,10 @@
 
 'use strict';
 
-export type ColorStop = {
-  color: string | number | NativeOrDynamicColorType,
-  offset: number,
-};
-
 export type NativeOrDynamicColorType = {
-  gradientDirection: string,
-  colorStops: Array<ColorStop>,
+  semantic?: string,
+  dynamic?: {
+    light: ?(string | number | NativeOrDynamicColorType),
+    dark: ?(string | number | NativeOrDynamicColorType),
+  },
 };


### PR DESCRIPTION
react-native win32 may use non-integer color types. Bring in the
microsoft/react-native version of AnimatedInterpolation that knows how
to deal with this. Upstreaming is tracked by #3984

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3985)