### PR TITLE
Allow Any Prerelease Version of 0.60 as Peer Dependency

### DIFF
--- a/change/@office-iss-react-native-win32-2020-01-30-14-09-45-looser-resolution.json
+++ b/change/@office-iss-react-native-win32-2020-01-30-14-09-45-looser-resolution.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Allow Any Prerelease Version 0f 0.60 as Peer Dependency",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "nick@nickgerleman.com",
+  "commit": "0461a6f5689e2c8fe99a05d5cef6ee263a070803",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T22:09:40.423Z"
+}

--- a/change/react-native-windows-2020-01-30-14-09-45-looser-resolution.json
+++ b/change/react-native-windows-2020-01-30-14-09-45-looser-resolution.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Allow Any Prerelease Version 0f 0.60 as Peer Dependency",
+  "packageName": "react-native-windows",
+  "email": "nick@nickgerleman.com",
+  "commit": "0461a6f5689e2c8fe99a05d5cef6ee263a070803",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T22:09:45.535Z"
+}

--- a/change/react-native-windows-extended-2020-01-30-14-09-45-looser-resolution.json
+++ b/change/react-native-windows-extended-2020-01-30-14-09-45-looser-resolution.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Allow Any Prerelease Version 0f 0.60 as Peer Dependency",
+  "packageName": "react-native-windows-extended",
+  "email": "nick@nickgerleman.com",
+  "commit": "0461a6f5689e2c8fe99a05d5cef6ee263a070803",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T22:09:43.335Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -57,7 +57,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react": "16.8.6"
   }
 }

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
+    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0 || 0.60.0-microsoft.40 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
+    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "vnext",


### PR DESCRIPTION
Internally, we will have some xplat Javascript that declares the
microsoft version of react-native as a dependency. This JS will be stuck
on 0.60 for some time, as we depend on MacOS support. This will keep us
on a stable branch of react-native-windows as it moves to 0.61.

Loosen peer dependency requirements of react-native-windows to allow
prerelease versions of react-native beyond a specific microsoft
version. This should allow us to rev sdx-platform to newer versions
without changing react-native-windows.

Confirmed that the setRNVersion script used by evergreen won't overwrite
this structure, since it just does a regex replace of
"0.x.x-microsoft.x".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/3999)