### PR TITLE
Set TabIndex to 0 for ScrollViewers

### DIFF
--- a/change/react-native-windows-2020-03-16-16-20-55-ScrollViewFix.json
+++ b/change/react-native-windows-2020-03-16-16-20-55-ScrollViewFix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Set TabIndex to 0 for ScrollViewers",
+  "packageName": "react-native-windows",
+  "email": "jagorrin@microsoft.com",
+  "commit": "43332258ca84856eff48e593e140e1ab91d7f7fa",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T23:20:55.206Z"
+}

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -94,6 +94,7 @@ void ScrollViewShadowNode::createView() {
   Super::createView();
 
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
+  scrollViewer.TabIndex(0);
   const auto scrollViewUWPImplementation = ScrollViewUWPImplementation(scrollViewer);
   scrollViewUWPImplementation.ScrollViewerSnapPointManager();
 


### PR DESCRIPTION
Currently, the default TabIndex for ScrollViewers is the maximum integer. This means that content inside of ScrollViewers will be last in keyboard navigation order. The expected behavior is that the user can keyboard navigate in XAML tree order. This change sets the default TabIndex value for ScrollViewers to 0 so that their contents can be accessed in tree order.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4328)