### PR TITLE
Fix compilation errors with LLVM9.0.1/clang due to missing #includes

### DIFF
--- a/change/react-native-windows-2020-02-06-17-37-00-master.json
+++ b/change/react-native-windows-2020-02-06-17-37-00-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fix compilation errors with LLVM9.0.1/clang",
+  "packageName": "react-native-windows",
+  "email": "chpurrer@fb.com",
+  "commit": "7a2fe1f7b3c29ab8b2707c0db760ed43a492bad7",
+  "dependentChangeType": "patch",
+  "date": "2020-02-07T01:37:00.357Z"
+}

--- a/vnext/Chakra/ChakraNativeModules.cpp
+++ b/vnext/Chakra/ChakraNativeModules.cpp
@@ -6,6 +6,7 @@
 #include "ChakraNativeModules.h"
 #include "ChakraValue.h"
 
+#include <glog/logging.h>
 #include <string>
 
 namespace facebook {

--- a/vnext/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
@@ -6,6 +6,7 @@
 #include "ExceptionsManagerModule.h"
 #include <assert.h>
 #include <cxxreact/JsArgumentHelpers.h>
+#include <sstream>
 
 namespace facebook {
 namespace react {

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -5,6 +5,7 @@ using namespace std;
 #include <cxxreact/JsArgumentHelpers.h>
 #include <folly/json.h>
 #include <algorithm>
+#include <glog/logging.h>
 #include <iostream>
 
 #include "ShadowNode.h"

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -4,8 +4,8 @@
 using namespace std;
 #include <cxxreact/JsArgumentHelpers.h>
 #include <folly/json.h>
-#include <algorithm>
 #include <glog/logging.h>
+#include <algorithm>
 #include <iostream>
 
 #include "ShadowNode.h"

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -5,6 +5,8 @@
 #include "ShadowNode.h"
 #include "ViewManager.h"
 
+#include <glog/logging.h>
+
 namespace facebook {
 namespace react {
 


### PR DESCRIPTION
- Compilation fails with Clang as certain imports are missing
- I assume those are pre-defined when using MSVC

- #include <sstream> is needed for std::stringstream stream;
- #include <glog/logging.h> is needed for CHECK() MARCO

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4021)