### PR TITLE
Add descriptions to dev menu items

### DIFF
--- a/change/react-native-windows-2020-02-29-07-53-40-nicedevmenu.json
+++ b/change/react-native-windows-2020-02-29-07-53-40-nicedevmenu.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Add descriptions to dev menu items",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "180a91ab0603a7e7faf29186c265efd7483cf850",
+  "dependentChangeType": "patch",
+  "date": "2020-02-29T15:53:40.827Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -440,33 +440,90 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
         L"<Grid Background='{ThemeResource ContentDialogDimmingThemeBrush}'"
         L"  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
         L"  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+        L"  <Grid.Resources>"
+        L"    <StaticResource x:Key='ButtonRevealBackground' ResourceKey='AppBarButtonRevealBackground' />"
+        L"    <StaticResource x:Key='ButtonRevealBackgroundPointerOver' ResourceKey='AppBarButtonRevealBackgroundPointerOver' />"
+        L"    <StaticResource x:Key='ButtonRevealBackgroundPressed' ResourceKey='AppBarButtonRevealBackgroundPressed' />"
+        L"    <StaticResource x:Key='ButtonRevealBackgroundDisabled' ResourceKey='AppBarButtonRevealBackgroundDisabled' />"
+        L"    <StaticResource x:Key='ButtonForeground' ResourceKey='AppBarButtonForeground' />"
+        L"    <StaticResource x:Key='ButtonForegroundPointerOver' ResourceKey='AppBarButtonForegroundPointerOver' />"
+        L"    <StaticResource x:Key='ButtonForegroundPressed' ResourceKey='AppBarButtonForegroundPressed' />"
+        L"    <StaticResource x:Key='ButtonForegroundDisabled' ResourceKey='AppBarButtonForegroundDisabled' />"
+        L"    <StaticResource x:Key='ButtonRevealBorderBrush' ResourceKey='AppBarButtonRevealBorderBrush' />"
+        L"    <StaticResource x:Key='ButtonRevealBorderBrushPointerOver' ResourceKey='AppBarButtonRevealBorderBrushPointerOver' />"
+        L"    <StaticResource x:Key='ButtonRevealBorderBrushPressed' ResourceKey='AppBarButtonRevealBorderBrushPressed' />"
+        L"    <StaticResource x:Key='ButtonRevealBorderBrushDisabled' ResourceKey='AppBarButtonRevealBorderBrushDisabled' />"
+        L"  </Grid.Resources>"
         L"  <Grid.Transitions>"
         L"    <TransitionCollection>"
         L"      <EntranceThemeTransition />"
         L"    </TransitionCollection>"
         L"  </Grid.Transitions>"
-        L"  <StackPanel HorizontalAlignment='Center'"
+        L"  <ScrollViewer"
         L"    VerticalAlignment='Center'"
+        L"    MaxWidth='900'"
+        L"    >"
+        L"  <StackPanel HorizontalAlignment='Center'"
         L"    Background='{ThemeResource ContentDialogBackground}'"
         L"    BorderBrush='{ThemeResource ContentDialogBorderBrush}'"
         L"    BorderThickness='{ThemeResource ContentDialogBorderWidth}'"
-        L"    Padding='{ThemeResource ContentDialogPadding}'"
+        L"    Padding='8'"
         L"    Spacing='4' >"
