### PR TITLE
Override Manifest Duplicate and UT Handling Fixes

### DIFF
--- a/packages/override-tools/src/Manifest.ts
+++ b/packages/override-tools/src/Manifest.ts
@@ -130,7 +130,7 @@ export default class Manifest {
    * Platform override specific version of {@see addOverride}
    */
   async addPlatformOverride(file: string) {
-    file = await this.checkAndNormalizeOverride(file);
+    file = await this.checkAndNormalizeOverrideFile(file);
     this.overrides.push({type: 'platform', file});
   }
 
@@ -138,7 +138,7 @@ export default class Manifest {
    * Dervied override specific version of {@see addOverride}
    */
   async addDerivedOverride(file: string, baseFile: string, issue?: number) {
-    file = await this.checkAndNormalizeOverride(file);
+    file = await this.checkAndNormalizeOverrideFile(file);
 
     const overrideBaseInfo = await this.getOverrideBaseInfo(baseFile);
     this.overrides.push({type: 'derived', file, ...overrideBaseInfo, issue});
@@ -148,7 +148,7 @@ export default class Manifest {
    * Patch override specific version of {@see addOverride}
    */
   async addPatchOverride(file: string, baseFile: string, issue: number) {
-    file = await this.checkAndNormalizeOverride(file);
+    file = await this.checkAndNormalizeOverrideFile(file);
 
     const overrideBaseInfo = await this.getOverrideBaseInfo(baseFile);
     this.overrides.push({type: 'patch', file, ...overrideBaseInfo, issue});
@@ -192,7 +192,7 @@ export default class Manifest {
     return hasher.digest('hex');
   }
 
-  private async checkAndNormalizeOverride(file: string): Promise<string> {
+  private async checkAndNormalizeOverrideFile(file: string): Promise<string> {
     const normalizedFile = path.normalize(file);
 
     if (this.hasOverride(normalizedFile)) {

--- a/packages/override-tools/src/Manifest.ts
+++ b/packages/override-tools/src/Manifest.ts
@@ -130,7 +130,7 @@ export default class Manifest {
    * Platform override specific version of {@see addOverride}
    */
   async addPlatformOverride(file: string) {
-    await this.checkOverrideFile(file);
+    file = await this.checkAndNormalizeOverride(file);
     this.overrides.push({type: 'platform', file});
   }
 
@@ -138,7 +138,7 @@ export default class Manifest {
    * Dervied override specific version of {@see addOverride}
    */
   async addDerivedOverride(file: string, baseFile: string, issue?: number) {
-    await this.checkOverrideFile(file);
+    file = await this.checkAndNormalizeOverride(file);
 
     const overrideBaseInfo = await this.getOverrideBaseInfo(baseFile);
     this.overrides.push({type: 'derived', file, ...overrideBaseInfo, issue});
@@ -148,7 +148,7 @@ export default class Manifest {
    * Patch override specific version of {@see addOverride}
    */
   async addPatchOverride(file: string, baseFile: string, issue: number) {
-    await this.checkOverrideFile(file);
+    file = await this.checkAndNormalizeOverride(file);
 
     const overrideBaseInfo = await this.getOverrideBaseInfo(baseFile);
     this.overrides.push({type: 'patch', file, ...overrideBaseInfo, issue});
@@ -192,11 +192,19 @@ export default class Manifest {
     return hasher.digest('hex');
   }
 
-  private async checkOverrideFile(file: string) {
-    const overrideContents = await this.overrideRepo.getFileContents(file);
-    if (overrideContents === null) {
+  private async checkAndNormalizeOverride(file: string): Promise<string> {
+    const normalizedFile = path.normalize(file);
+
+    if (this.hasOverride(normalizedFile)) {
+      throw new Error(`Override '${file}' already exists in manifest`);
+    }
+
+    const contents = await this.overrideRepo.getFileContents(normalizedFile);
+    if (contents === null) {
       throw new Error(`Could not find override '${file}'`);
     }
+
+    return normalizedFile;
   }
 
   private async getOverrideBaseInfo(file: string): Promise<OverrideBaseInfo> {

--- a/packages/override-tools/src/test/Manifest.test.ts
+++ b/packages/override-tools/src/test/Manifest.test.ts
@@ -16,17 +16,17 @@ import {
 
 const reactFiles: Array<MockFile> = [
   {
-    filename: 'aaa/aaa.js',
+    filename: 'aaa\\aaa.js',
     content:
       'I want your love, and I want your revenge;You and me could write a bad romance',
   },
   {
-    filename: 'aaa/bbb.android.js',
+    filename: 'aaa\\bbb.android.js',
     content:
       "Gimme, gimme, gimme a man after midnight. Won't somebody help me chase the shadows away",
   },
   {
-    filename: 'bbb/ccc.ios.js',
+    filename: 'bbb\\ccc.ios.js',
     content:
       "Cause honey I'll come get my things, but I can't let go I'm waiting for it, that green light, I want it",
   },
@@ -34,17 +34,17 @@ const reactFiles: Array<MockFile> = [
 
 const overrideFiles: Array<MockFile> = [
   {
-    filename: 'aaa/aaa.windows.js',
+    filename: 'aaa\\aaa.windows.js',
     content:
       'I want your love, and I want your mashed potatoes;You and me could make more mashed potatoes I guess',
   },
   {
-    filename: 'aaa/bbb.windows.js',
+    filename: 'aaa\\bbb.windows.js',
     content:
       "Gimme, gimme, gimme 500 live bees after midnight. Won't somebody help me chase the bees out of my house, this is actually quite frightening",
   },
   {
-    filename: 'bbb/ccc.win32.js',
+    filename: 'bbb\\ccc.win32.js',
     content:
       "Cause honey I'll come get my things, but I can't let go I'm waiting for it, the fall of civilization as we know it",
   },
@@ -56,9 +56,9 @@ const ovrRepo = new MockOverrideFileRepository(overrideFiles);
 test('AllListedInManifest', async () => {
   const manifest: ManifestData.Manifest = {
     overrides: [
-      {type: 'platform', file: 'aaa/aaa.windows.js'},
-      {type: 'platform', file: 'aaa/bbb.windows.js'},
-      {type: 'platform', file: 'bbb/ccc.win32.js'},
+      {type: 'platform', file: 'aaa\\aaa.windows.js'},
+      {type: 'platform', file: 'aaa\\bbb.windows.js'},
+      {type: 'platform', file: 'bbb\\ccc.win32.js'},
     ],
   };
 
@@ -69,8 +69,8 @@ test('AllListedInManifest', async () => {
 test('ManifestMissingFile', async () => {
   const manifest: ManifestData.Manifest = {
     overrides: [
-      {type: 'platform', file: 'aaa/aaa.windows.js'},
-      {type: 'platform', file: 'aaa/bbb.windows.js'},
+      {type: 'platform', file: 'aaa\\aaa.windows.js'},
+      {type: 'platform', file: 'aaa\\bbb.windows.js'},
     ],
   };
 
@@ -86,10 +86,10 @@ test('ManifestMissingFile', async () => {
 test('ManifestExtraFile', async () => {
   const manifest: ManifestData.Manifest = {
     overrides: [
-      {type: 'platform', file: 'aaa/aaa.windows.js'},
-      {type: 'platform', file: 'aaa/bbb.windows.js'},
-      {type: 'platform', file: 'bbb/ccc.win32.js'},
-      {type: 'platform', file: 'bbb/ddd.win32.js'},
+      {type: 'platform', file: 'aaa\\aaa.windows.js'},
+      {type: 'platform', file: 'aaa\\bbb.windows.js'},
+      {type: 'platform', file: 'bbb\\ccc.win32.js'},
+      {type: 'platform', file: 'bbb\\ddd.win32.js'},
     ],
   };
 
@@ -187,7 +187,7 @@ test('CannotRemoveOverride', async () => {
 });
 
 test('addOverrideSimple', async () => {
-  const manifest = new Manifest(testManifestData, ovrRepo, reactRepo);
+  const manifest = new Manifest({overrides: []}, ovrRepo, reactRepo);
 
   const patch = overrideFiles[0].filename;
   const patchOrig = reactFiles[0].filename;
@@ -205,7 +205,7 @@ test('addOverrideSimple', async () => {
 });
 
 test('addOverrideBadArgs', async () => {
-  const manifest = new Manifest(testManifestData, ovrRepo, reactRepo);
+  const manifest = new Manifest({overrides: []}, ovrRepo, reactRepo);
 
   // Missing issue number
   const patch = overrideFiles[0].filename;
@@ -224,7 +224,7 @@ test('addOverrideBadArgs', async () => {
 });
 
 test('addOverrideTypeSimple', async () => {
-  const manifest = new Manifest(testManifestData, ovrRepo, reactRepo);
+  const manifest = new Manifest({overrides: []}, ovrRepo, reactRepo);
 
   const patch = overrideFiles[0].filename;
   const patchOrig = reactFiles[0].filename;
@@ -241,8 +241,24 @@ test('addOverrideTypeSimple', async () => {
   expect(manifest.hasOverride(derived)).toBe(true);
 });
 
-test('addOverrideNoBase', async () => {
+test('addOverrideDuplicate', async () => {
   const manifest = new Manifest(testManifestData, ovrRepo, reactRepo);
+
+  const ovr = overrideFiles[0].filename;
+  // @ts-ignore Typings don't know about rejects
+  expect(manifest.addOverride('platform', ovr)).rejects.toThrow();
+});
+
+test('addOverrideDuplicateNonNormalized', async () => {
+  const manifest = new Manifest(testManifestData, ovrRepo, reactRepo);
+
+  const ovr = overrideFiles[0].filename.replace('\\', '/');
+  // @ts-ignore Typings don't know about rejects
+  expect(manifest.addOverride('platform', ovr)).rejects.toThrow();
+});
+
+test('addOverrideNoBase', async () => {
+  const manifest = new Manifest({overrides: []}, ovrRepo, reactRepo);
 
   const patch = overrideFiles[0].filename;
   const patchOrig = 'Never gonna make you cry';
@@ -256,7 +272,7 @@ test('addOverrideNoBase', async () => {
 });
 
 test('addOverrideNoOverride', async () => {
-  const manifest = new Manifest(testManifestData, ovrRepo, reactRepo);
+  const manifest = new Manifest({overrides: []}, ovrRepo, reactRepo);
 
   const patch = 'Never gonna tell a lie and hurt you';
   const patchOrig = reactFiles[0].filename;


### PR DESCRIPTION
This is a continuation from the last change that was auto-merged before I had a chance to fix a UT issue around adding to an existing manifest. Fix the UT issue to ensure our tests to add overrides are accurate, and add some logic to avoid manifest duplicates in general.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4231)