### PR TITLE
Add cli.js

### DIFF
--- a/change/react-native-windows-2020-03-12-10-45-38-add-cli.js.json
+++ b/change/react-native-windows-2020-03-12-10-45-38-add-cli.js.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Add cli.js",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "commit": "f7055a29a718f358921db2f658acbe5fb187b15d",
+  "dependentChangeType": "patch",
+  "date": "2020-03-12T17:45:38.430Z"
+}

--- a/vnext/local-cli/cli.js
+++ b/vnext/local-cli/cli.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+var cli = require('@react-native-community/cli');
+
+if (require.main === module) {
+  cli.run();
+}
+
+module.exports = cli;


### PR DESCRIPTION
Added cli.js file in local-cli folder.

For some reason we had to call `node node_modules/react-native-windows/local-cli/cli.js start` instead of `react-native start` to make the bundler work correctly for community module sample app. Possibly because @react-native-community/cli changes its behavior based on the path it's being invoked. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4304)