### PR TITLE
Let children onFocus onBlur events in TouchableWithoutFeedback pass through to parent

### DIFF
--- a/change/react-native-windows-2020-02-11-12-03-45-touchable-focus-blur-events.json
+++ b/change/react-native-windows-2020-02-11-12-03-45-touchable-focus-blur-events.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fix onFocus onBlur events",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "commit": "38bc6cad5c3cdd7d1e00ac0e3a7185e12a2fa381",
+  "dependentChangeType": "patch",
+  "date": "2020-02-11T20:03:45.062Z"
+}

--- a/packages/E2ETest/app/Consts.ts
+++ b/packages/E2ETest/app/Consts.ts
@@ -13,6 +13,7 @@ export const UNKNOWN_TESTPAGE = 'UnknownTestPage';
 export const TEXTINPUT_TESTPAGE = 'TextInputTestPage';
 
 export const TEXTINPUT_ON_TEXTINPUT = 'TextInput';
+export const CURTEXT_ON_TEXTINPUT = 'CurTextInput';
 export const PREVTEXT_ON_TEXTINPUT = 'PrevTextInput';
 export const ML_TEXTINPUT_ON_TEXTINPUT = 'TextInputMultiLine';
 export const CAP_TEXTINPUT_ON_TEXTINPUT = 'TextInputAutoCap';

--- a/packages/E2ETest/app/Consts.ts
+++ b/packages/E2ETest/app/Consts.ts
@@ -15,6 +15,7 @@ export const TEXTINPUT_TESTPAGE = 'TextInputTestPage';
 export const TEXTINPUT_ON_TEXTINPUT = 'TextInput';
 export const CURTEXT_ON_TEXTINPUT = 'CurTextInput';
 export const PREVTEXT_ON_TEXTINPUT = 'PrevTextInput';
+export const PREV2TEXT_ON_TEXTINPUT = 'Prev2TextInput';
 export const ML_TEXTINPUT_ON_TEXTINPUT = 'TextInputMultiLine';
 export const CAP_TEXTINPUT_ON_TEXTINPUT = 'TextInputAutoCap';
 

--- a/packages/E2ETest/app/TextInputTestPage.tsx
+++ b/packages/E2ETest/app/TextInputTestPage.tsx
@@ -5,8 +5,9 @@
  */
 
 import React from 'react';
-import {Text, TextInput, View} from 'react-native';
-import {TEXTINPUT_ON_TEXTINPUT, ML_TEXTINPUT_ON_TEXTINPUT, CURTEXT_ON_TEXTINPUT, PREVTEXT_ON_TEXTINPUT, CAP_TEXTINPUT_ON_TEXTINPUT} from './Consts';
+import {Text, TextInput, View, Alert} from 'react-native';
+import {TEXTINPUT_ON_TEXTINPUT, ML_TEXTINPUT_ON_TEXTINPUT, CURTEXT_ON_TEXTINPUT,
+  PREVTEXT_ON_TEXTINPUT, PREV2TEXT_ON_TEXTINPUT, CAP_TEXTINPUT_ON_TEXTINPUT} from './Consts';
 
 interface ITextInputTestPageState {
   curText: string;
@@ -82,7 +83,7 @@ export class TextInputTestPage extends React.Component<
         <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
           <Text testID={CURTEXT_ON_TEXTINPUT}>curText: {this.state.curText}</Text>
           <Text testID={PREVTEXT_ON_TEXTINPUT}>prev: {this.state.prevText}</Text>
-          <Text testID="Prev2Text">prev2: {this.state.prev2Text})</Text>
+          <Text testID={PREV2TEXT_ON_TEXTINPUT}>prev2: {this.state.prev2Text})</Text>
           <Text testID="Prev3Text">prev3: {this.state.prev3Text}</Text>
         </View>
       </View>

