### PR TITLE
Publish changes for 0.60-stable instead of master

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -8,10 +8,10 @@ trigger:
   batch: true
   branches:
     include:
-      - master
-      - 0.58-vnext-stable
+    # Avoid publishing master builds until we're on 0.61 to avoid version collisions with 0.60-stable
+    # - master
       - 0.59-vnext-stable
-      - fabric
+      - 0.60-stable
 
 pr: none
 


### PR DESCRIPTION
We forked a stable version of 0.60, but are not yet quite on 0.61. Avoid
publishing from our master branch until we're on 0.61 to avoid version
collisions from changes in 0.60-stable and changes in master on 0.60.

Disable publishing on some old branches while we're here that haven't
been updated for a while and nobody should be adding new changes to.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4000)