### PR TITLE
Support dependency config for RNW when running "react-native config"

### DIFF
--- a/change/react-native-windows-2020-03-06-09-06-45-autolink2.json
+++ b/change/react-native-windows-2020-03-06-09-06-45-autolink2.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Support dependency config for RNW",
+  "packageName": "react-native-windows",
+  "email": "dida@ntdev.microsoft.com",
+  "commit": "d763dfbf19b4e7830a8a51ba63aee9db941f54f8",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T17:06:45.060Z"
+}

--- a/vnext/local-cli/config/dependencyConfig.js
+++ b/vnext/local-cli/config/dependencyConfig.js
@@ -1,0 +1,104 @@
+const fs = require('fs')
+const path = require('path');
+const glob = require('glob');
+const xmldoc = require('xmldoc');
+
+function dependencyConfigWindows(folder, userConfig = {}) {
+  const sourceDir = userConfig.sourceDir || findWindowsAppFolder(folder);
+
+  if (!sourceDir) {
+    return null;
+  }
+
+  var packageName = null;
+  const packageIDL = findPackageProviderIDL(sourceDir);
+  if (packageIDL){
+    packageName = parsePackageIDLFile(packageIDL);
+  }
+  var cppProjFile = null;
+  var csProjectFile = null;
+  if (packageName)
+  {
+    cppProjFile = findCppProject(sourceDir, packageName);
+    csProjectFile = findCSProject(sourceDir,packageName);
+  }
+
+  var projGUID = null;
+  if (cppProjFile)
+  {
+    const proj = readProject(cppProjFile);
+    var groupNode = proj.childNamed('PropertyGroup');
+    if (groupNode){
+      var nameNode = groupNode.childNamed('ProjectGuid');
+      if (nameNode){
+        projGUID = nameNode.val;
+      }
+    }
+  }
+
+  return {
+    sourceDir,
+    packageIDL,
+    packageName,
+    cppProjFile,
+    csProjectFile,
+    projGUID,
+  }
+}
+
+function findWindowsAppFolder(folder) {
+  const winDir = 'windows';
+  const joinedDir = path.join(folder, winDir);
+  if (fs.existsSync(joinedDir)) {
+    return joinedDir;
+  }
+
+  return null;
+}
+
+// assumption is every cpp native module will have a ReactPackageProvider.idl defined
+function findPackageProviderIDL(folder) {
+  const PackageIDLPath = glob.sync(path.join('**', 'ReactPackageProvider.idl'), {
+    cwd: folder,
+    ignore: ['node_modules/**', '**/Debug/**', '**/Release/**', 'Generated Files']
+  })[0];
+
+  return PackageIDLPath ? path.join(folder, PackageIDLPath) : null;
+}
+
+// look for packagename 'XYZ' in string 'namesapce XYZ {'
+function parsePackageIDLFile(packageIDL) {
+  const buf = fs.readFileSync(packageIDL, 'utf8');
+  const indexofNameSpace = buf.indexOf('namespace') + 9;
+  const indexofBracket = buf.indexOf('{');
+  const packageName = buf.substring(indexofNameSpace, indexofBracket).replace(/\s+/g, ' ').trim();
+
+  return packageName;
+}
+
+// read visual studio project file which is actually a XML doc
+function readProject(projectPath) {
+  return new (xmldoc.XmlDocument)(fs.readFileSync(projectPath, 'utf8'));
+}
+
+function findCppProject(folder, projectName) {
+  const cppProj = glob.sync(path.join('**', projectName + '.vcxproj'), {
+    cwd: folder,
+    ignore: ['node_modules/**', '**/Debug/**', '**/Release/**', '**/Generated Files/**', '**/packages/**']
+  })[0];
+
+  return cppProj ? path.join(folder, cppProj) : null;
+}
+
+function findCSProject(folder, projectName) {
+  const cppProj = glob.sync(path.join('**', projectName + '.csproj'), {
+    cwd: folder,
+    ignore: ['node_modules/**', '**/Debug/**', '**/Release/**', '**/Generated Files/**', '**/packages/**']
+  })[0];
+
+  return cppProj ? path.join(folder, cppProj) : null;
+}
+
+module.exports = {
+  dependencyConfigWindows: dependencyConfigWindows
+}

--- a/vnext/local-cli/config/projectConfig.js
+++ b/vnext/local-cli/config/projectConfig.js
@@ -10,8 +10,10 @@ function projectConfigWindows(folder, userConfig = {}) {
   }
 
   const projectSolution = findSolution(sourceDir);
-  var extension = path.extname(projectSolution);
-  var projectName = path.basename(projectSolution, extension);
+  if (projectSolution){
+    var extension = path.extname(projectSolution);
+    var projectName = path.basename(projectSolution, extension);
+  }
   const cppProjFile = findCppProject(sourceDir, projectName);
   const csProjectFile = findCSProject(sourceDir,projectName);
 

--- a/vnext/react-native.config.js
+++ b/vnext/react-native.config.js
@@ -1,5 +1,7 @@
 // @ts-check
 const projectConfig = require('./local-cli/config/projectConfig');
+const dependencyConfig = require('./local-cli/config/dependencyConfig');
+
 module.exports = {
     // **** This section defined commands and options on how to provide the windows platform to external applications
     commands: [
@@ -9,7 +11,7 @@ module.exports = {
       windows: {
         linkConfig: () => null,
         projectConfig: projectConfig.projectConfigWindows,
-        dependencyConfig: (projectRoot, dependencyParams) => null,
+        dependencyConfig: dependencyConfig.dependencyConfigWindows,
       },
     },
 


### PR DESCRIPTION
#2853 
Dependency config checks each installed native module location and emits the config information which will be used for auto-linking. Along with project config, we will be using them to update solution/project file and code gen headers. 

Example output from RNV community module for windows platform:
       "windows": {
          "sourceDir": "c:\\rnw612\\node_modules\\react-native-video\\windows",
          "packageIDL": "c:\\rnw612\\node_modules\\react-native-video\\windows\\ReactNativeVideoCPP\\ReactPackageProvider.idl",
          "packageName": "ReactNativeVideoCPP",
          "cppProjFile": "c:\\rnw612\\node_modules\\react-native-video\\windows\\ReactNativeVideoCPP\\ReactNativeVideoCPP.vcxproj",
          "csProjectFile": null,
          "projGUID": "{765365e4-9553-4900-9f69-e26d4309c8da}"
        }

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4251)