### PR TITLE
Fix ReactNativeHost without package providers

### DIFF
--- a/change/react-native-windows-2020-02-20-17-38-43-FixNoPackageProvider.json
+++ b/change/react-native-windows-2020-02-20-17-38-43-FixNoPackageProvider.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactNativeHost without package providers",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "a428fb05a4a9c52aa523a1dccefdb7c8e6adcd85",
+  "dependentChangeType": "patch",
+  "date": "2020-02-21T01:38:42.760Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -55,8 +55,10 @@ void ReactNativeHost::ReloadInstance() noexcept {
   if (!m_packageBuilder) {
     m_packageBuilder = make<ReactPackageBuilder>(modulesProvider, viewManagersProvider);
 
-    for (auto const &packageProvider : m_packageProviders) {
-      packageProvider.CreatePackage(m_packageBuilder);
+    if (m_packageProviders) {
+      for (auto const &packageProvider : m_packageProviders) {
+        packageProvider.CreatePackage(m_packageBuilder);
+      }
     }
   }
 


### PR DESCRIPTION
The `ReactNativeHost.PackageProvider` property creates collection on demand. But if we never touched that property, then the internal field m_packageProviders is null and we see a crash if application does not provide any custom packages.

In this PR we add a simple check if m_packageProviders is null to avoid the runtime crash.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4159)