### PR TITLE
Fix a couple of places in run-windows that has incorrect assumptions on install layout

### DIFF
--- a/change/react-native-windows-2020-02-29-10-23-04-runWindowsHoist.json
+++ b/change/react-native-windows-2020-02-29-10-23-04-runWindowsHoist.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix a couple of places in run-windows that has incorrect assumptions on install layout",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "159db47fe3b904bd36189e2710c24b53a294a6d0",
+  "dependentChangeType": "patch",
+  "date": "2020-02-29T18:23:04.409Z"
+}

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -67,8 +67,10 @@ function getAppPackage(options) {
 
 function getWindowsStoreAppUtils(options) {
   const popd = pushd(options.root);
-  const windowsStoreAppUtilsPath =
-    './node_modules/react-native-windows/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1';
+  const windowsStoreAppUtilsPath = path.resolve(
+    __dirname,
+    'WindowsStoreAppUtils.ps1',
+  );
   execSync(`powershell Unblock-File "${windowsStoreAppUtilsPath}"`);
   popd();
   return windowsStoreAppUtilsPath;
@@ -259,8 +261,9 @@ function startServerInNewWindow(options, verbose) {
 
 function launchServer(options, verbose) {
   newSuccess('Starting the React-Native Server');
-  const launchPackagerScript = path.join(
-    'node_modules/react-native-windows/Scripts/launchPackager.bat',
+  const launchPackagerScript = path.resolve(
+    __dirname,
+    '../../../Scripts/launchPackager.bat',
   );
   const opts = {
     cwd: options.root,


### PR DESCRIPTION
I don't think the current react-native-cli supports having react-native hoisted, but newer versions do, and so we should ensure that our code doesn't assume that react-native-windows isn't hoisted too, ready for that.

This fixes a couple of places in run-windows code that assume that react-native-windows wasn't hoisted.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4214)