### PR TITLE
Support poject config for RNW when running "react-native config"

### DIFF
--- a/change/react-native-windows-2020-03-04-11-59-23-events.json
+++ b/change/react-native-windows-2020-03-04-11-59-23-events.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Support RNW project config",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "58098b2a16189d720eb55e26d77ace64eb3d411b",
+  "dependentChangeType": "patch",
+  "date": "2020-03-04T19:59:23.284Z"
+}

--- a/vnext/local-cli/config/projectConfig.js
+++ b/vnext/local-cli/config/projectConfig.js
@@ -1,0 +1,66 @@
+const fs = require('fs')
+const path = require('path');
+const glob = require('glob');
+
+function projectConfigWindows(folder, userConfig = {}) {
+  const sourceDir = userConfig.sourceDir || findWindowsAppFolder(folder);
+
+  if (!sourceDir) {
+    return null;
+  }
+
+  const projectSolution = findSolution(sourceDir);
+  var extension = path.extname(projectSolution);
+  var projectName = path.basename(projectSolution, extension);
+  const cppProjFile = findCppProject(sourceDir, projectName);
+  const csProjectFile = findCSProject(sourceDir,projectName);
+
+  return {
+    sourceDir,
+    projectSolution,
+    projectName,
+    cppProjFile,
+    csProjectFile,
+  }
+}
+
+function findWindowsAppFolder(folder) {
+  const winDir = 'windows';
+  const joinedDir = path.join(folder, winDir);
+  if (fs.existsSync(joinedDir)) {
+    return joinedDir;
+  }
+
+  return null;
+}
+
+function findSolution(folder) {
+  const solutionPath = glob.sync(path.join('**', '*.sln'), {
+    cwd: folder,
+    ignore: ['node_modules/**', '**/Debug/**', '**/Release/**', 'Generated Files']
+  })[0];
+
+  return solutionPath ? path.join(folder, solutionPath) : null;
+}
+
+function findCppProject(folder, projectName) {
+  const cppProj = glob.sync(path.join('**', projectName + '.vcxproj'), {
+    cwd: folder,
+    ignore: ['node_modules/**', '**/Debug/**', '**/Release/**', '**/Generated Files/**', '**/packages/**']
+  })[0];
+
+  return cppProj ? path.join(folder, cppProj) : null;
+}
+
+function findCSProject(folder, projectName) {
+  const cppProj = glob.sync(path.join('**', projectName + '.csproj'), {
+    cwd: folder,
+    ignore: ['node_modules/**', '**/Debug/**', '**/Release/**', '**/Generated Files/**', '**/packages/**']
+  })[0];
+
+  return cppProj ? path.join(folder, cppProj) : null;
+}
+
+module.exports = {
+  projectConfigWindows: projectConfigWindows
+}

--- a/vnext/react-native.config.js
+++ b/vnext/react-native.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-
+const projectConfig = require('./local-cli/config/projectConfig');
 module.exports = {
     // **** This section defined commands and options on how to provide the windows platform to external applications
     commands: [
@@ -8,7 +8,7 @@ module.exports = {
     platforms: {
       windows: {
         linkConfig: () => null,
-        projectConfig: (projectRoot, projectParams) => null,
+        projectConfig: projectConfig.projectConfigWindows,
         dependencyConfig: (projectRoot, dependencyParams) => null,
       },
     },


### PR DESCRIPTION
#2853 

"react-native config" command gathers platform config information for project and dependencies, it is used later for "auto-linking" between app project and  native module projects.

Right now, if you run "react-native config" command, it returns config info for iOS and Android but null for windows. This change adds some support for project config for windows, more to come later for native module's dependencies config. We may also need to tweak on what config info is needed too at later time depending on what auto-linking's requirements.

example output:

    "windows": {
      "sourceDir": "c:\\rnw61\\windows",
      "projectSolution": "c:\\rnw61\\windows\\rnw61.sln",
      "projectName": "rnw61",
      "cppProjFile": "c:\\rnw61\\windows\\rnw61\\rnw61.vcxproj",
      "csProjectFile": null
    }


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4235)