### PR TITLE
Fix some reliability isssues for current AsyncStorage implementation

### DIFF
--- a/change/react-native-windows-2020-02-19-10-20-40-storagefix.json
+++ b/change/react-native-windows-2020-02-19-10-20-40-storagefix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix some reliability isssues for current AsyncStorage implementation",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "e4be03a2d921fe401028cda19684e79899ec1b26",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T18:20:40.391Z"
+}

--- a/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.cpp
+++ b/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.cpp
@@ -70,7 +70,7 @@ void KeyValueStorage::load() {
 
   if (saveRequired) // cleanup the AOF by dumping the in memory map
   {
-     saveTable();
+    saveTable();
   }
   setStorageLoadedEvent();
 }

--- a/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.h
+++ b/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.h
@@ -28,7 +28,7 @@ class KeyValueStorage {
   static const uint32_t EstimatedValueSize = 200;
   static const char KeyPrefix = '$';
   static const char ValuePrefix = '%';
-  static const char RemovePrefix = 'R'; //Keep RemovePrefix to be backward compatible for the storage file format
+  static const char RemovePrefix = 'R'; // Keep RemovePrefix to be backward compatible for the storage file format
 
  private:
   std::map<std::string, std::string> m_kvMap;

--- a/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.h
+++ b/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.h
@@ -43,6 +43,7 @@ class KeyValueStorage {
  private:
   void load();
   void waitForStorageLoadComplete();
+  void setStorageLoadedEvent();
 };
 } // namespace react
 } // namespace facebook

--- a/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.h
+++ b/vnext/ReactWindowsCore/AsyncStorage/KeyValueStorage.h
@@ -28,7 +28,7 @@ class KeyValueStorage {
   static const uint32_t EstimatedValueSize = 200;
   static const char KeyPrefix = '$';
   static const char ValuePrefix = '%';
-  static const char RemovePrefix = 'R';
+  static const char RemovePrefix = 'R'; //Keep RemovePrefix to be backward compatible for the storage file format
 
  private:
   std::map<std::string, std::string> m_kvMap;
@@ -44,6 +44,7 @@ class KeyValueStorage {
   void load();
   void waitForStorageLoadComplete();
   void setStorageLoadedEvent();
+  void saveTable();
 };
 } // namespace react
 } // namespace facebook

--- a/vnext/Shared/AsyncStorage/StorageFileIO.cpp
+++ b/vnext/Shared/AsyncStorage/StorageFileIO.cpp
@@ -140,6 +140,10 @@ void StorageFileIO::append(const std::string &fileContent) {
   fwrite(fileContent.c_str(), sizeof(char), fileContent.size(), m_storageFile.get());
 }
 
+void StorageFileIO::flush() {
+  fflush(m_storageFile.get());
+}
+
 void StorageFileIO::throwLastErrorMessage() {
   char errorMessageBuffer[IOHelperBufferSize + 1] = {0};
 #ifdef LIBLET_BUILD // This is silly and makes our lives more difficult while

--- a/vnext/Shared/AsyncStorage/StorageFileIO.h
+++ b/vnext/Shared/AsyncStorage/StorageFileIO.h
@@ -21,6 +21,7 @@ class StorageFileIO {
   void append(const std::string &fileContent);
   void resetLine();
   bool getLine(std::string &line);
+  void flush();
 
   static void throwLastErrorMessage();
 


### PR DESCRIPTION
#3579 
#3392 
Issue #1:  After storage file is updated, the content of the change does not gets flushed to disk until fclose is called. flocse only happens when asyncStorage module is released. This can leads to data loss or corruption, for example app is shutdown abnormally. To fix it, we call fflush every time after updates are made.

Issue #2: There is a 30 seconds wait for each key value pair I/O operation on the the async load of the storage file content. One of the error path of load throws exception but does not set the load complete event which can cause I/O operation to stuck until 30 seconds wait timed out. We should also set the load complete event before throwing the exception.

Issue #3 The asyncStorage module has a behavior where multiple updates to same key are all written to the disk, so multiple entries for same key can exist on the disk. Those multiple entries are only cleaned up in the next table load when app is initializing, Same thing, any removed keys are added to the file just to be cleaned when next load is happening. This won't work well for scenarios when there are many updates to the same key in a session and the key value is fairly big. Per suggestions from Xbox team, I am making changes to always clear and save the whole table from memory to file when any updates happen.

Next step, I will move the AsyncStorage code as is to community module as it is going to be moved out of RN core soon.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4114)