### PR TITLE
Improve unit test error messages in testCheck.h

### DIFF
--- a/change/react-native-windows-2020-03-16-16-38-42-MS_FixTestCheck.json
+++ b/change/react-native-windows-2020-03-16-16-38-42-MS_FixTestCheck.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Improve unit test error message in testCheck.h macros",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "a8785d78a7c8d83a6656af0fdbd64ca3b79879e8",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T23:38:42.646Z"
+}

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -127,6 +127,7 @@
     <ClCompile Include="future\whenAllTest.cpp" />
     <ClCompile Include="future\whenAnyTest.cpp" />
     <ClCompile Include="guid\guidTest.cpp" />
+    <ClCompile Include="motifCpp\motifCppTest.cpp" />
     <ClCompile Include="object\objectRefCountTest.cpp" />
     <ClCompile Include="object\objectWithWeakRefTest.cpp" />
     <ClCompile Include="object\queryCastTest.cpp" />

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj.filters
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="guid">
       <UniqueIdentifier>{c57e3756-1c62-4042-8169-f1463f0def19}</UniqueIdentifier>
     </Filter>
+    <Filter Include="motifCpp">
+      <UniqueIdentifier>{bad95dc3-5f79-48dc-b144-0662fd73ff08}</UniqueIdentifier>
+    </Filter>
     <Filter Include="object">
       <UniqueIdentifier>{23127842-a753-4d07-b1c9-7f593a105091}</UniqueIdentifier>
     </Filter>
@@ -85,6 +88,9 @@
       <Filter>guid</Filter>
     </ClCompile>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="motifCpp\motifCppTest.cpp">
+      <Filter>motifCpp</Filter>
+    </ClCompile>
     <ClCompile Include="object\objectRefCountTest.cpp">
       <Filter>object</Filter>
     </ClCompile>

--- a/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
@@ -368,7 +368,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_EmplaceValue_NoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 1, 2, 3);
     });
 
     p1.EmplaceValue();
@@ -378,7 +378,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_EmplaceValue_OneArg) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 2, 3);
     });
 
     p1.EmplaceValue(5);
@@ -388,7 +388,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_EmplaceValue_TwoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 3);
     });
 
     p1.EmplaceValue(5, 6);
@@ -398,7 +398,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_EmplaceValue_ThreeArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 7);
     });
 
     p1.EmplaceValue(5, 6, 7);
@@ -469,7 +469,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_TryEmplaceValue_NoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 1, 2, 3);
     });
 
     TestCheck(p1.TryEmplaceValue());
@@ -479,7 +479,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_TryEmplaceValue_OneArg) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 2, 3);
     });
 
     TestCheck(p1.TryEmplaceValue(5));
@@ -489,7 +489,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_TryEmplaceValue_TwoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 3);
     });
 
     TestCheck(p1.TryEmplaceValue(5, 6));
@@ -499,7 +499,7 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(PromiseGroup_TryEmplaceValue_ThreeArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
     auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 7);
     });
 
     TestCheck(p1.TryEmplaceValue(5, 6, 7));

--- a/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
@@ -367,9 +367,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_EmplaceValue_NoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 1, 2, 3); });
 
     p1.EmplaceValue();
     Mso::FutureWait(future);
@@ -377,9 +376,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_EmplaceValue_OneArg) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 2, 3); });
 
     p1.EmplaceValue(5);
     Mso::FutureWait(future);
@@ -387,9 +385,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_EmplaceValue_TwoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 3); });
 
     p1.EmplaceValue(5, 6);
     Mso::FutureWait(future);
@@ -397,9 +394,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_EmplaceValue_ThreeArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 7); });
 
     p1.EmplaceValue(5, 6, 7);
     Mso::FutureWait(future);
@@ -468,9 +464,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_TryEmplaceValue_NoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 1, 2, 3); });
 
     TestCheck(p1.TryEmplaceValue());
     Mso::FutureWait(future);
@@ -478,9 +473,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_TryEmplaceValue_OneArg) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 2, 3); });
 
     TestCheck(p1.TryEmplaceValue(5));
     Mso::FutureWait(future);
@@ -488,9 +482,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_TryEmplaceValue_TwoArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 3); });
 
     TestCheck(p1.TryEmplaceValue(5, 6));
     Mso::FutureWait(future);
@@ -498,9 +491,8 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(PromiseGroup_TryEmplaceValue_ThreeArgs) {
     Mso::PromiseGroup<EmplacedType> p1;
-    auto future = p1.AddFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7);
-    });
+    auto future =
+        p1.AddFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 7); });
 
     TestCheck(p1.TryEmplaceValue(5, 6, 7));
     Mso::FutureWait(future);

