### PR TITLE
Added async code to native module test methods

### DIFF
--- a/change/react-native-windows-2020-02-11-10-24-03-MS_AsyncMethod_Tests.json
+++ b/change/react-native-windows-2020-02-11-10-24-03-MS_AsyncMethod_Tests.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Added async code to native module test methods",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "67bea149d386d9429e95587745b6c2f972480636",
+  "dependentChangeType": "patch",
+  "date": "2020-02-11T18:24:02.802Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/index.windows.js
+++ b/packages/microsoft-reactnative-sampleapps/index.windows.js
@@ -87,6 +87,12 @@ class SampleApp extends Component {
 
     var promise2 = NativeModules.SampleModuleCS.ExplicitPromiseMethodWithArgs(numberArg);
     promise2.then(getCallback('SampleModuleCS.ExplicitPromiseMethodWithArgs then => ')).catch(getErrorCallback('SampleModuleCS.ExplicitPromiseMethodWithArgs catch => '));
+    
+    var promise3 = NativeModules.SampleModuleCS.NegateAsyncPromise(5);
+    promise3.then(getCallback('SampleModuleCS.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCS.NegateAsyncPromise catch => '));
+    
+    var promise4 = NativeModules.SampleModuleCS.NegateAsyncPromise(-5);
+    promise4.then(getCallback('SampleModuleCS.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCS.NegateAsyncPromise catch => '));
 
     log('SampleModuleCS.SyncReturnMethod => ' + NativeModules.SampleModuleCS.SyncReturnMethod());
 
@@ -125,6 +131,12 @@ class SampleApp extends Component {
 
     var promise2 = NativeModules.SampleModuleCpp.ExplicitPromiseMethodWithArgs(numberArg);
     promise2.then(getCallback('SampleModuleCpp.ExplicitPromiseMethodWithArgs then => ')).catch(getErrorCallback('SampleModuleCpp.ExplicitPromiseMethodWithArgs catch => '));
+
+    var promise3 = NativeModules.SampleModuleCpp.NegateAsyncPromise(5);
+    promise3.then(getCallback('SampleModuleCpp.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCpp.NegateAsyncPromise catch => '));
+    
+    var promise4 = NativeModules.SampleModuleCpp.NegateAsyncPromise(-5);
+    promise4.then(getCallback('SampleModuleCpp.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCpp.NegateAsyncPromise catch => '));
 
     log('SampleModuleCpp.SyncReturnMethod => ' + NativeModules.SampleModuleCpp.SyncReturnMethod());
 

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -75,7 +75,7 @@ struct SampleModuleCppImpl {
   }
 
   REACT_METHOD(ExplicitPromiseMethod);
-  void ExplicitPromiseMethod(winrt::Microsoft::ReactNative::ReactPromise<double> &&result) noexcept {
+  void ExplicitPromiseMethod(winrt::Microsoft::ReactNative::ReactPromise<double> const &result) noexcept {
     DEBUG_OUTPUT("ExplicitPromiseMethod");
     try {
       result.Resolve(M_PI);
@@ -87,7 +87,7 @@ struct SampleModuleCppImpl {
   REACT_METHOD(ExplicitPromiseMethodWithArgs);
   void ExplicitPromiseMethodWithArgs(
       double arg,
-      winrt::Microsoft::ReactNative::ReactPromise<double> &&result) noexcept {
+      winrt::Microsoft::ReactNative::ReactPromise<double> const &result) noexcept {
     DEBUG_OUTPUT("ExplicitPromiseMethodWithArgs", arg);
     try {
       result.Resolve(M_PI);
@@ -129,7 +129,7 @@ struct SampleModuleCppImpl {
             TimedEvent(++m_timerCount);
           }
         },
-        std::chrono::milliseconds(TimedEventIntervalMS));
+        TimedEventInterval);
   }
 
   ~SampleModuleCppImpl() {
@@ -139,9 +139,9 @@ struct SampleModuleCppImpl {
   }
 
  private:
-  winrt::Windows::System::Threading::ThreadPoolTimer m_timer = nullptr;
-  int m_timerCount = 0;
-  const int TimedEventIntervalMS = 5000;
+  winrt::Windows::System::Threading::ThreadPoolTimer m_timer{nullptr};
+  int m_timerCount{0};
+  static constexpr std::chrono::milliseconds TimedEventInterval{5000};
 };
 
 } // namespace SampleLibraryCpp

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -96,6 +96,18 @@ struct SampleModuleCppImpl {
     }
   }
 
+  REACT_METHOD(NegateAsyncPromise)
+  winrt::fire_and_forget NegateAsyncPromise(int x, ReactPromise<int> const &result) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    ReactPromise<int> safeResult{result}; // make a copy for co-routine safe access
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      safeResult.Resolve(-x);
+    } else {
+      safeResult.Reject("Already negative");
+    }
+  }
+
 #pragma endregion
 
 #pragma region Synchronous Methods

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.ReactNative.Managed;
 using System;
 using System.Diagnostics;
