### PR TITLE
Deprecate JSValue typed value access functions

### DIFF
--- a/change/react-native-windows-2020-03-06-15-06-46-MS_FixJSValue.json
+++ b/change/react-native-windows-2020-03-06-15-06-46-MS_FixJSValue.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Deprecated JSValue typed value access functions",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "de23cd40fadddb7fe878b3dbd7d32c05fcae55a7",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T23:06:45.796Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/CustomUserControlViewManagerCPP.cpp
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/CustomUserControlViewManagerCPP.cpp
@@ -74,7 +74,7 @@ void CustomUserControlViewManagerCpp::UpdateProperties(
     FrameworkElement const &view,
     IJSValueReader const &propertyMapReader) noexcept {
   if (auto control = view.try_as<winrt::SampleLibraryCpp::CustomUserControlCpp>()) {
-    JSValueObject propertyMap = JSValue::ReadObjectFrom(propertyMapReader);
+    JSValueObject propertyMap = JSValueObject::ReadFrom(propertyMapReader);
 
     for (auto const &pair : propertyMap) {
       auto const &propertyName = pair.first;
@@ -82,7 +82,7 @@ void CustomUserControlViewManagerCpp::UpdateProperties(
 
       if (propertyName == "label") {
         if (!propertyValue.IsNull()) {
-          auto value = winrt::box_value(winrt::to_hstring(propertyValue.String()));
+          auto value = winrt::box_value(winrt::to_hstring(propertyValue.AsString()));
           control.SetValue(winrt::SampleLibraryCpp::CustomUserControlCpp::LabelProperty(), value);
         } else {
           control.ClearValue(winrt::SampleLibraryCpp::CustomUserControlCpp::LabelProperty());

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/pch.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/pch.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#define NOMINMAX
+
 #include <unknwn.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
@@ -24,13 +24,22 @@ TEST_CLASS (JSValueTest) {
 
     JSValue jsValue = JSValue::ReadFrom(reader);
     TestCheck(jsValue.Type() == JSValueType::Object);
-    TestCheck(jsValue.Object().at("NullValue").IsNull());
-    TestCheck(jsValue.Object().at("ObjValue").Object().empty());
-    TestCheck(jsValue.Object().at("ArrayValue").Array().empty());
-    TestCheck(jsValue.Object().at("StringValue").String() == "Hello");
-    TestCheck(jsValue.Object().at("BoolValue").Boolean() == true);
-    TestCheck(jsValue.Object().at("IntValue").Int64() == 42);
-    TestCheck(jsValue.Object().at("DoubleValue").Double() == 4.5);
+
+    TestCheck(jsValue["NullValue"].Type() == JSValueType::Null);
+    TestCheck(jsValue["ObjValue"].Type() == JSValueType::Object);
+    TestCheck(jsValue["ArrayValue"].Type() == JSValueType::Array);
+    TestCheck(jsValue["StringValue"].Type() == JSValueType::String);
+    TestCheck(jsValue["BoolValue"].Type() == JSValueType::Boolean);
+    TestCheck(jsValue["IntValue"].Type() == JSValueType::Int64);
+    TestCheck(jsValue["DoubleValue"].Type() == JSValueType::Double);
+
+    TestCheck(jsValue["NullValue"].IsNull());
+    TestCheck(jsValue["ObjValue"].TryGetObject()->empty());
+    TestCheck(jsValue["ArrayValue"].TryGetArray()->empty());
+    TestCheck(jsValue["StringValue"] == "Hello");
+    TestCheck(jsValue["BoolValue"] == true);
+    TestCheck(jsValue["IntValue"] == 42);
+    TestCheck(jsValue["DoubleValue"] == 4.5);
   } // namespace winrt::Microsoft::ReactNative
 
   TEST_METHOD(TestReadNestedObject) {
@@ -51,14 +60,24 @@ TEST_CLASS (JSValueTest) {
 
     JSValue jsValue = JSValue::ReadFrom(reader);
     TestCheck(jsValue.Type() == JSValueType::Object);
-    const auto &nestedObj = jsValue.Object().at("NestedObj").Object();
-    TestCheck(nestedObj.at("NullValue").IsNull());
-    TestCheck(nestedObj.at("ObjValue").Object().empty());
-    TestCheck(nestedObj.at("ArrayValue").Array().empty());
-    TestCheck(nestedObj.at("StringValue").String() == "Hello");
-    TestCheck(nestedObj.at("BoolValue").Boolean() == true);
-    TestCheck(nestedObj.at("IntValue").Int64() == 42);
-    TestCheck(nestedObj.at("DoubleValue").Double() == 4.5);
+    TestCheck(jsValue["NestedObj"].Type() == JSValueType::Object);
+    auto const &nestedObj = *jsValue["NestedObj"].TryGetObject();
+
+    TestCheck(nestedObj["NullValue"].Type() == JSValueType::Null);
+    TestCheck(nestedObj["ObjValue"].Type() == JSValueType::Object);
+    TestCheck(nestedObj["ArrayValue"].Type() == JSValueType::Array);
+    TestCheck(nestedObj["StringValue"].Type() == JSValueType::String);
+    TestCheck(nestedObj["BoolValue"].Type() == JSValueType::Boolean);
+    TestCheck(nestedObj["IntValue"].Type() == JSValueType::Int64);
+    TestCheck(nestedObj["DoubleValue"].Type() == JSValueType::Double);
+
+    TestCheck(nestedObj["NullValue"].IsNull());
+    TestCheck(nestedObj["ObjValue"].TryGetObject()->empty());
+    TestCheck(nestedObj["ArrayValue"].TryGetArray()->empty());
+    TestCheck(nestedObj["StringValue"] == "Hello");
+    TestCheck(nestedObj["BoolValue"] == true);
+    TestCheck(nestedObj["IntValue"] == 42);
+    TestCheck(nestedObj["DoubleValue"] == 4.5);
   }
 
   TEST_METHOD(TestReadArray) {
@@ -67,13 +86,22 @@ TEST_CLASS (JSValueTest) {
 
     JSValue jsValue = JSValue::ReadFrom(reader);
     TestCheck(jsValue.Type() == JSValueType::Array);
-    TestCheck(jsValue.Array()[0].IsNull());
-    TestCheck(jsValue.Array()[1].Object().empty());
-    TestCheck(jsValue.Array()[2].Array().empty());
-    TestCheck(jsValue.Array()[3].String() == "Hello");
-    TestCheck(jsValue.Array()[4].Boolean() == true);
-    TestCheck(jsValue.Array()[5].Int64() == 42);
-    TestCheck(jsValue.Array()[6].Double() == 4.5);
+
+    TestCheck(jsValue[0].Type() == JSValueType::Null);
+    TestCheck(jsValue[1].Type() == JSValueType::Object);
+    TestCheck(jsValue[2].Type() == JSValueType::Array);
+    TestCheck(jsValue[3].Type() == JSValueType::String);
+    TestCheck(jsValue[4].Type() == JSValueType::Boolean);
+    TestCheck(jsValue[5].Type() == JSValueType::Int64);
+    TestCheck(jsValue[6].Type() == JSValueType::Double);
+
+    TestCheck(jsValue[0].IsNull());
+    TestCheck(jsValue[1].TryGetObject()->empty());
+    TestCheck(jsValue[2].TryGetArray()->empty());
+    TestCheck(jsValue[3] == "Hello");
+    TestCheck(jsValue[4] == true);
+    TestCheck(jsValue[5] == 42);
+    TestCheck(jsValue[6] == 4.5);
   }
 
   TEST_METHOD(TestReadNestedArray) {
@@ -81,15 +109,510 @@ TEST_CLASS (JSValueTest) {
     IJSValueReader reader = make<JsonJSValueReader>(json);
 
     JSValue jsValue = JSValue::ReadFrom(reader);
-    TestCheck(jsValue.Type() == JSValueType::Array);
-    const auto &nestedArr = jsValue.Array()[0].Array();
+    TestCheck(jsValue[0].TryGetArray());
+    auto const &nestedArr = *jsValue[0].TryGetArray();
+
+    TestCheck(nestedArr[0].Type() == JSValueType::Null);
+    TestCheck(nestedArr[1].Type() == JSValueType::Object);
+    TestCheck(nestedArr[2].Type() == JSValueType::Array);
+    TestCheck(nestedArr[3].Type() == JSValueType::String);
+    TestCheck(nestedArr[4].Type() == JSValueType::Boolean);
+    TestCheck(nestedArr[5].Type() == JSValueType::Int64);
+    TestCheck(nestedArr[6].Type() == JSValueType::Double);
+
     TestCheck(nestedArr[0].IsNull());
-    TestCheck(nestedArr[1].Object().empty());
-    TestCheck(nestedArr[2].Array().empty());
-    TestCheck(nestedArr[3].String() == "Hello");
-    TestCheck(nestedArr[4].Boolean() == true);
-    TestCheck(nestedArr[5].Int64() == 42);
-    TestCheck(nestedArr[6].Double() == 4.5);
+    TestCheck(nestedArr[1].TryGetObject()->empty());
+    TestCheck(nestedArr[2].TryGetArray()->empty());
+    TestCheck(nestedArr[3] == "Hello");
+    TestCheck(nestedArr[4] == true);
+    TestCheck(nestedArr[5] == 42);
+    TestCheck(nestedArr[6] == 4.5);
+  }
+
+  void CheckConversion(
+      JSValue const &value, char const *strVal, bool boolVal, int64_t intVal, double doubleVal) noexcept {
+    TestCheckEqual(strVal, value.AsString());
+    TestCheckEqual(boolVal, value.AsBoolean());
+    TestCheckEqual(intVal, value.AsInt64());
+    if (std::isnan(doubleVal)) {
+      TestCheck(std::isnan(value.AsDouble()));
+    } else {
+      TestCheckEqual(doubleVal, value.AsDouble());
+    }
+  }
+
+  TEST_METHOD(TestDefaultAsConverters) {
+    CheckConversion(false, "false", false, 0, 0);
+    CheckConversion(true, "true", true, 1, 1);
+    CheckConversion(0, "0", false, 0, 0);
+    CheckConversion(1, "1", true, 1, 1);
+    CheckConversion("0", "0", true, 0, 0);
+    CheckConversion("000", "000", true, 0, 0);
+    CheckConversion("1", "1", true, 1, 1);
+    CheckConversion(NAN, "NaN", false, 0, NAN);
+    CheckConversion(INFINITY, "Infinity", true, std::numeric_limits<int64_t>::max(), INFINITY);
+    CheckConversion(-INFINITY, "-Infinity", true, std::numeric_limits<int64_t>::min(), -INFINITY);
+    CheckConversion("", "", false, 0, 0);
+    CheckConversion("20", "20", true, 20, 20);
+    CheckConversion("twenty", "twenty", true, 0, NAN);
+    CheckConversion(JSValueArray{}, "", true, 0, 0);
+    CheckConversion(JSValueArray{20}, "20", true, 20, 20);
+    CheckConversion(JSValueArray{10, 20}, "10,20", true, 0, NAN);
+    CheckConversion(JSValueArray{"twenty"}, "twenty", true, 0, NAN);
+    CheckConversion(JSValueArray{"ten", "twenty"}, "ten,twenty", true, 0, NAN);
+    CheckConversion(JSValueArray{NAN}, "NaN", true, 0, NAN);
+    CheckConversion(JSValueObject{}, "[object Object]", true, 0, NAN);
+    CheckConversion(nullptr, "null", false, 0, 0);
+  }
+
+  TEST_METHOD(TestEqualsWithConversion) {
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion(nullptr) == true);
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{nullptr}.EqualsAfterConversion(0.0) == false);
+
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueObject{}) == true);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("[object Object]") == true);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(
+        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}})
+            .EqualsAfterConversion(JSValueObject{{"prop2", 0}, {"prop1", "2"}}) == true);
+    TestCheck(
+        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}}).EqualsAfterConversion(JSValueObject{{"prop2", 0}}) ==
+        false);
+    TestCheck(
+        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}})
+            .EqualsAfterConversion(JSValueObject{{"prop1", 2}, {"prop25", false}}) == false);
+    TestCheck(
+        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}})
+            .EqualsAfterConversion(JSValueObject{{"prop1", 2}, {"prop2", true}}) == false);
+
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{}) == true);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("") == true);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(false) == true);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(0) == true);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(0.0) == true);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{1}) == true);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{true}) == true);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("1") == true);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(true) == true);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(1) == true);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(1.0) == true);
+
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"Hello"}) == true);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("Hello") == true);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{0, 1}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{false, true}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"0", "1"}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"0", true}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("0") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("1") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("0,1") == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("true") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("false") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(false) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(true) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(0) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(5) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(1) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{""}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{}) == true);
+    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{""}) == true);
+    TestCheck(JSValue{""}.EqualsAfterConversion("") == true);
+    TestCheck(JSValue{""}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(false) == true);
+    TestCheck(JSValue{""}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(0) == true);
+    TestCheck(JSValue{""}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(0.0) == true);
+    TestCheck(JSValue{""}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{""}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{"Hello"}) == true);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion("Hello") == true);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{0}) == true);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion("0") == true);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(false) == true);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(0) == true);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(0.0) == true);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{"0"}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{1}) == true);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion("1") == true);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(true) == true);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(1) == true);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{"1"}.EqualsAfterConversion(1.0) == true);
+
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{true}) == true);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{"true"}) == true);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion("true") == true);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{"true"}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{"[object Object]"}.EqualsAfterConversion(JSValueObject{}) == true);
+
+    TestCheck(JSValue{true}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{1}) == true);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion("1") == true);
+    TestCheck(JSValue{true}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(true) == true);
+    TestCheck(JSValue{true}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(1) == true);
+    TestCheck(JSValue{true}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{true}.EqualsAfterConversion(1.0) == true);
+
+    TestCheck(JSValue{false}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{}) == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{0}) == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion("") == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion("0") == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(false) == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(0) == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(0.0) == true);
+    TestCheck(JSValue{false}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{false}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{0}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{}) == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{0}) == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion("") == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion("0") == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(false) == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(0) == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(0.0) == true);
+    TestCheck(JSValue{0}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{0}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{1}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{1}) == true);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion("1") == true);
+    TestCheck(JSValue{1}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(true) == true);
+    TestCheck(JSValue{1}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(1) == true);
+    TestCheck(JSValue{1}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{1}.EqualsAfterConversion(1.0) == true);
+
+    TestCheck(JSValue{5}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(5) == true);
+    TestCheck(JSValue{5}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{5}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{}) == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{0}) == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion("") == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion("0") == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(false) == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(0) == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(0.0) == true);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{0.0}.EqualsAfterConversion(1.0) == false);
+
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{1}) == true);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion("1") == true);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(true) == true);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(1) == true);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(0.5) == false);
+    TestCheck(JSValue{1.0}.EqualsAfterConversion(1.0) == true);
+
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(nullptr) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueObject{}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{0}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{1}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{true}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion("") == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion("0") == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion("1") == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion("true") == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion("false") == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion("Hello") == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(false) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(true) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(0) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(5) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(1) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(0.0) == false);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(0.5) == true);
+    TestCheck(JSValue{0.5}.EqualsAfterConversion(1.0) == false);
   }
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
@@ -41,7 +41,7 @@ void ReactModuleBuilderMock::ExpectFunction(
     TestCheck(expectedModuleName == moduleName);
     TestCheck(expectedFuncName == funcName);
     TestCheck(value.Type() == JSValueType::Array);
-    checkValues(value.Array());
+    checkValues(value.AsArray());
   };
 }
 
