### PR TITLE
Fixed Developer menu and Live Reload

### DIFF
--- a/change/react-native-windows-2020-02-12-11-56-02-MS_FixDevMenu.json
+++ b/change/react-native-windows-2020-02-12-11-56-02-MS_FixDevMenu.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed Developer menu and Live Reaload",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "c6217cd2228493c884d0b61c45f1059f8010dd66",
+  "dependentChangeType": "patch",
+  "date": "2020-02-12T19:56:02.686Z"
+}

--- a/vnext/Microsoft.ReactNative/ABICxxModule.cpp
+++ b/vnext/Microsoft.ReactNative/ABICxxModule.cpp
@@ -57,16 +57,18 @@ std::vector<CxxModule::Method> ABICxxModule::getMethods() {
 
 void ABICxxModule::InitEvents(std::vector<ABICxxModuleEventHandlerSetter> const &eventHandlerSetters) noexcept {
   for (auto &eventHandler : eventHandlerSetters) {
-    eventHandler.EventHandlerSetter([ this, name = eventHandler.Name ](ReactArgWriter const &argWriter) noexcept {
-      auto writer = make<DynamicWriter>();
-      writer.WriteArrayBegin();
-      writer.WriteString(winrt::to_hstring(name));
-      argWriter(writer);
-      writer.WriteArrayEnd();
+    eventHandler.EventHandlerSetter(
+        [ name = eventHandler.Name, eventEmitterName = m_eventEmitterName, reactContext =
+          m_reactContext ](ReactArgWriter const &argWriter) noexcept {
+          auto writer = make<DynamicWriter>();
+          writer.WriteArrayBegin();
+          writer.WriteString(winrt::to_hstring(name));
+          argWriter(writer);
+          writer.WriteArrayEnd();
 
-      std::string emitterName = m_eventEmitterName.empty() ? DefaultEventEmitterName : m_eventEmitterName;
-      m_reactContext->CallJSFunction(std::move(emitterName), "emit", get_self<DynamicWriter>(writer)->TakeValue());
-    });
+          std::string emitterName = eventEmitterName.empty() ? DefaultEventEmitterName : eventEmitterName;
+          reactContext->CallJSFunction(std::move(emitterName), "emit", get_self<DynamicWriter>(writer)->TakeValue());
+        });
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -194,7 +194,6 @@
     <ClInclude Include="..\ReactUWP\Modules\Animated\TrackingAnimatedNode.h" />
     <ClInclude Include="..\ReactUWP\Modules\Animated\TransformAnimatedNode.h" />
     <ClInclude Include="..\ReactUWP\Modules\Animated\ValueAnimatedNode.h" />
-    <ClInclude Include="..\ReactUWP\Modules\AppStateModuleUwp.h" />
     <ClInclude Include="..\ReactUWP\Modules\AppThemeModuleUwp.h" />
     <ClInclude Include="..\ReactUWP\Modules\ClipboardModule.h" />
     <ClInclude Include="..\ReactUWP\Modules\DeviceInfoModule.h" />
@@ -268,6 +267,7 @@
       <DependentUpon>IReactModuleBuilder.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="LifecycleState.h" />
+    <ClInclude Include="Modules\AppStateData.h" />
     <ClInclude Include="NativeModulesProvider.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ReactApplication.h">
@@ -356,7 +356,6 @@
     <ClCompile Include="..\ReactUWP\Modules\Animated\TrackingAnimatedNode.cpp" />
     <ClCompile Include="..\ReactUWP\Modules\Animated\TransformAnimatedNode.cpp" />
     <ClCompile Include="..\ReactUWP\Modules\Animated\ValueAnimatedNode.cpp" />
-    <ClCompile Include="..\ReactUWP\Modules\AppStateModuleUwp.cpp" />
     <ClCompile Include="..\ReactUWP\Modules\AppThemeModuleUwp.cpp" />
     <ClCompile Include="..\ReactUWP\Modules\ClipboardModule.cpp" />
     <ClCompile Include="..\ReactUWP\Modules\DeviceInfoModule.cpp" />
@@ -430,6 +429,7 @@
     <ClCompile Include="IReactModuleBuilder.cpp">
       <DependentUpon>IReactModuleBuilder.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="Modules\AppStateData.cpp" />
     <ClCompile Include="NativeModulesProvider.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -86,9 +86,6 @@
     <ClCompile Include="..\ReactUWP\Modules\Animated\ValueAnimatedNode.cpp">
       <Filter>Modules\Animated</Filter>
     </ClCompile>
-    <ClCompile Include="..\ReactUWP\Modules\AppStateModuleUwp.cpp">
-      <Filter>Modules</Filter>
-    </ClCompile>
     <ClCompile Include="..\ReactUWP\Modules\AppThemeModuleUwp.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
@@ -277,6 +274,9 @@
     </ClCompile>
     <ClCompile Include="ABICxxModule.cpp" />
     <ClCompile Include="ABIViewManager.cpp" />
+    <ClCompile Include="Modules\AppStateData.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
     <ClCompile Include="NativeModulesProvider.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="ReactHost\AsyncActionQueue.cpp">
@@ -408,9 +408,6 @@
     </ClInclude>
     <ClInclude Include="..\ReactUWP\Modules\Animated\ValueAnimatedNode.h">
       <Filter>Modules\Animated</Filter>
-    </ClInclude>
-    <ClInclude Include="..\ReactUWP\Modules\AppStateModuleUwp.h">
-      <Filter>Modules</Filter>
     </ClInclude>
     <ClInclude Include="..\ReactUWP\Modules\AppThemeModuleUwp.h">
       <Filter>Modules</Filter>
@@ -596,6 +593,9 @@
     <ClInclude Include="ABIViewManager.h" />
     <ClInclude Include="HResult.h" />
     <ClInclude Include="LifecycleState.h" />
+    <ClInclude Include="Modules\AppStateData.h">
+      <Filter>Modules</Filter>
+    </ClInclude>
     <ClInclude Include="NativeModulesProvider.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ReactHost\AsyncActionQueue.h">

--- a/vnext/Microsoft.ReactNative/Modules/AppStateData.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateData.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "AppStateData.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+using namespace Windows::ApplicationModel;
+using namespace Windows::UI::Xaml;
+
+namespace react::uwp {
+
+AppStateData::AppStateData(Mso::React::IReactContext &reactContext) noexcept
+    : Super(Mso::DispatchQueue::MainUIQueue()), m_lastState{"active"}, m_reactContext{&reactContext} {}
+
+AppStateData::~AppStateData() = default;
+
+void AppStateData::Initialize() noexcept {
+  auto currentApp = Application::Current();
+
+  m_enteredBackgroundRevoker = currentApp.EnteredBackground(
+      winrt::auto_revoke,
+      [weakThis = Mso::WeakPtr{this}](
+          IInspectable const & /*sender*/, EnteredBackgroundEventArgs const & /*e*/) noexcept {
+        if (auto strongThis = weakThis.GetStrongPtr()) {
+          strongThis->RaiseEvent("background");
+        }
+      });
+
+  m_leavingBackgroundRevoker = currentApp.LeavingBackground(
+      winrt::auto_revoke,
+      [weakThis = Mso::WeakPtr{this}](
+          IInspectable const & /*sender*/, LeavingBackgroundEventArgs const & /*e*/) noexcept {
+        if (auto strongThis = weakThis.GetStrongPtr()) {
+          strongThis->RaiseEvent("active");
+        }
+      });
+}
+
+void AppStateData::Finalize() noexcept {
+  m_enteredBackgroundRevoker = {};
+  m_leavingBackgroundRevoker = {};
+}
+
+char const *AppStateData::GetState() noexcept {
+  std::lock_guard lock{m_stateMutex};
+  return m_lastState;
+}
+
+void AppStateData::RaiseEvent(char const *newState) noexcept {
+  {
+    std::lock_guard lock{m_stateMutex};
+    m_lastState = newState;
+  }
+
+  folly::dynamic parameters = folly::dynamic::object("app_state", newState);
+  m_reactContext->CallJSFunction(
+      "RCTDeviceEventEmitter", "emit", folly::dynamic::array("appStateDidChange", std::move(parameters)));
+}
+
+AppState2::AppState2(Mso::React::IReactContext &reactContext) noexcept
+    : m_data{Mso::Make<AppStateData>(reactContext)} {}
+
+AppState2::~AppState2() = default;
+
+char const *AppState2::getState() {
+  return m_data->GetState();
+}
+
+} // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Modules/AppStateData.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateData.h
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Modules/AppStateModule.h>
+#include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include "ReactHost/React.h"
+#include "activeObject/activeObject.h"
+
+namespace react::uwp {
+
+// AppStateData ensures that subscription and un-subscription to Application events is happening in Main UI thread.
+struct AppStateData : Mso::ActiveObject<> {
+  using Super = ActiveObjectType;
+
+  AppStateData(Mso::React::IReactContext &reactContext) noexcept;
+  ~AppStateData() override;
+  void Initialize() noexcept override;
+  void Finalize() noexcept override;
+
+  char const *GetState() noexcept;
+
+ private:
+  void RaiseEvent(char const *newState) noexcept;
+
+ private:
+  std::mutex m_stateMutex;
+  char const *m_lastState{nullptr};
+  Mso::CntPtr<Mso::React::IReactContext> m_reactContext;
+  winrt::Windows::UI::Xaml::Application::EnteredBackground_revoker m_enteredBackgroundRevoker;
+  winrt::Windows::UI::Xaml::Application::LeavingBackground_revoker m_leavingBackgroundRevoker;
+};
+
+// It is a temporary class that we need to keep until we remove ReactUWP
+class AppState2 : public facebook::react::AppState {
+ public:
+  AppState2(Mso::React::IReactContext &reactContext) noexcept;
+
+ public: // facebook::react::AppState
+  ~AppState2() override;
+  char const *getState() override;
+
+ private:
+  Mso::CntPtr<AppStateData> m_data;
+};
+
+} // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -74,9 +74,11 @@ void ReactNativeHost::ReloadInstance() noexcept {
   legacySettings.UseWebDebugger = m_instanceSettings.UseWebDebugger();
 
   Mso::React::ReactOptions reactOptions{};
+  reactOptions.DeveloperSettings.IsDevModeEnabled = legacySettings.EnableDeveloperMenu;
   reactOptions.DeveloperSettings.SourceBundlePath = legacySettings.DebugBundlePath;
   reactOptions.DeveloperSettings.UseWebDebugger = legacySettings.UseWebDebugger;
   reactOptions.DeveloperSettings.UseDirectDebugger = legacySettings.UseDirectDebugger;
+  reactOptions.DeveloperSettings.UseLiveReload = legacySettings.UseLiveReload;
   reactOptions.EnableJITCompilation = legacySettings.EnableJITCompilation;
   reactOptions.DeveloperSettings.DebugHost = legacySettings.DebugHost;
   reactOptions.BundleRootPath = legacySettings.BundleRootPath;

--- a/vnext/Microsoft.ReactNative/Threading/BatchingQueueThread.cpp
+++ b/vnext/Microsoft.ReactNative/Threading/BatchingQueueThread.cpp
@@ -62,8 +62,9 @@ void BatchingQueueThread::runOnQueueSync(std::function<void()> &&func) noexcept 
 }
 
 void BatchingQueueThread::quitSynchronous() noexcept {
-  assert(false && "Not supported");
-  std::terminate();
+  // Used by OInstance
+  // assert(false && "Not supported");
+  // std::terminate();
 }
 
 } // namespace react::uwp

--- a/vnext/ReactUWP/Base/CoreNativeModules.cpp
+++ b/vnext/ReactUWP/Base/CoreNativeModules.cpp
@@ -50,6 +50,7 @@ bool HasPackageIdentity() noexcept {
 std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     std::shared_ptr<facebook::react::IUIManager> uiManager,
     const std::shared_ptr<facebook::react::MessageQueueThread> &messageQueue,
+    const std::shared_ptr<facebook::react::MessageQueueThread> &uiMessageQueue,
     std::shared_ptr<DeviceInfo> deviceInfo,
     std::shared_ptr<facebook::react::DevSettings> devSettings,
     const I18nModule::I18nInfo &&i18nInfo,
@@ -61,7 +62,9 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
 
   modules.emplace_back(
       "UIManager",
-      [uiManager = std::move(uiManager)]() { return facebook::react::createUIManagerModule(uiManager); },
+      [uiManager = std::move(uiManager), uiMessageQueue]() {
+        return facebook::react::createUIManagerModule(std::shared_ptr(uiManager), std::shared_ptr(uiMessageQueue));
+      },
       messageQueue);
 
   modules.emplace_back(

--- a/vnext/ReactUWP/Base/CoreNativeModules.h
+++ b/vnext/ReactUWP/Base/CoreNativeModules.h
@@ -25,6 +25,7 @@ struct ViewManagerProvider;
 std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     std::shared_ptr<facebook::react::IUIManager> uiManager,
     const std::shared_ptr<facebook::react::MessageQueueThread> &messageQueue,
+    const std::shared_ptr<facebook::react::MessageQueueThread> &uiMessageQueue,
     std::shared_ptr<DeviceInfo> deviceInfo,
     std::shared_ptr<facebook::react::DevSettings> devSettings,
     const I18nModule::I18nInfo &&i18nInfo,

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -166,6 +166,7 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance> &spThis, cons
     std::vector<facebook::react::NativeModuleDescription> cxxModules = GetCoreModules(
         m_uiManager,
         m_batchingNativeThread,
+        m_defaultNativeThread,
         deviceInfo,
         devSettings,
         std::move(i18nInfo),

--- a/vnext/ReactWindowsCore/IUIManager.h
+++ b/vnext/ReactWindowsCore/IUIManager.h
@@ -69,6 +69,13 @@ class IUIManager {
 std::shared_ptr<IUIManager> createIUIManager(
     std::vector<std::unique_ptr<IViewManager>> &&viewManagers,
     INativeUIManager *nativeManager);
+
+std::unique_ptr<facebook::xplat::module::CxxModule> createUIManagerModule(
+    std::shared_ptr<IUIManager> &&uimanager,
+    std::shared_ptr<MessageQueueThread> &&uiQueue) noexcept;
+
+// Deprecated: use the overloaded version with two parameters.
+// It is here because it is being exported
 std::unique_ptr<facebook::xplat::module::CxxModule> createUIManagerModule(std::shared_ptr<IUIManager> uimanager);
 
 std::shared_ptr<IUIManager> createBatchingUIManager(

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.h
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.h
@@ -14,6 +14,7 @@ namespace react {
 
 struct IReactRootView;
 struct ShadowNode;
+class MessageQueueThread;
 
 class UIManager : public IUIManager, INativeUIManagerHost {
  public:
@@ -91,7 +92,8 @@ class UIManager : public IUIManager, INativeUIManagerHost {
 
 class UIManagerModule : public facebook::xplat::module::CxxModule {
  public:
-  UIManagerModule(std::shared_ptr<IUIManager> &&manager);
+  UIManagerModule(std::shared_ptr<IUIManager> &&manager, std::shared_ptr<MessageQueueThread> &&uiQueue) noexcept;
+  ~UIManagerModule() noexcept override;
 
   // CxxModule
   std::string getName() override;
@@ -100,6 +102,7 @@ class UIManagerModule : public facebook::xplat::module::CxxModule {
 
  private:
   std::shared_ptr<IUIManager> m_manager;
+  std::shared_ptr<MessageQueueThread> m_uiQueue;
 };
 
 } // namespace react


### PR DESCRIPTION
As a part of implementing new ReactNativeHost I have broke the dev menu and live reload functionality: https://github.com/microsoft/react-native-windows/issues/4072.
The initial fix was easy: in ReactNativeHost.cpp we just had to copy previously missed settings EnableDeveloperMenu and UseLiveReload. But after that we started to see more issues mostly because the new ReactInstance is managed in a background thread instead of UI thread. To address these issues we also had to:
- Make sure that we do not capture 'this' in ABICxxModule.
- Create new safer AppState component that subscribes to and unsubscribes from events in UI thread. The new AppState can be created in a background thread now.
- Remove std::terminate from BatchingQueueThread::quitSynchronous - it is called from the OInstance destructor.
- Fix deadlock in LooperScheduler::AwaitTermination
- Make sure that UIManager is destroyed in UI thread because it destroys XAML UI components in its destructor.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4092)