### PR TITLE
Add missing license to react-native-win32

### DIFF
--- a/change/@office-iss-react-native-win32-2020-02-27-05-32-05-missing-license.json
+++ b/change/@office-iss-react-native-win32-2020-02-27-05-32-05-missing-license.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Add missing license to react-native-win32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "commit": "56b9c03fba7c40dddad1e9b063f5fb26229dd8f0",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T13:32:05.222Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -2,6 +2,7 @@
   "name": "@office-iss/react-native-win32",
   "version": "0.61.0-beta.8",
   "description": "Implementation of react native on top of Office's Win32 platform.",
+  "license": "MIT",
   "main": "./Libraries/react-native/react-native-implementation.win32.js",
   "typings": "./Libraries/react-native/typings-main.d.ts",
   "scripts": {


### PR DESCRIPTION
Yarn gives us warnings about this is we do `yarn list`.  Add the missing license.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4198)