-
+using System.Threading.Tasks;
 using Windows.System.Threading;
-
-using Microsoft.ReactNative.Managed;
 
 namespace SampleLibraryCS
 {
@@ -15,6 +14,7 @@ namespace SampleLibraryCS
     [ReactModule]
     internal sealed class SampleModuleCS
     {
+        // It is only used by code in this class. Use ReactModuleAttribute to specify JavaScript name.
         public string Name => nameof(SampleModuleCS);
 
         #region Constants
@@ -64,7 +64,7 @@ namespace SampleLibraryCS
 
         #endregion
 
-        #region Methods using ReactCallBacks
+        #region Methods using ReactCallbacks
 
         [ReactMethod]
         public void ExplicitCallbackMethod(ReactCallback<double> callback)
@@ -107,6 +107,21 @@ namespace SampleLibraryCS
             catch (Exception ex)
             {
                 result.Reject(new ReactError { Message = ex.Message });
+            }
+        }
+
+        [ReactMethod]
+        public async void NegateAsyncPromise(int x, IReactPromise<int> result)
+        {
+            bool isPosititve = await Task.Run(() => x >= 0);
+            Debug.WriteLine($"{Name}.{nameof(NegateAsyncPromise)}({x})");
+            if (isPosititve)
+            {
+                result.Resolve(-x);
+            }
+            else
+            {
+                result.Reject(new ReactError { Message = "Already negative" });
             }
         }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
@@ -238,9 +238,9 @@ TEST_CLASS (JSValueReaderTest) {
         RobotPoint{/*X =*/5, /*Y =*/6}, RobotPoint{/*X =*/45, /*Y =*/90}, RobotPoint{/*X =*/15, /*Y =*/16}};
     robot.Extra = R2D2Extra{/*MovieSeries =*/"Episode 2"};
 
-    JSValue jsValue;
-    auto writer = MakeJSValueTreeWriter(jsValue);
+    auto writer = MakeJSValueTreeWriter();
     WriteValue(writer, robot);
+    auto jsValue = TakeJSValue(writer);
 
     TestCheck(jsValue["Model"] == (int)RobotModel::R2D2);
     TestCheck(jsValue["Name"] == "Bob");
@@ -437,8 +437,7 @@ TEST_CLASS (JSValueReaderTest) {
   }
 
   TEST_METHOD(TestWriteValueDefaultExtensions) {
-    JSValue jsValue;
-    auto writer = MakeJSValueTreeWriter(jsValue);
+    auto writer = MakeJSValueTreeWriter();
     writer.WriteObjectBegin();
     WriteProperty(writer, L"StringValue1", "");
     WriteProperty(writer, L"StringValue2", "5");
@@ -451,6 +450,7 @@ TEST_CLASS (JSValueReaderTest) {
     WriteProperty(writer, L"NullValue", nullptr);
     writer.WriteObjectEnd();
 
+    auto jsValue = TakeJSValue(writer);
     TestCheck(jsValue["StringValue1"] == "");
     TestCheck(jsValue["StringValue2"] == "5");
     TestCheck(jsValue["StringValue3"] == "Hello");

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+#include "ReactModuleBuilderMock.h"
+
 #include <sstream>
 #include "NativeModules.h"
-#include "ReactModuleBuilderMock.h"
+#include "future/futureWait.h"
 
 namespace winrt::Microsoft::ReactNative {
 
@@ -97,6 +99,24 @@ struct SimpleNativeModule {
     resolve(-x);
   }
 
+  REACT_METHOD(NegateAsyncCallback)
+  fire_and_forget NegateAsyncCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    auto safeResolve = resolve; // make a copy for co-routine safe access
+    co_await winrt::resume_background();
+    safeResolve(-x);
+  }
+
+  REACT_METHOD(NegateDispatchQueueCallback)
+  void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+  }
+
+  REACT_METHOD(NegateFutureCallback)
+  void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+  }
+
   REACT_METHOD(SayHelloCallback)
   void SayHelloCallback(std::function<void(const std::string &)> const &resolve) noexcept {
     resolve("Hello_2");
@@ -110,6 +130,24 @@ struct SimpleNativeModule {
   REACT_METHOD(StaticNegateCallback)
   static void StaticNegateCallback(int x, std::function<void(int)> const &resolve) noexcept {
     resolve(-x);
+  }
+
+  REACT_METHOD(StaticNegateAsyncCallback)
+  static fire_and_forget StaticNegateAsyncCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    auto safeResolve = resolve; // make a copy for co-routine safe access
+    co_await winrt::resume_background();
+    safeResolve(-x);
+  }
+
+  REACT_METHOD(StaticNegateDispatchQueueCallback)
+  static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+  }
+
+  REACT_METHOD(StaticNegateFutureCallback)
+  static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticSayHelloCallback)
@@ -140,6 +178,50 @@ struct SimpleNativeModule {
     } else {
       reject("Already negative");
     }
