### PR TITLE
Force coroutine method parameters pass by value

### DIFF
--- a/change/react-native-windows-2020-02-21-14-55-06-FixReactPromise.json
+++ b/change/react-native-windows-2020-02-21-14-55-06-FixReactPromise.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Force coroutine method parameters pass by value",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "8a3ffdebac72b7719fd0309ade2ee6e106d94040",
+  "dependentChangeType": "patch",
+  "date": "2020-02-21T22:55:06.208Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -131,14 +131,12 @@ struct SampleModuleCppImpl {
   }
 
   REACT_METHOD(NegateAsyncPromise)
-  winrt::fire_and_forget NegateAsyncPromise(int x, ReactPromise<int> const &result) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    ReactPromise<int> safeResult{result}; // make a copy for co-routine safe access
+  winrt::fire_and_forget NegateAsyncPromise(int x, ReactPromise<int> result) noexcept {
     co_await winrt::resume_background();
     if (x >= 0) {
-      safeResult.Resolve(-x);
+      result.Resolve(-x);
     } else {
-      safeResult.Reject("Already negative");
+      result.Reject("Already negative");
     }
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -110,11 +110,9 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(NegateAsyncCallback)
-  fire_and_forget NegateAsyncCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    auto safeResolve = resolve; // make a copy for co-routine safe access
+  fire_and_forget NegateAsyncCallback(int x, std::function<void(int)> resolve) noexcept {
     co_await winrt::resume_background();
-    safeResolve(-x);
+    resolve(-x);
   }
 
   REACT_METHOD(NegateDispatchQueueCallback)
@@ -143,11 +141,9 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(StaticNegateAsyncCallback)
-  static fire_and_forget StaticNegateAsyncCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    auto safeResolve = resolve; // make a copy for co-routine safe access
+  static fire_and_forget StaticNegateAsyncCallback(int x, std::function<void(int)> resolve) noexcept {
     co_await winrt::resume_background();
-    safeResolve(-x);
+    resolve(-x);
   }
 
   REACT_METHOD(StaticNegateDispatchQueueCallback)
@@ -193,16 +189,13 @@ struct SimpleNativeModule {
   REACT_METHOD(NegateAsyncCallbacks)
   fire_and_forget NegateAsyncCallbacks(
       int x,
-      std::function<void(int)> const &resolve,
-      std::function<void(const std::string &)> const &reject) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    auto safeResolve = resolve; // make a copy for co-routine safe access
-    auto safeReject = reject;
+      std::function<void(int)> resolve,
+      std::function<void(const std::string &)> reject) noexcept {
     co_await winrt::resume_background();
     if (x >= 0) {
-      safeResolve(-x);
+      resolve(-x);
     } else {
-      safeReject("Already negative");
+      reject("Already negative");
     }
   }
 
@@ -276,16 +269,13 @@ struct SimpleNativeModule {
   REACT_METHOD(StaticNegateAsyncCallbacks)
   static fire_and_forget StaticNegateAsyncCallbacks(
       int x,
-      std::function<void(int)> const &resolve,
-      std::function<void(const std::string &)> const &reject) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    auto safeResolve = resolve; // make a copy for co-routine safe access
-    auto safeReject = reject;
+      std::function<void(int)> resolve,
+      std::function<void(const std::string &)> reject) noexcept {
     co_await winrt::resume_background();
     if (x >= 0) {
-      safeResolve(-x);
+      resolve(-x);
     } else {
-      safeReject("Already negative");
+      reject("Already negative");
     }
   }
 
@@ -354,16 +344,14 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(NegateAsyncPromise)
-  fire_and_forget NegateAsyncPromise(int x, ReactPromise<int> const &result) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    ReactPromise<int> safeResult{result}; // make a copy for co-routine safe access
+  fire_and_forget NegateAsyncPromise(int x, ReactPromise<int> result) noexcept {
     co_await winrt::resume_background();
     if (x >= 0) {
-      safeResult.Resolve(-x);
+      result.Resolve(-x);
     } else {
       ReactError error{};
       error.Message = "Already negative";
-      safeResult.Reject(std::move(error));
+      result.Reject(std::move(error));
     }
   }
 
@@ -438,16 +426,14 @@ struct SimpleNativeModule {
   }
 
   REACT_METHOD(StaticNegateAsyncPromise)
-  static fire_and_forget StaticNegateAsyncPromise(int x, ReactPromise<int> const &result) noexcept {
-    // In co-routine we can safely use parameters passed by value and local variables kept on stack by value.
-    ReactPromise<int> safeResult{result}; // make a copy for co-routine safe access
+  static fire_and_forget StaticNegateAsyncPromise(int x, ReactPromise<int> result) noexcept {
     co_await winrt::resume_background();
     if (x >= 0) {
-      safeResult.Resolve(-x);
+      result.Resolve(-x);
     } else {
       ReactError error{};
       error.Message = "Already negative";
-      safeResult.Reject(std::move(error));
+      result.Reject(std::move(error));
     }
   }
 


### PR DESCRIPTION
In C++ coroutines preserve current function callstack when the function is suspended with the co_await operator. It creates an interesting issue with parameter passing: any parameter passed by reference may cause a crash if accessed after resuming. See for details: https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/concurrency (Parameter-passing section.) 
In our unit tests we had to copy Mso::ReactPromise and callbacks to ensure that we can call them safely after co_await. But, when developers write code, it is too easy to make such mistake.

In this PR we are adding a check that causes a compile-time error if parameters are not passed by value to a coroutine. We have updated our test native module coroutines to pass parameters by value instead of by reference.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4168)