--- a/packages/E2ETest/app/TextInputTestPage.tsx
+++ b/packages/E2ETest/app/TextInputTestPage.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import {Text, TextInput, View} from 'react-native';
-import {TEXTINPUT_ON_TEXTINPUT, ML_TEXTINPUT_ON_TEXTINPUT, PREVTEXT_ON_TEXTINPUT, CAP_TEXTINPUT_ON_TEXTINPUT} from './Consts';
+import {TEXTINPUT_ON_TEXTINPUT, ML_TEXTINPUT_ON_TEXTINPUT, CURTEXT_ON_TEXTINPUT, PREVTEXT_ON_TEXTINPUT, CAP_TEXTINPUT_ON_TEXTINPUT} from './Consts';
 
 interface ITextInputTestPageState {
   curText: string;
@@ -80,7 +80,7 @@ export class TextInputTestPage extends React.Component<
           autoCapitalize="characters"
         />
         <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-          <Text testID="CurText">curText: {this.state.curText}</Text>
+          <Text testID={CURTEXT_ON_TEXTINPUT}>curText: {this.state.curText}</Text>
           <Text testID={PREVTEXT_ON_TEXTINPUT}>prev: {this.state.prevText}</Text>
           <Text testID="Prev2Text">prev2: {this.state.prev2Text})</Text>
           <Text testID="Prev3Text">prev3: {this.state.prev3Text}</Text>

--- a/packages/E2ETest/app/TextInputTestPage.tsx
+++ b/packages/E2ETest/app/TextInputTestPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import {Text, TextInput, View, Alert} from 'react-native';
+import {Text, TextInput, View} from 'react-native';
 import {TEXTINPUT_ON_TEXTINPUT, ML_TEXTINPUT_ON_TEXTINPUT, CURTEXT_ON_TEXTINPUT,
   PREVTEXT_ON_TEXTINPUT, PREV2TEXT_ON_TEXTINPUT, CAP_TEXTINPUT_ON_TEXTINPUT} from './Consts';
 

--- a/packages/E2ETest/wdio/pages/TextInputTestPage.ts
+++ b/packages/E2ETest/wdio/pages/TextInputTestPage.ts
@@ -9,6 +9,7 @@ import {
   ML_TEXTINPUT_ON_TEXTINPUT,
   CAP_TEXTINPUT_ON_TEXTINPUT,
   PREVTEXT_ON_TEXTINPUT,
+  PREV2TEXT_ON_TEXTINPUT,
   CURTEXT_ON_TEXTINPUT,
 } from '../../app/Consts';
 
@@ -56,6 +57,10 @@ class TextInputTestPage extends BasePage {
     return this.prevTextInput.getText();
   }
 
+  getTextInputPrev2Text() {
+    return this.prev2TextInput.getText();
+  }
+
   getTextInputText() {
     return this.textInput.getText();
   }