+  }
+
+  REACT_METHOD(NegateAsyncCallbacks)
+  fire_and_forget NegateAsyncCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(const std::string &)> const &reject) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    auto safeResolve = resolve; // make a copy for co-routine safe access
+    auto safeReject = reject;
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      safeResolve(-x);
+    } else {
+      safeReject("Already negative");
+    }
+  }
+
+  REACT_METHOD(NegateDispatchQueueCallbacks)
+  void NegateDispatchQueueCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(const std::string &)> const &reject) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+      if (x >= 0) {
+        resolve(-x);
+      } else {
+        reject("Already negative");
+      }
+    });
+  }
+
+  REACT_METHOD(NegateFutureCallbacks)
+  void NegateFutureCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(const std::string &)> const &reject) noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+      if (x >= 0) {
+        resolve(-x);
+      } else {
+        reject("Already negative");
+      }
+    });
   }
 
   REACT_METHOD(ResolveSayHelloCallbacks)
@@ -181,6 +263,50 @@ struct SimpleNativeModule {
     }
   }
 
+  REACT_METHOD(StaticNegateAsyncCallbacks)
+  static fire_and_forget StaticNegateAsyncCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(const std::string &)> const &reject) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    auto safeResolve = resolve; // make a copy for co-routine safe access
+    auto safeReject = reject;
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      safeResolve(-x);
+    } else {
+      safeReject("Already negative");
+    }
+  }
+
+  REACT_METHOD(StaticNegateDispatchQueueCallbacks)
+  static void StaticNegateDispatchQueueCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(const std::string &)> const &reject) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+      if (x >= 0) {
+        resolve(-x);
+      } else {
+        reject("Already negative");
+      }
+    });
+  }
+
+  REACT_METHOD(StaticNegateFutureCallbacks)
+  static void StaticNegateFutureCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(const std::string &)> const &reject) noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+      if (x >= 0) {
+        resolve(-x);
+      } else {
+        reject("Already negative");
+      }
+    });
+  }
+
   REACT_METHOD(StaticResolveSayHelloCallbacks)
   static void StaticResolveSayHelloCallbacks(
       std::function<void(const std::string &)> const &resolve,
@@ -196,7 +322,7 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(DividePromise)
-  void DividePromise(int x, int y, ReactPromise<int> &&result) noexcept {
+  void DividePromise(int x, int y, ReactPromise<int> const &result) noexcept {
     if (y != 0) {
       result.Resolve(x / y);
     } else {
@@ -207,7 +333,7 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(NegatePromise)
-  void NegatePromise(int x, ReactPromise<int> &&result) noexcept {
+  void NegatePromise(int x, ReactPromise<int> const &result) noexcept {
     if (x >= 0) {
       result.Resolve(-x);
     } else {
@@ -217,9 +343,49 @@ struct SimpleNativeModule {
     }
   }
 
+  REACT_METHOD(NegateAsyncPromise)
+  fire_and_forget NegateAsyncPromise(int x, ReactPromise<int> const &result) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    ReactPromise<int> safeResult{result}; // make a copy for co-routine safe access
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      safeResult.Resolve(-x);
+    } else {
+      ReactError error{};
+      error.Message = "Already negative";
+      safeResult.Reject(std::move(error));
+    }
+  }
+
+  REACT_METHOD(NegateDispatchQueuePromise)
+  void NegateDispatchQueuePromise(int x, ReactPromise<int> const &result) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+      if (x >= 0) {
+        result.Resolve(-x);
+      } else {
+        ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+    });
+  }
+
+  REACT_METHOD(NegateFuturePromise)
+  void NegateFuturePromise(int x, ReactPromise<int> const &result) noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
+      if (x >= 0) {
+        result.Resolve(-x);
+      } else {
+        ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+    });
+  }
+
   // Each macro has second optional parameter: JS name.
   REACT_METHOD(VoidPromise, L"voidPromise")
