### PR TITLE
Set TabIndex to 0 for Pickers

### DIFF
--- a/change/react-native-windows-2020-03-17-09-47-45-PickerFix.json
+++ b/change/react-native-windows-2020-03-17-09-47-45-PickerFix.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Set TabIndex to 0 for Pickers",
+  "packageName": "react-native-windows",
+  "email": "jagorrin@microsoft.com",
+  "commit": "43332258ca84856eff48e593e140e1ab91d7f7fa",
+  "dependentChangeType": "patch",
+  "date": "2020-03-17T16:47:45.550Z"
+}

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -53,6 +53,7 @@ PickerShadowNode::PickerShadowNode() : Super() {
 void PickerShadowNode::createView() {
   Super::createView();
   auto combobox = GetView().as<winrt::ComboBox>();
+  combobox.TabIndex(0);
   auto wkinstance = GetViewManager()->GetReactInstance();
 
   combobox.AllowFocusOnInteraction(true);


### PR DESCRIPTION
Currently, the default TabIndex for Pickers is the maximum integer. This means that Pickers will be last in keyboard navigation order. The expected behavior is that the user can keyboard navigate in XAML tree order. This change sets the default TabIndex value for Pickers to 0 so that their contents can be accessed in tree order.

This is the same as #4328 but for Pickers.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4333)