@@ -78,6 +83,10 @@ class TextInputTestPage extends BasePage {
 
   private get prevTextInput() {
     return By(PREVTEXT_ON_TEXTINPUT);
+  }
+
+  private get prev2TextInput() {
+    return By(PREV2TEXT_ON_TEXTINPUT);
   }
 
   private get multiLineTextInput() {

--- a/packages/E2ETest/wdio/pages/TextInputTestPage.ts
+++ b/packages/E2ETest/wdio/pages/TextInputTestPage.ts
@@ -9,11 +9,20 @@ import {
   ML_TEXTINPUT_ON_TEXTINPUT,
   CAP_TEXTINPUT_ON_TEXTINPUT,
   PREVTEXT_ON_TEXTINPUT,
+  CURTEXT_ON_TEXTINPUT,
 } from '../../app/Consts';
 
 class TextInputTestPage extends BasePage {
   isPageLoaded() {
     return super.isPageLoaded() && this.textInput.isDisplayed();
+  }
+
+  clickTextInput() {
+    this.textInput.click();
+  }
+
+  clickMultilineTextInput() {
+    this.multiLineTextInput.click();
   }
 
   clearAndTypeOnTextInput(text: string) {
@@ -39,6 +48,10 @@ class TextInputTestPage extends BasePage {
     this.multiLineTextInput.addValue(text);
   }
 
+  getTextInputCurText() {
+    return this.curTextInput.getText();
+  }
+
   getTextInputPrevText() {
     return this.prevTextInput.getText();
   }
@@ -57,6 +70,10 @@ class TextInputTestPage extends BasePage {
 
   private get textInput() {
     return By(TEXTINPUT_ON_TEXTINPUT);
+  }
+
+  private get curTextInput() {
+    return By(CURTEXT_ON_TEXTINPUT);
   }
 
   private get prevTextInput() {

--- a/packages/E2ETest/wdio/test/testInput.spec.ts
+++ b/packages/E2ETest/wdio/test/testInput.spec.ts
@@ -18,7 +18,7 @@ describe('First', () => {
     assert.ok(TextInputTestPage.getTextInputCurText().includes('onFocus'));
   });
 
-  it('Click on multiline TextInput to move focus away', () => {
+  it('Click on multiline TextInput to move focus away from single line TextInput', () => {
     TextInputTestPage.clickMultilineTextInput();
     assert.ok(TextInputTestPage.getTextInputPrevText().includes('onBlur'));
   });
@@ -26,6 +26,7 @@ describe('First', () => {
   it('Type abc on TextInput', () => {
     TextInputTestPage.clearAndTypeOnTextInput('abc');
     assert.equal(TextInputTestPage.getTextInputText(), 'abc');
+    assert.ok(TextInputTestPage.getTextInputPrev2Text().includes('onKeyPress'));
   });
 
   it('Type def on TextInput', () => {

--- a/packages/E2ETest/wdio/test/testInput.spec.ts
+++ b/packages/E2ETest/wdio/test/testInput.spec.ts
@@ -13,6 +13,16 @@ beforeAll(() => {
 });
 
 describe('First', () => {
+  it('Click on TextInput to focus', () => {
+    TextInputTestPage.clickTextInput();
+    assert.ok(TextInputTestPage.getTextInputCurText().includes('onFocus'));
+  });
+
+  it('Click on multiline TextInput to move focus away', () => {
+    TextInputTestPage.clickMultilineTextInput();
+    assert.ok(TextInputTestPage.getTextInputPrevText().includes('onBlur'));
+  });
+
   it('Type abc on TextInput', () => {
     TextInputTestPage.clearAndTypeOnTextInput('abc');
     assert.equal(TextInputTestPage.getTextInputText(), 'abc');

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -342,8 +342,6 @@ const TouchableWithoutFeedback = ((createReactClass({
       onResponderTerminate: this.touchableHandleResponderTerminate,
       onKeyUp: this._onKeyUp,
       onKeyDown: this._onKeyDown,
-      onFocus: this.props.onFocus,
-      onBlur: this.props.onBlur,
       tooltip: this.props.tooltip, // TODO(macOS/win ISS#2323203)
       clickable:
         this.props.clickable !== false && this.props.onPress !== undefined, // TODO(android ISS)


### PR DESCRIPTION
Fixes #3927. 

TextInput's onFocus and onBlur callbacks are not functioning, this is because we [wrapped RCTTextInput in a TouchableWithoutFeedback](https://github.com/microsoft/react-native-windows/blob/master/vnext/src/Libraries/Components/TextInput/TextInput.windows.js#L1013-L1025), and onFocus onBlur were [overridden by TouchableWithoutFeedback](https://github.com/microsoft/react-native-windows/blob/master/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js#L345-L346).

To fix this we should let [OVERRIDE_PROPS](https://github.com/kaiguo/react-native-windows/blob/38bc6cad5c3cdd7d1e00ac0e3a7185e12a2fa381/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js#L313-L316) do the work and just copy the rest of the children props to parent.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4078)