### PR TITLE
Enable V8 JSI support for win32

### DIFF
--- a/change/react-native-windows-2020-03-05-10-04-59-0.60-stable.json
+++ b/change/react-native-windows-2020-03-05-10-04-59-0.60-stable.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Enable V8 JSI support",
+  "packageName": "react-native-windows",
+  "email": "tudorm@microsoft.com",
+  "commit": "cd2d2668ded93c00d91c8393c169e8b732958a63",
+  "dependentChangeType": "patch",
+  "date": "2020-03-05T18:04:59.246Z"
+}

--- a/packages/playground/windows/playground.sln
+++ b/packages/playground/windows/playground.sln
@@ -22,7 +22,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "..\..\.
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "PropertySheets", "{6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "..\..\..\vnext\PropertySheets", "{6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}"
 	ProjectSection(SolutionItems) = preProject
 		PropertySheets\ARM.props = PropertySheets\ARM.props
 		PropertySheets\Debug.props = PropertySheets\Debug.props

--- a/packages/playground/windows/playground/HostingPane.xaml
+++ b/packages/playground/windows/playground/HostingPane.xaml
@@ -115,6 +115,16 @@
         VerticalAlignment="Center"
         IsChecked="true"
         Content="Reuse Instance"/>
+      <TextBlock
+        Margin="5,2"
+        VerticalAlignment="Center"
+        Text="JS Engine:"/>
+      <ComboBox
+        x:Name="x_JsEngine"
+        Margin="5,2"
+        MinWidth="150"
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Center"/>
     </StackPanel>
 
     <Grid x:Name="RootElement"

--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -115,8 +115,7 @@ class SampleNativeModuleProvider final : public facebook::react::NativeModulePro
     std::vector<facebook::react::NativeModuleDescription> modules;
     std::shared_ptr<facebook::react::MessageQueueThread> queue = defaultQueueThread;
 
-    modules.emplace_back(
-        SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
+    modules.emplace_back(SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
 
     return modules;
   }

--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -115,7 +115,8 @@ class SampleNativeModuleProvider final : public facebook::react::NativeModulePro
     std::vector<facebook::react::NativeModuleDescription> modules;
     std::shared_ptr<facebook::react::MessageQueueThread> queue = defaultQueueThread;
 
-    modules.emplace_back(SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
+    modules.emplace_back(
+        SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
 
     return modules;
   }
@@ -212,6 +213,8 @@ std::shared_ptr<react::uwp::IReactInstance> HostingPane::getInstance() {
     settings.UseWebDebugger = x_UseWebDebuggerCheckBox->IsChecked->Value;
     settings.UseLiveReload = x_UseLiveReloadCheckBox->IsChecked->Value;
     settings.EnableDeveloperMenu = true;
+    settings.jsiEngine = static_cast<react::uwp::JSIEngine>(x_JsEngine->SelectedIndex);
+
     if (params.find("debughost") != params.end()) {
       settings.DebugHost = params["debughost"];
     }
@@ -435,6 +438,23 @@ void HostingPane::InitComboBoxes() {
     x_ReactAppName->IsEditable = true;
     x_JavaScriptFilename->IsEditable = true;
   }
+
+  m_jsEngineNames = ref new Platform::Collections::Vector<String ^>();
+  m_jsEngineNames->Append(L"Chakra");
+#if defined(USE_HERMES)
+  m_jsEngineNames->Append(L"Hermes");
+#else
+  m_jsEngineNames->Append(L"NOT AVAILABLE - Hermes");
+#endif
+
+#if defined(USE_V8)
+  m_jsEngineNames->Append(L"V8");
+#else
+  m_jsEngineNames->Append(L"NOT AVAILABLE - V8");
+#endif
+
+  x_JsEngine->ItemsSource = m_jsEngineNames;
+  x_JsEngine->SelectedIndex = 0;
 }
 
 void HostingPane::LoadKnownApps() {

--- a/packages/playground/windows/playground/HostingPane.xaml.h
+++ b/packages/playground/windows/playground/HostingPane.xaml.h
@@ -71,6 +71,7 @@ namespace Playground {
 
   Platform::Collections::Vector<Platform::String ^> ^ m_jsFileNames;
   Platform::Collections::Vector<Platform::String ^> ^ m_ReactAppNames;
+  Platform::Collections::Vector<Platform::String ^> ^ m_jsEngineNames;
 };
 
 } // namespace Playground

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -67,6 +67,7 @@
       <AdditionalOptions>/await /bigobj /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;4800;28204;4146;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PrecompiledHeader>Use</PrecompiledHeader>
+      <PreprocessorDefinitions Condition="'$(USE_V8)'=='true'">USE_V8;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(ReactNativeWindowsDir)target\$(PlatformTarget)\$(Configuration)\ReactUWP\React.uwp.lib;ChakraRT.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -52,7 +52,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ReactNativeDir)\ReactCommon;$(JSI_Source);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ReactNativeDir)\ReactCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <UseFullPaths>true</UseFullPaths>
     </ClCompile>

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -68,7 +68,7 @@
       we have a better solution for handling the absence of WinRT string and error DLLs on Win7.
       -->
       <AdditionalDependencies>WindowsApp_downlevel.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-string-l1-1-0.dll;ChakraCore.Debugger.DLL</DelayLoadDLLs>
+      <DelayLoadDLLs>api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-string-l1-1-0.dll;ChakraCore.Debugger.DLL;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
@@ -133,6 +133,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -142,6 +143,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
   <Target Name="GetTargetFileName" Returns="$(OutDir)$(TargetName).dll" />
 </Project>