--- a/vnext/Mso.UnitTests/future/promiseTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseTest.cpp
@@ -347,7 +347,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_EmplaceValue_NoArgs) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 1, 2, 3);
     });
 
     p1.EmplaceValue();
@@ -357,7 +357,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_EmplaceValue_OneArg) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 2, 3);
     });
 
     p1.EmplaceValue(5);
@@ -367,7 +367,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_EmplaceValue_TwoArgs) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 3);
     });
 
     p1.EmplaceValue(5, 6);
@@ -377,7 +377,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_EmplaceValue_ThreeArgs) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 7);
     });
 
     p1.EmplaceValue(5, 6, 7);
@@ -438,7 +438,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_TryEmplaceValue_NoArgs) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 1, 2, 3);
     });
 
     TestCheck(p1.TryEmplaceValue());
@@ -448,7 +448,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_TryEmplaceValue_OneArg) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 2, 3);
     });
 
     TestCheck(p1.TryEmplaceValue(5));
@@ -458,7 +458,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_TryEmplaceValue_TwoArgs) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 3);
     });
 
     TestCheck(p1.TryEmplaceValue(5, 6));
@@ -468,7 +468,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(Promise_TryEmplaceValue_ThreeArgs) {
     Mso::Promise<EmplacedType> p1;
     auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7, MSO_LINE_STR);
+      ValidateEmplacedType(value, 5, 6, 7);
     });
 
     TestCheck(p1.TryEmplaceValue(5, 6, 7));

--- a/vnext/Mso.UnitTests/future/promiseTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseTest.cpp
@@ -346,9 +346,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_EmplaceValue_NoArgs) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 1, 2, 3); });
 
     p1.EmplaceValue();
     Mso::FutureWait(future);
@@ -356,9 +354,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_EmplaceValue_OneArg) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 2, 3); });
 
     p1.EmplaceValue(5);
     Mso::FutureWait(future);
@@ -366,9 +362,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_EmplaceValue_TwoArgs) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 3); });
 
     p1.EmplaceValue(5, 6);
     Mso::FutureWait(future);
@@ -376,9 +370,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_EmplaceValue_ThreeArgs) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 7); });
 
     p1.EmplaceValue(5, 6, 7);
     Mso::FutureWait(future);
@@ -437,9 +429,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TryEmplaceValue_NoArgs) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 1, 2, 3);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 1, 2, 3); });
 
     TestCheck(p1.TryEmplaceValue());
     Mso::FutureWait(future);
@@ -447,9 +437,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TryEmplaceValue_OneArg) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 2, 3);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 2, 3); });
 
     TestCheck(p1.TryEmplaceValue(5));
     Mso::FutureWait(future);
@@ -457,9 +445,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TryEmplaceValue_TwoArgs) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 3);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 3); });
 
     TestCheck(p1.TryEmplaceValue(5, 6));
     Mso::FutureWait(future);
@@ -467,9 +453,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TryEmplaceValue_ThreeArgs) {
     Mso::Promise<EmplacedType> p1;
-    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept {
-      ValidateEmplacedType(value, 5, 6, 7);
-    });
+    auto future = p1.AsFuture().Then([&](const EmplacedType &value) noexcept { ValidateEmplacedType(value, 5, 6, 7); });
 
     TestCheck(p1.TryEmplaceValue(5, 6, 7));
     Mso::FutureWait(future);

--- a/vnext/Mso.UnitTests/future/testCheck.h
+++ b/vnext/Mso.UnitTests/future/testCheck.h
@@ -5,10 +5,10 @@
 
 #include "motifCpp/testCheck.h"
 
