### PR TITLE
Enable X64Debug CI configuration

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -27,11 +27,11 @@ jobs:
     condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
     strategy:
       matrix:
-        #X64Debug:
-        #  BuildConfiguration: Debug
-        #  BuildPlatform: x64
-        #  applyRnPatches: true
-        #  LayoutHeaders: true
+        X64Debug:
+          BuildConfiguration: Debug
+          BuildPlatform: x64
+          applyRnPatches: true
+          LayoutHeaders: true
         #X64Release:
         #  BuildConfiguration: Release
         #  BuildPlatform: x64

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -31,7 +31,7 @@ jobs:
           BuildConfiguration: Debug
           BuildPlatform: x64
           applyRnPatches: true
-          LayoutHeaders: true
+        #  LayoutHeaders: true
         #X64Release:
         #  BuildConfiguration: Release
         #  BuildPlatform: x64


### PR DESCRIPTION
We must be able to run unit tests in vnext CI loops.
Currently we cannot compile our unit tests for x86 because VS lib files for GTest use cdecl calling conventions while our code is compiled with stdcall calling conventions. As a result we see a lot of linker errors. But we can compile our tests for x64.
The issue is that our CI loop does not compile x64 code...
In this change we are enabling the x64debug configuration that should allow us to start running unit tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4040)