### PR TITLE
Add missing export needed for react-native-win32

### DIFF
--- a/change/react-native-windows-2020-01-31-11-55-07-exportloadscript.json
+++ b/change/react-native-windows-2020-01-31-11-55-07-exportloadscript.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Export loadScriptFromString from react-native-win32",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "6dec85a42e5f918b344680fe693b50c0b02ae761",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T19:55:07.196Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -39,6 +39,7 @@ EXPORTS
 ?get_ptr@dynamic@folly@@QEGBAPEBU12@V?$Range@PEBD@2@@Z
 ?get_ptrImpl@dynamic@folly@@AEGBAPEBU12@AEBU12@@Z
 ?hash@dynamic@folly@@QEBA_KXZ
+?loadScriptFromString@Instance@react@facebook@@QEAAXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PEBD@1@@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QEAA?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
 ?parseJson@folly@@YA?AUdynamic@1@V?$Range@PEBD@1@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -40,6 +40,7 @@ EXPORTS
 ?get_ptr@dynamic@folly@@QGBEPBU12@V?$Range@PBD@2@@Z
 ?get_ptrImpl@dynamic@folly@@AGBEPBU12@ABU12@@Z
 ?hash@dynamic@folly@@QBEIXZ
+?loadScriptFromString@Instance@react@facebook@@QAEXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YG?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
 ?parseJson@folly@@YG?AUdynamic@1@V?$Range@PBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QAEXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z


### PR DESCRIPTION
Export loadScriptFromString from react-native-win32

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4010)