### PR TITLE
rnpm-plugin-windows fails when using npm

### DIFF
--- a/change/rnpm-plugin-windows-2020-01-30-13-37-04-npmcli.json
+++ b/change/rnpm-plugin-windows-2020-01-30-13-37-04-npmcli.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix CLI dependency",
+  "packageName": "rnpm-plugin-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "33f9509e627c111fa5582e11c78d0b00a3b6ce05",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T21:37:04.338Z"
+}

--- a/current/local-cli/rnpm/windows/package.json
+++ b/current/local-cli/rnpm/windows/package.json
@@ -25,7 +25,7 @@
     "extract-zip": "^1.6.7",
     "fs-extra": "^7.0.1",
     "npm-registry": "^0.1.13",
-    "prompts": "^4.2.0",
+    "prompts": "^2.3.0",
     "request": "^2.88.0",
     "semver": "^6.1.1",
     "valid-url": "^1.0.9"

--- a/current/local-cli/rnpm/windows/package.json
+++ b/current/local-cli/rnpm/windows/package.json
@@ -25,6 +25,7 @@
     "extract-zip": "^1.6.7",
     "fs-extra": "^7.0.1",
     "npm-registry": "^0.1.13",
+    "prompts": "^4.2.0",
     "request": "^2.88.0",
     "semver": "^6.1.1",
     "valid-url": "^1.0.9"

--- a/current/local-cli/rnpm/windows/src/common.js
+++ b/current/local-cli/rnpm/windows/src/common.js
@@ -103,7 +103,7 @@ const getInstallPackage = function (version, tag, useStable) {
   }
 
   if (validVersion) {
-    return Promise.resolve(`${packageToInstall}@${resultVersion}`);
+    return Promise.resolve(`${packageToInstall}@${version}`);
   } else if (validRange) {
     return getMatchingVersion(version, tag, useStable)
       .then(resultVersion => `${packageToInstall}@${resultVersion}`);
@@ -150,5 +150,5 @@ module.exports = {
   getInstallPackage,
   getReactNativeVersion,
   getReactNativeAppName,
-  isGlobalCliUsingYarn
+  isGlobalCliUsingYarn,
 };

--- a/current/local-cli/rnpm/windows/src/windows.js
+++ b/current/local-cli/rnpm/windows/src/windows.js
@@ -8,7 +8,8 @@ const Common = require('./common');
 const chalk = require('chalk');
 const execSync = require('child_process').execSync;
 const path = require('path');
-const prompt = require('@react-native-community/cli/build/tools/generator/promptSync').default();
+const prompts = require('prompts');
+const semver = require('semver');
 
 const REACT_NATIVE_WINDOWS_GENERATE_PATH = function() {
   return path.resolve(
@@ -20,30 +21,50 @@ const REACT_NATIVE_WINDOWS_GENERATE_PATH = function() {
   );
 };
 
-module.exports = function (config, args, options) {
-  const name = args[0] ? args[0] : Common.getReactNativeAppName();
-  const ns = options.namespace ? options.namespace : name;
-  const version = options.windowsVersion ? options.windowsVersion : Common.getReactNativeVersion();
+module.exports = async function (config, args, options) {
+  try {
+    const name = args[0] ? args[0] : Common.getReactNativeAppName();
+    const ns = options.namespace ? options.namespace : name;
+    let version = options.windowsVersion ? options.windowsVersion : Common.getReactNativeVersion();
 
-  let template = options.template;
-  if (!template) {
-    console.log("What version of react-native-windows would you like to install?  Choose one of:  legacy, latest [default]:");
-    template = prompt();
-    if (template === '') {
-      template = 'vnext'
+    let template = options.template;
+    if (!template) {
+      const validVersion = semver.valid(version);
+      const validRange = semver.validRange(version);
+      // If the RN version is >= 0.60 we know they have to use vnext
+      if ((validVersion && semver.gte(validVersion, '0.60')) ||
+          (!validVersion && validRange && semver.ltr('0.59.1000', validRange))) {
+            template = 'vnext';
+          }
+
+      // If the RN version is >= 0.59 then we need to query which version the user wants
+      if (!template && ((validVersion && semver.gte(validVersion, '0.59.0')) ||
+          (!validVersion && validRange && semver.ltr('0.58.1000', validRange)))) {
+            template = (await prompts({
+              type: 'select',
+              name: 'template',
+              message: 'What version of react-native-windows would you like to install?',
+              choices: [
+                { value: 'vnext', title: ' [1mLatest[22m      - High performance react-native-windows built on a shared C++ core from facebook (supports C++ or C#).' },
+                { value: 'legacy', title: ' [1mLegacy[22m      - Older react-native-windows implementation - (C# only, react-native <= 0.59 only)' },
+              ],
+            })).template;
+      }
     }
+
+    let rnwPackage = await Common.getInstallPackage(version, template, !!template);
+
+    console.log(`Installing ${rnwPackage}...`);
+    const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';
+
+    const execOptions = options.verbose ? { stdio: 'inherit' } : {};
+    execSync(`${pkgmgr} ${rnwPackage}`, execOptions);
+    console.log(chalk.green(`${rnwPackage} successfully installed.`));
+
+    const generateWindows = require(REACT_NATIVE_WINDOWS_GENERATE_PATH());
+    generateWindows(process.cwd(), name, ns, options);
+  } catch (error) {
+    console.error(chalk.red(error.message));
+    console.error(error);
   }
-
-  return Common.getInstallPackage(version, template, true)
-    .then(rnwPackage => {
-      console.log(`Installing ${rnwPackage}...`);
-      const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';
-
-      const execOptions = options.verbose ? { stdio: 'inherit' } : {};
-      execSync(`${pkgmgr} ${rnwPackage}`, execOptions);
-      console.log(chalk.green(`${rnwPackage} successfully installed.`));
-
-      const generateWindows = require(REACT_NATIVE_WINDOWS_GENERATE_PATH());
-      generateWindows(process.cwd(), name, ns, options);
-    }).catch(error => console.error(chalk.red(error.message)));
 };


### PR DESCRIPTION
Fixes #3862

rnpm-plugin-windows was using a dependency that it wasn't declaring.  Rather than having rnpm declare a specific react-native-community\cli dependency, which can cause issues since different RN versions require different versions of the CLI.  I changed the dependency to use another package.

This also changes the CLI to only prompt the vnext/legacy prompt when used against RN 0.59.  Since thats the only version that has a good legacy and vnext version.

If the user it using >=0.60 we will automatically use the vnext version.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3998)