### PR TITLE
Fixed JSValueObject operator[]

### DIFF
--- a/change/react-native-windows-2020-03-11-12-43-39-FixJSValueIndex.json
+++ b/change/react-native-windows-2020-03-11-12-43-39-FixJSValueIndex.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix JSValueObject operator[]",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "7cd87be7f031f025b87eb757388fab7adfffe49f",
+  "dependentChangeType": "patch",
+  "date": "2020-03-11T19:43:38.816Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
@@ -129,6 +129,57 @@ TEST_CLASS (JSValueTest) {
     TestCheck(nestedArr[6] == 4.5);
   }
 
+  TEST_METHOD(TestJSValueObject1) {
+    JSValue value = JSValueObject{{"prop1", 1}, {"prop2", "Two"}};
+    TestCheck(value.Type() == JSValueType::Object);
+    TestCheck(value.PropertyCount() == 2);
+    TestCheck(value["prop1"] == 1);
+    TestCheck(value["prop2"] == "Two");
+    TestCheck(value.AsObject()["prop1"] == 1);
+    TestCheck(value.AsObject()["prop2"] == "Two");
+  }
+
+  TEST_METHOD(TestJSValueObject2) {
+    JSValueObject obj;
+    obj["prop1"] = 1;
+    obj["prop2"] = "Two";
+    JSValue value = std::move(obj);
+    TestCheck(value.Type() == JSValueType::Object);
+    TestCheck(value.PropertyCount() == 2);
+    TestCheck(value["prop1"] == 1);
+    TestCheck(value["prop2"] == "Two");
+    TestCheck(value.AsObject()["prop1"] == 1);
+    TestCheck(value.AsObject()["prop2"] == "Two");
+  }
+
+  TEST_METHOD(TestJSValueArray1) {
+    JSValue value = JSValueArray{1, "Two", 3.3, true, nullptr};
+    TestCheck(value.Type() == JSValueType::Array);
+    TestCheck(value.ItemCount() == 5);
+    TestCheck(value[0] == 1);
+    TestCheck(value[1] == "Two");
+    TestCheck(value[2] == 3.3);
+    TestCheck(value[3] == true);
+    TestCheck(value[4] == nullptr);
+  }
+
+  TEST_METHOD(TestJSValueArray2) {
+    JSValueArray arr(5);
+    arr[0] = 1;
+    arr[1] = "Two";
+    arr[2] = 3.3;
+    arr[3] = true;
+    arr[4] = nullptr;
+    JSValue value = std::move(arr);
+    TestCheck(value.Type() == JSValueType::Array);
+    TestCheck(value.ItemCount() == 5);
+    TestCheck(value[0] == 1);
+    TestCheck(value[1] == "Two");
+    TestCheck(value[2] == 3.3);
+    TestCheck(value[3] == true);
+    TestCheck(value[4] == nullptr);
+  }
+
   void CheckConversion(
       JSValue const &value, char const *strVal, bool boolVal, int64_t intVal, double doubleVal) noexcept {
     TestCheckEqual(strVal, value.AsString());

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
@@ -135,6 +135,7 @@ TEST_CLASS (JSValueTest) {
     TestCheck(value.PropertyCount() == 2);
     TestCheck(value["prop1"] == 1);
     TestCheck(value["prop2"] == "Two");
+    TestCheck(value.AsObject().size() == 2);
     TestCheck(value.AsObject()["prop1"] == 1);
     TestCheck(value.AsObject()["prop2"] == "Two");
   }
@@ -148,8 +149,40 @@ TEST_CLASS (JSValueTest) {
     TestCheck(value.PropertyCount() == 2);
     TestCheck(value["prop1"] == 1);
     TestCheck(value["prop2"] == "Two");
+    TestCheck(value.AsObject().size() == 2);
     TestCheck(value.AsObject()["prop1"] == 1);
     TestCheck(value.AsObject()["prop2"] == "Two");
+  }
+
+  TEST_METHOD(TestJSValueObjectInsertion) {
+    // See if our JSValueObject operator[] works correctly.
+    // We use a random order of keys to insert.
+    JSValueObject obj;
+    obj["prop03"] = 3;
+    obj["prop02"] = 2;
+    obj["prop08"] = 8;
+    obj["prop06"] = 6;
+    obj["prop10"] = 10;
+    obj["prop09"] = 9;
+    obj["prop04"] = 4;
+    obj["prop01"] = 1;
+    obj["prop05"] = 5;
+    obj["prop07"] = 7;
+    // Modify
+    obj["prop02"] = 22;
+    JSValue value = std::move(obj);
+    TestCheck(value.Type() == JSValueType::Object);
+    TestCheck(value.PropertyCount() == 10);
+    TestCheck(value["prop01"] == 1);
+    TestCheck(value["prop02"] == 22);
+    TestCheck(value["prop03"] == 3);
+    TestCheck(value["prop04"] == 4);
+    TestCheck(value["prop05"] == 5);
+    TestCheck(value["prop06"] == 6);
+    TestCheck(value["prop07"] == 7);
+    TestCheck(value["prop08"] == 8);
+    TestCheck(value["prop09"] == 9);
+    TestCheck(value["prop10"] == 10);
   }
 
   TEST_METHOD(TestJSValueArray1) {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
@@ -349,6 +349,11 @@ JSValueObject JSValueObject::Copy() const noexcept {
   return object;
 }
 
+JSValue &JSValueObject::operator[](std::string_view propertyName) noexcept {
+  auto result = try_emplace(propertyName.data(), nullptr);
+  return result.first->second;
+}
+
 JSValue const &JSValueObject::operator[](std::string_view propertyName) const noexcept {
   auto it = find(propertyName);
   if (it != end()) {
@@ -419,6 +424,20 @@ void JSValueObject::WriteTo(IJSValueWriter const &writer) const noexcept {
 //===========================================================================
 // JSValueArray implementation
 //===========================================================================
+
+JSValueArray::JSValueArray(size_type size) noexcept {
+  reserve(size);
+  for (size_type i = 0; i < size; ++i) {
+    emplace_back(nullptr);
+  }
+}
+
+JSValueArray::JSValueArray(size_type size, JSValue const &defaultValue) noexcept {
+  reserve(size);
+  for (size_type i = 0; i < size; ++i) {
+    push_back(defaultValue.Copy());
+  }
+}
 
 JSValueArray::JSValueArray(std::initializer_list<JSValueArrayItem> initArray) noexcept {
   for (auto const &item : initArray) {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
@@ -350,8 +350,13 @@ JSValueObject JSValueObject::Copy() const noexcept {
 }
 
 JSValue &JSValueObject::operator[](std::string_view propertyName) noexcept {
-  auto result = try_emplace(propertyName.data(), nullptr);
-  return result.first->second;
+  // When we search for a node we do no want to convert string_view to a string.
+  auto it = lower_bound(propertyName);
+  if (it != end() && !key_comp()(propertyName, it->first)) {
+    return it->second;
+  } else {
+    return emplace_hint(it, propertyName, nullptr)->second;
+  }
 }
 
 JSValue const &JSValueObject::operator[](std::string_view propertyName) const noexcept {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.h
@@ -62,6 +62,13 @@ struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
 
 #pragma endregion
 
+#pragma region Change JSValueObject
+  //! Get a reference to object property value if the property is found,
+  //! or a reference to a new property created with JSValue::Null value otherwise.
+  JSValue &operator[](std::string_view propertyName) noexcept;
+
+#pragma endregion
+
 #pragma region Inspect JSValueObject
 
   //! Get a reference to object property value if the property is found,
@@ -105,6 +112,13 @@ struct JSValueArray : std::vector<JSValue> {
 
   //! Default constructor.
   JSValueArray() = default;
+
+  //! Constructs JSValueArray with size JSValue::Null elements.
+  explicit JSValueArray(size_type size) noexcept;
+
+  //! Constructs JSValueArray with size elements.
+  //! Each element is a copy of defaultValue.
+  JSValueArray(size_type size, JSValue const &defaultValue) noexcept;
 
   //! Construct JSValueArray from the move iterator.
   template <class TMoveInputIterator>


### PR DESCRIPTION
Previously we have added new JSValueObject operator[] that could help access items in case if JSValueObject is const. But this new operator prohibits access to the base std::map mutating operator[].
In this PR, we are adding the mutating operator[] to JSValueObject and adding unit tests to verify the usage.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4294)