### PR TITLE
Fix for NormalizePath resolving IntDir based on current working directory (#4108)

### DIFF
--- a/change/react-native-windows-2020-02-14-16-56-53-users-aschultz-build.json
+++ b/change/react-native-windows-2020-02-14-16-56-53-users-aschultz-build.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix issues with relative IntDir breaking builds",
+  "packageName": "react-native-windows",
+  "email": "aschultz@microsoft.com",
+  "commit": "7ce4e87f02db6eb98f9d42214e8a770b64a07022",
+  "dependentChangeType": "patch",
+  "date": "2020-02-15T00:56:53.034Z"
+}

--- a/vnext/PropertySheets/ReactPackageDirectories.props
+++ b/vnext/PropertySheets/ReactPackageDirectories.props
@@ -15,6 +15,10 @@
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$(MSBuildThisFileDirectory)\..\</ReactNativeWindowsDir>
     <ReactNativePackageDir Condition="'$(ReactNativePackageDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativePackageDir>
     <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$(IntDir)\react-native-patched\</ReactNativeDir>
+    
+    <!-- For relative paths, make it relative to MSBuildProjectDirectory not CurrentWorkingDirectory. -->
+    <ReactNativeDir>$([MSBuild]::NormalizeDirectory( $([System.IO.Path]::Combine( $(MSBuildProjectDirectory), $(ReactNativeDir) )) ))</ReactNativeDir>
+
     <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)\ReactCommon\yoga</YogaDir>
     <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
   </PropertyGroup>

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -50,7 +50,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UnmergedWinmdDirectory>$([MSBuild]::NormalizePath($(IntDir)UnmergedWinMD))</UnmergedWinmdDirectory>
+    <!-- For relative paths, make it relative to MSBuildProjectDirectory not CurrentWorkingDirectory -->
+    <UnmergedWinmdDirectory>$([MSBuild]::NormalizeDirectory( $([System.IO.Path]::Combine( $(MSBuildProjectDirectory), $(IntDir)UnmergedWinMD )) ))</UnmergedWinmdDirectory>
     <!-- MDMERGE.EXE fails if output dir has trailing slash. -->
     <MergedWinmdDirectory>$(OutDir.TrimEnd("/\"))</MergedWinmdDirectory>
     <IdlHeaderDirectory>$(MSBuildThisFileDirectory)GeneratedWinmdHeader</IdlHeaderDirectory>


### PR DESCRIPTION
To bring this into the 0.60 branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4161)