### PR TITLE
Enable C++/WinRT heap enforcement

### DIFF
--- a/change/react-native-windows-2020-02-06-14-30-19-MS_CppWinRT_HeapEnforcement.json
+++ b/change/react-native-windows-2020-02-06-14-30-19-MS_CppWinRT_HeapEnforcement.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Enabled C++/WinRT heap enforcement",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "0eb4d076e3fe339ec92445ada236607e6bd89ebd",
+  "dependentChangeType": "patch",
+  "date": "2020-02-06T22:30:18.833Z"
+}

--- a/vnext/Microsoft.ReactNative/ABICxxModule.cpp
+++ b/vnext/Microsoft.ReactNative/ABICxxModule.cpp
@@ -57,15 +57,15 @@ std::vector<CxxModule::Method> ABICxxModule::getMethods() {
 
 void ABICxxModule::InitEvents(std::vector<ABICxxModuleEventHandlerSetter> const &eventHandlerSetters) noexcept {
   for (auto &eventHandler : eventHandlerSetters) {
-    eventHandler.EventHandlerSetter([ this, name = eventHandler.Name ](ReactArgWriter const &argWriter) noexcept {
-      DynamicWriter writer;
+    eventHandler.EventHandlerSetter([this, name = eventHandler.Name](ReactArgWriter const &argWriter) noexcept {
+      auto writer = make<DynamicWriter>();
       writer.WriteArrayBegin();
       writer.WriteString(winrt::to_hstring(name));
       argWriter(writer);
       writer.WriteArrayEnd();
 
       std::string emitterName = m_eventEmitterName.empty() ? DefaultEventEmitterName : m_eventEmitterName;
-      m_reactContext->CallJSFunction(std::move(emitterName), "emit", writer.TakeValue());
+      m_reactContext->CallJSFunction(std::move(emitterName), "emit", get_self<DynamicWriter>(writer)->TakeValue());
     });
   }
 }

--- a/vnext/Microsoft.ReactNative/ABICxxModule.cpp
+++ b/vnext/Microsoft.ReactNative/ABICxxModule.cpp
@@ -57,7 +57,7 @@ std::vector<CxxModule::Method> ABICxxModule::getMethods() {
 
 void ABICxxModule::InitEvents(std::vector<ABICxxModuleEventHandlerSetter> const &eventHandlerSetters) noexcept {
   for (auto &eventHandler : eventHandlerSetters) {
-    eventHandler.EventHandlerSetter([this, name = eventHandler.Name](ReactArgWriter const &argWriter) noexcept {
+    eventHandler.EventHandlerSetter([ this, name = eventHandler.Name ](ReactArgWriter const &argWriter) noexcept {
       auto writer = make<DynamicWriter>();
       writer.WriteArrayBegin();
       writer.WriteString(winrt::to_hstring(name));

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -30,8 +30,8 @@ void ReactModuleBuilder::AddMethod(
       to_string(name),
       [method = std::move(method)](
           folly::dynamic args, CxxModule::Callback resolve, CxxModule::Callback reject) mutable noexcept {
-        DynamicReader argReader{args};
-        DynamicWriter resultWriter;
+        auto argReader = make<DynamicReader>(args);
+        auto resultWriter = make<DynamicWriter>();
         auto resolveCallback = MakeMethodResultCallback(std::move(resolve));
         auto rejectCallback = MakeMethodResultCallback(std::move(reject));
         method(argReader, resultWriter, resolveCallback, rejectCallback);
@@ -62,10 +62,10 @@ void ReactModuleBuilder::AddSyncMethod(hstring const &name, SyncMethodDelegate c
   CxxModule::Method cxxMethod(
       to_string(name),
       [method = std::move(method)](folly::dynamic args) mutable noexcept {
-        DynamicReader argReader{args};
-        DynamicWriter resultWriter;
+        auto argReader = make<DynamicReader>(args);
+        auto resultWriter = make<DynamicWriter>();
         method(argReader, resultWriter);
-        return resultWriter.TakeValue();
+        return get_self<DynamicWriter>(resultWriter)->TakeValue();
       },
       CxxModule::SyncTag);
 

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -94,8 +94,6 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>/await %(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION /wd4100 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>
         $(ReactNativeWindowsDir)ReactUWP;
         $(ReactNativeWindowsDir)ReactUWP\Views;

--- a/vnext/local-cli/generator-windows/templates/cpp/proj/MyApp.vcxproj
+++ b/vnext/local-cli/generator-windows/templates/cpp/proj/MyApp.vcxproj
@@ -88,8 +88,6 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
This is to address issue https://github.com/microsoft/react-native-windows/issues/3807.
Previously the ReactRootView was created using std::make_shared and I guess it was the main reason to disable the C++/WinRT check that all C++/WinRT objects are allocated on the heap instead of stack.

The ReactRootView behavior was changed in https://github.com/microsoft/react-native-windows/pull/4022 . We do not use the old ReactRootView from ReactUWP anymore and instead ReactRootView is a pure XAML control, while the other part that we named ReactRootControl is not C++/Winrt based.

In this change:
- We removed the C++/WinRT heap enforcement suppression from project files.
- Fixed code that stopped to compile due to the heap enforcement. These were most probably bugs that would show only for asynchronous code and would be difficult to debug.

@chrisglein, @licanhua could you please review the https://github.com/microsoft/react-native-windows/issues/4019 which was part of the bug being fixed. I believe the issue could be closed because we already use the C++/WinRT -optimized flag.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4045)