--- a/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.h
+++ b/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.h
@@ -3,7 +3,7 @@
 #include <DevSettings.h>
 
 #include <JSI/Shared/RuntimeHolder.h>
-#include <JSI/Shared/ScriptStore.h>
+#include <ScriptStore.h>
 
 #include <JSI/Shared/ChakraRuntimeArgs.h>
 

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -40,7 +40,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)Desktop;$(ReactNativeWindowsDir)IntegrationTests;$(MSBuildProjectDirectory);$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)Desktop;$(ReactNativeWindowsDir)IntegrationTests;$(ReactNativeWindowsDir)JSI\Shared;$(MSBuildProjectDirectory);$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -54,7 +54,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Shlwapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Shlwapi.lib;Version.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -109,6 +109,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -118,6 +119,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
   <Target Name="Test">
     <Exec Command="$(OutDir)$(TargetFileName)" IgnoreStandardErrorWarningFormat="true" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -47,7 +47,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(MSBuildProjectDirectory);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(MSBuildProjectDirectory);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(ReactNativeWindowsDir)JSI\Shared;$(JSI_Source);$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -168,6 +168,7 @@
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -179,5 +180,6 @@
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
 </Project>

--- a/vnext/Desktop/packages.config
+++ b/vnext/Desktop/packages.config
@@ -5,4 +5,5 @@
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.2.3" targetFramework="native" />
 </packages>

