### PR TITLE
Add partial generated override manifests

### DIFF
--- a/change/@office-iss-react-native-win32-2020-02-27-10-11-57-generate-patches.json
+++ b/change/@office-iss-react-native-win32-2020-02-27-10-11-57-generate-patches.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Add partial generated override manifests",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "commit": "380d6b1fe5dc69a1b6c6aa55c3aa42d5462c2d58",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T18:11:56.205Z"
+}

--- a/change/react-native-windows-2020-02-27-10-11-57-generate-patches.json
+++ b/change/react-native-windows-2020-02-27-10-11-57-generate-patches.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Add partial generated override manifests",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "380d6b1fe5dc69a1b6c6aa55c3aa42d5462c2d58",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T18:11:57.821Z"
+}

--- a/packages/override-tools/package.json
+++ b/packages/override-tools/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "chalk": "^3.0.0",
+    "diff-match-patch": "^1.0.4",
     "io-ts": "^2.1.1",
     "lodash": "^4.17.15",
     "ora": "^4.0.3",
@@ -33,6 +34,7 @@
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-typescript": "^7.8.3",
     "@types/chalk": "^2.2.0",
+    "@types/diff-match-patch": "^1.0.32",
     "@types/jest": "^24.9.1",
     "@types/lodash": "^4.14.149",
     "@types/node": "^13.7.4",

--- a/packages/override-tools/src/GitReactFileRepository.ts
+++ b/packages/override-tools/src/GitReactFileRepository.ts
@@ -6,6 +6,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as simplegit from 'simple-git/promise';
 
@@ -13,6 +14,7 @@ import ActionQueue from './ActionQueue';
 import {VersionedReactFileRepository} from './FileRepository';
 
 const REACT_NATIVE_GITHUB_URL = 'https://github.com/facebook/react-native.git';
