### PR TITLE
Define _WIN32_WINNT instead of WINVER.

### DIFF
--- a/change/react-native-windows-2020-03-03-19-44-38-win32_winnt.json
+++ b/change/react-native-windows-2020-03-03-19-44-38-win32_winnt.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Define _WIN32_WINNT instead of WINVER.",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "commit": "b6b6b4498465f73dcbb549abd3f09216cf266a04",
+  "dependentChangeType": "patch",
+  "date": "2020-03-04T03:44:38.629Z"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -58,7 +58,7 @@
         REACTWINDOWS_BUILD;
         BOOST_ASIO_HAS_IOCP;
         _WINSOCK_DEPRECATED_NO_WARNINGS;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         WIN32;
         _WINDOWS;
         _USRDLL;

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -49,7 +49,7 @@
       <!-- See https://stackoverflow.com/questions/42847103/stdtr1-with-visual-studio-2017. -->
       <PreprocessorDefinitions>
         BOOST_ASIO_HAS_IOCP;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         WIN32;
         _WINDOWS;
         REACTNATIVEWIN32_EXPORTS;

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -49,7 +49,7 @@
       <PreprocessorDefinitions>
         BOOST_ASIO_HAS_IOCP;
         GTEST_LANG_CXX11=1;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         WIN32;
         _WINDOWS;
         REACTNATIVEWIN32_EXPORTS;

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -58,7 +58,7 @@
       <PreprocessorDefinitions>
         BOOST_ASIO_HAS_IOCP;
         _WINSOCK_DEPRECATED_NO_WARNINGS;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         WIN32;
         _WINDOWS;
         REACTNATIVEWIN32_EXPORTS;

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -48,7 +48,7 @@
         REACTWINDOWS_BUILD;
         BOOST_ASIO_HAS_IOCP;
         _WINSOCK_DEPRECATED_NO_WARNINGS;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         WIN32;
         _WINDOWS;
         REACTNATIVEWIN32_EXPORTS;

--- a/vnext/Test/React.Windows.Test.vcxproj
+++ b/vnext/Test/React.Windows.Test.vcxproj
@@ -60,7 +60,7 @@
       -->
       <PreprocessorDefinitions>
         BOOST_ASIO_HAS_IOCP;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
     </ClCompile>

--- a/vnext/V8Inspector/V8Inspector.vcxproj
+++ b/vnext/V8Inspector/V8Inspector.vcxproj
@@ -80,7 +80,7 @@
         BOOST_ASIO_DISABLE_BOOST_REGEX;
         BOOST_ERROR_CODE_HEADER_ONLY;
         BOOST_ASIO_HAS_IOCP;
-        WINVER=$(WinVer);
+        _WIN32_WINNT=$(WinVer);
         WIN32;
         _WINDOWS;
         _WIN32;


### PR DESCRIPTION
Minor change.

Even though Microsoft Docs claim macros `_WIN32_WINNT` and `WINVER` are equivalent, MSBuild explicitly requests to set `_WIN32_WINNT` to set the minimum target Desktop version:
```
Please define _WIN32_WINNT or _WIN32_WINDOWS appropriately. For example:
- add -D_WIN32_WINNT=0x0501 to the compiler command line; or
- add _WIN32_WINNT=0x0501 to your project's Preprocessor Definitions.
Assuming _WIN32_WINNT=0x0501 (i.e. Windows XP target).
Generating Code...
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4229)