### PR TITLE
Release build fails if you dont have react-native globally installed

### DIFF
--- a/change/react-native-windows-2020-03-06-15-18-23-noglobalrn.json
+++ b/change/react-native-windows-2020-03-06-15-18-23-noglobalrn.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Bundle commands should work if you dont have react-native installed globally",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "c8cf0fbea6665137497b3cb8eee5bdf3e985cbb4",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T23:18:22.987Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/SampleAppCpp.vcxproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/SampleAppCpp.vcxproj
@@ -176,7 +176,7 @@
   <PropertyGroup>
     <BundleCommand>
       cd $(SolutionDir)..
-      react-native bundle --platform windows --entry-file index.windows.js --bundle-output windows/SampleAppCpp/Bundle/index.windows.bundle --assets-dest windows/SampleAppCpp/Bundle
+      npx --no-install react-native bundle --platform windows --entry-file index.windows.js --bundle-output windows/SampleAppCpp/Bundle/index.windows.bundle --assets-dest windows/SampleAppCpp/Bundle
     </BundleCommand>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.Cpp.targets" />

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
@@ -176,7 +176,7 @@
   <PropertyGroup>
     <BundleCommand>
       cd $(SolutionDir)..
-      react-native bundle --platform windows --entry-file index.windows.js --bundle-output windows/SampleAppCS/Bundle/index.windows.bundle --assets-dest windows/SampleAppCS/Bundle
+      npx --no-install react-native bundle --platform windows --entry-file index.windows.js --bundle-output windows/SampleAppCS/Bundle/index.windows.bundle --assets-dest windows/SampleAppCS/Bundle
     </BundleCommand>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.targets" />

--- a/vnext/local-cli/generator-windows/templates/cpp/proj/MyApp.vcxproj
+++ b/vnext/local-cli/generator-windows/templates/cpp/proj/MyApp.vcxproj
@@ -160,7 +160,7 @@
   <PropertyGroup>
     <BundleCommand>
       cd $(SolutionDir)..
-      react-native bundle --platform windows --entry-file index.js --bundle-output windows/$(SolutionName)/Bundle/index.windows.bundle --assets-dest windows/$(SolutionName)/Bundle
+      npx --no-install react-native bundle --platform windows --entry-file index.js --bundle-output windows/$(SolutionName)/Bundle/index.windows.bundle --assets-dest windows/$(SolutionName)/Bundle
     </BundleCommand>
   </PropertyGroup>
   <Import Project="..\..\node_modules\react-native-windows\PropertySheets\Bundle.Cpp.targets"/>

--- a/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
+++ b/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
@@ -170,7 +170,7 @@
   <PropertyGroup>
     <BundleCommand>
       cd $(SolutionDir)..
-      react-native bundle --platform windows --entry-file index.js --bundle-output windows/$(SolutionName)/Bundle/index.windows.bundle --assets-dest windows/$(SolutionName)/Bundle
+      npx --no-install react-native bundle --platform windows --entry-file index.js --bundle-output windows/$(SolutionName)/Bundle/index.windows.bundle --assets-dest windows/$(SolutionName)/Bundle
     </BundleCommand>
   </PropertyGroup>
   <Import Project="..\..\node_modules\react-native-windows\PropertySheets\Bundle.targets"/>


### PR DESCRIPTION
The current default template has VS trigger a bundle command that only works if you have react-native installed globally. -- which also means that it maybe triggering the bundle command from a different version of react-native than the one the project is using.

The command should instead use the version of react-native that is locally installed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4258)