### PR TITLE
Fix concurrency issue in NetworkingModule

### DIFF
--- a/change/react-native-windows-2020-02-25-11-16-19-networkingmodulefix.json
+++ b/change/react-native-windows-2020-02-25-11-16-19-networkingmodulefix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix concurrency issue in NetworkingModule",
+  "packageName": "react-native-windows",
+  "email": "lamdoan@microsoft.com",
+  "commit": "9a4348df3b8177f0bf4bc451bbc1d93df5215dc4",
+  "dependentChangeType": "patch",
+  "date": "2020-02-25T19:16:19.779Z"
+}

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -344,7 +344,7 @@ void NetworkingModule::NetworkingHelper::AbortRequest(int64_t requestId) noexcep
       winrt::Windows::Web::Http::HttpProgress>
       httpRequest(nullptr);
   {
-    std::scoped_lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     auto iter = m_requests.find(requestId);
     if (iter == end(m_requests))
       return;

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -66,9 +66,11 @@ class NetworkingModule::NetworkingHelper : public std::enable_shared_from_this<N
       winrt::Windows::Foundation::IAsyncOperationWithProgress<
           winrt::Windows::Web::Http::HttpResponseMessage,
           winrt::Windows::Web::Http::HttpProgress> completion) {
+    std::scoped_lock lock(m_mutex);
     m_requests[requestId] = completion;
   }
   void RemoveRequest(int64_t requestId) {
+    std::scoped_lock lock(m_mutex);
     m_requests.erase(requestId);
   }
 
@@ -87,6 +89,7 @@ class NetworkingModule::NetworkingHelper : public std::enable_shared_from_this<N
           winrt::Windows::Web::Http::HttpResponseMessage,
           winrt::Windows::Web::Http::HttpProgress>>
       m_requests;
+  std::mutex m_mutex;
   static std::int64_t s_lastRequestId;
 };
 

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -339,11 +339,17 @@ void NetworkingModule::NetworkingHelper::SendRequest(
 }
 
 void NetworkingModule::NetworkingHelper::AbortRequest(int64_t requestId) noexcept {
-  auto iter = m_requests.find(requestId);
-  if (iter == end(m_requests))
-    return;
+  winrt::Windows::Foundation::IAsyncOperationWithProgress<
+    winrt::Windows::Web::Http::HttpResponseMessage, 
+    winrt::Windows::Web::Http::HttpProgress> httpRequest(nullptr);
+  {
+    std::scoped_lock(m_mutex);
+    auto iter = m_requests.find(requestId);
+    if (iter == end(m_requests))
+      return;
+    httpRequest = iter->second;
+  }
 
-  auto httpRequest = iter->second;
   try {
     httpRequest.Cancel();
   } catch (...) {

--- a/vnext/ReactUWP/Modules/NetworkingModule.cpp
+++ b/vnext/ReactUWP/Modules/NetworkingModule.cpp
@@ -340,8 +340,9 @@ void NetworkingModule::NetworkingHelper::SendRequest(
 
 void NetworkingModule::NetworkingHelper::AbortRequest(int64_t requestId) noexcept {
   winrt::Windows::Foundation::IAsyncOperationWithProgress<
-    winrt::Windows::Web::Http::HttpResponseMessage, 
-    winrt::Windows::Web::Http::HttpProgress> httpRequest(nullptr);
+      winrt::Windows::Web::Http::HttpResponseMessage,
+      winrt::Windows::Web::Http::HttpProgress>
+      httpRequest(nullptr);
   {
     std::scoped_lock(m_mutex);
     auto iter = m_requests.find(requestId);


### PR DESCRIPTION
Fix #4174 

- Add locking around modifications to m_requests map.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4179)