### PR TITLE
Dont show loading bar in release apps

### DIFF
--- a/change/react-native-windows-2020-03-06-15-28-57-noloadingship.json
+++ b/change/react-native-windows-2020-03-06-15-28-57-noloadingship.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Dont show loading/redbox in ship mode",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "93ccc4bca669131515a78f315acc59bd7cee204e",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T23:28:57.062Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -160,6 +160,7 @@ void ReactRootControl::InitRootView(
   const auto &devSettings = m_reactOptions->DeveloperSettings;
   m_useLiveReload = devSettings.UseLiveReload;
   m_useWebDebugger = devSettings.UseWebDebugger;
+  m_isDevModeEnabled = devSettings.IsDevModeEnabled;
   if (devSettings.IsDevModeEnabled) {
     InitializeDeveloperMenu();
   }
@@ -269,6 +270,9 @@ void ReactRootControl::ShowInstanceLoaded(Mso::React::IReactInstance &reactInsta
 }
 
 void ReactRootControl::ShowInstanceError(Mso::React::IReactInstance &reactInstance) noexcept {
+  if (!m_isDevModeEnabled)
+    return;
+
   if (XamlView xamlRootView = m_weakXamlRootView.get()) {
     auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
 
@@ -335,6 +339,9 @@ void ReactRootControl::ShowInstanceWaiting(Mso::React::IReactInstance & /*reactI
 }
 
 void ReactRootControl::ShowInstanceLoading(Mso::React::IReactInstance & /*reactInstance*/) noexcept {
+  if (!m_isDevModeEnabled)
+    return;
+
   if (XamlView xamlRootView = m_weakXamlRootView.get()) {
     auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
 
@@ -610,6 +617,7 @@ void ReactRootControl::ToggleInspector() noexcept {
 void ReactRootControl::ReloadHost() noexcept {
   if (auto reactViewHost = m_reactViewHost.Get()) {
     auto options = reactViewHost->ReactHost().Options();
+    options.DeveloperSettings.IsDevModeEnabled = m_isDevModeEnabled;
     options.DeveloperSettings.UseLiveReload = m_useLiveReload;
     options.DeveloperSettings.UseWebDebugger = m_useWebDebugger;
     options.DeveloperSettings.UseDirectDebugger = m_directDebugging;

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
@@ -99,6 +99,7 @@ struct ReactRootControl final : std::enable_shared_from_this<ReactRootControl>, 
   std::unique_ptr<Mso::React::ReactViewOptions> m_reactViewOptions;
   std::weak_ptr<facebook::react::InstanceWrapper> m_fbReactInstance;
 
+  bool m_isDevModeEnabled{false};
   bool m_useLiveReload{false};
   bool m_useWebDebugger{false};
   bool m_directDebugging{false};


### PR DESCRIPTION
Fixes: #4252 

Basically apps in release mode shouldn't show the green loading bar, or red box error UI. -- This aligns with react-native on android/iOS.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4259)