### PR TITLE
Strip out color code characters from redbox error message

### DIFF
--- a/change/react-native-windows-2020-03-09-16-23-48-stripchalk.json
+++ b/change/react-native-windows-2020-03-09-16-23-48-stripchalk.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Strip out color markers from redbox error messages",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "ad04ab83c14306bd625344617df8376c294349e6",
+  "dependentChangeType": "patch",
+  "date": "2020-03-09T23:23:48.958Z"
+}

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -6,6 +6,7 @@
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
+#include <regex>
 #include "Unicode.h"
 
 namespace Mso::React {
@@ -112,7 +113,10 @@ std::function<void(facebook::react::JSExceptionInfo &&)> CreateRedBoxExceptionCa
             popup.Closed(*tokenClosed);
             delete tokenClosed;
           });
-      errorMessageText.Text(Microsoft::Common::Unicode::Utf8ToUtf16(jsExceptionInfo.exceptionMessage));
+
+      std::regex colorsreg("\\x1b\\[[0-9;]*m"); // strip out console colors which is often added to JS error messages
+      errorMessageText.Text(
+          Microsoft::Common::Unicode::Utf8ToUtf16(std::regex_replace(jsExceptionInfo.exceptionMessage, colorsreg, "")));
 
       popup.Child(redboxContent);
       popup.IsOpen(true);


### PR DESCRIPTION
This aligns with a similar change that was made in Android/iOS: https://github.com/facebook/react-native/pull/24662

This greatly increases the readability of certain kinds of errors.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4278)