### PR TITLE
Avoid having native modules without methods

### DIFF
--- a/change/react-native-windows-2020-02-19-17-21-37-MS_NoEmptyModule.json
+++ b/change/react-native-windows-2020-02-19-17-21-37-MS_NoEmptyModule.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid having native modules without methods",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "31945e60d3c1820b27aa4a1c137e326ef53a34f5",
+  "dependentChangeType": "patch",
+  "date": "2020-02-20T01:21:37.282Z"
+}

--- a/vnext/Microsoft.ReactNative/ABICxxModule.cpp
+++ b/vnext/Microsoft.ReactNative/ABICxxModule.cpp
@@ -46,11 +46,11 @@ std::map<std::string, folly::dynamic> ABICxxModule::getConstants() noexcept {
 std::vector<CxxModule::Method> ABICxxModule::getMethods() noexcept {
   auto result = std::move(m_methods);
   if (result.empty()) {
-    // Module without methods will be not registered in JS configuration.
-    // It will cause index mismatch between JS and C++ code.
-    // As a result, JS code will code methods on a wrong native module.
+    // Module without methods are not registered in JS configuration.
+    // It causes index mismatch between JS and C++ code.
+    // As a result, JS code will call methods on a wrong native module.
     // See for details ReactCommon\cxxreact\ModuleRegistry.cpp, line 133: that reads 'if (!methodNames.empty()) {'
-    // To work around this issue we add a Dummy method.
+    // To work around this issue we add a Dummy method if native module has no methods.
     result.emplace_back("Dummy", []() {});
   }
 

--- a/vnext/Microsoft.ReactNative/ABICxxModule.cpp
+++ b/vnext/Microsoft.ReactNative/ABICxxModule.cpp
@@ -45,15 +45,6 @@ std::map<std::string, folly::dynamic> ABICxxModule::getConstants() noexcept {
 
 std::vector<CxxModule::Method> ABICxxModule::getMethods() noexcept {
   auto result = std::move(m_methods);
-  if (result.empty()) {
-    // Module without methods are not registered in JS configuration.
-    // It causes index mismatch between JS and C++ code.
-    // As a result, JS code will call methods on a wrong native module.
-    // See for details ReactCommon\cxxreact\ModuleRegistry.cpp, line 133: that reads 'if (!methodNames.empty()) {'
-    // To work around this issue we add a Dummy method if native module has no methods.
-    result.emplace_back("Dummy", []() {});
-  }
-
   return result;
 }
 

--- a/vnext/Microsoft.ReactNative/ABICxxModule.cpp
+++ b/vnext/Microsoft.ReactNative/ABICxxModule.cpp
@@ -45,6 +45,15 @@ std::map<std::string, folly::dynamic> ABICxxModule::getConstants() noexcept {
 
 std::vector<CxxModule::Method> ABICxxModule::getMethods() noexcept {
   auto result = std::move(m_methods);
+  if (result.empty()) {
+    // Module without methods will be not registered in JS configuration.
+    // It will cause index mismatch between JS and C++ code.
+    // As a result, JS code will code methods on a wrong native module.
+    // See for details ReactCommon\cxxreact\ModuleRegistry.cpp, line 133: that reads 'if (!methodNames.empty()) {'
+    // To work around this issue we add a Dummy method.
+    result.emplace_back("Dummy", []() {});
+  }
+
   return result;
 }
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -500,11 +500,10 @@ InstanceImpl::InstanceImpl(
     folly::dynamic configArray = folly::dynamic::array;
     for (auto const &moduleName : m_moduleRegistry->moduleNames()) {
       auto moduleConfig = m_moduleRegistry->getConfig(moduleName);
-      if (moduleConfig) {
-        configArray.push_back(std::move(moduleConfig->config));
-      }
+      configArray.push_back(moduleConfig ? std::move(moduleConfig->config) : nullptr);
     }
-    folly::dynamic configs = folly::dynamic::object("remoteModuleConfig", configArray);
+
+    folly::dynamic configs = folly::dynamic::object("remoteModuleConfig", std::move(configArray));
     m_innerInstance->setGlobalVariable(
         "__fbBatchedBridgeConfig", std::make_unique<JSBigStdString>(folly::toJson(configs)));
   }


### PR DESCRIPTION
This PR addresses one of the most common issues developers see when JS code calls wrong C++ module method. 
Modules without constants and methods are returning empty configuration from the module registry. Then, the code in OInstance.cpp was not adding module with empty configuration to the configArray. Since native modules are invoked by the array index, the mismatch between module list in the ModuleRegistry and the configArray sent to JS engine causes wrong native module be invoked.

To fix the issue we changed code in OInstance.cpp to match RCTObjcExecutor.mm where nullptr is added to configArray for empty configs.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4128)