### PR TITLE
Enable hermes when using USE_HERMES.

### DIFF
--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -217,7 +217,6 @@ void ReactInstanceWin::Initialize() noexcept {
                 devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
 #endif
                 break;
-
               case react::uwp::JSIEngine::V8:
 #if defined(USE_V8)
                 preparedScriptStore =
@@ -227,7 +226,6 @@ void ReactInstanceWin::Initialize() noexcept {
                     devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
 #endif
                 break;
-
               case react::uwp::JSIEngine::Chakra:
                 if (m_options.LegacySettings.EnableByteCodeCaching ||
                     !m_options.LegacySettings.ByteCodeFileUri.empty()) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -215,8 +215,9 @@ void ReactInstanceWin::Initialize() noexcept {
               case react::uwp::JSIEngine::Hermes:
 #if defined(USE_HERMES)
                 devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
-                break;
 #endif
+                break;
+
               case react::uwp::JSIEngine::V8:
 #if defined(USE_V8)
                 preparedScriptStore =
@@ -224,8 +225,9 @@ void ReactInstanceWin::Initialize() noexcept {
 
                 devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
                     devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
-                break;
 #endif
+                break;
+
               case react::uwp::JSIEngine::Chakra:
                 if (m_options.LegacySettings.EnableByteCodeCaching ||
                     !m_options.LegacySettings.ByteCodeFileUri.empty()) {

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -50,7 +50,14 @@ struct ReactInstanceSettings {
   std::string BundleRootPath;
   facebook::react::NativeLoggingHook LoggingCallback;
   std::function<void(facebook::react::JSExceptionInfo &&)> JsExceptionCallback;
+
+#if defined(USE_HERMES)
+  JSIEngine jsiEngine{JSIEngine::Hermes};
+#elif defined(USE_V8)
+  JSIEngine jsiEngine{JSIEngine::V8};
+#else
   JSIEngine jsiEngine{JSIEngine::Chakra};
+#endif
 };
 
 struct IReactInstance {

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -50,7 +50,6 @@ struct ReactInstanceSettings {
   std::string BundleRootPath;
   facebook::react::NativeLoggingHook LoggingCallback;
   std::function<void(facebook::react::JSExceptionInfo &&)> JsExceptionCallback;
-
 #if defined(USE_HERMES)
   JSIEngine jsiEngine{JSIEngine::Hermes};
 #elif defined(USE_V8)

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -52,8 +52,6 @@ struct ReactInstanceSettings {
   std::function<void(facebook::react::JSExceptionInfo &&)> JsExceptionCallback;
 #if defined(USE_HERMES)
   JSIEngine jsiEngine{JSIEngine::Hermes};
-#elif defined(USE_V8)
-  JSIEngine jsiEngine{JSIEngine::V8};
 #else
   JSIEngine jsiEngine{JSIEngine::Chakra};
 #endif


### PR DESCRIPTION
Using the flag USE_HERMES never actually enabled the hermes js engine. 

It simply enabled the ability to use it. But there is currently no mechanism to actually use it. 

So while there should probably be a way to have everything 'enabled' and then choose from a settings(longer term fix needed: #4288).
This should allow someone to control which JS engine they want properly with the flags in the interim.

Also there was some weirdness with the switch statement, if you somehow had set the engine to hermes but hadn't enabled it, it'd "fall thru" the switch statement into v8.  

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4287)