-  void VoidPromise(int x, ReactPromise<void> &&result) noexcept {
+  void VoidPromise(int x, ReactPromise<void> const &result) noexcept {
     if (x % 2 == 0) {
       result.Resolve();
     } else {
@@ -228,19 +394,19 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(ResolveSayHelloPromise)
-  void ResolveSayHelloPromise(ReactPromise<std::string> &&result) noexcept {
+  void ResolveSayHelloPromise(ReactPromise<std::string> const &result) noexcept {
     result.Resolve("Hello_4");
   }
 
   REACT_METHOD(RejectSayHelloPromise)
-  void RejectSayHelloPromise(ReactPromise<std::string> &&result) noexcept {
+  void RejectSayHelloPromise(ReactPromise<std::string> const &result) noexcept {
     ReactError error{};
     error.Message = "Promise rejected";
     result.Reject(std::move(error));
   }
 
   REACT_METHOD(StaticDividePromise)
-  static void StaticDividePromise(int x, int y, ReactPromise<int> &&result) noexcept {
+  static void StaticDividePromise(int x, int y, ReactPromise<int> const &result) noexcept {
     if (y != 0) {
       result.Resolve(x / y);
     } else {
@@ -251,7 +417,7 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(StaticNegatePromise)
-  static void StaticNegatePromise(int x, ReactPromise<int> &&result) noexcept {
+  static void StaticNegatePromise(int x, ReactPromise<int> const &result) noexcept {
     if (x >= 0) {
       result.Resolve(-x);
     } else {
@@ -261,9 +427,49 @@ struct SimpleNativeModule {
     }
   }
 
+  REACT_METHOD(StaticNegateAsyncPromise)
+  static fire_and_forget StaticNegateAsyncPromise(int x, ReactPromise<int> const &result) noexcept {
+    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
+    ReactPromise<int> safeResult{result}; // make a copy for co-routine safe access
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      safeResult.Resolve(-x);
+    } else {
+      ReactError error{};
+      error.Message = "Already negative";
+      safeResult.Reject(std::move(error));
+    }
+  }
+
+  REACT_METHOD(StaticNegateDispatchQueuePromise)
+  static void StaticNegateDispatchQueuePromise(int x, ReactPromise<int> const &result) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+      if (x >= 0) {
+        result.Resolve(-x);
+      } else {
+        ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+    });
+  }
+
+  REACT_METHOD(StaticNegateFuturePromise)
+  static void StaticNegateFuturePromise(int x, ReactPromise<int> const &result) noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
+      if (x >= 0) {
+        result.Resolve(-x);
+      } else {
+        ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+    });
+  }
+
   // Each macro has second optional parameter: JS name.
   REACT_METHOD(StaticVoidPromise, L"staticVoidPromise")
-  void StaticVoidPromise(int x, ReactPromise<void> &&result) noexcept {
+  void StaticVoidPromise(int x, ReactPromise<void> const &result) noexcept {
     if (x % 2 == 0) {
       result.Resolve();
     } else {
@@ -272,12 +478,12 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(StaticResolveSayHelloPromise)
-  static void StaticResolveSayHelloPromise(ReactPromise<std::string> &&result) noexcept {
+  static void StaticResolveSayHelloPromise(ReactPromise<std::string> const &result) noexcept {
     result.Resolve("Hello_4");
   }
 
   REACT_METHOD(StaticRejectSayHelloPromise)
-  static void StaticRejectSayHelloPromise(ReactPromise<std::string> &&result) noexcept {
+  static void StaticRejectSayHelloPromise(ReactPromise<std::string> const &result) noexcept {
     ReactError error{};
     error.Message = "Promise rejected";
     result.Reject(std::move(error));
@@ -444,6 +650,26 @@ TEST_CLASS (NativeModuleTest) {
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
+  TEST_METHOD(TestMethodCall_NegateAsyncCallback) {
+    Mso::FutureWait(m_builderMock.Call1(
+        L"NegateAsyncCallback", std::function<void(int)>([](int result) noexcept { TestCheck(result == -4); }), 4));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateDispatchQueueCallback) {
+    Mso::FutureWait(m_builderMock.Call1(
+        L"NegateDispatchQueueCallback",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -4); }),
+        4));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateFutureCallback) {
+    Mso::FutureWait(m_builderMock.Call1(
+        L"NegateFutureCallback", std::function<void(int)>([](int result) noexcept { TestCheck(result == -4); }), 4));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
     m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
                         ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
@@ -459,6 +685,30 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestMethodCall_StaticNegateCallback) {
     m_builderMock.Call1(
         L"StaticNegateCallback", std::function<void(int)>([](int result) noexcept { TestCheck(result == -33); }), 33);
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateAsyncCallback) {
+    Mso::FutureWait(m_builderMock.Call1(
+        L"StaticNegateAsyncCallback",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -4); }),
+        4));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateDispatchQueueCallback) {
+    Mso::FutureWait(m_builderMock.Call1(
+        L"StaticNegateDispatchQueueCallback",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -4); }),
+        4));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateFutureCallback) {
+    Mso::FutureWait(m_builderMock.Call1(
+        L"StaticNegateFutureCallback",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -4); }),
+        4));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -507,6 +757,66 @@ TEST_CLASS (NativeModuleTest) {
         std::function<void(JSValue const &)>(
             [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
         -5);
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateAsyncCallbacks) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateAsyncCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateAsyncCallbacksError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateAsyncCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateDispatchQueueCallbacks) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateDispatchQueueCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateDispatchQueueCallbacksError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateDispatchQueueCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateFutureCallbacks) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateFutureCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateFutureCallbacksError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateFutureCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
     TestCheck(m_builderMock.IsRejectCallbackCalled());
   }
 
