### PR TITLE
[Cherry-Pick] Fix Support For SystraceSection (#4267)

### DIFF
--- a/change/react-native-windows-2020-03-07-06-25-07-fix-etw.json
+++ b/change/react-native-windows-2020-03-07-06-25-07-fix-etw.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Support For SysTraceSection",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "6745910fa922e880c314c9581419a6a2cc3f2e2a",
+  "dependentChangeType": "patch",
+  "date": "2020-03-07T14:25:07.210Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -41,7 +41,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(ENABLE_ETW_TRACING)'=='true'">ENABLE_ETW_TRACING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)'=='true' AND '$PATCH_RN'=='true'">ENABLE_JS_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)'=='true'">ENABLE_JS_SYSTRACE_TO_ETW;WITH_FBSYSTRACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/vnext/ReactWindowsCore/tracing/fbsystrace.h
+++ b/vnext/ReactWindowsCore/tracing/fbsystrace.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <stdint.h>
@@ -6,6 +9,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #define TRACE_TAG_REACT_CXX_BRIDGE 1 << 10
@@ -51,37 +55,11 @@ class FbSystraceSection {
             .count());
   }
 
-  void init(std::string &&v) {
-    args_[index_++] = std::move(v);
-    begin_section();
-  }
-
-  void init(const std::string &v) {
-    args_[index_++] = v; // copy
-    begin_section();
-  }
-
-  void init() {
-    begin_section();
-  }
-
-  template <typename... ConvertsToStringPiece>
-  void init(std::string &&v, ConvertsToStringPiece &&... rest) {
-    args_[index_++] = std::move(v);
-    init(std::forward<ConvertsToStringPiece>(rest)...);
-  }
-
-  template <typename... ConvertsToStringPiece>
-  void init(const std::string &v, ConvertsToStringPiece &&... rest) {
-    args_[index_++] = v; // copy
-    init(std::forward<ConvertsToStringPiece>(rest)...);
-  }
-
-  template <typename... ConvertsToStringPiece>
-  FbSystraceSection(uint64_t tag, std::string &&v, ConvertsToStringPiece &&... rest)
-      : tag_(tag), profile_name_(std::move(v)) {
+  template <typename... RestArg>
+  FbSystraceSection(uint64_t tag, std::string &&profileName, RestArg &&... rest)
+      : tag_(tag), profile_name_(std::move(profileName)) {
     id_ = s_id_counter++;
-    init(std::forward<ConvertsToStringPiece>(rest)...);
+    init(std::forward<RestArg>(rest)...);
   }
 
   ~FbSystraceSection() {
@@ -89,6 +67,21 @@ class FbSystraceSection {
   }
 
  private:
+  void init() {
+    begin_section();
+  }
+
+  template <typename Arg, typename... RestArg>
+  void init(Arg &&arg, RestArg &&... rest) {
+    if constexpr (std::is_convertible_v<Arg, std::string>) {
+      args_[index_++] = std::forward<Arg>(arg);
+    } else {
+      args_[index_++] = std::to_string(std::forward<Arg>(arg));
+    }
+
+    init(std::forward<RestArg>(rest)...);
+  }
+
   std::array<std::string, SYSTRACE_SECTION_MAX_ARGS> args_;
   uint64_t tag_{0};
 


### PR DESCRIPTION
* Fix Support For SysTraceSection

Addresses #4245, During deforking work I left a build logic typo which caused SysTraceSection to noop. When trying to reenable in deforked React Native, we end up having a compile error since stock Facebook code will pass doubles as an arg to SysTraceSection, and we will internally only accept string.

This was fixed in microsof/react-native by commenting out the SysTraceSection call that passed a double. A real solution is to allow our implementation of FbSystraceSection to accept non-string args and convert to strings, as Facebook's seemingly does.

- Use type traits to call std::to_string on args not convertible to string
- Move functions to be private instead of public

Still need a plan to validate this.

* Simplify things a bit

* Solely rely on is_convertible

Constructable was sort of wrong before, because we're actually doing assignment, but even then we likely only want things that allow implicit conversions.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4273)