@@ -90,7 +90,7 @@ JSValueObject ReactModuleBuilderMock::GetConstants() noexcept {
   }
 
   constantWriter.WriteObjectEnd();
-  return TakeJSValue(constantWriter).TakeObject();
+  return TakeJSValue(constantWriter).MoveObject();
 }
 
 MethodDelegate ReactModuleBuilderMock::GetMethod0(std::wstring const &methodName) const noexcept {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
@@ -3,8 +3,323 @@
 
 #include "pch.h"
 #include "JSValue.h"
+#include <iomanip>
+#include <sstream>
+#include <string_view>
 
 namespace winrt::Microsoft::ReactNative {
+
+//===========================================================================
+// JSValue type conversion helpers.
+//===========================================================================
+
+namespace {
+
+struct NullConverter {
+  static constexpr char const *NullString = "null";
+};
+
+struct ObjectConverter {
+  static constexpr char const *JavaScriptString = "[object Object]";
+};
+
+struct StringConverter {
+  static std::string_view TrimString(std::string const &value) noexcept {
+    constexpr char const *WhiteSpace = " \n\r\t\f\v";
+
+    size_t start = value.find_first_not_of(WhiteSpace);
+    if (start == std::string::npos) {
+      return "";
+    }
+
+    size_t end = value.find_last_not_of(WhiteSpace);
+    return {value.data() + start, end - start + 1};
+  }
+
+  static std::ostream &WriteAsJsonString(std::ostream &stream, std::string const &value) noexcept {
+    auto writeChar = [](std::ostream & stream, char ch) noexcept->std::ostream & {
+      switch (ch) {
+        case '"':
+          return stream << "\\\"";
+        case '\\':
+          return stream << "\\\\";
+        case '\b':
+          return stream << "\\b";
+        case '\f':
+          return stream << "\\f";
+        case '\n':
+          return stream << "\\n";
+        case '\r':
+          return stream << "\\r";
+        case '\t':
+          return stream << "\\t";
+        default:
+          if ('\x00' <= ch && ch <= '\x1f') {
+            return stream << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (int)ch;
+          } else {
+            return stream << ch;
+          }
+      }
+    };
+
+    stream << '"';
+    for (auto ch : value) {
+      writeChar(stream, ch);
+    }
+    return stream << '"';
+  }
+};
+
+struct BooleanConverter {
+  static char const *ToString(bool value) noexcept {
+    return value ? "true" : "false";
+  }
+
+  static bool FromString(std::string const &value) noexcept {
+    return !value.empty();
+  }
+
+  static double ToDouble(bool value) noexcept {
+    return value ? 1.0 : +0.0;
+  }
+
+  static int64_t ToInt64(bool value) noexcept {
+    return value ? 1 : 0;
+  }
+};
+
+struct Int64Converter {
+  static std::string ToString(int64_t value) noexcept {
+    return std::to_string(value);
+  }
+
+  static std::ostream &WriteAsString(std::ostream &stream, int64_t value) noexcept {
+    return stream << value;
+  }
+
+  static int64_t FromDouble(double value) noexcept {
+    if (std::isfinite(value)) {
+      if (value > std::numeric_limits<int64_t>::max()) {
+        return std::numeric_limits<int64_t>::max();
+      } else if (value < std::numeric_limits<int64_t>::min()) {
+        return std::numeric_limits<int64_t>::min();
+      } else {
+        return static_cast<int64_t>(value);
+      }
+    } else if (std::isnan(value)) {
+      return 0;
+    } else if (value == std::numeric_limits<double>::infinity()) {
+      return std::numeric_limits<int64_t>::max();
+    } else if (value == -std::numeric_limits<double>::infinity()) {
+      return std::numeric_limits<int64_t>::min();
+    } else {
+      return 0;
+    }
+  }
+
+  // Cast Int64 to a smaller signed type.
+  // In case if value is bigger or smaller than the target type allows, use the type max or min values.
+  template <
+      class T,
+      std::enable_if_t<std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t>, int> = 1>
+  static T To(int64_t value) noexcept {
+    if (value > std::numeric_limits<T>::max()) {
+      return std::numeric_limits<T>::max();
+    } else if (value < std::numeric_limits<T>::min()) {
+      return std::numeric_limits<T>::min();
+    } else {
+      return static_cast<T>(value);
+    }
+  }
+};
+
+struct UInt64Converter {
+  // Cast UInt64 to a smaller unsigned type.
+  // In case if value is bigger than the target type allows, use the type max value.
+  template <
+      class T,
+      std::enable_if_t<std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t>, int> =
+          1>
+  static T To(uint64_t value) noexcept {
+    if (value > std::numeric_limits<T>::max()) {
+      return std::numeric_limits<T>::max();
+    } else {
+      return static_cast<T>(value);
+    }
+  }
+};
+
+struct DoubleConverter {
+  static char const *NaNToString(double value) noexcept {
+    if (std::isnan(value)) {
+      return "NaN";
+    } else if (value == std::numeric_limits<double>::infinity()) {
+      return "Infinity";
+    } else if (value == -std::numeric_limits<double>::infinity()) {
+      return "-Infinity";
+    } else {
+      return nullptr;
+    }
+  }
+
+  static std::string ToString(double value) noexcept {
+    if (std::isfinite(value)) {
+      return std::to_string(value);
+    } else {
+      return NaNToString(value);
+    }
+  }
+
+  static std::ostream &WriteAsString(std::ostream &stream, double value) noexcept {
+    if (std::isfinite(value)) {
+      return stream << value;
+    } else {
+      return stream << NaNToString(value);
+    }
+  }
+
+  static double FromString(std::string const &value) noexcept {
+    auto trimmedStr = StringConverter::TrimString(value);
+    if (trimmedStr.empty()) {
+      return 0;
+    }
+    char *end;
+    double result = strtod(trimmedStr.data(), &end);
+    return (end == trimmedStr.data() + trimmedStr.size()) ? result : std::numeric_limits<double>::quiet_NaN();
+  }
+};
+
+struct JSValueAsStringWriter {
+  static constexpr char const *IndentString = "  ";
+
+  JSValueAsStringWriter(std::ostream &stream) noexcept : m_stream{stream} {}
+
+  static std::string ToString(JSValue const &value) noexcept {
+    std::stringstream stream;
+    JSValueAsStringWriter writer{stream};
+    writer.WriteValue(value);
+    return stream.str();
+  }
+
+  static std::string ToString(JSValueArray const &value) noexcept {
+    std::stringstream stream;
+    JSValueAsStringWriter writer{stream};
+    writer.WriteArray(value);
+    return stream.str();
+  }
+
+  std::ostream &WriteValue(JSValue const &value) noexcept {
+    if (value.IsNull()) {
+      return m_stream << NullConverter::NullString;
+    } else if (value.TryGetObject()) {
+      return m_stream << ObjectConverter::JavaScriptString;
+    } else if (auto arrayPtr = value.TryGetArray()) {
+      return WriteArray(*arrayPtr);
+    } else if (auto stringPtr = value.TryGetString()) {
+      return m_stream << *stringPtr;
+    } else if (auto boolPtr = value.TryGetBoolean()) {
+      return m_stream << BooleanConverter::ToString(*boolPtr);
+    } else if (auto int64Ptr = value.TryGetInt64()) {
+      return Int64Converter::WriteAsString(m_stream, *int64Ptr);
+    } else if (auto doublePtr = value.TryGetDouble()) {
+      return DoubleConverter::WriteAsString(m_stream, *doublePtr);
+    } else {
+      VerifyElseCrashSz(false, "Unexpected JSValue type");
+    }
+  }
+
+  std::ostream &WriteArray(JSValueArray const &value) noexcept {
+    bool start = true;
+    for (auto const &item : value) {
+      m_stream << (start ? (start = false, "") : ",");
+      WriteValue(item);
+    }
+    return m_stream;
+  }
+
+ private:
+  std::ostream &m_stream;
+};
+
+struct JSValueLogWriter {
+  static constexpr char const *IndentString = "  ";
+
+  JSValueLogWriter(std::ostream &stream) noexcept : m_stream{stream} {}
+
+  static std::string ToString(JSValue const &value) noexcept {
+    std::stringstream stream;
+    JSValueLogWriter writer{stream};
+    writer.WriteValue(value);
+    return stream.str();
+  }
+
+  std::ostream &WriteIndent() noexcept {
+    for (size_t i = 0; i < m_indent; ++i) {
+      m_stream << IndentString;
+    }
+
+    return m_stream;
+  }
+
+  std::ostream &WriteValue(JSValue const &value) noexcept {
+    if (value.IsNull()) {
+      return m_stream << NullConverter::NullString;
+    } else if (auto objectPtr = value.TryGetObject()) {
+      return WriteObject(*objectPtr);
+    } else if (auto arrayPtr = value.TryGetArray()) {
+      return WriteArray(*arrayPtr);
+    } else if (auto stringPtr = value.TryGetString()) {
+      return StringConverter::WriteAsJsonString(m_stream, *stringPtr);
+    } else if (auto boolPtr = value.TryGetBoolean()) {
+      return m_stream << BooleanConverter::ToString(*boolPtr);
+    } else if (auto int64Ptr = value.TryGetInt64()) {
+      return Int64Converter::WriteAsString(m_stream, *int64Ptr);
+    } else if (auto doublePtr = value.TryGetDouble()) {
+      return DoubleConverter::WriteAsString(m_stream, *doublePtr);
+    } else {
+      VerifyElseCrashSz(false, "Unexpected JSValue type");
+    }
+  }
+
+  std::ostream &WriteObject(JSValueObject const &value) noexcept {
+    m_stream << "{";
+    ++m_indent;
+    bool start = true;
+    for (auto const &prop : value) {
+      m_stream << start ? (start = false, "") : ",\n";
+      WriteIndent() << prop.first << ": ";
+      WriteValue(prop.second);
+    }
+    --m_indent;
+    if (!start) {
+      m_stream << "\n";
+      WriteIndent();
+    }
+    return m_stream << "}";
+  }
+
+  std::ostream &WriteArray(JSValueArray const &value) noexcept {
+    m_stream << "[";
+    ++m_indent;
+    bool start = true;
+    for (auto const &item : value) {
+      m_stream << start ? (start = false, "") : ",\n";
+      WriteValue(item);
+    }
+    --m_indent;
+    if (!start) {
+      m_stream << "\n";
+      WriteIndent();
+    }
+    return m_stream << "]";
+  }
+
+ private:
+  size_t m_indent{0};
+  std::ostream &m_stream;
+};
+
+} // namespace
 
 //===========================================================================
 // JSValueObject implementation
@@ -14,6 +329,83 @@ JSValueObject::JSValueObject(std::initializer_list<JSValueObjectKeyValue> initOb
   for (auto const &item : initObject) {
     this->try_emplace(std::string(item.Key), std::move(*const_cast<JSValue *>(&item.Value)));
   }
+}
+
+JSValueObject::JSValueObject(std::map<std::string, JSValue, std::less<>> &&other) noexcept : map{std::move(other)} {}
+
+JSValueObject JSValueObject::Copy() const noexcept {
+  JSValueObject object;
+  for (auto const &property : *this) {
+    object.try_emplace(property.first, property.second.Copy());
+  }
+
+  return object;
+}
+
+JSValue const &JSValueObject::operator[](std::string_view propertyName) const noexcept {
+  auto it = find(propertyName);
+  if (it != end()) {
+    return it->second;
+  }
+
+  return JSValue::Null;
+}
+
+bool JSValueObject::Equals(JSValueObject const &other) const noexcept {
+  if (size() != other.size()) {
+    return false;
+  }
+
+  // std::map keeps key-values in an ordered sequence.
+  // Make sure that pairs are matching at the same position.
+  auto otherIt = other.begin();
+  for (auto const &property : *this) {
+    auto it = otherIt++;
+    if (property.first != it->first || !property.second.Equals(it->second)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool JSValueObject::EqualsAfterConversion(JSValueObject const &other) const noexcept {
+  if (size() != other.size()) {
+    return false;
+  }
+
+  // std::map keeps key-values in an ordered sequence.
+  // Make sure that pairs are matching at the same position.
+  auto otherIt = other.begin();
+  for (auto const &property : *this) {
+    auto it = otherIt++;
+    if (property.first != it->first || !property.second.EqualsAfterConversion(it->second)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*static*/ JSValueObject JSValueObject::ReadFrom(IJSValueReader const &reader) noexcept {
+  JSValueObject object;
+  if (reader.ValueType() == JSValueType::Object) {
+    hstring propertyName;
+    while (reader.GetNextObjectProperty(/*ref*/ propertyName)) {
+      object.try_emplace(to_string(propertyName), JSValue::ReadFrom(reader));
+    }
+  }
+
+  return object;
+}
+
+void JSValueObject::WriteTo(IJSValueWriter const &writer) const noexcept {
+  writer.WriteObjectBegin();
+  for (auto const &property : *this) {
+    writer.WritePropertyName(to_hstring(property.first));
+    property.second.WriteTo(writer);
+  }
+  writer.WriteObjectEnd();
 }
 
 //===========================================================================
@@ -26,7 +418,66 @@ JSValueArray::JSValueArray(std::initializer_list<JSValueArrayItem> initArray) no
   }
 }
 
-JSValueArray::JSValueArray(size_t capacity) noexcept : std::vector<JSValue>(capacity) {}
+JSValueArray::JSValueArray(std::vector<JSValue> &&other) noexcept : vector{std::move(other)} {}
+
+JSValueArray JSValueArray::Copy() const noexcept {
+  JSValueArray array;
+  array.reserve(size());
+  for (auto const &item : *this) {
+    array.push_back(item.Copy());
+  }
+
+  return array;
+}
+
+bool JSValueArray::Equals(JSValueArray const &other) const noexcept {
+  if (size() != other.size()) {
+    return false;
+  }
+
+  auto otherIt = other.begin();
+  for (auto const &item : *this) {
+    if (!item.Equals(*otherIt++)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool JSValueArray::EqualsAfterConversion(JSValueArray const &other) const noexcept {
+  if (size() != other.size()) {
+    return false;
+  }
+
+  auto otherIt = other.begin();
+  for (auto const &item : *this) {
+    if (!item.EqualsAfterConversion(*otherIt++)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*static*/ JSValueArray JSValueArray::ReadFrom(IJSValueReader const &reader) noexcept {
+  JSValueArray array;
+  if (reader.ValueType() == JSValueType::Array) {
+    while (reader.GetNextArrayItem()) {
+      array.push_back(JSValue::ReadFrom(reader));
+    }
+  }
+
+  return array;
+}
+
+void JSValueArray::WriteTo(IJSValueWriter const &writer) const noexcept {
+  writer.WriteArrayBegin();
+  for (const JSValue &item : *this) {
+    item.WriteTo(writer);
+  }
+  writer.WriteArrayEnd();
+}
 
 //===========================================================================
 // JSValue implementation
@@ -36,6 +487,42 @@ JSValueArray::JSValueArray(size_t capacity) noexcept : std::vector<JSValue>(capa
 /*static*/ const JSValueObject JSValue::EmptyObject;
 /*static*/ const JSValueArray JSValue::EmptyArray;
 /*static*/ const std::string JSValue::EmptyString;
+
+JSValue::~JSValue() noexcept {
+  switch (m_type) {
+    case JSValueType::Object:
+      m_object.~JSValueObject();
+      break;
+    case JSValueType::Array:
+      m_array.~JSValueArray();
+      break;
+    case JSValueType::String:
+      m_string.~basic_string();
+      break;
+  }
+
+  m_type = JSValueType::Null;
+  m_int64 = 0;
+}
+
+JSValue JSValue::Copy() const noexcept {
+  switch (m_type) {
+    case JSValueType::Object:
+      return JSValue{m_object.Copy()};
+    case JSValueType::Array:
+      return JSValue{m_array.Copy()};
+    case JSValueType::String:
+      return JSValue{std::string(m_string)};
+    case JSValueType::Boolean:
+      return JSValue{m_bool};
+    case JSValueType::Int64:
+      return JSValue{m_int64};
+    case JSValueType::Double:
+      return JSValue{m_double};
+    default:
+      return JSValue{};
+  }
+}
 
 #pragma warning(push)
 #pragma warning(disable : 26495) // False positive for union member not initialized
@@ -75,89 +562,168 @@ JSValue &JSValue::operator=(JSValue &&other) noexcept {
   return *this;
 }
 
-JSValue::~JSValue() noexcept {
-  switch (m_type) {
-    case JSValueType::Object:
-      m_object.~JSValueObject();
-      break;
-    case JSValueType::Array:
-      m_array.~JSValueArray();
-      break;
-    case JSValueType::String:
-      m_string.~basic_string();
-      break;
-  }
-
-  m_int64 = 0;
-  m_type = JSValueType::Null;
-}
-
-JSValue JSValue::Copy() const noexcept {
-  switch (m_type) {
-    case JSValueType::Object:
-      return JSValue{CopyObject(m_object)};
-    case JSValueType::Array:
-      return JSValue{CopyArray(m_array)};
-    case JSValueType::String:
-      return JSValue{std::string(m_string)};
-    case JSValueType::Boolean:
-      return JSValue{m_bool};
-    case JSValueType::Int64:
-      return JSValue{m_int64};
-    case JSValueType::Double:
-      return JSValue{m_double};
-    default:
-      return JSValue{};
-  }
-}
-
-/*static*/ JSValueObject JSValue::CopyObject(const JSValueObject &other) noexcept {
-  JSValueObject result;
-  for (const auto &property : other) {
-    result.emplace(property.first, property.second.Copy());
-  }
-
-  return result;
-}
-
-/*static*/ JSValueArray JSValue::CopyArray(const JSValueArray &other) noexcept {
-  JSValueArray result(other.size());
-  for (const auto &item : other) {
-    result.push_back(item.Copy());
-  }
-
-  return result;
-}
-
-JSValueObject JSValue::TakeObject() noexcept {
+JSValueObject JSValue::MoveObject() noexcept {
   JSValueObject result;
   if (m_type == JSValueType::Object) {
     result = std::move(m_object);
-    m_int64 = 0;
     m_type = JSValueType::Null;
+    m_int64 = 0;
   }
   return result;
 }
 
-JSValueArray JSValue::TakeArray() noexcept {
+JSValueArray JSValue::MoveArray() noexcept {
   JSValueArray result;
   if (m_type == JSValueType::Array) {
     result = std::move(m_array);
-    m_int64 = 0;
     m_type = JSValueType::Null;
+    m_int64 = 0;
   }
   return result;
+}
+
+std::string JSValue::AsString() const noexcept {
+  switch (m_type) {
+    case JSValueType::Null:
+      return NullConverter::NullString;
+    case JSValueType::Object:
+      return ObjectConverter::JavaScriptString;
+    case JSValueType::Array:
+      return JSValueAsStringWriter::ToString(m_array);
+    case JSValueType::String:
+      return m_string;
+    case JSValueType::Boolean:
+      return BooleanConverter::ToString(m_bool);
+    case JSValueType::Int64:
+      return Int64Converter::ToString(m_int64);
+    case JSValueType::Double:
+      return DoubleConverter::ToString(m_double);
+    default:
+      VerifyElseCrashSz(false, "Unexpected JSValue type");
+  }
+}
+
+bool JSValue::AsBoolean() const noexcept {
+  switch (m_type) {
+    case JSValueType::Object:
+    case JSValueType::Array:
+      return true;
+    case JSValueType::String:
+      return BooleanConverter::FromString(m_string);
+    case JSValueType::Boolean:
+      return m_bool;
+    case JSValueType::Int64:
+      return m_int64 != 0;
+    case JSValueType::Double:
+      return !std::isnan(m_double) && m_double != 0;
+    default:
+      return false;
+  }
+}
+
+int8_t JSValue::AsInt8() const noexcept {
+  return Int64Converter::To<int8_t>(AsInt64());
+}
+
+int16_t JSValue::AsInt16() const noexcept {
+  return Int64Converter::To<int16_t>(AsInt64());
+}
+
+int32_t JSValue::AsInt32() const noexcept {
+  return Int64Converter::To<int32_t>(AsInt64());
+}
+
+int64_t JSValue::AsInt64() const noexcept {
+  switch (m_type) {
+    case JSValueType::Object:
+    case JSValueType::Array:
+    case JSValueType::String:
+      return Int64Converter::FromDouble(AsDouble());
+    case JSValueType::Boolean:
+      return BooleanConverter::ToInt64(m_bool);
+    case JSValueType::Int64:
+      return m_int64;
+    case JSValueType::Double:
+      return Int64Converter::FromDouble(m_double);
+    default:
+      return 0;
+  }
+}
+
+uint8_t JSValue::AsUInt8() const noexcept {
+  return UInt64Converter::To<uint8_t>(AsUInt64());
+}
+
+uint16_t JSValue::AsUInt16() const noexcept {
+  return UInt64Converter::To<uint16_t>(AsUInt64());
+}
+
+uint32_t JSValue::AsUInt32() const noexcept {
+  return UInt64Converter::To<uint32_t>(AsUInt64());
+}
+
+uint64_t JSValue::AsUInt64() const noexcept {
+  // Convert negative values to zero.
+  int64_t value = AsInt64();
+  return value >= 0 ? value : 0;
+}
+
+double JSValue::AsDouble() const noexcept {
+  switch (m_type) {
+    case JSValueType::Object:
+      return std::numeric_limits<double>::quiet_NaN();
+    case JSValueType::Array: {
+      switch (m_array.size()) {
+        case 0:
+          return 0;
+        case 1:
+          return m_array[0].AsDouble();
+        default:
+          return std::numeric_limits<double>::quiet_NaN();
+      }
+    }
+    case JSValueType::String:
+      return DoubleConverter::FromString(m_string);
+    case JSValueType::Boolean:
+      return BooleanConverter::ToDouble(m_bool);
+    case JSValueType::Int64:
+      return static_cast<double>(m_int64);
+    case JSValueType::Double:
+      return m_double;
+    default:
+      return 0;
+  }
+}
+
+float JSValue::AsFloat() const noexcept {
+  return static_cast<float>(AsDouble());
+}
+
+std::string JSValue::ToString() const noexcept {
+  switch (m_type) {
+    case JSValueType::Null:
+      return NullConverter::NullString;
+    case JSValueType::Object:
+    case JSValueType::Array:
+      return JSValueLogWriter::ToString(*this);
+    case JSValueType::String:
+      return m_string;
+    case JSValueType::Boolean:
+      return BooleanConverter::ToString(m_bool);
+    case JSValueType::Int64:
+      return Int64Converter::ToString(m_int64);
+    case JSValueType::Double:
+      return DoubleConverter::ToString(m_double);
+    default:
+      VerifyElseCrashSz(false, "Unexpected JSValue type");
+  }
 }
 
 size_t JSValue::PropertyCount() const noexcept {
   return (m_type == JSValueType::Object) ? m_object.size() : 0;
 }
 
-size_t JSValue::ItemCount() const noexcept {
-  return (m_type == JSValueType::Array) ? m_array.size() : 0;
-}
-
-const JSValue &JSValue::GetObjectProperty(std::string_view propertyName) const noexcept {
+JSValue const &JSValue::GetObjectProperty(std::string_view propertyName) const noexcept {
   if (m_type == JSValueType::Object) {
     auto it = m_object.find(propertyName);
     if (it != m_object.end()) {
@@ -168,7 +734,11 @@ const JSValue &JSValue::GetObjectProperty(std::string_view propertyName) const n
   return Null;
 }
 
-const JSValue &JSValue::GetArrayItem(JSValueArray::size_type index) const noexcept {
+size_t JSValue::ItemCount() const noexcept {
+  return (m_type == JSValueType::Array) ? m_array.size() : 0;
+}
+
+JSValue const &JSValue::GetArrayItem(JSValueArray::size_type index) const noexcept {
   if (m_type == JSValueType::Array && index < m_array.size()) {
     return m_array[index];
   }
@@ -177,28 +747,127 @@ const JSValue &JSValue::GetArrayItem(JSValueArray::size_type index) const noexce
 }
 
 bool JSValue::Equals(const JSValue &other) const noexcept {
-  if (m_type == other.m_type) {
-    switch (m_type) {
-      case JSValueType::Null:
-        return true;
-      case JSValueType::Object:
-        return ObjectEquals(other.m_object);
-      case JSValueType::Array:
-        return ArrayEquals(other.m_array);
-      case JSValueType::String:
-        return m_string == other.m_string;
-      case JSValueType::Boolean:
-        return m_bool == other.m_bool;
-      case JSValueType::Int64:
-        return m_int64 == other.m_int64;
-      case JSValueType::Double:
-        return m_double == other.m_double;
-      default:
-        return false;
-    }
+  if (m_type != other.m_type) {
+    return false;
   }
 
-  return false;
+  switch (m_type) {
+    case JSValueType::Null:
+      return true;
+    case JSValueType::Object:
+      return m_object.Equals(other.m_object);
+    case JSValueType::Array:
+      return m_array.Equals(other.m_array);
+    case JSValueType::String:
+      return m_string == other.m_string;
+    case JSValueType::Boolean:
+      return m_bool == other.m_bool;
+    case JSValueType::Int64:
+      return m_int64 == other.m_int64;
+    case JSValueType::Double:
+      return m_double == other.m_double;
+    default:
+      return false;
+  }
+}
+
+bool JSValue::EqualsAfterConversion(const JSValue &other) const noexcept {
+  switch (m_type) {
+    case JSValueType::Null:
+      return other.m_type == JSValueType::Null;
+    case JSValueType::Object:
+      switch (other.m_type) {
+        case JSValueType::Object:
+          return m_object.EqualsAfterConversion(other.m_object);
+        case JSValueType::String:
+          return ObjectConverter::JavaScriptString == other.m_string;
+        default:
+          return false;
+      }
+    case JSValueType::Array:
+      switch (other.m_type) {
+        case JSValueType::Array:
+          return m_array.EqualsAfterConversion(other.m_array);
+        case JSValueType::String:
+          return JSValueAsStringWriter::ToString(m_array) == other.m_string;
+        case JSValueType::Boolean:
+          return DoubleConverter::FromString(JSValueAsStringWriter::ToString(m_array)) ==
+              BooleanConverter::ToDouble(other.m_bool);
+        case JSValueType::Int64:
+          return DoubleConverter::FromString(JSValueAsStringWriter::ToString(m_array)) ==
+              static_cast<double>(other.m_int64);
+        case JSValueType::Double:
+          return DoubleConverter::FromString(JSValueAsStringWriter::ToString(m_array)) == other.m_double;
+        default:
+          return false;
+      }
+    case JSValueType::String:
+      switch (other.m_type) {
+        case JSValueType::Object:
+          return m_string == ObjectConverter::JavaScriptString;
+        case JSValueType::Array:
+          return m_string == JSValueAsStringWriter::ToString(other.m_array);
+        case JSValueType::String:
+          return m_string == other.m_string;
+        case JSValueType::Boolean:
+          return DoubleConverter::FromString(m_string) == BooleanConverter::ToDouble(other.m_bool);
+        case JSValueType::Int64:
+          return DoubleConverter::FromString(m_string) == static_cast<double>(other.m_int64);
+        case JSValueType::Double:
+          return DoubleConverter::FromString(m_string) == other.m_double;
+        default:
+          return false;
+      }
+    case JSValueType::Boolean:
+      switch (other.m_type) {
+        case JSValueType::Array:
+          return BooleanConverter::ToDouble(m_bool) ==
+              DoubleConverter::FromString(JSValueAsStringWriter::ToString(other.m_array));
+        case JSValueType::String:
+          return BooleanConverter::ToDouble(m_bool) == DoubleConverter::FromString(other.m_string);
+        case JSValueType::Boolean:
+          return m_bool == other.m_bool;
+        case JSValueType::Int64:
+          return BooleanConverter::ToInt64(m_bool) == other.m_int64;
+        case JSValueType::Double:
+          return BooleanConverter::ToDouble(m_bool) == other.m_double;
+        default:
+          return false;
+      }
+    case JSValueType::Int64:
+      switch (other.m_type) {
+        case JSValueType::Array:
+          return static_cast<double>(m_int64) ==
+              DoubleConverter::FromString(JSValueAsStringWriter::ToString(other.m_array));
+        case JSValueType::String:
+          return static_cast<double>(m_int64) == DoubleConverter::FromString(other.m_string);
+        case JSValueType::Boolean:
+          return m_int64 == BooleanConverter::ToInt64(other.m_bool);
+        case JSValueType::Int64:
+          return m_int64 == other.m_int64;
+        case JSValueType::Double:
+          return static_cast<double>(m_int64) == other.m_double;
+        default:
+          return false;
+      }
+    case JSValueType::Double:
+      switch (other.m_type) {
+        case JSValueType::Array:
+          return m_double == DoubleConverter::FromString(JSValueAsStringWriter::ToString(other.m_array));
+        case JSValueType::String:
+          return m_double == DoubleConverter::FromString(other.m_string);
+        case JSValueType::Boolean:
+          return m_double == BooleanConverter::ToDouble(other.m_bool);
+        case JSValueType::Int64:
+          return m_double == static_cast<double>(other.m_int64);
+        case JSValueType::Double:
+          return m_double == other.m_double;
+        default:
+          return false;
+      }
+    default:
+      return false;
+  }
 }
 
 /*static*/ JSValue JSValue::ReadFrom(IJSValueReader const &reader) noexcept {
@@ -206,9 +875,9 @@ bool JSValue::Equals(const JSValue &other) const noexcept {
     case JSValueType::Null:
       return JSValue();
     case JSValueType::Object:
-      return JSValue(ReadObjectProperties(reader));
+      return JSValue(JSValueObject::ReadFrom(reader));
     case JSValueType::Array:
-      return JSValue(ReadArrayItems(reader));
+      return JSValue(JSValueArray::ReadFrom(reader));
     case JSValueType::String:
       return JSValue(to_string(reader.GetString()));
     case JSValueType::Boolean:
@@ -218,132 +887,29 @@ bool JSValue::Equals(const JSValue &other) const noexcept {
     case JSValueType::Double:
       return JSValue(reader.GetDouble());
     default:
-      VerifyElseCrashSz(false, "Unexpected JSValueType");
+      VerifyElseCrashSz(false, "Unexpected JSValue type");
   }
-}
-
-/*static*/ JSValueObject JSValue::ReadObjectFrom(IJSValueReader const &reader) noexcept {
-  if (reader.ValueType() == JSValueType::Object) {
-    return ReadObjectProperties(reader);
-  }
-
-  return JSValueObject{};
-}
-
-/*static*/ JSValueArray JSValue::ReadArrayFrom(IJSValueReader const &reader) noexcept {
-  if (reader.ValueType() == JSValueType::Array) {
-    return ReadArrayItems(reader);
-  }
-
-  return JSValueArray{};
 }
 
 void JSValue::WriteTo(IJSValueWriter const &writer) const noexcept {
   switch (m_type) {
     case JSValueType::Null:
-      writer.WriteNull();
-      break;
+      return writer.WriteNull();
     case JSValueType::Object:
-      WriteObjectTo(writer, m_object);
-      break;
+      return m_object.WriteTo(writer);
     case JSValueType::Array:
-      WriteArrayTo(writer, m_array);
-      break;
+      return m_array.WriteTo(writer);
     case JSValueType::String:
-      writer.WriteString(to_hstring(m_string));
-      break;
+      return writer.WriteString(to_hstring(m_string));
     case JSValueType::Boolean:
-      writer.WriteBoolean(m_bool);
-      break;
+      return writer.WriteBoolean(m_bool);
     case JSValueType::Int64:
-      writer.WriteInt64(m_int64);
-      break;
+      return writer.WriteInt64(m_int64);
     case JSValueType::Double:
-      writer.WriteDouble(m_double);
-      break;
+      return writer.WriteDouble(m_double);
+    default:
+      VerifyElseCrashSz(false, "Unexpected JSValue type");
   }
-}
-
-/*static*/ void JSValue::WriteObjectTo(IJSValueWriter const &writer, JSValueObjectView object) noexcept {
-  writer.WriteObjectBegin();
-  for (const auto &property : object) {
-    writer.WritePropertyName(to_hstring(property.first));
-    property.second.WriteTo(writer);
-  }
-  writer.WriteObjectEnd();
-}
-
-/*static*/ void JSValue::WriteArrayTo(IJSValueWriter const &writer, JSValueArrayView value) noexcept {
-  writer.WriteArrayBegin();
-  for (const JSValue &item : value) {
-    item.WriteTo(writer);
-  }
-  writer.WriteArrayEnd();
-}
-
-bool JSValue::ObjectEquals(const JSValueObject &other) const noexcept {
-  if (m_object.size() != other.size()) {
-    return false;
-  }
-
-  for (const auto &entry : m_object) {
-    auto it = other.find(entry.first);
-    if (it == other.end()) {
-      return false;
-    }
-
-    if (!entry.second.Equals(it->second)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-bool JSValue::ArrayEquals(const JSValueArray &other) const noexcept {
-  if (m_array.size() != other.size()) {
-    return false;
-  }
-
-  auto otherIt = other.begin();
-  for (const JSValue &item : m_array) {
-    if (!item.Equals(*(otherIt++))) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-// Read object properties without checking value type.
-/*static*/ JSValueObject JSValue::ReadObjectProperties(IJSValueReader const &reader) noexcept {
-  JSValueObject properties;
-  hstring propertyName;
-  while (reader.GetNextObjectProperty(/*ref*/ propertyName)) {
-    properties.emplace(to_string(propertyName), ReadFrom(reader));
-  }
-
-  return properties;
-}
-
-// Read array items without checking value type.
-/*static*/ JSValueArray JSValue::ReadArrayItems(IJSValueReader const &reader) noexcept {
-  JSValueArray items;
-  while (reader.GetNextArrayItem()) {
-    items.push_back(ReadFrom(reader));
-  }
-
-  return items;
-}
-
-//===========================================================================
-// Standalone functions implementation
-//===========================================================================
-
-void swap(JSValue &left, JSValue &right) noexcept {
-  JSValue temp{std::move(right)};
-  right = std::move(left);
-  left = std::move(temp);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
@@ -54,7 +54,7 @@ struct StringConverter {
         case '\t':
           return stream << "\\t";
         default:
-          if ('\x00' <= ch && ch <= '\x1f') {
+          if ('\x00' <= ch && ch <= '\x1f') { // Non-printable ASCII characters.
             return stream << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (int)ch;
           } else {
             return stream << ch;
@@ -66,6 +66,7 @@ struct StringConverter {
     for (auto ch : value) {
       writeChar(stream, ch);
     }
+
     return stream << '"';
   }
 };
@@ -80,7 +81,7 @@ struct BooleanConverter {
   }
 
   static double ToDouble(bool value) noexcept {
-    return value ? 1.0 : +0.0;
+    return value ? 1.0 : 0.0;
   }
 
   static int64_t ToInt64(bool value) noexcept {
@@ -183,6 +184,7 @@ struct DoubleConverter {
     if (trimmedStr.empty()) {
       return 0;
     }
+
     char *end;
     double result = strtod(trimmedStr.data(), &end);
     return (end == trimmedStr.data() + trimmedStr.size()) ? result : std::numeric_limits<double>::quiet_NaN();
@@ -234,6 +236,7 @@ struct JSValueAsStringWriter {
       m_stream << (start ? (start = false, "") : ",");
       WriteValue(item);
     }
+
     return m_stream;
   }
 
@@ -290,11 +293,13 @@ struct JSValueLogWriter {
       WriteIndent() << prop.first << ": ";
       WriteValue(prop.second);
     }
+
     --m_indent;
     if (!start) {
       m_stream << "\n";
       WriteIndent();
     }
+
     return m_stream << "}";
   }
 
@@ -306,11 +311,13 @@ struct JSValueLogWriter {
       m_stream << start ? (start = false, "") : ",\n";
       WriteValue(item);
     }
+
     --m_indent;
     if (!start) {
       m_stream << "\n";
       WriteIndent();
     }
+
     return m_stream << "]";
   }
 
@@ -405,6 +412,7 @@ void JSValueObject::WriteTo(IJSValueWriter const &writer) const noexcept {
     writer.WritePropertyName(to_hstring(property.first));
     property.second.WriteTo(writer);
   }
+
   writer.WriteObjectEnd();
 }
 
@@ -476,6 +484,7 @@ void JSValueArray::WriteTo(IJSValueWriter const &writer) const noexcept {
   for (const JSValue &item : *this) {
     item.WriteTo(writer);
   }
+
   writer.WriteArrayEnd();
 }
 
@@ -569,6 +578,7 @@ JSValueObject JSValue::MoveObject() noexcept {
     m_type = JSValueType::Null;
     m_int64 = 0;
   }
+
   return result;
 }
 
@@ -579,6 +589,7 @@ JSValueArray JSValue::MoveArray() noexcept {
     m_type = JSValueType::Null;
     m_int64 = 0;
   }
+
   return result;
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.h
@@ -19,119 +19,438 @@ IJSValueReader MakeJSValueTreeReader(JSValue &&root) noexcept;
 IJSValueWriter MakeJSValueTreeWriter() noexcept;
 JSValue TakeJSValue(IJSValueWriter const &writer) noexcept;
 
-// JSValueObject is based on std::map and has a custom constructor with intializer_list.
+// JSValueObject is based on std::map and has a custom constructor with std::intializer_list.
 // It is possible to write: JSValueObject{{"X", 4}, {"Y", 5}} and pass it as JSValue.
 struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
+#pragma region Constructors
+
+  //! Default constructor.
   JSValueObject() = default;
+
+  //! Construct JSValueObject from the move iterator.
+  template <class TMoveInputIterator>
+  JSValueObject(TMoveInputIterator first, TMoveInputIterator last) noexcept;
+
+  //! Move-construct JSValueObject from the initializer list.
   JSValueObject(std::initializer_list<JSValueObjectKeyValue> initObject) noexcept;
+
+  //! Move-construct JSValueObject from the string-JSValue map.
+  JSValueObject(std::map<std::string, JSValue, std::less<>> &&other) noexcept;
+
+#pragma endregion
+
+#pragma region Copy semantic
+
+  //! Delete copy constructor to avoid unexpected copies. Use the Copy method instead.
+  JSValueObject(JSValueObject const &) = delete;
+
+  //! Delete copy assignment to avoid unexpected copies. Use the Copy method instead.
+  JSValueObject &operator=(JSValueObject const &) = delete;
+
+  //! Do a deep copy of JSValueObject.
+  JSValueObject Copy() const noexcept;
+
+#pragma endregion
+
+#pragma region Move semantic
+
+  // Default move constructor.
+  JSValueObject(JSValueObject &&) = default;
+
+  // Default move assignment.
+  JSValueObject &operator=(JSValueObject &&) = default;
+
+#pragma endregion
+
+#pragma region Inspect JSValueObject
+
+  //! Get a reference to object property value if the property is found,
+  //! or a reference to JSValue::Null otherwise.
+  JSValue const &operator[](std::string_view propertyName) const noexcept;
+
+  //! Return true if this JSValueObject is strictly equal to other JSValueObject.
+  //! Both objects must have the same set of equal properties.
+  //! Property values must have the same type and value.
+  bool Equals(JSValueObject const &other) const noexcept;
+
+  //! Return true if this JSValueObject is strictly equal to other JSValueObject
+  //! after their property values are converted to the same type.
+  //! See JSValue::EqualsAfterConversion for details about the conversion.
+  bool EqualsAfterConversion(const JSValueObject &other) const noexcept;
+
+#pragma endregion
+
+#pragma region JSValueObject serialization and deserialization.
+
+  //! Create JSValueObject from IJSValueReader.
+  static JSValueObject ReadFrom(IJSValueReader const &reader) noexcept;
+
+  //! Write this JSValueObject to IJSValueWriter.
+  void WriteTo(IJSValueWriter const &writer) const noexcept;
+
+#pragma endregion
 };
 
-// JSValueArray is based on std::vector and has a custom constructor with intializer_list.
-// It is possible to write: JSValueArray{"X", 4, true} and pass it as JSValue.
+#pragma region Standalone JSValueObject functions
+
+bool operator==(const JSValueObject &left, const JSValueObject &right) noexcept;
+bool operator!=(const JSValueObject &left, const JSValueObject &right) noexcept;
+
+#pragma endregion
+
+//! JSValueArray is based on std::vector<JSValue> and has a custom constructor with std::intializer_list.
+//! It is possible to write: JSValueArray{"X", 4, true} and pass it as JSValue.
 struct JSValueArray : std::vector<JSValue> {
+#pragma region Constructors
+
+  //! Default constructor.
   JSValueArray() = default;
-  JSValueArray(size_t capacity) noexcept;
-  JSValueArray(std::initializer_list<JSValueArrayItem> initArray) noexcept;
+
+  //! Construct JSValueArray from the move iterator.
+  template <class TMoveInputIterator>
+  JSValueArray(TMoveInputIterator first, TMoveInputIterator last) noexcept;
+
+  //! Move-construct JSValueArray from the initializer list.
+  JSValueArray(std::initializer_list<JSValueArrayItem> initObject) noexcept;
+
+  //! Move-construct JSValueArray from the JSValue vector.
+  JSValueArray(std::vector<JSValue> &&other) noexcept;
+
+#pragma endregion
+
+#pragma region Copy semantic
+
+  //! Delete copy constructor to avoid unexpected copies. Use the Copy method instead.
+  JSValueArray(JSValueArray const &) = delete;
+
+  //! Delete copy assignment to avoid unexpected copies. Use the Copy method instead.
+  JSValueArray &operator=(JSValueArray const &) = delete;
+
+  //! Do a deep copy of JSValueArray.
+  JSValueArray Copy() const noexcept;
+
+#pragma endregion
+
+#pragma region Move semantic
+
+  // Default move constructor.
+  JSValueArray(JSValueArray &&) = default;
+
+  // Default move assignment.
+  JSValueArray &operator=(JSValueArray &&) = default;
+
+#pragma endregion
+
+#pragma region Inspect JSValueArray
+
+  //! Return true if this JSValueArray is strictly equal to other JSValueArray.
+  //! Both arrays must have the same set of items.
+  //! Items must have the same type and value.
+  bool Equals(JSValueArray const &other) const noexcept;
+
+  //! Return true if this JSValueArray is strictly equal to other JSValueArray
+  //! after their items are converted to the same type.
+  //! See JSValue::EqualsAfterConversion for details about the conversion.
+  bool EqualsAfterConversion(const JSValueArray &other) const noexcept;
+
+#pragma endregion
+
+#pragma region JSValueArray serialization and deserialization.
+
+  //! Create JSValueArray from IJSValueReader.
+  static JSValueArray ReadFrom(IJSValueReader const &reader) noexcept;
+
+  //! Write this JSValueArray to IJSValueWriter.
+  void WriteTo(IJSValueWriter const &writer) const noexcept;
+
+#pragma endregion
 };
 
-// A view for JSValueObject
-struct JSValueObjectView {
-  JSValueObjectView(const JSValueObject &object) noexcept;
-  auto begin() const noexcept;
-  auto end() const noexcept;
+#pragma region Standalone JSValueArray functions
 
- private:
-  const JSValueObject &m_object;
-};
+bool operator==(const JSValueArray &left, const JSValueArray &right) noexcept;
+bool operator!=(const JSValueArray &left, const JSValueArray &right) noexcept;
 
-// A view for JSObjectArray
-struct JSValueArrayView {
-  JSValueArrayView(const JSValueArray &array) noexcept;
-  auto begin() const noexcept;
-  auto end() const noexcept;
+#pragma endregion
 
- private:
-  const JSValueArray &m_array;
-};
-
-// JSValue represents an immutable JavaScript value that can be passed as a parameter.
-// It is created to simplify working with IJSValueReader in some complex cases.
-// It takes more resources than direct use of IJSValueReader, but provides more flexibility.
-// The JSValue is an immutable and is safe to be used from multiple threads.
-// It is move-only to avoid unnecessary or unexpected copying of values.
+//! JSValue represents an immutable JavaScript value that can be passed as a parameter.
+//! It is created to simplify working with IJSValueReader in some complex cases.
+//! It takes more resources than direct use of IJSValueReader, but provides more flexibility.
+//! The JSValue is an immutable and is safe to be used from multiple threads.
+//! It is move-only to avoid unnecessary or unexpected copying of values.
+//! For copy operations the explicit Copy() method must be used.
+//! Note that the move operations are not thread safe.
 struct JSValue {
+#pragma region Predefined constants
+
   static const JSValue Null;
   static const JSValueObject EmptyObject;
   static const JSValueArray EmptyArray;
   static const std::string EmptyString;
 
+#pragma endregion
+
+#pragma region Constructors
+
+  //! Create a Null JSValue.
   JSValue() noexcept;
+
+  //! Create a Null JSValue.
   JSValue(std::nullptr_t) noexcept;
+
+  //! Create an Object JSValue.
   JSValue(JSValueObject &&value) noexcept;
+
+  //! Create an Array JSValue.
   JSValue(JSValueArray &&value) noexcept;
+
+  //! Create a String JSValue.
   JSValue(std::string &&value) noexcept;
+
+  //! Create a String JSValue from any type that can be converted to std::string_view.
   template <class TStringView, std::enable_if_t<std::is_convertible_v<TStringView, std::string_view>, int> = 1>
   JSValue(TStringView value) noexcept;
+
+  //! Create a Boolean JSValue.
   template <class TBool, std::enable_if_t<std::is_same_v<TBool, bool>, int> = 1>
   JSValue(TBool value) noexcept;
+
+  //! Create an Int64 JSValue from any integral type except bool.
   template <class TInt, std::enable_if_t<std::is_integral_v<TInt> && !std::is_same_v<TInt, bool>, int> = 1>
   JSValue(TInt value) noexcept;
+
+  //! Create a Double JSValue.
   JSValue(double value) noexcept;
 
-  JSValue(const JSValue &other) = delete;
-  JSValue &operator=(const JSValue &other) = delete;
+  //! Create JSValue from a type that has WriteValue method defined to write to IJSValueWriter.
+  template <class T>
+  static JSValue From(T const &value) noexcept;
 
-  JSValue(JSValue &&other) noexcept;
-  JSValue &operator=(JSValue &&other) noexcept;
+#pragma endregion
+
+#pragma region Destructor
 
   ~JSValue() noexcept;
 
+#pragma endregion
+
+#pragma region JSValue copy semantic
+
+  //! Delete the copy constructor to avoid unexpected copies. Use the Copy method instead.
+  JSValue(const JSValue &other) = delete;
+
+  //! Delete the copy assignment to avoid unexpected copies. Use the Copy method instead.
+  JSValue &operator=(const JSValue &other) = delete;
+
+  //! Do a deep copy of JSValue.
   JSValue Copy() const noexcept;
-  static JSValueObject CopyObject(const JSValueObject &other) noexcept;
-  static JSValueArray CopyArray(const JSValueArray &other) noexcept;
 
+#pragma endregion
+
+#pragma region JSValue move semantic
+
+  //! Move constructor. The 'other' JSValue becomes JSValue::Null.
+  JSValue(JSValue &&other) noexcept;
+
+  //! Move assignment. The 'other' JSValue becomes JSValue::Null.
+  JSValue &operator=(JSValue &&other) noexcept;
+
+  //! Move out Object and set this to JSValue::Null. It returns JSValue::EmptyObject
+  //! and keeps this JSValue unchanged if current type is not an object.
+  JSValueObject MoveObject() noexcept;
+
+  //! Move out Array and set this to JSValue::Null. It returns JSValue::EmptyArray
+  //! and keeps this JSValue unchanged if current type is not an array.
+  JSValueArray MoveArray() noexcept;
+
+#pragma endregion
+
+#pragma region Inspect JSValue
+
+  //! Get JSValue type.
   JSValueType Type() const noexcept;
+
+  //! Return true if JSValue type is Null.
   bool IsNull() const noexcept;
-  const JSValueObject &Object() const noexcept;
-  const JSValueArray &Array() const noexcept;
-  const std::string &String() const noexcept;
-  bool Boolean() const noexcept;
-  int64_t Int64() const noexcept;
-  double Double() const noexcept;
 
-  JSValueObject TakeObject() noexcept;
-  JSValueArray TakeArray() noexcept;
+  //! Return pointer to JSValueObject if JSValue type is Object, or nullptr otherwise.
+  JSValueObject const *TryGetObject() const noexcept;
 
-  size_t PropertyCount() const noexcept;
-  size_t ItemCount() const noexcept;
+  //! Return pointer to JSValueArray if JSValue type is Array, or nullptr otherwise.
+  JSValueArray const *TryGetArray() const noexcept;
 
-  template <typename T, std::enable_if_t<std::is_default_constructible_v<T>, int> = 0>
-  T To() const noexcept;
-  template <typename T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int> = 0>
-  T To() const noexcept;
-  template <class T>
-  static JSValue From(const T &value) noexcept;
+  //! Return pointer to string if JSValue type is String, or nullptr otherwise.
+  std::string const *TryGetString() const noexcept;
 
-  const JSValue &GetObjectProperty(std::string_view propertyName) const noexcept;
-  const JSValue &GetArrayItem(JSValueArray::size_type index) const noexcept;
-  const JSValue &operator[](std::string_view propertyName) const noexcept;
-  const JSValue &operator[](JSValueArray::size_type index) const noexcept;
+  //! Return pointer to bool value if JSValue type is Boolean, or nullptr otherwise.
+  bool const *TryGetBoolean() const noexcept;
 
+  //! Return pointer to int64_t value if JSValue type is Int64, or nullptr otherwise.
+  int64_t const *TryGetInt64() const noexcept;
+
+  //! Return pointer to double value if JSValue type is Double, or nullptr otherwise.
+  double const *TryGetDouble() const noexcept;
+
+  //! Return true if this JSValue is strictly equal to JSValue.
+  //! Compared values must have the same type and value.
+  //!
+  //! The behavior is similar to JavaScript === operator except for Object and Array for which
+  //! this functions does a deep structured comparison instead of pointer equality.
   bool Equals(const JSValue &other) const noexcept;
 
+  //! Return true if this JSValue is strictly equal to JSValue after they are converted to the same type.
+  //!
+  //! Null is not converted to any other type before comparison.
+  //! Object and Array types are converted first to a String type using AsString() before comparing
+  //! with other types, and then we apply the same rules as for the String type.
+  //! String is converted to Double before comparing with Boolean, Int64, or Double.
+  //! Boolean is converted to 1.0 and +0.0 when comparing with String or Double.
+  //! Boolean is converted to 1 and 0 when comparing with Int64.
+  //! Int64 is converted to Double when comparing with Double.
+  //!
+  //! The behavior is similar to JavaScript == operator except for Object and Array for which
+  //! this functions does a deep structured comparison using EqualsAfterConversion instead
+  //! of pointer equality.
+  bool EqualsAfterConversion(const JSValue &other) const noexcept;
+
+#pragma endregion
+
+#pragma region Inspect JSValueObject
+
+  //! Return property count if JSValue is Object, or 0 otherwise.
+  size_t PropertyCount() const noexcept;
+
+  //! Get a reference to object property value if JSValue type is Object and the property is found,
+  //! or a reference to JSValue::Null otherwise.
+  JSValue const &GetObjectProperty(std::string_view propertyName) const noexcept;
+
+  //! Get a reference to object property value if JSValue type is Object and the property is found,
+  //! or a reference to JSValue::Null otherwise.
+  JSValue const &operator[](std::string_view propertyName) const noexcept;
+
+#pragma endregion
+
+#pragma region Inspect JSValueArray
+
+  //! Return item count if JSValue is Array, or 0 otherwise.
+  size_t ItemCount() const noexcept;
+
+  //! Get a reference to array item if JSValue type is Array and the index is in bounds,
+  //! or a reference to JSValue::Null otherwise.
+  JSValue const &GetArrayItem(JSValueArray::size_type index) const noexcept;
+
+  //! Get a reference to array item if JSValue type is Array and the index is in bounds,
+  //! or a reference to JSValue::Null otherwise.
+  JSValue const &operator[](JSValueArray::size_type index) const noexcept;
+
+#pragma endregion
+
+#pragma region Convert JSValue to other type
+
+  //! Return Object representation of JSValue. It is JSValue::EmptyObject if type is not Object.
+  JSValueObject const &AsObject() const noexcept;
+
+  //! Return Array representation of JSValue. It is JSValue::EmptyArray if type is not Object.
+  JSValueArray const &AsArray() const noexcept;
+
+  //! Return a string representation of JSValue. It is the same as JavaScript String(value) result.
+  std::string AsString() const noexcept;
+
+  //! Return a Boolean representation of JSValue. It is the same as JavaScript Boolean(value) result.
+  bool AsBoolean() const noexcept;
+
+  //! Return an Int8 representation of JSValue. It is the same as JavaScript Number(value) result casted to int8_t.
+  int8_t AsInt8() const noexcept;
+
+  //! Return an Int16 representation of JSValue. It is the same as JavaScript Number(value) result casted to int16_t.
+  int16_t AsInt16() const noexcept;
+
+  //! Return an Int32 representation of JSValue. It is the same as JavaScript Number(value) result casted to int32_t.
+  int32_t AsInt32() const noexcept;
+
+  //! Return an Int64 representation of JSValue. It is the same as JavaScript Number(value) result casted to int64_t.
+  int64_t AsInt64() const noexcept;
+
+  //! Return an UInt8 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint8_t.
+  uint8_t AsUInt8() const noexcept;
+
+  //! Return an UInt16 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint16_t.
+  uint16_t AsUInt16() const noexcept;
+
+  //! Return an UInt32 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint32_t.
+  uint32_t AsUInt32() const noexcept;
+
+  //! Return an UInt64 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint64_t.
+  uint64_t AsUInt64() const noexcept;
+
+  //! Return a Double representation of JSValue. It is the same as JavaScript Number(value) result.
+  double AsDouble() const noexcept;
+
+  //! Return an Float representation of JSValue. It is the same as JavaScript Number(value) result casted to float.
+  float AsFloat() const noexcept;
+
+  //! Return value T that is created from JSValue using the ReadValue function override.
+  //! Default T is constructed by using default constructor.
+  template <
+      class T,
+      std::enable_if_t<std::is_default_constructible_v<T> && !std::is_constructible_v<T, std::nullptr_t>, int> = 0>
+  T As() const noexcept;
+
+  //! Return value T that is created from JSValue using the ReadValue function override.
+  //! Default T is constructed by using constructor that receives nullptr as a parameter.
+  template <class T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int> = 0>
+  T As() const noexcept;
+
+  //! Return value T that is created from JSValue using the ReadValue function override.
+  //! Default T is constructed from the provided 'default' value.
+  template <class T>
+  T As(T &&defaultValue) const noexcept;
+
+  //! Convert JSValue to a readable string that can be used for logging.
+  std::string ToString() const noexcept;
+
+#pragma endregion
+
+#pragma region JSValue serialization and deserialization.
+
+  //! Create JSValue from IJSValueReader.
   static JSValue ReadFrom(IJSValueReader const &reader) noexcept;
-  static JSValueObject ReadObjectFrom(IJSValueReader const &reader) noexcept;
-  static JSValueArray ReadArrayFrom(IJSValueReader const &reader) noexcept;
 
+  //! Write this JSValue to IJSValueWriter.
   void WriteTo(IJSValueWriter const &writer) const noexcept;
-  static void WriteObjectTo(IJSValueWriter const &writer, JSValueObjectView object) noexcept;
-  static void WriteArrayTo(IJSValueWriter const &writer, JSValueArrayView value) noexcept;
 
- private:
-  bool ObjectEquals(const JSValueObject &other) const noexcept;
-  bool ArrayEquals(const JSValueArray &other) const noexcept;
-  static JSValueObject ReadObjectProperties(IJSValueReader const &reader) noexcept;
-  static JSValueArray ReadArrayItems(IJSValueReader const &reader) noexcept;
+#pragma endregion
+
+#pragma region Deprecated methods
+
+  // The methods below are deprecated in favor of other methods with clearer semantic
+  [[deprecated("Use TryGetObject or AsObject")]] JSValueObject const &Object() const noexcept;
+  [[deprecated("Use TryGetArray or As Array")]] JSValueArray const &Array() const noexcept;
+  [[deprecated("Use TryGetString or AsString")]] std::string const &String() const noexcept;
+  [[deprecated("Use TryGetBoolean or AsBoolean")]] bool Boolean() const noexcept;
+  [[deprecated("Use TryGetInt64 or AsInt64")]] int64_t Int64() const noexcept;
+  [[deprecated("Use TryGetDouble or AsDouble")]] double Double() const noexcept;
+
+  // We have renamed or moved the methods below.
+  template <class T>
+  [[deprecated("Use As<T>")]] T To() const noexcept;
+  [[deprecated("Use MoveObject")]] JSValueObject TakeObject() noexcept;
+  [[deprecated("Use MoveArray")]] JSValueArray TakeArray() noexcept;
+  [[deprecated("Use JSValueObject::Copy")]] static JSValueObject CopyObject(const JSValueObject &other) noexcept;
+  [[deprecated("Use JSValueArray::Copy")]] static JSValueArray CopyArray(const JSValueArray &other) noexcept;
+  [[deprecated("Use JSValueObject::ReadFrom")]] static JSValueObject ReadObjectFrom(
+      IJSValueReader const &reader) noexcept;
+  [[deprecated("Use JSValueArray::ReadFrom")]] static JSValueArray ReadArrayFrom(IJSValueReader const &reader) noexcept;
+  [[deprecated("Use JSValueObject::WriteTo")]] static void WriteObjectTo(
+      IJSValueWriter const &writer,
+      JSValueObject const &value) noexcept;
+  [[deprecated("Use JSValueArray::WriteTo")]] static void WriteArrayTo(
+      IJSValueWriter const &writer,
+      JSValueArray const &value) noexcept;
+
+#pragma endregion
+
+#pragma region Private fields
 
  private: // Instance fields
   JSValueType m_type;
@@ -143,13 +462,19 @@ struct JSValue {
     int64_t m_int64;
     double m_double;
   };
+
+#pragma endregion
 };
+
+#pragma region Standalone JSValue functions
 
 bool operator==(const JSValue &left, const JSValue &right) noexcept;
 bool operator!=(const JSValue &left, const JSValue &right) noexcept;
-void swap(JSValue &left, JSValue &right) noexcept;
 
-// Helps initialize key-value pairs for JSValueObject
+#pragma endregion
+
+//! Helps initialize key-value pairs for JSValueObject.
+//! It creates its own instance of JSValue which then can be moved to JSValueObject.
 struct JSValueObjectKeyValue {
   template <class TKey, class TValue>
   JSValueObjectKeyValue(TKey &&key, TValue &&value) noexcept
@@ -159,7 +484,8 @@ struct JSValueObjectKeyValue {
   JSValue Value;
 };
 
-// Helps initialize items for JSValueArray
+//! Helps initialize items for JSValueArray.
+//! It creates its own instance of JSValue which then can be moved to JSValueArray.
 struct JSValueArrayItem {
   template <class TItem>
   JSValueArrayItem(TItem &&item) noexcept : Item(std::forward<TItem>(item)) {}
@@ -168,39 +494,56 @@ struct JSValueArrayItem {
 };
 
 //===========================================================================
-// JSValueObjectKeyValue inline implementation
+// Inline JSValueObject implementation.
 //===========================================================================
 
-//===========================================================================
-// JSValueArrayItem inline implementation
-//===========================================================================
-
-inline JSValueObjectView::JSValueObjectView(const JSValueObject &object) noexcept : m_object{object} {}
-
-inline auto JSValueObjectView::begin() const noexcept {
-  return m_object.begin();
-}
-
-inline auto JSValueObjectView::end() const noexcept {
-  return m_object.end();
+template <class TMoveInputIterator>
+JSValueObject::JSValueObject(TMoveInputIterator first, TMoveInputIterator last) noexcept {
+  auto it = first;
+  while (it != last) {
+    auto pair = *it++;
+    try_emplace(std::move(pair.first), std::move(pair.second));
+  }
 }
 
 //===========================================================================
-// JSValueArrayView inline implementation
+// Inline JSValueObject standalone function implementations.
 //===========================================================================
 
-inline JSValueArrayView::JSValueArrayView(const JSValueArray &array) noexcept : m_array{array} {}
-
-inline auto JSValueArrayView::begin() const noexcept {
-  return m_array.begin();
+inline bool operator==(const JSValueObject &left, const JSValueObject &right) noexcept {
+  return left.Equals(right);
 }
 
-inline auto JSValueArrayView::end() const noexcept {
-  return m_array.end();
+inline bool operator!=(const JSValueObject &left, const JSValueObject &right) noexcept {
+  return !left.Equals(right);
 }
 
 //===========================================================================
-// JSValue inline implementation
+// Inline JSValueArray implementation.
+//===========================================================================
+
+template <class TMoveInputIterator>
+JSValueArray::JSValueArray(TMoveInputIterator first, TMoveInputIterator last) noexcept {
+  auto it = first;
+  while (it != last) {
+    push_back(*it++);
+  }
+}
+
+//===========================================================================
+// Inline JSValueArray standalone function implementations.
+//===========================================================================
+
+inline bool operator==(const JSValueArray &left, const JSValueArray &right) noexcept {
+  return left.Equals(right);
+}
+
+inline bool operator!=(const JSValueArray &left, const JSValueArray &right) noexcept {
+  return !left.Equals(right);
+}
+
+//===========================================================================
+// Inline JSValue implementation.
 //===========================================================================
 
 #pragma warning(push)
@@ -219,6 +562,13 @@ inline JSValue::JSValue(TInt value) noexcept : m_type{JSValueType::Int64}, m_int
 inline JSValue::JSValue(double value) noexcept : m_type{JSValueType::Double}, m_double{value} {}
 #pragma warning(pop)
 
+template <class T>
+static JSValue From(T const &value) noexcept {
+  auto writer = MakeJSValueTreeWriter();
+  WriteValue(writer, value);
+  return TakeJSValue(writer);
+}
+
 inline JSValueType JSValue::Type() const noexcept {
   return m_type;
 }
@@ -226,6 +576,96 @@ inline JSValueType JSValue::Type() const noexcept {
 inline bool JSValue::IsNull() const noexcept {
   return m_type == JSValueType::Null;
 }
+
+inline JSValueObject const *JSValue::TryGetObject() const noexcept {
+  return (m_type == JSValueType::Object) ? &m_object : nullptr;
+}
+
+inline JSValueArray const *JSValue::TryGetArray() const noexcept {
+  return (m_type == JSValueType::Array) ? &m_array : nullptr;
+}
+
+inline std::string const *JSValue::TryGetString() const noexcept {
+  return (m_type == JSValueType::String) ? &m_string : nullptr;
+}
+
+inline bool const *JSValue::TryGetBoolean() const noexcept {
+  return (m_type == JSValueType::Boolean) ? &m_bool : nullptr;
+}
+
+inline int64_t const *JSValue::TryGetInt64() const noexcept {
+  return (m_type == JSValueType::Int64) ? &m_int64 : nullptr;
+}
+
+inline double const *JSValue::TryGetDouble() const noexcept {
+  return (m_type == JSValueType::Double) ? &m_double : nullptr;
+}
+
+inline JSValueObject const &JSValue::AsObject() const noexcept {
+  return (m_type == JSValueType::Object) ? m_object : EmptyObject;
+}
+
+inline JSValueArray const &JSValue::AsArray() const noexcept {
+  return (m_type == JSValueType::Array) ? m_array : EmptyArray;
+}
+
+template <>
+inline std::string JSValue::As() const noexcept {
+  return AsString();
+}
+
+template <>
+inline bool JSValue::As() const noexcept {
+  return AsBoolean();
+}
+
+template <>
+inline int8_t JSValue::As() const noexcept {
+  return AsInt8();
+}
+
+template <>
+inline int16_t JSValue::As() const noexcept {
+  return AsInt16();
+}
+
+template <>
+inline int32_t JSValue::As() const noexcept {
+  return AsInt32();
+}
+
+template <>
+inline int64_t JSValue::As() const noexcept {
+  return AsInt64();
+}
+
+template <
+    class T,
+    std::enable_if_t<std::is_default_constructible_v<T> && !std::is_constructible_v<T, std::nullptr_t>, int>>
+inline T JSValue::As() const noexcept {
+  T result;
+  ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
+  return result;
+}
+
+template <class T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int>>
+inline T JSValue::As() const noexcept {
+  T result{nullptr};
+  ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
+  return result;
+}
+
+inline const JSValue &JSValue::operator[](std::string_view propertyName) const noexcept {
+  return GetObjectProperty(propertyName);
+}
+
+inline const JSValue &JSValue::operator[](JSValueArray::size_type index) const noexcept {
+  return GetArrayItem(index);
+}
+
+//===========================================================================
+// JSValue deprecated methods.
+//===========================================================================
 
 inline const JSValueObject &JSValue::Object() const noexcept {
   return (m_type == JSValueType::Object) ? m_object : EmptyObject;
@@ -251,37 +691,44 @@ inline double JSValue::Double() const noexcept {
   return (m_type == JSValueType::Double) ? m_double : 0;
 }
 
-template <typename T, std::enable_if_t<std::is_default_constructible_v<T>, int>>
-inline T JSValue::To() const noexcept {
-  T result;
-  ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
-  return result;
-}
-
-template <typename T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int>>
-inline T JSValue::To() const noexcept {
-  T result{nullptr};
-  ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
-  return result;
-}
-
 template <class T>
-static JSValue From(const T &value) noexcept {
-  auto writer = MakeJSValueTreeWriter();
-  WriteValue(writer, value);
-  return TakeJSValue(writer);
+inline T JSValue::To() const noexcept {
+  return As<T>();
 }
 
-inline const JSValue &JSValue::operator[](std::string_view propertyName) const noexcept {
-  return GetObjectProperty(propertyName);
+inline JSValueObject JSValue::TakeObject() noexcept {
+  return MoveObject();
 }
 
-inline const JSValue &JSValue::operator[](JSValueArray::size_type index) const noexcept {
-  return GetArrayItem(index);
+inline JSValueArray JSValue::TakeArray() noexcept {
+  return MoveArray();
+}
+
+inline /*static*/ JSValueObject JSValue::CopyObject(const JSValueObject &other) noexcept {
+  return other.Copy();
+}
+
+inline /*static*/ JSValueArray JSValue::CopyArray(const JSValueArray &other) noexcept {
+  return other.Copy();
+}
+
+inline /*static*/ JSValueObject JSValue::ReadObjectFrom(IJSValueReader const &reader) noexcept {
+  return JSValueObject::ReadFrom(reader);
+}
+
+inline /*static*/ JSValueArray JSValue::ReadArrayFrom(IJSValueReader const &reader) noexcept {
+  return JSValueArray::ReadFrom(reader);
+}
+
+inline /*static*/ void JSValue::WriteObjectTo(IJSValueWriter const &writer, JSValueObject const &value) noexcept {
+  value.WriteTo(writer);
+}
+inline /*static*/ void JSValue::WriteArrayTo(IJSValueWriter const &writer, JSValueArray const &value) noexcept {
+  value.WriteTo(writer);
 }
 
 //===========================================================================
-// Standalone inline functions implementation
+// Inline JSValue standalone function implementations.
 //===========================================================================
 
 inline bool operator==(const JSValue &left, const JSValue &right) noexcept {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -388,11 +388,11 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ JSValue &value) noex
 }
 
 inline void ReadValue(IJSValueReader const &reader, /*out*/ JSValueObject &value) noexcept {
-  value = JSValue::ReadObjectFrom(reader);
+  value = JSValueObject::ReadFrom(reader);
 }
 
 inline void ReadValue(IJSValueReader const &reader, /*out*/ JSValueArray &value) noexcept {
-  value = JSValue::ReadArrayFrom(reader);
+  value = JSValueArray::ReadFrom(reader);
 }
 
 template <class T, std::enable_if_t<!std::is_void_v<decltype(GetStructInfo(static_cast<T *>(nullptr)))>, int>>

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -183,11 +183,11 @@ inline void WriteValue(IJSValueWriter const &writer, JSValue const &value) noexc
 }
 
 inline void WriteValue(IJSValueWriter const &writer, JSValueObject const &value) noexcept {
-  JSValue::WriteObjectTo(writer, value);
+  value.WriteTo(writer);
 }
 
 inline void WriteValue(IJSValueWriter const &writer, JSValueArray const &value) noexcept {
-  JSValue::WriteArrayTo(writer, value);
+  value.WriteTo(writer);
 }
 
 inline void WriteCustomDirectEventTypeConstant(
@@ -242,7 +242,7 @@ inline void WriteProperties(IJSValueWriter const &writer, T const &value) noexce
   auto jsValueWriter = MakeJSValueTreeWriter();
   WriteValue(jsValueWriter, value);
   auto jsValue = TakeJSValue(jsValueWriter);
-  for (auto &property : jsValue.Object()) {
+  for (auto &property : jsValue.AsObject()) {
     WriteProperty(writer, property.first, property.second);
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
@@ -194,13 +194,13 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     }
 
     [ReactMethod]
-    public void ResolveSayHelloCallbacks(Action<string> resolve, Action<string> reject)
+    public void ResolveSayHelloCallbacks(Action<string> resolve, Action<string> _)
     {
       resolve("Hello_3");
     }
 
     [ReactMethod]
-    public void RejectSayHelloCallbacks(Action<string> resolve, Action<string> reject)
+    public void RejectSayHelloCallbacks(Action<string> _, Action<string> reject)
     {
       reject("Goodbye");
     }
@@ -247,13 +247,13 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
 
     [ReactMethod]
-    public static void StaticResolveSayHelloCallbacks(Action<string> resolve, Action<string> reject)
+    public static void StaticResolveSayHelloCallbacks(Action<string> resolve, Action<string> _)
     {
       resolve("Hello_3");
     }
 
     [ReactMethod]
-    public static void StaticRejectSayHelloCallbacks(Action<string> resolve, Action<string> reject)
+    public static void StaticRejectSayHelloCallbacks(Action<string> _, Action<string> reject)
     {
       reject("Goodbye");
     }

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValue.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValue.cs
@@ -184,6 +184,8 @@ namespace Microsoft.ReactNative.Managed
       }
     }
 
+    public T As<T>() => (new JSValueTreeReader(this)).ReadValue<T>();
+
     public T To<T>() => (new JSValueTreeReader(this)).ReadValue<T>();
 
     public JSValue From<T>(T value)

--- a/vnext/local-cli/generator-windows/templates/cpp/src/pch.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/pch.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#define NOMINMAX
+
 #include <hstring.h>
 #include <restrictederrorinfo.h>
 #include <unknwn.h>


### PR DESCRIPTION
This PR addresses issue https://github.com/microsoft/react-native-windows/issues/4181 that says that `JSValue::Double()` function has an unexpected behavior comparing with the `folly::dynamic::asDouble()` function. Though the `JSValue::Double()` was intended to behave as `folly::dynamic::getDouble()`, the issue brings a very important feedback:
- current API is not intuitively understood
- it is difficult to use when we need to convert values to a specific type
- it is difficult/inefficient to use when we want to work with typed values because functions silently return some default value instead of returning an error.

In this PR:
- We deprecate all functions that access typed values: `JSValue::Object()`, `JSValue::Array()`, `JSValue::String()`, `JSValue::Boolean()`, `JSValue::Int64()`, and `JSValue::Double()`. These function will be removed soon.
- Instead, we add two sets of new functions. The first set can be used to cast JSValue to a desired type, and the second is to work with typed values as they are stored in `JSValue`:
  - The new type casting functions are:
    - `JSValue::AsObject()` casts `JSValue` to `JSValueObject` value. It is either `JSValueObject` stored in `JSValue` or `JSValue::EmptyObject` otherwise.
    - `JSValue::AsArray()` casts `JSValue` to `JSValueArray` value. It is either `JSValueArray` stored in `JSValue` or `JSValue::EmptyArray` otherwise.
    - `JSValue::AsString()` casts `JSValue` to `std::string` value using the same rules as JavaScript's `String(...)` function.
    - `JSValue::AsBoolean()` casts `JSValue` to `bool` value using the same rules as JavaScript's `Boolean(...)` function.
    - `JSValue::AsDouble()` casts `JSValue` to `double` value using the same rules as JavaScript's `Number(...)` function.
    - `JSValue::AsInt64()` casts `JSValue` to `int64_t` by calling `JSValue::AsDouble()` first and then converting `double` value to `int64_t` value. `NAN` is converted to `0`, `+Infinity` and values exceeding `max(int64_t)` are converted to `max(int64_t)`, `-Infinity` and values below `min(int64_t)` are converted to `min(int64_t)`.
    - `JSValue::AsUInt64()` casts `JSValue` to `uint64_t` by calling `JSValue::AsInt64()` first and then replacing all negative values with `0`.
    - `JSValue::AsInt8()`, `JSValue::AsInt16()`, `JSValue::AsInt32()`, `JSValue::AsUInt8()`, `JSValue::AsUInt16()`, and `JSValue::AsUInt32()` cast `JSValue` to `int8_t`, `int16_t`, `int32_t`, `uint8_t`, `uint16_t`, and `uint32_t` by calling `JSValue::AsInt64()` or `JSValue::AsUInt64()` first and then adjusting the min and max values.
  - The new functions to work with typed values are: `JSValue::TryGetObject()`, `JSValue::TryGetArray()`, `JSValue::TryGetString()`, `JSValue::TryGetBoolean()`, `JSValue::TryGetInt64()`, and `JSValue::TryGetDouble()`. These functions return a pointer that in case if `JSValue::Type()` matches the requested value type returns a pointer to `JSValueObject`, `JSValueArray`, `std::string`, `bool`, `int64_t`, or `double` value, otherwise they return null. There functions could be used to observe `JSValue` typed values in the following way:
```C++
    if (jsValue.IsNull()) {
       // Observe Null value 
    } else if (auto objectPtr = jsValue.TryGetObject()) {
       // Use *objectPtr 
    } else if (auto arrayPtr = jsValue.TryGetArray()) {
       // Use *arrayPtr 
    } else if (auto stringPtr = jsValue.TryGetString()) {
       // Use *stringPtr 
    } else if (auto boolPtr = jsValue.TryGetBoolean()) {
       // Use *boolPtr 
    } else if (auto int64Ptr = jsValue.TryGetInt64()) {
       // Use *int64Ptr 
    } else if (auto doublePtr = jsValue.TryGetDouble()) {
       // Use *doublePtr 
    }
```

Other related changes:
- Added `JSValue::EqualsAfterConversion()` method that behaves similar to JavcaScript's `==` operator except for Object and Array types where we try to compare contents of these values instead of just references.
- Expanded `JSValueObject` and `JSValueArrays` with more methods. Some methods were moved from `JSValue`.
- Renamed `JSValue::TakeObject()` and `JSValue::TakeArray()` to `JSValue::MoveObject()` and `JSValue::MoveArray()`
- Added comments for JSValue.h APIs.

Note that these changes mostly for C++ code except for a few warning removing C# changes. We will have another PR for C# with corresponding JSValue changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4260)