+const DEFAULT_DIR = path.join(os.tmpdir(), 'react-native-windows-override-git');
 
 /**
  * Retrives React Native files using the React Native Github repo. Switching
@@ -28,15 +30,15 @@ export default class GitReactFileRepository
   private constructor() {}
 
   static async createAndInit(
-    gitDirectory: string,
+    gitDirectory?: string,
   ): Promise<GitReactFileRepository> {
     let repo = new GitReactFileRepository();
-    repo.gitDirectory = gitDirectory;
     repo.actionQueue = new ActionQueue();
 
-    await fs.promises.mkdir(gitDirectory, {recursive: true});
+    repo.gitDirectory = gitDirectory || DEFAULT_DIR;
+    await fs.promises.mkdir(repo.gitDirectory, {recursive: true});
 
-    repo.gitClient = simplegit(gitDirectory);
+    repo.gitClient = simplegit(repo.gitDirectory);
     if (!(await repo.gitClient.checkIsRepo())) {
       await repo.gitClient.init();
       await repo.gitClient.addRemote('origin', REACT_NATIVE_GITHUB_URL);

--- a/packages/override-tools/src/Manifest.ts
+++ b/packages/override-tools/src/Manifest.ts
@@ -77,6 +77,18 @@ export function parse(json: string): Manifest {
   return parsed;
 }
 
+/**
+ * Writes the manifest to a JSON file. Does not validate correctness of the
+ * manifest.
+ */
+export async function writeToFile(manifest: Manifest, filePath: string) {
+  manifest.overrides.sort((a, b) => a.file.localeCompare(b.file));
+
+  const json = JSON.stringify(manifest, null /*replacer*/, 2 /*space*/);
+  await fs.promises.mkdir(path.dirname(filePath), {recursive: true});
+  await fs.promises.writeFile(filePath, json);
+}
+
 export interface ValidationError {
   type:
     | 'fileMissingFromManifest' // An override file is present with no manifest entry

--- a/packages/override-tools/src/PackageUtils.ts
+++ b/packages/override-tools/src/PackageUtils.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Try to find the currently installed version of React Native by seaching for
+ * it's package.json.
+ */
+export async function getInstalledRNVersion(
+  targetPath: string,
+): Promise<string> {
+  const relativeRnPackage = 'node_modules\\react-native\\package.json';
+
+  let searchPath = path.resolve(targetPath);
+  while (path.resolve(searchPath, '..') !== searchPath) {
+    try {
+      const rnPackage = path.join(searchPath, relativeRnPackage);
+      const packageJson = (await fs.promises.readFile(rnPackage)).toString();
+      const version = JSON.parse(packageJson).version;
+
+      if (typeof version !== 'string') {
+        throw new Error('Unexpected formt of React Native package.json');
+      }
+
+      return version;
+    } catch (ex) {
+      if (ex.code === 'ENOENT') {
+        searchPath = path.resolve(searchPath, '..');
+      } else {
+        throw ex;
+      }
+    }
+  }
+
+  throw new Error('Could not find a valid package.json for React Native');
+}

--- a/packages/override-tools/src/scripts/generateManifest.ts
+++ b/packages/override-tools/src/scripts/generateManifest.ts
@@ -176,7 +176,7 @@ function computeSimilarity(
   return {similar, editDistance};
 }
 
-function stripCopyrightHeaders(str: string) : string {
+function stripCopyrightHeaders(str: string): string {
   if (!str.startsWith('/*')) {
     return str;
   }

--- a/packages/override-tools/src/scripts/generateManifest.ts
+++ b/packages/override-tools/src/scripts/generateManifest.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as FileRepository from '../FileRepository';
+import * as Manifest from '../Manifest';
+
+import * as ora from 'ora';
+import * as path from 'path';
+
+import GitReactFileRepository from '../GitReactFileRepository';
+import OverrideFileRepositoryImpl from '../OverrideFileRepositoryImpl';
+
+import {diff_match_patch} from 'diff-match-patch';
+import {getInstalledRNVersion} from '../PackageUtils';
+
+const WIN_PLATFORM_EXT = /\.win32|\.windows|\.windesktop/;
+
+(async () => {
+  const ovrPath = process.argv[2];
+  if (!ovrPath) {
+    throw new Error('Expected ovrPath to be provided');
+  }
+
+  const spinner = ora();
+  spinner.start('Creating manifest');
+
+  const version = await getInstalledRNVersion(ovrPath);
+  const [overrides, reactSources] = await getFileRepos(ovrPath, version);
+  const manifest: Manifest.Manifest = {overrides: []};
+  const overrideFiles = await overrides.listFiles();
+
+  let i = 0;
+  for (const file of overrideFiles) {
+    spinner.text = `Creating manifest (${++i}/${overrideFiles.length})`;
+
+    const contents = await overrides.getFileContents(file);
+    (await tryAddPatch(file, version, contents, reactSources, manifest)) ||
+      (await tryAddDerived(file, version, contents, reactSources, manifest)) ||
+      addUnknown(file, version, manifest);
+  }
+
+  const ovrFile = path.join(ovrPath, 'overrides.json');
+  await Manifest.writeToFile(manifest as Manifest.Manifest, ovrFile);
+
+  spinner.succeed();
+})();
+
+async function tryAddPatch(
+  filename: string,
+  rnVersion: string,
+  override: string,
+  reactSources: FileRepository.ReactFileRepository,
+  manifest: Manifest.Manifest,
+): Promise<boolean> {
+  const baseFile = filename.replace(WIN_PLATFORM_EXT, '');
+  const baseContents = await reactSources.getFileContents(baseFile);
+
+  if (!baseContents) {
+    return false;
+  }
+
+  const {similar} = computeSimilarity(override, baseContents);
+  if (similar) {
+    manifest.overrides.push({
+      type: 'patch',
+      file: filename,
+      baseFile: baseFile,
+      baseVersion: rnVersion,
+      baseHash: Manifest.hashContent(baseContents),
+      issue: 'LEGACY_FIXME',
+    });
+  } else {
+    addUnknown(filename, rnVersion, manifest);
+  }
+
+  return true;
+}
+
+async function tryAddDerived(
+  filename: string,
+  rnVersion: string,
+  override: string,
+  reactSources: FileRepository.ReactFileRepository,
+  manifest: Manifest.Manifest,
+): Promise<boolean> {
+  const matches: Array<{file: string; contents: string; dist: number}> = [];
+
+  const droidFile = filename.replace(WIN_PLATFORM_EXT, '.android');
+  const droidContents = await reactSources.getFileContents(droidFile);
+  const droidSim = droidContents && computeSimilarity(override, droidContents);
+  if (droidSim && droidSim.similar) {
+    matches.push({
+      file: droidFile,
+      contents: droidContents,
+      dist: droidSim.editDistance,
+    });
+  }
+
+  const iosFile = filename.replace(WIN_PLATFORM_EXT, '.ios');
+  const iosContents = await reactSources.getFileContents(iosFile);
+  const iosSim = iosContents && computeSimilarity(override, iosContents);
+  if (iosSim && iosSim.similar) {
+    matches.push({
+      file: iosFile,
+      contents: iosContents,
+      dist: iosSim.editDistance,
+    });
+  }
+
+  if (matches.length === 0) {
+    return false;
+  }
+
+  const bestMatch = matches.reduce((a, b) => (a.dist < b.dist ? a : b));
+  manifest.overrides.push({
+    type: 'derived',
+    file: filename,
+    baseFile: bestMatch.file,
+    baseVersion: rnVersion,
+    baseHash: Manifest.hashContent(bestMatch.contents),
+    issue: 'LEGACY_FIXME',
+  });
+
+  return true;
+}
+
+function addUnknown(
+  filename: string,
+  rnVersion: string,
+  manifest: Manifest.Manifest,
+) {
+  (manifest.overrides as Array<any>).push({
+    type: '???',
+    file: filename,
+    baseFile: '???',
+    baseVersion: rnVersion,
+    baseHash: '???',
+    issue: 'LEGACY_FIXME',
+  });
+}
+
+async function getFileRepos(
+  overrideovrPath: string,
+  rnVersion: string,
+): Promise<
+  [FileRepository.OverrideFileRepository, FileRepository.ReactFileRepository]
+> {
+  const ovrPattern = /^.*\.(js|ts|jsx|tsx)$/;
+  const overrides = new OverrideFileRepositoryImpl(overrideovrPath, ovrPattern);
+
+  const versionedReactSources = await GitReactFileRepository.createAndInit();
+  const reactSources = FileRepository.bindVersion(
+    versionedReactSources,
+    rnVersion,
+  );
+
+  return [overrides, reactSources];
+}
+
+function computeSimilarity(
+  override: string,
+  source: string,
+): {similar: boolean; editDistance: number} {
+  override = stripCopyrightHeaders(override);
+  source = stripCopyrightHeaders(source);
+
+  const differ = new diff_match_patch();
+  const diffs = differ.diff_main(source, override);
+
+  const editDistance = differ.diff_levenshtein(diffs);
+  const similar = editDistance / Math.max(override.length, source.length) < 0.8;
+  return {similar, editDistance};
+}
+
+function stripCopyrightHeaders(str: string) : string {
+  if (!str.startsWith('/*')) {
+    return str;
+  }
+
+  const headerEnd = str.indexOf('*/') + 1;
+  return str.slice(headerEnd);
+}

--- a/packages/react-native-win32/src/overrides.json
+++ b/packages/react-native-win32/src/overrides.json
@@ -1,0 +1,796 @@
+{
+  "overrides": [
+    {
+      "type": "???",
+      "file": "index.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Alert\\Alert.win32.js",
+      "baseFile": "Libraries\\Alert\\Alert.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "dd77ba5b6da36da0aea70e638bf6bc2f88e4d073",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Animated\\src\\nodes\\AnimatedInterpolation.win32.js",
+      "baseFile": "Libraries\\Animated\\src\\nodes\\AnimatedInterpolation.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "833b32ae88fecb57858d3dc025fcabaa8f3cbb54",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Color\\NativeOrDynamicColorType.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Color\\normalizeColor.win32.js",
+      "baseFile": "Libraries\\Color\\normalizeColor.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "4bc82a7b34323bd68fe74e78effb762267d784d1",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Color\\normalizeColorObject.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.win32.js",
+      "baseFile": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "d095ab7eaf3fd9fab83187d226905ae90742bccc",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\AccessibilityInfo\\NativeAccessibilityInfo.win32.js",
+      "baseFile": "Libraries\\Components\\AccessibilityInfo\\NativeAccessibilityInfo.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "92c59d658858c52fb82d708a9cc94e9597f5c36c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Button\\ButtonWin32.Props.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Button\\ButtonWin32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\CheckBox\\CheckBox.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePicker\\DatePickerIOS.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\EnterString.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\MaskedView\\MaskedViewIOS.win32.js",
+      "baseFile": "Libraries\\Components\\MaskedView\\MaskedViewIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "2b46c2ecc8e3cfe8f40f119b628cee2f8fd2d441",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\Picker.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\PickerAndroid.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\PickerIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\SafeAreaView\\SafeAreaView.win32.js",
+      "baseFile": "Libraries\\Components\\SafeAreaView\\SafeAreaView.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "800022db8bf078f907dcd5ce8de2460e2d54d02f",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ScrollView\\RecyclerViewBackedScrollView.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\StatusBar\\StatusBar.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\StatusBar\\StatusBarIOS.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Text\\TextWin32.Props.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Text\\TextWin32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TextInput\\Tests\\TextInputTest.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TextInput\\TextInput.Types.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TextInput\\TextInput.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\TextInput\\TextInputState.win32.js",
+      "baseFile": "Libraries\\Components\\TextInput\\TextInputState.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "f55224fb7c1402127cdce024d02b62377988b4f6",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TimePickerAndroid\\TimePickerAndroid.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ToastAndroid\\ToastAndroid.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\Tests\\TouchableWin32Test.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableNativeFeedback.Props.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableNativeFeedback.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableWin32.Props.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableWin32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableWin32.Types.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\ActivityIndicatorIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\IntentAndroid.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\NavigationHeaderBackButton.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\NavigatorBreadcrumbNavigationBarStyles.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\NavigatorIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\SliderIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\SnapshotViewIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\SwitchAndroid.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\SwitchIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\TabBarIOS.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\ToolbarAndroid.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\UnimplementedViews.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\VibrationIOS.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\UnimplementedStubs\\ViewPagerAndroid.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\View\\PlatformViewPropTypes.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\View\\ReactNativeViewAttributes.win32.js",
+      "baseFile": "Libraries\\Components\\View\\ReactNativeViewAttributes.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "2d767736cb8411f3a7f55624e4407cb428e6ee27",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\View\\ReactNativeViewViewConfig.win32.js",
+      "baseFile": "Libraries\\Components\\View\\ReactNativeViewViewConfig.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "37075ba2b670098da40a2a6450c4f7e0b436428d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\View\\Tests\\ViewWin32Test.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\View\\ViewWin32.Props.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\View\\ViewWin32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\core\\ReactNativeVersionCheck.win32.js",
+      "baseFile": "Libraries\\core\\ReactNativeVersionCheck.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "b9e2bca9fae696f7b62b8a44305a97c7b537a960",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\core\\setUpDeveloperTools.win32.js",
+      "baseFile": "Libraries\\core\\setUpDeveloperTools.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "8a250151f5616ab454d9799f6d3e747916f31520",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Image\\Image.win32.js",
+      "baseFile": "Libraries\\Image\\Image.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "96c015ca1381817447cc98f72319ac89b30651b1",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Image\\ImageTypes.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Image\\resolveAssetSource.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Image\\Tests\\ImageWin32Test.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Inspector\\Inspector.win32.js",
+      "baseFile": "Libraries\\Inspector\\Inspector.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "9b1e79a244568f46c9dd54c50ef607c94957e364",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Inspector\\InspectorOverlay.win32.js",
+      "baseFile": "Libraries\\Inspector\\InspectorOverlay.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "a8cb0b3e6bd7334214a37db8bb1bb91510a5e838",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Network\\Network.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Network\\RCTNetworking.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\PersonaCoin\\PersonaCoin.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\PersonaCoin\\PersonaCoinPropTypes.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\PersonaCoin\\PersonaCoinTypes.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\react-native\\react-native-implementation.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\react-native\\typings-main.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\ReactNative\\getNativeComponentAttributes.win32.js",
+      "baseFile": "Libraries\\ReactNative\\getNativeComponentAttributes.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "2de5175e2d006f6d36fca098d3e47cbcc7e05c25",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Settings\\Settings.win32.js",
+      "baseFile": "Libraries\\Settings\\Settings.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\StyleSheet\\processColor.win32.js",
+      "baseFile": "Libraries\\StyleSheet\\processColor.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "9efad52529662cc8601b94d30c27fe8fe285255e",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\StyleSheet\\processColorArray.win32.js",
+      "baseFile": "Libraries\\StyleSheet\\processColorArray.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "66b19d011a777ed38e5513eda9da2d61c9045595",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\StyleSheet\\processColorObject.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\StyleSheet\\StyleSheet.win32.js",
+      "baseFile": "Libraries\\StyleSheet\\StyleSheet.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "cd76d00373696522aa0088b2ce57bbd686e09e3d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\BackAndroid.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\BackHandler.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\DeviceInfo.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\Dimensions.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\HMRLoadingView.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\NativePlatformConstantsWin.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Utilities\\Platform.win32.js",
+      "baseFile": "Libraries\\Utilities\\Platform.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "725d90afef2dc0acc032f9c9f9b9dfc18a40d71d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\YellowBox\\UI\\YellowBoxInspectorHeader.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\YellowBox\\UI\\YellowBoxInspectorSourceMapStatus.win32.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\YellowBox\\UI\\YellowBoxList.win32.js",
+      "baseFile": "Libraries\\YellowBox\\UI\\YellowBoxList.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "8093d13818e1c1e0dec5b6fb46b89d9152053d3c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\APIExamples\\AccessibilityExampleWin32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\APIExamples\\ThemingModuleAPI.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\AsyncStorageStub.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "RNTester\\js\\components\\ListExampleShared.win32.js",
+      "baseFile": "RNTester\\js\\components\\ListExampleShared.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "200941a9f13b28f395f5a7569759278d4b41ac3c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "RNTester\\js\\components\\RNTesterExampleFilter.win32.js",
+      "baseFile": "RNTester\\js\\components\\RNTesterExampleFilter.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "cc1dccf3c246a12281a627e2a21025af88c46db8",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\RNTesterApp.win32.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\utils\\RNTesterList.win32.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    }
+  ]
+}

--- a/vnext/src/overrides.json
+++ b/vnext/src/overrides.json
@@ -1,0 +1,1316 @@
+{
+  "overrides": [
+    {
+      "type": "patch",
+      "file": "IntegrationTests\\AsyncStorageTest.windesktop.js",
+      "baseFile": "IntegrationTests\\AsyncStorageTest.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "d37101fcfa67d62a95b2c66a32bb3e820d983ebe",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "IntegrationTests\\DummyTest.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "IntegrationTests\\IntegrationTestsApp.windesktop.js",
+      "baseFile": "IntegrationTests\\IntegrationTestsApp.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "5c059df1be2af6446556a3ed9afc558b9b85eadc",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "IntegrationTests\\LoggingTest.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "IntegrationTests\\XHRTest.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "jest\\hasteImpl.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Alert\\Alert.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Alert\\Alert.windows.js",
+      "baseFile": "Libraries\\Alert\\Alert.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "dd77ba5b6da36da0aea70e638bf6bc2f88e4d073",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Animated\\src\\nodes\\AnimatedInterpolation.windows.js",
+      "baseFile": "Libraries\\Animated\\src\\nodes\\AnimatedInterpolation.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "833b32ae88fecb57858d3dc025fcabaa8f3cbb54",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\AppTheme\\AppTheme.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\AppTheme\\AppTheme.windows.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\AppTheme\\AppThemeTypes.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Color\\NativeOrDynamicColorType.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Color\\normalizeColor.windows.js",
+      "baseFile": "Libraries\\Color\\normalizeColor.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "4bc82a7b34323bd68fe74e78effb762267d784d1",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Color\\normalizeColorObject.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Color\\normalizeColorObject.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.windesktop.js",
+      "baseFile": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "d095ab7eaf3fd9fab83187d226905ae90742bccc",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.windows.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Button.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\Button.windows.js",
+      "baseFile": "Libraries\\Components\\Button.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "34851284106cfe8352b46caa77289367c336c756",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\CheckBox\\CheckBox.windesktop.js",
+      "baseFile": "Libraries\\Components\\CheckBox\\CheckBox.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e14e6a445ff26f0fb16b9f44c230bda53c440def",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\CheckBox\\CheckBox.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\CheckBox\\CheckBoxProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePicker\\DatePicker.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePicker\\DatePicker.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePicker\\DatePickerIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePicker\\DatePickerIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePicker\\DatePickerProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePickerMacOS\\DatePickerMacOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\DatePickerMacOS\\DatePickerMacOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.windesktop.js",
+      "baseFile": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.windows.js",
+      "baseFile": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Flyout\\Flyout.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Flyout\\Flyout.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Flyout\\FlyoutProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Glyph\\Glyph.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Glyph\\Glyph.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Glyph\\GlyphProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Keyboard\\KeyboardExt.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Keyboard\\KeyboardExt.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Keyboard\\KeyboardExtProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\MaskedView\\MaskedViewIOS.windesktop.js",
+      "baseFile": "Libraries\\Components\\MaskedView\\MaskedViewIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "2b46c2ecc8e3cfe8f40f119b628cee2f8fd2d441",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\MaskedView\\MaskedViewIOS.windows.js",
+      "baseFile": "Libraries\\Components\\MaskedView\\MaskedViewIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "2b46c2ecc8e3cfe8f40f119b628cee2f8fd2d441",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Navigation\\NavigatorIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Navigation\\NavigatorIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\Picker.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\Picker\\PickerAndroid.windesktop.js",
+      "baseFile": "Libraries\\Components\\Picker\\PickerAndroid.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\Picker\\PickerAndroid.windows.js",
+      "baseFile": "Libraries\\Components\\Picker\\PickerAndroid.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\Picker\\PickerIOS.windesktop.js",
+      "baseFile": "Libraries\\Components\\Picker\\PickerIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "1fe21e833da3c9e426a6d3abb453e37c3671b0be",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\Picker\\PickerIOS.windows.js",
+      "baseFile": "Libraries\\Components\\Picker\\PickerIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "1fe21e833da3c9e426a6d3abb453e37c3671b0be",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\PickerProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\PickerWindows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Picker\\PickerWindows.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\Picker\\RCTPickerNativeComponent.windows.js",
+      "baseFile": "Libraries\\Components\\Picker\\RCTPickerNativeComponent.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "1f302709355a11ff1262f2b953c77938581cddb1",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Popup\\Popup.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Popup\\Popup.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Popup\\PopupProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.windesktop.js",
+      "baseFile": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.windows.js",
+      "baseFile": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\RefreshControl\\RefreshControl.windows.js",
+      "baseFile": "Libraries\\Components\\RefreshControl\\RefreshControl.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "35842dac1d284850cad925585d202f70bcfeb1fc",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\SafeAreaView\\SafeAreaView.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\SafeAreaView\\SafeAreaView.windows.js",
+      "baseFile": "Libraries\\Components\\SafeAreaView\\SafeAreaView.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "800022db8bf078f907dcd5ce8de2460e2d54d02f",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ScrollView\\ScrollView.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\ScrollView\\ScrollView.windows.js",
+      "baseFile": "Libraries\\Components\\ScrollView\\ScrollView.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "3946a93af82bb49e4a438b8b7d61536181ebdb9d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\StatusBar\\StatusBarIOS.windesktop.js",
+      "baseFile": "Libraries\\Components\\StatusBar\\StatusBarIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "aeeb1cb69ea1ea151ad037995cd9bf12fe4b93e3",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\StatusBar\\StatusBarIOS.windows.js",
+      "baseFile": "Libraries\\Components\\StatusBar\\StatusBarIOS.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "aeeb1cb69ea1ea151ad037995cd9bf12fe4b93e3",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Switch\\Switch.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\Switch\\SwitchNativeComponent.windows.js",
+      "baseFile": "Libraries\\Components\\Switch\\SwitchNativeComponent.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "12c5d2497568f3fa0eb487342de39aaac0e7e42e",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Switch\\SwitchProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TabBarIOS\\TabBarIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TabBarIOS\\TabBarIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TabBarIOS\\TabBarItemIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TabBarIOS\\TabBarItemIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TextInput\\TextInput.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\TextInput\\TextInput.windows.js",
+      "baseFile": "Libraries\\Components\\TextInput\\TextInput.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "53a59e839404c2f565cb47b00fee6b4541045d6c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\TextInput\\TextInputState.windows.js",
+      "baseFile": "Libraries\\Components\\TextInput\\TextInputState.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "f55224fb7c1402127cdce024d02b62377988b4f6",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TimePickerAndroid\\TimePickerAndroid.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\TimePickerAndroid\\TimePickerAndroid.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ToastAndroid\\ToastAndroid.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ToastAndroid\\ToastAndroid.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ToolbarAndroid\\ToolbarAndroid.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ToolbarAndroid\\ToolbarAndroid.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\Touchable\\TouchableHighlight.windows.js",
+      "baseFile": "Libraries\\Components\\Touchable\\TouchableHighlight.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "abdab04c325389eb9380feef0a35dfc5ba4ea64a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableNativeFeedback.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\Touchable\\TouchableNativeFeedback.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\Touchable\\TouchableOpacity.windows.js",
+      "baseFile": "Libraries\\Components\\Touchable\\TouchableOpacity.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "6d291945cff157c0418793efac2e8adb5deaa90c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\Touchable\\TouchableWithoutFeedback.windows.js",
+      "baseFile": "Libraries\\Components\\Touchable\\TouchableWithoutFeedback.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "869bbbbdae6aade61594671504096d90a1ed303c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\View\\PlatformViewPropTypes.windesktop.js",
+      "baseFile": "Libraries\\Components\\View\\PlatformViewPropTypes.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "215c4c06a2850cc475e4803e521f7394a48fb86f",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Components\\View\\PlatformViewPropTypes.windows.js",
+      "baseFile": "Libraries\\Components\\View\\PlatformViewPropTypes.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "215c4c06a2850cc475e4803e521f7394a48fb86f",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\View\\ReactNativeViewViewConfig.windows.js",
+      "baseFile": "Libraries\\Components\\View\\ReactNativeViewViewConfig.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "37075ba2b670098da40a2a6450c4f7e0b436428d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\View\\ViewAccessibility.windows.js",
+      "baseFile": "Libraries\\Components\\View\\ViewAccessibility.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "40af15708bbf06eceba820ff7fbf1141f8d9a86b",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Components\\View\\ViewPropTypes.windows.js",
+      "baseFile": "Libraries\\Components\\View\\ViewPropTypes.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "fcafff8a18b3bdda10c8554be930f03fcac08072",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\View\\ViewWindows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\View\\ViewWindowsProps.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ViewPager\\ViewPagerAndroid.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\ViewPager\\ViewPagerAndroid.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\WebView\\WebView.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Components\\WebView\\WebView.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\core\\setUpDeveloperTools.windesktop.js",
+      "baseFile": "Libraries\\core\\setUpDeveloperTools.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "8a250151f5616ab454d9799f6d3e747916f31520",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\core\\setUpDeveloperTools.windows.js",
+      "baseFile": "Libraries\\core\\setUpDeveloperTools.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "8a250151f5616ab454d9799f6d3e747916f31520",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\DeprecatedPropTypes\\DeprecatedViewAccessibility.windows.js",
+      "baseFile": "Libraries\\DeprecatedPropTypes\\DeprecatedViewAccessibility.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "352313596826cb18d54719c8bad7f71a28336bfc",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Image\\Image.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Image\\Image.windows.js",
+      "baseFile": "Libraries\\Image\\Image.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "96c015ca1381817447cc98f72319ac89b30651b1",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Inspector\\Inspector.windesktop.js",
+      "baseFile": "Libraries\\Inspector\\Inspector.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "9b1e79a244568f46c9dd54c50ef607c94957e364",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Inspector\\InspectorOverlay.windesktop.js",
+      "baseFile": "Libraries\\Inspector\\InspectorOverlay.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "a8cb0b3e6bd7334214a37db8bb1bb91510a5e838",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Lists\\VirtualizedList.windows.js",
+      "baseFile": "Libraries\\Lists\\VirtualizedList.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "15e28aa49e648fe89de850316201eb77b92b0200",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Network\\RCTNetworking.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Network\\RCTNetworking.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Network\\RCTNetworkingWinShared.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\NewAppScreen\\components\\DebugInstructions.windows.js",
+      "baseFile": "Libraries\\NewAppScreen\\components\\DebugInstructions.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "531d94f3ac637cbb16f139db8f7e70e10d90af54",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\NewAppScreen\\components\\ReloadInstructions.windows.js",
+      "baseFile": "Libraries\\NewAppScreen\\components\\ReloadInstructions.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "15c20c06f08da16817151e84123a5c0517273423",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\RCTTest\\SnapshotViewIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\RCTTest\\SnapshotViewIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\react-native\\react-native-implementation.windows.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\react-native\\typings-index.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Settings\\Settings.windesktop.js",
+      "baseFile": "Libraries\\Settings\\Settings.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Settings\\Settings.windows.js",
+      "baseFile": "Libraries\\Settings\\Settings.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\StyleSheet\\processColor.windows.js",
+      "baseFile": "Libraries\\StyleSheet\\processColor.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "9efad52529662cc8601b94d30c27fe8fe285255e",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\StyleSheet\\processColorArray.windows.js",
+      "baseFile": "Libraries\\StyleSheet\\processColorArray.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "66b19d011a777ed38e5513eda9da2d61c9045595",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\StyleSheet\\processColorObject.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\StyleSheet\\processColorObject.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\StyleSheet\\StyleSheetTypes.windows.js",
+      "baseFile": "Libraries\\StyleSheet\\StyleSheetTypes.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "d20e4c88ff912a97918bc47d2b6240b1735f6f4a",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "Libraries\\Types\\CoreEventTypes.js",
+      "baseFile": "Libraries\\Types\\CoreEventTypes.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "96ab4d3761db860dc6ea2f9584bbaee6f73bad1d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Utilities\\BackHandler.windesktop.js",
+      "baseFile": "Libraries\\Utilities\\BackHandler.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "bd2c891ca871c9385b63e0e6e26004f25ca98652",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Utilities\\BackHandler.windows.js",
+      "baseFile": "Libraries\\Utilities\\BackHandler.ios.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "bd2c891ca871c9385b63e0e6e26004f25ca98652",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\HMRLoadingView.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\HMRLoadingView.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Utilities\\NativePlatformConstantsWin.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Utilities\\Platform.windesktop.js",
+      "baseFile": "Libraries\\Utilities\\Platform.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "725d90afef2dc0acc032f9c9f9b9dfc18a40d71d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "derived",
+      "file": "Libraries\\Utilities\\Platform.windows.js",
+      "baseFile": "Libraries\\Utilities\\Platform.android.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "725d90afef2dc0acc032f9c9f9b9dfc18a40d71d",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Vibration\\VibrationIOS.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\Vibration\\VibrationIOS.windows.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\YellowBox\\UI\\YellowBoxInspectorHeader.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\YellowBox\\UI\\YellowBoxInspectorSourceMapStatus.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "Libraries\\YellowBox\\UI\\YellowBoxList.windesktop.js",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "RNTester\\js\\components\\ListExampleShared.windows.js",
+      "baseFile": "RNTester\\js\\components\\ListExampleShared.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "200941a9f13b28f395f5a7569759278d4b41ac3c",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "RNTester\\js\\components\\RNTesterExampleList.windows.js",
+      "baseFile": "RNTester\\js\\components\\RNTesterExampleList.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "d9b4912cb42b5709362ea8d4e3974641b56e60a8",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Accessibility\\AccessibilityExampleWindows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\CustomView\\CustomViewExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\DatePicker\\DatePickerExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\FastText\\FastTextExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Flyout\\FlyoutExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Glyph\\GlyphExample.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Keyboard\\KeyboardExample.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Keyboard\\KeyboardExtensionExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Keyboard\\KeyboardFocusExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Picker\\PickerWindowsExample.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Popup\\PopupExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Text\\TextExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\TextInput\\TextInputExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\Theming\\ThemingExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\TransferProperties\\TransferPropertiesExample.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\examples-win\\WindowsBrush\\WindowsBrushExample.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "RNTester\\js\\examples\\ScrollView\\ScrollViewExample.windows.js",
+      "baseFile": "RNTester\\js\\examples\\ScrollView\\ScrollViewExample.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "fcf88b82e07ee3eea31011f713dba9760ea16ed7",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "RNTester\\js\\examples\\View\\ViewExample.windows.js",
+      "baseFile": "RNTester\\js\\examples\\View\\ViewExample.js",
+      "baseVersion": "0.61.5",
+      "baseHash": "2883fb236a49da83cb59fb6871a11665779036e0",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\RNTesterApp.windows.tsx",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "???",
+      "file": "RNTester\\js\\utils\\RNTesterList.windows.ts",
+      "baseFile": "???",
+      "baseVersion": "0.61.5",
+      "baseHash": "???",
+      "issue": "LEGACY_FIXME"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,6 +2670,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/diff-match-patch@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.32.tgz#d9c3b8c914aa8229485351db4865328337a3d09f"
+  integrity sha512-bPYT5ECFiblzsVzyURaNhljBH2Gh1t9LowgUwciMrNAhFewLkHT2H0Mto07Y4/3KCOGZHRQll3CTtQZ0X11D/A==
+
 "@types/es6-collections@^0.5.29":
   version "0.5.31"
   resolved "https://registry.yarnpkg.com/@types/es6-collections/-/es6-collections-0.5.31.tgz#faad21c930cd0ea7f71f51b9e5b555796c5ab23f"
@@ -2977,22 +2982,10 @@
     loglevel-plugin-prefix "^0.8.4"
     strip-ansi "^5.2.0"
 
-"@wdio/protocols@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-5.13.2.tgz#06718f8d8a173a8756e2147d7b7c6d8163f3b43a"
-  integrity sha512-R6QJaa8gSew50LWrGcy/kO01xzDx4fpSoX25GYvLc/Q7gEYyDwdfiB7vIPWnKR7pHjBujNDt100ACSA3Aen/gw==
-
 "@wdio/protocols@5.14.0":
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-5.14.0.tgz#9007b67d14f4bcebd2b9097f611d4a558024c308"
   integrity sha512-7jRxGkreibkqHKQV5jlQmAyqzIIU43lg9KSNGy0ThrUz8kLsOzClaTdL2qDlFUkLcplqMvRFcnmwFPjvCptmVg==
-
-"@wdio/repl@5.13.2", "@wdio/repl@^5.9.4":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-5.13.2.tgz#6a7a56ff231c4dd926c26c4bfc1cddc0e90b74ce"
-  integrity sha512-mNGj+UcodJTQa4Ecb30iItdcRHrB7GhC+DT0+/J/cO2MQPIf3ZlcpsBGTXZL8ZHcpOUYm0nLt2vKchdRPGVRtw==
-  dependencies:
-    "@wdio/config" "5.13.2"
 
 "@wdio/repl@5.14.4":
   version "5.14.4"
@@ -3000,6 +2993,13 @@
   integrity sha512-AF24ExIyd1lvqo/K1wHxzTzJi4005kLDJePMDYoQi0lyprA6SbmzKiWJ2W6sf0CO9QNzRKdsBxBgkuGC2wiCwQ==
   dependencies:
     "@wdio/utils" "5.14.4"
+
+"@wdio/repl@^5.9.4":
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-5.13.2.tgz#6a7a56ff231c4dd926c26c4bfc1cddc0e90b74ce"
+  integrity sha512-mNGj+UcodJTQa4Ecb30iItdcRHrB7GhC+DT0+/J/cO2MQPIf3ZlcpsBGTXZL8ZHcpOUYm0nLt2vKchdRPGVRtw==
+  dependencies:
+    "@wdio/config" "5.13.2"
 
 "@wdio/reporter@^5.11.7", "@wdio/reporter@^5.12.1":
   version "5.14.5"
@@ -3029,18 +3029,18 @@
     "@wdio/logger" "^5.9.3"
     fibers "^4.0.0"
 
-"@wdio/utils@5.13.2", "@wdio/utils@^5.9.3":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-5.13.2.tgz#2e56b5488521e394bce02de9b4236f21d1d582eb"
-  integrity sha512-DGwoZZKpGo6BkLOIXnBHu+9mg0RABq0Sh9cb1GLOAeBeIEW7efCDYqT9+rczEJSgHKnKJra1+T8I4IfoxyUX/w==
-  dependencies:
-    "@wdio/logger" "5.13.2"
-    deepmerge "^4.0.0"
-
 "@wdio/utils@5.14.4":
   version "5.14.4"
   resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-5.14.4.tgz#3ee571fefcba547d132b2b120403a7fd793b84b9"
   integrity sha512-sRBCR20VpDxcB0bvU6Sg4dco7PehPVul7JOK+abn5Tk/Azau0C/JypAh7abRnTil5udiz+NTWQyE9A/vrcXs0Q==
+  dependencies:
+    "@wdio/logger" "5.13.2"
+    deepmerge "^4.0.0"
+
+"@wdio/utils@^5.9.3":
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-5.13.2.tgz#2e56b5488521e394bce02de9b4236f21d1d582eb"
+  integrity sha512-DGwoZZKpGo6BkLOIXnBHu+9mg0RABq0Sh9cb1GLOAeBeIEW7efCDYqT9+rczEJSgHKnKJra1+T8I4IfoxyUX/w==
   dependencies:
     "@wdio/logger" "5.13.2"
     deepmerge "^4.0.0"
@@ -3980,7 +3980,7 @@ array-ify@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
-array-includes@^3.0.3, array-includes@^3.1.1:
+array-includes@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
   integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
@@ -5795,7 +5795,7 @@ diagnostics@^1.1.1:
     enabled "1.0.x"
     kuler "1.0.x"
 
-diff-match-patch@1.0.4:
+diff-match-patch@1.0.4, diff-match-patch@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.4.tgz#6ac4b55237463761c4daf0dc603eb869124744b1"
   integrity sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==
@@ -6134,21 +6134,18 @@ eslint-plugin-react-native@3.6.0:
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 
-eslint-plugin-react@7.12.4, eslint-plugin-react@^7.14.1:
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz#8be671b7f6be095098e79d27ac32f9580f599bc8"
-  integrity sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==
+eslint-plugin-react@7.12.4:
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
+  integrity sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==
   dependencies:
-    array-includes "^3.1.1"
+    array-includes "^3.0.3"
     doctrine "^2.1.0"
     has "^1.0.3"
-    jsx-ast-utils "^2.2.3"
-    object.entries "^1.1.1"
-    object.fromentries "^2.0.2"
-    object.values "^1.1.1"
-    prop-types "^15.7.2"
-    resolve "^1.14.2"
-    string.prototype.matchall "^4.0.2"
+    jsx-ast-utils "^2.0.1"
+    object.fromentries "^2.0.0"
+    prop-types "^15.6.2"
+    resolve "^1.9.0"
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -7579,15 +7576,6 @@ inquirer@^6.2.0, inquirer@^6.2.1:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-internal-slot@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.2.tgz#9c2e9fb3cd8e5e4256c6f45fe310067fcfa378a3"
-  integrity sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==
-  dependencies:
-    es-abstract "^1.17.0-next.1"
-    has "^1.0.3"
-    side-channel "^1.0.2"
-
 interpret@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
@@ -8608,7 +8596,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.2.3:
+jsx-ast-utils@^2.0.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
   integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
@@ -10324,17 +10312,7 @@ object.defaults@^1.0.0:
     for-own "^1.0.0"
     isobject "^3.0.0"
 
-object.entries@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
-  integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-
-object.fromentries@^2.0.2:
+object.fromentries@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.2.tgz#4a09c9b9bb3843dd0f89acdb517a794d4f355ac9"
   integrity sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==
@@ -10366,16 +10344,6 @@ object.reduce@^1.0.0:
   dependencies:
     for-own "^1.0.0"
     make-iterator "^1.0.0"
-
-object.values@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
-  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
 
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"
@@ -11561,7 +11529,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
+regexp.prototype.flags@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
   integrity sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==
@@ -11746,7 +11714,7 @@ resolve@1.8.1:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -12185,14 +12153,6 @@ shimmer@^1.1.0, shimmer@^1.2.0:
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
-side-channel@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"
-  integrity sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==
-  dependencies:
-    es-abstract "^1.17.0-next.1"
-    object-inspect "^1.7.0"
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -12559,18 +12519,6 @@ string.prototype.matchall@^2.0.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     regexp.prototype.flags "^1.2.0"
-
-string.prototype.matchall@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
-  integrity sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0"
-    has-symbols "^1.0.1"
-    internal-slot "^1.0.2"
-    regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.2"
 
 string.prototype.trim@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
Add partially complete override manifests for RNW and react-native-win32. These were generated using a tool to determine the simple cases of patching or derived files. This is incomplete and will require some manual fixup.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4203)