### PR TITLE
Force Interpretation of Code as UTF-8 When no BOM Present

### DIFF
--- a/change/react-native-windows-2020-02-13-08-27-44-master.json
+++ b/change/react-native-windows-2020-02-13-08-27-44-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Force Interpretation of Code as UTF-8 When no BOM Present",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "faf2a18a780ac71a81403452cac6972543b6426b",
+  "dependentChangeType": "patch",
+  "date": "2020-02-13T16:27:44.257Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -88,6 +88,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <ControlFlowGuard Condition="'$(Configuration)' != 'Debug'">Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Issue #4099 showed a user unable to build due to MSVC interpreting source code using the Simplified Chinese character set. This is due to MSVC behavior of interpreting source files using the user's locale-defined character set if a BOM isn't present. This change instructs MSVC to fall-back to UTF-8 instead.

I wasn't able to locally reproduce the issue with changing Windows settings to simplified Chinese as a default, so I'm not sure which locale factors lead to determining chosen character set. This fix should theoretically avoid the issue entirely though.

Validated we can build the Universal solution. Will rely on CI to catch anything else.

See https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=vs-2019 for more context

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4100)