### PR TITLE
CI loop not actually building the samples projects

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -242,14 +242,14 @@ jobs:
         displayName: run-windows (Debug)
         inputs:
           script: react-native run-windows --no-packager --no-launch --no-deploy --arch $(BuildPlatform) --logging
-          workingDirectory: packages/E2ETest
+          workingDirectory: packages/microsoft-reactnative-sampleapps
         condition: and(succeeded(), eq(variables['applyRnPatches'], 'true'), eq(variables['BuildConfiguration'], 'Debug'))
 
       - task: CmdLine@2
         displayName: run-windows (Release)
         inputs:
           script: react-native run-windows --no-packager --no-launch --no-deploy --arch $(BuildPlatform) --logging --release
-          workingDirectory: packages/E2ETest
+          workingDirectory: packages/microsoft-reactnative-sampleapps
         condition: and(succeeded(), eq(variables['applyRnPatches'], 'true'), eq(variables['BuildConfiguration'], 'Release'))
 
       - task: CmdLine@2


### PR DESCRIPTION
#4254 attempted to add validation to the CI to build the sample apps, but actually just made us build the E2E package a bunch of times.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4299)