### PR TITLE
Fix scroll indicators being shown when not required

### DIFF
--- a/change/react-native-windows-2020-02-07-15-55-25-ScrollIndicatorFix.json
+++ b/change/react-native-windows-2020-02-07-15-55-25-ScrollIndicatorFix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix scroll indicators being shown when not required",
+  "packageName": "react-native-windows",
+  "email": "jagorrin@microsoft.com",
+  "commit": "ffaa1051f2f2f154630e710596bae3dea5ae4aa1",
+  "dependentChangeType": "patch",
+  "date": "2020-02-07T23:55:25.611Z"
+}

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -449,8 +449,8 @@ folly::dynamic ScrollViewManager::GetExportedCustomDirectEventTypeConstants() co
 XamlView ScrollViewManager::CreateViewCore(int64_t tag) {
   const auto scrollViewer = winrt::ScrollViewer{};
 
-  scrollViewer.HorizontalScrollBarVisibility(winrt::ScrollBarVisibility::Visible);
-  scrollViewer.VerticalScrollBarVisibility(winrt::ScrollBarVisibility::Visible);
+  scrollViewer.HorizontalScrollBarVisibility(winrt::ScrollBarVisibility::Auto);
+  scrollViewer.VerticalScrollBarVisibility(winrt::ScrollBarVisibility::Auto);
   scrollViewer.VerticalSnapPointsAlignment(winrt::SnapPointsAlignment::Near);
   scrollViewer.VerticalSnapPointsType(winrt::SnapPointsType::Mandatory);
   scrollViewer.HorizontalSnapPointsType(winrt::SnapPointsType::Mandatory);


### PR DESCRIPTION
Fix for #4060 

The behavior of the horizontal and vertical scroll bars was to always be visible. This changes that so that they are visible automatically when required, but are not shown when not required based on the size of the content in the scrollview.