### PR TITLE
Remove reference to #react-native-platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Want to develop a React Native Windows app? Head over to our [Getting Started Gu
 
 ## Getting Help
 
-- Chat with us on [Reactiflux](https://discord.gg/0ZcbPKXt5bWJVmUY) in #react-native-platforms
+- Chat with us on [Reactiflux](https://discord.gg/0ZcbPKXt5bWJVmUY) in #react-native
 - If it turns out that you may have found a bug, please [open an issue](#opening-issues)
 
 ## Documentation


### PR DESCRIPTION
This channel doesn't seem to exist in the linked Discord anymore.

I'm not sure the right replacement, but #react-native (which does exist) seems reasonable enough.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4111)