@@ -572,6 +882,66 @@ TEST_CLASS (NativeModuleTest) {
     TestCheck(m_builderMock.IsRejectCallbackCalled());
   }
 
+  TEST_METHOD(TestMethodCall_StaticNegateAsyncCallbacks) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateAsyncCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateAsyncCallbacksError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateAsyncCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateDispatchQueueCallbacks) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateDispatchQueueCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateDispatchQueueCallbacksError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateDispatchQueueCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateFutureCallbacks) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateFutureCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateFutureCallbacksError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateFutureCallbacks",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
   TEST_METHOD(TestMethodCall_StaticResolveSayHelloCallbacks) {
     m_builderMock.Call2(
         L"StaticResolveSayHelloCallbacks",
@@ -631,6 +1001,66 @@ TEST_CLASS (NativeModuleTest) {
         std::function<void(JSValue const &)>(
             [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
         -5);
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateAsyncPromise) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateAsyncPromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateAsyncPromiseError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateAsyncPromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateDispatchQueuePromise) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateDispatchQueuePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateDispatchQueuePromiseError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateDispatchQueuePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateFuturePromise) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateFuturePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_NegateFuturePromiseError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"NegateFuturePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
     TestCheck(m_builderMock.IsRejectCallbackCalled());
   }
 
@@ -707,12 +1137,72 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticNegatePromiseError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateAsyncPromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateAsyncPromise) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateAsyncPromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateAsyncPromiseError) {
     m_builderMock.Call2(
         L"StaticNegatePromise",
         std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
         std::function<void(JSValue const &)>(
             [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
         -5);
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateDispatchQueuePromise) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateDispatchQueuePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateDispatchQueuePromiseError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateDispatchQueuePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateFuturePromise) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateFuturePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        5));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_StaticNegateFuturePromiseError) {
+    Mso::FutureWait(m_builderMock.Call2(
+        L"StaticNegateFuturePromise",
+        std::function<void(int)>([](int result) noexcept { TestCheck(result == -5); }),
+        std::function<void(JSValue const &)>(
+            [](JSValue const &error) noexcept { TestCheck(error["message"] == "Already negative"); }),
+        -5));
     TestCheck(m_builderMock.IsRejectCallbackCalled());
   }
 
@@ -841,14 +1331,13 @@ TEST_CLASS (NativeModuleTest) {
           eventRaised = true;
         }));
 
-    JSValue data = JSValue();
-    auto writer = MakeJSValueTreeWriter(data);
+    auto writer = MakeJSValueTreeWriter();
     writer.WriteObjectBegin();
     WriteProperty(writer, "X", 4);
     WriteProperty(writer, "Y", 2);
     writer.WriteObjectEnd();
 
-    m_module->OnObjectResult3(data);
+    m_module->OnObjectResult3(TakeJSValue(writer));
     TestCheck(eventRaised == true);
   }
 };

