### PR TITLE
TextBox should have a default tabIndex of 0

### DIFF
--- a/change/react-native-windows-2020-02-27-11-28-17-textinput.tabindex.json
+++ b/change/react-native-windows-2020-02-27-11-28-17-textinput.tabindex.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "TextBox should have a default tabIndex of 0",
+  "packageName": "react-native-windows",
+  "email": "lamdoan@microsoft.com",
+  "commit": "4fa31c345c0d2e29af34a9357272d26d7b0a8603",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T19:28:17.048Z"
+}

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -594,6 +594,7 @@ facebook::react::ShadowNode *TextInputViewManager::createShadow() const {
 
 XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/) {
   winrt::TextBox textBox;
+  textBox.TabIndex(0);
   return textBox;
 }
 


### PR DESCRIPTION
Currently all TextInputs get tab focus last so we should to set the default tabIndex to 0.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4204)