### PR TITLE
Set playground to use Light app theme

### DIFF
--- a/packages/playground/windows/playground/App.xaml
+++ b/packages/playground/windows/playground/App.xaml
@@ -2,7 +2,8 @@
     x:Class="Playground.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Playground">
+    xmlns:local="using:Playground"
+    RequestedTheme="Light">
     <Application.Resources>
         <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
     </Application.Resources>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11501,10 +11501,10 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rnpm-plugin-windows@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.4.1.tgz#8d5fb61eab06ec205d2454de490aca06840c7334"
-  integrity sha512-JE66v6l79sGFj5LKM+/ogHS/P3D3dKvA2v0qcIk8Ajt0wfnjpCo58lXbSuNRJrlAy0OujzJZV8kT04UiMwlbFA==
+rnpm-plugin-windows@^0.5.1-0:
+  version "0.5.1-0"
+  resolved "https://registry.yarnpkg.com/rnpm-plugin-windows/-/rnpm-plugin-windows-0.5.1-0.tgz#9ffdd38653c6024c538a98a1046a37625d56eddb"
+  integrity sha512-0EX2shP1OI18MylpVHmZRhDX5GSdvHDgSQoFDZx/Ir73dt3dPVtz7iNviiz3vPa8/8HgTOog3Xzn/gXxfPRrnw==
   dependencies:
     chalk "^1.1.3"
     extract-zip "^1.6.7"


### PR DESCRIPTION
Workaround for #4014 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4079)