### PR TITLE
Fix ReactInstanceWin::GetBundleRootPath

### DIFF
--- a/change/react-native-windows-2020-03-18-12-05-40-issue4295.json
+++ b/change/react-native-windows-2020-03-18-12-05-40-issue4295.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactInstanceWin::GetBundleRootPath",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "commit": "c2d0019489a858be74dd55be161e3b77e6c55c4a",
+  "dependentChangeType": "patch",
+  "date": "2020-03-18T19:05:40.850Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -636,7 +636,7 @@ std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() 
 }
 
 std::string ReactInstanceWin::GetBundleRootPath() noexcept {
-  return m_options.LegacySettings.BundleRootPath;
+  return m_bundleRootPath.empty() ? m_options.LegacySettings.BundleRootPath : m_bundleRootPath;
 }
 
 std::shared_ptr<react::uwp::IReactInstance> ReactInstanceWin::UwpReactInstance() noexcept {


### PR DESCRIPTION
Before it returned `m_options.LegacySettings.BundleRootPath`.

While that value gets whatever was sent into it, during any of the many setting-copying operations , we also copy the value into `m_bundleRootPath`. However we also (in several different places) check if the value is empty first, in which case, we save `"ms-appx:///Bundle/"` into `m_bundleRootPath` instead, which is actually what is necessary for bundled assets to load properly from within a published package.

Fixes issue #4295 by checking `m_bundleRootPath` first, but really this is just another symptom of #4354.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4355)