--- a/vnext/JSI.Desktop.UnitTests/ChakraCoreRuntimeUnitTests.cpp
+++ b/vnext/JSI.Desktop.UnitTests/ChakraCoreRuntimeUnitTests.cpp
@@ -29,8 +29,7 @@ using Microsoft::React::Test::TestMessageQueueThread;
 // behaviors such as ScriptStore. This may require us to bring back JSITestBase.
 
 std::vector<RuntimeFactory> runtimeGenerators() {
-  return {
-    []() -> std::unique_ptr<Runtime> {
+  return {[]() -> std::unique_ptr<Runtime> {
     ChakraRuntimeArgs args{};
 
     args.jsQueue = std::make_shared<TestMessageQueueThread>();
@@ -40,8 +39,7 @@ std::vector<RuntimeFactory> runtimeGenerators() {
     args.memoryTracker = CreateMemoryTracker(std::move(memoryTrackerCallbackQueue));
 
     return makeChakraRuntime(std::move(args));
-    }
-  };
+  }};
 }
 
 INSTANTIATE_TEST_CASE_P(ChakraRuntimeTest_Base, JsiRuntimeUnitTests, ::testing::ValuesIn(runtimeGenerators()));
@@ -49,8 +47,7 @@ INSTANTIATE_TEST_CASE_P(ChakraRuntimeTest, JsiRuntimeUnitTests_Chakra, ::testing
 
 #if defined(USE_V8)
 
-RuntimeFactory getV8Runtime()
-{
+RuntimeFactory getV8Runtime() {
   return []() -> std::unique_ptr<Runtime> {
     v8runtime::V8RuntimeArgs args;
 

--- a/vnext/JSI.Desktop.UnitTests/ChakraCoreRuntimeUnitTests.cpp
+++ b/vnext/JSI.Desktop.UnitTests/ChakraCoreRuntimeUnitTests.cpp
@@ -3,6 +3,9 @@
 #include "JSI/Shared/ChakraRuntimeArgs.h"
 #include "JSI/Shared/ChakraRuntimeFactory.h"
 #include "MemoryTracker.h"
+#if defined(USE_V8)
+#include <V8JsiRuntime.h>
+#endif
 
 // TODO (yicyao): #2730 Introduces a vcxitem for shared test code and move this
 // there.
@@ -13,6 +16,7 @@
 #include <vector>
 
 using facebook::jsi::JsiRuntimeUnitTests;
+using facebook::jsi::JsiRuntimeUnitTests_Chakra;
 using facebook::jsi::Runtime;
 using facebook::jsi::RuntimeFactory;
 using facebook::react::CreateMemoryTracker;
@@ -25,7 +29,8 @@ using Microsoft::React::Test::TestMessageQueueThread;
 // behaviors such as ScriptStore. This may require us to bring back JSITestBase.
 
 std::vector<RuntimeFactory> runtimeGenerators() {
-  return {[]() -> std::unique_ptr<Runtime> {
+  return {
+    []() -> std::unique_ptr<Runtime> {
     ChakraRuntimeArgs args{};
 
     args.jsQueue = std::make_shared<TestMessageQueueThread>();
@@ -35,7 +40,23 @@ std::vector<RuntimeFactory> runtimeGenerators() {
     args.memoryTracker = CreateMemoryTracker(std::move(memoryTrackerCallbackQueue));
 
     return makeChakraRuntime(std::move(args));
-  }};
+    }
+  };
 }
 
-INSTANTIATE_TEST_CASE_P(ChakraRuntimeTest, JsiRuntimeUnitTests, ::testing::ValuesIn(runtimeGenerators()));
+INSTANTIATE_TEST_CASE_P(ChakraRuntimeTest_Base, JsiRuntimeUnitTests, ::testing::ValuesIn(runtimeGenerators()));
+INSTANTIATE_TEST_CASE_P(ChakraRuntimeTest, JsiRuntimeUnitTests_Chakra, ::testing::ValuesIn(runtimeGenerators()));
+
+#if defined(USE_V8)
+
+RuntimeFactory getV8Runtime()
+{
+  return []() -> std::unique_ptr<Runtime> {
+    v8runtime::V8RuntimeArgs args;
+
+    return v8runtime::makeV8Runtime(std::move(args));
+  };
+}
+
+INSTANTIATE_TEST_CASE_P(V8RuntimeTest, JsiRuntimeUnitTests, ::testing::Values(getV8Runtime()));
+#endif

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -35,7 +35,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)Desktop;$(ReactNativeWindowsDir)IntegrationTests;$(MSBuildProjectDirectory);$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)Desktop;$(ReactNativeWindowsDir)IntegrationTests;$(ReactNativeWindowsDir)JSI\Shared;$(MSBuildProjectDirectory);$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -55,7 +55,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>-minpdbpathlen:256</AdditionalOptions>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Shlwapi.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -120,6 +120,7 @@
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -130,5 +131,6 @@
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
 </Project>

--- a/vnext/JSI.Desktop.UnitTests/JsiRuntimeUnitTests.cpp
+++ b/vnext/JSI.Desktop.UnitTests/JsiRuntimeUnitTests.cpp
@@ -8,7 +8,6 @@
 #include "JsiRuntimeUnitTests.h"
 
 #include <gtest/gtest.h>
-#include <jsi/decorator.h>
 #include <jsi/jsi.h>
 
 #include <stdlib.h>
@@ -159,7 +158,7 @@ TEST_P(JsiRuntimeUnitTests, ObjectTest) {
   EXPECT_EQ(names.getValueAtIndex(rt, 0).getString(rt).utf8(rt), "a");
 }
 
-TEST_P(JsiRuntimeUnitTests, HostObjectTest) {
+TEST_P(JsiRuntimeUnitTests_Chakra, HostObjectTest) {
   class ConstantHostObject : public HostObject {
     Value get(Runtime &, const PropNameID &sym) override {
       return 9000;
@@ -329,7 +328,7 @@ TEST_P(JsiRuntimeUnitTests, HostObjectTest) {
   EXPECT_FALSE(hasOwnPropertyName.call(rt, howpn, String::createFromAscii(rt, "not_existing")).getBool());
 }
 
-TEST_P(JsiRuntimeUnitTests, ArrayTest) {
+TEST_P(JsiRuntimeUnitTests_Chakra, ArrayTest) {
   eval("x = {1:2, '3':4, 5:'six', 'seven':['eight', 'nine']}");
 
   Object x = rt.global().getPropertyAsObject(rt, "x");
@@ -520,7 +519,7 @@ TEST_P(JsiRuntimeUnitTests, InstanceOfTest) {
   EXPECT_TRUE(ctor.callAsConstructor(rt, nullptr, 0).getObject(rt).instanceOf(rt, ctor));
 }
 
-TEST_P(JsiRuntimeUnitTests, HostFunctionTest) {
+TEST_P(JsiRuntimeUnitTests_Chakra, HostFunctionTest) {
   auto one = std::make_shared<int>(1);
   Function plusOne = Function::createFromHostFunction(
       rt,

--- a/vnext/JSI.Desktop.UnitTests/JsiRuntimeUnitTests.h
+++ b/vnext/JSI.Desktop.UnitTests/JsiRuntimeUnitTests.h
@@ -37,4 +37,7 @@ class JsiRuntimeUnitTests : public ::testing::TestWithParam<RuntimeFactory> {
   Runtime &rt;
 };
 
+// V8 doesn't currently pass all the tests (particularly around hostobjects), move those out into _Chakra for now
+class JsiRuntimeUnitTests_Chakra : public JsiRuntimeUnitTests {};
+
 } // namespace facebook::jsi

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -42,7 +42,7 @@
   <PropertyGroup>
     <!-- We need $(ReactNativeWindowsDir)Chakra for ChakraCoreDebugger.h.
     We should remove it from IncludePath once we retire the ChakraExecutor stack. -->
-    <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -82,6 +82,7 @@
   <ImportGroup Label="ExtensionTargets" Condition="'$(CHAKRACOREUWP)'!='true'">
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild" Condition="'$(CHAKRACOREUWP)'!='true'">
     <PropertyGroup>
@@ -89,5 +90,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
 </Project>

--- a/vnext/JSI/Shared/ByteArrayBuffer.h
+++ b/vnext/JSI/Shared/ByteArrayBuffer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "jsi/jsi.h"
+#include <jsi/jsi.h>
 
 #include <memory>
 

--- a/vnext/JSI/Shared/ChakraObjectRef.cpp
+++ b/vnext/JSI/Shared/ChakraObjectRef.cpp
@@ -6,7 +6,7 @@
 #include "Unicode.h"
 #include "Utilities.h"
 
-#include "jsi//jsi.h"
+#include <jsi/jsi.h>
 
 #include <memory>
 #include <sstream>

--- a/vnext/JSI/Shared/ChakraObjectRef.h
+++ b/vnext/JSI/Shared/ChakraObjectRef.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "jsi/jsi.h"
+#include <jsi/jsi.h>
 
 #ifdef CHAKRACORE
 #include "ChakraCore.h"

--- a/vnext/JSI/Shared/ChakraRuntime.h
+++ b/vnext/JSI/Shared/ChakraRuntime.h
@@ -6,7 +6,7 @@
 #include "ChakraObjectRef.h"
 #include "ChakraRuntimeArgs.h"
 
-#include "jsi/jsi.h"
+#include <jsi/jsi.h>
 
 #ifdef CHAKRACORE
 #include "ChakraCore.h"

--- a/vnext/JSI/Shared/ChakraRuntimeArgs.h
+++ b/vnext/JSI/Shared/ChakraRuntimeArgs.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <jsi/jsi.h>
 #include <ScriptStore.h>
+#include <jsi/jsi.h>
 
 namespace facebook::react {
 class MemoryTracker;

--- a/vnext/JSI/Shared/ChakraRuntimeArgs.h
+++ b/vnext/JSI/Shared/ChakraRuntimeArgs.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include <jsi/jsi.h>
-#include "ScriptStore.h"
+#include <ScriptStore.h>
 
 namespace facebook::react {
 class MemoryTracker;

--- a/vnext/JSI/Shared/ScriptStore.h
+++ b/vnext/JSI/Shared/ScriptStore.h
@@ -2,14 +2,15 @@
 // Licensed under the MIT license.
 #pragma once
 
-#include <memory>
 #include <jsi/jsi.h>
+#include <memory>
 
 namespace facebook {
 namespace jsi {
 
 // Integer type as it's persist friently.
-using ScriptVersion_t = uint64_t;  // It shouldbe std::optional<uint64_t> once we have c++17 available everywhere. Until then, 0 implies versioning not available.
+using ScriptVersion_t = uint64_t; // It shouldbe std::optional<uint64_t> once we have c++17 available everywhere. Until
+                                  // then, 0 implies versioning not available.
 using JSRuntimeVersion_t = uint64_t; // 0 implies version can't be computed. We assert whenever that happens.
 
 struct VersionedBuffer {
@@ -27,47 +28,51 @@ struct JSRuntimeSignature {
   JSRuntimeVersion_t version;
 };
 
-// Most JSI::Runtime implementation offer some form of prepared JavaScript which offers better performance characteristics when loading comparing to plain JavaScript.
-// Embedders can provide an instance of this interface (through JSI::Runtime implementation's factory method),
-// to enable persistance of the prepared script and retrieval on subsequent evaluation of a script.
+// Most JSI::Runtime implementation offer some form of prepared JavaScript which offers better performance
+// characteristics when loading comparing to plain JavaScript. Embedders can provide an instance of this interface
+// (through JSI::Runtime implementation's factory method), to enable persistance of the prepared script and retrieval on
+// subsequent evaluation of a script.
 struct PreparedScriptStore {
   virtual ~PreparedScriptStore() = default;
 
   // Try to retrieve the prepared javascript for a given combination of script & runtime.
   // scriptSignature : Javascript url and version
   // RuntimeSignature : Javascript engine type and version
-  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
-  // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
+  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while
+  // experimentation and can be null. It is possible that no prepared script is available for a given script & runtime
+  // signature. This method should null if so
   virtual std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
-    const ScriptSignature& scriptSignature,
-    const JSRuntimeSignature& runtimeSignature,
-    const char* prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
-  ) noexcept = 0;
+      const ScriptSignature &scriptSignature,
+      const JSRuntimeSignature &runtimeSignature,
+      const char *prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
+      ) noexcept = 0;
 
   // Persist the perpared javascript for a given combination of script & runtime.
   // scriptSignature : Javascript url and version
   // RuntimeSignature : Javascript engine type and version
-  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
-  // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
-  // Any failure in persistance should be identified during the subsequent retrieval through the integrity mechanism which must be put into the storage.
+  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while
+  // experimentation and can be null. It is possible that no prepared script is available for a given script & runtime
+  // signature. This method should null if so Any failure in persistance should be identified during the subsequent
+  // retrieval through the integrity mechanism which must be put into the storage.
   virtual void persistPreparedScript(
-    std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
-    const ScriptSignature& scriptMetadata,
-    const JSRuntimeSignature& runtimeMetadata,
-    const char* prepareTag  // Optional tag. For e.g. eagerly evaluated vs lazy cache.
-  ) noexcept = 0;
+      std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
+      const ScriptSignature &scriptMetadata,
+      const JSRuntimeSignature &runtimeMetadata,
+      const char *prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
+      ) noexcept = 0;
 };
 
-// JSI::Runtime implementation must be provided an instance on this interface to enable version sensitive capabilities such as usage of pre-prepared javascript script.
-// Alternatively, this entity can be used to directly provide the Javascript buffer and rich metadata to the JSI::Runtime instance.
+// JSI::Runtime implementation must be provided an instance on this interface to enable version sensitive capabilities
+// such as usage of pre-prepared javascript script. Alternatively, this entity can be used to directly provide the
+// Javascript buffer and rich metadata to the JSI::Runtime instance.
 struct ScriptStore {
   virtual ~ScriptStore() = default;
 
   // Return the Javascript buffer and version corresponding to a given url.
-  virtual VersionedBuffer getVersionedScript(const std::string& url) noexcept = 0;
+  virtual VersionedBuffer getVersionedScript(const std::string &url) noexcept = 0;
 
   // Return the version of the Javascript buffer corresponding to a given url.
-  virtual ScriptVersion_t getScriptVersion(const std::string& url) noexcept = 0;
+  virtual ScriptVersion_t getScriptVersion(const std::string &url) noexcept = 0;
 };
 
 } // namespace jsi

--- a/vnext/JSI/Shared/ScriptStore.h
+++ b/vnext/JSI/Shared/ScriptStore.h
@@ -1,14 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 #pragma once
 
-#include <jsi/jsi.h>
 #include <memory>
+#include <jsi/jsi.h>
 
 namespace facebook {
 namespace jsi {
 
 // Integer type as it's persist friently.
-using ScriptVersion_t = uint64_t; // It shouldbe std::optional<uint64_t> once we have c++17 available everywhere. Until
-                                  // then, 0 implies versioning not available.
+using ScriptVersion_t = uint64_t;  // It shouldbe std::optional<uint64_t> once we have c++17 available everywhere. Until then, 0 implies versioning not available.
 using JSRuntimeVersion_t = uint64_t; // 0 implies version can't be computed. We assert whenever that happens.
 
 struct VersionedBuffer {
@@ -26,47 +27,47 @@ struct JSRuntimeSignature {
   JSRuntimeVersion_t version;
 };
 
-// Most JSI::Runtime implementation offer some form of prepared JavaScript which offers better performance
-// characteristics when loading comparing to plain JavaScript. Embedders can provide an instance of this interface
-// (through JSI::Runtime implementation's factory method), to enable persistance of the prepared script and retrieval on
-// subsequent evaluation of a script.
+// Most JSI::Runtime implementation offer some form of prepared JavaScript which offers better performance characteristics when loading comparing to plain JavaScript.
+// Embedders can provide an instance of this interface (through JSI::Runtime implementation's factory method),
+// to enable persistance of the prepared script and retrieval on subsequent evaluation of a script.
 struct PreparedScriptStore {
+  virtual ~PreparedScriptStore() = default;
+
   // Try to retrieve the prepared javascript for a given combination of script & runtime.
   // scriptSignature : Javascript url and version
   // RuntimeSignature : Javascript engine type and version
-  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while
-  // experimentation and can be null. It is possible that no prepared script is available for a given script & runtime
-  // signature. This method should null if so
+  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
+  // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
   virtual std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
-      const ScriptSignature &scriptSignature,
-      const JSRuntimeSignature &runtimeSignature,
-      const char *prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
-      ) noexcept = 0;
+    const ScriptSignature& scriptSignature,
+    const JSRuntimeSignature& runtimeSignature,
+    const char* prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
+  ) noexcept = 0;
 
   // Persist the perpared javascript for a given combination of script & runtime.
   // scriptSignature : Javascript url and version
   // RuntimeSignature : Javascript engine type and version
-  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while
-  // experimentation and can be null. It is possible that no prepared script is available for a given script & runtime
-  // signature. This method should null if so Any failure in persistance should be identified during the subsequent
-  // retrieval through the integrity mechanism which must be put into the storage.
+  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
+  // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
+  // Any failure in persistance should be identified during the subsequent retrieval through the integrity mechanism which must be put into the storage.
   virtual void persistPreparedScript(
-      std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
-      const ScriptSignature &scriptMetadata,
-      const JSRuntimeSignature &runtimeMetadata,
-      const char *prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
-      ) noexcept = 0;
+    std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
+    const ScriptSignature& scriptMetadata,
+    const JSRuntimeSignature& runtimeMetadata,
+    const char* prepareTag  // Optional tag. For e.g. eagerly evaluated vs lazy cache.
+  ) noexcept = 0;
 };
 
-// JSI::Runtime implementation must be provided an instance on this interface to enable version sensitive capabilities
-// such as usage of pre-prepared javascript script. Alternatively, this entity can be used to directly provide the
-// Javascript buffer and rich metadata to the JSI::Runtime instance.
+// JSI::Runtime implementation must be provided an instance on this interface to enable version sensitive capabilities such as usage of pre-prepared javascript script.
+// Alternatively, this entity can be used to directly provide the Javascript buffer and rich metadata to the JSI::Runtime instance.
 struct ScriptStore {
+  virtual ~ScriptStore() = default;
+
   // Return the Javascript buffer and version corresponding to a given url.
-  virtual VersionedBuffer getVersionedScript(const std::string &url) noexcept = 0;
+  virtual VersionedBuffer getVersionedScript(const std::string& url) noexcept = 0;
 
   // Return the version of the Javascript buffer corresponding to a given url.
-  virtual ScriptVersion_t getScriptVersion(const std::string &url) noexcept = 0;
+  virtual ScriptVersion_t getScriptVersion(const std::string& url) noexcept = 0;
 };
 
 } // namespace jsi

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj
@@ -63,7 +63,7 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -101,6 +101,7 @@
         $(ReactNativeWindowsDir)Microsoft.ReactNative\Views;
         $(FollyDir);
         $(ReactNativeDir)ReactCommon;
+        $(JSI_SourcePath);
         $(ReactNativeDir)ReactCommon\jsi;
         $(ReactNativeWindowsDir);
         $(ReactNativeWindowsDir)Common;
@@ -136,7 +137,7 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ChakraRT.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ChakraRT.lib;dxguid.lib;dloadhelper.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <ModuleDefinitionFile>Microsoft.ReactNative.def</ModuleDefinitionFile>
@@ -548,6 +549,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -557,6 +559,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
   <Target Name="AfterCppClean">
     <RemoveDir Directories="$(IdlHeaderDirectory)" ContinueOnError="true" />

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -23,9 +23,9 @@
     <HERMES_Version Condition="'$(HERMES_Version)' == ''">0.1.6</HERMES_Version>
     <HERMES_Package Condition="'$(HERMES_Package)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HERMES_Version)</HERMES_Package>
 
-    <USE_V8 Condition="'$(USE_V8)' == ''">false</USE_V8>
-    <V8_Version Condition="'$(V8_Version)' == ''">0.1.6</V8_Version>
-    <V8_Package Condition="'$(V8_Package)' == ''">$(SolutionDir)packages\ReactNative.V8JSI.Windows.$(V8_Version)</V8_Package>
+    <USE_V8 Condition="'$(USE_V8)' == '' AND '$(Platform)' != 'ARM' AND '$(Platform)' != 'ARM64'">true</USE_V8>
+    <V8_Version Condition="'$(V8_Version)' == ''">0.2.3</V8_Version>
+    <V8_Package Condition="'$(V8_Package)' == ''">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
 
     <!-- Enables React-Native-Windows ETW Provider : React-Native-Windows-Provider  -->
     <ENABLE_ETW_TRACING Condition="'$(ENABLE_ETW_TRACING)' == ''">true</ENABLE_ETW_TRACING>
@@ -46,9 +46,13 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
+    <!-- This prop is used for shared JSI code and headers -->
     <JSI_Source Condition="'$(JSI_Source)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_Source>
     <JSI_Source Condition="'$(USE_HERMES)' == 'true'">$(HERMES_Package)\installed\x64-windows\include\jsi_ref</JSI_Source>
-    <JSI_Source Condition="'$(USE_V8)' == 'true'">$(V8_Package)\installed\x64-windows\include\jsi_ref</JSI_Source>
+
+    <!-- This prop is used for JSI code that may be overridden in external JSI implementations -->
+    <JSI_SourcePath Condition="'$(JSI_SourcePath)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_SourcePath>
+    <JSI_SourcePath Condition="'$(USE_V8)' == 'true'">$(V8_Package)\build\native\include</JSI_SourcePath>
   </PropertyGroup>
 
   <ImportGroup Label="Defaults">

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -68,7 +68,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeDir)\ReactCommon\jscallinvoker;$(ReactNativeDir)\ReactCommon\jsiexecutor;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeDir)\ReactCommon\jscallinvoker;$(ReactNativeDir)\ReactCommon\jsiexecutor;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32;_CRT_SECURE_NO_WARNINGS;FOLLY_NO_CONFIG;NOMINMAX;RN_EXPORT=;JSI_EXPORT=;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
       <DisableSpecificWarnings>4715;4146;4251;4800;4804;4305;4722;%(DisableSpecificWarnings)</DisableSpecificWarnings>
@@ -84,13 +84,9 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="$(JSI_Source)\jsi\decorator.h" />
-    <ClInclude Include="$(JSI_Source)\jsi\instrumentation.h" />
-    <ClInclude Include="$(JSI_Source)\jsi\jsi-inl.h" />
-    <ClInclude Include="$(JSI_Source)\jsi\jsi.h" />
-    <ClInclude Include="$(JSI_Source)\jsi\JSIDynamic.h" />
-    <ClInclude Include="$(JSI_Source)\jsi\jsilib.h" />
-    <ClInclude Include="$(JSI_Source)\jsi\threadsafe.h" />
+    <ClInclude Include="$(JSI_SourcePath)\jsi\instrumentation.h" />
+    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi-inl.h" />
+    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi.h" />
     <ClInclude Include="..\stubs\sys\mman.h" />
     <ClInclude Include="..\stubs\sys\time.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\cxxreact\CxxModule.h" />
@@ -135,9 +131,8 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\NativeToJsBridge.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\RAMBundleRegistry.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\ReactMarker.cpp" />
-    <ClCompile Include="$(JSI_Source)\jsi\jsi.cpp" />
+    <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp" />
     <ClCompile Include="$(JSI_Source)\jsi\JSIDynamic.cpp" />
-    <ClCompile Include="$(JSI_Source)\jsi\jsilib-windows.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSIExecutor.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSINativeModules.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.cpp">

--- a/vnext/ReactCommon/ReactCommon.vcxproj.filters
+++ b/vnext/ReactCommon/ReactCommon.vcxproj.filters
@@ -102,13 +102,7 @@
     <ClCompile Include="$(YogaDir)\yoga\Yoga.cpp">
       <Filter>yoga</Filter>
     </ClCompile>
-    <ClCompile Include="$(JSI_Source)\jsi\jsi.cpp">
-      <Filter>jsi\jsi</Filter>
-    </ClCompile>
-    <ClCompile Include="$(JSI_Source)\jsi\JSIDynamic.cpp">
-      <Filter>jsi\jsi</Filter>
-    </ClCompile>
-    <ClCompile Include="$(JSI_Source)\jsi\jsilib-windows.cpp">
+    <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp">
       <Filter>jsi\jsi</Filter>
     </ClCompile>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.cpp">
@@ -236,25 +230,13 @@
     <ClInclude Include="$(YogaDir)\yoga\Yoga.h">
       <Filter>yoga</Filter>
     </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\decorator.h">
+    <ClInclude Include="$(JSI_SourcePath)\jsi\instrumentation.h">
       <Filter>jsi\jsi</Filter>
     </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\instrumentation.h">
+    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi.h">
       <Filter>jsi\jsi</Filter>
     </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\jsi.h">
-      <Filter>jsi\jsi</Filter>
-    </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\JSIDynamic.h">
-      <Filter>jsi\jsi</Filter>
-    </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\jsi-inl.h">
-      <Filter>jsi\jsi</Filter>
-    </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\jsilib.h">
-      <Filter>jsi\jsi</Filter>
-    </ClInclude>
-    <ClInclude Include="$(JSI_Source)\jsi\threadsafe.h">
+    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi-inl.h">
       <Filter>jsi\jsi</Filter>
     </ClInclude>
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.h">

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -381,29 +381,30 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance> &spThis, cons
       std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
       std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
-      switch(settings.jsiEngine) {
+      switch (settings.jsiEngine) {
         case JSIEngine::Hermes:
 #if defined(USE_HERMES)
-      devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
+          devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
           break;
 #endif
         case JSIEngine::V8:
 #if defined(USE_V8)
-      preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationLocalFolder());
+          preparedScriptStore =
+              std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationLocalFolder());
 
-      devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
-          devSettings, jsQueue, std::move(scriptStore), std::move(preparedScriptStore));
+          devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
+              devSettings, jsQueue, std::move(scriptStore), std::move(preparedScriptStore));
           break;
 #endif
         case JSIEngine::Chakra:
-      if (settings.EnableByteCodeCaching || !settings.ByteCodeFileUri.empty()) {
-        scriptStore = std::make_unique<UwpScriptStore>();
-        preparedScriptStore = std::make_unique<UwpPreparedScriptStore>(winrt::to_hstring(settings.ByteCodeFileUri));
-      }
-      devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
-          devSettings, jsQueue, std::move(scriptStore), std::move(preparedScriptStore));
+          if (settings.EnableByteCodeCaching || !settings.ByteCodeFileUri.empty()) {
+            scriptStore = std::make_unique<UwpScriptStore>();
+            preparedScriptStore = std::make_unique<UwpPreparedScriptStore>(winrt::to_hstring(settings.ByteCodeFileUri));
+          }
+          devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
+              devSettings, jsQueue, std::move(scriptStore), std::move(preparedScriptStore));
           break;
-    }
+      }
     }
 #endif
 

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -89,12 +89,9 @@
 #include "V8JSIRuntimeHolder.h"
 
 #include <winrt/Windows.Storage.h>
-
-#include <codecvt>
-#include <locale>
-#else
-#include "ChakraRuntimeHolder.h"
 #endif
+#include "ChakraRuntimeHolder.h"
+
 #endif
 
 #include <tuple>
@@ -384,21 +381,29 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance> &spThis, cons
       std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
       std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
+      switch(settings.jsiEngine) {
+        case JSIEngine::Hermes:
 #if defined(USE_HERMES)
       devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
-#elif defined(USE_V8)
+          break;
+#endif
+        case JSIEngine::V8:
+#if defined(USE_V8)
       preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationLocalFolder());
 
       devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
           devSettings, jsQueue, std::move(scriptStore), std::move(preparedScriptStore));
-#else
+          break;
+#endif
+        case JSIEngine::Chakra:
       if (settings.EnableByteCodeCaching || !settings.ByteCodeFileUri.empty()) {
         scriptStore = std::make_unique<UwpScriptStore>();
         preparedScriptStore = std::make_unique<UwpPreparedScriptStore>(winrt::to_hstring(settings.ByteCodeFileUri));
       }
       devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
           devSettings, jsQueue, std::move(scriptStore), std::move(preparedScriptStore));
-#endif
+          break;
+    }
     }
 #endif
 
