### PR TITLE
Add Tooling to Manually or Automatically Update Overrides

### DIFF
--- a/packages/override-tools/package.json
+++ b/packages/override-tools/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "chalk": "^3.0.0",
-    "diff-match-patch": "^1.0.4",
     "io-ts": "^2.1.1",
     "lodash": "^4.17.15",
     "ora": "^4.0.3",
@@ -43,6 +42,7 @@
     "@types/prompts": "^2.0.3",
     "@types/yargs": "^15.0.3",
     "babel-jest": "^24.9.0",
+    "diff-match-patch": "^1.0.4",
     "fp-ts": "^2.5.0",
     "jest": "^24.9.0",
     "just-scripts": "^0.36.1"

--- a/packages/override-tools/src/ActionQueue.ts
+++ b/packages/override-tools/src/ActionQueue.ts
@@ -8,10 +8,10 @@
 /**
  * Executes actions sequentially, fullfilling the returned promise once complete.
  */
-export default class ActionQueue<T> {
+export default class ActionQueue {
   private actions: Array<() => Promise<void>> = [];
 
-  enqueue(action: () => Promise<T>): Promise<T> {
+  enqueue<T>(action: () => Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
       this.actions.push(async () => {
         try {

--- a/packages/override-tools/src/Cli.ts
+++ b/packages/override-tools/src/Cli.ts
@@ -5,7 +5,6 @@
  * @format
  */
 
-import * as FileRepository from './FileRepository';
 import * as FileSearch from './FileSearch';
 import * as ManifestData from './ManifestData';
 import * as OverridePrompt from './OverridePrompt';
@@ -17,6 +16,11 @@ import * as path from 'path';
 import * as yargs from 'yargs';
 
 import Manifest, {ValidationError} from './Manifest';
+import {
+  OverrideFileRepository,
+  VersionedReactFileRepository,
+  bindVersion,
+} from './FileRepository';
 
 import CrossProcessLock from './CrossProcessLock';
 import GitReactFileRepository from './GitReactFileRepository';
@@ -59,6 +63,22 @@ doMain(() => {
             override: {type: 'string', describe: 'The override to remove'},
           }),
         cmdArgv => removeOverride(cmdArgv.override),
+      )
+      .command(
+        'auto-upgrade <manifest>',
+        'Attempts to automatically merge new changes into out-of-date overrides',
+        cmdYargs =>
+          cmdYargs.options({
+            manifest: {
+              type: 'string',
+              describe: 'Path to an override manifest',
+            },
+            version: {
+              type: 'string',
+              describe: 'Optional React Native version to check against',
+            },
+          }),
+        cmdArgv => autoUpgrade(cmdArgv.manifest, cmdArgv.version),
       )
       .epilogue(
         'This tool allows managing JavaScript overrides for React Native Windows',
@@ -180,6 +200,140 @@ async function removeOverride(overridePath: string) {
 }
 
 /**
+ * Attempts to automatically merge changes from the current version into
+ * out-of-date overrides.
+ */
+async function autoUpgrade(manifestPath: string, version?: string) {
+  const spinner = ora('Merging overrides').start();
+
+  try {
+    const reactRepo = await GitReactFileRepository.createAndInit();
+    const ovrRepo = new OverrideFileRepositoryImpl(path.dirname(manifestPath));
+    const manifest = await readManifestUsingRepos(
+      manifestPath,
+      ovrRepo,
+      reactRepo,
+      version,
+    );
+
+    const validationErrors = await manifest.validate();
+    const outOfDateFiles = validationErrors
+      .filter(err => err.type === 'outOfDate')
+      .map(err => err.file);
+
+    const numFiles = outOfDateFiles.length;
+    const cachedFiles = await cacheFiles(outOfDateFiles, reactRepo, manifest);
+
+    let mergedFiles = 0;
+    for (const file of outOfDateFiles) {
+      const overrideEntry = manifest.findOverride(file);
+      const upgraded = await upgradeOverride(
+        overrideEntry,
+        ovrRepo,
+        cachedFiles,
+        manifest.currentVersion(),
+      );
+      if (!upgraded.includes('=========')) {
+        await manifest.markUpToDate(file);
+        await ovrRepo.setFileContents(file, upgraded);
+        await ManifestData.writeToFile(manifest.getAsData(), manifestPath);
+        mergedFiles++;
+      }
+    }
+
+    spinner.succeed(`${mergedFiles}/${numFiles} out-of-date overrides merged`);
+  } catch (ex) {
+    if (spinner.isSpinning) {
+      spinner.fail();
+    }
+    throw ex;
+  }
+}
+
+async function upgradeOverride(
+  override: ManifestData.Entry,
+  ovrRepo: OverrideFileRepository,
+  cachedFiles: Array<ReactSource>,
+  currentVersion: string,
+): Promise<MergeResult> {
+  if (override.type === 'platform') {
+    throw new Error('Unexpected out of date platform override');
+  }
+
+  const origBaseContent = cachedFiles.find(
+    cachedFile =>
+      cachedFile.file === override.baseFile &&
+      cachedFile.version === override.baseVersion,
+  ).content;
+  const newBaseContent = cachedFiles.find(
+    cachedFile =>
+      cachedFile.file === override.baseFile &&
+      cachedFile.version === currentVersion,
+  ).content;
+  const origOverrideContent = await ovrRepo.getFileContents(override.file);
+
+  return diff3.mergeDigIn(origBaseContent, origOverrideContent, newBaseContent);
+}
+
+interface ReactSource {
+  file: string;
+  version: string;
+  content: string;
+}
+
+/**
+ * Efficiently fetches old and new source files for out-of-date overrides
+ */
+async function cacheFiles(
+  outOfDateFiles: Array<string>,
+  reactRepo: VersionedReactFileRepository,
+  manifest: Manifest,
+): Promise<Array<ReactSource>> {
+  let sourceRequests: Array<ReactSourceRequest> = [];
+  outOfDateFiles.forEach(file => {
+    const overrideEntry = manifest.findOverride(file);
+    if (overrideEntry.type === 'platform') {
+      throw new Error('Unexected out of date platform entry');
+    }
+
+    const baseFile = overrideEntry.baseFile;
+    const baseVersion = overrideEntry.baseVersion;
+
+    sourceRequests.push({file: baseFile, version: baseVersion});
+    sourceRequests.push({file: baseFile, version: manifest.currentVersion()});
+  });
+
+  return fetchReactSources(sourceRequests, reactRepo);
+}
+
+interface ReactSourceRequest {
+  file: string;
+  version: string;
+}
+
+/**
+ * Fetches source files in batches, attempting to avoid GitReactFileRepositoy
+ * checkout overhead when switching between versions.
+ */
+async function fetchReactSources(
+  sourcesToCache: Array<ReactSourceRequest>,
+  reactRepo: VersionedReactFileRepository,
+): Promise<Array<ReactSource>> {
+  sourcesToCache.sort((a, b) => a.version.localeCompare(b.version));
+
+  const sources: Array<ReactSource> = [];
+  for (const req of sourcesToCache) {
+    sources.push({
+      file: req.file,
+      version: req.version,
+      content: await reactRepo.getFileContents(req.file, req.version),
+    });
+  }
+
+  return sources;
+}
+
+/**
  * Prints validation errors in a user-readable form to stderr
  */
 function printValidationErrors(errors: Array<ValidationError>) {
@@ -257,6 +411,21 @@ async function checkFileExists(friendlyName: string, filePath: string) {
  * Read a manifest and print a pretty error if we can't
  */
 async function readManifest(file: string, version?: string): Promise<Manifest> {
+  const gitReactRepo = await GitReactFileRepository.createAndInit();
+  const ovrRepo = new OverrideFileRepositoryImpl(path.dirname(file));
+
+  return readManifestUsingRepos(file, ovrRepo, gitReactRepo, version);
+}
+
+/**
+ * Like {@see readManifest}, but allows providing the file repositories to use.
+ */
+async function readManifestUsingRepos(
+  file: string,
+  ovrRepo: OverrideFileRepository,
+  versionedReactRepo: VersionedReactFileRepository,
+  version?: string,
+): Promise<Manifest> {
   await checkFileExists('manifest', file);
 
   let data: ManifestData.Manifest;
@@ -268,14 +437,8 @@ async function readManifest(file: string, version?: string): Promise<Manifest> {
     throw ex;
   }
 
-  const gitReactRepo = await GitReactFileRepository.createAndInit();
-
-  const ovrPath = path.dirname(file);
-  const ovrFilter = /^.*\.(js|ts|jsx|tsx|cpp|h)$/;
-  const ovrRepo = new OverrideFileRepositoryImpl(ovrPath, ovrFilter);
-
   const rnVersion = version || (await getInstalledRNVersion(file));
-  const reactRepo = FileRepository.bindVersion(gitReactRepo, rnVersion);
+  const reactRepo = bindVersion(versionedReactRepo, rnVersion);
 
   return new Manifest(data, ovrRepo, reactRepo);
 }

--- a/packages/override-tools/src/Cli.ts
+++ b/packages/override-tools/src/Cli.ts
@@ -294,7 +294,7 @@ async function stageBaseFiles(
 
   for (const ovr of overrides) {
     const base = await reactRepo.getFileContents(ovr.baseFile, ovr.baseVersion);
-    const ovrPath = path.join(manifestPath, ovr.file);
+    const ovrPath = path.join(manifestDir, ovr.file);
     await fs.promises.writeFile(ovrPath, base);
     await localGit.add(ovr.file);
   }

--- a/packages/override-tools/src/FileRepository.ts
+++ b/packages/override-tools/src/FileRepository.ts
@@ -19,6 +19,12 @@ export interface OverrideFileRepository {
    * @param filename is expected to be relative to the React Native source root.
    */
   getFileContents(filename: string): Promise<string | null>;
+
+  /**
+   * Sets the contents of an override file. Rejects the promise if the override
+   * doesn't exist.
+   */
+  setFileContents(filename: string, content: string): Promise<void>;
 }
 
 /**

--- a/packages/override-tools/src/GitReactFileRepository.ts
+++ b/packages/override-tools/src/GitReactFileRepository.ts
@@ -69,6 +69,10 @@ export default class GitReactFileRepository
     });
   }
 
+  /**
+   * Generate a Git-style patch to transform the given file into the given
+   * content.
+   */
   async generatePatch(
     filename: string,
     reactNativeVersion: string,
@@ -91,7 +95,11 @@ export default class GitReactFileRepository
     });
   }
 
-  async applyPatchToFile(
+  /**
+   * Apply a patch to the given file, returning the merged result, which may
+   * include conflict markers. The underlying file is not mutated.
+   */
+  async getPatchedFile(
     filename: string,
     reactNativeVersion: string,
     patchContent: string,

--- a/packages/override-tools/src/ManifestData.ts
+++ b/packages/override-tools/src/ManifestData.ts
@@ -60,18 +60,20 @@ const CopyEntryType = t.type({
   issue: t.number,
 });
 
-const EntryType = t.union([
-  PlatformEntryType,
+const NonPlatformEntryType = t.union([
   PatchEntryType,
   DerivedEntryType,
   CopyEntryType,
 ]);
+const EntryType = t.union([PlatformEntryType, NonPlatformEntryType]);
+
 const ManifestType = t.type({overrides: t.array(EntryType)});
 
 export type PlatformEntry = t.TypeOf<typeof PlatformEntryType>;
 export type PatchEntry = t.TypeOf<typeof PatchEntryType>;
 export type DerivedEntry = t.TypeOf<typeof DerivedEntryType>;
 export type CopyEntry = t.TypeOf<typeof CopyEntryType>;
+export type NonPlatformEntry = t.TypeOf<typeof NonPlatformEntryType>;
 export type Entry = t.TypeOf<typeof EntryType>;
 export type Manifest = t.TypeOf<typeof ManifestType>;
 

--- a/packages/override-tools/src/OverrideFileRepositoryImpl.ts
+++ b/packages/override-tools/src/OverrideFileRepositoryImpl.ts
@@ -10,6 +10,8 @@ import * as path from 'path';
 
 import {OverrideFileRepository} from './FileRepository';
 
+const DEFAULT_FILTER = /^.*\.(js|ts|jsx|tsx|cpp|h)$/;
+
 /**
  * Allows reading phsyical override files based on a passed in directory
  */
@@ -18,9 +20,9 @@ export default class OverrideFileRepositoryImpl
   private baseDir: string;
   private filter: RegExp;
 
-  constructor(baseDir: string, filter: RegExp) {
+  constructor(baseDir: string, filter?: RegExp) {
     this.baseDir = baseDir;
-    this.filter = filter;
+    this.filter = filter || DEFAULT_FILTER;
   }
 
   async listFiles(): Promise<Array<string>> {
@@ -36,6 +38,11 @@ export default class OverrideFileRepositoryImpl
     } catch {
       return null;
     }
+  }
+
+  async setFileContents(filename: string, content: string) {
+    const filePath = path.join(this.baseDir, filename);
+    return fs.promises.writeFile(filePath, content);
   }
 
   private async listFilesRec(file: string): Promise<Array<string>> {

--- a/packages/override-tools/src/OverrideUpgrader.ts
+++ b/packages/override-tools/src/OverrideUpgrader.ts
@@ -27,7 +27,7 @@ export default class OverrideUpgrader {
     this.ovrRepo = ovrRepo;
   }
 
-  async performUpgrade(
+  async getUpgraded(
     override: NonPlatformEntry,
     newVersion: string,
   ): Promise<UpgradeResult> {
@@ -49,7 +49,7 @@ export default class OverrideUpgrader {
       ovrContent,
     );
 
-    const patched = (await this.reactRepo.applyPatchToFile(
+    const patched = (await this.reactRepo.getPatchedFile(
       override.baseFile,
       newVersion,
       ovrAsPatch,

--- a/packages/override-tools/src/OverrideUpgrader.ts
+++ b/packages/override-tools/src/OverrideUpgrader.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as ManifestData from './ManifestData';
+
+import * as _ from 'lodash';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import GitReactFileRepository from './GitReactFileRepository';
+import {OverrideFileRepository} from './FileRepository';
+
+const DEFAULT_MERGE_DIR = path.join(os.tmpdir(), 'react-native-windows-merge');
+
+export interface UpgradeRequest {
+  overrideEntry: ManifestData.NonPlatformEntry;
+  newVersion: string;
+}
+
+export interface UpgradeResult {
+  overrideFile: string;
+  hasConflicts: boolean;
+  content: string;
+}
+
+interface MergeResult {
+  hasConflicts: boolean;
+  content: string;
+}
+
+export default class OverrideUpgrader {
+  private reactRepo: GitReactFileRepository;
+  private ovrRepo: OverrideFileRepository;
+  private tmpMergeDir: string;
+
+  constructor(
+    reactRepo: GitReactFileRepository,
+    ovrRepo: OverrideFileRepository,
+    tmpMergeDir?: string,
+  ) {
+    this.reactRepo = reactRepo;
+    this.ovrRepo = ovrRepo;
+    this.tmpMergeDir = tmpMergeDir || DEFAULT_MERGE_DIR;
+  }
+
+  async perform(reqs: Array<UpgradeRequest>): Promise<Array<UpgradeResult>> {
+    const filesToCache = _.flatMap(reqs, req => [
+      {name: req.overrideEntry.baseFile, vers: req.overrideEntry.baseVersion},
+      {name: req.overrideEntry.baseFile, vers: req.newVersion},
+    ]);
+
+    const sources = await ReactSourceCache.create(filesToCache, this.reactRepo);
+
+    const results: Array<UpgradeResult> = [];
+
+    for (const req of reqs) {
+      const ovrFile = req.overrideEntry.file;
+      const baseFile = req.overrideEntry.baseFile;
+      const baseVersion = req.overrideEntry.baseVersion;
+
+      const base = sources.getFileContents(baseFile, baseVersion);
+      const ours = await this.ovrRepo.getFileContents(ovrFile);
+      const theirs = sources.getFileContents(baseFile, req.newVersion);
+      const merged = await this.threeWayMerge(base, ours, theirs);
+
+      results.push({overrideFile: ovrFile, ...merged});
+    }
+
+    return results;
+  }
+
+  private async threeWayMerge(
+    base: string,
+    ours: string,
+    theirs: string,
+  ): Promise<MergeResult> {
+    const basePath = path.join(this.tmpMergeDir, 'base');
+    const oursPath = path.join(this.tmpMergeDir, 'ours');
+    const theirsPath = path.join(this.tmpMergeDir, 'theirs');
+
+    await fs.promises.writeFile(basePath, this.normLineEndings(base));
+    await fs.promises.writeFile(oursPath, this.normLineEndings(ours));
+    await fs.promises.writeFile(theirsPath, this.normLineEndings(theirs));
+
+    const content = await Diff3.diff(oursPath, basePath, theirsPath);
+    return {content, hasConflicts: content.includes('<<<<<<<')};
+  }
+
+  private normLineEndings(str: string): string {
+    return str.replace(/([^\r])\n/g, '$1\r\n');
+  }
+}
+
+/**
+ * Caches requested React source files in memory. Retrieves files batched by
+ * version to minimize the performance penalty of branch switching in
+ * GitReactFileRepository.
+ */
+class ReactSourceCache {
+  private cachedFiles: Array<{name: string; version: string; content: string}>;
+
+  private constructor() {}
+
+  static async create(
+    filesToCache: Array<{name: string; vers: string}>,
+    reactRepo: VersionedReactFileRepository,
+  ): Promise<ReactSourceCache> {
+    const cache = new ReactSourceCache();
+    cache.cachedFiles = [];
+
+    const sortedFilesToCache = filesToCache.sort((a, b) =>
+      a.vers.localeCompare(b.vers),
+    );
+
+    for (const file of sortedFilesToCache) {
+      const content = await reactRepo.getFileContents(file.name, file.vers);
+      cache.cachedFiles.push({name: file.name, version: file.vers, content});
+    }
+
+    return cache;
+  }
+
+  getFileContents(name: string, version: string): string {
+    return this.cachedFiles.find(f => f.name === name && f.version === version)
+      .content;
+  }
+}

--- a/packages/override-tools/src/OverrideUpgrader.ts
+++ b/packages/override-tools/src/OverrideUpgrader.ts
@@ -54,8 +54,8 @@ export default class OverrideUpgrader {
       newVersion,
       ovrAsPatch,
     ))
-      .replace('<<<<<<< ours', '<<<<<<< Upstream')
-      .replace('>>>>>>> theirs', '>>>>>>> Override');
+      .replace(/<<<<<<< ours/g, '<<<<<<< Upstream')
+      .replace(/>>>>>>> theirs/g, '>>>>>>> Override');
 
     return {
       overrideFile: override.file,

--- a/packages/override-tools/src/OverrideUpgrader.ts
+++ b/packages/override-tools/src/OverrideUpgrader.ts
@@ -5,22 +5,9 @@
  * @format
  */
 
-import * as ManifestData from './ManifestData';
-
-import * as _ from 'lodash';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-
 import GitReactFileRepository from './GitReactFileRepository';
+import {NonPlatformEntry} from './ManifestData';
 import {OverrideFileRepository} from './FileRepository';
-
-const DEFAULT_MERGE_DIR = path.join(os.tmpdir(), 'react-native-windows-merge');
-
-export interface UpgradeRequest {
-  overrideEntry: ManifestData.NonPlatformEntry;
-  newVersion: string;
-}
 
 export interface UpgradeResult {
   overrideFile: string;
@@ -28,105 +15,52 @@ export interface UpgradeResult {
   content: string;
 }
 
-interface MergeResult {
-  hasConflicts: boolean;
-  content: string;
-}
-
 export default class OverrideUpgrader {
   private reactRepo: GitReactFileRepository;
   private ovrRepo: OverrideFileRepository;
-  private tmpMergeDir: string;
 
   constructor(
     reactRepo: GitReactFileRepository,
     ovrRepo: OverrideFileRepository,
-    tmpMergeDir?: string,
   ) {
     this.reactRepo = reactRepo;
     this.ovrRepo = ovrRepo;
-    this.tmpMergeDir = tmpMergeDir || DEFAULT_MERGE_DIR;
   }
 
-  async perform(reqs: Array<UpgradeRequest>): Promise<Array<UpgradeResult>> {
-    const filesToCache = _.flatMap(reqs, req => [
-      {name: req.overrideEntry.baseFile, vers: req.overrideEntry.baseVersion},
-      {name: req.overrideEntry.baseFile, vers: req.newVersion},
-    ]);
-
-    const sources = await ReactSourceCache.create(filesToCache, this.reactRepo);
-
-    const results: Array<UpgradeResult> = [];
-
-    for (const req of reqs) {
-      const ovrFile = req.overrideEntry.file;
-      const baseFile = req.overrideEntry.baseFile;
-      const baseVersion = req.overrideEntry.baseVersion;
-
-      const base = sources.getFileContents(baseFile, baseVersion);
-      const ours = await this.ovrRepo.getFileContents(ovrFile);
-      const theirs = sources.getFileContents(baseFile, req.newVersion);
-      const merged = await this.threeWayMerge(base, ours, theirs);
-
-      results.push({overrideFile: ovrFile, ...merged});
+  async performUpgrade(
+    override: NonPlatformEntry,
+    newVersion: string,
+  ): Promise<UpgradeResult> {
+    if (override.type === 'copy') {
+      return {
+        overrideFile: override.file,
+        hasConflicts: false,
+        content: await this.reactRepo.getFileContents(
+          override.baseFile,
+          newVersion,
+        ),
+      };
     }
 
-    return results;
-  }
-
-  private async threeWayMerge(
-    base: string,
-    ours: string,
-    theirs: string,
-  ): Promise<MergeResult> {
-    const basePath = path.join(this.tmpMergeDir, 'base');
-    const oursPath = path.join(this.tmpMergeDir, 'ours');
-    const theirsPath = path.join(this.tmpMergeDir, 'theirs');
-
-    await fs.promises.writeFile(basePath, this.normLineEndings(base));
-    await fs.promises.writeFile(oursPath, this.normLineEndings(ours));
-    await fs.promises.writeFile(theirsPath, this.normLineEndings(theirs));
-
-    const content = await Diff3.diff(oursPath, basePath, theirsPath);
-    return {content, hasConflicts: content.includes('<<<<<<<')};
-  }
-
-  private normLineEndings(str: string): string {
-    return str.replace(/([^\r])\n/g, '$1\r\n');
-  }
-}
-
-/**
- * Caches requested React source files in memory. Retrieves files batched by
- * version to minimize the performance penalty of branch switching in
- * GitReactFileRepository.
- */
-class ReactSourceCache {
-  private cachedFiles: Array<{name: string; version: string; content: string}>;
-
-  private constructor() {}
-
-  static async create(
-    filesToCache: Array<{name: string; vers: string}>,
-    reactRepo: VersionedReactFileRepository,
-  ): Promise<ReactSourceCache> {
-    const cache = new ReactSourceCache();
-    cache.cachedFiles = [];
-
-    const sortedFilesToCache = filesToCache.sort((a, b) =>
-      a.vers.localeCompare(b.vers),
+    const ovrContent = await this.ovrRepo.getFileContents(override.file);
+    const ovrAsPatch = await this.reactRepo.generatePatch(
+      override.baseFile,
+      override.baseVersion,
+      ovrContent,
     );
 
-    for (const file of sortedFilesToCache) {
-      const content = await reactRepo.getFileContents(file.name, file.vers);
-      cache.cachedFiles.push({name: file.name, version: file.vers, content});
-    }
+    const patched = (await this.reactRepo.applyPatchToFile(
+      override.baseFile,
+      newVersion,
+      ovrAsPatch,
+    ))
+      .replace('<<<<<<< ours', '<<<<<<< Upstream')
+      .replace('>>>>>>> theirs', '>>>>>>> Override');
 
-    return cache;
-  }
-
-  getFileContents(name: string, version: string): string {
-    return this.cachedFiles.find(f => f.name === name && f.version === version)
-      .content;
+    return {
+      overrideFile: override.file,
+      hasConflicts: patched.includes('<<<<<<<'),
+      content: patched,
+    };
   }
 }

--- a/packages/override-tools/src/scripts/generateManifest.ts
+++ b/packages/override-tools/src/scripts/generateManifest.ts
@@ -179,8 +179,7 @@ async function getFileRepos(
 ): Promise<
   [FileRepository.OverrideFileRepository, FileRepository.ReactFileRepository]
 > {
-  const ovrPattern = /^.*\.(js|ts|jsx|tsx|cpp|h)$/;
-  const overrides = new OverrideFileRepositoryImpl(overrideovrPath, ovrPattern);
+  const overrides = new OverrideFileRepositoryImpl(overrideovrPath);
 
   const versionedReactSources = await GitReactFileRepository.createAndInit();
   const reactSources = FileRepository.bindVersion(

--- a/packages/override-tools/src/test/Manifest.test.ts
+++ b/packages/override-tools/src/test/Manifest.test.ts
@@ -296,8 +296,7 @@ test('addPatchExportedAsData', async () => {
   const base = reactFiles[0].filename;
   await manifest.addPatchOverride(override, base, 1234);
 
-  const manifestData = manifest.getAsData();
-  const entryData = manifestData.overrides.find(ovr => ovr.file === override);
+  const entryData = manifest.findOverride(override);
 
   const patchEntryData = entryData as ManifestData.DerivedEntry;
   expect(patchEntryData.type).toBe('patch');
@@ -315,8 +314,7 @@ test('addDerivedExportedAsData', async () => {
   const base = reactFiles[0].filename;
   await manifest.addDerivedOverride(override, base, 1234);
 
-  const manifestData = manifest.getAsData();
-  const entryData = manifestData.overrides.find(ovr => ovr.file === override);
+  const entryData = manifest.findOverride(override);
 
   const derivedEntryData = entryData as ManifestData.DerivedEntry;
   expect(derivedEntryData.type).toBe('derived');
@@ -334,8 +332,7 @@ test('addDerivedNoIssueExportedAsData', async () => {
   const base = reactFiles[0].filename;
   await manifest.addDerivedOverride(override, base);
 
-  const manifestData = manifest.getAsData();
-  const entryData = manifestData.overrides.find(ovr => ovr.file === override);
+  const entryData = manifest.findOverride(override);
 
   const derivedEntryData = entryData as ManifestData.DerivedEntry;
   expect(derivedEntryData.type).toBe('derived');
@@ -352,8 +349,7 @@ test('addPlatformExportedAsData', async () => {
   const override = overrideFiles[0].filename;
   await manifest.addPlatformOverride(override);
 
-  const manifestData = manifest.getAsData();
-  const entryData = manifestData.overrides.find(ovr => ovr.file === override);
+  const entryData = manifest.findOverride(override);
 
   const platformEntryData = entryData as ManifestData.PlatformEntry;
   expect(platformEntryData.type).toBe('platform');

--- a/packages/override-tools/src/test/MockFileRepository.ts
+++ b/packages/override-tools/src/test/MockFileRepository.ts
@@ -50,11 +50,16 @@ export class MockOverrideFileRepository implements OverrideFileRepository {
   }
 
   async getFileContents(filename: string): Promise<string | null> {
-    const matches = _.filter(this.files, file => file.filename === filename);
+    const matches = this.files.filter(file => file.filename === filename);
     if (matches.length === 0) {
       return null;
     } else {
       return matches[0].content;
     }
+  }
+
+  async setFileContents(filename: string, content: string) {
+    const matchFile = this.files.find(file => file.filename === filename);
+    matchFile.content = content;
   }
 }

--- a/packages/override-tools/tsconfig.json
+++ b/packages/override-tools/tsconfig.json
@@ -4,12 +4,12 @@
         "target": "es6",
         "sourceMap": true,
         "noImplicitAny": true,
-        "preserveConstEnums": true, 
+        "preserveConstEnums": true,
         "moduleResolution": "node",
         "noUnusedLocals": true,
         "skipLibCheck": true,
         "rootDirs": ["src"],
     },
     "include": ["src"],
-    "exclude": ["node_modules", "../../node_modules"]
+    "exclude": ["node_modules"]
 }

--- a/packages/override-tools/tsconfig.json
+++ b/packages/override-tools/tsconfig.json
@@ -4,12 +4,12 @@
         "target": "es6",
         "sourceMap": true,
         "noImplicitAny": true,
-        "preserveConstEnums": true,
+        "preserveConstEnums": true, 
         "moduleResolution": "node",
         "noUnusedLocals": true,
         "skipLibCheck": true,
         "rootDirs": ["src"],
     },
     "include": ["src"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "../../node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -892,6 +892,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
+"@babel/runtime-corejs3@^7.8.3":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz#8209d9dff2f33aa2616cb319c83fe159ffb07b8c"
+  integrity sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -5421,6 +5429,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.3"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -6158,9 +6171,9 @@ eslint-plugin-react-native@3.6.0:
     eslint-plugin-react-native-globals "^0.1.1"
 
 eslint-plugin-react@7.12.4, eslint-plugin-react@^7.14.1:
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz#8be671b7f6be095098e79d27ac32f9580f599bc8"
-  integrity sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz#6d08f9673628aa69c5559d33489e855d83551666"
+  integrity sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==
   dependencies:
     array-includes "^3.1.1"
     doctrine "^2.1.0"
@@ -6170,8 +6183,10 @@ eslint-plugin-react@7.12.4, eslint-plugin-react@^7.14.1:
     object.fromentries "^2.0.2"
     object.values "^1.1.1"
     prop-types "^15.7.2"
-    resolve "^1.14.2"
+    resolve "^1.15.1"
+    semver "^6.3.0"
     string.prototype.matchall "^4.0.2"
+    xregexp "^4.3.0"
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -11769,7 +11784,7 @@ resolve@1.8.1:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -13841,6 +13856,13 @@ xpipe@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
   integrity sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98=
+
+xregexp@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"
+  integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.8.3"
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Extend `override-tools` with commands to perform three-way merge on out-of-date overrides. Commands are added to do both automatic resolution, along with generation of partially merged files with conflict markers that can be merged using tools like VSCode:
![image](https://user-images.githubusercontent.com/835219/76370161-2d9c1480-62f3-11ea-91d6-e42f8ea1d2b4.png)

The state of three-way-merge libraries is poor, so we end up abusing our scratch Git repo to do this. This ends up being relatively simple and reliable, although not particularly performant.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4286)