### PR TITLE
Fix transform center point

### DIFF
--- a/change/react-native-windows-2020-02-24-11-56-09-fix-transform.json
+++ b/change/react-native-windows-2020-02-24-11-56-09-fix-transform.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Fix transform center",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "commit": "b5f62bb28ce8a8f4277dcf380fcba1631580a299",
+  "dependentChangeType": "patch",
+  "date": "2020-02-24T19:56:08.924Z"
+}

--- a/packages/E2ETest/app/Consts.ts
+++ b/packages/E2ETest/app/Consts.ts
@@ -46,3 +46,8 @@ export const IMAGE_CONTAINER = 'ImageContainer';
 // Control Style Test Page
 export const CONTROL_STYLE_TESTPAGE = 'ControlStyleTestPage';
 export const SHOWBORDER_ON_CONTROLSTYLE = 'ShowBorder';
+
+// TransformTestPage
+export const TRANSFORM_TESTPAGE = 'TransformTestPage';
+export const TRANSFORM_TEST_RESULT = 'TransfromTestResult';
+export const APPLY_SCALE_TRANSFORM_BUTTON = 'ApplyScaleTransformButton';

--- a/packages/E2ETest/app/TestPages.ts
+++ b/packages/E2ETest/app/TestPages.ts
@@ -15,12 +15,14 @@ import {
   DIRECT_MANIPULATION_TESTPAGE,
   IMAGE_TESTPAGE,
   CONTROL_STYLE_TESTPAGE,
+  TRANSFORM_TESTPAGE,
 } from './Consts';
 import { LoginTestPage } from './LoginTestPage';
 import { AccessibilityTestPage } from './AccessibilityTestPage';
 import { DirectManipulationTestPage } from './DirectManipulationPage';
 import { ImageTestPage } from './ImageTestPage';
 import { ControlStyleTestPage } from './ControlStyleTestPage';
