### PR TITLE
Fix crash in timers during instance shutdown, and in systrace

### DIFF
--- a/change/react-native-windows-2020-03-10-22-14-59-reloadcrashes.json
+++ b/change/react-native-windows-2020-03-10-22-14-59-reloadcrashes.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in timers during instance shutdown, and in systrace",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "d8cf799a2df255fd3c590ba9df5319368cc6f682",
+  "dependentChangeType": "patch",
+  "date": "2020-03-11T05:14:59.356Z"
+}

--- a/vnext/ReactUWP/Modules/TimingModule.h
+++ b/vnext/ReactUWP/Modules/TimingModule.h
@@ -58,7 +58,7 @@ class TimerQueue {
   std::vector<Timer> m_timerVector;
 };
 
-class Timing {
+class Timing : public std::enable_shared_from_this<Timing> {
  public:
   Timing(TimingModule *parent);
   void Disconnect();
@@ -69,9 +69,7 @@ class Timing {
 
  private:
   std::weak_ptr<facebook::react::Instance> getInstance() noexcept;
-  void OnRendering(
-      const winrt::Windows::Foundation::IInspectable &,
-      const winrt::Windows::Foundation::IInspectable &args);
+  void OnRendering();
 
  private:
   TimingModule *m_parent;

--- a/vnext/ReactWindowsCore/tracing/tracing.cpp
+++ b/vnext/ReactWindowsCore/tracing/tracing.cpp
@@ -33,6 +33,7 @@ std::mutex g_pages_mutex;
 }
 
 /*static */ void FbSystraceAsyncFlow::end(uint64_t tag, const char *name, int cookie) {
+  std::lock_guard<std::mutex> guard(s_tracker_mutex_);
   auto search = s_tracker_.find(cookie);
   double duration = -1;
 
@@ -42,7 +43,6 @@ std::mutex g_pages_mutex;
                    .count();
 
     // Flow has ended. Clear the cookie tracker.
-    std::lock_guard<std::mutex> guard(s_tracker_mutex_);
     s_tracker_.erase(cookie);
   }
 


### PR DESCRIPTION
Timers use the CompositionTarget::Rendering event, which is async, and can fire even after its been unregistered.  This would cause random crashes during instance shutdown if there were any outstanding JS timers-- So I changed the event handler to use a weak_ptr and verify the object is still around before trying to fire timers.

The systrace impl was accessing an object that is supposed to be protected by a mutex outside of the mutex. -- Moved the mutex guard to cover the object access.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4291)