### PR TITLE
Fix Mso.UnitTest project for Release mode

### DIFF
--- a/change/react-native-windows-2020-01-30-21-53-47-MS_Fix_Mso_UnitTest_Release.json
+++ b/change/react-native-windows-2020-01-30-21-53-47-MS_Fix_Mso_UnitTest_Release.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fixed Mso.UnitTests Release compilation",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "6ef3f2e1250bbc4ca8f12a09cbeab495f0a4854d",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T05:53:47.603Z"
+}

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -135,8 +135,7 @@
     <ClCompile Include="object\unknownObjectTest.cpp" />
     <ClCompile Include="object\weakPtrTest.cpp" />
     <ClCompile Include="pch.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="main.cpp" />
   </ItemGroup>


### PR DESCRIPTION
It fixes compile break in Release mode caused by wrong PCH creation configuration.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4005)