+import { TransformTestPage } from './TransformTestPage';
 
 export interface ITestPage {
   testId: string;
@@ -58,6 +60,11 @@ const TestPages: ITestPage[] = [
     testId: CONTROL_STYLE_TESTPAGE,
     description: 'Control Style Test Page',
     content: ControlStyleTestPage,
+  },
+  {
+    testId: TRANSFORM_TESTPAGE,
+    description: 'Transform Test Page',
+    content: TransformTestPage,
   },
   {
     testId: UNKNOWN_TESTPAGE,

--- a/packages/E2ETest/app/TransformTestPage.tsx
+++ b/packages/E2ETest/app/TransformTestPage.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React, { useState } from 'react';
+import { Text, View, StyleSheet, Button, findNodeHandle } from 'react-native';
+import { APPLY_SCALE_TRANSFORM_BUTTON, MEASURE_LAYOUT_BUTTON, TRANSFORM_TEST_RESULT } from './Consts';
+
+const styles = StyleSheet.create({
+    text: {
+        textAlign: 'center',
+        fontWeight: '700',
+        height: 30
+    },
+    childView: {
+        width: 60,
+        height: 60,
+        marginTop: 50,
+        backgroundColor: 'lightgreen',
+        marginBottom: 20,
+    }
+});
+
+const rootViewRef = React.createRef<View>();
+const childViewRef = React.createRef<View>();
+
+export function TransformTestPage() {
+    const [resultTextState, setResultTextState] = useState('');
+    const [viewScale, setViewScale] = useState(1);
+
+    const measureLayoutSucceeded = (x: number, y: number, width: number, height: number) => {
+        setResultTextState(`x=${x};y=${y};width=${Math.trunc(width)};height=${Math.trunc(height)}`);
+    }
+
+    const measureLayoutFailed = () => {
+        setResultTextState('MeasureLayout failed');
+    }
+
+    return (
+        <View ref={rootViewRef}>
+            <Text testID={TRANSFORM_TEST_RESULT}>
+                {resultTextState}
+            </Text>
+            <View style={[styles.childView, { transform: [{ scale: viewScale }] }]} ref={childViewRef}></View>
+            <Button title='Apply ScaleTransform'
+                onPress={() => {
+                    setViewScale(viewScale === 1 ? 0.5 : 1);
+                }}
+                testID={APPLY_SCALE_TRANSFORM_BUTTON} />
+
+            <Button title='MeasureLayout'
+                onPress={() => {
+                    if (childViewRef.current) {
+                        const rootViewHandle = findNodeHandle(rootViewRef.current);
+                        if (rootViewHandle) {
+                            childViewRef.current.measureLayout(rootViewHandle, measureLayoutSucceeded, measureLayoutFailed);
+                        }
+                    }
+                }}
+                testID={MEASURE_LAYOUT_BUTTON} />
+
+        </View >);
+}

--- a/packages/E2ETest/wdio/pages/HomePage.ts
+++ b/packages/E2ETest/wdio/pages/HomePage.ts
@@ -11,6 +11,7 @@ import {
   DIRECT_MANIPULATION_TESTPAGE,
   IMAGE_TESTPAGE,
   CONTROL_STYLE_TESTPAGE,
+  TRANSFORM_TESTPAGE,
 } from '../../app/Consts';
 import LoginPage from './LoginPage';
 import DirectManipulationPage from './DirectManipulationPage';
@@ -52,6 +53,11 @@ class HomePage extends BasePage {
     ControlStyleTestPage.waitForPageLoaded();
   }
 
+  clickAndGotoTransformTestPage() {
+    this.TransformTestPageButton.click();
+    ControlStyleTestPage.waitForPageLoaded();
+  }
+
   private get testInputTestPageButton() {
     return By(TEXTINPUT_TESTPAGE);
   }
@@ -70,6 +76,10 @@ class HomePage extends BasePage {
 
   private get ControlStylePageButton() {
     return By(CONTROL_STYLE_TESTPAGE);
+  }
+
+  private get TransformTestPageButton() {
+    return By(TRANSFORM_TESTPAGE);
   }
 }
 

--- a/packages/E2ETest/wdio/pages/TransformTestPage.ts
+++ b/packages/E2ETest/wdio/pages/TransformTestPage.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { BasePage, By } from './BasePage';
+import {
+  APPLY_SCALE_TRANSFORM_BUTTON,
+  TRANSFORM_TEST_RESULT,
+  MEASURE_LAYOUT_BUTTON,
+} from '../../app/Consts';
+
+class DirectManipulationPage extends BasePage {
+  backToHomePage() {
+    this.homeButton.click();
+    this.waitForPageLoaded();
+  }
+
+  isPageLoaded() {
+    return super.isPageLoaded() && this.measureLayoutButton.isDisplayed();
+  }
+
+  clickApplyScaleTransform() {
+    this.applyScaleTransformButton.click();
+  }
+
+  clickMeasureLayoutAndGetResult() {
+    this.measureLayoutButton.click();
+    return this.transformTestResult.getText();
+  }
+
+  private get applyScaleTransformButton() {
+    return By(APPLY_SCALE_TRANSFORM_BUTTON);
+  }
+
+  private get measureLayoutButton() {
+    return By(MEASURE_LAYOUT_BUTTON);
+  }
+
+  private get transformTestResult() {
+    return By(TRANSFORM_TEST_RESULT);
+  }
+}
+
+export default new DirectManipulationPage();

--- a/packages/E2ETest/wdio/test/TransformTest.spec.ts
+++ b/packages/E2ETest/wdio/test/TransformTest.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import HomePage from '../pages/HomePage';
+import TransformTestPage from '../pages/TransformTestPage';
+import assert from 'assert';
+
+beforeAll(() => {
+  HomePage.backToHomePage();
+  HomePage.clickAndGotoTransformTestPage();
+});
+
+describe('TransformTest', () => {
+  it('Measure original size and position', () => {
+    const result = TransformTestPage.clickMeasureLayoutAndGetResult();
+    assert.ok(result.includes('width=60'), 'measureLayout response width=60');
+    assert.ok(result.includes('x=0;'), 'measureLayout response x=20');
+  });
+
+  it('Apply 0.5 scale transform', () => {
+    TransformTestPage.clickApplyScaleTransform();
+    const result = TransformTestPage.clickMeasureLayoutAndGetResult();
+    assert.ok(result.includes('width=30'), 'measureLayout response width=30');
+    assert.ok(result.includes('x=15;'), 'measureLayout response x=15');
+  });
+});

--- a/packages/E2ETest/wdio/test/TransformTest.spec.ts
+++ b/packages/E2ETest/wdio/test/TransformTest.spec.ts
@@ -19,10 +19,13 @@ describe('TransformTest', () => {
     assert.ok(result.includes('x=0;'), 'measureLayout response x=20');
   });
 
-  it('Apply 0.5 scale transform', () => {
-    TransformTestPage.clickApplyScaleTransform();
-    const result = TransformTestPage.clickMeasureLayoutAndGetResult();
-    assert.ok(result.includes('width=30'), 'measureLayout response width=30');
-    assert.ok(result.includes('x=15;'), 'measureLayout response x=15');
-  });
+  // Uncomment and run this test on 19h1+ when Platform.Version is available.
+  // https://github.com/microsoft/react-native-windows/issues/4176
+
+  // it('Apply 0.5 scale transform', () => {
+  //   TransformTestPage.clickApplyScaleTransform();
+  //   const result = TransformTestPage.clickMeasureLayoutAndGetResult();
+  //   assert.ok(result.includes('width=30'), 'measureLayout response width=30');
+  //   assert.ok(result.includes('x=15;'), 'measureLayout response x=15');
+  // });
 });

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -122,11 +122,6 @@ void PropsAnimatedNode::StartAnimations() {
         if (!m_centerPointAnimation) {
           m_centerPointAnimation = winrt::Window::Current().Compositor().CreateExpressionAnimation();
           m_centerPointAnimation.Target(L"CenterPoint");
-
-          if (g_HasActualSizeProperty == TriBit::Undefined) {
-            // ActualSize works on 19H1+ only
-            g_HasActualSizeProperty = (uiElement.try_as<winrt::IUIElement10>()) ? TriBit::Set : TriBit::NotSet;
-          }
           m_centerPointAnimation.SetReferenceParameter(
               L"centerPointPropertySet", GetShadowNodeBase()->EnsureTransformPS());
           m_centerPointAnimation.Expression(L"centerPointPropertySet.center");

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -12,6 +12,7 @@
 #include <Views/ViewManagerBase.h>
 #include <WindowsNumerics.h>
 #include "Views/KeyboardEventHandler.h"
+#include "XamlFeatures.h"
 
 using namespace std::placeholders;
 
@@ -99,12 +100,18 @@ winrt::Windows::UI::Composition::CompositionPropertySet ShadowNodeBase::EnsureTr
 // "center":  This is the center of the UIElement
 // "transform": This will hold the un-centered TransformMatrix we want to apply
 void ShadowNodeBase::UpdateTransformPS() {
+  auto uielement = m_view.try_as<winrt::UIElement>();
+  assert(uielement != nullptr);
+
+  if (g_HasActualSizeProperty == TriBit::Undefined) {
+    // ActualSize works on 19H1+ only
+    g_HasActualSizeProperty = (uielement.try_as<winrt::IUIElement10>()) ? TriBit::Set : TriBit::NotSet;
+  }
+
   if (m_transformPS != nullptr) {
     // First build up an ExpressionAnimation to compute the "center" property,
     // like so: The input to the expression is UIElement.ActualSize/2, output is
     // a vector3 with [cx, cy, 0].
-    auto uielement = m_view.try_as<winrt::UIElement>();
-    assert(uielement != nullptr);
     m_transformPS = EnsureTransformPS();
     m_transformPS.InsertVector3(L"center", {0, 0, 0});
     auto instance = GetViewManager()->GetReactInstance().lock();


### PR DESCRIPTION
Fixes #4077.

The `g_HasActualSizeProperty` was not properly initialized which leads to a wrong code path when [creating center vector](https://github.com/microsoft/react-native-windows/blob/master/vnext/ReactUWP/Views/ExpressionAnimationStore.cpp#L49-L51). Moving the initialization to ShadowNodeBase so that we can have the correct value ready before the checks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4169)