### PR TITLE
Enable screen reader announcements for accessibilityLiveRegion

### DIFF
--- a/change/react-native-windows-2020-02-06-10-15-05-accessibilityLiveRegionFix.json
+++ b/change/react-native-windows-2020-02-06-10-15-05-accessibilityLiveRegionFix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Enable screen reader announcements for accessibilityLiveRegion",
+  "packageName": "react-native-windows",
+  "email": "jagorrin@microsoft.com",
+  "commit": "4571c3c9445b1e31fbb623393644aef9e9fe6c09",
+  "dependentChangeType": "patch",
+  "date": "2020-02-06T18:15:05.072Z"
+}

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -141,10 +141,10 @@ void FrameworkElementViewManager::TransferProperties(XamlView oldView, XamlView 
 
 folly::dynamic FrameworkElementViewManager::GetNativeProps() const {
   folly::dynamic props = Super::GetNativeProps();
-  props.update(
-      folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")("accessibilityStates", "array")(
-          "accessibilityHint", "string")("accessibilityLabel", "string")("accessibilityPosInSet", "number")(
-          "accessibilitySetSize", "number")("testID", "string")("tooltip", "string")("accessibilityActions", "array")("accessibilityLiveRegion", "string"));
+  props.update(folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")(
+      "accessibilityStates", "array")("accessibilityHint", "string")("accessibilityLabel", "string")(
+      "accessibilityPosInSet", "number")("accessibilitySetSize", "number")("testID", "string")("tooltip", "string")(
+      "accessibilityActions", "array")("accessibilityLiveRegion", "string"));
   return props;
 }
 

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -144,7 +144,7 @@ folly::dynamic FrameworkElementViewManager::GetNativeProps() const {
   props.update(
       folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")("accessibilityStates", "array")(
           "accessibilityHint", "string")("accessibilityLabel", "string")("accessibilityPosInSet", "number")(
-          "accessibilitySetSize", "number")("testID", "string")("tooltip", "string")("accessibilityActions", "array"));
+          "accessibilitySetSize", "number")("testID", "string")("tooltip", "string")("accessibilityActions", "array")("accessibilityLiveRegion", "string"));
   return props;
 }
 


### PR DESCRIPTION
Fix for #3783.

Enables screen reader announcements when using an accessibilityLiveRegion. FrameworkElementViewManager already has code for handling an accessibilityLiveRegion announcement, but is currently filtering it out due to GetNativeProps not having an entry for it. This change adds that to the list of native props so that the existing code that responds when the accessibilityLiveRegion changes actually executes.

The existing code in question is in the same file under this if statement:
`else if (propertyName == "accessibilityLiveRegion")`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4043)