### PR TITLE
Use verdaccio to validate react native init

### DIFF
--- a/.ado/npmAddUser.js
+++ b/.ado/npmAddUser.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// @ts-check
+
+const child_process = require("child_process");
+
+const username = process.argv[2];
+const password = process.argv[3];
+const email = process.argv[4];
+const registry = process.argv[5];
+
+if (!username) {
+  console.error("Please specify username");
+  process.exit(1);
+}
+
+if (!password) {
+  console.error("Please specify password");
+  process.exit(1);
+}
+
+if (!email) {
+  console.error("Please specify email");
+  process.exit(1);
+}
+
+const child = child_process.exec(`npm adduser${registry? (' --registry ' + registry) :''}` );
+
+child.stdout.on("data", d => {
+  const data = d.toString();
+  process.stdout.write(d + "\n");
+  if (data.match(/username/i)) {
+    child.stdin.write(username + "\n");
+  } else if (data.match(/password/i)) {
+    child.stdin.write(password + "\n");
+  } else if (data.match(/email/i)) {
+    child.stdin.write(email + "\n");
+  } else if (data.match(/logged in as/i)) {
+    child.stdin.end();
+  }
+});

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -43,7 +43,7 @@ steps:
     displayName: Wait for verdaccio server to boot
 
   - script: |
-      node scripts/npmAddUser.js user pass mail@nomail.com http://localhost:4873
+      node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
     displayName: Add npm user to verdaccio
 
   - script: |

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -27,27 +27,25 @@ steps:
       script: yarn build
       workingDirectory: vnext
 
-  # yarn ends up copying the whole node_modules folder when doing an install of a file package
-  # Delete node_modules, so that resolution is more like when installing from a published npm package
-  - task: CmdLine@2
-    displayName: Remove node_modules
-    inputs:
-      script: rd /S /Q node_modules
-      workingDirectory: vnext
+  - script: |
+      start npx verdaccio --config ./ado/verdaccio/config.yaml
+    displayName: Launch test npm server (verdaccio)
 
-  # Remove directory ignored by npm
-  - task: CmdLine@2
-    displayName: Remove RNTesterCopy
-    inputs:
-      script: rd /S /Q RNTesterCopy
-      workingDirectory: vnext
+  - script: |
+      npm set registry http://localhost:4873
+    displayName: Modify default npm config to point to local verdaccio server
 
-  # Remove directory ignored by npm
-  - task: CmdLine@2
-    displayName: Remove IntegrationTestsCopy
-    inputs:
-      script: rd /S /Q IntegrationTestsCopy
-      workingDirectory: vnext
+  - script: |
+      node .ado/waitForVerdaccio.js
+    displayName: Wait for verdaccio server to boot
+
+  - script: |
+      node scripts/npmAddUser.js user pass mail@nomail.com http://localhost:4873
+    displayName: Add npm user to verdaccio
+
+  - script: |
+      npx --no-install beachball publish --no-push --registry http://localhost:4873 --yes --access public
+    displayName: Publish packages to verdaccio
 
   - task: CmdLine@2
     displayName: Install react-native cli
@@ -63,13 +61,13 @@ steps:
   - task: CmdLine@2
     displayName: Install rnpm-plugin-windows
     inputs:
-      script: yarn add rnpm-plugin-windows@file:$(Build.SourcesDirectory)\current\local-cli\rnpm\windows
+      script: yarn add rnpm-plugin-windows
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: react-native windows --template vnext --windowsVersion file:$(Build.SourcesDirectory)\vnext --overwrite --language ${{ parameters.language }}
+      script: react-native windows --template vnext --overwrite --language ${{ parameters.language }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: NuGetCommand@2

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -28,7 +28,7 @@ steps:
       workingDirectory: vnext
 
   - script: |
-      start npx verdaccio --config ./ado/verdaccio/config.yaml
+      start-process npx -ArgumentList @('verdaccio', '--config', './.ado/verdaccio/config.yaml')
     displayName: Launch test npm server (verdaccio)
 
   - script: |

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -67,7 +67,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: react-native windows --template vnext --overwrite --language ${{ parameters.language }}
+      script: react-native windows --template beta --overwrite --language ${{ parameters.language }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: NuGetCommand@2

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -27,9 +27,12 @@ steps:
       script: yarn build
       workingDirectory: vnext
 
-  - script: |
-      start-process npx -ArgumentList @('verdaccio', '--config', './.ado/verdaccio/config.yaml')
+  - task: PowerShell@2
     displayName: Launch test npm server (verdaccio)
+    inputs:
+      targetType: inline
+      script: |
+        start-process npx -ArgumentList @('verdaccio', '--config', './.ado/verdaccio/config.yaml')
 
   - script: |
       npm set registry http://localhost:4873

--- a/.ado/verdaccio/config.yaml
+++ b/.ado/verdaccio/config.yaml
@@ -1,0 +1,25 @@
+storage: ./storage
+auth:
+  htpasswd:
+    file: ./htpasswd
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    max_fails: 40
+    maxage: 30m
+    timeout: 60s
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
+packages:
+  '@*/*':
+    access: $all
+    publish: $all
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $all
+    proxy: npmjs
+logs:
+  - {type: file, path: verdaccio.log, format: pretty, level: debug}

--- a/.ado/waitForVerdaccio.js
+++ b/.ado/waitForVerdaccio.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// @ts-check
+
+const http = require('http');
+
+function queryForServerStatus() {
+
+  http.get('http://localhost:4873', res => {
+    console.log(`Server status: ${res.statusCode}`);
+    if (res.statusCode != 200) {
+      setTimeout(queryForServerStatus, 2000);
+    }
+  }).on('error', err => {
+    console.log(err.message);
+    setTimeout(queryForServerStatus, 2000);
+  });
+}
+
+console.log('Waiting for verdaccio instance to respond...');
+
+queryForServerStatus();

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -393,7 +393,7 @@ jobs:
 
       - template: templates/react-native-init.yml
         parameters:
-          version: 0.60.6
+          version: 0.61.5
           platform: x64
           vsComponents: $(VsComponents)
 

--- a/change/react-native-windows-2020-02-19-16-14-22-verdaccio.json
+++ b/change/react-native-windows-2020-02-19-16-14-22-verdaccio.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Use verdaccio to validate react native init",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "b6459ca85c68b936920aab3a7d9dc231cb171621",
+  "dependentChangeType": "patch",
+  "date": "2020-02-20T00:14:22.749Z"
+}


### PR DESCRIPTION
Fixes #3846 

We've said we needed proper publish validation for a while, and there was a recent break in publishing that would have been caught by this.

Also in the process of this work, I notice that we actually have not been testing init at all with the 0.61 update, as the init test was testing that you could init a new 0.60 project.  -- Kind of crazy that that was working using react-native 0.60, and react-native-windows 0.61.  -- But that speaks as much to the need to expand the testing on the init project as anything else (ideally we'd add E2E testing on the init'd project.. but thats out of scope for this change)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4126)