### PR TITLE
Export Instance->getModuleRegistry from react-native-win32.dll

### DIFF
--- a/change/react-native-windows-2020-01-31-17-25-09-exportgetmoduleregistry.json
+++ b/change/react-native-windows-2020-01-31-17-25-09-exportgetmoduleregistry.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Export Instance->getModuleRegistry from react-native-win32.dll",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "c559fcfc31c1219f4873351f936d148a962c28ab",
+  "dependentChangeType": "patch",
+  "date": "2020-02-01T01:25:09.556Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -35,6 +35,7 @@ EXPORTS
 ?createUIManagerModule@react@facebook@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$shared_ptr@VIUIManager@react@facebook@@@4@@Z
 ?destroy@dynamic@folly@@AEAAXXZ
 ?dispatchCommand@ShadowNode@react@facebook@@UEAAX_JAEBUdynamic@folly@@@Z
+?getModuleRegistry@Instance@react@facebook@@QEAAAEAVModuleRegistry@23@XZ
 ?getPeakJsMemoryUsage@Instance@react@facebook@@QEBA_JXZ
 ?get_ptr@dynamic@folly@@QEGBAPEBU12@V?$Range@PEBD@2@@Z
 ?get_ptrImpl@dynamic@folly@@AEGBAPEBU12@AEBU12@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -36,6 +36,7 @@ EXPORTS
 ?createUIManagerModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$shared_ptr@VIUIManager@react@facebook@@@4@@Z
 ?destroy@dynamic@folly@@AAEXXZ
 ?dispatchCommand@ShadowNode@react@facebook@@UAEX_JABUdynamic@folly@@@Z
+?getModuleRegistry@Instance@react@facebook@@QAEAAVModuleRegistry@23@XZ
 ?getPeakJsMemoryUsage@Instance@react@facebook@@QBE_JXZ
 ?get_ptr@dynamic@folly@@QGBEPBU12@V?$Range@PBD@2@@Z
 ?get_ptrImpl@dynamic@folly@@AGBEPBU12@ABU12@@Z


### PR DESCRIPTION
Another method that office is using that needs to be exported so we can ingest latest version of react-native-win32.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4013)