### PR TITLE
Declare MessageQueueThread in header that uses it

### DIFF
--- a/change/react-native-windows-2020-02-24-12-16-25-mqtdec.json
+++ b/change/react-native-windows-2020-02-24-12-16-25-mqtdec.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Declare MessageQueueThread in header that uses it",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "2a3b2b301b4b6a972af50eba3cea72bc65dca6fc",
+  "dependentChangeType": "patch",
+  "date": "2020-02-24T20:16:25.637Z"
+}

--- a/vnext/ReactWindowsCore/IUIManager.h
+++ b/vnext/ReactWindowsCore/IUIManager.h
@@ -16,6 +16,7 @@ struct INativeUIManager;
 struct IReactRootView;
 class IViewManager;
 struct ShadowNode;
+class MessageQueueThread;
 
 class IUIManager {
  public:


### PR DESCRIPTION
Currently IUIManager.h causes undefined identifier errors when included without including MessageQueueThread.h first.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4175)