-        L"    <TextBlock Margin='0,0,0,10' FontSize='40'>Developer Menu</TextBlock>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='Reload'>Reload Javascript</Button>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='RemoteDebug'></Button>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='DirectDebug' ToolTipService.ToolTip='If using Chakra, this will allow Visual Studio to be attached directly to the application using \"Script Debugging\" to debug the JS running directly in this app.\nIf using V8/Hermes, this will enable standard JS debugging tools such as VSCode to attach to the application.'></Button>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='BreakOnNextLine' ToolTipService.ToolTip='If using V8/Hermes, the JS engine will break on the first statement, until you attach a debugger to it, and hit continue. (Requires Direct Debugging to be enabled)'></Button>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='LiveReload'></Button>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='Inspector'>Toggle Inspector</Button>"
-        L"    <Button HorizontalAlignment='Stretch' x:Name='Cancel'>Cancel</Button>"
+        L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='Reload' Style='{StaticResource ButtonRevealStyle}'>"
+        L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+        L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE72C;'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='0'>Reload Javascript</TextBlock>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>Restarts the JS instance. Any javascript state will be lost.</TextBlock>"
+        L"      </Grid>"
+        L"    </Button>"
+        L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='RemoteDebug' Style='{StaticResource ButtonRevealStyle}'>"
+        L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+        L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE8AF;'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='RemoteDebugText'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>When enabled runs the JS remotely in VSCode or Chrome based on what you attach to the packager.  This means that the JS may run with a different JS engine than it runs in on in the real application, in addition synchronous native module calls, and JSI native modules will not work.</TextBlock>"
+        L"      </Grid>"
+        L"    </Button>"
+        L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='DirectDebug' Style='{StaticResource ButtonRevealStyle}'>"
+        L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+        L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xEBE8;'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='DirectDebugText'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>If using Chakra, this will allow Visual Studio to be attached directly to the application using \"Script Debugging\" to debug the JS running directly in this app.\nIf using V8/Hermes, this will enable standard JS debugging tools such as VSCode to attach to the application.</TextBlock>"
+        L"      </Grid>"
+        L"    </Button>"
+        L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='BreakOnNextLine' Style='{StaticResource ButtonRevealStyle}'>"
+        L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+        L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE769;'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='BreakOnNextLineText'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>If using V8/Hermes, the JS engine will break on the first statement, until you attach a debugger to it, and hit continue. (Requires Direct Debugging to be enabled)</TextBlock>"
+        L"      </Grid>"
+        L"    </Button>"
+        L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='LiveReload' Style='{StaticResource ButtonRevealStyle}'>"
+        L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+        L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xEC58;'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='LiveReloadText'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>When loading a bundle from a bundler server that is watching files, this will cause the instance to be reloaded with new bundles when a file changes.</TextBlock>"
+        L"      </Grid>"
+        L"    </Button>"
+        L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='Inspector' Style='{StaticResource ButtonRevealStyle}'>"
+        L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+        L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE773;'/>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='InspectorText'>Toggle Inspector</TextBlock>"
+        L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>Will bring up an overlay that lets you tap on any UI element and see information about it</TextBlock>"
+        L"      </Grid>"
+        L"    </Button>"
+        L"    <Button HorizontalAlignment='Stretch' x:Name='Cancel' Style='{StaticResource ButtonRevealStyle}'>Cancel</Button>"
         L"  </StackPanel>"
+        L"  </ScrollViewer>"
         L"</Grid>";
     m_developerMenuRoot = winrt::unbox_value<winrt::Grid>(winrt::Markup::XamlReader::Load(xamlString));
-    auto reloadJSButton = m_developerMenuRoot.FindName(L"Reload").as<winrt::Button>();
+    auto remoteDebugJSText = m_developerMenuRoot.FindName(L"RemoteDebugText").as<winrt::TextBlock>();
     auto remoteDebugJSButton = m_developerMenuRoot.FindName(L"RemoteDebug").as<winrt::Button>();
+    auto reloadJSButton = m_developerMenuRoot.FindName(L"Reload").as<winrt::Button>();
+    auto directDebugText = m_developerMenuRoot.FindName(L"DirectDebugText").as<winrt::TextBlock>();
     auto directDebugButton = m_developerMenuRoot.FindName(L"DirectDebug").as<winrt::Button>();
+    auto breakOnNextLineText = m_developerMenuRoot.FindName(L"BreakOnNextLineText").as<winrt::TextBlock>();
     auto breakOnNextLineButton = m_developerMenuRoot.FindName(L"BreakOnNextLine").as<winrt::Button>();
+    auto liveReloadText = m_developerMenuRoot.FindName(L"LiveReloadText").as<winrt::TextBlock>();
     auto liveReloadButton = m_developerMenuRoot.FindName(L"LiveReload").as<winrt::Button>();
     auto toggleInspector = m_developerMenuRoot.FindName(L"Inspector").as<winrt::Button>();
     auto cancelButton = m_developerMenuRoot.FindName(L"Cancel").as<winrt::Button>();
@@ -477,8 +534,7 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
           ReloadHost();
         });
 
-    remoteDebugJSButton.Content(
-        winrt::box_value(m_useWebDebugger ? L"Disable Remote JS Debugging" : L"Enable Remote JS Debugging"));
+    remoteDebugJSText.Text(m_useWebDebugger ? L"Disable Remote JS Debugging" : L"Enable Remote JS Debugging");
     m_remoteDebugJSRevoker = remoteDebugJSButton.Click(
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
@@ -486,8 +542,7 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
           ReloadHost();
         });
 
