### PR TITLE
Added TryAddAttributedModule method

### DIFF
--- a/change/react-native-windows-2020-03-05-09-29-39-MS_ModuleRegistration.json
+++ b/change/react-native-windows-2020-03-05-09-29-39-MS_ModuleRegistration.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Added TryAddAttributedModule in addition to AddAttributedModules",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "4e5d620dd2d200f39de9202b77020051e839d67f",
+  "dependentChangeType": "patch",
+  "date": "2020-03-05T17:29:39.521Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
@@ -8,14 +8,24 @@ namespace winrt::Microsoft::ReactNative {
 
 const ModuleRegistration *ModuleRegistration::s_head{nullptr};
 
-ModuleRegistration::ModuleRegistration(const wchar_t *moduleName) noexcept : m_moduleName{moduleName}, m_next{s_head} {
+ModuleRegistration::ModuleRegistration(wchar_t const *moduleName) noexcept : m_moduleName{moduleName}, m_next{s_head} {
   s_head = this;
 }
 
 void AddAttributedModules(IReactPackageBuilder const &packageBuilder) noexcept {
-  for (const ModuleRegistration *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
-    packageBuilder.AddModule(winrt::to_hstring(reg->ModuleName()), reg->MakeModuleProvider());
+  for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
+    packageBuilder.AddModule(reg->ModuleName(), reg->MakeModuleProvider());
   }
+}
+
+bool TryAddAttributedModule(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept {
+  for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
+    if (moduleName == reg->ModuleName()) {
+      packageBuilder.AddModule(moduleName, reg->MakeModuleProvider());
+      return true;
+    }
+  }
+  return false;
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -44,29 +44,31 @@
 namespace winrt::Microsoft::ReactNative {
 
 struct ModuleRegistration {
-  ModuleRegistration(const wchar_t *moduleName) noexcept;
+  ModuleRegistration(wchar_t const *moduleName) noexcept;
 
   virtual ReactModuleProvider MakeModuleProvider() const noexcept = 0;
 
-  static const ModuleRegistration *Head() noexcept {
+  static ModuleRegistration const *Head() noexcept {
     return s_head;
   }
 
-  const ModuleRegistration *Next() const noexcept {
+  ModuleRegistration const *Next() const noexcept {
     return m_next;
   }
 
-  const wchar_t *ModuleName() const noexcept {
+  wchar_t const *ModuleName() const noexcept {
     return m_moduleName;
   }
 
  private:
-  const wchar_t *m_moduleName;
-  const ModuleRegistration *m_next{nullptr};
+  wchar_t const *m_moduleName{nullptr};
+  ModuleRegistration const *m_next{nullptr};
 
   static const ModuleRegistration *s_head;
 };
 
 void AddAttributedModules(IReactPackageBuilder const &packageBuilder) noexcept;
+
+bool TryAddAttributedModule(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept;
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.SharedManaged/ReactModuleInfo.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/ReactModuleInfo.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ReactNative.Managed
     public ReactModuleInfo(Type moduleType, ReactModuleAttribute moduleAttribute)
     {
       ModuleType = moduleType;
-      ModuleName = moduleAttribute.ModuleName ?? moduleType.Name;
+      ModuleName = GetModuleName(moduleType, moduleAttribute);
       EventEmitterName = moduleAttribute.EventEmitterName ?? "RCTDeviceEventEmitter";
       ModuleProvider = (IReactModuleBuilder moduleBuilder) =>
       {
@@ -44,6 +44,11 @@ namespace Microsoft.ReactNative.Managed
       m_syncMethodInfos = new Lazy<List<ReactSyncMethodInfo>>(InitSyncMethodInfos, LazyThreadSafetyMode.PublicationOnly);
       m_functionInfos = new Lazy<List<ReactFunctionInfo>>(InitFunctionInfos, LazyThreadSafetyMode.PublicationOnly);
       m_eventInfos = new Lazy<List<ReactEventInfo>>(InitEventInfos, LazyThreadSafetyMode.PublicationOnly);
+    }
+
+    public static string GetModuleName(Type moduleType, ReactModuleAttribute moduleAttribute)
+    {
+      return moduleAttribute.ModuleName ?? moduleType.Name;
     }
 
     internal static ReactModuleInfo GetOrAddModuleInfo(Type moduleType, ReactModuleAttribute moduleAttribute)

--- a/vnext/Microsoft.ReactNative.SharedManaged/ReactPackageBuilderExtensions.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/ReactPackageBuilderExtensions.cs
@@ -2,24 +2,57 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 
 namespace Microsoft.ReactNative.Managed
 {
   static class ReactPackageBuilderExtensions
   {
-    internal static void AddAttributedModules(this IReactPackageBuilder packageBuilder)
+    struct AttributedModule
     {
-      foreach (var type in typeof(ReactPackageBuilderExtensions).GetTypeInfo().Assembly.GetTypes())
+      public Type ModuleType;
+      public ReactModuleAttribute ModuleAttribute;
+
+      public void AddToPackageBuilder(IReactPackageBuilder packageBuilder)
       {
-        var moduleAttribute = type.GetTypeInfo().GetCustomAttribute<ReactModuleAttribute>();
-        if (moduleAttribute != null)
-        {
-          ReactModuleInfo moduleInfo = ReactModuleInfo.GetOrAddModuleInfo(type, moduleAttribute);
-          packageBuilder.AddModule(moduleInfo.ModuleName, moduleInfo.ModuleProvider);
-        }
+        ReactModuleInfo moduleInfo = ReactModuleInfo.GetOrAddModuleInfo(ModuleType, ModuleAttribute);
+        packageBuilder.AddModule(moduleInfo.ModuleName, moduleInfo.ModuleProvider);
       }
+    }
+
+    private static readonly Lazy<Dictionary<string, AttributedModule>> m_attributedModules =
+      new Lazy<Dictionary<string, AttributedModule>>(InitAttributedModules, LazyThreadSafetyMode.PublicationOnly);
+
+    private static Dictionary<string, AttributedModule> InitAttributedModules()
+    {
+      var initializers =
+        from typeInfo in typeof(ReactPackageBuilderExtensions).GetTypeInfo().Assembly.DefinedTypes
+        let moduleAttribute = typeInfo.GetCustomAttribute<ReactModuleAttribute>()
+        where moduleAttribute != null
+        select new AttributedModule { ModuleType = typeInfo.AsType(), ModuleAttribute = moduleAttribute };
+      return initializers.ToDictionary(m => ReactModuleInfo.GetModuleName(m.ModuleType, m.ModuleAttribute));
+    }
+
+    public static void AddAttributedModules(this IReactPackageBuilder packageBuilder)
+    {
+      foreach (var attributedModule in m_attributedModules.Value)
+      {
+        attributedModule.Value.AddToPackageBuilder(packageBuilder);
+      }
+    }
+
+    public static bool TryAddAttributedModule(this IReactPackageBuilder packageBuilder, string moduleName)
+    {
+      if (m_attributedModules.Value.TryGetValue(moduleName, out var attributedModule))
+      {
+        attributedModule.AddToPackageBuilder(packageBuilder);
+        return true;
+      }
+
+      return false;
     }
 
     internal static void AddViewManagers(this IReactPackageBuilder packageBuilder)

--- a/vnext/include/Include.vcxitems.filters
+++ b/vnext/include/Include.vcxitems.filters
@@ -59,33 +59,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\XamlView.h">
       <Filter>ReactUWP</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\CppWinrtLessExceptions.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\Helpers.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\LocalBundleReader.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\PropertyHandlerUtils.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\PropertyUtils.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\ResourceBrushUtils.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\StandardControlResourceKeyNames.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\UwpPreparedScriptStore.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\UwpScriptStore.h">
-      <Filter>ReactUWP\Utils</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ReactUWP">


### PR DESCRIPTION
Currently we only provide capability to register all registered attributed native modules. In some scenarios there is a need to pick only specific modules by name. In this PR we are adding a new TryAddAttributedModule that tries to add attributed modules with specified name into an IReactPackageBuilder. This method returns true in case of success and false if module was not found by name.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4240)