--- a/vnext/Microsoft.ReactNative.Cxx/Crash.h
+++ b/vnext/Microsoft.ReactNative.Cxx/Crash.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#ifndef VerifyElseCrash
 #define VerifyElseCrash(condition) \
   do {                             \
     if (!(condition)) {            \
@@ -10,7 +11,9 @@
       std::terminate();            \
     }                              \
   } while (false)
+#endif
 
+#ifndef VerifyElseCrashSz
 #define VerifyElseCrashSz(condition, message) \
   do {                                        \
     if (!(condition)) {                       \
@@ -18,3 +21,4 @@
       std::terminate();                       \
     }                                         \
   } while (false)
+#endif

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.h
@@ -14,7 +14,8 @@ namespace winrt::Microsoft::ReactNative {
 struct JSValue;
 IJSValueReader MakeJSValueTreeReader(const JSValue &root) noexcept;
 IJSValueReader MakeJSValueTreeReader(JSValue &&root) noexcept;
-IJSValueWriter MakeJSValueTreeWriter(JSValue &resultValue) noexcept;
+IJSValueWriter MakeJSValueTreeWriter() noexcept;
+JSValue TakeJSValue(IJSValueWriter const &writer) noexcept;
 
 // Type alias for JSValue object type
 using JSValueObject = std::map<std::string, JSValue, std::less<>>;
@@ -232,10 +233,9 @@ inline winrt::Windows::UI::Xaml::Media::Brush JSValue::To() const noexcept {
 
 template <class T>
 static JSValue From(const T &value) noexcept {
-  JSValue result;
-  auto writer = MakeJSValueTreeWriter(result);
-  WriteValue(writer, value);
-  return result;
+  auto writer = MakeJSValueTreeWriter();
+  WriteValue(*writer, value);
+  return TakeJSValue(writer);
 }
 
 inline const JSValue &JSValue::operator[](std::string_view propertyName) const noexcept {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueTreeWriter.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueTreeWriter.cpp
@@ -11,8 +11,12 @@ namespace winrt::Microsoft::ReactNative {
 // JSValueTreeWriter implementation
 //===========================================================================
 
-JSValueTreeWriter::JSValueTreeWriter(JSValue &resultValue) noexcept : m_resultValue{resultValue} {
+JSValueTreeWriter::JSValueTreeWriter() noexcept {
   m_containerStack.push(ContainerInfo{ContainerType::None});
+}
+
+JSValue JSValueTreeWriter::TakeValue() noexcept {
+  return std::move(m_resultValue);
 }
 
 void JSValueTreeWriter::WriteNull() noexcept {
@@ -80,8 +84,12 @@ void JSValueTreeWriter::WriteValue(JSValue &&value) noexcept {
   }
 }
 
-IJSValueWriter MakeJSValueTreeWriter(JSValue &resultValue) noexcept {
-  return make<JSValueTreeWriter>(resultValue);
+IJSValueWriter MakeJSValueTreeWriter() noexcept {
+  return make<JSValueTreeWriter>();
+}
+
+JSValue TakeJSValue(IJSValueWriter const &writer) noexcept {
+  return get_self<JSValueTreeWriter>(writer)->TakeValue();
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueTreeWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueTreeWriter.h
@@ -12,7 +12,8 @@ namespace winrt::Microsoft::ReactNative {
 
 // Writes to a tree of JSValue objects.
 struct JSValueTreeWriter : implements<JSValueTreeWriter, IJSValueWriter> {
-  JSValueTreeWriter(JSValue &resultValue) noexcept;
+  JSValueTreeWriter() noexcept;
+  JSValue TakeValue() noexcept;
 
  public: // IJSValueWriter
   void WriteNull() noexcept;
@@ -43,7 +44,7 @@ struct JSValueTreeWriter : implements<JSValueTreeWriter, IJSValueWriter> {
 
  private:
   std::stack<ContainerInfo> m_containerStack;
-  JSValue &m_resultValue;
+  JSValue m_resultValue;
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -61,7 +61,7 @@ void WriteProperties(IJSValueWriter const &writer, T const &value) noexcept;
 template <class... TArgs>
 void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexcept;
 
-IJSValueWriter MakeJSValueTreeWriter(JSValue &resultValue) noexcept;
+IJSValueWriter MakeJSValueTreeWriter() noexcept;
 
 //==============================================================================
 // IJSValueWriter extensions implementation
@@ -239,8 +239,9 @@ inline void WriteProperty(IJSValueWriter const &writer, std::wstring_view proper
 
 template <class T>
 inline void WriteProperties(IJSValueWriter const &writer, T const &value) noexcept {
-  JSValue jsValue;
-  WriteValue(MakeJSValueTreeWriter(/*ref*/ jsValue), value);
+  auto jsValueWriter = MakeJSValueTreeWriter();
+  WriteValue(jsValueWriter, value);
+  auto jsValue = TakeJSValue(jsValueWriter);
   for (auto &property : jsValue.Object()) {
     WriteProperty(writer, property.first, property.second);
   }

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleMemberRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleMemberRegistration.h
@@ -9,9 +9,9 @@
 #include "ReactMemberInfo.h"
 
 // Internal implementation details.
-// Registration of a method relies on a TLS context that is setup when object is
-// created. The advantage is that we do zero work during static initialization.
-// The disadvantage is that we require to have one bool field per registration.
+// For each registered member we create a static method that can register it.
+// The member id is generated as a ReactMemberId<__COUNTER__> type.
+// To invoke the static registration methods, we just try next ReactMemberId until static member exists.
 #define INTERNAL_REACT_METHOD_3_ARGS(methodType, method, methodName)                             \
   template <class TClass, class TRegistry>                                                       \
   static void RegisterMember(                                                                    \

--- a/vnext/Microsoft.ReactNative.Cxx/ReactPromise.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactPromise.cpp
@@ -19,84 +19,94 @@ ReactPromiseBase::ReactPromiseBase(
     IJSValueWriter const &writer,
     MethodResultCallback const &resolve,
     MethodResultCallback const &reject) noexcept
-    : m_writer{writer}, m_resolve{resolve}, m_reject{reject} {}
+    : m_state{new std::atomic<State>{State::Pending}}, m_writer{writer}, m_resolve{resolve}, m_reject{reject} {}
+
+ReactPromiseBase::~ReactPromiseBase() noexcept {
+  if (m_state.use_count() == 1) {
+    Reject(L"Promise destroyed.");
+  }
+}
 
 // Reject the ReactPromise and report an error.
-void ReactPromiseBase::Reject(ReactError &&error) noexcept {
-  if (m_reject == nullptr) {
-    Clear();
-    return;
+void ReactPromiseBase::Reject(ReactError const &error) const noexcept {
+  if (TrySetState(State::Rejected)) {
+    m_writer.WriteArrayBegin();
+    m_writer.WriteObjectBegin();
+
+    if (!error.Code.empty()) {
+      WriteProperty(m_writer, ErrorMapKeyCode, error.Code);
+    } else {
+      WriteProperty(m_writer, ErrorMapKeyCode, ErrorDefaultCode);
+    }
+
+    if (!error.Message.empty()) {
+      WriteProperty(m_writer, ErrorMapKeyMessage, error.Message);
+    } else {
+      WriteProperty(m_writer, ErrorMapKeyMessage, ErrorDefaultMessage);
+    }
+
+    // For consistency with iOS ensure userInfo key exists, even if we null it.
+    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+    WriteProperty(m_writer, ErrorMapKeyUserInfo, error.UserInfo);
+
+    m_writer.WriteObjectEnd();
+    m_writer.WriteArrayEnd();
+    m_reject(m_writer);
   }
-
-  JSValueObject errorInfo;
-  errorInfo.emplace(ErrorMapKeyCode, !error.Code.empty() ? error.Code : ErrorDefaultCode);
-  errorInfo.emplace(ErrorMapKeyMessage, !error.Message.empty() ? error.Message : ErrorDefaultMessage);
-
-  // For consistency with iOS ensure userInfo key exists, even if we null it.
-  // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-  errorInfo.emplace(ErrorMapKeyUserInfo, !error.UserInfo.empty() ? JSValue(std::move(error.UserInfo)) : nullptr);
-
-  WriteArgs(m_writer, errorInfo);
-  m_reject(m_writer);
-  Clear();
 }
 
-void ReactPromiseBase::Reject(const char *errorMessage) noexcept {
-  if (m_reject == nullptr) {
-    Clear();
-    return;
+void ReactPromiseBase::Reject(char const *errorMessage) const noexcept {
+  if (TrySetState(State::Rejected)) {
+    m_writer.WriteArrayBegin();
+    m_writer.WriteObjectBegin();
+
+    WriteProperty(m_writer, ErrorMapKeyCode, ErrorDefaultCode);
+    WriteProperty(m_writer, ErrorMapKeyMessage, errorMessage);
+
+    // For consistency with iOS ensure userInfo key exists, even if we null it.
+    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+    WriteProperty(m_writer, ErrorMapKeyUserInfo, nullptr);
+
+    m_writer.WriteObjectEnd();
+    m_writer.WriteArrayEnd();
+    m_reject(m_writer);
   }
-
-  m_writer.WriteArrayBegin();
-  m_writer.WriteObjectBegin();
-
-  WriteProperty(m_writer, ErrorMapKeyCode, ErrorDefaultCode);
-  WriteProperty(m_writer, ErrorMapKeyMessage, errorMessage);
-
-  // For consistency with iOS ensure userInfo key exists, even if we null it.
-  // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-  WriteProperty(m_writer, ErrorMapKeyUserInfo, nullptr);
-
-  m_writer.WriteObjectEnd();
-  m_writer.WriteArrayEnd();
-  m_reject(m_writer);
-  Clear();
 }
 
-void ReactPromiseBase::Reject(const wchar_t *errorMessage) noexcept {
-  if (m_reject == nullptr) {
-    Clear();
-    return;
+void ReactPromiseBase::Reject(wchar_t const *errorMessage) const noexcept {
+  if (TrySetState(State::Rejected)) {
+    m_writer.WriteArrayBegin();
+    m_writer.WriteObjectBegin();
+
+    WriteProperty(m_writer, ErrorMapKeyCode, ErrorDefaultCode);
+    WriteProperty(m_writer, ErrorMapKeyMessage, errorMessage);
+
+    // For consistency with iOS ensure userInfo key exists, even if we null it.
+    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+    WriteProperty(m_writer, ErrorMapKeyUserInfo, nullptr);
+
+    m_writer.WriteObjectEnd();
+    m_writer.WriteArrayEnd();
+    m_reject(m_writer);
   }
-
-  m_writer.WriteArrayBegin();
-  m_writer.WriteObjectBegin();
-
-  WriteProperty(m_writer, ErrorMapKeyCode, ErrorDefaultCode);
-  WriteProperty(m_writer, ErrorMapKeyMessage, errorMessage);
-
-  // For consistency with iOS ensure userInfo key exists, even if we null it.
-  // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-  WriteProperty(m_writer, ErrorMapKeyUserInfo, nullptr);
-
-  m_writer.WriteObjectEnd();
-  m_writer.WriteArrayEnd();
-  m_reject(m_writer);
-  Clear();
 }
 
-void ReactPromiseBase::Clear() noexcept {
-  m_resolve = nullptr;
-  m_reject = nullptr;
-  m_writer = nullptr;
+bool ReactPromiseBase::TrySetState(State newState) const noexcept {
+  auto state = m_state->load(std::memory_order_relaxed);
+  while (state == State::Pending) {
+    if (m_state->compare_exchange_weak(state, newState, std::memory_order_release, std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 // Successfully resolve the ReactPromise<void>.
-void ReactPromise<void>::Resolve() noexcept {
-  if (m_resolve) {
+void ReactPromise<void>::Resolve() const noexcept {
+  if (TrySetState(State::Resolved) && m_resolve) {
     WriteArgs(m_writer, nullptr);
     m_resolve(m_writer);
-    Clear();
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11501,10 +11501,10 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rnpm-plugin-windows@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.4.1.tgz#8d5fb61eab06ec205d2454de490aca06840c7334"
-  integrity sha512-JE66v6l79sGFj5LKM+/ogHS/P3D3dKvA2v0qcIk8Ajt0wfnjpCo58lXbSuNRJrlAy0OujzJZV8kT04UiMwlbFA==
+rnpm-plugin-windows@^0.5.1-0:
+  version "0.5.1-0"
+  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.5.1-0.tgz#9ffdd38653c6024c538a98a1046a37625d56eddb"
+  integrity sha512-0EX2shP1OI18MylpVHmZRhDX5GSdvHDgSQoFDZx/Ir73dt3dPVtz7iNviiz3vPa8/8HgTOog3Xzn/gXxfPRrnw==
   dependencies:
     chalk "^1.1.3"
     extract-zip "^1.6.7"


### PR DESCRIPTION
This PR addresses issue https://github.com/microsoft/react-native-windows/issues/4046
The question was if the native module methods support asynchronous code.
The issue was that previously we had a bug that JSValue writer was created on call stack and was crashing for asynchronous code. It was fixed by PR https://github.com/microsoft/react-native-windows/pull/4045 . In This PR I wanted to add unit tests that verify that. The C# tests were simple, but for C++ we had to do more changes:
- Enable use of co-routines and thus allow fire_and_forget method return type.
- Change implementation of ReactPromise to allow it to be copied to a different thread.
- Change test mock environment to enable use of  the async code

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4076)