-    directDebugButton.Content(
-        winrt::box_value(m_directDebugging ? L"Disable Direct Debugging" : L"Enable Direct Debugging"));
+    directDebugText.Text(m_directDebugging ? L"Disable Direct Debugging" : L"Enable Direct Debugging");
     m_directDebuggingRevoker = directDebugButton.Click(
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
@@ -495,8 +550,7 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
           ReloadHost();
         });
 
-    breakOnNextLineButton.Content(
-        winrt::box_value(m_breakOnNextLine ? L"Disable Break on First Line" : L"Enable Break on First Line"));
+    breakOnNextLineText.Text(m_breakOnNextLine ? L"Disable Break on First Line" : L"Enable Break on First Line");
     m_breakOnNextLineRevoker = directDebugButton.Click(
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
@@ -504,7 +558,7 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
           ReloadHost();
         });
 
-    liveReloadButton.Content(winrt::box_value(m_useLiveReload ? L"Disable Live Reload" : L"Enable Live Reload"));
+    liveReloadText.Text(m_useLiveReload ? L"Disable Live Reload" : L"Enable Live Reload");
     m_liveReloadRevoker = liveReloadButton.Click(
         winrt::auto_revoke, [this](auto & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -399,40 +399,96 @@ void ReactControl::ShowDeveloperMenu() {
       L"<Grid Background='{ThemeResource ContentDialogDimmingThemeBrush}'"
       L"  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
       L"  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+      L"  <Grid.Resources>"
+      L"    <StaticResource x:Key='ButtonRevealBackground' ResourceKey='AppBarButtonRevealBackground' />"
+      L"    <StaticResource x:Key='ButtonRevealBackgroundPointerOver' ResourceKey='AppBarButtonRevealBackgroundPointerOver' />"
+      L"    <StaticResource x:Key='ButtonRevealBackgroundPressed' ResourceKey='AppBarButtonRevealBackgroundPressed' />"
+      L"    <StaticResource x:Key='ButtonRevealBackgroundDisabled' ResourceKey='AppBarButtonRevealBackgroundDisabled' />"
+      L"    <StaticResource x:Key='ButtonForeground' ResourceKey='AppBarButtonForeground' />"
+      L"    <StaticResource x:Key='ButtonForegroundPointerOver' ResourceKey='AppBarButtonForegroundPointerOver' />"
+      L"    <StaticResource x:Key='ButtonForegroundPressed' ResourceKey='AppBarButtonForegroundPressed' />"
+      L"    <StaticResource x:Key='ButtonForegroundDisabled' ResourceKey='AppBarButtonForegroundDisabled' />"
+      L"    <StaticResource x:Key='ButtonRevealBorderBrush' ResourceKey='AppBarButtonRevealBorderBrush' />"
+      L"    <StaticResource x:Key='ButtonRevealBorderBrushPointerOver' ResourceKey='AppBarButtonRevealBorderBrushPointerOver' />"
+      L"    <StaticResource x:Key='ButtonRevealBorderBrushPressed' ResourceKey='AppBarButtonRevealBorderBrushPressed' />"
+      L"    <StaticResource x:Key='ButtonRevealBorderBrushDisabled' ResourceKey='AppBarButtonRevealBorderBrushDisabled' />"
+      L"  </Grid.Resources>"
       L"  <Grid.Transitions>"
       L"    <TransitionCollection>"
       L"      <EntranceThemeTransition />"
       L"    </TransitionCollection>"
       L"  </Grid.Transitions>"
-      L"  <StackPanel HorizontalAlignment='Center'"
+      L"  <ScrollViewer"
       L"    VerticalAlignment='Center'"
+      L"    MaxWidth='900'"
+      L"    >"
+      L"  <StackPanel HorizontalAlignment='Center'"
       L"    Background='{ThemeResource ContentDialogBackground}'"
       L"    BorderBrush='{ThemeResource ContentDialogBorderBrush}'"
       L"    BorderThickness='{ThemeResource ContentDialogBorderWidth}'"
-      L"    Padding='{ThemeResource ContentDialogPadding}'"
+      L"    Padding='8'"
       L"    Spacing='4' >"
-      L"    <TextBlock Margin='0,0,0,10' FontSize='40'>Developer Menu</TextBlock>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='Reload'>Reload Javascript</Button>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='RemoteDebug'></Button>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='DirectDebug' ToolTipService.ToolTip='If using Chakra, this will allow Visual Studio to be attached directly to the application using \"Script Debugging\" to debug the JS running directly in this app.\nIf using V8/Hermes, this will enable standard JS debugging tools such as VSCode to attach to the application.'></Button>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='BreakOnNextLine' ToolTipService.ToolTip='If using V8/Hermes, the JS engine will break on the first statement, until you attach a debugger to it, and hit continue. (Requires Direct Debugging to be enabled)'></Button>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='LiveReload'></Button>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='Inspector'>Toggle Inspector</Button>"
-      L"    <Button HorizontalAlignment='Stretch' x:Name='Cancel'>Cancel</Button>"
+      L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='Reload' Style='{StaticResource ButtonRevealStyle}'>"
+      L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+      L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE72C;'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='0'>Reload Javascript</TextBlock>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>Restarts the JS instance. Any javascript state will be lost.</TextBlock>"
+      L"      </Grid>"
+      L"    </Button>"
+      L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='RemoteDebug' Style='{StaticResource ButtonRevealStyle}'>"
+      L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+      L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE8AF;'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='RemoteDebugText'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>When enabled runs the JS remotely in VSCode or Chrome based on what you attach to the packager.  This means that the JS may run with a different JS engine than it runs in on in the real application, in addition synchronous native module calls, and JSI native modules will not work.</TextBlock>"
+      L"      </Grid>"
+      L"    </Button>"
+      L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='DirectDebug' Style='{StaticResource ButtonRevealStyle}'>"
+      L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+      L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xEBE8;'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='DirectDebugText'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>If using Chakra, this will allow Visual Studio to be attached directly to the application using \"Script Debugging\" to debug the JS running directly in this app.\nIf using V8/Hermes, this will enable standard JS debugging tools such as VSCode to attach to the application.</TextBlock>"
+      L"      </Grid>"
+      L"    </Button>"
+      L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='BreakOnNextLine' Style='{StaticResource ButtonRevealStyle}'>"
+      L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+      L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE769;'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='BreakOnNextLineText'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>If using V8/Hermes, the JS engine will break on the first statement, until you attach a debugger to it, and hit continue. (Requires Direct Debugging to be enabled)</TextBlock>"
+      L"      </Grid>"
+      L"    </Button>"
+      L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='LiveReload' Style='{StaticResource ButtonRevealStyle}'>"
+      L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+      L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xEC58;'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='LiveReloadText'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>When loading a bundle from a bundler server that is watching files, this will cause the instance to be reloaded with new bundles when a file changes.</TextBlock>"
+      L"      </Grid>"
+      L"    </Button>"
+      L"    <Button HorizontalAlignment='Stretch' HorizontalContentAlignment='Stretch' x:Name='Inspector' Style='{StaticResource ButtonRevealStyle}'>"
+      L"      <Grid HorizontalAlignment='Stretch'><Grid.ColumnDefinitions><ColumnDefinition Width='Auto'/><ColumnDefinition Width='*'/></Grid.ColumnDefinitions><Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>"
+      L"        <FontIcon Grid.Column='0' Grid.Row='0' Grid.RowSpan='2' VerticalAlignment='Top' FontFamily='{StaticResource SymbolThemeFontFamily}' Foreground='{StaticResource SystemControlForegroundAccentBrush}' Margin='8,8,16,8' Glyph='&#xE773;'/>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='0' x:Name='InspectorText'>Toggle Inspector</TextBlock>"
+      L"        <TextBlock Grid.Column='1' Grid.Row='1' FontSize='12' Opacity='0.5' TextWrapping='Wrap'>Will bring up an overlay that lets you tap on any UI element and see information about it</TextBlock>"
+      L"      </Grid>"
+      L"    </Button>"
+      L"    <Button HorizontalAlignment='Stretch' x:Name='Cancel' Style='{StaticResource ButtonRevealStyle}'>Cancel</Button>"
       L"  </StackPanel>"
+      L"  </ScrollViewer>"
       L"</Grid>";
   m_developerMenuRoot = winrt::unbox_value<winrt::Grid>(winrt::Markup::XamlReader::Load(xamlString));
+  auto remoteDebugJSText = m_developerMenuRoot.FindName(L"RemoteDebugText").as<winrt::TextBlock>();
   auto remoteDebugJSButton = m_developerMenuRoot.FindName(L"RemoteDebug").as<winrt::Button>();
   auto reloadJSButton = m_developerMenuRoot.FindName(L"Reload").as<winrt::Button>();
+  auto directDebugText = m_developerMenuRoot.FindName(L"DirectDebugText").as<winrt::TextBlock>();
   auto directDebugButton = m_developerMenuRoot.FindName(L"DirectDebug").as<winrt::Button>();
+  auto breakOnNextLineText = m_developerMenuRoot.FindName(L"BreakOnNextLineText").as<winrt::TextBlock>();
   auto breakOnNextLineButton = m_developerMenuRoot.FindName(L"BreakOnNextLine").as<winrt::Button>();
-  auto cancelButton = m_developerMenuRoot.FindName(L"Cancel").as<winrt::Button>();
-  auto toggleInspector = m_developerMenuRoot.FindName(L"Inspector").as<winrt::Button>();
+  auto liveReloadText = m_developerMenuRoot.FindName(L"LiveReloadText").as<winrt::TextBlock>();
   auto liveReloadButton = m_developerMenuRoot.FindName(L"LiveReload").as<winrt::Button>();
+  auto toggleInspector = m_developerMenuRoot.FindName(L"Inspector").as<winrt::Button>();
+  auto cancelButton = m_developerMenuRoot.FindName(L"Cancel").as<winrt::Button>();
 
   bool useWebDebugger = m_reactInstance->GetReactInstanceSettings().UseWebDebugger;
-  remoteDebugJSButton.Content(
-      winrt::box_value(useWebDebugger ? L"Disable Remote JS Debugging" : L"Enable Remote JS Debugging"));
+  remoteDebugJSText.Text(useWebDebugger ? L"Disable Remote JS Debugging" : L"Enable Remote JS Debugging");
   m_remoteDebugJSRevoker = remoteDebugJSButton.Click(
       winrt::auto_revoke, [this, useWebDebugger](const auto &sender, const winrt::RoutedEventArgs &args) {
         DismissDeveloperMenu();
@@ -453,8 +509,7 @@ void ReactControl::ShowDeveloperMenu() {
       });
 
   bool directDebugging = m_reactInstance->GetReactInstanceSettings().UseDirectDebugger;
-  directDebugButton.Content(
-      winrt::box_value(directDebugging ? L"Disable Direct Debugging" : L"Enable Direct Debugging"));
+  directDebugText.Text(directDebugging ? L"Disable Direct Debugging" : L"Enable Direct Debugging");
   m_directDebuggingRevoker = directDebugButton.Click(
       winrt::auto_revoke,
       [ this, directDebugging ](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
@@ -464,8 +519,7 @@ void ReactControl::ShowDeveloperMenu() {
       });
 
   bool breakOnNextLine = m_reactInstance->GetReactInstanceSettings().DebuggerBreakOnNextLine;
-  breakOnNextLineButton.Content(
-      winrt::box_value(breakOnNextLine ? L"Disable Break on First Line" : L"Enable Break on First Line"));
+  breakOnNextLineText.Text(breakOnNextLine ? L"Disable Break on First Line" : L"Enable Break on First Line");
   m_breakOnNextLineRevoker = breakOnNextLineButton.Click(
       winrt::auto_revoke,
       [ this, breakOnNextLine ](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
@@ -476,7 +530,7 @@ void ReactControl::ShowDeveloperMenu() {
 
   bool supportLiveReload = m_reactInstance->GetReactInstanceSettings().UseLiveReload;
 
-  liveReloadButton.Content(winrt::box_value(supportLiveReload ? L"Disable Live Reload" : L"Enable Live Reload"));
+  liveReloadText.Text(supportLiveReload ? L"Disable Live Reload" : L"Enable Live Reload");
   m_liveReloadRevoker = liveReloadButton.Click(
       winrt::auto_revoke, [this, supportLiveReload](const auto &sender, const winrt::RoutedEventArgs &args) {
         DismissDeveloperMenu();


### PR DESCRIPTION
Now that the dev menu has options for direct debugging and remote debugging, adding some more information to the menu options so users know what they do.

(Also spruced up the visuals some)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4213)