@@ -595,7 +600,7 @@ void UwpReactInstance::CallXamlViewCreatedTestHook(react::uwp::XamlView view) {
 std::string UwpReactInstance::getApplicationLocalFolder() {
   auto local = winrt::Windows::Storage::ApplicationData::Current().LocalFolder().Path();
 
-  return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(std::wstring(local.c_str(), local.size())) + "\\";
+  return Microsoft::Common::Unicode::Utf16ToUtf8(local.c_str(), local.size()) + "\\";
 }
 #endif
 

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -98,7 +98,7 @@
         _HAS_AUTO_PTR_ETC;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Pch;$(ReactNativeWindowsDir)ReactUWP\GeneratedWinmdHeader;$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactUWP;$(YogaDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Pch;$(ReactNativeWindowsDir)ReactUWP\GeneratedWinmdHeader;$(ReactNativeWindowsDir)ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeWindowsDir)include\ReactUWP;$(YogaDir);$(ReactNativeDir)\ReactCommon;$(ReactNativeWindowsDir)\JSI\Shared;$(JSI_Source);$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(CHAKRACOREUWP)'=='true'">$(ChakraCoreInclude);$(ChakraCoreDebugInclude);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <ShowIncludes>false</ShowIncludes>
@@ -109,7 +109,7 @@
       <AdditionalOptions>-minpdbpathlen:256</AdditionalOptions>
       <AdditionalDependencies Condition="'$(CHAKRACOREUWP)'=='true'">ChakraCore.Debugger.Protocol.lib;ChakraCore.Debugger.ProtocolHandler.lib;ChakraCore.Debugger.Service.lib;ChakraCore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(CHAKRACOREUWP)'=='true'">$(ChakraCoreLibDir);$(ChakraCoreDebugLibDir)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;dloadhelper.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>$(ProjectDir)ABI\idl;$(ProjectDir)Views\cppwinrt</AdditionalIncludeDirectories>
@@ -415,6 +415,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -424,6 +425,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
   <Target Name="AfterCppClean">
     <RemoveDir Directories="$(IdlHeaderDirectory)" ContinueOnError="true" />

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
@@ -5,7 +5,7 @@
 #include <winrt/Windows.Storage.FileProperties.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include "Unicode.h"
-#include "jsi/jsi.h"
+#include <jsi/jsi.h>
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage

--- a/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
+++ b/vnext/ReactUWP/Utils/UwpPreparedScriptStore.cpp
@@ -2,10 +2,10 @@
 
 #include <Utils/UwpPreparedScriptStore.h>
 #include <Utils/UwpScriptStore.h>
+#include <jsi/jsi.h>
 #include <winrt/Windows.Storage.FileProperties.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include "Unicode.h"
-#include <jsi/jsi.h>
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage

--- a/vnext/ReactWindows-Universal.sln
+++ b/vnext/ReactWindows-Universal.sln
@@ -116,7 +116,6 @@ Global
 		include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/vnext/ReactWindowsCore/BaseScriptStoreImpl.h
+++ b/vnext/ReactWindowsCore/BaseScriptStoreImpl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JSI/Shared/ScriptStore.h>
+#include <ScriptStore.h>
 #include <jsi/jsi.h>
 
 #include <algorithm>

--- a/vnext/ReactWindowsCore/ChakraRuntimeHolder.h
+++ b/vnext/ReactWindowsCore/ChakraRuntimeHolder.h
@@ -2,8 +2,8 @@
 
 #include <DevSettings.h>
 
-#include <JSI/Shared/RuntimeHolder.h>
 #include <JSI/Shared/ChakraRuntimeArgs.h>
+#include <JSI/Shared/RuntimeHolder.h>
 
 #include <Logging.h>
 

--- a/vnext/ReactWindowsCore/ChakraRuntimeHolder.h
+++ b/vnext/ReactWindowsCore/ChakraRuntimeHolder.h
@@ -3,8 +3,6 @@
 #include <DevSettings.h>
 
 #include <JSI/Shared/RuntimeHolder.h>
-#include <jsi/Shared/ScriptStore.h>
-
 #include <JSI/Shared/ChakraRuntimeArgs.h>
 
 #include <Logging.h>

--- a/vnext/ReactWindowsCore/MemoryMappedBuffer.h
+++ b/vnext/ReactWindowsCore/MemoryMappedBuffer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "jsi/jsi.h"
+#include <jsi/jsi.h>
 
 #include <memory>
 

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -78,10 +78,8 @@
       -->
       <PreprocessorDefinitions>REACTWINDOWS_BUILD;NOMINMAX;FOLLY_NO_CONFIG;WIN32=0;RN_EXPORT=;CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(USE_HERMES)'=='true'">USE_HERMES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(USE_V8)'=='true'">USE_V8;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(USE_V8)'=='true'">$(V8_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessToFile>false</PreprocessToFile>
     </ClCompile>
     <Link>
@@ -90,9 +88,7 @@
     </Link>
     <Lib>
       <AdditionalLibraryDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(USE_V8)'=='true'">$(V8_Package)\installed\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="'$(USE_HERMES)'=='true'">hermes.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(USE_V8)'=='true'">v8jsi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
@@ -191,7 +187,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(HERMES_Package)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(HERMES_Package)\build\native\ReactNative.Hermes.Windows.targets') AND '$(PATCH_RN)' != 'true' AND '$(USE_HERMES)' == 'true'" />
-    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(PATCH_RN)' != 'true' AND '$(USE_V8)' == 'true'" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(PATCH_RN)' == 'true' AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
@@ -3,7 +3,7 @@
 #include <DevSettings.h>
 
 #include <JSI/Shared/RuntimeHolder.h>
-#include <JSI/Shared/ScriptStore.h>
+#include <ScriptStore.h>
 
 #include <Logging.h>
 

--- a/vnext/ReactWindowsCore/packages.config
+++ b/vnext/ReactWindowsCore/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.1.6" targetFramework="native" Condition="'$(PATCH_RN)' != 'true' AND '$(USE_HERMES)' == 'true'" />
-  <package id="ReactNative.V8JSI.Windows" version="0.1.6" targetFramework="native" Condition="'$(PATCH_RN)' != 'true' AND '$(USE_V8)' == 'true'"/>
+  <package id="ReactNative.V8Jsi.Windows" version="0.2.3" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
 </packages>

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -420,7 +420,7 @@ InstanceImpl::InstanceImpl(
           char tempPath[MAX_PATH];
           if (GetTempPathA(MAX_PATH, tempPath)) {
             preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
-            }
+          }
 
           m_devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
               m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -416,14 +416,12 @@ InstanceImpl::InstanceImpl(
 #if defined(USE_V8)
           std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
           std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
-          if (!m_devSettings->bytecodeFileName.empty()) {
-            // Take the root path of the bytecode location if provided
-            auto lastSepPosition = m_devSettings->bytecodeFileName.find_last_of("/\\");
-            if (lastSepPosition != std::string::npos) {
-              preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(
-                  m_devSettings->bytecodeFileName.substr(0, lastSepPosition + 1));
+
+          char tempPath[MAX_PATH];
+          if (GetTempPathA(MAX_PATH, tempPath)) {
+            preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
             }
-          }
+
           m_devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
               m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
           break;

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -28,6 +28,12 @@ typedef unsigned int LiveReloadCallbackCookie;
 typedef unsigned int ErrorCallbackCookie;
 typedef unsigned int DebuggerAttachCallbackCookie;
 
+enum class JSIEngine : int32_t {
+  Chakra = 0, // Use the JSIExecutorFactory with ChakraRuntime
+  Hermes = 1, // Use the JSIExecutorFactory with Hermes
+  V8 = 2, // Use the JSIExecutorFactory with V8
+};
+
 struct ReactInstanceSettings {
   bool UseWebDebugger{false};
   bool UseLiveReload{false};
@@ -43,6 +49,7 @@ struct ReactInstanceSettings {
   std::string BundleRootPath;
   facebook::react::NativeLoggingHook LoggingCallback;
   std::function<void(facebook::react::JSExceptionInfo &&)> JsExceptionCallback;
+  JSIEngine jsiEngine{JSIEngine::Chakra};
 };
 
 struct IReactInstance {

--- a/vnext/include/ReactUWP/Utils/UwpPreparedScriptStore.h
+++ b/vnext/include/ReactUWP/Utils/UwpPreparedScriptStore.h
@@ -1,11 +1,11 @@
 #pragma once
-#include <JSI/Shared/ScriptStore.h>
+#include <ScriptStore.h>
 #include <cxxreact/JSBigString.h>
+#include <jsi/jsi.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.h>
 #include <future>
 #include <string>
-#include "jsi/jsi.h"
 
 namespace react {
 namespace uwp {

--- a/vnext/include/ReactUWP/Utils/UwpScriptStore.h
+++ b/vnext/include/ReactUWP/Utils/UwpScriptStore.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <JSI/Shared/ScriptStore.h>
+#include <ScriptStore.h>
 #include <future>
 
 namespace react {


### PR DESCRIPTION
This backports the same change from master; it enables V8 as an optional JSI engine implementation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4241)