### PR TITLE
Simple fix to IReactContext.cpp and add a writer helper function for direct event type constant

### DIFF
--- a/change/react-native-windows-2020-01-30-09-32-57-didaReactContext.json
+++ b/change/react-native-windows-2020-01-30-09-32-57-didaReactContext.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Simple fixes to IReactContext.cpp and add a writer helper function for direct event type constant",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "e5d49e832d0b4449bb08093445864264601d1ae2",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T17:32:57.576Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -200,6 +200,21 @@ inline void WriteCustomDirectEventTypeConstant(
   writer.WriteObjectEnd();
 }
 
+inline void WriteCustomDirectEventTypeConstant(
+    IJSValueWriter const &writer,
+    std::string_view propertyName,
+    std::string_view registrationName) noexcept {
+  WriteCustomDirectEventTypeConstant(writer, to_hstring(propertyName), to_hstring(registrationName));
+}
+
+inline void WriteCustomDirectEventTypeConstant(IJSValueWriter const &writer, std::wstring_view eventName) noexcept {
+  WriteCustomDirectEventTypeConstant(writer, L"top" + eventName, L"on" + eventName);
+}
+
+inline void WriteCustomDirectEventTypeConstant(IJSValueWriter const &writer, std::string_view eventName) noexcept {
+  WriteCustomDirectEventTypeConstant(writer, L"top" + to_hstring(eventName), L"on" + to_hstring(eventName));
+}
+
 template <class T, std::enable_if_t<!std::is_void_v<decltype(GetStructInfo(static_cast<T *>(nullptr)))>, int>>
 inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
   writer.WriteObjectBegin();

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -194,7 +194,7 @@ inline void WriteCustomDirectEventTypeConstant(
     IJSValueWriter const &writer,
     std::wstring_view propertyName,
     std::wstring_view registrationName) noexcept {
-	writer.WritePropertyName(propertyName);
+  writer.WritePropertyName(propertyName);
   writer.WriteObjectBegin();
   WriteProperty(writer, L"registrationName", registrationName);
   writer.WriteObjectEnd();

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -190,6 +190,16 @@ inline void WriteValue(IJSValueWriter const &writer, JSValueArray const &value) 
   JSValue::WriteArrayTo(writer, value);
 }
 
+inline void WriteCustomDirectEventTypeConstant(
+    IJSValueWriter const &writer,
+    std::wstring_view propertyName,
+    std::wstring_view registrationName) noexcept {
+	writer.WritePropertyName(propertyName);
+  writer.WriteObjectBegin();
+  WriteProperty(writer, L"registrationName", registrationName);
+  writer.WriteObjectEnd();
+}
+
 template <class T, std::enable_if_t<!std::is_void_v<decltype(GetStructInfo(static_cast<T *>(nullptr)))>, int>>
 inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
   writer.WriteObjectBegin();

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -11,10 +11,13 @@ void ReactContext::DispatchEvent(
     hstring const &eventName,
     ReactArgWriter const &eventDataArgWriter) noexcept {
   if (auto instance = m_instance.lock()) {
-    IJSValueWriter eventDataWriter = winrt::make<DynamicWriter>();
-    eventDataArgWriter(eventDataWriter);
-
-    auto eventData = eventDataWriter.as<DynamicWriter>()->TakeValue();
+    folly::dynamic eventData; // default to NULLT
+    if (eventDataArgWriter != nullptr)
+    {
+      IJSValueWriter eventDataWriter = winrt::make<DynamicWriter>();
+      eventDataArgWriter(eventDataWriter);
+      eventData = eventDataWriter.as<DynamicWriter>()->TakeValue();
+    }
     instance->DispatchEvent(unbox_value<int64_t>(view.Tag()), to_string(eventName), std::move(eventData));
   }
 }

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -12,8 +12,7 @@ void ReactContext::DispatchEvent(
     ReactArgWriter const &eventDataArgWriter) noexcept {
   if (auto instance = m_instance.lock()) {
     folly::dynamic eventData; // default to NULLT
-    if (eventDataArgWriter != nullptr)
-    {
+    if (eventDataArgWriter != nullptr) {
       IJSValueWriter eventDataWriter = winrt::make<DynamicWriter>();
       eventDataArgWriter(eventDataWriter);
       eventData = eventDataWriter.as<DynamicWriter>()->TakeValue();

--- a/vnext/docs/NativeModulesSetup.md
+++ b/vnext/docs/NativeModulesSetup.md
@@ -59,7 +59,9 @@ Next you'll be prompted to select the versions of Windows you'll support. This s
 1. Set the `Target version` to `Windows 10, version 1903 (10.0; Build 18362)`.
 1. Set the `Minimum version` to `Windows 10 Creators Update (10.0; Build 15063)`.
 
-You should now have a new `MyLibrary` solution file at `.\MyLibrary\MyLibrary.sln` and a `MyLibrary` project at `.\MyLibrary\MyLibrary\MyLibrary.csproj` for C# or `.\MyLibrary\MyLibrary\MyLibrary.vcxproj` for C++.
+You should now have a new `MyLibrary` solution file at `.\MyLibrary\MyLibrary.sln` and a `MyLibrary` project at `.\MyLibrary\MyLibrary\MyLibrary.csproj` for C# or `.\MyLibrary\MyLibrary\MyLibrary.vcxproj` for C++. 
+
+For C++/WinRT project, right click on the project and choose `Manage Nuget Packages...`, select version 2.0.190730.2 for Microsoft.Windows.CppWinRT pacakge.
 
 Now, we want to rename the root directory of the Windows native code to `windows` to match the peer `android` and `ios` directories:
 


### PR DESCRIPTION
- ReactContext.DispatchEvent should support null input for eventDataArgWriter instead of crash, when event has no data payload.

- Add a writer helper function for export custom direct event type constants.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3996)