-#define ValidateEmplacedType(obj, v1, v2, v3, line) \
-  TestCheckEqualL(v1, obj.Value1, line);            \
-  TestCheckEqualL(v2, obj.Value2, line);            \
-  TestCheckEqualL(v3, obj.Value3, line);
+#define ValidateEmplacedType(obj, v1, v2, v3)           \
+  TestCheckEqualAt(__FILE__, __LINE__, v1, obj.Value1); \
+  TestCheckEqualAt(__FILE__, __LINE__, v2, obj.Value2); \
+  TestCheckEqualAt(__FILE__, __LINE__, v3, obj.Value3);
 
 struct EmplacedType {
   EmplacedType() noexcept {}

--- a/vnext/Mso.UnitTests/motifCpp/motifCppTest.cpp
+++ b/vnext/Mso.UnitTests/motifCpp/motifCppTest.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "crash/verifyElseCrash.h"
+#include "motifCpp/testCheck.h"
+
+// Uncomment to see errors
+//#define MOTIF_TEST_SHOW_ERRORS
+
+TEST_CLASS (MotifCppTest) {
+#ifdef MOTIF_TEST_SHOW_ERRORS
+
+  TEST_METHOD(GTestFailCalled) {
+    FAIL();
+  }
+
+  TEST_METHOD(GTestFailCalledWithMessage) {
+    FAIL() << "Test must fail";
+  }
+
+  TEST_METHOD(GTestFailCalledWithMessageArgs) {
+    FAIL() << TestAssert::FormatMsg("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(GTestAssertTrueFailed) {
+    ASSERT_TRUE(std::string("Foo") == "Bar");
+  }
+
+  TEST_METHOD(GTestAssertTrueFailedWithMessage) {
+    ASSERT_TRUE(std::string("Foo") == "Bar") << "Test must fail";
+  }
+
+  TEST_METHOD(GTestAssertTrueFailedWithMessageArgs) {
+    ASSERT_TRUE(std::string("Foo") == "Bar") << TestAssert::FormatMsg("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(GTestAssertEQFailed) {
+    ASSERT_EQ(std::string("Foo"), "Bar");
+  }
+
+  TEST_METHOD(GTestAssertEQFailedWithMessage) {
+    ASSERT_EQ(std::string("Foo"), "Bar") << "Test must fail";
+  }
+
+  TEST_METHOD(GTestAssertEQFailedWithMessageArgs) {
+    ASSERT_EQ(std::string("Foo"), "Bar") << TestAssert::FormatMsg("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckFailCalled) {
+    TestCheckFail();
+  }
+
+  TEST_METHOD(TestCheckFailCalledWithMessage) {
+    TestCheckFail("Test must fail");
+  }
+
+  TEST_METHOD(TestCheckFailCalledWithMessageArgs) {
+    TestCheckFail("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckFailed) {
+    TestCheck(std::string("Foo") == "Bar");
+  }
+
+  TEST_METHOD(TestCheckFailedWithMessage) {
+    TestCheck(std::string("Foo") == "Bar", "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckFailedWithMessageArgs) {
+    TestCheck(std::string("Foo") == "Bar", "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckEqualFailed) {
+    TestCheckEqual(std::string("Foo"), "Bar");
+  }
+
+  TEST_METHOD(TestCheckEqualFailedWithMessage) {
+    TestCheckEqual(std::string("Foo"), "Bar", "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckEqualFailedWithMessageArgs) {
+    TestCheckEqual(std::string("Foo"), "Bar", "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckCrashFailed) {
+    TestCheckCrash(VerifyElseCrashSz(true, "No crash"));
+  }
+
+  TEST_METHOD(TestCheckCrashFailedWithMessage) {
+    TestCheckCrash(VerifyElseCrashSz(true, "No crash"), "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckCrashFailedWithMessageArgs) {
+    TestCheckCrash(VerifyElseCrashSz(true, "No crash"), "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckCrashSucceeded) {
+    TestCheckCrash(VerifyElseCrashSz(false, "Must crash"));
+  }
+
+  TEST_METHOD(TestCheckCrashSucceededWithMessage) {
+    TestCheckCrash(VerifyElseCrashSz(false, "Must crash"), "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckCrashSucceededWithMessageArgs) {
+    TestCheckCrash(VerifyElseCrashSz(false, "Must crash"), "Test %s %s %d", "must", "succeed", 2);
+  }
+
+  TEST_METHOD(TestCheckTerminateFailed) {
+    TestCheckTerminate(2 + 2);
+  }
+
+  TEST_METHOD(TestCheckTerminateFailedWithMessage) {
+    TestCheckTerminate(2 + 2, "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckTerminateFailedWithMessageArgs) {
+    TestCheckTerminate(2 + 2, "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckTerminateSucceeded) {
+    TestCheckTerminate(std::terminate());
+  }
+
+  TEST_METHOD(TestCheckTerminateSucceededWithMessage) {
+    TestCheckTerminate(std::terminate(), "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckTerminateSucceededWithMessageArgs) {
+    TestCheckTerminate(std::terminate(), "Test %s %s %d", "must", "succeed", 2);
+  }
+
+  TEST_METHOD(TestCheckExceptionFailed) {
+    TestCheckException(std::exception, 2 + 2);
+  }
+
+  TEST_METHOD(TestCheckExceptionFailedWithMessage) {
+    TestCheckException(std::exception, 2 + 2, "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckExceptionFailedWithMessageArgs) {
+    TestCheckException(std::exception, 2 + 2, "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckExceptionSucceeded) {
+    TestCheckException(std::exception, throw std::exception());
+  }
+
+  TEST_METHOD(TestCheckExceptionSucceededWithMessage) {
+    TestCheckException(std::exception, throw std::exception(), "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckExceptionSucceededWithMessageArgs) {
+    TestCheckException(std::exception, throw std::exception(), "Test %s %s %d", "must", "succeed", 2);
+  }
+
+  TEST_METHOD(TestCheckNoThrowFailed) {
+    TestCheckNoThrow(throw std::exception());
+  }
+
+  TEST_METHOD(TestCheckNoThrowFailedWithMessage) {
+    TestCheckNoThrow(throw std::exception(), "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckNoThrowFailedWithMessageArgs) {
+    TestCheckNoThrow(throw std::exception(), "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckNoThrowSucceeded) {
+    TestCheckNoThrow(2 + 2);
+  }
+
+  TEST_METHOD(TestCheckNoThrowSucceededWithMessage) {
+    TestCheckNoThrow(2 + 2, "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckNoThrowSucceededWithMessageArgs) {
+    TestCheckNoThrow(2 + 2, "Test %s %s %d", "must", "succeed", 2);
+  }
+#endif
+};

--- a/vnext/Mso/motifCpp/motifCppTest.h
+++ b/vnext/Mso/motifCpp/motifCppTest.h
@@ -9,14 +9,321 @@
 #include <csignal>
 #include <cstdarg>
 #include <functional>
+#include <string>
 #include <type_traits>
 #include "comUtil/IUnknownShim.h"
 #include "motifCpp/gTestAdapter.h"
 #include "oacr/oacr.h"
 
-typedef wchar_t WCHAR;
+using WCHAR = wchar_t;
+
+#define GTEST_ASSERT_AT_(file, line, expression, on_failure)    \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                 \
+  if (const ::testing::AssertionResult gtest_ar = (expression)) \
+    ;                                                           \
+  else                                                          \
+    on_failure(file, line, gtest_ar.failure_message())
+
+#define GTEST_FATAL_FAILURE_AT_(file, line, message) \
+  return GTEST_MESSAGE_AT_(file, line, message, ::testing::TestPartResult::kFatalFailure)
 
 namespace TestAssert {
+
+inline std::string FormatMsg(char const *format, ...) noexcept {
+  std::string result;
+  va_list vlist;
+  va_start(vlist, format);
+  auto size = std::vsnprintf(nullptr, 0, format, vlist);
+  result.append(size + 1, '\0');
+  std::vsnprintf(&result[0], size + 1, format, vlist);
+  result.resize(size);
+  va_end(vlist);
+  return result;
+}
+
+inline std::string FormatCustomMsg(int line, char const *message = "") {
+  return FormatMsg(
+      "    Line: %d%s%s",
+      line,
+      (message == nullptr || message[0] == '\0') ? "" : "\n",
+      message == nullptr ? "" : message);
+}
+
+inline void FailInternalAt(char const *file, int line, char const *message, std::string &&errorMessage) {
+  GTEST_FATAL_FAILURE_AT_(file, line, "") << errorMessage << FormatCustomMsg(line, message).c_str();
+}
+
+inline void FailAt(char const *file, int line, char const *message = "") {
+  FailInternalAt(file, line, message, "Failed\n");
+}
+
+inline void IsTrueAt(char const *file, int line, bool condition, char const *exprStr, char const *message = "") {
+  if (!condition) {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] is true\n"
+            "  Actual: it is false\n",
+            exprStr));
+  }
+}
+
+template <class T, std::enable_if_t<!std::is_same_v<bool, T>, int> = 1>
+inline void IsTrueAt(char const *file, int line, T condition, char const *exprStr, char const *message = "") {
+  return IsTrueAt(file, line, !!condition, exprStr, message);
+}
+
+template <class TExpected, class TActual>
+inline void AreEqualAt(
+    char const *file,
+    int line,
+    TExpected const &expected,
+    TActual const &actual,
+    char const *expectedExpr,
+    char const *actualExpr,
+    char const *message = "") {
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+          expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+template <
+    class TExpected,
+    class TActual,
+    std::enable_if_t<
+        std::is_same_v<TExpected, TActual> && !std::is_same_v<TExpected, WCHAR> && !std::is_same_v<TExpected, char>,
+        int> = 1>
+void AreEqualAt(
+    char const *file,
+    int line,
+    TExpected const *expected,
+    TActual const *actual,
+    char const *expectedExpr,
+    char const *actualExpr,
+    char const *message = "") {
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+          expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const *file,
+    int line,
+    WCHAR const *expected,
+    WCHAR const *actual,
+    char const *expectedExpr,
+    char const *actualExpr,
+    char const *message = "") {
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const *file,
+    int line,
+    char const *expected,
+    char const *actual,
+    char const *expectedExpr,
+    char const *actualExpr,
+    char const *message = "") {
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const *file,
+    int line,
+    WCHAR *expected,
+    WCHAR const *actual,
+    char const *expectedExpr,
+    char const *actualExpr,
+    char const *message = "") {
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const *file,
+    int line,
+    char *expected,
+    const char *actual,
+    char const *expectedExpr,
+    char const *actualExpr,
+    const char *message = "") {
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+// Code used for all the C++ exceptions
+constexpr uint32_t EXCEPTION_CPLUSPLUS = static_cast<uint32_t>(0xE06D7363);
+
+inline uint32_t FilterCrashExceptions(uint32_t exceptionCode) noexcept {
+  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
+      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
+  {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
+  {
+    FailAt(__FILE__, __LINE__, "Test function did not crash, but exception is thrown!");
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+template <class TLambda>
+inline bool ExpectCrashCore(TLambda const &lambda) {
+  __try {
+    lambda();
+    return false;
+  } __except (FilterCrashExceptions(GetExceptionCode())) {
+    return true;
+  }
+}
+
+template <class TLambda>
+inline void
+ExpectCrashAt(char const *file, int line, TLambda const &lambda, char const *exprStr, char const *message = "") {
+  if (!ExpectCrashCore(lambda)) {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] must crash\n"
+            "  Actual: it does not crash\n",
+            exprStr));
+  }
+}
+
+struct TerminateHandlerRestorer {
+  ~TerminateHandlerRestorer() noexcept {
+    std::set_terminate(Handler);
+  }
+
+  std::terminate_handler Handler;
+};
+
+#pragma warning(push)
+#pragma warning(disable : 4611) // interaction between '_setjmp' and C++ object destruction is non-portable
+template <class TLambda>
+inline bool ExpectTerminateCore(TLambda const &lambda) {
+  static jmp_buf buf;
+
+  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
+  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
+
+  // setjmp originally returns 0, and when longjmp is called it returns 1.
+  if (!setjmp(buf)) {
+    lambda();
+    return false; // must not be executed if fn() caused termination and the longjmp is executed.
+  } else {
+    return true; // executed if longjmp is executed in the terminate handler.
+  }
+}
+#pragma warning(pop)
+
+template <class TLambda>
+inline void
+ExpectTerminateAt(char const *file, int line, TLambda const &lambda, char const *exprStr, char const *message = "") {
+  if (!ExpectTerminateCore(lambda)) {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] must terminate\n"
+            "  Actual: it does not terminate\n",
+            exprStr));
+  }
+}
+
+template <class TException, class TLambda>
+inline void ExpectExceptionAt(
+    char const *file,
+    int line,
+    TLambda const &lambda,
+    char const *exceptionStr,
+    char const *exprStr,
+    char const *message = "") {
+  char const *actualIssue = "";
+  bool isFailed = false;
+  bool isExpectedExceptionCaught = false;
+
+  try {
+    lambda();
+  } catch (TException const &) {
+    isExpectedExceptionCaught = true;
+  } catch (...) {
+    isFailed = true;
+    actualIssue = "it throws a different type";
+  }
+
+  if (!isExpectedExceptionCaught && !isFailed) {
+    isFailed = true;
+    actualIssue = "it does not throw";
+  }
+
+  if (isFailed) {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] throws an exception of type %s\n"
+            "  Actual: %s\n",
+            exprStr,
+            exceptionStr,
+            actualIssue));
+  }
+}
+
+template <class TLambda>
+inline void
+ExpectNoThrowAt(char const *file, int line, TLambda const &lambda, char const *exprStr, char const *message = "") {
+  try {
+    lambda();
+  } catch (...) {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] does not throw an exception\n"
+            "  Actual: it throws an exception\n",
+            exprStr));
+  }
+}
 
 // Asserts that the specified condition is true, if it is false the unit test will fail
 inline void IsTrue(bool condition, _In_z_ const WCHAR *message = L"") {
@@ -50,14 +357,14 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value &&
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value &&
         !std::is_same<ExpectedType, char>::value>::type>
 void AreEqual(_In_ const ExpectedType *expected, _In_ const ActualType *actual, _In_z_ const WCHAR *message = L"") {
   std::wstring wstrMessage(message);
   ASSERT_EQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ const wchar_t *expected, _In_ const wchar_t *actual, _In_z_ const WCHAR *message = L"") {
+inline void AreEqual(_In_ const WCHAR *expected, _In_ const WCHAR *actual, _In_z_ const WCHAR *message = L"") {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
 }
@@ -67,7 +374,7 @@ inline void AreEqual(_In_ const char *expected, _In_ const char *actual, _In_z_ 
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ wchar_t *expected, _In_ const wchar_t *actual, _In_z_ const WCHAR *message = L"") {
+inline void AreEqual(_In_ WCHAR *expected, _In_ const WCHAR *actual, _In_z_ const WCHAR *message = L"") {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
 }
@@ -88,13 +395,13 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value &&
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value &&
         !std::is_same<ExpectedType, char>::value>::type>
 void AreNotEqual(_In_ const ExpectedType *expected, _In_ const ActualType *actual, _In_z_ const WCHAR *message = L"") {
   AreNotEqual(*expected, *actual, message);
 }
 
-inline void AreNotEqual(_In_ const wchar_t *expected, _In_ const wchar_t *actual, _In_z_ const WCHAR *message = L"") {
+inline void AreNotEqual(_In_ const WCHAR *expected, _In_ const WCHAR *actual, _In_z_ const WCHAR *message = L"") {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
 }
@@ -104,7 +411,7 @@ inline void AreNotEqual(_In_ const char *expected, _In_ const char *actual, _In_
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreNotEqual(_In_ wchar_t *expected, _In_ const wchar_t *actual, _In_z_ const WCHAR *message = L"") {
+inline void AreNotEqual(_In_ WCHAR *expected, _In_ const WCHAR *actual, _In_z_ const WCHAR *message = L"") {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
 }
@@ -176,40 +483,9 @@ inline void HrFailed(HRESULT hr, _In_z_ const WCHAR *message = L"") {
   ASSERT_FALSE(SUCCEEDED(hr)) << message;
 }
 
-// Code used for all the C++ exceptions
-static const DWORD EXCEPTION_CPLUSPLUS = static_cast<DWORD>(0xE06D7363);
-
-inline DWORD FilterCrashExceptions(DWORD exceptionCode) noexcept {
-  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
-      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
-  {
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
-  {
-    TestAssert::Fail(L"Test function did not crash, but exception is thrown!");
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  return EXCEPTION_EXECUTE_HANDLER;
-}
-
-template <typename Fn>
-inline bool ExpectCrashCore(const Fn &fn, const WCHAR * /*message*/) {
-  __try {
-    fn();
-  } __except (FilterCrashExceptions(GetExceptionCode())) {
-    // Pass(message == nullptr || message[0] == L'\0' ? L"Crash occurred as expected." : message);
-    return true;
-  }
-  // Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not crash!" : message);
-  return false;
-}
-
 template <typename Fn>
 inline void ExpectVEC(const Fn &fn, const WCHAR *message = L"") {
-  if (!ExpectCrashCore(fn, message)) {
+  if (!ExpectCrashCore(fn)) {
     Fail(message);
   }
 }

--- a/vnext/Mso/motifCpp/testCheck.h
+++ b/vnext/Mso/motifCpp/testCheck.h
@@ -61,8 +61,7 @@
 // TestCheckCrash expects that the provided expression causes a crash.
 //=============================================================================
 #define TestCheckCrashAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::ExpectCrashAt(                                     \
-      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+  TestAssert::ExpectCrashAt(file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
 #define TestCheckCrashAt(file, line, expr, ...) TestCheckCrashAtInternal(file, line, expr, #expr, __VA_ARGS__)
 #define TestCheckCrash(expr, ...) TestCheckCrashAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
@@ -76,8 +75,7 @@
 // You should disable memory leak detection in tests that use TestCheckTerminate.
 //=============================================================================
 #define TestCheckTerminateAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::ExpectTerminateAt(                                     \
-      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+  TestAssert::ExpectTerminateAt(file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
 #define TestCheckTerminateAt(file, line, expr, ...) TestCheckTerminateAtInternal(file, line, expr, #expr, __VA_ARGS__)
 #define TestCheckTerminate(expr, ...) TestCheckTerminateAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
@@ -104,8 +102,7 @@
 // TestCheckNoThrow expects that the provided expression does not throw an exception.
 //=============================================================================
 #define TestCheckNoThrowAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::ExpectNoThrowAt(                                     \
-      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+  TestAssert::ExpectNoThrowAt(file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
 #define TestCheckNoThrowAt(file, line, expr, ...) TestCheckNoThrowAtInternal(file, line, expr, #expr, __VA_ARGS__)
 #define TestCheckNoThrow(expr, ...) TestCheckNoThrowAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 

--- a/vnext/Mso/motifCpp/testCheck.h
+++ b/vnext/Mso/motifCpp/testCheck.h
@@ -16,48 +16,39 @@
 // use the macros we provide.
 //=============================================================================
 
-#include <csetjmp>
-#include <csignal>
 #include "motifCpp/assert_motifApi.h"
-
-//=============================================================================
-// A helper macro to provide current line number as a wide char string.
-//=============================================================================
-#ifndef MSO_TO_STR
-#define MSO_INTERNAL_TO_STR(value) #value
-#define MSO_TO_STR(value) MSO_INTERNAL_TO_STR(value)
-#endif
-
-#ifndef MSO_WIDE_STR
-#define MSO_INTERNAL_WIDE_STR(str) L##str
-#define MSO_WIDE_STR(str) MSO_INTERNAL_WIDE_STR(str)
-#endif
-
-#define MSO_LINE_STR MSO_TO_STR(__LINE__)
-#define MSO_LINE_WIDE_STR MSO_WIDE_STR(MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckFail fails the test unconditionally.
 //=============================================================================
-#define TestCheckFailL(message, line) TestAssert::Fail(MSO_WIDE_STR("Line: " line " " message))
-#define TestCheckFail(message) TestCheckFailL(message, MSO_LINE_STR)
+#define TestCheckFailAt(file, line, ...) TestAssert::FailAt(file, line, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckFail(...) TestCheckFailAt(__FILE__, __LINE__, __VA_ARGS__)
 
 //=============================================================================
 // TestCheck checks if provided expression evaluates to true.
 // If check fails then it reports the line number and the failed expression.
+//
+// Note that we convert expression to string before we pass it to an
+// Internal macro. This is for better message in case if expression is a macro.
+// It will be shown as macro usage rather than macro being expanded.
 //=============================================================================
-#define TestCheckL(expr, line) TestAssert::IsTrue(expr, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expr) " ]"))
-#define TestCheck(expr) TestCheckL(expr, MSO_LINE_STR)
+#define TestCheckAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::IsTrueAt(file, line, expr, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckAt(file, line, expr, ...) TestCheckAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheck(expr, ...) TestCheckAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckEqual checks if two provided values are equal.
 // If check fails then it reports the line number and the failed expression.
 // In addition the TestAssert::AreEqual reports expected and actual values.
 //=============================================================================
-#define TestCheckEqualL(expected, actual, line) \
-  TestAssert::AreEqual(                         \
-      expected, actual, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expected) " == " MSO_TO_STR(actual) " ]"))
-#define TestCheckEqual(expected, actual) TestCheckEqualL(expected, actual, MSO_LINE_STR)
+#define TestCheckEqualAtInternal(file, line, expected, actual, expectedStr, actualStr, ...) \
+  TestAssert::AreEqualAt(                                                                   \
+      file, line, expected, actual, expectedStr, actualStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckEqualAt(file, line, expected, actual, ...) \
+  TestCheckEqualAtInternal(file, line, expected, actual, #expected, #actual, __VA_ARGS__)
+#define TestCheckEqual(expected, actual, ...) \
+  TestCheckEqualAtInternal(__FILE__, __LINE__, expected, actual, #expected, #actual, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckIgnore ignores the provided expression.
@@ -69,15 +60,11 @@
 //=============================================================================
 // TestCheckCrash expects that the provided expression causes a crash.
 //=============================================================================
-//	Mso::IgnoreAllAsserts ignore;
-#define TestCheckCrashL(expr, line) \
-  TestAssert::ExpectVEC(            \
-      [&]() {                       \
-        OACR_POSSIBLE_THROW;        \
-        expr;                       \
-      },                            \
-      MSO_WIDE_STR("Line: " line " Must crash: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckCrash(expr) TestCheckCrashL(expr, MSO_LINE_STR)
+#define TestCheckCrashAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectCrashAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckCrashAt(file, line, expr, ...) TestCheckCrashAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckCrash(expr, ...) TestCheckCrashAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckTerminate expects that the provided expression causes process termination
@@ -88,24 +75,39 @@
 // the call stack is not unwinded correctly.
 // You should disable memory leak detection in tests that use TestCheckTerminate.
 //=============================================================================
-#define TestCheckTerminateL(expr, line) \
-  TestAssert::ExpectTerminate([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must terminate: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckTerminate(expr) TestCheckTerminateL(expr, MSO_LINE_STR)
+#define TestCheckTerminateAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectTerminateAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckTerminateAt(file, line, expr, ...) TestCheckTerminateAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckTerminate(expr, ...) TestCheckTerminateAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckException expects that the provided expression throws an exception.
 //=============================================================================
-#define TestCheckExceptionL(ex, expr, line) \
-  TestAssert::ExpectException<ex>(          \
-      [&]() { expr; }, MSO_WIDE_STR("Line: " line " Must throw: " MSO_TO_STR(ex) " [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckException(ex, expr) TestCheckExceptionL(ex, expr, MSO_LINE_STR)
+#define TestCheckExceptionAtInternal(file, line, ex, expr, exStr, exprStr, ...) \
+  TestAssert::ExpectExceptionAt<ex>(                                            \
+      file,                                                                     \
+      line,                                                                     \
+      [&]() {                                                                   \
+        OACR_POSSIBLE_THROW;                                                    \
+        expr;                                                                   \
+      },                                                                        \
+      exStr,                                                                    \
+      exprStr,                                                                  \
+      TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckExceptionAt(file, line, ex, expr, ...) \
+  TestCheckExceptionAtInternal(file, line, ex, expr, #ex, #expr, __VA_ARGS__)
+#define TestCheckException(ex, expr, ...) \
+  TestCheckExceptionAtInternal(__FILE__, __LINE__, ex, expr, #ex, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckNoThrow expects that the provided expression does not throw an exception.
 //=============================================================================
-#define TestCheckNoThrowL(expr, line) \
-  TestAssert::ExpectNoThrow([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must not throw: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckNoThrow(expr) TestCheckNoThrowL(expr, MSO_LINE_STR)
+#define TestCheckNoThrowAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectNoThrowAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckNoThrowAt(file, line, expr, ...) TestCheckNoThrowAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckNoThrow(expr, ...) TestCheckNoThrowAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckAssert checks for the code to produce assert with specified tag.
@@ -126,46 +128,5 @@
 	//{ \
 	//	StartTrackingMemoryAllocations(); \
 	//});
-
-//=============================================================================
-// Helper functions to implement TestCheckTerminate.
-//=============================================================================
-namespace TestAssert {
-
-struct TerminateHandlerRestorer {
-  ~TerminateHandlerRestorer() noexcept {
-    std::set_terminate(Handler);
-  }
-
-  std::terminate_handler Handler;
-};
-
-#pragma warning(push)
-#pragma warning(disable : 4611) // interaction between '_setjmp' and C++ object destruction is non-portable
-template <class Fn>
-inline bool ExpectTerminateCore(const Fn &fn) {
-  static jmp_buf buf;
-
-  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
-  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
-
-  // setjmp originally returns 0, and when longjmp is called it returns 1.
-  if (!setjmp(buf)) {
-    fn();
-    return false; // must not be executed if fn() caused termination and the longjmp is executed.
-  } else {
-    return true; // executed if longjmp is executed in the terminate handler.
-  }
-}
-#pragma warning(pop)
-
-template <class Fn>
-inline void ExpectTerminate(const Fn &fn, const WCHAR *message = L"") {
-  if (!ExpectTerminateCore(fn)) {
-    Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not terminate!" : message);
-  }
-}
-
-} // namespace TestAssert
 
 #endif // MSO_MOTIFCPP_TESTCHECK_H


### PR DESCRIPTION
For C++ unit tests we use the Mso subset of Motif tests that are based on GTest in our open source implementation that we use in RNW. A good unit test must report accurate test failure information such as:
- the file and a line of code;
- what expression failed and why.

Unfortunately, the `TestAssert::AreEqual`-like function calls do not provide such information, unlike the macros used in GTest. To address this limitation, the testCheck.h file has a number of macros such as `TestCheck` and `TestCheckEquals` that can capture the important test failure information.
The issue was that their implementation was based on the `TestAssert::AreEqual`-like functions and it was losing all the important information.

In this change we fix the testCheck.h macros to be able to report error location and expressions that failed.

We have also improved ability to combine the lower level checking primitives into more complex checks: developers can use `TestCheckAt`-like macros to report issue at a location that they need. See the 'future/testCheck.h' as an example.

A new MotifCppTest.cpp unit test is added to observe the error messages. To see the errors we should just un-comment the `#define MOTIF_TEST_SHOW_ERRORS` line on top of the file.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4329)