### PR TITLE
Add Override Manifest for Native Code

### DIFF
--- a/change/react-native-windows-2020-03-06-17-27-30-native-manifest.json
+++ b/change/react-native-windows-2020-03-06-17-27-30-native-manifest.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Add Override Manifest for Native Code",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "cb6fa7e7fc278b054a94b27a8b3b3991aa10f79e",
+  "dependentChangeType": "patch",
+  "date": "2020-03-07T01:27:30.373Z"
+}

--- a/packages/override-tools/src/Cli.ts
+++ b/packages/override-tools/src/Cli.ts
@@ -183,6 +183,13 @@ async function removeOverride(overridePath: string) {
  * Prints validation errors in a user-readable form to stderr
  */
 function printValidationErrors(errors: Array<ValidationError>) {
+  if (errors.length === 0) {
+    return;
+  }
+
+  // Add an initial line of separation
+  console.error();
+
   errors.sort((a, b) => a.file.localeCompare(b.file));
 
   const filesMissing = errors.filter(err => {
@@ -200,31 +207,35 @@ function printValidationErrors(errors: Array<ValidationError>) {
 
   if (filesMissing.length > 0) {
     const errorMessage =
-      "\nFound override files that aren't listed in the manifest. Overrides can be added to the manifest by using 'yarn override add <override>':";
+      "Found override files that aren't listed in the manifest. Overrides can be added to the manifest by using 'yarn override add <override>':";
     console.error(chalk.red(errorMessage));
     filesMissing.forEach(err => console.error(` - ${err.file}`));
+    console.error();
   }
 
   if (overridesMissing.length > 0) {
     const errorMessage =
-      "\nFound overrides in the manifest that don't exist on disk. Remove existing overrides using 'yarn override remove <override>':";
+      "Found overrides in the manifest that don't exist on disk. Remove existing overrides using 'yarn override remove <override>':";
     console.error(chalk.red(errorMessage));
     overridesMissing.forEach(err => console.error(` - ${err.file}`));
+    console.error();
   }
 
   if (baseFilesNotFound.length > 0) {
     const errorMessage =
-      "\nFound overrides whose original files do not exist. Remove existing overrides using 'yarn override remove <override>':";
+      "Found overrides whose original files do not exist. Remove existing overrides using 'yarn override remove <override>':";
     console.error(chalk.red(errorMessage));
     baseFilesNotFound.forEach(err => console.error(` - ${err.file}`));
+    console.error();
   }
 
   if (outOfDateFiles.length > 0) {
     // TODO: Instruct users to use 'yarn override upgrade' once that exists
     console.error(
-      chalk.red('\nFound overrides whose original files have changed:'),
+      chalk.red('Found overrides whose original files have changed:'),
     );
     outOfDateFiles.forEach(err => console.error(` - ${err.file}`));
+    console.error();
   }
 }
 
@@ -260,7 +271,7 @@ async function readManifest(file: string, version?: string): Promise<Manifest> {
   const gitReactRepo = await GitReactFileRepository.createAndInit();
 
   const ovrPath = path.dirname(file);
-  const ovrFilter = /^.*\.(js|ts|jsx|tsx)$/;
+  const ovrFilter = /^.*\.(js|ts|jsx|tsx|cpp|h)$/;
   const ovrRepo = new OverrideFileRepositoryImpl(ovrPath, ovrFilter);
 
   const rnVersion = version || (await getInstalledRNVersion(file));

--- a/packages/override-tools/src/scripts/generateManifest.ts
+++ b/packages/override-tools/src/scripts/generateManifest.ts
@@ -179,7 +179,7 @@ async function getFileRepos(
 ): Promise<
   [FileRepository.OverrideFileRepository, FileRepository.ReactFileRepository]
 > {
-  const ovrPattern = /^.*\.(js|ts|jsx|tsx)$/;
+  const ovrPattern = /^.*\.(js|ts|jsx|tsx|cpp|h)$/;
   const overrides = new OverrideFileRepositoryImpl(overrideovrPath, ovrPattern);
 
   const versionedReactSources = await GitReactFileRepository.createAndInit();

--- a/vnext/DeforkingPatches/overrides.json
+++ b/vnext/DeforkingPatches/overrides.json
@@ -1,0 +1,36 @@
+{
+  "overrides": [
+    {
+      "type": "patch",
+      "file": "ReactCommon\\cxxreact\\NativeToJsBridge.h",
+      "baseFile": "ReactCommon\\cxxreact\\NativeToJsBridge.h",
+      "baseVersion": "0.61.5",
+      "baseHash": "b499aa46b3ed91570f8cb0de60e3add6c48cdf12",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.cpp",
+      "baseFile": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.cpp",
+      "baseVersion": "0.61.5",
+      "baseHash": "32ede21afc7337f33184e0ce267b6fde32a6dcc1",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.h",
+      "baseFile": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.h",
+      "baseVersion": "0.61.5",
+      "baseHash": "d4b1ccfd00c77d4a9dacf5f1e668119847895895",
+      "issue": "LEGACY_FIXME"
+    },
+    {
+      "type": "patch",
+      "file": "ReactCommon\\yoga\\yoga\\Yoga.cpp",
+      "baseFile": "ReactCommon\\yoga\\yoga\\Yoga.cpp",
+      "baseVersion": "0.61.5",
+      "baseHash": "73d61e0276175fd2c9649f4c4b390f6173d365ae",
+      "issue": 3994
+    }
+  ]
+}

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -20,7 +20,7 @@
     "lint": "just-scripts lint",
     "start": "react-native start",
     "watch": "tsc -w",
-    "validate-overrides": "override validate ./src/overrides.json ./ReactCopies/overrides.json"
+    "validate-overrides": "override validate ./src/overrides.json ./ReactCopies/overrides.json ./DeforkingPatches/overrides.json"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.0",


### PR DESCRIPTION
Also make some visual tweaks to how we print errors so that separation between manifests is less confusing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4263)