### PR TITLE
Move ViewPanel import from PropertyUtils to FrameworkElementViewManager

### DIFF
--- a/change/react-native-windows-2020-03-04-16-35-45-ViewPanelImportFix.json
+++ b/change/react-native-windows-2020-03-04-16-35-45-ViewPanelImportFix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Move ViewPanel import from PropertyUtils to FrameworkElementViewManager",
+  "packageName": "react-native-windows",
+  "email": "jagorrin@microsoft.com",
+  "commit": "9dfc7b5bce7de1508eb2dc31fbdf597929f839f3",
+  "dependentChangeType": "patch",
+  "date": "2020-03-05T00:35:45.422Z"
+}

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -25,6 +25,8 @@
 
 #include "DynamicAutomationProperties.h"
 
+#include <Views/ViewPanel.h>
+
 namespace winrt {
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -17,8 +17,6 @@
 
 #include <Views/ShadowNodeBase.h>
 
-#include <Views/ViewPanel.h>
-
 namespace winrt {
 using namespace Windows::UI::Xaml;
 }


### PR DESCRIPTION
This change moves the line `#include <Views/ViewPanel.h>` from PropertyUtils.h to FrameworkElementViewManager.cpp.

FrameworkElementViewManager was making use of ViewPanel.h by importing it indirectly through PropertyUtils.h. Since PropertyUtils.h does not have a dependency on ViewPanel.h, it is being removed and placed into FrameworkElementViewManager.cpp directly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4236)