### PR TITLE
Rename "Verify change files, lint, and test" to "Extra Checks"

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -419,8 +419,8 @@ jobs:
           platform: x64
           vsComponents: $(VsComponents)
 
-  - job: RNWFormatting
-    displayName: Verify change files, lint, and test
+  - job: RNWExtraChecks
+    displayName: Extra Checks
     dependsOn: Setup
     condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
     pool:


### PR DESCRIPTION
Too many of our pipelines begin with "Verify" and this name is getting verbose/inaccurate/hard to find. Rename the pipeline to "Extra Checks".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4244)