### PR TITLE
Fix Support For SystraceSection

### DIFF
--- a/change/react-native-windows-2020-03-07-06-25-07-fix-etw.json
+++ b/change/react-native-windows-2020-03-07-06-25-07-fix-etw.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Support For SysTraceSection",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "6745910fa922e880c314c9581419a6a2cc3f2e2a",
+  "dependentChangeType": "patch",
+  "date": "2020-03-07T14:25:07.210Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -45,9 +45,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(ENABLE_ETW_TRACING)'=='true'">ENABLE_ETW_TRACING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <!-- This has been broken since deforking (#4245)
-        <PreprocessorDefinitions Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)'=='true'">ENABLE_JS_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      -->
+      <PreprocessorDefinitions Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)'=='true'">ENABLE_JS_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/vnext/ReactWindowsCore/tracing/fbsystrace.h
+++ b/vnext/ReactWindowsCore/tracing/fbsystrace.h
@@ -67,17 +67,13 @@ class FbSystraceSection {
   }
 
  private:
-  template <typename T>
-  static constexpr bool constructs_to_string_v =
-      std::is_convertible_v<T, std::string> || std::is_constructible_v<std::string, T>;
-
   void init() {
     begin_section();
   }
 
   template <typename Arg, typename... RestArg>
   void init(Arg &&arg, RestArg &&... rest) {
-    if constexpr (constructs_to_string_v<Arg>) {
+    if constexpr (std::is_convertible_v<Arg, std::string>) {
       args_[index_++] = std::forward<Arg>(arg);
     } else {
       args_[index_++] = std::to_string(std::forward<Arg>(arg));


### PR DESCRIPTION
Addresses #4245, During deforking work I left a build logic typo which caused SystraceSection to noop. When trying to re-enable in deforked React Native, we end up having a compile error since stock Facebook code will pass doubles as an arg to SysTraceSection, and we will internally only accept string.

This was fixed in microsof/react-native by commenting out the SystraceSection call that passed a double. A real solution is to allow our implementation of FbSystraceSection to accept non-string args and convert to strings, as Facebook's seemingly does.

- Add a SFINAE based overload for non-string-like types to call std::to_string on them
- Move functions to be private instead of public

Still need a plan to validate this. Any recommendations @mganandraj @stecrain ?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4267)