### PR TITLE
Changed C# JSValue to match C++ JSValue

### DIFF
--- a/change/react-native-windows-2020-03-18-10-57-47-MS_FixJSValueCS.json
+++ b/change/react-native-windows-2020-03-18-10-57-47-MS_FixJSValueCS.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Changed C# JSValue API to match C++ version",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "6c072821b73dc13e8c7d461fd59b413bdafeb306",
+  "dependentChangeType": "patch",
+  "date": "2020-03-18T17:57:47.382Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
@@ -25,7 +25,7 @@ namespace SampleLibraryCS
         #region Initializer
 
         [ReactInitializer]
-        public void Initialize(IReactContext reactContext)
+        public void Initialize(IReactContext _)
         {
             _timer = ThreadPoolTimer.CreatePeriodicTimer(new TimerElapsedHandler((timer) =>
             {

--- a/vnext/.editorconfig
+++ b/vnext/.editorconfig
@@ -18,6 +18,9 @@ end_of_line = crlf
 end_of_line = crlf
 insert_final_newline = false
 
+# IDE0034: Simplify 'default' expression
+csharp_prefer_simple_default_expression = false:none
+
 [*.ps1]
 indent_style = tab
 indent_size = 4

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
@@ -5,6 +5,9 @@
 #include "JSValue.h"
 #include "JsonJSValueReader.h"
 
+#undef max
+#undef min
+
 namespace winrt::Microsoft::ReactNative {
 
 TEST_CLASS (JSValueTest) {
@@ -12,35 +15,49 @@ TEST_CLASS (JSValueTest) {
     const wchar_t *json =
         LR"JSON({
         "NullValue": null,
-        "ObjValue": {},
-        "ArrayValue": [],
+        "ObjValue": {"prop1": 2},
+        "ArrayValue": [1, 2],
         "StringValue": "Hello",
         "BoolValue": true,
         "IntValue": 42,
         "DoubleValue": 4.5
       })JSON";
-
     IJSValueReader reader = make<JsonJSValueReader>(json);
-
     JSValue jsValue = JSValue::ReadFrom(reader);
-    TestCheck(jsValue.Type() == JSValueType::Object);
 
-    TestCheck(jsValue["NullValue"].Type() == JSValueType::Null);
-    TestCheck(jsValue["ObjValue"].Type() == JSValueType::Object);
-    TestCheck(jsValue["ArrayValue"].Type() == JSValueType::Array);
-    TestCheck(jsValue["StringValue"].Type() == JSValueType::String);
-    TestCheck(jsValue["BoolValue"].Type() == JSValueType::Boolean);
-    TestCheck(jsValue["IntValue"].Type() == JSValueType::Int64);
-    TestCheck(jsValue["DoubleValue"].Type() == JSValueType::Double);
+    TestCheckEqual(JSValueType::Object, jsValue.Type());
+    TestCheckEqual(JSValueType::Null, jsValue["NullValue"].Type());
+    TestCheckEqual(JSValueType::Object, jsValue["ObjValue"].Type());
+    TestCheckEqual(JSValueType::Array, jsValue["ArrayValue"].Type());
+    TestCheckEqual(JSValueType::String, jsValue["StringValue"].Type());
+    TestCheckEqual(JSValueType::Boolean, jsValue["BoolValue"].Type());
+    TestCheckEqual(JSValueType::Int64, jsValue["IntValue"].Type());
+    TestCheckEqual(JSValueType::Double, jsValue["DoubleValue"].Type());
+
+    JSValueObject const *objValue = nullptr;
+    JSValueArray const *arrayValue = nullptr;
+    std::string const *stringValue = nullptr;
+    bool const *boolValue = nullptr;
+    int64_t const *intValue = nullptr;
+    double const *doubleValue = nullptr;
 
     TestCheck(jsValue["NullValue"].IsNull());
-    TestCheck(jsValue["ObjValue"].TryGetObject()->empty());
-    TestCheck(jsValue["ArrayValue"].TryGetArray()->empty());
-    TestCheck(jsValue["StringValue"] == "Hello");
-    TestCheck(jsValue["BoolValue"] == true);
-    TestCheck(jsValue["IntValue"] == 42);
-    TestCheck(jsValue["DoubleValue"] == 4.5);
-  } // namespace winrt::Microsoft::ReactNative
+    TestCheck(objValue = jsValue["ObjValue"].TryGetObject());
+    TestCheck(arrayValue = jsValue["ArrayValue"].TryGetArray());
+    TestCheck(stringValue = jsValue["StringValue"].TryGetString());
+    TestCheck(boolValue = jsValue["BoolValue"].TryGetBoolean());
+    TestCheck(intValue = jsValue["IntValue"].TryGetInt64());
+    TestCheck(doubleValue = jsValue["DoubleValue"].TryGetDouble());
+
+    TestCheckEqual(1, objValue->size());
+    TestCheckEqual(1, jsValue["ObjValue"].PropertyCount());
+    TestCheckEqual(2, arrayValue->size());
+    TestCheckEqual(2, jsValue["ArrayValue"].ItemCount());
+    TestCheckEqual("Hello", *stringValue);
+    TestCheckEqual(true, *boolValue);
+    TestCheckEqual(42, *intValue);
+    TestCheckEqual(4.5, *doubleValue);
+  }
 
   TEST_METHOD(TestReadNestedObject) {
     const wchar_t *json =
@@ -55,78 +72,502 @@ TEST_CLASS (JSValueTest) {
           "DoubleValue": 4.5
         }
       })JSON";
-
     IJSValueReader reader = make<JsonJSValueReader>(json);
-
     JSValue jsValue = JSValue::ReadFrom(reader);
-    TestCheck(jsValue.Type() == JSValueType::Object);
-    TestCheck(jsValue["NestedObj"].Type() == JSValueType::Object);
+
+    TestCheckEqual(JSValueType::Object, jsValue.Type());
+    TestCheckEqual(JSValueType::Object, jsValue["NestedObj"].Type());
     auto const &nestedObj = *jsValue["NestedObj"].TryGetObject();
 
-    TestCheck(nestedObj["NullValue"].Type() == JSValueType::Null);
-    TestCheck(nestedObj["ObjValue"].Type() == JSValueType::Object);
-    TestCheck(nestedObj["ArrayValue"].Type() == JSValueType::Array);
-    TestCheck(nestedObj["StringValue"].Type() == JSValueType::String);
-    TestCheck(nestedObj["BoolValue"].Type() == JSValueType::Boolean);
-    TestCheck(nestedObj["IntValue"].Type() == JSValueType::Int64);
-    TestCheck(nestedObj["DoubleValue"].Type() == JSValueType::Double);
+    TestCheckEqual(JSValueType::Null, nestedObj["NullValue"].Type());
+    TestCheckEqual(JSValueType::Object, nestedObj["ObjValue"].Type());
+    TestCheckEqual(JSValueType::Array, nestedObj["ArrayValue"].Type());
+    TestCheckEqual(JSValueType::String, nestedObj["StringValue"].Type());
+    TestCheckEqual(JSValueType::Boolean, nestedObj["BoolValue"].Type());
+    TestCheckEqual(JSValueType::Int64, nestedObj["IntValue"].Type());
+    TestCheckEqual(JSValueType::Double, nestedObj["DoubleValue"].Type());
 
     TestCheck(nestedObj["NullValue"].IsNull());
-    TestCheck(nestedObj["ObjValue"].TryGetObject()->empty());
-    TestCheck(nestedObj["ArrayValue"].TryGetArray()->empty());
-    TestCheck(nestedObj["StringValue"] == "Hello");
-    TestCheck(nestedObj["BoolValue"] == true);
-    TestCheck(nestedObj["IntValue"] == 42);
-    TestCheck(nestedObj["DoubleValue"] == 4.5);
+    TestCheck(nestedObj["ObjValue"].TryGetObject());
+    TestCheck(nestedObj["ArrayValue"].TryGetArray());
+    TestCheckEqual("Hello", nestedObj["StringValue"]);
+    TestCheckEqual(true, nestedObj["BoolValue"]);
+    TestCheckEqual(42, nestedObj["IntValue"]);
+    TestCheckEqual(4.5, nestedObj["DoubleValue"]);
   }
 
   TEST_METHOD(TestReadArray) {
     const wchar_t *json = LR"JSON([null, {}, [], "Hello", true, 42, 4.5])JSON";
     IJSValueReader reader = make<JsonJSValueReader>(json);
-
     JSValue jsValue = JSValue::ReadFrom(reader);
-    TestCheck(jsValue.Type() == JSValueType::Array);
 
-    TestCheck(jsValue[0].Type() == JSValueType::Null);
-    TestCheck(jsValue[1].Type() == JSValueType::Object);
-    TestCheck(jsValue[2].Type() == JSValueType::Array);
-    TestCheck(jsValue[3].Type() == JSValueType::String);
-    TestCheck(jsValue[4].Type() == JSValueType::Boolean);
-    TestCheck(jsValue[5].Type() == JSValueType::Int64);
-    TestCheck(jsValue[6].Type() == JSValueType::Double);
+    TestCheckEqual(JSValueType::Array, jsValue.Type());
+    TestCheckEqual(JSValueType::Null, jsValue[0].Type());
+    TestCheckEqual(JSValueType::Object, jsValue[1].Type());
+    TestCheckEqual(JSValueType::Array, jsValue[2].Type());
+    TestCheckEqual(JSValueType::String, jsValue[3].Type());
+    TestCheckEqual(JSValueType::Boolean, jsValue[4].Type());
+    TestCheckEqual(JSValueType::Int64, jsValue[5].Type());
+    TestCheckEqual(JSValueType::Double, jsValue[6].Type());
 
     TestCheck(jsValue[0].IsNull());
-    TestCheck(jsValue[1].TryGetObject()->empty());
-    TestCheck(jsValue[2].TryGetArray()->empty());
-    TestCheck(jsValue[3] == "Hello");
-    TestCheck(jsValue[4] == true);
-    TestCheck(jsValue[5] == 42);
-    TestCheck(jsValue[6] == 4.5);
+    TestCheck(jsValue[1].TryGetObject());
+    TestCheck(jsValue[2].TryGetArray());
+    TestCheckEqual("Hello", jsValue[3]);
+    TestCheckEqual(true, jsValue[4]);
+    TestCheckEqual(42, jsValue[5]);
+    TestCheckEqual(4.5, jsValue[6]);
   }
 
   TEST_METHOD(TestReadNestedArray) {
     const wchar_t *json = LR"JSON([[null, {}, [], "Hello", true, 42, 4.5]])JSON";
     IJSValueReader reader = make<JsonJSValueReader>(json);
-
     JSValue jsValue = JSValue::ReadFrom(reader);
-    TestCheck(jsValue[0].TryGetArray());
+
+    TestCheckEqual(JSValueType::Array, jsValue.Type());
+    TestCheckEqual(JSValueType::Array, jsValue[0].Type());
     auto const &nestedArr = *jsValue[0].TryGetArray();
 
-    TestCheck(nestedArr[0].Type() == JSValueType::Null);
-    TestCheck(nestedArr[1].Type() == JSValueType::Object);
-    TestCheck(nestedArr[2].Type() == JSValueType::Array);
-    TestCheck(nestedArr[3].Type() == JSValueType::String);
-    TestCheck(nestedArr[4].Type() == JSValueType::Boolean);
-    TestCheck(nestedArr[5].Type() == JSValueType::Int64);
-    TestCheck(nestedArr[6].Type() == JSValueType::Double);
+    TestCheckEqual(JSValueType::Null, nestedArr[0].Type());
+    TestCheckEqual(JSValueType::Object, nestedArr[1].Type());
+    TestCheckEqual(JSValueType::Array, nestedArr[2].Type());
+    TestCheckEqual(JSValueType::String, nestedArr[3].Type());
+    TestCheckEqual(JSValueType::Boolean, nestedArr[4].Type());
+    TestCheckEqual(JSValueType::Int64, nestedArr[5].Type());
+    TestCheckEqual(JSValueType::Double, nestedArr[6].Type());
 
     TestCheck(nestedArr[0].IsNull());
-    TestCheck(nestedArr[1].TryGetObject()->empty());
-    TestCheck(nestedArr[2].TryGetArray()->empty());
-    TestCheck(nestedArr[3] == "Hello");
-    TestCheck(nestedArr[4] == true);
-    TestCheck(nestedArr[5] == 42);
-    TestCheck(nestedArr[6] == 4.5);
+    TestCheck(nestedArr[1].TryGetObject());
+    TestCheck(nestedArr[2].TryGetArray());
+    TestCheckEqual("Hello", nestedArr[3]);
+    TestCheckEqual(true, nestedArr[4]);
+    TestCheckEqual(42, nestedArr[5]);
+    TestCheckEqual(4.5, nestedArr[6]);
+  }
+
+  TEST_METHOD(TestJSSimpleLiterals) {
+    JSValue jsValue01 = nullptr;
+    JSValue jsValue02 = "Hello";
+    JSValue jsValue03 = "";
+    JSValue jsValue04 = true;
+    JSValue jsValue05 = false;
+    JSValue jsValue06 = 42;
+    JSValue jsValue07 = 0;
+    JSValue jsValue08 = 4.5;
+    JSValue jsValue09 = 0.0;
+    JSValue jsValue10 = NAN;
+    JSValue jsValue11 = INFINITY;
+    JSValue jsValue12 = -INFINITY;
+
+    TestCheckEqual(JSValueType::Null, jsValue01.Type());
+    TestCheckEqual(JSValueType::String, jsValue02.Type());
+    TestCheckEqual(JSValueType::String, jsValue03.Type());
+    TestCheckEqual(JSValueType::Boolean, jsValue04.Type());
+    TestCheckEqual(JSValueType::Boolean, jsValue05.Type());
+    TestCheckEqual(JSValueType::Int64, jsValue06.Type());
+    TestCheckEqual(JSValueType::Int64, jsValue07.Type());
+    TestCheckEqual(JSValueType::Double, jsValue08.Type());
+    TestCheckEqual(JSValueType::Double, jsValue09.Type());
+    TestCheckEqual(JSValueType::Double, jsValue10.Type());
+    TestCheckEqual(JSValueType::Double, jsValue11.Type());
+    TestCheckEqual(JSValueType::Double, jsValue12.Type());
+
+    TestCheck(jsValue01.IsNull());
+    TestCheckEqual("Hello", *jsValue02.TryGetString());
+    TestCheckEqual("", *jsValue03.TryGetString());
+    TestCheckEqual(true, *jsValue04.TryGetBoolean());
+    TestCheckEqual(false, *jsValue05.TryGetBoolean());
+    TestCheckEqual(42, *jsValue06.TryGetInt64());
+    TestCheckEqual(0, *jsValue07.TryGetInt64());
+    TestCheckEqual(4.5, *jsValue08.TryGetDouble());
+    TestCheckEqual(0.0, *jsValue09.TryGetDouble());
+    TestCheck(std::isnan(*jsValue10.TryGetDouble()));
+    TestCheckEqual(INFINITY, *jsValue11.TryGetDouble());
+    TestCheckEqual(-INFINITY, *jsValue12.TryGetDouble());
+  }
+
+  TEST_METHOD(TestObjectLiteral) {
+    JSValue jsValue = JSValueObject{{"NullValue1", nullptr},
+                                    {"NullValue2", JSValue::Null.Copy()},
+                                    {"ObjValue", JSValueObject{{"prop1", 2}}},
+                                    {"ObjValueEmpty", JSValue::EmptyObject.Copy()},
+                                    {"ArrayValue", JSValueArray{1, 2}},
+                                    {"ArrayValueEmpty", JSValue::EmptyArray.Copy()},
+                                    {"StringValue1", "Hello"},
+                                    {"StringValue2", JSValue::EmptyString.Copy()},
+                                    {"BoolValue", true},
+                                    {"IntValue", 42},
+                                    {"DoubleValue", 4.5}};
+    TestCheckEqual(JSValueType::Object, jsValue.Type());
+    TestCheckEqual(JSValueType::Null, jsValue["NullValue1"].Type());
+    TestCheckEqual(JSValueType::Null, jsValue["NullValue2"].Type());
+    TestCheckEqual(JSValueType::Object, jsValue["ObjValue"].Type());
+    TestCheckEqual(JSValueType::Object, jsValue["ObjValueEmpty"].Type());
+    TestCheckEqual(JSValueType::Array, jsValue["ArrayValue"].Type());
+    TestCheckEqual(JSValueType::Array, jsValue["ArrayValueEmpty"].Type());
+    TestCheckEqual(JSValueType::String, jsValue["StringValue1"].Type());
+    TestCheckEqual(JSValueType::String, jsValue["StringValue2"].Type());
+    TestCheckEqual(JSValueType::Boolean, jsValue["BoolValue"].Type());
+    TestCheckEqual(JSValueType::Int64, jsValue["IntValue"].Type());
+    TestCheckEqual(JSValueType::Double, jsValue["DoubleValue"].Type());
+
+    TestCheck(jsValue["NullValue1"].IsNull());
+    TestCheck(jsValue["NullValue2"].IsNull());
+    TestCheckEqual(1, jsValue["ObjValue"].PropertyCount());
+    TestCheckEqual(2, jsValue["ObjValue"]["prop1"]);
+    TestCheckEqual(0, jsValue["ObjValueEmpty"].PropertyCount());
+    TestCheckEqual(2, jsValue["ArrayValue"].ItemCount());
+    TestCheckEqual(1, jsValue["ArrayValue"][0]);
+    TestCheckEqual(2, jsValue["ArrayValue"][1]);
+    TestCheckEqual(0, jsValue["ArrayValueEmpty"].ItemCount());
+    TestCheckEqual("Hello", jsValue["StringValue1"]);
+    TestCheckEqual("", jsValue["StringValue2"]);
+    TestCheckEqual(true, jsValue["BoolValue"]);
+    TestCheckEqual(42, jsValue["IntValue"]);
+    TestCheck(24 != jsValue["IntValue"]);
+    TestCheckEqual(4.5, jsValue["DoubleValue"]);
+  }
+
+  TEST_METHOD(TestArrayLiteral) {
+    JSValue jsValue = JSValueArray{nullptr,
+                                   JSValueObject{{"prop1", 2}},
+                                   JSValueObject{},
+                                   JSValueArray{1, 2},
+                                   JSValueArray{},
+                                   "Hello",
+                                   true,
+                                   42,
+                                   4.5};
+
+    TestCheckEqual(JSValueType::Array, jsValue.Type());
+    TestCheckEqual(JSValueType::Null, jsValue[0].Type());
+    TestCheckEqual(JSValueType::Object, jsValue[1].Type());
+    TestCheckEqual(JSValueType::Object, jsValue[2].Type());
+    TestCheckEqual(JSValueType::Array, jsValue[3].Type());
+    TestCheckEqual(JSValueType::Array, jsValue[4].Type());
+    TestCheckEqual(JSValueType::String, jsValue[5].Type());
+    TestCheckEqual(JSValueType::Boolean, jsValue[6].Type());
+    TestCheckEqual(JSValueType::Int64, jsValue[7].Type());
+    TestCheckEqual(JSValueType::Double, jsValue[8].Type());
+
+    TestCheck(jsValue["NullValue"].IsNull());
+    TestCheckEqual(1, jsValue[1].PropertyCount());
+    TestCheckEqual(2, jsValue[1]["prop1"]);
+    TestCheckEqual(0, jsValue[2].PropertyCount());
+    TestCheckEqual(2, jsValue[3].ItemCount());
+    TestCheckEqual(1, jsValue[3][0]);
+    TestCheckEqual(2, jsValue[3][1]);
+    TestCheckEqual(0, jsValue[4].ItemCount());
+    TestCheckEqual("Hello", jsValue[5]);
+    TestCheckEqual(true, jsValue[6]);
+    TestCheckEqual(42, jsValue[7]);
+    TestCheck(24 != jsValue[7]);
+    TestCheckEqual(4.5, jsValue[8]);
+  }
+
+  TEST_METHOD(TestJSValueConstructor) {
+    JSValue value01;
+    JSValue value02{JSValueObject{{"prop1", 3}}};
+    JSValue value03{JSValueObject{}};
+    JSValue value04{JSValueArray{1, 2}};
+    JSValue value05{JSValueArray{}};
+    JSValue value06{"Hello"};
+    JSValue value07{true};
+    JSValue value08{false};
+    JSValue value09{0};
+    JSValue value10{42};
+    JSValue value11{4.2};
+
+    TestCheckEqual(JSValueType::Null, value01.Type());
+    TestCheckEqual(JSValueType::Object, value02.Type());
+    TestCheckEqual(JSValueType::Object, value03.Type());
+    TestCheckEqual(JSValueType::Array, value04.Type());
+    TestCheckEqual(JSValueType::Array, value05.Type());
+    TestCheckEqual(JSValueType::String, value06.Type());
+    TestCheckEqual(JSValueType::Boolean, value07.Type());
+    TestCheckEqual(JSValueType::Boolean, value08.Type());
+    TestCheckEqual(JSValueType::Int64, value09.Type());
+    TestCheckEqual(JSValueType::Int64, value10.Type());
+    TestCheckEqual(JSValueType::Double, value11.Type());
+
+    TestCheck(value01.IsNull());
+    TestCheckEqual(1, value02.TryGetObject()->size());
+    TestCheckEqual(0, value03.TryGetObject()->size());
+    TestCheckEqual(2, value04.TryGetArray()->size());
+    TestCheckEqual(0, value05.TryGetArray()->size());
+    TestCheckEqual("Hello", *value06.TryGetString());
+    TestCheckEqual(true, *value07.TryGetBoolean());
+    TestCheckEqual(false, *value08.TryGetBoolean());
+    TestCheckEqual(0, *value09.TryGetInt64());
+    TestCheckEqual(42, *value10.TryGetInt64());
+    TestCheckEqual(4.2, *value11.TryGetDouble());
+  }
+
+  TEST_METHOD(TestJSValueImplicitCast) {
+    // We do not assign values directly here sbecause it would be an explicit constructor call.
+    JSValue value01, value02, value03, value04, value05, value06, value07, value08, value09, value10, value11, value12,
+        value13, value14, value15, value16, value17, value18, value19, value20, value21;
+
+    std::vector<std::pair<std::string, JSValue>> objInput1;
+    objInput1.emplace_back("prop1", nullptr);
+    objInput1.emplace_back("prop2", 42);
+    objInput1.emplace_back("prop3", "Hello");
+
+    std::map<std::string, JSValue, std::less<>> objInput2;
+    objInput2["prop1"] = nullptr;
+    objInput2["prop2"] = 42;
+    objInput2["prop3"] = "Hello";
+
+    std::vector<JSValue> arrInput1;
+    arrInput1.emplace_back(nullptr);
+    arrInput1.emplace_back(42);
+    arrInput1.emplace_back("Hello");
+
+    value01 = JSValueObject(std::move_iterator(objInput1.begin()), std::move_iterator(objInput1.end()));
+    value02 = JSValueObject(std::move(objInput2));
+    value03 = JSValueObject{{"prop1", 3}};
+    value04 = JSValueArray(3); // Array of 3 JSValue::Null
+    value05 = JSValueArray{3}; // Array with one JSValue(3) item
+    value06 = JSValueArray(2, 42); // Array with two JSValue(42) items
+    value07 = JSValueArray(std::move(arrInput1));
+    value08 = JSValueArray{nullptr, 42, "Hello"};
+    value09 = "Hello";
+    value10 = true;
+    value11 = false;
+    value12 = (int8_t)42;
+    value13 = (int16_t)42;
+    value14 = (int32_t)42;
+    value15 = (int64_t)42;
+    value16 = (uint8_t)42;
+    value17 = (uint16_t)42;
+    value18 = (uint32_t)42;
+    value19 = (uint64_t)42;
+    value20 = (float)4.2;
+    value21 = 4.2;
+
+    TestCheckEqual(JSValueType::Object, value01.Type());
+    TestCheckEqual(JSValueType::Object, value02.Type());
+    TestCheckEqual(JSValueType::Object, value03.Type());
+    TestCheckEqual(JSValueType::Array, value04.Type());
+    TestCheckEqual(JSValueType::Array, value05.Type());
+    TestCheckEqual(JSValueType::Array, value06.Type());
+    TestCheckEqual(JSValueType::Array, value07.Type());
+    TestCheckEqual(JSValueType::Array, value08.Type());
+    TestCheckEqual(JSValueType::String, value09.Type());
+    TestCheckEqual(JSValueType::Boolean, value10.Type());
+    TestCheckEqual(JSValueType::Boolean, value11.Type());
+    TestCheckEqual(JSValueType::Int64, value12.Type());
+    TestCheckEqual(JSValueType::Int64, value13.Type());
+    TestCheckEqual(JSValueType::Int64, value14.Type());
+    TestCheckEqual(JSValueType::Int64, value15.Type());
+    TestCheckEqual(JSValueType::Int64, value16.Type());
+    TestCheckEqual(JSValueType::Int64, value17.Type());
+    TestCheckEqual(JSValueType::Int64, value18.Type());
+    TestCheckEqual(JSValueType::Int64, value19.Type());
+    TestCheckEqual(JSValueType::Double, value20.Type());
+    TestCheckEqual(JSValueType::Double, value21.Type());
+
+    TestCheckEqual(3, value01.PropertyCount());
+    TestCheckEqual(nullptr, value01["prop1"]);
+    TestCheckEqual(42, value01["prop2"]);
+    TestCheckEqual("Hello", value01["prop3"]);
+
+    TestCheckEqual(3, value02.PropertyCount());
+    TestCheckEqual(nullptr, value02["prop1"]);
+    TestCheckEqual(42, value02["prop2"]);
+    TestCheckEqual("Hello", value02["prop3"]);
+
+    TestCheckEqual(1, value03.PropertyCount());
+    TestCheckEqual(3, value03["prop1"]);
+
+    TestCheckEqual(3, value04.ItemCount());
+    TestCheckEqual(nullptr, value04[0]);
+    TestCheckEqual(nullptr, value04[1]);
+    TestCheckEqual(nullptr, value04[2]);
+
+    TestCheckEqual(1, value05.ItemCount());
+    TestCheckEqual(3, value05[0]);
+
+    TestCheckEqual(2, value06.ItemCount());
+    TestCheckEqual(42, value06[0]);
+    TestCheckEqual(42, value06[1]);
+
+    TestCheckEqual(3, value07.ItemCount());
+    TestCheckEqual(nullptr, value07[0]);
+    TestCheckEqual(42, value07[1]);
+    TestCheckEqual("Hello", value07[2]);
+
+    TestCheckEqual(3, value08.ItemCount());
+    TestCheckEqual(nullptr, value08[0]);
+    TestCheckEqual(42, value08[1]);
+    TestCheckEqual("Hello", value08[2]);
+
+    TestCheckEqual("Hello", value09);
+    TestCheckEqual(true, value10);
+    TestCheckEqual(false, value11);
+    TestCheckEqual(42, value12);
+    TestCheckEqual(42, value13);
+    TestCheckEqual(42, value14);
+    TestCheckEqual(42, value15);
+    TestCheckEqual(42, value16);
+    TestCheckEqual(42, value17);
+    TestCheckEqual(42, value18);
+    TestCheckEqual(42, value19);
+    TestCheckEqual((float)4.2, value20);
+    TestCheckEqual(4.2, value21);
+  }
+
+  TEST_METHOD(TestAsObject) {
+    // Any type except for Object is returned as EmptyObject.
+    auto AsObjectIsEmpty = [](JSValue const &value) { return value.AsObject().empty(); };
+
+    TestCheck(!AsObjectIsEmpty(JSValueObject{{"prop1", 42}}));
+    TestCheck(AsObjectIsEmpty(JSValue::EmptyObject));
+    TestCheck(AsObjectIsEmpty(JSValueArray{42, 78}));
+    TestCheck(AsObjectIsEmpty(JSValue::EmptyArray));
+    TestCheck(AsObjectIsEmpty(""));
+    TestCheck(AsObjectIsEmpty("Hello"));
+    TestCheck(AsObjectIsEmpty(true));
+    TestCheck(AsObjectIsEmpty(false));
+    TestCheck(AsObjectIsEmpty(0));
+    TestCheck(AsObjectIsEmpty(42));
+    TestCheck(AsObjectIsEmpty(std::numeric_limits<int64_t>::max()));
+    TestCheck(AsObjectIsEmpty(std::numeric_limits<int64_t>::min()));
+    TestCheck(AsObjectIsEmpty(0.0));
+    TestCheck(AsObjectIsEmpty(4.2));
+    TestCheck(AsObjectIsEmpty(std::numeric_limits<double>::quiet_NaN()));
+    TestCheck(AsObjectIsEmpty(std::numeric_limits<double>::infinity()));
+    TestCheck(AsObjectIsEmpty(-std::numeric_limits<double>::infinity()));
+    TestCheck(AsObjectIsEmpty(JSValue::Null));
+  }
+
+  TEST_METHOD(TestAsArray) {
+    // Any type except for Array is returned as EmptyArray.
+    auto AsArrayIsEmpty = [](JSValue const &value) { return value.AsArray().empty(); };
+
+    TestCheck(AsArrayIsEmpty(JSValueObject{{"prop1", 42}}));
+    TestCheck(AsArrayIsEmpty(JSValue::EmptyObject));
+    TestCheck(!AsArrayIsEmpty(JSValueArray{42, 78}));
+    TestCheck(AsArrayIsEmpty(JSValue::EmptyArray));
+    TestCheck(AsArrayIsEmpty(""));
+    TestCheck(AsArrayIsEmpty("Hello"));
+    TestCheck(AsArrayIsEmpty(true));
+    TestCheck(AsArrayIsEmpty(false));
+    TestCheck(AsArrayIsEmpty(0));
+    TestCheck(AsArrayIsEmpty(42));
+    TestCheck(AsArrayIsEmpty(std::numeric_limits<int64_t>::max()));
+    TestCheck(AsArrayIsEmpty(std::numeric_limits<int64_t>::min()));
+    TestCheck(AsArrayIsEmpty(0.0));
+    TestCheck(AsArrayIsEmpty(4.2));
+    TestCheck(AsArrayIsEmpty(std::numeric_limits<double>::quiet_NaN()));
+    TestCheck(AsArrayIsEmpty(std::numeric_limits<double>::infinity()));
+    TestCheck(AsArrayIsEmpty(-std::numeric_limits<double>::infinity()));
+    TestCheck(AsArrayIsEmpty(JSValue::Null));
+  }
+
+  // Check AsString, AsBoolean, AsInt64, and AsDouble conversions.
+  void CheckAsConverterImpl(
+      char const *file,
+      int line,
+      JSValue const &value,
+      char const *asString,
+      bool asBoolean,
+      int64_t asInt64,
+      double asDouble) {
+    TestCheckEqualAt(file, line, asString, value.AsString());
+    TestCheckEqualAt(file, line, asBoolean, value.AsBoolean());
+    TestCheckEqualAt(file, line, asInt64, value.AsInt64());
+    if (std::isnan(asDouble)) {
+      TestCheckAt(file, line, std::isnan(value.AsDouble()));
+    } else {
+      TestCheckEqualAt(file, line, asDouble, value.AsDouble());
+    }
+
+    // Explicit cast is an alternative to the As conversion.
+    TestCheckEqualAt(file, line, asString, static_cast<std::string>(value));
+    TestCheckEqualAt(file, line, asBoolean, static_cast<bool>(value));
+    TestCheckEqualAt(file, line, asInt64, static_cast<int64_t>(value));
+    if (std::isnan(asDouble)) {
+      TestCheckAt(file, line, std::isnan(static_cast<double>(value)));
+    } else {
+      TestCheckEqualAt(file, line, asDouble, static_cast<double>(value));
+    }
+  }
+
+#define CheckAsConverter(value, asString, asBoolean, asInt64, asDouble) \
+  CheckAsConverterImpl(__FILE__, __LINE__, value, asString, asBoolean, asInt64, asDouble)
+
+  TEST_METHOD(TestAsConverters) {
+    CheckAsConverter((JSValueObject{{"prop1", 42}}), "", true, 0, 0);
+    CheckAsConverter(JSValue::EmptyObject, "", false, 0, 0);
+    CheckAsConverter((JSValueArray{42, 78}), "", true, 0, 0);
+    CheckAsConverter(JSValue::EmptyArray, "", false, 0, 0);
+    CheckAsConverter("", "", false, 0, 0);
+    CheckAsConverter("  ", "  ", false, 0, 0);
+    CheckAsConverter("42", "42", false, 42, 42);
+    CheckAsConverter("  42  ", "  42  ", false, 42, 42);
+    CheckAsConverter("4.2", "4.2", false, 4, 4.2);
+    CheckAsConverter("Hello", "Hello", false, 0, NAN);
+    CheckAsConverter("true", "true", true, 0, NAN);
+    CheckAsConverter("false", "false", false, 0, NAN);
+    CheckAsConverter("True", "True", true, 0, NAN);
+    CheckAsConverter("False", "False", false, 0, NAN);
+    CheckAsConverter("TRUE", "TRUE", true, 0, NAN);
+    CheckAsConverter("FALSE", "FALSE", false, 0, NAN);
+    CheckAsConverter("on", "on", true, 0, NAN);
+    CheckAsConverter("off", "off", false, 0, NAN);
+    CheckAsConverter("On", "On", true, 0, NAN);
+    CheckAsConverter("Off", "Off", false, 0, NAN);
+    CheckAsConverter("ON", "ON", true, 0, NAN);
+    CheckAsConverter("OFF", "OFF", false, 0, NAN);
+    CheckAsConverter("yes", "yes", true, 0, NAN);
+    CheckAsConverter("no", "no", false, 0, NAN);
+    CheckAsConverter("y", "y", true, 0, NAN);
+    CheckAsConverter("n", "n", false, 0, NAN);
+    CheckAsConverter("Y", "Y", true, 0, NAN);
+    CheckAsConverter("N", "N", false, 0, NAN);
+    CheckAsConverter("1", "1", true, 1, 1);
+    CheckAsConverter("0", "0", false, 0, 0);
+    CheckAsConverter(true, "true", true, 1, 1);
+    CheckAsConverter(false, "false", false, 0, 0);
+    CheckAsConverter(0, "0", false, 0, 0);
+    CheckAsConverter(42, "42", true, 42, 42);
+    CheckAsConverter(
+        std::numeric_limits<int64_t>::max(),
+        "9223372036854775807",
+        true,
+        std::numeric_limits<int64_t>::max(),
+        (double)std::numeric_limits<int64_t>::max());
+    CheckAsConverter(
+        std::numeric_limits<int64_t>::min(),
+        "-9223372036854775808",
+        true,
+        std::numeric_limits<int64_t>::min(),
+        (double)std::numeric_limits<int64_t>::min());
+    CheckAsConverter(0.0, "0", false, 0, 0);
+    CheckAsConverter(4.2, "4.2", true, 4, 4.2);
+    CheckAsConverter(-4.2, "-4.2", true, -4, -4.2);
+    CheckAsConverter(std::numeric_limits<double>::max(), "1.79769e+308", true, 0, std::numeric_limits<double>::max());
+    CheckAsConverter(
+        -std::numeric_limits<double>::max(), "-1.79769e+308", true, 0, -std::numeric_limits<double>::max());
+    CheckAsConverter(NAN, "NaN", false, 0, NAN);
+    CheckAsConverter(INFINITY, "Infinity", true, 0, INFINITY);
+    CheckAsConverter(-INFINITY, "-Infinity", true, 0, -INFINITY);
+    CheckAsConverter(JSValue::Null, "null", false, 0, 0);
+  }
+
+  TEST_METHOD(TestExplicitNumberConversion) {
+    // Check that explicit number conversions are defined
+    TestCheckEqual(42, static_cast<int8_t>(JSValue{42}));
+    TestCheckEqual(42, static_cast<int16_t>(JSValue{42}));
+    TestCheckEqual(42, static_cast<int32_t>(JSValue{42}));
+    TestCheckEqual(42, static_cast<int64_t>(JSValue{42}));
+    TestCheckEqual(42u, static_cast<uint8_t>(JSValue{42}));
+    TestCheckEqual(42u, static_cast<uint16_t>(JSValue{42}));
+    TestCheckEqual(42u, static_cast<uint32_t>(JSValue{42}));
+    TestCheckEqual(42u, static_cast<uint64_t>(JSValue{42}));
+    TestCheckEqual((float)4.2, static_cast<float>(JSValue{4.2}));
+    TestCheckEqual(4.2, static_cast<double>(JSValue{4.2}));
   }
 
   TEST_METHOD(TestJSValueObject1) {
@@ -213,490 +654,592 @@ TEST_CLASS (JSValueTest) {
     TestCheck(value[4] == nullptr);
   }
 
-  void CheckConversion(
-      JSValue const &value, char const *strVal, bool boolVal, int64_t intVal, double doubleVal) noexcept {
-    TestCheckEqual(strVal, value.AsString());
-    TestCheckEqual(boolVal, value.AsBoolean());
-    TestCheckEqual(intVal, value.AsInt64());
-    if (std::isnan(doubleVal)) {
-      TestCheck(std::isnan(value.AsDouble()));
+  void CheckJSConversionImpl(
+      char const *file,
+      int line,
+      JSValue const &jsValue,
+      char const *stringValue,
+      bool boolValue,
+      double numberValue,
+      char const *message) noexcept {
+    // We must have "%s" parameter for messages because the first format parameter must be a constant.
+    TestCheckEqualAt(file, line, stringValue, jsValue.AsJSString(), "%s", message);
+    TestCheckEqualAt(file, line, boolValue, jsValue.AsJSBoolean(), "%s", message);
+    if (std::isnan(numberValue)) {
+      TestCheckAt(file, line, std::isnan(jsValue.AsJSNumber()), "%s", message);
     } else {
-      TestCheckEqual(doubleVal, value.AsDouble());
+      TestCheckEqualAt(file, line, numberValue, jsValue.AsJSNumber(), "%s", message);
     }
   }
 
+#define CheckJSConversion(jsValue, stringValue, boolValue, numberValue) \
+  CheckJSConversionImpl(                                                \
+      __FILE__,                                                         \
+      __LINE__,                                                         \
+      jsValue,                                                          \
+      stringValue,                                                      \
+      boolValue,                                                        \
+      numberValue,                                                      \
+      "Conversion: [ " #jsValue " ==> " #stringValue ", " #boolValue ", " #numberValue " ] ");
+
   TEST_METHOD(TestDefaultAsConverters) {
-    CheckConversion(false, "false", false, 0, 0);
-    CheckConversion(true, "true", true, 1, 1);
-    CheckConversion(0, "0", false, 0, 0);
-    CheckConversion(1, "1", true, 1, 1);
-    CheckConversion("0", "0", true, 0, 0);
-    CheckConversion("000", "000", true, 0, 0);
-    CheckConversion("1", "1", true, 1, 1);
-    CheckConversion(NAN, "NaN", false, 0, NAN);
-    CheckConversion(INFINITY, "Infinity", true, std::numeric_limits<int64_t>::max(), INFINITY);
-    CheckConversion(-INFINITY, "-Infinity", true, std::numeric_limits<int64_t>::min(), -INFINITY);
-    CheckConversion("", "", false, 0, 0);
-    CheckConversion("20", "20", true, 20, 20);
-    CheckConversion("twenty", "twenty", true, 0, NAN);
-    CheckConversion(JSValueArray{}, "", true, 0, 0);
-    CheckConversion(JSValueArray{20}, "20", true, 20, 20);
-    CheckConversion(JSValueArray{10, 20}, "10,20", true, 0, NAN);
-    CheckConversion(JSValueArray{"twenty"}, "twenty", true, 0, NAN);
-    CheckConversion(JSValueArray{"ten", "twenty"}, "ten,twenty", true, 0, NAN);
-    CheckConversion(JSValueArray{NAN}, "NaN", true, 0, NAN);
-    CheckConversion(JSValueObject{}, "[object Object]", true, 0, NAN);
-    CheckConversion(nullptr, "null", false, 0, 0);
+    CheckJSConversion(false, "false", false, 0);
+    CheckJSConversion(true, "true", true, 1);
+    CheckJSConversion(0, "0", false, 0);
+    CheckJSConversion(1, "1", true, 1);
+    CheckJSConversion("0", "0", true, 0);
+    CheckJSConversion("000", "000", true, 0);
+    CheckJSConversion("1", "1", true, 1);
+    CheckJSConversion(NAN, "NaN", false, NAN);
+    CheckJSConversion(INFINITY, "Infinity", true, INFINITY);
+    CheckJSConversion(-INFINITY, "-Infinity", true, -INFINITY);
+    CheckJSConversion("", "", false, 0);
+    CheckJSConversion("20", "20", true, 20);
+    CheckJSConversion("twenty", "twenty", true, NAN);
+    CheckJSConversion(JSValueArray{}, "", true, 0);
+    CheckJSConversion(JSValueArray{20}, "20", true, 20);
+    CheckJSConversion((JSValueArray{10, 20}), "10,20", true, NAN);
+    CheckJSConversion(JSValueArray{"twenty"}, "twenty", true, NAN);
+    CheckJSConversion((JSValueArray{"ten", "twenty"}), "ten,twenty", true, NAN);
+    CheckJSConversion(JSValueArray{NAN}, "NaN", true, NAN);
+    CheckJSConversion(JSValueObject{}, "[object Object]", true, NAN);
+    CheckJSConversion(nullptr, "null", false, 0);
   }
 
-  TEST_METHOD(TestEqualsWithConversion) {
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion(nullptr) == true);
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{nullptr}.EqualsAfterConversion(0.0) == false);
+  TEST_METHOD(TestJSEquals) {
+    TestCheck(JSValue{nullptr}.JSEquals(nullptr) == true);
+    TestCheck(JSValue{nullptr}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{nullptr}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{nullptr}.JSEquals("") == false);
+    TestCheck(JSValue{nullptr}.JSEquals(false) == false);
+    TestCheck(JSValue{nullptr}.JSEquals(0) == false);
+    TestCheck(JSValue{nullptr}.JSEquals(0.0) == false);
 
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueObject{}) == true);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion("[object Object]") == true);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{JSValueObject{}}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueObject{}) == true);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("") == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("0") == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("1") == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("true") == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("false") == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("Hello") == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals("[object Object]") == true);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(false) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(true) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(0) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(5) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(1) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(0.0) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(0.5) == false);
+    TestCheck(JSValue{JSValueObject{}}.JSEquals(1.0) == false);
 
+    TestCheck(
+        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}}).JSEquals(JSValueObject{{"prop2", 0}, {"prop1", "2"}}) ==
+        true);
+    TestCheck(JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}}).JSEquals(JSValueObject{{"prop2", 0}}) == false);
     TestCheck(
         JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}})
-            .EqualsAfterConversion(JSValueObject{{"prop2", 0}, {"prop1", "2"}}) == true);
+            .JSEquals(JSValueObject{{"prop1", 2}, {"prop25", false}}) == false);
     TestCheck(
-        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}}).EqualsAfterConversion(JSValueObject{{"prop2", 0}}) ==
+        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}}).JSEquals(JSValueObject{{"prop1", 2}, {"prop2", true}}) ==
         false);
-    TestCheck(
-        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}})
-            .EqualsAfterConversion(JSValueObject{{"prop1", 2}, {"prop25", false}}) == false);
-    TestCheck(
-        JSValue(JSValueObject{{"prop1", 2}, {"prop2", false}})
-            .EqualsAfterConversion(JSValueObject{{"prop1", 2}, {"prop2", true}}) == false);
 
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{}) == true);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("") == true);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(false) == true);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(0) == true);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(0.0) == true);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{JSValueArray{}}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{}) == true);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals("") == true);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals("0") == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals("1") == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals("true") == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals("false") == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals("Hello") == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(false) == true);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(true) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(0) == true);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(5) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(1) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(0.0) == true);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(0.5) == false);
+    TestCheck(JSValue{JSValueArray{}}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{1}) == true);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"1"}) == true);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{true}) == true);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("1") == true);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(true) == true);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(1) == true);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{JSValueArray{1}}.EqualsAfterConversion(1.0) == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{1}) == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{true}) == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals("") == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals("0") == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals("1") == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals("true") == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals("false") == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals("Hello") == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(false) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(true) == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(0) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(5) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(1) == true);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(0.0) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(0.5) == false);
+    TestCheck(JSValue{JSValueArray{1}}.JSEquals(1.0) == true);
 
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"Hello"}) == true);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion("Hello") == true);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{JSValueArray{"Hello"}}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{"Hello"}) == true);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals("") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals("0") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals("1") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals("true") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals("false") == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals("Hello") == true);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(false) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(true) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(0) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(5) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(1) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(0.0) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(0.5) == false);
+    TestCheck(JSValue{JSValueArray{"Hello"}}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{0, 1}) == true);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{false, true}) == true);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"0", "1"}) == true);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(JSValueArray{"0", true}) == true);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("") == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("0") == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("1") == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("0,1") == true);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("true") == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("false") == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(false) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(true) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(0) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(5) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(1) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue(JSValueArray{0, 1}).EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(nullptr) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{0, 1}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{false, true}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{"0", "1"}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(JSValueArray{"0", true}) == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("0") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("1") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("0,1") == true);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("true") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("false") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals("Hello") == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(false) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(true) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(0) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(5) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(1) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(0.0) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(0.5) == false);
+    TestCheck(JSValue(JSValueArray{0, 1}).JSEquals(1.0) == false);
 
-    TestCheck(JSValue{""}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{}) == true);
-    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(JSValueArray{""}) == true);
-    TestCheck(JSValue{""}.EqualsAfterConversion("") == true);
-    TestCheck(JSValue{""}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(false) == true);
-    TestCheck(JSValue{""}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(0) == true);
-    TestCheck(JSValue{""}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(0.0) == true);
-    TestCheck(JSValue{""}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{""}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{""}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{""}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{""}.JSEquals(JSValueArray{}) == true);
+    TestCheck(JSValue{""}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{""}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{""}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{""}.JSEquals(JSValueArray{""}) == true);
+    TestCheck(JSValue{""}.JSEquals("") == true);
+    TestCheck(JSValue{""}.JSEquals("1") == false);
+    TestCheck(JSValue{""}.JSEquals("Hello") == false);
+    TestCheck(JSValue{""}.JSEquals(false) == true);
+    TestCheck(JSValue{""}.JSEquals(true) == false);
+    TestCheck(JSValue{""}.JSEquals(0) == true);
+    TestCheck(JSValue{""}.JSEquals(5) == false);
+    TestCheck(JSValue{""}.JSEquals(1) == false);
+    TestCheck(JSValue{""}.JSEquals(0.0) == true);
+    TestCheck(JSValue{""}.JSEquals(0.5) == false);
+    TestCheck(JSValue{""}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(JSValueArray{"Hello"}) == true);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion("Hello") == true);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{"Hello"}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(JSValueArray{"Hello"}) == true);
+    TestCheck(JSValue{"Hello"}.JSEquals("") == false);
+    TestCheck(JSValue{"Hello"}.JSEquals("1") == false);
+    TestCheck(JSValue{"Hello"}.JSEquals("Hello") == true);
+    TestCheck(JSValue{"Hello"}.JSEquals(false) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(true) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(0) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(5) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(1) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(0.0) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(0.5) == false);
+    TestCheck(JSValue{"Hello"}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{"0"}) == true);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(JSValueArray{0}) == true);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion("0") == true);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(false) == true);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(0) == true);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(0.0) == true);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{"0"}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{"0"}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{"0"}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{"0"}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{"0"}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{"0"}.JSEquals(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{"0"}.JSEquals(JSValueArray{0}) == true);
+    TestCheck(JSValue{"0"}.JSEquals("") == false);
+    TestCheck(JSValue{"0"}.JSEquals("0") == true);
+    TestCheck(JSValue{"0"}.JSEquals("Hello") == false);
+    TestCheck(JSValue{"0"}.JSEquals(false) == true);
+    TestCheck(JSValue{"0"}.JSEquals(true) == false);
+    TestCheck(JSValue{"0"}.JSEquals(0) == true);
+    TestCheck(JSValue{"0"}.JSEquals(5) == false);
+    TestCheck(JSValue{"0"}.JSEquals(1) == false);
+    TestCheck(JSValue{"0"}.JSEquals(0.0) == true);
+    TestCheck(JSValue{"0"}.JSEquals(0.5) == false);
+    TestCheck(JSValue{"0"}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{"1"}) == true);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(JSValueArray{1}) == true);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion("1") == true);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(true) == true);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(1) == true);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{"1"}.EqualsAfterConversion(1.0) == true);
+    TestCheck(JSValue{"1"}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{"1"}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{"1"}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{"1"}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{"1"}.JSEquals(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{"1"}.JSEquals(JSValueArray{1}) == true);
+    TestCheck(JSValue{"1"}.JSEquals("") == false);
+    TestCheck(JSValue{"1"}.JSEquals("1") == true);
+    TestCheck(JSValue{"1"}.JSEquals("Hello") == false);
+    TestCheck(JSValue{"1"}.JSEquals(false) == false);
+    TestCheck(JSValue{"1"}.JSEquals(true) == true);
+    TestCheck(JSValue{"1"}.JSEquals(0) == false);
+    TestCheck(JSValue{"1"}.JSEquals(5) == false);
+    TestCheck(JSValue{"1"}.JSEquals(1) == true);
+    TestCheck(JSValue{"1"}.JSEquals(0.0) == false);
+    TestCheck(JSValue{"1"}.JSEquals(0.5) == false);
+    TestCheck(JSValue{"1"}.JSEquals(1.0) == true);
 
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{true}) == true);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(JSValueArray{"true"}) == true);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion("true") == true);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{"true"}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{"true"}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{"true"}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{"true"}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{"true"}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{"true"}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{"true"}.JSEquals(JSValueArray{true}) == true);
+    TestCheck(JSValue{"true"}.JSEquals(JSValueArray{"true"}) == true);
+    TestCheck(JSValue{"true"}.JSEquals("") == false);
+    TestCheck(JSValue{"true"}.JSEquals("1") == false);
+    TestCheck(JSValue{"true"}.JSEquals("Hello") == false);
+    TestCheck(JSValue{"true"}.JSEquals("true") == true);
+    TestCheck(JSValue{"true"}.JSEquals(false) == false);
+    TestCheck(JSValue{"true"}.JSEquals(true) == false);
+    TestCheck(JSValue{"true"}.JSEquals(0) == false);
+    TestCheck(JSValue{"true"}.JSEquals(5) == false);
+    TestCheck(JSValue{"true"}.JSEquals(1) == false);
+    TestCheck(JSValue{"true"}.JSEquals(0.0) == false);
+    TestCheck(JSValue{"true"}.JSEquals(0.5) == false);
+    TestCheck(JSValue{"true"}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{"[object Object]"}.EqualsAfterConversion(JSValueObject{}) == true);
+    TestCheck(JSValue{"[object Object]"}.JSEquals(JSValueObject{}) == true);
 
-    TestCheck(JSValue{true}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{1}) == true);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"1"}) == true);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion("1") == true);
-    TestCheck(JSValue{true}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(true) == true);
-    TestCheck(JSValue{true}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(1) == true);
-    TestCheck(JSValue{true}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{true}.EqualsAfterConversion(1.0) == true);
+    TestCheck(JSValue{true}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{1}) == true);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{true}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{true}.JSEquals("") == false);
+    TestCheck(JSValue{true}.JSEquals("0") == false);
+    TestCheck(JSValue{true}.JSEquals("1") == true);
+    TestCheck(JSValue{true}.JSEquals("true") == false);
+    TestCheck(JSValue{true}.JSEquals("false") == false);
+    TestCheck(JSValue{true}.JSEquals("Hello") == false);
+    TestCheck(JSValue{true}.JSEquals(false) == false);
+    TestCheck(JSValue{true}.JSEquals(true) == true);
+    TestCheck(JSValue{true}.JSEquals(0) == false);
+    TestCheck(JSValue{true}.JSEquals(5) == false);
+    TestCheck(JSValue{true}.JSEquals(1) == true);
+    TestCheck(JSValue{true}.JSEquals(0.0) == false);
+    TestCheck(JSValue{true}.JSEquals(0.5) == false);
+    TestCheck(JSValue{true}.JSEquals(1.0) == true);
 
-    TestCheck(JSValue{false}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{}) == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{0}) == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"0"}) == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion("") == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion("0") == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(false) == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(0) == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(0.0) == true);
-    TestCheck(JSValue{false}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{false}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{false}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{false}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{}) == true);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{0}) == true);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{false}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{false}.JSEquals("") == true);
+    TestCheck(JSValue{false}.JSEquals("0") == true);
+    TestCheck(JSValue{false}.JSEquals("1") == false);
+    TestCheck(JSValue{false}.JSEquals("true") == false);
+    TestCheck(JSValue{false}.JSEquals("false") == false);
+    TestCheck(JSValue{false}.JSEquals("Hello") == false);
+    TestCheck(JSValue{false}.JSEquals(false) == true);
+    TestCheck(JSValue{false}.JSEquals(true) == false);
+    TestCheck(JSValue{false}.JSEquals(0) == true);
+    TestCheck(JSValue{false}.JSEquals(5) == false);
+    TestCheck(JSValue{false}.JSEquals(1) == false);
+    TestCheck(JSValue{false}.JSEquals(0.0) == true);
+    TestCheck(JSValue{false}.JSEquals(0.5) == false);
+    TestCheck(JSValue{false}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{0}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{}) == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{0}) == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"0"}) == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion("") == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion("0") == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(false) == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(0) == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(0.0) == true);
-    TestCheck(JSValue{0}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{0}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{0}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{0}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{}) == true);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{0}) == true);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{0}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{0}.JSEquals("") == true);
+    TestCheck(JSValue{0}.JSEquals("0") == true);
+    TestCheck(JSValue{0}.JSEquals("1") == false);
+    TestCheck(JSValue{0}.JSEquals("true") == false);
+    TestCheck(JSValue{0}.JSEquals("false") == false);
+    TestCheck(JSValue{0}.JSEquals("Hello") == false);
+    TestCheck(JSValue{0}.JSEquals(false) == true);
+    TestCheck(JSValue{0}.JSEquals(true) == false);
+    TestCheck(JSValue{0}.JSEquals(0) == true);
+    TestCheck(JSValue{0}.JSEquals(5) == false);
+    TestCheck(JSValue{0}.JSEquals(1) == false);
+    TestCheck(JSValue{0}.JSEquals(0.0) == true);
+    TestCheck(JSValue{0}.JSEquals(0.5) == false);
+    TestCheck(JSValue{0}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{1}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{1}) == true);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"1"}) == true);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion("1") == true);
-    TestCheck(JSValue{1}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(true) == true);
-    TestCheck(JSValue{1}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(1) == true);
-    TestCheck(JSValue{1}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{1}.EqualsAfterConversion(1.0) == true);
+    TestCheck(JSValue{1}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{1}) == true);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{1}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{1}.JSEquals("") == false);
+    TestCheck(JSValue{1}.JSEquals("0") == false);
+    TestCheck(JSValue{1}.JSEquals("1") == true);
+    TestCheck(JSValue{1}.JSEquals("true") == false);
+    TestCheck(JSValue{1}.JSEquals("false") == false);
+    TestCheck(JSValue{1}.JSEquals("Hello") == false);
+    TestCheck(JSValue{1}.JSEquals(false) == false);
+    TestCheck(JSValue{1}.JSEquals(true) == true);
+    TestCheck(JSValue{1}.JSEquals(0) == false);
+    TestCheck(JSValue{1}.JSEquals(5) == false);
+    TestCheck(JSValue{1}.JSEquals(1) == true);
+    TestCheck(JSValue{1}.JSEquals(0.0) == false);
+    TestCheck(JSValue{1}.JSEquals(0.5) == false);
+    TestCheck(JSValue{1}.JSEquals(1.0) == true);
 
-    TestCheck(JSValue{5}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(5) == true);
-    TestCheck(JSValue{5}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{5}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{5}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{5}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{5}.JSEquals("") == false);
+    TestCheck(JSValue{5}.JSEquals("0") == false);
+    TestCheck(JSValue{5}.JSEquals("1") == false);
+    TestCheck(JSValue{5}.JSEquals("true") == false);
+    TestCheck(JSValue{5}.JSEquals("false") == false);
+    TestCheck(JSValue{5}.JSEquals("Hello") == false);
+    TestCheck(JSValue{5}.JSEquals(false) == false);
+    TestCheck(JSValue{5}.JSEquals(true) == false);
+    TestCheck(JSValue{5}.JSEquals(0) == false);
+    TestCheck(JSValue{5}.JSEquals(5) == true);
+    TestCheck(JSValue{5}.JSEquals(1) == false);
+    TestCheck(JSValue{5}.JSEquals(0.0) == false);
+    TestCheck(JSValue{5}.JSEquals(0.5) == false);
+    TestCheck(JSValue{5}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{}) == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{0}) == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"0"}) == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion("") == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion("0") == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(false) == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(0) == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(0.0) == true);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{0.0}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{0.0}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{}) == true);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{0}) == true);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{"0"}) == true);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{0.0}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{0.0}.JSEquals("") == true);
+    TestCheck(JSValue{0.0}.JSEquals("0") == true);
+    TestCheck(JSValue{0.0}.JSEquals("1") == false);
+    TestCheck(JSValue{0.0}.JSEquals("true") == false);
+    TestCheck(JSValue{0.0}.JSEquals("false") == false);
+    TestCheck(JSValue{0.0}.JSEquals("Hello") == false);
+    TestCheck(JSValue{0.0}.JSEquals(false) == true);
+    TestCheck(JSValue{0.0}.JSEquals(true) == false);
+    TestCheck(JSValue{0.0}.JSEquals(0) == true);
+    TestCheck(JSValue{0.0}.JSEquals(5) == false);
+    TestCheck(JSValue{0.0}.JSEquals(1) == false);
+    TestCheck(JSValue{0.0}.JSEquals(0.0) == true);
+    TestCheck(JSValue{0.0}.JSEquals(0.5) == false);
+    TestCheck(JSValue{0.0}.JSEquals(1.0) == false);
 
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{1}) == true);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"1"}) == true);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion("1") == true);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(true) == true);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(1) == true);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(0.5) == false);
-    TestCheck(JSValue{1.0}.EqualsAfterConversion(1.0) == true);
+    TestCheck(JSValue{1.0}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{1}) == true);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{"1"}) == true);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{1.0}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{1.0}.JSEquals("") == false);
+    TestCheck(JSValue{1.0}.JSEquals("0") == false);
+    TestCheck(JSValue{1.0}.JSEquals("1") == true);
+    TestCheck(JSValue{1.0}.JSEquals("true") == false);
+    TestCheck(JSValue{1.0}.JSEquals("false") == false);
+    TestCheck(JSValue{1.0}.JSEquals("Hello") == false);
+    TestCheck(JSValue{1.0}.JSEquals(false) == false);
+    TestCheck(JSValue{1.0}.JSEquals(true) == true);
+    TestCheck(JSValue{1.0}.JSEquals(0) == false);
+    TestCheck(JSValue{1.0}.JSEquals(5) == false);
+    TestCheck(JSValue{1.0}.JSEquals(1) == true);
+    TestCheck(JSValue{1.0}.JSEquals(0.0) == false);
+    TestCheck(JSValue{1.0}.JSEquals(0.5) == false);
+    TestCheck(JSValue{1.0}.JSEquals(1.0) == true);
 
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(nullptr) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueObject{}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"Hello"}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{0}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"0"}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{1}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"1"}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{true}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(JSValueArray{"true"}) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion("") == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion("0") == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion("1") == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion("true") == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion("false") == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion("Hello") == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(false) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(true) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(0) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(5) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(1) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(0.0) == false);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(0.5) == true);
-    TestCheck(JSValue{0.5}.EqualsAfterConversion(1.0) == false);
+    TestCheck(JSValue{0.5}.JSEquals(nullptr) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueObject{}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{"Hello"}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{0}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{"0"}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{1}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{"1"}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{true}) == false);
+    TestCheck(JSValue{0.5}.JSEquals(JSValueArray{"true"}) == false);
+    TestCheck(JSValue{0.5}.JSEquals("") == false);
+    TestCheck(JSValue{0.5}.JSEquals("0") == false);
+    TestCheck(JSValue{0.5}.JSEquals("1") == false);
+    TestCheck(JSValue{0.5}.JSEquals("true") == false);
+    TestCheck(JSValue{0.5}.JSEquals("false") == false);
+    TestCheck(JSValue{0.5}.JSEquals("Hello") == false);
+    TestCheck(JSValue{0.5}.JSEquals(false) == false);
+    TestCheck(JSValue{0.5}.JSEquals(true) == false);
+    TestCheck(JSValue{0.5}.JSEquals(0) == false);
+    TestCheck(JSValue{0.5}.JSEquals(5) == false);
+    TestCheck(JSValue{0.5}.JSEquals(1) == false);
+    TestCheck(JSValue{0.5}.JSEquals(0.0) == false);
+    TestCheck(JSValue{0.5}.JSEquals(0.5) == true);
+    TestCheck(JSValue{0.5}.JSEquals(1.0) == false);
+  }
+
+  void CheckEqualsImpl(char const *file, int line, JSValue const &left, JSValue const &right) noexcept {
+    TestCheckAt(file, line, left.Equals(right));
+    TestCheckAt(file, line, left == right);
+  }
+
+  void CheckNotEqualsImpl(char const *file, int line, JSValue const &left, JSValue const &right) noexcept {
+    TestCheckAt(file, line, !left.Equals(right));
+    TestCheckAt(file, line, left != right);
+  }
+
+#define CheckEquals(left, right) CheckEqualsImpl(__FILE__, __LINE__, left, right)
+#define CheckNotEquals(left, right) CheckNotEqualsImpl(__FILE__, __LINE__, left, right);
+
+  TEST_METHOD(TestEquals) {
+    CheckEquals(JSValueObject{}, JSValueObject{});
+    CheckEquals((JSValueObject{{"prop1", 1}}), (JSValueObject{{"prop1", 1}}));
+    CheckEquals((JSValueObject{{"prop1", 1}, {"prop2", "Hello"}}), (JSValueObject{{"prop1", 1}, {"prop2", "Hello"}}));
+    CheckEquals((JSValueObject{{"prop1", JSValueObject{}}}), (JSValueObject{{"prop1", JSValueObject{}}}));
+    CheckEquals(
+        (JSValueObject{{"prop1", JSValueObject{{"prop1", 1}}}}),
+        (JSValueObject{{"prop1", JSValueObject{{"prop1", 1}}}}));
+    CheckEquals((JSValueObject{{"prop1", JSValueArray{}}}), (JSValueObject{{"prop1", JSValueArray{}}}));
+    CheckEquals((JSValueObject{{"prop1", JSValueArray{1}}}), (JSValueObject{{"prop1", JSValueArray{1}}}));
+    CheckNotEquals((JSValueObject{{"prop1", 1}}), JSValueObject{});
+    CheckNotEquals((JSValueObject{{"prop1", 1}}), (JSValueObject{{"prop1", 2}}));
+    CheckNotEquals(JSValueObject{}, JSValueArray{});
+    CheckNotEquals(JSValueObject{}, "");
+    CheckNotEquals(JSValueObject{}, false);
+    CheckNotEquals(JSValueObject{}, true);
+    CheckNotEquals(JSValueObject{}, 0);
+    CheckNotEquals(JSValueObject{}, 0.0);
+
+    CheckEquals(JSValueArray{}, JSValueArray{});
+    CheckEquals(JSValueArray{1}, JSValueArray{1});
+    CheckEquals((JSValueArray{1, "Hello"}), (JSValueArray{1, "Hello"}));
+    CheckEquals(JSValueArray{JSValueArray{}}, JSValueArray{JSValueArray{}});
+    CheckEquals(JSValueArray{JSValueArray{1}}, JSValueArray{JSValueArray{1}});
+    CheckEquals(JSValueArray{JSValueObject{}}, JSValueArray{JSValueObject{}});
+    CheckEquals((JSValueArray{JSValueObject{{"prop1", 1}}}), (JSValueArray{JSValueObject{{"prop1", 1}}}));
+    CheckNotEquals(JSValueArray{1}, JSValueArray{});
+    CheckNotEquals(JSValueArray{1}, JSValueArray{2});
+    CheckNotEquals(JSValueArray{}, JSValueObject{});
+    CheckNotEquals(JSValueArray{}, "");
+    CheckNotEquals(JSValueArray{}, false);
+    CheckNotEquals(JSValueArray{}, true);
+    CheckNotEquals(JSValueArray{}, 0);
+    CheckNotEquals(JSValueArray{}, 0.0);
+
+    CheckEquals("", "");
+    CheckEquals("Hello", "Hello");
+    CheckNotEquals("Hello1", "Hello2");
+    CheckNotEquals("", JSValueObject{});
+    CheckNotEquals("", JSValueArray{});
+    CheckNotEquals("", false);
+    CheckNotEquals("", 0);
+    CheckNotEquals("", 0.0);
+
+    CheckEquals(false, false);
+    CheckEquals(true, true);
+    CheckNotEquals(false, true);
+    CheckNotEquals(true, false);
+    CheckNotEquals(false, JSValueObject{});
+    CheckNotEquals(false, JSValueArray{});
+    CheckNotEquals(false, "");
+    CheckNotEquals(false, 0);
+    CheckNotEquals(false, 0.0);
+
+    CheckEquals(0, 0);
+    CheckEquals(42, 42);
+    CheckNotEquals(2, 3);
+    CheckNotEquals(-1, 1);
+    CheckNotEquals(0, JSValueObject{});
+    CheckNotEquals(0, JSValueArray{});
+    CheckNotEquals(0, "");
+    CheckNotEquals(0, false);
+    CheckNotEquals(0, 0.0);
+
+    CheckEquals(0.0, 0.0);
+    CheckEquals(4.2, 4.2);
+    CheckNotEquals(0.2, 0.3);
+    CheckNotEquals(-0.1, 0.1);
+    CheckNotEquals(0.0, JSValueObject{});
+    CheckNotEquals(0.0, JSValueArray{});
+    CheckNotEquals(0.0, "");
+    CheckNotEquals(0.0, false);
+    CheckNotEquals(0.0, 0);
   }
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.h
@@ -10,20 +10,27 @@
 
 namespace winrt::Microsoft::ReactNative {
 
-// Forward declarations
+//==============================================================================
+// Forward declarations.
+//==============================================================================
+
 struct JSValue;
 struct JSValueObjectKeyValue;
 struct JSValueArrayItem;
-IJSValueReader MakeJSValueTreeReader(const JSValue &root) noexcept;
+IJSValueReader MakeJSValueTreeReader(JSValue const &root) noexcept;
 IJSValueReader MakeJSValueTreeReader(JSValue &&root) noexcept;
 IJSValueWriter MakeJSValueTreeWriter() noexcept;
 JSValue TakeJSValue(IJSValueWriter const &writer) noexcept;
 
-// JSValueObject is based on std::map and has a custom constructor with std::intializer_list.
-// It is possible to write: JSValueObject{{"X", 4}, {"Y", 5}} and pass it as JSValue.
-struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
-#pragma region Constructors
+//==============================================================================
+// JSValueObject declaration.
+//==============================================================================
 
+//! JSValueObject is based on std::map and has a custom constructor with std::intializer_list.
+//! It is possible to write: JSValueObject{{"X", 4}, {"Y", 5}} and assign it to JSValue.
+//! It uses the std::less<> comparison algorithm that allows an efficient
+//! key lookup using std::string_view that does not allocate memory for the std::string key.
+struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
   //! Default constructor.
   JSValueObject() = default;
 
@@ -37,39 +44,24 @@ struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
   //! Move-construct JSValueObject from the string-JSValue map.
   JSValueObject(std::map<std::string, JSValue, std::less<>> &&other) noexcept;
 
-#pragma endregion
-
-#pragma region Copy semantic
-
   //! Delete copy constructor to avoid unexpected copies. Use the Copy method instead.
   JSValueObject(JSValueObject const &) = delete;
-
-  //! Delete copy assignment to avoid unexpected copies. Use the Copy method instead.
-  JSValueObject &operator=(JSValueObject const &) = delete;
-
-  //! Do a deep copy of JSValueObject.
-  JSValueObject Copy() const noexcept;
-
-#pragma endregion
-
-#pragma region Move semantic
 
   // Default move constructor.
   JSValueObject(JSValueObject &&) = default;
 
+  //! Delete copy assignment to avoid unexpected copies. Use the Copy method instead.
+  JSValueObject &operator=(JSValueObject const &) = delete;
+
   // Default move assignment.
   JSValueObject &operator=(JSValueObject &&) = default;
 
-#pragma endregion
+  //! Do a deep copy of JSValueObject.
+  JSValueObject Copy() const noexcept;
 
-#pragma region Change JSValueObject
   //! Get a reference to object property value if the property is found,
   //! or a reference to a new property created with JSValue::Null value otherwise.
   JSValue &operator[](std::string_view propertyName) noexcept;
-
-#pragma endregion
-
-#pragma region Inspect JSValueObject
 
   //! Get a reference to object property value if the property is found,
   //! or a reference to JSValue::Null otherwise.
@@ -77,17 +69,13 @@ struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
 
   //! Return true if this JSValueObject is strictly equal to other JSValueObject.
   //! Both objects must have the same set of equal properties.
-  //! Property values must have the same type and value.
+  //! Property values must be equal.
   bool Equals(JSValueObject const &other) const noexcept;
 
   //! Return true if this JSValueObject is strictly equal to other JSValueObject
   //! after their property values are converted to the same type.
-  //! See JSValue::EqualsAfterConversion for details about the conversion.
-  bool EqualsAfterConversion(const JSValueObject &other) const noexcept;
-
-#pragma endregion
-
-#pragma region JSValueObject serialization and deserialization.
+  //! See JSValue::JSEquals for details about the conversion.
+  bool JSEquals(JSValueObject const &other) const noexcept;
 
   //! Create JSValueObject from IJSValueReader.
   static JSValueObject ReadFrom(IJSValueReader const &reader) noexcept;
@@ -95,33 +83,38 @@ struct JSValueObject : std::map<std::string, JSValue, std::less<>> {
   //! Write this JSValueObject to IJSValueWriter.
   void WriteTo(IJSValueWriter const &writer) const noexcept;
 
+#pragma region Deprecated methods
+
+  [[deprecated("Use JSEquals")]] bool EqualsAfterConversion(JSValueObject const &other) const noexcept;
+
 #pragma endregion
 };
 
-#pragma region Standalone JSValueObject functions
+//! True if left.Equals(right)
+bool operator==(JSValueObject const &left, JSValueObject const &right) noexcept;
 
-bool operator==(const JSValueObject &left, const JSValueObject &right) noexcept;
-bool operator!=(const JSValueObject &left, const JSValueObject &right) noexcept;
+//! True if !left.Equals(right)
+bool operator!=(JSValueObject const &left, JSValueObject const &right) noexcept;
 
-#pragma endregion
+//==============================================================================
+// JSValueArray declaration.
+//==============================================================================
 
 //! JSValueArray is based on std::vector<JSValue> and has a custom constructor with std::intializer_list.
-//! It is possible to write: JSValueArray{"X", 4, true} and pass it as JSValue.
+//! It is possible to write: JSValueArray{"X", 42, nullptr, true} and assign it to JSValue.
 struct JSValueArray : std::vector<JSValue> {
-#pragma region Constructors
-
   //! Default constructor.
   JSValueArray() = default;
 
-  //! Constructs JSValueArray with size JSValue::Null elements.
+  //! Constructs JSValueArray with 'size' count of JSValue::Null elements.
   explicit JSValueArray(size_type size) noexcept;
 
-  //! Constructs JSValueArray with size elements.
+  //! Constructs JSValueArray with 'size' count elements.
   //! Each element is a copy of defaultValue.
   JSValueArray(size_type size, JSValue const &defaultValue) noexcept;
 
   //! Construct JSValueArray from the move iterator.
-  template <class TMoveInputIterator>
+  template <class TMoveInputIterator, std::enable_if_t<!std::is_integral_v<TMoveInputIterator>, int> = 1>
   JSValueArray(TMoveInputIterator first, TMoveInputIterator last) noexcept;
 
   //! Move-construct JSValueArray from the initializer list.
@@ -130,46 +123,29 @@ struct JSValueArray : std::vector<JSValue> {
   //! Move-construct JSValueArray from the JSValue vector.
   JSValueArray(std::vector<JSValue> &&other) noexcept;
 
-#pragma endregion
-
-#pragma region Copy semantic
-
   //! Delete copy constructor to avoid unexpected copies. Use the Copy method instead.
   JSValueArray(JSValueArray const &) = delete;
-
-  //! Delete copy assignment to avoid unexpected copies. Use the Copy method instead.
-  JSValueArray &operator=(JSValueArray const &) = delete;
-
-  //! Do a deep copy of JSValueArray.
-  JSValueArray Copy() const noexcept;
-
-#pragma endregion
-
-#pragma region Move semantic
 
   // Default move constructor.
   JSValueArray(JSValueArray &&) = default;
 
+  //! Delete copy assignment to avoid unexpected copies. Use the Copy method instead.
+  JSValueArray &operator=(JSValueArray const &) = delete;
+
   // Default move assignment.
   JSValueArray &operator=(JSValueArray &&) = default;
 
-#pragma endregion
-
-#pragma region Inspect JSValueArray
+  //! Do a deep copy of JSValueArray.
+  JSValueArray Copy() const noexcept;
 
   //! Return true if this JSValueArray is strictly equal to other JSValueArray.
-  //! Both arrays must have the same set of items.
-  //! Items must have the same type and value.
+  //! Both arrays must have the same set of items. Items must have the same type and value.
   bool Equals(JSValueArray const &other) const noexcept;
 
   //! Return true if this JSValueArray is strictly equal to other JSValueArray
   //! after their items are converted to the same type.
-  //! See JSValue::EqualsAfterConversion for details about the conversion.
-  bool EqualsAfterConversion(const JSValueArray &other) const noexcept;
-
-#pragma endregion
-
-#pragma region JSValueArray serialization and deserialization.
+  //! See JSValue::JSEquals for details about the conversion.
+  bool JSEquals(JSValueArray const &other) const noexcept;
 
   //! Create JSValueArray from IJSValueReader.
   static JSValueArray ReadFrom(IJSValueReader const &reader) noexcept;
@@ -177,15 +153,22 @@ struct JSValueArray : std::vector<JSValue> {
   //! Write this JSValueArray to IJSValueWriter.
   void WriteTo(IJSValueWriter const &writer) const noexcept;
 
+#pragma region Deprecated methods
+
+  [[deprecated("Use JSEquals")]] bool EqualsAfterConversion(JSValueArray const &other) const noexcept;
+
 #pragma endregion
 };
 
-#pragma region Standalone JSValueArray functions
+//! True if left.Equals(right)
+bool operator==(JSValueArray const &left, JSValueArray const &right) noexcept;
 
-bool operator==(const JSValueArray &left, const JSValueArray &right) noexcept;
-bool operator!=(const JSValueArray &left, const JSValueArray &right) noexcept;
+//! True if !left.Equals(right)
+bool operator!=(JSValueArray const &left, JSValueArray const &right) noexcept;
 
-#pragma endregion
+//==============================================================================
+// JSValue declaration.
+//==============================================================================
 
 //! JSValue represents an immutable JavaScript value that can be passed as a parameter.
 //! It is created to simplify working with IJSValueReader in some complex cases.
@@ -195,16 +178,17 @@ bool operator!=(const JSValueArray &left, const JSValueArray &right) noexcept;
 //! For copy operations the explicit Copy() method must be used.
 //! Note that the move operations are not thread safe.
 struct JSValue {
-#pragma region Predefined constants
+  //! JSValue with JSValueType::Null.
+  static JSValue const Null;
 
-  static const JSValue Null;
-  static const JSValueObject EmptyObject;
-  static const JSValueArray EmptyArray;
-  static const std::string EmptyString;
+  //! JSValue with empty object.
+  static JSValue const EmptyObject;
 
-#pragma endregion
+  //! JSValue with empty array.
+  static JSValue const EmptyArray;
 
-#pragma region Constructors
+  //! JSValue with empty string.
+  static JSValue const EmptyString;
 
   //! Create a Null JSValue.
   JSValue() noexcept;
@@ -236,38 +220,23 @@ struct JSValue {
   //! Create a Double JSValue.
   JSValue(double value) noexcept;
 
-  //! Create JSValue from a type that has WriteValue method defined to write to IJSValueWriter.
-  template <class T>
-  static JSValue From(T const &value) noexcept;
-
-#pragma endregion
-
-#pragma region Destructor
-
-  ~JSValue() noexcept;
-
-#pragma endregion
-
-#pragma region JSValue copy semantic
-
   //! Delete the copy constructor to avoid unexpected copies. Use the Copy method instead.
   JSValue(const JSValue &other) = delete;
-
-  //! Delete the copy assignment to avoid unexpected copies. Use the Copy method instead.
-  JSValue &operator=(const JSValue &other) = delete;
-
-  //! Do a deep copy of JSValue.
-  JSValue Copy() const noexcept;
-
-#pragma endregion
-
-#pragma region JSValue move semantic
 
   //! Move constructor. The 'other' JSValue becomes JSValue::Null.
   JSValue(JSValue &&other) noexcept;
 
+  //! Destroys JSValue.
+  ~JSValue() noexcept;
+
+  //! Delete the copy assignment to avoid unexpected copies. Use the Copy method instead.
+  JSValue &operator=(JSValue const &other) = delete;
+
   //! Move assignment. The 'other' JSValue becomes JSValue::Null.
   JSValue &operator=(JSValue &&other) noexcept;
+
+  //! Do a deep copy of JSValue.
+  JSValue Copy() const noexcept;
 
   //! Move out Object and set this to JSValue::Null. It returns JSValue::EmptyObject
   //! and keeps this JSValue unchanged if current type is not an object.
@@ -276,10 +245,6 @@ struct JSValue {
   //! Move out Array and set this to JSValue::Null. It returns JSValue::EmptyArray
   //! and keeps this JSValue unchanged if current type is not an array.
   JSValueArray MoveArray() noexcept;
-
-#pragma endregion
-
-#pragma region Inspect JSValue
 
   //! Get JSValue type.
   JSValueType Type() const noexcept;
@@ -305,34 +270,135 @@ struct JSValue {
   //! Return pointer to double value if JSValue type is Double, or nullptr otherwise.
   double const *TryGetDouble() const noexcept;
 
-  //! Return true if this JSValue is strictly equal to JSValue.
-  //! Compared values must have the same type and value.
-  //!
-  //! The behavior is similar to JavaScript === operator except for Object and Array for which
-  //! this functions does a deep structured comparison instead of pointer equality.
-  bool Equals(const JSValue &other) const noexcept;
+  //! Return Object representation of JSValue. It is JSValue::EmptyObject if type is not Object.
+  JSValueObject const &AsObject() const noexcept;
 
-  //! Return true if this JSValue is strictly equal to JSValue after they are converted to the same type.
-  //!
-  //! Null is not converted to any other type before comparison.
-  //! Object and Array types are converted first to a String type using AsString() before comparing
-  //! with other types, and then we apply the same rules as for the String type.
-  //! String is converted to Double before comparing with Boolean, Int64, or Double.
-  //! Boolean is converted to 1.0 and +0.0 when comparing with String or Double.
-  //! Boolean is converted to 1 and 0 when comparing with Int64.
-  //! Int64 is converted to Double when comparing with Double.
-  //!
-  //! The behavior is similar to JavaScript == operator except for Object and Array for which
-  //! this functions does a deep structured comparison using EqualsAfterConversion instead
-  //! of pointer equality.
-  bool EqualsAfterConversion(const JSValue &other) const noexcept;
+  //! Return Array representation of JSValue. It is JSValue::EmptyArray if type is not Object.
+  JSValueArray const &AsArray() const noexcept;
 
-#pragma endregion
+  //! Return a string representation of JSValue.
+  //! Null is "null".
+  //! Object and Array are empty strings "".
+  //! Boolean is "true" or "false".
+  //! Int64 is converted to string using integer representation.
+  //! Double uses AsJSString() conversion which uses "NaN", "Infinity", and "-Infinity" for special values.
+  std::string AsString() const noexcept;
 
-#pragma region Inspect JSValueObject
+  //! Return a Boolean representation of JSValue.
+  //! Object and Array are true if they are not empty.
+  //! String is true if it case-insensitively matches "true", "1", "yes", "y", or "on" strings.
+  //! Int64 or Double are false if they are zero or NAN.
+  bool AsBoolean() const noexcept;
+
+  //! Return an int8_t representation of JSValue. It is the same as (int8_t)AsInt64().
+  int8_t AsInt8() const noexcept;
+
+  //! Return an int16_t representation of JSValue. It is the same as (int16_t)AsInt64().
+  int16_t AsInt16() const noexcept;
+
+  //! Return an int32_t representation of JSValue. It is the same as (int32_t)AsInt64().
+  int32_t AsInt32() const noexcept;
+
+  //! Return an int64_t representation of JSValue.
+  //! String is converted to double first before converting to Int64.
+  //! Boolean is converted to 0 or 1.
+  int64_t AsInt64() const noexcept;
+
+  //! Return an uint8_t representation of JSValue. It is the same as (uint8_t)AsInt64().
+  uint8_t AsUInt8() const noexcept;
+
+  //! Return an uint16_t representation of JSValue. It is the same as (uint16_t)AsInt64().
+  uint16_t AsUInt16() const noexcept;
+
+  //! Return an uint32_t representation of JSValue. It is the same as (uint32_t)AsInt64().
+  uint32_t AsUInt32() const noexcept;
+
+  //! Return an uint64_t representation of JSValue. It is the same as (uint64_t)AsInt64().
+  uint64_t AsUInt64() const noexcept;
+
+  //! Return a float representation of JSValue. It is the same as (float)AsDouble().
+  float AsSingle() const noexcept;
+
+  //! Return a double representation of JSValue.
+  //! Boolean is converted to 0.0 or 1.0.
+  //! Null, Object, and Array are 0.
+  double AsDouble() const noexcept;
+
+  //! Cast JSValue to std::string using AsString() call.
+  explicit operator std::string() const noexcept;
+
+  //! Cast JSValue to bool using AsBoolean() call.
+  explicit operator bool() const noexcept;
+
+  //! Cast JSValue to int8_t using AsInt8() call.
+  explicit operator int8_t() const noexcept;
+
+  //! Cast JSValue to int16_t using AsInt16() call.
+  explicit operator int16_t() const noexcept;
+
+  //! Cast JSValue to int32_t using AsInt32() call.
+  explicit operator int32_t() const noexcept;
+
+  //! Cast JSValue to int64_t using AsInt64() call.
+  explicit operator int64_t() const noexcept;
+
+  //! Cast JSValue to uint8_t using AsUInt8() call.
+  explicit operator uint8_t() const noexcept;
+
+  //! Cast JSValue to uint16_t using AsUInt16() call.
+  explicit operator uint16_t() const noexcept;
+
+  //! Cast JSValue to uint32_t using AsUInt32() call.
+  explicit operator uint32_t() const noexcept;
+
+  //! Cast JSValue to uint64_t using AsUInt64() call.
+  explicit operator uint64_t() const noexcept;
+
+  //! Cast JSValue to float using (float)AsDouble() call.
+  explicit operator float() const noexcept;
+
+  //! Cast JSValue to double using AsDouble() call.
+  explicit operator double() const noexcept;
+
+  //! Return a string representation of JSValue. It is equivalent to JavaScript String(value) result.
+  std::string AsJSString() const noexcept;
+
+  //! Return a bool representation of JSValue. It is equivalent to JavaScript Boolean(value) result.
+  bool AsJSBoolean() const noexcept;
+
+  //! Return a Double representation of JSValue. It is equivalent to JavaScript Number(value) result.
+  double AsJSNumber() const noexcept;
+
+  //! Convert JSValue to a readable string that can be used for logging.
+  std::string ToString() const noexcept;
+
+  //! Return value T that is created from JSValue using the ReadValue function override.
+  //! Default T is constructed by using default constructor.
+  template <
+      class T,
+      std::enable_if_t<std::is_default_constructible_v<T> && !std::is_constructible_v<T, std::nullptr_t>, int> = 0>
+  T To() const noexcept;
+
+  //! Return value T that is created from JSValue using the ReadValue function override.
+  //! Default T is constructed by using constructor that receives nullptr as a parameter.
+  template <class T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int> = 0>
+  T To() const noexcept;
+
+  //! Return value T that is created from JSValue using the ReadValue function override.
+  //! Default T is constructed from the provided 'default' value.
+  template <class T>
+  T To(T &&defaultValue) const noexcept;
+
+  //! Create JSValue from a type that has WriteValue method defined to write to IJSValueWriter.
+  template <class T>
+  static JSValue From(T const &value) noexcept;
 
   //! Return property count if JSValue is Object, or 0 otherwise.
   size_t PropertyCount() const noexcept;
+
+  //! Get a pointer to object property value if JSValue type is Object and the property is found,
+  //! or nullptr otherwise.
+  JSValue const *TryGetObjectProperty(std::string_view propertyName) const noexcept;
 
   //! Get a reference to object property value if JSValue type is Object and the property is found,
   //! or a reference to JSValue::Null otherwise.
@@ -342,12 +408,12 @@ struct JSValue {
   //! or a reference to JSValue::Null otherwise.
   JSValue const &operator[](std::string_view propertyName) const noexcept;
 
-#pragma endregion
-
-#pragma region Inspect JSValueArray
-
   //! Return item count if JSValue is Array, or 0 otherwise.
   size_t ItemCount() const noexcept;
+
+  //! Get a pointer to array item if JSValue type is Array and the index is in bounds,
+  //! or nullptr otherwise.
+  JSValue const *TryGetArrayItem(JSValueArray::size_type index) const noexcept;
 
   //! Get a reference to array item if JSValue type is Array and the index is in bounds,
   //! or a reference to JSValue::Null otherwise.
@@ -357,114 +423,68 @@ struct JSValue {
   //! or a reference to JSValue::Null otherwise.
   JSValue const &operator[](JSValueArray::size_type index) const noexcept;
 
-#pragma endregion
+  //! Return true if this JSValue is strictly equal to JSValue.
+  //! Compared values must have the same type and value.
+  //!
+  //! The behavior is similar to JavaScript === operator except for Object and Array where
+  //! this functions does a deep structured comparison instead of pointer equality.
+  bool Equals(JSValue const &other) const noexcept;
 
-#pragma region Convert JSValue to other type
-
-  //! Return Object representation of JSValue. It is JSValue::EmptyObject if type is not Object.
-  JSValueObject const &AsObject() const noexcept;
-
-  //! Return Array representation of JSValue. It is JSValue::EmptyArray if type is not Object.
-  JSValueArray const &AsArray() const noexcept;
-
-  //! Return a string representation of JSValue. It is the same as JavaScript String(value) result.
-  std::string AsString() const noexcept;
-
-  //! Return a Boolean representation of JSValue. It is the same as JavaScript Boolean(value) result.
-  bool AsBoolean() const noexcept;
-
-  //! Return an Int8 representation of JSValue. It is the same as JavaScript Number(value) result casted to int8_t.
-  int8_t AsInt8() const noexcept;
-
-  //! Return an Int16 representation of JSValue. It is the same as JavaScript Number(value) result casted to int16_t.
-  int16_t AsInt16() const noexcept;
-
-  //! Return an Int32 representation of JSValue. It is the same as JavaScript Number(value) result casted to int32_t.
-  int32_t AsInt32() const noexcept;
-
-  //! Return an Int64 representation of JSValue. It is the same as JavaScript Number(value) result casted to int64_t.
-  int64_t AsInt64() const noexcept;
-
-  //! Return an UInt8 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint8_t.
-  uint8_t AsUInt8() const noexcept;
-
-  //! Return an UInt16 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint16_t.
-  uint16_t AsUInt16() const noexcept;
-
-  //! Return an UInt32 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint32_t.
-  uint32_t AsUInt32() const noexcept;
-
-  //! Return an UInt64 representation of JSValue. It is the same as JavaScript Number(value) result casted to uint64_t.
-  uint64_t AsUInt64() const noexcept;
-
-  //! Return a Double representation of JSValue. It is the same as JavaScript Number(value) result.
-  double AsDouble() const noexcept;
-
-  //! Return an Float representation of JSValue. It is the same as JavaScript Number(value) result casted to float.
-  float AsFloat() const noexcept;
-
-  //! Return value T that is created from JSValue using the ReadValue function override.
-  //! Default T is constructed by using default constructor.
-  template <
-      class T,
-      std::enable_if_t<std::is_default_constructible_v<T> && !std::is_constructible_v<T, std::nullptr_t>, int> = 0>
-  T As() const noexcept;
-
-  //! Return value T that is created from JSValue using the ReadValue function override.
-  //! Default T is constructed by using constructor that receives nullptr as a parameter.
-  template <class T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int> = 0>
-  T As() const noexcept;
-
-  //! Return value T that is created from JSValue using the ReadValue function override.
-  //! Default T is constructed from the provided 'default' value.
-  template <class T>
-  T As(T &&defaultValue) const noexcept;
-
-  //! Convert JSValue to a readable string that can be used for logging.
-  std::string ToString() const noexcept;
-
-#pragma endregion
-
-#pragma region JSValue serialization and deserialization.
+  //! Return true if this JSValue is strictly equal to JSValue after they are converted to the same type.
+  //!
+  //! Null is not converted to any other type before comparison.
+  //! Object and Array types are converted first to a String type using AsString() before comparing
+  //! with other types, and then we apply the same rules as for the String type.
+  //! String is converted to Double before comparing with Boolean, Int64, or Double.
+  //! Boolean is converted to 1.0 and +0.0 when comparing with String, Int64, or Double.
+  //! Int64 is converted to Double before comparing with other types.
+  //!
+  //! The behavior is similar to JavaScript == operator except for Object and Array for which
+  //! this functions does a deep structured comparison using JSEquals instead
+  //! of pointer equality.
+  bool JSEquals(JSValue const &other) const noexcept;
 
   //! Create JSValue from IJSValueReader.
   static JSValue ReadFrom(IJSValueReader const &reader) noexcept;
 
+  //! Create JSValueObject from IJSValueReader.
+  static JSValueObject ReadObjectFrom(IJSValueReader const &reader) noexcept;
+
+  //! Create JSValueArray from IJSValueReader.
+  static JSValueArray ReadArrayFrom(IJSValueReader const &reader) noexcept;
+
   //! Write this JSValue to IJSValueWriter.
   void WriteTo(IJSValueWriter const &writer) const noexcept;
-
-#pragma endregion
 
 #pragma region Deprecated methods
 
   // The methods below are deprecated in favor of other methods with clearer semantic
   [[deprecated("Use TryGetObject or AsObject")]] JSValueObject const &Object() const noexcept;
   [[deprecated("Use TryGetArray or As Array")]] JSValueArray const &Array() const noexcept;
-  [[deprecated("Use TryGetString or AsString")]] std::string const &String() const noexcept;
-  [[deprecated("Use TryGetBoolean or AsBoolean")]] bool Boolean() const noexcept;
-  [[deprecated("Use TryGetInt64 or AsInt64")]] int64_t Int64() const noexcept;
-  [[deprecated("Use TryGetDouble or AsDouble")]] double Double() const noexcept;
+  [[deprecated("Use TryGetString, AsString, or AsJSString")]] std::string const &String() const noexcept;
+  [[deprecated("Use TryGetBoolean, AsBoolean, or AsJSBoolean")]] bool Boolean() const noexcept;
+  [[deprecated("Use TryGetInt64, AsInt64, or AsJSNumber")]] int64_t Int64() const noexcept;
+  [[deprecated("Use TryGetDouble, AsDouble, or AsJSNumber")]] double Double() const noexcept;
 
   // We have renamed or moved the methods below.
   template <class T>
-  [[deprecated("Use As<T>")]] T To() const noexcept;
+  [[deprecated("Use JSValue::To")]] T As() const noexcept;
+  template <class T>
+  [[deprecated("Use JSValue::To")]] T As(T &&defaultValue) const noexcept;
   [[deprecated("Use MoveObject")]] JSValueObject TakeObject() noexcept;
   [[deprecated("Use MoveArray")]] JSValueArray TakeArray() noexcept;
-  [[deprecated("Use JSValueObject::Copy")]] static JSValueObject CopyObject(const JSValueObject &other) noexcept;
-  [[deprecated("Use JSValueArray::Copy")]] static JSValueArray CopyArray(const JSValueArray &other) noexcept;
-  [[deprecated("Use JSValueObject::ReadFrom")]] static JSValueObject ReadObjectFrom(
-      IJSValueReader const &reader) noexcept;
-  [[deprecated("Use JSValueArray::ReadFrom")]] static JSValueArray ReadArrayFrom(IJSValueReader const &reader) noexcept;
+  [[deprecated("Use JSValueObject::Copy")]] static JSValueObject CopyObject(JSValueObject const &other) noexcept;
+  [[deprecated("Use JSValueArray::Copy")]] static JSValueArray CopyArray(JSValueArray const &other) noexcept;
   [[deprecated("Use JSValueObject::WriteTo")]] static void WriteObjectTo(
       IJSValueWriter const &writer,
       JSValueObject const &value) noexcept;
   [[deprecated("Use JSValueArray::WriteTo")]] static void WriteArrayTo(
       IJSValueWriter const &writer,
       JSValueArray const &value) noexcept;
+  [[deprecated("Use JSEquals")]] bool EqualsAfterConversion(JSValue const &other) const noexcept;
+  [[deprecated("Use AsSingle")]] float AsFloat() const noexcept;
 
 #pragma endregion
-
-#pragma region Private fields
 
  private: // Instance fields
   JSValueType m_type;
@@ -476,16 +496,17 @@ struct JSValue {
     int64_t m_int64;
     double m_double;
   };
-
-#pragma endregion
 };
 
-#pragma region Standalone JSValue functions
+//! True if left.Equals(right)
+bool operator==(JSValue const &left, JSValue const &right) noexcept;
 
-bool operator==(const JSValue &left, const JSValue &right) noexcept;
-bool operator!=(const JSValue &left, const JSValue &right) noexcept;
+//! True if !left.Equals(right)
+bool operator!=(JSValue const &left, JSValue const &right) noexcept;
 
-#pragma endregion
+//===========================================================================
+// Helper classes for JSValueObject and JSValueArray initialization lists.
+//===========================================================================
 
 //! Helps initialize key-value pairs for JSValueObject.
 //! It creates its own instance of JSValue which then can be moved to JSValueObject.
@@ -510,7 +531,6 @@ struct JSValueArrayItem {
 //===========================================================================
 // Inline JSValueObject implementation.
 //===========================================================================
-
 template <class TMoveInputIterator>
 JSValueObject::JSValueObject(TMoveInputIterator first, TMoveInputIterator last) noexcept {
   auto it = first;
@@ -520,15 +540,20 @@ JSValueObject::JSValueObject(TMoveInputIterator first, TMoveInputIterator last) 
   }
 }
 
+// Deprecated
+inline bool JSValueObject::EqualsAfterConversion(JSValueObject const &other) const noexcept {
+  return JSEquals(other);
+}
+
 //===========================================================================
 // Inline JSValueObject standalone function implementations.
 //===========================================================================
 
-inline bool operator==(const JSValueObject &left, const JSValueObject &right) noexcept {
+inline bool operator==(JSValueObject const &left, JSValueObject const &right) noexcept {
   return left.Equals(right);
 }
 
-inline bool operator!=(const JSValueObject &left, const JSValueObject &right) noexcept {
+inline bool operator!=(JSValueObject const &left, JSValueObject const &right) noexcept {
   return !left.Equals(right);
 }
 
@@ -536,7 +561,7 @@ inline bool operator!=(const JSValueObject &left, const JSValueObject &right) no
 // Inline JSValueArray implementation.
 //===========================================================================
 
-template <class TMoveInputIterator>
+template <class TMoveInputIterator, std::enable_if_t<!std::is_integral_v<TMoveInputIterator>, int>>
 JSValueArray::JSValueArray(TMoveInputIterator first, TMoveInputIterator last) noexcept {
   auto it = first;
   while (it != last) {
@@ -544,15 +569,20 @@ JSValueArray::JSValueArray(TMoveInputIterator first, TMoveInputIterator last) no
   }
 }
 
+// Deprecated
+inline bool JSValueArray::EqualsAfterConversion(JSValueArray const &other) const noexcept {
+  return JSEquals(other);
+}
+
 //===========================================================================
 // Inline JSValueArray standalone function implementations.
 //===========================================================================
 
-inline bool operator==(const JSValueArray &left, const JSValueArray &right) noexcept {
+inline bool operator==(JSValueArray const &left, JSValueArray const &right) noexcept {
   return left.Equals(right);
 }
 
-inline bool operator!=(const JSValueArray &left, const JSValueArray &right) noexcept {
+inline bool operator!=(JSValueArray const &left, JSValueArray const &right) noexcept {
   return !left.Equals(right);
 }
 
@@ -564,7 +594,7 @@ inline bool operator!=(const JSValueArray &left, const JSValueArray &right) noex
 #pragma warning(disable : 26495) // False positive for union member not initialized
 inline JSValue::JSValue() noexcept : m_type{JSValueType::Null}, m_int64{0} {}
 inline JSValue::JSValue(std::nullptr_t) noexcept : m_type{JSValueType::Null}, m_int64{0} {}
-inline JSValue::JSValue(JSValueObject &&value) noexcept : m_type{JSValueType::Object}, m_object{std::move(value)} {}
+inline JSValue::JSValue(JSValueObject &&value) noexcept : m_type{JSValueType::Object}, m_object(std::move(value)) {}
 inline JSValue::JSValue(JSValueArray &&value) noexcept : m_type{JSValueType::Array}, m_array(std::move(value)) {}
 inline JSValue::JSValue(std::string &&value) noexcept : m_type{JSValueType::String}, m_string{std::move(value)} {}
 template <class TStringView, std::enable_if_t<std::is_convertible_v<TStringView, std::string_view>, int>>
@@ -575,13 +605,6 @@ template <class TInt, std::enable_if_t<std::is_integral_v<TInt> && !std::is_same
 inline JSValue::JSValue(TInt value) noexcept : m_type{JSValueType::Int64}, m_int64{static_cast<int64_t>(value)} {}
 inline JSValue::JSValue(double value) noexcept : m_type{JSValueType::Double}, m_double{value} {}
 #pragma warning(pop)
-
-template <class T>
-static JSValue From(T const &value) noexcept {
-  auto writer = MakeJSValueTreeWriter();
-  WriteValue(writer, value);
-  return TakeJSValue(writer);
-}
 
 inline JSValueType JSValue::Type() const noexcept {
   return m_type;
@@ -616,65 +639,197 @@ inline double const *JSValue::TryGetDouble() const noexcept {
 }
 
 inline JSValueObject const &JSValue::AsObject() const noexcept {
-  return (m_type == JSValueType::Object) ? m_object : EmptyObject;
+  return (m_type == JSValueType::Object) ? m_object : EmptyObject.m_object;
 }
 
 inline JSValueArray const &JSValue::AsArray() const noexcept {
-  return (m_type == JSValueType::Array) ? m_array : EmptyArray;
+  return (m_type == JSValueType::Array) ? m_array : EmptyArray.m_array;
+}
+
+inline int8_t JSValue::AsInt8() const noexcept {
+  return (int8_t)AsInt64();
+}
+
+inline int16_t JSValue::AsInt16() const noexcept {
+  return (int16_t)AsInt64();
+}
+
+inline int32_t JSValue::AsInt32() const noexcept {
+  return (int32_t)AsInt64();
+}
+
+inline uint8_t JSValue::AsUInt8() const noexcept {
+  return (uint8_t)AsInt64();
+}
+
+inline uint16_t JSValue::AsUInt16() const noexcept {
+  return (uint16_t)AsInt64();
+}
+
+inline uint32_t JSValue::AsUInt32() const noexcept {
+  return (uint32_t)AsInt64();
+}
+
+inline uint64_t JSValue::AsUInt64() const noexcept {
+  return (uint64_t)AsInt64();
+}
+
+inline float JSValue::AsSingle() const noexcept {
+  return (float)AsDouble();
+}
+
+inline JSValue::operator std::string() const noexcept {
+  return AsString();
+}
+
+inline JSValue::operator bool() const noexcept {
+  return AsBoolean();
+}
+
+inline JSValue::operator int8_t() const noexcept {
+  return AsInt8();
+}
+
+inline JSValue::operator int16_t() const noexcept {
+  return AsInt16();
+}
+
+inline JSValue::operator int32_t() const noexcept {
+  return AsInt32();
+}
+
+inline JSValue::operator int64_t() const noexcept {
+  return AsInt64();
+}
+
+inline JSValue::operator uint8_t() const noexcept {
+  return AsUInt8();
+}
+
+inline JSValue::operator uint16_t() const noexcept {
+  return AsUInt16();
+}
+
+inline JSValue::operator uint32_t() const noexcept {
+  return AsUInt32();
+}
+
+inline JSValue::operator uint64_t() const noexcept {
+  return AsUInt64();
+}
+
+inline JSValue::operator float() const noexcept {
+  return AsSingle();
+}
+
+inline JSValue::operator double() const noexcept {
+  return AsDouble();
+}
+
+inline JSValue const &JSValue::operator[](std::string_view propertyName) const noexcept {
+  return GetObjectProperty(propertyName);
+}
+
+inline JSValue const &JSValue::operator[](JSValueArray::size_type index) const noexcept {
+  return GetArrayItem(index);
 }
 
 template <>
-inline std::string JSValue::As() const noexcept {
+inline std::string JSValue::To() const noexcept {
   return AsString();
 }
 
 template <>
-inline bool JSValue::As() const noexcept {
+inline bool JSValue::To() const noexcept {
   return AsBoolean();
 }
 
 template <>
-inline int8_t JSValue::As() const noexcept {
+inline int8_t JSValue::To() const noexcept {
   return AsInt8();
 }
 
 template <>
-inline int16_t JSValue::As() const noexcept {
+inline int16_t JSValue::To() const noexcept {
   return AsInt16();
 }
 
 template <>
-inline int32_t JSValue::As() const noexcept {
+inline int32_t JSValue::To() const noexcept {
   return AsInt32();
 }
 
 template <>
-inline int64_t JSValue::As() const noexcept {
+inline int64_t JSValue::To() const noexcept {
   return AsInt64();
+}
+
+template <>
+inline uint8_t JSValue::To() const noexcept {
+  return AsUInt8();
+}
+
+template <>
+inline uint16_t JSValue::To() const noexcept {
+  return AsUInt16();
+}
+
+template <>
+inline uint32_t JSValue::To() const noexcept {
+  return AsUInt32();
+}
+
+template <>
+inline uint64_t JSValue::To() const noexcept {
+  return AsUInt64();
+}
+
+template <>
+inline float JSValue::To() const noexcept {
+  return AsSingle();
+}
+
+template <>
+inline double JSValue::To() const noexcept {
+  return AsDouble();
 }
 
 template <
     class T,
     std::enable_if_t<std::is_default_constructible_v<T> && !std::is_constructible_v<T, std::nullptr_t>, int>>
-inline T JSValue::As() const noexcept {
+inline T JSValue::To() const noexcept {
   T result;
   ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
   return result;
 }
 
 template <class T, std::enable_if_t<std::is_constructible_v<T, std::nullptr_t>, int>>
-inline T JSValue::As() const noexcept {
+inline T JSValue::To() const noexcept {
   T result{nullptr};
   ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
   return result;
 }
 
-inline const JSValue &JSValue::operator[](std::string_view propertyName) const noexcept {
-  return GetObjectProperty(propertyName);
+template <class T>
+inline T JSValue::To(T &&defaultValue) const noexcept {
+  T result{std::move(defaultValue)};
+  ReadValue(MakeJSValueTreeReader(*this), /*out*/ result);
+  return result;
 }
 
-inline const JSValue &JSValue::operator[](JSValueArray::size_type index) const noexcept {
-  return GetArrayItem(index);
+template <class T>
+static JSValue JSValue::From(T const &value) noexcept {
+  auto writer = MakeJSValueTreeWriter();
+  WriteValue(writer, value);
+  return TakeJSValue(writer);
+}
+
+inline /*static*/ JSValueObject JSValue::ReadObjectFrom(IJSValueReader const &reader) noexcept {
+  return JSValueObject::ReadFrom(reader);
+}
+
+inline /*static*/ JSValueArray JSValue::ReadArrayFrom(IJSValueReader const &reader) noexcept {
+  return JSValueArray::ReadFrom(reader);
 }
 
 //===========================================================================
@@ -682,15 +837,15 @@ inline const JSValue &JSValue::operator[](JSValueArray::size_type index) const n
 //===========================================================================
 
 inline const JSValueObject &JSValue::Object() const noexcept {
-  return (m_type == JSValueType::Object) ? m_object : EmptyObject;
+  return AsObject();
 }
 
 inline const JSValueArray &JSValue::Array() const noexcept {
-  return (m_type == JSValueType::Array) ? m_array : EmptyArray;
+  return AsArray();
 }
 
 inline const std::string &JSValue::String() const noexcept {
-  return (m_type == JSValueType::String) ? m_string : EmptyString;
+  return (m_type == JSValueType::String) ? m_string : EmptyString.m_string;
 }
 
 inline bool JSValue::Boolean() const noexcept {
@@ -706,8 +861,13 @@ inline double JSValue::Double() const noexcept {
 }
 
 template <class T>
-inline T JSValue::To() const noexcept {
-  return As<T>();
+inline T JSValue::As() const noexcept {
+  return To<T>();
+}
+
+template <class T>
+inline T JSValue::As(T &&defaultValue) const noexcept {
+  return To<T>(std::move(defaultValue));
 }
 
 inline JSValueObject JSValue::TakeObject() noexcept {
@@ -718,38 +878,39 @@ inline JSValueArray JSValue::TakeArray() noexcept {
   return MoveArray();
 }
 
-inline /*static*/ JSValueObject JSValue::CopyObject(const JSValueObject &other) noexcept {
+inline /*static*/ JSValueObject JSValue::CopyObject(JSValueObject const &other) noexcept {
   return other.Copy();
 }
 
-inline /*static*/ JSValueArray JSValue::CopyArray(const JSValueArray &other) noexcept {
+inline /*static*/ JSValueArray JSValue::CopyArray(JSValueArray const &other) noexcept {
   return other.Copy();
-}
-
-inline /*static*/ JSValueObject JSValue::ReadObjectFrom(IJSValueReader const &reader) noexcept {
-  return JSValueObject::ReadFrom(reader);
-}
-
-inline /*static*/ JSValueArray JSValue::ReadArrayFrom(IJSValueReader const &reader) noexcept {
-  return JSValueArray::ReadFrom(reader);
 }
 
 inline /*static*/ void JSValue::WriteObjectTo(IJSValueWriter const &writer, JSValueObject const &value) noexcept {
   value.WriteTo(writer);
 }
+
 inline /*static*/ void JSValue::WriteArrayTo(IJSValueWriter const &writer, JSValueArray const &value) noexcept {
   value.WriteTo(writer);
+}
+
+inline bool JSValue::EqualsAfterConversion(JSValue const &other) const noexcept {
+  return JSEquals(other);
+}
+
+inline float JSValue::AsFloat() const noexcept {
+  return (float)AsDouble();
 }
 
 //===========================================================================
 // Inline JSValue standalone function implementations.
 //===========================================================================
 
-inline bool operator==(const JSValue &left, const JSValue &right) noexcept {
+inline bool operator==(JSValue const &left, JSValue const &right) noexcept {
   return left.Equals(right);
 }
 
-inline bool operator!=(const JSValue &left, const JSValue &right) noexcept {
+inline bool operator!=(JSValue const &left, JSValue const &right) noexcept {
   return !left.Equals(right);
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -100,7 +100,7 @@ inline T ReadValue(IJSValueReader const &reader) noexcept {
 
 // This is a convenience method to call ReadValue for JSValue.
 template <class T>
-inline T ReadValue(const JSValue &jsValue) noexcept {
+inline T ReadValue(JSValue const &jsValue) noexcept {
   T result;
   ReadValue(jsValue, /*out*/ result);
   return result;

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/JSValueTest.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/JSValueTest.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.ReactNative.Managed.UnitTests
 {
@@ -13,53 +15,80 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestReadObject()
     {
       JObject jobj = JObject.Parse(@"{
-              NullValue: null,
-              ObjValue: {},
-              ArrayValue: [],
-              StringValue: ""Hello"",
-              BoolValue: true,
-              IntValue: 42,
-              DoubleValue: 4.5
+              ""NullValue"": null,
+              ""ObjValue"": {""prop1"": 2},
+              ""ArrayValue"": [1, 2],
+              ""StringValue"": ""Hello"",
+              ""BoolValue"": true,
+              ""IntValue"": 42,
+              ""DoubleValue"": 4.5
             }");
       IJSValueReader reader = new JTokenJSValueReader(jobj);
-
       JSValue jsValue = JSValue.ReadFrom(reader);
-      Assert.AreEqual(JSValueType.Object, jsValue.Type);
-      Assert.IsTrue(jsValue.Object["NullValue"].IsNull);
-      Assert.IsNotNull(jsValue.Object["ObjValue"].Object);
-      Assert.IsNotNull(jsValue.Object["ArrayValue"].Array);
-      Assert.AreEqual("Hello", jsValue.Object["StringValue"].String);
-      Assert.AreEqual(true, jsValue.Object["BoolValue"].Boolean);
-      Assert.AreEqual(42, jsValue.Object["IntValue"].Int64);
-      Assert.AreEqual(4.5, jsValue.Object["DoubleValue"].Double);
+
+      Assert.AreEqual(JSValueType.Object, jsValue.Type, "tag_a101");
+      Assert.AreEqual(JSValueType.Null, jsValue["NullValue"].Type, "tag_1a02");
+      Assert.AreEqual(JSValueType.Object, jsValue["ObjValue"].Type, "tag_a103");
+      Assert.AreEqual(JSValueType.Array, jsValue["ArrayValue"].Type, "tag_a104");
+      Assert.AreEqual(JSValueType.String, jsValue["StringValue"].Type, "tag_a105");
+      Assert.AreEqual(JSValueType.Boolean, jsValue["BoolValue"].Type, "tag_a106");
+      Assert.AreEqual(JSValueType.Int64, jsValue["IntValue"].Type, "tag_a107");
+      Assert.AreEqual(JSValueType.Double, jsValue["DoubleValue"].Type, "tag_a108");
+
+      Assert.IsTrue(jsValue["NullValue"].IsNull, "tag_a201");
+      Assert.IsTrue(jsValue["ObjValue"].TryGetObject(out var objValue), "tag_a202");
+      Assert.IsTrue(jsValue["ArrayValue"].TryGetArray(out var arrayValue), "tag_a203");
+      Assert.IsTrue(jsValue["StringValue"].TryGetString(out var stringValue), "tag_a204");
+      Assert.IsTrue(jsValue["BoolValue"].TryGetBoolean(out var boolValue), "tag_a205");
+      Assert.IsTrue(jsValue["IntValue"].TryGetInt64(out var intValue), "tag_a206");
+      Assert.IsTrue(jsValue["DoubleValue"].TryGetDouble(out var doubleValue), "tag_a207");
+
+      Assert.AreEqual(1, objValue.Count, "tag_a301");
+      Assert.AreEqual(1, jsValue["ObjValue"].PropertyCount, "tag_a302");
+      Assert.AreEqual(2, arrayValue.Count, "tag_a303");
+      Assert.AreEqual(2, jsValue["ArrayValue"].ItemCount, "tag_a304");
+      Assert.AreEqual("Hello", stringValue, "tag_a305");
+      Assert.AreEqual(true, boolValue, "tag_a306");
+      Assert.AreEqual(42, intValue, "tag_a307");
+      Assert.AreEqual(4.5, doubleValue, "tag_a308");
     }
 
     [TestMethod]
     public void TestReadNestedObject()
     {
       JObject jobj = JObject.Parse(@"{
-              NestedObj: {
-                NullValue: null,
-                ObjValue: {},
-                ArrayValue: [],
-                StringValue: ""Hello"",
-                BoolValue: true,
-                IntValue: 42,
-                DoubleValue: 4.5
+              ""NestedObj"": {
+                ""NullValue"": null,
+                ""ObjValue"": {},
+                ""ArrayValue"": [],
+                ""StringValue"": ""Hello"",
+                ""BoolValue"": true,
+                ""IntValue"": 42,
+                ""DoubleValue"": 4.5
               }
             }");
       IJSValueReader reader = new JTokenJSValueReader(jobj);
-
       JSValue jsValue = JSValue.ReadFrom(reader);
-      Assert.AreEqual(JSValueType.Object, jsValue.Type);
-      var nestedObj = jsValue.Object["NestedObj"].Object;
-      Assert.IsTrue(nestedObj["NullValue"].IsNull);
-      Assert.IsNotNull(nestedObj["ObjValue"].Object);
-      Assert.IsNotNull(nestedObj["ArrayValue"].Array);
-      Assert.AreEqual("Hello", nestedObj["StringValue"].String);
-      Assert.AreEqual(true, nestedObj["BoolValue"].Boolean);
-      Assert.AreEqual(42, nestedObj["IntValue"].Int64);
-      Assert.AreEqual(4.5, nestedObj["DoubleValue"].Double);
+
+      Assert.AreEqual(JSValueType.Object, jsValue.Type, "tag_b101");
+      Assert.AreEqual(JSValueType.Object, jsValue["NestedObj"].Type, "tag_b102");
+      jsValue["NestedObj"].TryGetObject(out var nestedObj);
+
+      Assert.AreEqual(JSValueType.Null, nestedObj["NullValue"].Type, "tag_b201");
+      Assert.AreEqual(JSValueType.Object, nestedObj["ObjValue"].Type, "tag_b202");
+      Assert.AreEqual(JSValueType.Array, nestedObj["ArrayValue"].Type, "tag_b203");
+      Assert.AreEqual(JSValueType.String, nestedObj["StringValue"].Type, "tag_b204");
+      Assert.AreEqual(JSValueType.Boolean, nestedObj["BoolValue"].Type, "tag_b205");
+      Assert.AreEqual(JSValueType.Int64, nestedObj["IntValue"].Type, "tag_b206");
+      Assert.AreEqual(JSValueType.Double, nestedObj["DoubleValue"].Type, "tag_b207");
+
+      Assert.IsTrue(nestedObj["NullValue"].IsNull, "tag_b301");
+      Assert.IsTrue(nestedObj["ObjValue"].TryGetObject(out var _), "tag_b302");
+      Assert.IsTrue(nestedObj["ArrayValue"].TryGetArray(out var _), "tag_b303");
+      Assert.AreEqual("Hello", nestedObj["StringValue"], "tag_b304");
+      Assert.AreEqual(true, nestedObj["BoolValue"], "tag_b305");
+      Assert.AreEqual(42, nestedObj["IntValue"], "tag_b306");
+      Assert.AreEqual(4.5, nestedObj["DoubleValue"], "tag_b307");
     }
 
     [TestMethod]
@@ -67,16 +96,24 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       JArray jarr = JArray.Parse(@"[null, {}, [], ""Hello"", true, 42, 4.5]");
       IJSValueReader reader = new JTokenJSValueReader(jarr);
-
       JSValue jsValue = JSValue.ReadFrom(reader);
-      Assert.AreEqual(JSValueType.Array, jsValue.Type);
-      Assert.IsTrue(jsValue.Array[0].IsNull);
-      Assert.IsNotNull(jsValue.Array[1].Object);
-      Assert.IsNotNull(jsValue.Array[2].Array);
-      Assert.AreEqual("Hello", jsValue.Array[3].String);
-      Assert.AreEqual(true, jsValue.Array[4].Boolean);
-      Assert.AreEqual(42, jsValue.Array[5].Int64);
-      Assert.AreEqual(4.5, jsValue.Array[6].Double);
+
+      Assert.AreEqual(JSValueType.Array, jsValue.Type, "tag_c101");
+      Assert.AreEqual(JSValueType.Null, jsValue[0].Type, "tag_c102");
+      Assert.AreEqual(JSValueType.Object, jsValue[1].Type, "tag_c103");
+      Assert.AreEqual(JSValueType.Array, jsValue[2].Type, "tag_c104");
+      Assert.AreEqual(JSValueType.String, jsValue[3].Type, "tag_c105");
+      Assert.AreEqual(JSValueType.Boolean, jsValue[4].Type, "tag_c106");
+      Assert.AreEqual(JSValueType.Int64, jsValue[5].Type, "tag_c107");
+      Assert.AreEqual(JSValueType.Double, jsValue[6].Type, "tag_c108");
+
+      Assert.IsTrue(jsValue[0].IsNull, "tag_c201");
+      Assert.IsTrue(jsValue[1].TryGetObject(out var _), "tag_c202");
+      Assert.IsTrue(jsValue[2].TryGetArray(out var _), "tag_c203");
+      Assert.AreEqual("Hello", jsValue[3], "tag_c204");
+      Assert.AreEqual(true, jsValue[4], "tag_c205");
+      Assert.AreEqual(42, jsValue[5], "tag_c206");
+      Assert.AreEqual(4.5, jsValue[6], "tag_c207");
     }
 
     [TestMethod]
@@ -84,17 +121,974 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       JArray jarr = JArray.Parse(@"[[null, {}, [], ""Hello"", true, 42, 4.5]]");
       IJSValueReader reader = new JTokenJSValueReader(jarr);
-
       JSValue jsValue = JSValue.ReadFrom(reader);
-      Assert.AreEqual(JSValueType.Array, jsValue.Type);
-      var nestedArr = jsValue.Array[0].Array;
-      Assert.IsTrue(nestedArr[0].IsNull);
-      Assert.IsNotNull(nestedArr[1].Object);
-      Assert.IsNotNull(nestedArr[2].Array);
-      Assert.AreEqual("Hello", nestedArr[3].String);
-      Assert.AreEqual(true, nestedArr[4].Boolean);
-      Assert.AreEqual(42, nestedArr[5].Int64);
-      Assert.AreEqual(4.5, nestedArr[6].Double);
+
+      Assert.AreEqual(JSValueType.Array, jsValue.Type, "tag_d101");
+      Assert.AreEqual(JSValueType.Array, jsValue[0].Type, "tag_d102");
+      jsValue[0].TryGetArray(out var nestedArr);
+
+      Assert.AreEqual(JSValueType.Null, nestedArr[0].Type, "tag_d201");
+      Assert.AreEqual(JSValueType.Object, nestedArr[1].Type, "tag_d202");
+      Assert.AreEqual(JSValueType.Array, nestedArr[2].Type, "tag_d203");
+      Assert.AreEqual(JSValueType.String, nestedArr[3].Type, "tag_d204");
+      Assert.AreEqual(JSValueType.Boolean, nestedArr[4].Type, "tag_d205");
+      Assert.AreEqual(JSValueType.Int64, nestedArr[5].Type, "tag_d206");
+      Assert.AreEqual(JSValueType.Double, nestedArr[6].Type, "tag_d207");
+
+      Assert.IsTrue(nestedArr[0].IsNull, "tag_d301");
+      Assert.IsTrue(nestedArr[1].TryGetObject(out var _), "tag_d302");
+      Assert.IsTrue(nestedArr[2].TryGetArray(out var _), "tag_d303");
+      Assert.AreEqual("Hello", nestedArr[3], "tag_d304");
+      Assert.AreEqual(true, nestedArr[4], "tag_d305");
+      Assert.AreEqual(42, nestedArr[5], "tag_d306");
+      Assert.AreEqual(4.5, nestedArr[6], "tag_d307");
+    }
+
+    [TestMethod]
+    public void TestJSSimpleLiterals()
+    {
+      JSValue jsValue01 = JSValue.Null;
+      JSValue jsValue02 = "Hello";
+      JSValue jsValue03 = "";
+      JSValue jsValue04 = true;
+      JSValue jsValue05 = false;
+      JSValue jsValue06 = 42;
+      JSValue jsValue07 = 0;
+      JSValue jsValue08 = 4.5;
+      JSValue jsValue09 = 0.0;
+      JSValue jsValue10 = double.NaN;
+      JSValue jsValue11 = double.PositiveInfinity;
+      JSValue jsValue12 = double.NegativeInfinity;
+
+      Assert.AreEqual(JSValueType.Null, jsValue01.Type, "tag_e101");
+      Assert.AreEqual(JSValueType.String, jsValue02.Type, "tag_e102");
+      Assert.AreEqual(JSValueType.String, jsValue03.Type, "tag_e103");
+      Assert.AreEqual(JSValueType.Boolean, jsValue04.Type, "tag_e104");
+      Assert.AreEqual(JSValueType.Boolean, jsValue05.Type, "tag_e105");
+      Assert.AreEqual(JSValueType.Int64, jsValue06.Type, "tag_e106");
+      Assert.AreEqual(JSValueType.Int64, jsValue07.Type, "tag_e107");
+      Assert.AreEqual(JSValueType.Double, jsValue08.Type, "tag_e108");
+      Assert.AreEqual(JSValueType.Double, jsValue09.Type, "tag_e109");
+      Assert.AreEqual(JSValueType.Double, jsValue10.Type, "tag_e110");
+      Assert.AreEqual(JSValueType.Double, jsValue11.Type, "tag_e111");
+      Assert.AreEqual(JSValueType.Double, jsValue12.Type, "tag_e112");
+
+      Assert.IsTrue(jsValue01.IsNull, "tag_e201");
+      Assert.IsTrue(jsValue02.TryGetString(out var str1) && str1 == "Hello", "tag_e202");
+      Assert.IsTrue(jsValue03.TryGetString(out var str2) && str2 == "", "tag_e203");
+      Assert.IsTrue(jsValue04.TryGetBoolean(out var bool1) && bool1 == true, "tag_e204");
+      Assert.IsTrue(jsValue05.TryGetBoolean(out var bool2) && bool2 == false, "tag_e205");
+      Assert.IsTrue(jsValue06.TryGetInt64(out var int1) && int1 == 42, "tag_e206");
+      Assert.IsTrue(jsValue07.TryGetInt64(out var int2) && int2 == 0, "tag_e207");
+      Assert.IsTrue(jsValue08.TryGetDouble(out var double1) && double1 == 4.5, "tag_e208");
+      Assert.IsTrue(jsValue09.TryGetDouble(out var double2) && double2 == 0, "tag_e209");
+      Assert.IsTrue(jsValue10.TryGetDouble(out var double3) && double.IsNaN(double3), "tag_e210");
+      Assert.IsTrue(jsValue11.TryGetDouble(out var double4) && double4 == double.PositiveInfinity, "tag_e211");
+      Assert.IsTrue(jsValue12.TryGetDouble(out var double5) && double5 == double.NegativeInfinity, "tag_e212");
+    }
+
+    [TestMethod]
+    public void TestObjectLiteral()
+    {
+      JSValue jsValue = new JSValueObject
+      {
+        ["NullValue"] = JSValue.Null,
+        ["ObjValue"] = new JSValueObject { ["prop1"] = 2 },
+        ["ObjValueEmpty"] = JSValue.EmptyObject,
+        ["ArrayValue"] = new JSValueArray { 1, 2 },
+        ["ArrayValueEmpty"] = JSValue.EmptyArray,
+        ["StringValue"] = "Hello",
+        ["BoolValue"] = true,
+        ["IntValue"] = 42,
+        ["DoubleValue"] = 4.5
+      };
+
+      Assert.AreEqual(JSValueType.Object, jsValue.Type, "tag_f101");
+      Assert.AreEqual(JSValueType.Null, jsValue["NullValue"].Type, "tag_f102");
+      Assert.AreEqual(JSValueType.Object, jsValue["ObjValue"].Type, "tag_f103");
+      Assert.AreEqual(JSValueType.Object, jsValue["ObjValueEmpty"].Type, "tag_f104");
+      Assert.AreEqual(JSValueType.Array, jsValue["ArrayValue"].Type, "tag_f105");
+      Assert.AreEqual(JSValueType.Array, jsValue["ArrayValueEmpty"].Type, "tag_f106");
+      Assert.AreEqual(JSValueType.String, jsValue["StringValue"].Type, "tag_f107");
+      Assert.AreEqual(JSValueType.Boolean, jsValue["BoolValue"].Type, "tag_f108");
+      Assert.AreEqual(JSValueType.Int64, jsValue["IntValue"].Type, "tag_f109");
+      Assert.AreEqual(JSValueType.Double, jsValue["DoubleValue"].Type, "tag_f110");
+
+      Assert.IsTrue(jsValue["NullValue"].IsNull, "tag_f201");
+      Assert.AreEqual(1, jsValue["ObjValue"].PropertyCount, "tag_f202");
+      Assert.AreEqual(2, jsValue["ObjValue"]["prop1"], "tag_f203");
+      Assert.AreEqual(0, jsValue["ObjValueEmpty"].PropertyCount, "tag_f204");
+      Assert.AreEqual(2, jsValue["ArrayValue"].ItemCount, "tag_f205");
+      Assert.AreEqual(1, jsValue["ArrayValue"][0], "tag_f206");
+      Assert.AreEqual(2, jsValue["ArrayValue"][1], "tag_f207");
+      Assert.AreEqual(0, jsValue["ArrayValueEmpty"].ItemCount, "tag_f208");
+      Assert.AreEqual("Hello", jsValue["StringValue"], "tag_f209");
+      Assert.AreEqual(true, jsValue["BoolValue"], "tag_f210");
+      Assert.AreEqual(42, jsValue["IntValue"], "tag_f211");
+      Assert.AreNotEqual(24, jsValue["IntValue"], "tag_f212");
+      Assert.AreEqual(4.5, jsValue["DoubleValue"], "tag_f213");
+    }
+
+    [TestMethod]
+    public void TestArrayLiteral()
+    {
+      JSValue jsValue = new JSValueArray
+      {
+        JSValue.Null,
+        new JSValueObject { ["prop1"] = 2 },
+        JSValue.EmptyObject,
+        new JSValueArray { 1, 2 },
+        JSValue.EmptyArray,
+        "Hello",
+        true,
+        42,
+        4.5
+      };
+
+      Assert.AreEqual(JSValueType.Array, jsValue.Type, "tag_g101");
+      Assert.AreEqual(JSValueType.Null, jsValue[0].Type, "tag_g102");
+      Assert.AreEqual(JSValueType.Object, jsValue[1].Type, "tag_g103");
+      Assert.AreEqual(JSValueType.Object, jsValue[2].Type, "tag_g104");
+      Assert.AreEqual(JSValueType.Array, jsValue[3].Type, "tag_g105");
+      Assert.AreEqual(JSValueType.Array, jsValue[4].Type, "tag_g106");
+      Assert.AreEqual(JSValueType.String, jsValue[5].Type, "tag_g107");
+      Assert.AreEqual(JSValueType.Boolean, jsValue[6].Type, "tag_g108");
+      Assert.AreEqual(JSValueType.Int64, jsValue[7].Type, "tag_g109");
+      Assert.AreEqual(JSValueType.Double, jsValue[8].Type, "tag_g110");
+
+      Assert.IsTrue(jsValue["NullValue"].IsNull, "tag_g201");
+      Assert.AreEqual(1, jsValue[1].PropertyCount, "tag_g202");
+      Assert.AreEqual(2, jsValue[1]["prop1"], "tag_g203");
+      Assert.AreEqual(0, jsValue[2].PropertyCount, "tag_g204");
+      Assert.AreEqual(2, jsValue[3].ItemCount, "tag_g205");
+      Assert.AreEqual(1, jsValue[3][0], "tag_g206");
+      Assert.AreEqual(2, jsValue[3][1], "tag_g207");
+      Assert.AreEqual(0, jsValue[4].ItemCount, "tag_g208");
+      Assert.AreEqual("Hello", jsValue[5], "tag_g209");
+      Assert.AreEqual(true, jsValue[6], "tag_g210");
+      Assert.AreEqual(42, jsValue[7], "tag_g211");
+      Assert.AreNotEqual(24, jsValue[7], "tag_g212");
+      Assert.AreEqual(4.5, jsValue[8], "tag_g213");
+    }
+
+    [TestMethod]
+    public void TestJSValueConstructor()
+    {
+      var value01 = new JSValue();
+      var value02 = new JSValue(new JSValueObject { ["prop1"] = 3 });
+      var value03 = new JSValue(new JSValueObject { });
+      var value04 = new JSValue(new JSValueArray { 1, 2 });
+      var value05 = new JSValue(new JSValueArray { });
+      var value06 = new JSValue("Hello");
+      var value07 = new JSValue(true);
+      var value08 = new JSValue(false);
+      var value09 = new JSValue(0);
+      var value10 = new JSValue(42);
+      var value11 = new JSValue(4.2);
+
+      Assert.AreEqual(JSValueType.Null, value01.Type, "tag_h101");
+      Assert.AreEqual(JSValueType.Object, value02.Type, "tag_h102");
+      Assert.AreEqual(JSValueType.Object, value03.Type, "tag_h103");
+      Assert.AreEqual(JSValueType.Array, value04.Type, "tag_h104");
+      Assert.AreEqual(JSValueType.Array, value05.Type, "tag_h105");
+      Assert.AreEqual(JSValueType.String, value06.Type, "tag_h106");
+      Assert.AreEqual(JSValueType.Boolean, value07.Type, "tag_h107");
+      Assert.AreEqual(JSValueType.Boolean, value08.Type, "tag_h108");
+      Assert.AreEqual(JSValueType.Int64, value09.Type, "tag_h109");
+      Assert.AreEqual(JSValueType.Int64, value10.Type, "tag_h110");
+      Assert.AreEqual(JSValueType.Double, value11.Type, "tag_h111");
+
+      Assert.IsTrue(value01.IsNull, "tag_h2001");
+      Assert.IsTrue(value02.TryGetObject(out var objValue02) && objValue02.Count == 1, "tag_h202");
+      Assert.IsTrue(value03.TryGetObject(out var objValue03) && objValue03.Count == 0, "tag_h203");
+      Assert.IsTrue(value04.TryGetArray(out var arrValue04) && arrValue04.Count == 2, "tag_h204");
+      Assert.IsTrue(value05.TryGetArray(out var arrValue05) && arrValue05.Count == 0, "tag_h205");
+      Assert.IsTrue(value06.TryGetString(out var strValue06) && strValue06 == "Hello", "tag_h206");
+      Assert.IsTrue(value07.TryGetBoolean(out var boolValue07) && boolValue07 == true, "tag_h207");
+      Assert.IsTrue(value08.TryGetBoolean(out var boolValue08) && boolValue08 == false, "tag_h208");
+      Assert.IsTrue(value09.TryGetInt64(out var intValue09) && intValue09 == 0, "tag_h209");
+      Assert.IsTrue(value10.TryGetInt64(out var intValue10) && intValue10 == 42, "tag_h210");
+      Assert.IsTrue(value11.TryGetDouble(out var doubleValue11) && doubleValue11 == 4.2, "tag_h211");
+    }
+
+    [TestMethod]
+    public void TestJSValueImplicitCast()
+    {
+      JSValue value01 = new ReadOnlyDictionary<string, JSValue>(new Dictionary<string, JSValue> { ["prop1"] = 3 });
+      JSValue value02 = new Dictionary<string, JSValue> { ["prop1"] = 3 };
+      JSValue value03 = new JSValueObject { ["prop1"] = 3 };
+      JSValue value04 = new ReadOnlyCollection<JSValue>(new List<JSValue> { 1, 2 });
+      JSValue value05 = new List<JSValue> { 1, 2 };
+      JSValue value06 = new JSValueArray { 1, 2 };
+      JSValue value07 = "Hello";
+      JSValue value08 = true;
+      JSValue value09 = false;
+      JSValue value10 = (sbyte)42;
+      JSValue value11 = (short)42;
+      JSValue value12 = 42;
+      JSValue value13 = (long)42;
+      JSValue value14 = (byte)42;
+      JSValue value15 = (ushort)42;
+      JSValue value16 = (uint)42;
+      JSValue value17 = (ulong)42;
+      JSValue value18 = (float)4.2;
+      JSValue value19 = 4.2;
+
+      Assert.AreEqual(JSValueType.Object, value01.Type, "tag_i101");
+      Assert.AreEqual(JSValueType.Object, value02.Type, "tag_i102");
+      Assert.AreEqual(JSValueType.Object, value03.Type, "tag_i103");
+      Assert.AreEqual(JSValueType.Array, value04.Type, "tag_i104");
+      Assert.AreEqual(JSValueType.Array, value05.Type, "tag_i105");
+      Assert.AreEqual(JSValueType.Array, value06.Type, "tag_i106");
+      Assert.AreEqual(JSValueType.String, value07.Type, "tag_i107");
+      Assert.AreEqual(JSValueType.Boolean, value08.Type, "tag_i108");
+      Assert.AreEqual(JSValueType.Boolean, value09.Type, "tag_i109");
+      Assert.AreEqual(JSValueType.Int64, value10.Type, "tag_i110");
+      Assert.AreEqual(JSValueType.Int64, value11.Type, "tag_i111");
+      Assert.AreEqual(JSValueType.Int64, value12.Type, "tag_i112");
+      Assert.AreEqual(JSValueType.Int64, value13.Type, "tag_i113");
+      Assert.AreEqual(JSValueType.Int64, value14.Type, "tag_i114");
+      Assert.AreEqual(JSValueType.Int64, value15.Type, "tag_i115");
+      Assert.AreEqual(JSValueType.Int64, value16.Type, "tag_i116");
+      Assert.AreEqual(JSValueType.Int64, value17.Type, "tag_i117");
+      Assert.AreEqual(JSValueType.Double, value18.Type, "tag_i118");
+      Assert.AreEqual(JSValueType.Double, value19.Type, "tag_i119");
+
+      Assert.IsTrue(value01.TryGetObject(out var objValue01) && objValue01.Count == 1, "tag_i201");
+      Assert.IsTrue(value02.TryGetObject(out var objValue02) && objValue02.Count == 1, "tag_i202");
+      Assert.IsTrue(value03.TryGetObject(out var objValue03) && objValue03.Count == 1, "tag_i203");
+      Assert.IsTrue(value04.TryGetArray(out var arrValue04) && arrValue04.Count == 2, "tag_i204");
+      Assert.IsTrue(value05.TryGetArray(out var arrValue05) && arrValue05.Count == 2, "tag_i205");
+      Assert.IsTrue(value06.TryGetArray(out var arrValue06) && arrValue06.Count == 2, "tag_i206");
+      Assert.IsTrue(value07.TryGetString(out var strValue07) && strValue07 == "Hello", "tag_i207");
+      Assert.IsTrue(value08.TryGetBoolean(out var boolValue08) && boolValue08 == true, "tag_i208");
+      Assert.IsTrue(value09.TryGetBoolean(out var boolValue09) && boolValue09 == false, "tag_i209");
+      Assert.IsTrue(value10.TryGetInt64(out var intValue10) && intValue10 == 42, "tag_i210");
+      Assert.IsTrue(value11.TryGetInt64(out var intValue11) && intValue11 == 42, "tag_i211");
+      Assert.IsTrue(value12.TryGetInt64(out var intValue12) && intValue12 == 42, "tag_i212");
+      Assert.IsTrue(value13.TryGetInt64(out var intValue13) && intValue13 == 42, "tag_i213");
+      Assert.IsTrue(value14.TryGetInt64(out var intValue14) && intValue14 == 42, "tag_i214");
+      Assert.IsTrue(value15.TryGetInt64(out var intValue15) && intValue15 == 42, "tag_i215");
+      Assert.IsTrue(value16.TryGetInt64(out var intValue16) && intValue16 == 42, "tag_i216");
+      Assert.IsTrue(value17.TryGetInt64(out var intValue17) && intValue17 == 42, "tag_i217");
+      Assert.IsTrue(value18.TryGetDouble(out var doubleValue18) && doubleValue18 == (float)4.2, "tag_i218");
+      Assert.IsTrue(value19.TryGetDouble(out var doubleValue19) && doubleValue19 == 4.2, "tag_i219");
+    }
+
+    [TestMethod]
+    public void TestAsObject()
+    {
+      // Any type except for Object is returned as EmptyObject.
+      bool AsObjectIsEmpty(JSValue value) => value.AsObject().Count == 0;
+
+      Assert.IsFalse(AsObjectIsEmpty(new JSValueObject { ["prop1"] = 42 }), "tag_j01");
+      Assert.IsTrue(AsObjectIsEmpty(JSValue.EmptyObject), "tag_j02");
+      Assert.IsTrue(AsObjectIsEmpty(new JSValueArray { 42, 78 }), "tag_j03");
+      Assert.IsTrue(AsObjectIsEmpty(JSValue.EmptyArray), "tag_j04");
+      Assert.IsTrue(AsObjectIsEmpty(""), "tag_j05");
+      Assert.IsTrue(AsObjectIsEmpty("Hello"), "tag_j06");
+      Assert.IsTrue(AsObjectIsEmpty(true), "tag_j07");
+      Assert.IsTrue(AsObjectIsEmpty(false), "tag_j08");
+      Assert.IsTrue(AsObjectIsEmpty(0), "tag_j09");
+      Assert.IsTrue(AsObjectIsEmpty(42), "tag_j10");
+      Assert.IsTrue(AsObjectIsEmpty(long.MaxValue), "tag_j11");
+      Assert.IsTrue(AsObjectIsEmpty(long.MinValue), "tag_j12");
+      Assert.IsTrue(AsObjectIsEmpty(0.0), "tag_j13");
+      Assert.IsTrue(AsObjectIsEmpty(4.2), "tag_j14");
+      Assert.IsTrue(AsObjectIsEmpty(double.NaN), "tag_j15");
+      Assert.IsTrue(AsObjectIsEmpty(double.PositiveInfinity), "tag_j16");
+      Assert.IsTrue(AsObjectIsEmpty(double.NegativeInfinity), "tag_j17");
+      Assert.IsTrue(AsObjectIsEmpty(JSValue.Null), "tag_j18");
+    }
+
+    [TestMethod]
+    public void TestAsArray()
+    {
+      // Any type except for Array is returned as EmptyObject.
+      bool AsArrayIsEmpty(JSValue value) => value.AsArray().Count == 0;
+
+      Assert.IsTrue(AsArrayIsEmpty(new JSValueObject { ["prop1"] = 42 }), "tag_k01");
+      Assert.IsTrue(AsArrayIsEmpty(JSValue.EmptyObject), "tag_k02");
+      Assert.IsFalse(AsArrayIsEmpty(new JSValueArray { 42, 78 }), "tag_k03");
+      Assert.IsTrue(AsArrayIsEmpty(JSValue.EmptyArray), "tag_k04");
+      Assert.IsTrue(AsArrayIsEmpty(""), "tag_k05");
+      Assert.IsTrue(AsArrayIsEmpty("Hello"), "tag_k06");
+      Assert.IsTrue(AsArrayIsEmpty(true), "tag_k07");
+      Assert.IsTrue(AsArrayIsEmpty(false), "tag_k08");
+      Assert.IsTrue(AsArrayIsEmpty(0), "tag_k09");
+      Assert.IsTrue(AsArrayIsEmpty(42), "tag_k10");
+      Assert.IsTrue(AsArrayIsEmpty(long.MaxValue), "tag_k11");
+      Assert.IsTrue(AsArrayIsEmpty(long.MinValue), "tag_k12");
+      Assert.IsTrue(AsArrayIsEmpty(0.0), "tag_k13");
+      Assert.IsTrue(AsArrayIsEmpty(4.2), "tag_k14");
+      Assert.IsTrue(AsArrayIsEmpty(double.NaN), "tag_k15");
+      Assert.IsTrue(AsArrayIsEmpty(double.PositiveInfinity), "tag_k16");
+      Assert.IsTrue(AsArrayIsEmpty(double.NegativeInfinity), "tag_k17");
+      Assert.IsTrue(AsArrayIsEmpty(JSValue.Null), "tag_k18");
+    }
+
+    [TestMethod]
+    public void TestAsConverters()
+    {
+      // Check AsString, AsBoolean, AsInt64, and AsDouble conversions.
+      void CheckAsConverter(JSValue value, string asString, bool asBoolean, long asInt64, double asDouble, string tag)
+      {
+        Assert.AreEqual(asString, value.AsString(), "AsString: {0}", tag);
+        Assert.AreEqual(asBoolean, value.AsBoolean(), "AsBoolean: {0}", tag);
+        Assert.AreEqual(asInt64, value.AsInt64(), "AsInt64: {0}", tag);
+        Assert.AreEqual(asDouble, value.AsDouble(), "AsDouble: {0}", tag);
+
+        // Explicit cast is an alternative to the As conversion.
+        Assert.AreEqual(asString, (string)value, "(string): {0}", tag);
+        Assert.AreEqual(asBoolean, (bool)value, "(bool): {0}", tag);
+        Assert.AreEqual(asInt64, (long)value, "(long): {0}", tag);
+        Assert.AreEqual(asDouble, (double)value, "(double): {0}", tag);
+      }
+
+      CheckAsConverter(new JSValueObject { ["prop1"] = 42 }, "", true, 0, 0, "tag_l01");
+      CheckAsConverter(JSValue.EmptyObject, "", false, 0, 0, "tag_l02");
+      CheckAsConverter(new JSValueArray { 42, 78 }, "", true, 0, 0, "tag_l03");
+      CheckAsConverter(JSValue.EmptyArray, "", false, 0, 0, "tag_l04");
+      CheckAsConverter("", "", false, 0, 0, "tag_l05");
+      CheckAsConverter("  ", "  ", false, 0, 0, "tag_l06");
+      CheckAsConverter("42", "42", false, 42, 42, "tag_l07");
+      CheckAsConverter("  42  ", "  42  ", false, 42, 42, "tag_l08");
+      CheckAsConverter("4.2", "4.2", false, 4, 4.2, "tag_l09");
+      CheckAsConverter("Hello", "Hello", false, 0, double.NaN, "tag_l10");
+      CheckAsConverter("true", "true", true, 0, double.NaN, "tag_l11");
+      CheckAsConverter("false", "false", false, 0, double.NaN, "tag_l12");
+      CheckAsConverter("True", "True", true, 0, double.NaN, "tag_l13");
+      CheckAsConverter("False", "False", false, 0, double.NaN, "tag_l14");
+      CheckAsConverter("TRUE", "TRUE", true, 0, double.NaN, "tag_l15");
+      CheckAsConverter("FALSE", "FALSE", false, 0, double.NaN, "tag_l16");
+      CheckAsConverter("on", "on", true, 0, double.NaN, "tag_l17");
+      CheckAsConverter("off", "off", false, 0, double.NaN, "tag_l18");
+      CheckAsConverter("On", "On", true, 0, double.NaN, "tag_l19");
+      CheckAsConverter("Off", "Off", false, 0, double.NaN, "tag_l20");
+      CheckAsConverter("ON", "ON", true, 0, double.NaN, "tag_l21");
+      CheckAsConverter("OFF", "OFF", false, 0, double.NaN, "tag_l22");
+      CheckAsConverter("yes", "yes", true, 0, double.NaN, "tag_l23");
+      CheckAsConverter("no", "no", false, 0, double.NaN, "tag_l24");
+      CheckAsConverter("y", "y", true, 0, double.NaN, "tag_l25");
+      CheckAsConverter("n", "n", false, 0, double.NaN, "tag_l26");
+      CheckAsConverter("Y", "Y", true, 0, double.NaN, "tag_l27");
+      CheckAsConverter("N", "N", false, 0, double.NaN, "tag_l28");
+      CheckAsConverter("1", "1", true, 1, 1, "tag_l29");
+      CheckAsConverter("0", "0", false, 0, 0, "tag_l20");
+      CheckAsConverter(true, "true", true, 1, 1, "tag_l31");
+      CheckAsConverter(false, "false", false, 0, 0, "tag_l32");
+      CheckAsConverter(0, "0", false, 0, 0, "tag_l33");
+      CheckAsConverter(42, "42", true, 42, 42, "tag_l34");
+      CheckAsConverter(long.MaxValue, "9223372036854775807", true, long.MaxValue, long.MaxValue, "tag_l35");
+      CheckAsConverter(long.MinValue, "-9223372036854775808", true, long.MinValue, long.MinValue, "tag_l36");
+      CheckAsConverter(0.0, "0", false, 0, 0, "tag_l37");
+      CheckAsConverter(4.2, "4.2", true, 4, 4.2, "tag_l38");
+      CheckAsConverter(-4.2, "-4.2", true, -4, -4.2, "tag_l39");
+      CheckAsConverter(double.MaxValue, "1.79769313486232E+308", true, 0, double.MaxValue, "tag_l40");
+      CheckAsConverter(double.MinValue, "-1.79769313486232E+308", true, 0, double.MinValue, "tag_l41");
+      CheckAsConverter(double.NaN, "NaN", false, 0, double.NaN, "tag_l42");
+      CheckAsConverter(double.PositiveInfinity, "Infinity", true, 0, double.PositiveInfinity, "tag_l43");
+      CheckAsConverter(double.NegativeInfinity, "-Infinity", true, 0, double.NegativeInfinity, "tag_l44");
+      CheckAsConverter(JSValue.Null, "null", false, 0, 0, "tag_l45");
+    }
+
+    [TestMethod]
+    public void TestExplicitNumberConversion()
+    {
+      // Check that explicit number conversions are defined
+      Assert.AreEqual(42, (sbyte)new JSValue(42), "tag_m01");
+      Assert.AreEqual(42, (short)new JSValue(42), "tag_m02");
+      Assert.AreEqual(42, (int)new JSValue(42), "tag_m03");
+      Assert.AreEqual(42, (long)new JSValue(42), "tag_m04");
+      Assert.AreEqual(42, (byte)new JSValue(42), "tag_m05");
+      Assert.AreEqual(42, (ushort)new JSValue(42), "tag_m06");
+      Assert.AreEqual(42u, (uint)new JSValue(42), "tag_m07");
+      Assert.AreEqual(42u, (ulong)new JSValue(42), "tag_m08");
+      Assert.AreEqual((float)4.2, (float)new JSValue(4.2), "tag_m09");
+      Assert.AreEqual(4.2, (double)new JSValue(4.2), "tag_m10");
+    }
+
+    [TestMethod]
+    public void TestAsJSConverters()
+    {
+      // Check AsJSString, AsJSBoolean, and AsJSNumber conversions.
+      // They must match the JavaScript String(), Boolean(), and Number() conversions. 
+      void CheckAsJSConverter(JSValue value, string asJSString, bool asJSBoolean, double asJSNumber, string tag)
+      {
+        Assert.AreEqual(asJSString, value.AsJSString(), "AsJSString: {0}", tag);
+        Assert.AreEqual(asJSBoolean, value.AsJSBoolean(), "AsJSBoolean: {0}", tag);
+        Assert.AreEqual(asJSNumber, value.AsJSNumber(), "AsJSNumber: {0}", tag);
+      }
+
+      CheckAsJSConverter(false, "false", false, 0, "tag_n01");
+      CheckAsJSConverter(true, "true", true, 1, "tag_n02");
+      CheckAsJSConverter(0, "0", false, 0, "tag_n03");
+      CheckAsJSConverter(1, "1", true, 1, "tag_n04");
+      CheckAsJSConverter("0", "0", true, 0, "tag_n05");
+      CheckAsJSConverter("000", "000", true, 0, "tag_n06");
+      CheckAsJSConverter("1", "1", true, 1, "tag_n07");
+      CheckAsJSConverter(double.NaN, "NaN", false, double.NaN, "tag_n08");
+      CheckAsJSConverter(double.PositiveInfinity, "Infinity", true, double.PositiveInfinity, "tag_n09");
+      CheckAsJSConverter(double.NegativeInfinity, "-Infinity", true, double.NegativeInfinity, "tag_n10");
+      CheckAsJSConverter("", "", false, 0, "tag_n11");
+      CheckAsJSConverter("20", "20", true, 20, "tag_n12");
+      CheckAsJSConverter("twenty", "twenty", true, double.NaN, "tag_n13");
+      CheckAsJSConverter(new JSValueArray { }, "", true, 0, "tag_n14");
+      CheckAsJSConverter(new JSValueArray { 20 }, "20", true, 20, "tag_n15");
+      CheckAsJSConverter(new JSValueArray { 10, 20 }, "10,20", true, double.NaN, "tag_n16");
+      CheckAsJSConverter(new JSValueArray { "twenty" }, "twenty", true, double.NaN, "tag_n17");
+      CheckAsJSConverter(new JSValueArray { "ten", "twenty" }, "ten,twenty", true, double.NaN, "tag_n18");
+      CheckAsJSConverter(new JSValueArray { double.NaN }, "NaN", true, double.NaN, "tag_n19");
+      CheckAsJSConverter(new JSValueObject { }, "[object Object]", true, double.NaN, "tag_n20");
+      CheckAsJSConverter(JSValue.Null, "null", false, 0, "tag_n21");
+    }
+
+    [TestMethod]
+    public void TestJSEquals()
+    {
+      Assert.IsTrue(new JSValue().JSEquals(JSValue.Null), "tag_o1001");
+      Assert.IsFalse(new JSValue().JSEquals(new JSValueObject { }), "tag_o1002");
+      Assert.IsFalse(new JSValue().JSEquals(new JSValueArray { }), "tag_o1003");
+      Assert.IsFalse(new JSValue().JSEquals(""), "tag_o1004");
+      Assert.IsFalse(new JSValue().JSEquals(false), "tag_o1005");
+      Assert.IsFalse(new JSValue().JSEquals(0), "tag_o1006");
+      Assert.IsFalse(new JSValue().JSEquals(0.0), "tag_o1007");
+
+      Assert.IsFalse(new JSValue(new JSValueObject()).JSEquals(JSValue.Null), "tag_o2001");
+      Assert.IsTrue(new JSValue(new JSValueObject { }).JSEquals(new JSValueObject { }), "tag_o2002");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { }), "tag_o2003");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { "Hello" }), "tag_o2004");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { 0 }), "tag_o2005");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { "0" }), "tag_o2006");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { 1 }), "tag_o2007");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { "1" }), "tag_o2008");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { true }), "tag_o2009");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(new JSValueArray { "true" }), "tag_o2010");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(""), "tag_o2011");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals("0"), "tag_o2012");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals("1"), "tag_o2013");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals("true"), "tag_o2014");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals("false"), "tag_o2015");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals("Hello"), "tag_o2016");
+      Assert.IsTrue(new JSValue(new JSValueObject { }).JSEquals("[object Object]"), "tag_o2017");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(false), "tag_o2018");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(true), "tag_o2019");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(0), "tag_o2020");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(5), "tag_o2021");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(1), "tag_o2022");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(0.0), "tag_o2023");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(0.5), "tag_o2024");
+      Assert.IsFalse(new JSValue(new JSValueObject { }).JSEquals(1.0), "tag_o2025");
+
+      Assert.IsTrue(new JSValue(new JSValueObject { { "prop1", 2 }, { "prop2", false } })
+                      .JSEquals(new JSValueObject { { "prop2", 0 }, { "prop1", "2" } }), "tag_o3001");
+      Assert.IsFalse(new JSValue(new JSValueObject { { "prop1", 2 }, { "prop2", false } })
+                       .JSEquals(new JSValueObject { { "prop2", 0 } }), "tag_o3002");
+      Assert.IsFalse(new JSValue(new JSValueObject { { "prop1", 2 }, { "prop2", false } })
+                       .JSEquals(new JSValueObject { { "prop1", 2 }, { "prop25", false } }), "tag_o3003");
+      Assert.IsFalse(new JSValue(new JSValueObject { { "prop1", 2 }, { "prop2", false } })
+                       .JSEquals(new JSValueObject { { "prop1", 2 }, { "prop2", true } }), "tag_o3004");
+
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(JSValue.Null), "tag_o4001");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueObject { }), "tag_o4002");
+      Assert.IsTrue(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { }), "tag_o4003");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { "Hello" }), "tag_o4004");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { 0 }), "tag_o4005");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { "0" }), "tag_o4006");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { 1 }), "tag_o4007");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { "1" }), "tag_o4008");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { true }), "tag_o4009");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(new JSValueArray { "true" }), "tag_o4010");
+      Assert.IsTrue(new JSValue(new JSValueArray { }).JSEquals(""), "tag_o4011");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals("0"), "tag_o4012");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals("1"), "tag_o4013");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals("true"), "tag_o4014");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals("false"), "tag_o4015");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals("Hello"), "tag_o4016");
+      Assert.IsTrue(new JSValue(new JSValueArray { }).JSEquals(false), "tag_o4017");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(true), "tag_o4018");
+      Assert.IsTrue(new JSValue(new JSValueArray { }).JSEquals(0), "tag_o4019");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(5), "tag_o4020");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(1), "tag_o4021");
+      Assert.IsTrue(new JSValue(new JSValueArray { }).JSEquals(0.0), "tag_o4022");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(0.5), "tag_o4023");
+      Assert.IsFalse(new JSValue(new JSValueArray { }).JSEquals(1.0), "tag_o4024");
+
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(JSValue.Null), "tag_o5001");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueObject { }), "tag_o5002");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { }), "tag_o5003");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { "Hello" }), "tag_o5004");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { 0 }), "tag_o5005");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { "0" }), "tag_o5006");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { 1 }), "tag_o5007");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { "1" }), "tag_o5008");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { true }), "tag_o5009");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(new JSValueArray { "true" }), "tag_o5010");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(""), "tag_o5011");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals("0"), "tag_o5012");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals("1"), "tag_o5013");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals("true"), "tag_o5014");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals("false"), "tag_o5015");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals("Hello"), "tag_o5016");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(false), "tag_o5017");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals(true), "tag_o5018");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(0), "tag_o5019");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(5), "tag_o5020");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals(1), "tag_o5021");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(0.0), "tag_o5022");
+      Assert.IsFalse(new JSValue(new JSValueArray { 1 }).JSEquals(0.5), "tag_o5023");
+      Assert.IsTrue(new JSValue(new JSValueArray { 1 }).JSEquals(1.0), "tag_o5024");
+
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(JSValue.Null), "tag_o6001");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueObject { }), "tag_o6002");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { }), "tag_o6003");
+      Assert.IsTrue(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { "Hello" }), "tag_o6004");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { 0 }), "tag_o6005");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { "0" }), "tag_o6006");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { 1 }), "tag_o6007");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { "1" }), "tag_o6008");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { true }), "tag_o6009");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(new JSValueArray { "true" }), "tag_o6010");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(""), "tag_o6011");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals("0"), "tag_o6012");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals("1"), "tag_o6013");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals("true"), "tag_o6014");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals("false"), "tag_o6015");
+      Assert.IsTrue(new JSValue(new JSValueArray { "Hello" }).JSEquals("Hello"), "tag_o6016");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(false), "tag_o6017");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(true), "tag_o6018");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(0), "tag_o6019");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(5), "tag_o6020");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(1), "tag_o6021");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(0.0), "tag_o6022");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(0.5), "tag_o6023");
+      Assert.IsFalse(new JSValue(new JSValueArray { "Hello" }).JSEquals(1.0), "tag_o6024");
+
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(JSValue.Null), "tag_o7001");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueObject { }), "tag_o7002");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { }), "tag_o7003");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { "Hello" }), "tag_o7004");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { 0 }), "tag_o7005");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { "0" }), "tag_o7006");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { 1 }), "tag_o7007");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { "1" }), "tag_o7008");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { true }), "tag_o7009");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { "true" }), "tag_o7010");
+      Assert.IsTrue(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { 0, 1 }), "tag_o7011");
+      Assert.IsTrue(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { false, true }), "tag_o7012");
+      Assert.IsTrue(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { "0", "1" }), "tag_o7013");
+      Assert.IsTrue(new JSValue(new JSValueArray { 0, 1 }).JSEquals(new JSValueArray { "0", true }), "tag_o7014");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(""), "tag_o7015");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals("0"), "tag_o7016");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals("1"), "tag_o7017");
+      Assert.IsTrue(new JSValue(new JSValueArray { 0, 1 }).JSEquals("0,1"), "tag_o7018");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals("true"), "tag_o7019");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals("false"), "tag_o7020");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals("Hello"), "tag_o7021");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(false), "tag_o7022");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(true), "tag_o7023");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(0), "tag_o7024");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(5), "tag_o7025");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(1), "tag_o7026");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(0.0), "tag_o7027");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(0.5), "tag_o7028");
+      Assert.IsFalse(new JSValue(new JSValueArray { 0, 1 }).JSEquals(1.0), "tag_o7029");
+
+      Assert.IsFalse(new JSValue("").JSEquals(JSValue.Null), "tag_o8001");
+      Assert.IsFalse(new JSValue("").JSEquals(new JSValueObject { }), "tag_o8002");
+      Assert.IsTrue(new JSValue("").JSEquals(new JSValueArray { }), "tag_o8003");
+      Assert.IsFalse(new JSValue("").JSEquals(new JSValueArray { 0 }), "tag_o8004");
+      Assert.IsFalse(new JSValue("").JSEquals(new JSValueArray { 1 }), "tag_o8005");
+      Assert.IsFalse(new JSValue("").JSEquals(new JSValueArray { true }), "tag_o8006");
+      Assert.IsTrue(new JSValue("").JSEquals(new JSValueArray { "" }), "tag_o8007");
+      Assert.IsTrue(new JSValue("").JSEquals(""), "tag_o8008");
+      Assert.IsFalse(new JSValue("").JSEquals("1"), "tag_o8009");
+      Assert.IsFalse(new JSValue("").JSEquals("Hello"), "tag_o8010");
+      Assert.IsTrue(new JSValue("").JSEquals(false), "tag_o8011");
+      Assert.IsFalse(new JSValue("").JSEquals(true), "tag_o8012");
+      Assert.IsTrue(new JSValue("").JSEquals(0), "tag_o8013");
+      Assert.IsFalse(new JSValue("").JSEquals(5), "tag_o8014");
+      Assert.IsFalse(new JSValue("").JSEquals(1), "tag_o8015");
+      Assert.IsTrue(new JSValue("").JSEquals(0.0), "tag_o8016");
+      Assert.IsFalse(new JSValue("").JSEquals(0.5), "tag_o8017");
+      Assert.IsFalse(new JSValue("").JSEquals(1.0), "tag_o8018");
+
+      Assert.IsFalse(new JSValue("Hello").JSEquals(JSValue.Null), "tag_o9001");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(new JSValueObject { }), "tag_o9002");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(new JSValueArray { }), "tag_o9003");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(new JSValueArray { 0 }), "tag_o9004");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(new JSValueArray { 1 }), "tag_o9005");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(new JSValueArray { true }), "tag_o9006");
+      Assert.IsTrue(new JSValue("Hello").JSEquals(new JSValueArray { "Hello" }), "tag_o9007");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(""), "tag_o9008");
+      Assert.IsFalse(new JSValue("Hello").JSEquals("1"), "tag_o9009");
+      Assert.IsTrue(new JSValue("Hello").JSEquals("Hello"), "tag_o9010");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(false), "tag_o9011");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(true), "tag_o9012");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(0), "tag_o9013");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(5), "tag_o9014");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(1), "tag_o9015");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(0.0), "tag_o9016");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(0.5), "tag_o9017");
+      Assert.IsFalse(new JSValue("Hello").JSEquals(1.0), "tag_o9018");
+
+      Assert.IsFalse(new JSValue("0").JSEquals(JSValue.Null), "tag_o10001");
+      Assert.IsFalse(new JSValue("0").JSEquals(new JSValueObject { }), "tag_o10002");
+      Assert.IsFalse(new JSValue("0").JSEquals(new JSValueArray { }), "tag_o10003");
+      Assert.IsFalse(new JSValue("0").JSEquals(new JSValueArray { "Hello" }), "tag_o10004");
+      Assert.IsTrue(new JSValue("0").JSEquals(new JSValueArray { "0" }), "tag_o10005");
+      Assert.IsTrue(new JSValue("0").JSEquals(new JSValueArray { 0 }), "tag_o10006");
+      Assert.IsFalse(new JSValue("0").JSEquals(""), "tag_o10007");
+      Assert.IsTrue(new JSValue("0").JSEquals("0"), "tag_o10008");
+      Assert.IsFalse(new JSValue("0").JSEquals("Hello"), "tag_o10009");
+      Assert.IsTrue(new JSValue("0").JSEquals(false), "tag_o10010");
+      Assert.IsFalse(new JSValue("0").JSEquals(true), "tag_o10011");
+      Assert.IsTrue(new JSValue("0").JSEquals(0), "tag_o10012");
+      Assert.IsFalse(new JSValue("0").JSEquals(5), "tag_o10013");
+      Assert.IsFalse(new JSValue("0").JSEquals(1), "tag_o10014");
+      Assert.IsTrue(new JSValue("0").JSEquals(0.0), "tag_o10015");
+      Assert.IsFalse(new JSValue("0").JSEquals(0.5), "tag_o10016");
+      Assert.IsFalse(new JSValue("0").JSEquals(1.0), "tag_o10017");
+
+      Assert.IsFalse(new JSValue("1").JSEquals(JSValue.Null), "tag_o11001");
+      Assert.IsFalse(new JSValue("1").JSEquals(new JSValueObject { }), "tag_o11002");
+      Assert.IsFalse(new JSValue("1").JSEquals(new JSValueArray { }), "tag_o11003");
+      Assert.IsFalse(new JSValue("1").JSEquals(new JSValueArray { "Hello" }), "tag_o11004");
+      Assert.IsTrue(new JSValue("1").JSEquals(new JSValueArray { "1" }), "tag_o11005");
+      Assert.IsTrue(new JSValue("1").JSEquals(new JSValueArray { 1 }), "tag_o11006");
+      Assert.IsFalse(new JSValue("1").JSEquals(""), "tag_o11007");
+      Assert.IsTrue(new JSValue("1").JSEquals("1"), "tag_o11008");
+      Assert.IsFalse(new JSValue("1").JSEquals("Hello"), "tag_o11009");
+      Assert.IsFalse(new JSValue("1").JSEquals(false), "tag_o11010");
+      Assert.IsTrue(new JSValue("1").JSEquals(true), "tag_o11011");
+      Assert.IsFalse(new JSValue("1").JSEquals(0), "tag_o11012");
+      Assert.IsFalse(new JSValue("1").JSEquals(5), "tag_o11013");
+      Assert.IsTrue(new JSValue("1").JSEquals(1), "tag_o11014");
+      Assert.IsFalse(new JSValue("1").JSEquals(0.0), "tag_o11015");
+      Assert.IsFalse(new JSValue("1").JSEquals(0.5), "tag_o11016");
+      Assert.IsTrue(new JSValue("1").JSEquals(1.0), "tag_o11017");
+
+      Assert.IsFalse(new JSValue("true").JSEquals(JSValue.Null), "tag_o12001");
+      Assert.IsFalse(new JSValue("true").JSEquals(new JSValueObject { }), "tag_o12002");
+      Assert.IsFalse(new JSValue("true").JSEquals(new JSValueArray { }), "tag_o12003");
+      Assert.IsFalse(new JSValue("true").JSEquals(new JSValueArray { 0 }), "tag_o12004");
+      Assert.IsFalse(new JSValue("true").JSEquals(new JSValueArray { 1 }), "tag_o12005");
+      Assert.IsTrue(new JSValue("true").JSEquals(new JSValueArray { true }), "tag_o12006");
+      Assert.IsTrue(new JSValue("true").JSEquals(new JSValueArray { "true" }), "tag_o12007");
+      Assert.IsFalse(new JSValue("true").JSEquals(""), "tag_o12008");
+      Assert.IsFalse(new JSValue("true").JSEquals("1"), "tag_o12009");
+      Assert.IsFalse(new JSValue("true").JSEquals("Hello"), "tag_o12010");
+      Assert.IsTrue(new JSValue("true").JSEquals("true"), "tag_o12011");
+      Assert.IsFalse(new JSValue("true").JSEquals(false), "tag_o12012");
+      Assert.IsFalse(new JSValue("true").JSEquals(true), "tag_o12013");
+      Assert.IsFalse(new JSValue("true").JSEquals(0), "tag_o12014");
+      Assert.IsFalse(new JSValue("true").JSEquals(5), "tag_o12015");
+      Assert.IsFalse(new JSValue("true").JSEquals(1), "tag_o12016");
+      Assert.IsFalse(new JSValue("true").JSEquals(0.0), "tag_o12017");
+      Assert.IsFalse(new JSValue("true").JSEquals(0.5), "tag_o12018");
+      Assert.IsFalse(new JSValue("true").JSEquals(1.0), "tag_o12019");
+
+      Assert.IsTrue(new JSValue("[object Object]").JSEquals(new JSValueObject { }), "tag_o13001");
+
+      Assert.IsFalse(new JSValue(true).JSEquals(JSValue.Null), "tag_o14001");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueObject { }), "tag_o14002");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueArray { }), "tag_o14003");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueArray { "Hello" }), "tag_o14004");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueArray { 0 }), "tag_o14005");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueArray { "0" }), "tag_o14006");
+      Assert.IsTrue(new JSValue(true).JSEquals(new JSValueArray { 1 }), "tag_o14007");
+      Assert.IsTrue(new JSValue(true).JSEquals(new JSValueArray { "1" }), "tag_o14008");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueArray { true }), "tag_o14009");
+      Assert.IsFalse(new JSValue(true).JSEquals(new JSValueArray { "true" }), "tag_o14010");
+      Assert.IsFalse(new JSValue(true).JSEquals(""), "tag_o14011");
+      Assert.IsFalse(new JSValue(true).JSEquals("0"), "tag_o14012");
+      Assert.IsTrue(new JSValue(true).JSEquals("1"), "tag_o14013");
+      Assert.IsFalse(new JSValue(true).JSEquals("true"), "tag_o14014");
+      Assert.IsFalse(new JSValue(true).JSEquals("false"), "tag_o14015");
+      Assert.IsFalse(new JSValue(true).JSEquals("Hello"), "tag_o14016");
+      Assert.IsFalse(new JSValue(true).JSEquals(false), "tag_o14017");
+      Assert.IsTrue(new JSValue(true).JSEquals(true), "tag_o14018");
+      Assert.IsFalse(new JSValue(true).JSEquals(0), "tag_o14019");
+      Assert.IsFalse(new JSValue(true).JSEquals(5), "tag_o14020");
+      Assert.IsTrue(new JSValue(true).JSEquals(1), "tag_o14021");
+      Assert.IsFalse(new JSValue(true).JSEquals(0.0), "tag_o14022");
+      Assert.IsFalse(new JSValue(true).JSEquals(0.5), "tag_o14023");
+      Assert.IsTrue(new JSValue(true).JSEquals(1.0), "tag_o14024");
+
+      Assert.IsFalse(new JSValue(false).JSEquals(JSValue.Null), "tag_o15001");
+      Assert.IsFalse(new JSValue(false).JSEquals(new JSValueObject { }), "tag_o15002");
+      Assert.IsTrue(new JSValue(false).JSEquals(new JSValueArray { }), "tag_o15003");
+      Assert.IsFalse(new JSValue(false).JSEquals(new JSValueArray { "Hello" }), "tag_o15004");
+      Assert.IsTrue(new JSValue(false).JSEquals(new JSValueArray { 0 }), "tag_o15005");
+      Assert.IsTrue(new JSValue(false).JSEquals(new JSValueArray { "0" }), "tag_o15006");
+      Assert.IsFalse(new JSValue(false).JSEquals(new JSValueArray { 1 }), "tag_o15007");
+      Assert.IsFalse(new JSValue(false).JSEquals(new JSValueArray { "1" }), "tag_o15008");
+      Assert.IsFalse(new JSValue(false).JSEquals(new JSValueArray { true }), "tag_o15009");
+      Assert.IsFalse(new JSValue(false).JSEquals(new JSValueArray { "true" }), "tag_o15010");
+      Assert.IsTrue(new JSValue(false).JSEquals(""), "tag_o15011");
+      Assert.IsTrue(new JSValue(false).JSEquals("0"), "tag_o15012");
+      Assert.IsFalse(new JSValue(false).JSEquals("1"), "tag_o15013");
+      Assert.IsFalse(new JSValue(false).JSEquals("true"), "tag_o15014");
+      Assert.IsFalse(new JSValue(false).JSEquals("false"), "tag_o15015");
+      Assert.IsFalse(new JSValue(false).JSEquals("Hello"), "tag_o15016");
+      Assert.IsTrue(new JSValue(false).JSEquals(false), "tag_o15017");
+      Assert.IsFalse(new JSValue(false).JSEquals(true), "tag_o15018");
+      Assert.IsTrue(new JSValue(false).JSEquals(0), "tag_o15019");
+      Assert.IsFalse(new JSValue(false).JSEquals(5), "tag_o15020");
+      Assert.IsFalse(new JSValue(false).JSEquals(1), "tag_o15021");
+      Assert.IsTrue(new JSValue(false).JSEquals(0.0), "tag_o15022");
+      Assert.IsFalse(new JSValue(false).JSEquals(0.5), "tag_o15023");
+      Assert.IsFalse(new JSValue(false).JSEquals(1.0), "tag_o15024");
+
+      Assert.IsFalse(new JSValue(0).JSEquals(JSValue.Null), "tag_o16001");
+      Assert.IsFalse(new JSValue(0).JSEquals(new JSValueObject { }), "tag_o16002");
+      Assert.IsTrue(new JSValue(0).JSEquals(new JSValueArray { }), "tag_o16003");
+      Assert.IsFalse(new JSValue(0).JSEquals(new JSValueArray { "Hello" }), "tag_o16004");
+      Assert.IsTrue(new JSValue(0).JSEquals(new JSValueArray { 0 }), "tag_o16005");
+      Assert.IsTrue(new JSValue(0).JSEquals(new JSValueArray { "0" }), "tag_o16006");
+      Assert.IsFalse(new JSValue(0).JSEquals(new JSValueArray { 1 }), "tag_o16007");
+      Assert.IsFalse(new JSValue(0).JSEquals(new JSValueArray { "1" }), "tag_o16008");
+      Assert.IsFalse(new JSValue(0).JSEquals(new JSValueArray { true }), "tag_o16009");
+      Assert.IsFalse(new JSValue(0).JSEquals(new JSValueArray { "true" }), "tag_o16010");
+      Assert.IsTrue(new JSValue(0).JSEquals(""), "tag_o16011");
+      Assert.IsTrue(new JSValue(0).JSEquals("0"), "tag_o16012");
+      Assert.IsFalse(new JSValue(0).JSEquals("1"), "tag_o16013");
+      Assert.IsFalse(new JSValue(0).JSEquals("true"), "tag_o16014");
+      Assert.IsFalse(new JSValue(0).JSEquals("false"), "tag_o16015");
+      Assert.IsFalse(new JSValue(0).JSEquals("Hello"), "tag_o16016");
+      Assert.IsTrue(new JSValue(0).JSEquals(false), "tag_o16017");
+      Assert.IsFalse(new JSValue(0).JSEquals(true), "tag_o16018");
+      Assert.IsTrue(new JSValue(0).JSEquals(0), "tag_o16019");
+      Assert.IsFalse(new JSValue(0).JSEquals(5), "tag_o16020");
+      Assert.IsFalse(new JSValue(0).JSEquals(1), "tag_o16021");
+      Assert.IsTrue(new JSValue(0).JSEquals(0.0), "tag_o16022");
+      Assert.IsFalse(new JSValue(0).JSEquals(0.5), "tag_o16023");
+      Assert.IsFalse(new JSValue(0).JSEquals(1.0), "tag_o16024");
+
+      Assert.IsFalse(new JSValue(1).JSEquals(JSValue.Null), "tag_o17001");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueObject { }), "tag_o17002");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueArray { }), "tag_o17003");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueArray { "Hello" }), "tag_o17004");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueArray { 0 }), "tag_o17005");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueArray { "0" }), "tag_o17006");
+      Assert.IsTrue(new JSValue(1).JSEquals(new JSValueArray { 1 }), "tag_o17007");
+      Assert.IsTrue(new JSValue(1).JSEquals(new JSValueArray { "1" }), "tag_o17008");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueArray { true }), "tag_o17009");
+      Assert.IsFalse(new JSValue(1).JSEquals(new JSValueArray { "true" }), "tag_o17010");
+      Assert.IsFalse(new JSValue(1).JSEquals(""), "tag_o17011");
+      Assert.IsFalse(new JSValue(1).JSEquals("0"), "tag_o17012");
+      Assert.IsTrue(new JSValue(1).JSEquals("1"), "tag_o17013");
+      Assert.IsFalse(new JSValue(1).JSEquals("true"), "tag_o17014");
+      Assert.IsFalse(new JSValue(1).JSEquals("false"), "tag_o17015");
+      Assert.IsFalse(new JSValue(1).JSEquals("Hello"), "tag_o17016");
+      Assert.IsFalse(new JSValue(1).JSEquals(false), "tag_o17017");
+      Assert.IsTrue(new JSValue(1).JSEquals(true), "tag_o17018");
+      Assert.IsFalse(new JSValue(1).JSEquals(0), "tag_o17019");
+      Assert.IsFalse(new JSValue(1).JSEquals(5), "tag_o17020");
+      Assert.IsTrue(new JSValue(1).JSEquals(1), "tag_o17021");
+      Assert.IsFalse(new JSValue(1).JSEquals(0.0), "tag_o17022");
+      Assert.IsFalse(new JSValue(1).JSEquals(0.5), "tag_o17023");
+      Assert.IsTrue(new JSValue(1).JSEquals(1.0), "tag_o17024");
+
+      Assert.IsFalse(new JSValue(5).JSEquals(JSValue.Null), "tag_o18001");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueObject { }), "tag_o18002");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { }), "tag_o18003");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { "Hello" }), "tag_o18004");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { 0 }), "tag_o18005");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { "0" }), "tag_o18006");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { 1 }), "tag_o18007");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { "1" }), "tag_o18008");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { true }), "tag_o18009");
+      Assert.IsFalse(new JSValue(5).JSEquals(new JSValueArray { "true" }), "tag_o18010");
+      Assert.IsFalse(new JSValue(5).JSEquals(""), "tag_o18011");
+      Assert.IsFalse(new JSValue(5).JSEquals("0"), "tag_o18012");
+      Assert.IsFalse(new JSValue(5).JSEquals("1"), "tag_o18013");
+      Assert.IsFalse(new JSValue(5).JSEquals("true"), "tag_o18014");
+      Assert.IsFalse(new JSValue(5).JSEquals("false"), "tag_o18015");
+      Assert.IsFalse(new JSValue(5).JSEquals("Hello"), "tag_o18016");
+      Assert.IsFalse(new JSValue(5).JSEquals(false), "tag_o18017");
+      Assert.IsFalse(new JSValue(5).JSEquals(true), "tag_o18018");
+      Assert.IsFalse(new JSValue(5).JSEquals(0), "tag_o18019");
+      Assert.IsTrue(new JSValue(5).JSEquals(5), "tag_o18020");
+      Assert.IsFalse(new JSValue(5).JSEquals(1), "tag_o18021");
+      Assert.IsFalse(new JSValue(5).JSEquals(0.0), "tag_o18022");
+      Assert.IsFalse(new JSValue(5).JSEquals(0.5), "tag_o18023");
+      Assert.IsFalse(new JSValue(5).JSEquals(1.0), "tag_o18024");
+
+      Assert.IsFalse(new JSValue(0.0).JSEquals(JSValue.Null), "tag_o19001");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(new JSValueObject { }), "tag_o19002");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(new JSValueArray { }), "tag_o19003");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(new JSValueArray { "Hello" }), "tag_o19004");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(new JSValueArray { 0 }), "tag_o19005");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(new JSValueArray { "0" }), "tag_o19006");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(new JSValueArray { 1 }), "tag_o19007");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(new JSValueArray { "1" }), "tag_o19008");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(new JSValueArray { true }), "tag_o19009");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(new JSValueArray { "true" }), "tag_o19010");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(""), "tag_o19011");
+      Assert.IsTrue(new JSValue(0.0).JSEquals("0"), "tag_o19012");
+      Assert.IsFalse(new JSValue(0.0).JSEquals("1"), "tag_o19013");
+      Assert.IsFalse(new JSValue(0.0).JSEquals("true"), "tag_o19014");
+      Assert.IsFalse(new JSValue(0.0).JSEquals("false"), "tag_o19015");
+      Assert.IsFalse(new JSValue(0.0).JSEquals("Hello"), "tag_o19016");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(false), "tag_o19017");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(true), "tag_o19018");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(0), "tag_o19019");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(5), "tag_o19020");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(1), "tag_o19021");
+      Assert.IsTrue(new JSValue(0.0).JSEquals(0.0), "tag_o19022");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(0.5), "tag_o19023");
+      Assert.IsFalse(new JSValue(0.0).JSEquals(1.0), "tag_o19024");
+
+      Assert.IsFalse(new JSValue(1.0).JSEquals(JSValue.Null), "tag_o20001");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueObject { }), "tag_o20002");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueArray { }), "tag_o20003");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueArray { "Hello" }), "tag_o20004");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueArray { 0 }), "tag_o20005");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueArray { "0" }), "tag_o20006");
+      Assert.IsTrue(new JSValue(1.0).JSEquals(new JSValueArray { 1 }), "tag_o20007");
+      Assert.IsTrue(new JSValue(1.0).JSEquals(new JSValueArray { "1" }), "tag_o20008");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueArray { true }), "tag_o20009");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(new JSValueArray { "true" }), "tag_o20010");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(""), "tag_o20011");
+      Assert.IsFalse(new JSValue(1.0).JSEquals("0"), "tag_o20012");
+      Assert.IsTrue(new JSValue(1.0).JSEquals("1"), "tag_o20013");
+      Assert.IsFalse(new JSValue(1.0).JSEquals("true"), "tag_o20014");
+      Assert.IsFalse(new JSValue(1.0).JSEquals("false"), "tag_o20015");
+      Assert.IsFalse(new JSValue(1.0).JSEquals("Hello"), "tag_o20016");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(false), "tag_o20017");
+      Assert.IsTrue(new JSValue(1.0).JSEquals(true), "tag_o20018");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(0), "tag_o20019");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(5), "tag_o20020");
+      Assert.IsTrue(new JSValue(1.0).JSEquals(1), "tag_o20021");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(0.0), "tag_o20022");
+      Assert.IsFalse(new JSValue(1.0).JSEquals(0.5), "tag_o20023");
+      Assert.IsTrue(new JSValue(1.0).JSEquals(1.0), "tag_o20024");
+
+      Assert.IsFalse(new JSValue(0.5).JSEquals(JSValue.Null), "tag_o21001");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueObject { }), "tag_o21002");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { }), "tag_o21003");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { "Hello" }), "tag_o21004");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { 0 }), "tag_o21005");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { "0" }), "tag_o21006");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { 1 }), "tag_o21007");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { "1" }), "tag_o21008");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { true }), "tag_o21009");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(new JSValueArray { "true" }), "tag_o21010");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(""), "tag_o21011");
+      Assert.IsFalse(new JSValue(0.5).JSEquals("0"), "tag_o21012");
+      Assert.IsFalse(new JSValue(0.5).JSEquals("1"), "tag_o21013");
+      Assert.IsFalse(new JSValue(0.5).JSEquals("true"), "tag_o21014");
+      Assert.IsFalse(new JSValue(0.5).JSEquals("false"), "tag_o21015");
+      Assert.IsFalse(new JSValue(0.5).JSEquals("Hello"), "tag_o21016");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(false), "tag_o21017");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(true), "tag_o21018");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(0), "tag_o21019");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(5), "tag_o21020");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(1), "tag_o21021");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(0.0), "tag_o21022");
+      Assert.IsTrue(new JSValue(0.5).JSEquals(0.5), "tag_o21023");
+      Assert.IsFalse(new JSValue(0.5).JSEquals(1.0), "tag_o21024");
+    }
+
+    [TestMethod]
+    public void TestEquals()
+    {
+      void CheckEquals(JSValue left, JSValue right, string tag)
+      {
+        Assert.IsTrue(left.Equals(right), "Equals: {0}", tag);
+        Assert.IsTrue(left.Equals((object)right), "Equals(object): {0}", tag);
+        Assert.IsTrue(left == right, "operator ==: {0}", tag);
+      }
+
+      void CheckNotEquals(JSValue left, JSValue right, string tag)
+      {
+        Assert.IsFalse(left.Equals(right), "!Equals: {0}", tag);
+        Assert.IsFalse(left.Equals((object)right), "!Equals(object): {0}", tag);
+        Assert.IsTrue(left != right, "operator !=: {0}", tag);
+      }
+
+      CheckEquals(new JSValueObject { }, new JSValueObject { }, "tag_p101");
+      CheckEquals(new JSValueObject { ["prop1"] = 1 }, new JSValueObject { ["prop1"] = 1 }, "tag_p102");
+      CheckEquals(new JSValueObject { ["prop1"] = 1, ["prop2"] = "Hello" },
+                  new JSValueObject { ["prop1"] = 1, ["prop2"] = "Hello" }, "tag_p103");
+      CheckEquals(new JSValueObject { ["prop1"] = new JSValueObject { } },
+                  new JSValueObject { ["prop1"] = new JSValueObject { } }, "tag_p104");
+      CheckEquals(new JSValueObject { ["prop1"] = new JSValueObject { ["prop1"] = 1 } },
+                  new JSValueObject { ["prop1"] = new JSValueObject { ["prop1"] = 1 } }, "tag_p105");
+      CheckEquals(new JSValueObject { ["prop1"] = new JSValueArray { } },
+                  new JSValueObject { ["prop1"] = new JSValueArray { } }, "tag_p106");
+      CheckEquals(new JSValueObject { ["prop1"] = new JSValueArray { 1 } },
+                  new JSValueObject { ["prop1"] = new JSValueArray { 1 } }, "tag_p107");
+      CheckNotEquals(new JSValueObject { ["prop1"] = 1 }, new JSValueObject { }, "tag_p108");
+      CheckNotEquals(new JSValueObject { ["prop1"] = 1 }, new JSValueObject { ["prop1"] = 2 }, "tag_p109");
+      CheckNotEquals(new JSValueObject { }, new JSValueArray { }, "tag_p110");
+      CheckNotEquals(new JSValueObject { }, "", "tag_p111");
+      CheckNotEquals(new JSValueObject { }, false, "tag_p112");
+      CheckNotEquals(new JSValueObject { }, true, "tag_p113");
+      CheckNotEquals(new JSValueObject { }, 0, "tag_p114");
+      CheckNotEquals(new JSValueObject { }, 0.0, "tag_p115");
+
+
+      CheckEquals(new JSValueArray { }, new JSValueArray { }, "tag_p201");
+      CheckEquals(new JSValueArray { 1 }, new JSValueArray { 1 }, "tag_p202");
+      CheckEquals(new JSValueArray { 1, "Hello" },
+                  new JSValueArray { 1, "Hello" }, "tag_p203");
+      CheckEquals(new JSValueArray { new JSValueArray { } },
+                  new JSValueArray { new JSValueArray { } }, "tag_p204");
+      CheckEquals(new JSValueArray { new JSValueArray { 1 } },
+                  new JSValueArray { new JSValueArray { 1 } }, "tag_p205");
+      CheckEquals(new JSValueArray { new JSValueObject { } },
+                  new JSValueArray { new JSValueObject { } }, "tag_p206");
+      CheckEquals(new JSValueArray { new JSValueObject { ["prop1"] = 1 } },
+                  new JSValueArray { new JSValueObject { ["prop1"] = 1 } }, "tag_p207");
+      CheckNotEquals(new JSValueArray { 1 }, new JSValueArray { }, "tag_p208");
+      CheckNotEquals(new JSValueArray { 1 }, new JSValueArray { 2 }, "tag_p209");
+      CheckNotEquals(new JSValueArray { }, new JSValueObject { }, "tag_p210");
+      CheckNotEquals(new JSValueArray { }, "", "tag_p211");
+      CheckNotEquals(new JSValueArray { }, false, "tag_p212");
+      CheckNotEquals(new JSValueArray { }, true, "tag_p213");
+      CheckNotEquals(new JSValueArray { }, 0, "tag_p214");
+      CheckNotEquals(new JSValueArray { }, 0.0, "tag_p215");
+
+      CheckEquals("", "", "tag_p301");
+      CheckEquals("Hello", "Hello", "tag_p302");
+      CheckNotEquals("Hello1", "Hello2", "tag_p303");
+      CheckNotEquals("", new JSValueObject { }, "tag_p304");
+      CheckNotEquals("", new JSValueArray { }, "tag_p305");
+      CheckNotEquals("", false, "tag_p306");
+      CheckNotEquals("", 0, "tag_p307");
+      CheckNotEquals("", 0.0, "tag_p308");
+
+      CheckEquals(false, false, "tag_p401");
+      CheckEquals(true, true, "tag_p402");
+      CheckNotEquals(false, true, "tag_p403");
+      CheckNotEquals(true, false, "tag_p404");
+      CheckNotEquals(false, new JSValueObject { }, "tag_p405");
+      CheckNotEquals(false, new JSValueArray { }, "tag_p406");
+      CheckNotEquals(false, "", "tag_p407");
+      CheckNotEquals(false, 0, "tag_p408");
+      CheckNotEquals(false, 0.0, "tag_p409");
+
+      CheckEquals(0, 0, "tag_p501");
+      CheckEquals(42, 42, "tag_p502");
+      CheckNotEquals(2, 3, "tag_p503");
+      CheckNotEquals(-1, 1, "tag_p504");
+      CheckNotEquals(0, new JSValueObject { }, "tag_p505");
+      CheckNotEquals(0, new JSValueArray { }, "tag_p506");
+      CheckNotEquals(0, "", "tag_p507");
+      CheckNotEquals(0, false, "tag_p508");
+      CheckNotEquals(0, 0.0, "tag_p509");
+
+      CheckEquals(0.0, 0.0, "tag_p601");
+      CheckEquals(4.2, 4.2, "tag_p602");
+      CheckNotEquals(0.2, 0.3, "tag_p603");
+      CheckNotEquals(-0.1, 0.1, "tag_p604");
+      CheckNotEquals(0.0, new JSValueObject { }, "tag_p605");
+      CheckNotEquals(0.0, new JSValueArray { }, "tag_p606");
+      CheckNotEquals(0.0, "", "tag_p607");
+      CheckNotEquals(0.0, false, "tag_p608");
+      CheckNotEquals(0.0, 0, "tag_p609");
     }
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
@@ -839,7 +839,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.DividePromise), 6, 2,
           (int result) => Assert.AreEqual(3, result),
-          (JSValue error) => Assert.AreEqual("Division by 0", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -848,7 +848,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.DividePromise), 6, 0,
           (int result) => Assert.AreEqual(3, result),
-          (JSValue error) => Assert.AreEqual("Division by 0", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -857,7 +857,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegatePromise), 5,
           (int result) => Assert.AreEqual(-5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -866,7 +866,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegatePromise), -5,
           (int result) => Assert.AreEqual(5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -875,7 +875,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateAsyncPromise), 5,
           (int result) => Assert.AreEqual(-5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String)).Wait();
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -884,7 +884,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateAsyncPromise), -5,
           (int result) => Assert.AreEqual(5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String)).Wait();
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -893,7 +893,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2("voidPromise", 2,
           (JSValue.Void result) => { },
-          (JSValue error) => Assert.AreEqual("Odd unexpected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -902,7 +902,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2("voidPromise", 3,
           (JSValue.Void result) => { },
-          (JSValue error) => Assert.AreEqual("Odd unexpected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -911,7 +911,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.ResolveSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
-          (JSValue error) => Assert.AreEqual("Promise rejected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -920,7 +920,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.RejectSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
-          (JSValue error) => Assert.AreEqual("Promise rejected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -929,7 +929,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticDividePromise), 6, 2,
           (int result) => Assert.AreEqual(3, result),
-          (JSValue error) => Assert.AreEqual("Division by 0", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -938,7 +938,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticDividePromise), 6, 0,
           (int result) => Assert.AreEqual(3, result),
-          (JSValue error) => Assert.AreEqual("Division by 0", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -947,7 +947,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegatePromise), 5,
           (int result) => Assert.AreEqual(-5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -956,7 +956,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegatePromise), -5,
           (int result) => Assert.AreEqual(5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -965,7 +965,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateAsyncPromise), 5,
           (int result) => Assert.AreEqual(-5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String)).Wait();
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -974,7 +974,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateAsyncPromise), -5,
           (int result) => Assert.AreEqual(5, result),
-          (JSValue error) => Assert.AreEqual("Already negative", error.Object["message"].String)).Wait();
+          (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -983,7 +983,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2("staticVoidPromise", 2,
           (JSValue.Void result) => { },
-          (JSValue error) => Assert.AreEqual("Odd unexpected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -992,7 +992,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2("staticVoidPromise", 3,
           (JSValue.Void result) => { },
-          (JSValue error) => Assert.AreEqual("Odd unexpected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -1002,7 +1002,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticResolveSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
-          (JSValue error) => Assert.AreEqual("Promise rejected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -1011,7 +1011,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticRejectSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
-          (JSValue error) => Assert.AreEqual("Promise rejected", error.Object["message"].String));
+          (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
@@ -1061,14 +1061,14 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestConstants()
     {
       var constants = m_moduleBuilderMock.GetConstants();
-      Assert.AreEqual("MyConstant1", constants[nameof(SimpleNativeModule.Constant1)].String);
-      Assert.AreEqual("MyConstant2", constants["const2"].String);
+      Assert.AreEqual("MyConstant1", constants[nameof(SimpleNativeModule.Constant1)]);
+      Assert.AreEqual("MyConstant2", constants["const2"]);
       Assert.AreEqual(new Point { X = 2, Y = 3 }, constants["const3"].To<Point>());
       Assert.AreEqual(new Point { X = 3, Y = 4 }, constants[nameof(SimpleNativeModule.Constant4)].To<Point>());
       Assert.AreEqual(new Point { X = 12, Y = 14 }, constants["const51"].To<Point>());
-      Assert.AreEqual("MyConstant52", constants["const52"].String);
+      Assert.AreEqual("MyConstant52", constants["const52"]);
       Assert.AreEqual(new Point { X = 15, Y = 17 }, constants["const61"].To<Point>());
-      Assert.AreEqual("MyConstant62", constants["const62"].String);
+      Assert.AreEqual("MyConstant62", constants["const62"]);
     }
 
     [TestMethod]

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -11,12 +11,12 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 {
   class ReactModuleBuilderMock : IReactModuleBuilder
   {
-    private List<InitializerDelegate> m_initializers = new List<InitializerDelegate>();
-    private Dictionary<string, Tuple<MethodReturnType, MethodDelegate>> m_methods =
+    private readonly List<InitializerDelegate> m_initializers = new List<InitializerDelegate>();
+    private readonly Dictionary<string, Tuple<MethodReturnType, MethodDelegate>> m_methods =
         new Dictionary<string, Tuple<MethodReturnType, MethodDelegate>>();
-    private Dictionary<string, SyncMethodDelegate> m_syncMethods =
+    private readonly Dictionary<string, SyncMethodDelegate> m_syncMethods =
         new Dictionary<string, SyncMethodDelegate>();
-    private List<ConstantProviderDelegate> m_constantProviders = new List<ConstantProviderDelegate>();
+    private readonly List<ConstantProviderDelegate> m_constantProviders = new List<ConstantProviderDelegate>();
     private Action<string, string, JSValue> m_jsEventHandler;
     private Action<string, string, JSValue> m_jsFunctionHandler;
 
@@ -223,7 +223,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       }
 
       constantWriter.WriteObjectEnd();
-      return constantWriter.TakeValue().Object;
+      return constantWriter.TakeValue().AsObject();
     }
 
     public void ExpectEvent(string eventEmitterName, string eventName, Action<JSValue> checkValue)
@@ -243,7 +243,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
         Assert.AreEqual(moduleName, actualModuleName);
         Assert.AreEqual(functionName, actualFunctionName);
         Assert.AreEqual(JSValueType.Array, value.Type);
-        checkValues(value.Array);
+        checkValues(value.AsArray());
       };
     }
 
@@ -264,7 +264,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
   class ReactContextMock : IReactContext
   {
-    private ReactModuleBuilderMock m_builder;
+    private readonly ReactModuleBuilderMock m_builder;
 
     public ReactContextMock(ReactModuleBuilderMock builder)
     {

--- a/vnext/Microsoft.ReactNative.SharedManaged/AttributedViewManager.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/AttributedViewManager.cs
@@ -119,10 +119,12 @@ namespace Microsoft.ReactNative.Managed
             var propertyAttribute = methodInfo.GetCustomAttribute<ViewManagerPropertyAttribute>();
             if (null != propertyAttribute)
             {
-              var setter = new ViewManagerProperty<TFrameworkElement>();
-              setter.Name = propertyAttribute.PropertyName ?? methodInfo.Name;
-              setter.Type = propertyAttribute.PropertyType ?? TypeToViewManagerPropertyType(methodInfo.GetParameters()[1].ParameterType);
-              setter.Setter = MakeJSValueMethod(methodInfo);
+              var setter = new ViewManagerProperty<TFrameworkElement>
+              {
+                Name = propertyAttribute.PropertyName ?? methodInfo.Name,
+                Type = propertyAttribute.PropertyType ?? TypeToViewManagerPropertyType(methodInfo.GetParameters()[1].ParameterType),
+                Setter = MakeJSValueMethod(methodInfo)
+              };
 
               properties.Add(setter.Name, setter);
             }
@@ -183,7 +185,7 @@ namespace Microsoft.ReactNative.Managed
 
     private static bool IsEnum(Type t)
     {
-      return IsNullableEnum(t, out Type underlyingType) || t.GetTypeInfo().IsEnum;
+      return IsNullableEnum(t, out _) || t.GetTypeInfo().IsEnum;
     }
 
     #endregion
@@ -238,10 +240,12 @@ namespace Microsoft.ReactNative.Managed
             var commandAttribute = methodInfo.GetCustomAttribute<ViewManagerCommandAttribute>();
             if (null != commandAttribute)
             {
-              var command = new ViewManagerCommand<TFrameworkElement>();
-              command.CommandName = commandAttribute.CommandName ?? methodInfo.Name;
-              command.CommandId = viewManagerCommands.Count;
-              command.CommandMethod = MakeReaderMethod(methodInfo);
+              var command = new ViewManagerCommand<TFrameworkElement>
+              {
+                CommandName = commandAttribute.CommandName ?? methodInfo.Name,
+                CommandId = viewManagerCommands.Count,
+                CommandMethod = MakeReaderMethod(methodInfo)
+              };
               viewManagerCommands.Add(command.CommandId, command);
             }
           }

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValue.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValue.cs
@@ -2,53 +2,298 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
-using Windows.UI.Notifications;
 
 namespace Microsoft.ReactNative.Managed
 {
+  // JSValueObject is based on Dictionary<string, JSValue> and can be used to initialize Object value in JSValue.
+  // It is possible to write: JSValueObject{{"X", 4}, {"Y", 5}} or JSValueObject{["X"] = 4, ["Y"] = 5} and assign it to JSValue.
+  class JSValueObject : Dictionary<string, JSValue>, IEquatable<JSValueObject>
+  {
+    // Default constructor
+    public JSValueObject() { }
+
+    // Create JSValueObject as a shallow copy of 'other'.
+    public static JSValueObject CopyFrom(IReadOnlyDictionary<string, JSValue> other)
+    {
+      JSValueObject obj = new JSValueObject();
+      foreach (var keyValue in other)
+      {
+        obj.Add(keyValue.Key, keyValue.Value);
+      }
+
+      return obj;
+    }
+
+    // Return true if two JSValueObject interfaces are strictly equal to each other.
+    // Both objects must have the same set of equal properties.
+    // Property values must be equal.
+    public static bool Equals(IReadOnlyDictionary<string, JSValue> left, IReadOnlyDictionary<string, JSValue> right)
+    {
+      if (left == right) { return true; }
+      else if (left == null) { return false; }
+      else if (right == null) { return false; }
+      else if (left.Count != right.Count) { return false; }
+
+      foreach (var entry in left)
+      {
+        if (!right.TryGetValue(entry.Key, out var value) || !value.Equals(entry.Value))
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // Return true if this JSValueObject is strictly equal to 'other'.
+    public bool Equals(JSValueObject other)
+    {
+      return Equals(this as IReadOnlyDictionary<string, JSValue>, other as IReadOnlyDictionary<string, JSValue>);
+    }
+
+    // Return true if this JSValueObject is strictly equal to 'other'.
+    public bool Equals(IReadOnlyDictionary<string, JSValue> other)
+    {
+      return Equals(this as IReadOnlyDictionary<string, JSValue>, other);
+    }
+
+    // Return true if this JSValueObject is strictly equal to 'obj'.
+    public override bool Equals(object obj)
+    {
+      return Equals(this as IReadOnlyDictionary<string, JSValue>, obj as IReadOnlyDictionary<string, JSValue>);
+    }
+
+    // True if Equals(left, right)
+    public static bool operator ==(JSValueObject left, IReadOnlyDictionary<string, JSValue> right)
+    {
+      return Equals(left, right);
+    }
+
+    // True if !Equals(left, right)
+    public static bool operator !=(JSValueObject left, IReadOnlyDictionary<string, JSValue> right)
+    {
+      return !Equals(left, right);
+    }
+
+    // True if Equals(left, right)
+    public static bool operator ==(IReadOnlyDictionary<string, JSValue> left, JSValueObject right)
+    {
+      return Equals(left, right);
+    }
+
+    // True if !Equals(left, right)
+    public static bool operator !=(IReadOnlyDictionary<string, JSValue> left, JSValueObject right)
+    {
+      return !Equals(left, right);
+    }
+
+    // Return true if this JSValueObject is strictly equal to other JSValueObject
+    // after their property values are converted to the same type.
+    // See JSValue::JSEquals for details about the conversion.
+    public static bool JSEquals(IReadOnlyDictionary<string, JSValue> left, IReadOnlyDictionary<string, JSValue> right)
+    {
+      if (left == right) { return true; }
+      else if (left == null) { return false; }
+      else if (right == null) { return false; }
+      else if (left.Count != right.Count) { return false; }
+
+      foreach (var keyValue in left)
+      {
+        if (!right.TryGetValue(keyValue.Key, out var rightValue) || !keyValue.Value.JSEquals(rightValue))
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // Calculation of the JSValueObject hash code is quite expensive.
+    // It is not implemented.
+    public override int GetHashCode()
+    {
+      throw new NotImplementedException("JSValueObject currently does not support hash codes");
+    }
+
+    // Create JSValueObject from IJSValueReader.
+    public static JSValueObject ReadFrom(IJSValueReader reader) => JSValue.ReadObjectFrom(reader);
+
+    // Write this JSValueObject to IJSValueWriter.
+    public void WriteTo(IJSValueWriter writer) => JSValue.WriteObject(writer, this);
+  }
+
+  // JSValueObject is based on List<JSValue> and can be used to initialize Array value in JSValue.
+  // It is possible to write: JSValueArray{"X", 42, JSValue.Null, true} and assign it to JSValue.
+  class JSValueArray : List<JSValue>, IEquatable<JSValueArray>
+  {
+    // Default constructor
+    public JSValueArray() { }
+
+    public static JSValueArray CopyFrom(IReadOnlyList<JSValue> other)
+    {
+      JSValueArray arr = new JSValueArray();
+      foreach (var item in other)
+      {
+        arr.Add(item);
+      }
+
+      return arr;
+    }
+
+    // Return true if two JSValuearray interfaces are strictly equal to each other.
+    // Both arrays must have the same set of items. Items must be equal.
+    public static bool Equals(IReadOnlyList<JSValue> left, IReadOnlyList<JSValue> right)
+    {
+      if (left == right) { return true; }
+      else if (left == null) { return false; }
+      else if (right == null) { return false; }
+      else if (left.Count != right.Count) { return false; }
+
+      for (int i = 0; i < left.Count; ++i)
+      {
+        if (!left[i].Equals(right[i]))
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // Return true if this JSValueArray is strictly equal to 'other'.
+    public bool Equals(JSValueArray other)
+    {
+      return Equals(this as IReadOnlyList<JSValue>, other as IReadOnlyList<JSValue>);
+    }
+
+    // Return true if this JSValueArray is strictly equal to 'other'.
+    public bool Equals(IReadOnlyList<JSValue> other)
+    {
+      return Equals(this as IReadOnlyList<JSValue>, other);
+    }
+
+    // Return true if this JSValueArray is strictly equal to 'obj'.
+    public override bool Equals(object obj)
+    {
+      return Equals(this as IReadOnlyList<JSValue>, obj as IReadOnlyList<JSValue>);
+    }
+
+    // True if Equals(left, right)
+    public static bool operator ==(JSValueArray left, IReadOnlyList<JSValue> right)
+    {
+      return Equals(left, right);
+    }
+
+    // True if !Equals(left, right)
+    public static bool operator !=(JSValueArray left, IReadOnlyList<JSValue> right)
+    {
+      return !Equals(left, right);
+    }
+
+    // True if Equals(left, right)
+    public static bool operator ==(IReadOnlyList<JSValue> left, JSValueArray right)
+    {
+      return Equals(left, right);
+    }
+
+    // True if !Equals(left, right)
+    public static bool operator !=(IReadOnlyList<JSValue> left, JSValueArray right)
+    {
+      return !Equals(left, right);
+    }
+
+    // Return true if this JSValueArray is strictly equal to other JSValueArray
+    // after their property values are converted to the same type.
+    // See JSValue::JSEquals for details about the conversion.
+    public static bool JSEquals(IReadOnlyList<JSValue> left, IReadOnlyList<JSValue> right)
+    {
+      if (left == right) { return true; }
+      else if (left == null) { return false; }
+      else if (right == null) { return false; }
+      else if (left.Count != right.Count) { return false; }
+
+      for (int i = 0; i < left.Count; ++i)
+      {
+        if (!left[i].JSEquals(right[i]))
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // Calculation of the JSValueArray hash code is quite expensive.
+    // It is not implemented.
+    public override int GetHashCode()
+    {
+      throw new NotImplementedException("JSValueArray currently does not support hash codes");
+    }
+
+    // Create JSValueArray from IJSValueReader.
+    public static JSValueArray ReadFrom(IJSValueReader reader) => JSValue.ReadArrayFrom(reader);
+
+    // Write this JSValueArray to IJSValueWriter.
+    public void WriteTo(IJSValueWriter writer) => JSValue.WriteArray(writer, this);
+  }
+
   // JSValue represents an immutable JavaScript value passed as a parameter.
-  // It is created to simplify working with IJSValueReader.
+  // It is created to simplify working with IJSValueReader in complex situations.
+  // For example, when we need to serialize a TypeScript discriminating union and
+  // we need to read 'kind' property before we process other properties.
   //
   // JSValue is designed to minimize number of memory allocations:
-  // - It is a struct that avoid extra memory allocations when it is stored in a container.
+  // - It is a struct that avoids extra memory allocations when it is stored in a container.
   // - It avoids boxing simple values by using a union type to store them.
   // The JSValue is an immutable and is safe to be used from multiple threads.
   // It does not implement GetHashCode() and must not be used as a key in a dictionary.
   struct JSValue : IEquatable<JSValue>
   {
     public static readonly JSValue Null = new JSValue();
+    public static readonly JSValue EmptyObject = new JSValueObject();
+    public static readonly JSValue EmptyArray = new JSValueArray();
+    public static readonly JSValue EmptyString = "";
 
+    // Used by AsBoolean() conversion from a string to a Boolean.
+    private static readonly HashSet<string> StringToBoolean =
+      new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "true", "1", "yes", "y", "on" };
+
+    // The Void type could be used instead of void in generic types.
     public struct Void { };
 
     private readonly SimpleValue m_simpleValue;
     private readonly object m_objValue;
 
+    // Create an Object JSValue.
     public JSValue(IReadOnlyDictionary<string, JSValue> value)
     {
       Type = JSValueType.Object;
       m_simpleValue = new SimpleValue();
-      m_objValue = value;
+      m_objValue = value ?? EmptyObject.ObjectValue;
     }
 
+    // Create an Array JSValue.
     public JSValue(IReadOnlyList<JSValue> value)
     {
       Type = JSValueType.Array;
       m_simpleValue = new SimpleValue();
-      m_objValue = value;
+      m_objValue = value ?? EmptyArray.ArrayValue;
     }
 
+    // Create a String JSValue.
     public JSValue(string value)
     {
       Type = JSValueType.String;
       m_simpleValue = new SimpleValue();
-      m_objValue = value;
+      m_objValue = value ?? "";
     }
 
+    // Create a Boolean JSValue.
     public JSValue(bool value)
     {
       Type = JSValueType.Boolean;
@@ -56,6 +301,7 @@ namespace Microsoft.ReactNative.Managed
       m_objValue = null;
     }
 
+    // Create an Int64 JSValue.
     public JSValue(long value)
     {
       Type = JSValueType.Int64;
@@ -63,6 +309,7 @@ namespace Microsoft.ReactNative.Managed
       m_objValue = null;
     }
 
+    // Create a Double JSValue.
     public JSValue(double value)
     {
       Type = JSValueType.Double;
@@ -70,6 +317,12 @@ namespace Microsoft.ReactNative.Managed
       m_objValue = null;
     }
 
+    public static implicit operator JSValue(ReadOnlyDictionary<string, JSValue> value) => new JSValue(value);
+    public static implicit operator JSValue(Dictionary<string, JSValue> value) => new JSValue(value);
+    public static implicit operator JSValue(JSValueObject value) => new JSValue(value);
+    public static implicit operator JSValue(ReadOnlyCollection<JSValue> value) => new JSValue(value);
+    public static implicit operator JSValue(List<JSValue> value) => new JSValue(value);
+    public static implicit operator JSValue(JSValueArray value) => new JSValue(value);
     public static implicit operator JSValue(string value) => new JSValue(value);
     public static implicit operator JSValue(bool value) => new JSValue(value);
     public static implicit operator JSValue(sbyte value) => new JSValue(value);
@@ -83,135 +336,318 @@ namespace Microsoft.ReactNative.Managed
     public static implicit operator JSValue(float value) => new JSValue(value);
     public static implicit operator JSValue(double value) => new JSValue(value);
 
+    // Get JSValue type.
     public JSValueType Type { get; }
 
+    // Return true if JSValue type is Null.
     public bool IsNull => Type == JSValueType.Null;
 
-    public IReadOnlyDictionary<string, JSValue> Object => (IReadOnlyDictionary<string, JSValue>)m_objValue;
-    public IReadOnlyList<JSValue> Array => (IReadOnlyList<JSValue>)m_objValue;
-    public string String => (string)m_objValue;
-    public bool Boolean => m_simpleValue.BooleanValue;
-    public long Int64 => m_simpleValue.Int64Value;
-    public double Double => m_simpleValue.DoubleValue;
-
-    public static explicit operator string(JSValue value)
+    // Return true and Object value if JSValue type is Object, or false and JSValue.Null otherwise.
+    public bool TryGetObject(out IReadOnlyDictionary<string, JSValue> value)
     {
-      switch (value.Type)
+      value = (Type == JSValueType.Object) ? (IReadOnlyDictionary<string, JSValue>)m_objValue : null;
+      return value != null;
+    }
+
+    // Return true and Array value if JSValue type is Array, or false and JSValue.Null otherwise.
+    public bool TryGetArray(out IReadOnlyList<JSValue> value)
+    {
+      value = (Type == JSValueType.Array) ? (IReadOnlyList<JSValue>)m_objValue : null;
+      return value != null;
+    }
+
+    // Return true and String value if JSValue type is String, or false and JSValue.Null otherwise.
+    public bool TryGetString(out string value)
+    {
+      value = (Type == JSValueType.String) ? (string)m_objValue : null;
+      return value != null;
+    }
+
+    // Return true and Boolean value if JSValue type is Boolean, or false and JSValue.Null otherwise.
+    public bool TryGetBoolean(out bool value)
+    {
+      if (Type == JSValueType.Boolean)
       {
-        case JSValueType.String: return value.String;
-        case JSValueType.Boolean: return value.Boolean ? "true" : "false"; 
-        case JSValueType.Int64: return value.Int64.ToString(); 
-        case JSValueType.Double: return value.Double.ToString();
+        value = m_simpleValue.BooleanValue;
+        return true;
+      }
+
+      value = false;
+      return false;
+    }
+
+    // Return true and Int64 value if JSValue type is Int64, or false and JSValue.Null otherwise.
+    public bool TryGetInt64(out long value)
+    {
+      if (Type == JSValueType.Int64)
+      {
+        value = m_simpleValue.Int64Value;
+        return true;
+      }
+
+      value = 0;
+      return false;
+    }
+
+    // Return true and Double value if JSValue type is Double, or false and JSValue.Null otherwise.
+    public bool TryGetDouble(out double value)
+    {
+      if (Type == JSValueType.Double)
+      {
+        value = m_simpleValue.DoubleValue;
+        return true;
+      }
+
+      value = 0;
+      return false;
+    }
+
+    // Return Object representation of JSValue. It is JSValue.EmptyObject if type is not Object.
+    public IReadOnlyDictionary<string, JSValue> AsObject() =>
+      Type == JSValueType.Object ? ObjectValue : EmptyObject.ObjectValue;
+
+    // Return Array representation of JSValue. It is JSValue.EmptyArray if type is not Array.
+    public IReadOnlyList<JSValue> AsArray() =>
+      Type == JSValueType.Array ? ArrayValue : EmptyArray.ArrayValue;
+
+    // Return a String representation of JSValue.
+    // Null is "null".
+    // Object and Array are empty strings "".
+    // Boolean is "true" or "false".
+    // Int64 is converted to string using integer representation.
+    // Double uses AsJSString() conversion which uses "NaN", "Infinity", and "-Infinity" for special values.
+    public string AsString()
+    {
+      switch (Type)
+      {
+        case JSValueType.Null: return JSConverter.NullString;
+        case JSValueType.String: return StringValue;
+        case JSValueType.Boolean: return JSConverter.ToJSString(BooleanValue);
+        case JSValueType.Int64: return Int64Value.ToString();
+        case JSValueType.Double: return JSConverter.ToJSString(DoubleValue);
         default: return "";
       }
     }
 
-    public static explicit operator bool(JSValue value)
+    // Return a Boolean representation of JSValue.
+    // Object and Array are true if they are not empty.
+    // String is true if it case-insensitively matches "true", "1", "yes", "y", or "on" strings.
+    // Int64 or Double are false if they are zero or NAN.
+    public bool AsBoolean()
     {
-      switch (value.Type)
+      switch (Type)
       {
-        case JSValueType.Object: return true;
-        case JSValueType.Array: return true;
-        case JSValueType.String: return !string.IsNullOrEmpty(value.String);
-        case JSValueType.Boolean: return value.Boolean;
-        case JSValueType.Int64: return value.Int64 != 0;
-        case JSValueType.Double: return value.Double != 0;
+        case JSValueType.Object: return ObjectValue.Count != 0;
+        case JSValueType.Array: return ArrayValue.Count != 0;
+        case JSValueType.String: return StringToBoolean.Contains(StringValue);
+        case JSValueType.Boolean: return BooleanValue;
+        case JSValueType.Int64: return Int64Value != 0;
+        case JSValueType.Double: return !double.IsNaN(DoubleValue) && DoubleValue != 0;
         default: return false;
       }
     }
 
-    public static explicit operator sbyte(JSValue value)
-    {
-      return (sbyte)(long)value;
-    }
+    // Return an Int8 representation of JSValue. It is the same as (Int8)AsInt64().
+    public sbyte AsInt8() => (sbyte)AsInt64();
 
-    public static explicit operator short(JSValue value)
-    {
-      return (short)(long)value;
-    }
+    // Return an Int16 representation of JSValue. It is the same as (Int16)AsInt64().
+    public short AsInt16() => (short)AsInt64();
 
-    public static explicit operator int(JSValue value)
-    {
-      return (int)(long)value;
-    }
+    // Return an Int32 representation of JSValue. It is the same as (Int32)AsInt64().
+    public int AsInt32() => (int)AsInt64();
 
-    public static explicit operator long(JSValue value)
+    // Return an Int64 representation of JSValue.
+    // String is converted to double first before converting to Int64.
+    // Boolean is converted to 0 or 1.
+    // Null, Object, and Array are 0.
+    public long AsInt64()
     {
-      switch (value.Type)
+      switch (Type)
       {
-        case JSValueType.String: return long.TryParse(value.String, out long result) ? result : 0;
-        case JSValueType.Boolean: return value.Boolean ? 1 : 0;
-        case JSValueType.Int64: return value.Int64;
-        case JSValueType.Double: return (long)value.Double;
+        case JSValueType.String: return JSConverter.ToInt64(JSConverter.ToJSNumber(StringValue));
+        case JSValueType.Boolean: return BooleanValue ? 1 : 0;
+        case JSValueType.Int64: return Int64Value;
+        case JSValueType.Double: return JSConverter.ToInt64(DoubleValue);
         default: return 0;
       }
     }
 
-    public static explicit operator byte(JSValue value)
-    {
-      return (byte)(long)value;
-    }
+    // Return an Uint8 representation of JSValue. It is the same as (UInt8)AsInt64().
+    public byte AsUInt8() => (byte)AsInt64();
 
-    public static explicit operator ushort(JSValue value)
-    {
-      return (ushort)(long)value;
-    }
+    // Return an UInt16 representation of JSValue. It is the same as (UInt16)AsInt64().
+    public ushort AsUInt16() => (ushort)AsInt64();
 
-    public static explicit operator uint(JSValue value)
-    {
-      return (uint)(long)value;
-    }
+    // Return an UInt32 representation of JSValue. It is the same as (UInt32)AsInt64().
+    public uint AsUInt32() => (uint)AsInt64();
 
-    public static explicit operator ulong(JSValue value)
-    {
-      return (ulong)(long)value;
-    }
+    // Return an UInt64 representation of JSValue. It is the same as (UInt64)AsInt64().
+    public ulong AsUInt64() => (ulong)AsInt64();
 
-    public static explicit operator float(JSValue value)
-    {
-      return (float)(double)value;
-    }
+    // Return a Single representation of JSValue. It is the same as (Single)AsDouble().
+    public float AsSingle() => (float)AsDouble();
 
-    public static explicit operator double(JSValue value)
+    // Return a double representation of JSValue.
+    // Boolean is converted to 0.0 or 1.0.
+    // Null, Object, and Array are 0.
+    public double AsDouble()
     {
-      switch (value.Type)
+      switch (Type)
       {
-        case JSValueType.String: return double.TryParse(value.String, out double result) ? result : 0;
-        case JSValueType.Boolean: return value.Boolean ? 1 : 0;
-        case JSValueType.Int64: return value.Int64;
-        case JSValueType.Double: return value.Double;
+        case JSValueType.String: return JSConverter.ToJSNumber(StringValue);
+        case JSValueType.Boolean: return BooleanValue ? 1.0 : 0.0;
+        case JSValueType.Int64: return Int64Value;
+        case JSValueType.Double: return DoubleValue;
         default: return 0;
       }
     }
 
-    public T As<T>() => (new JSValueTreeReader(this)).ReadValue<T>();
+    // Cast JSValue to String using AsString() call.
+    public static explicit operator string(JSValue value) => value.AsString();
 
-    public T To<T>() => (new JSValueTreeReader(this)).ReadValue<T>();
+    // Cast JSValue to Boolean using AsBoolean() call.
+    public static explicit operator bool(JSValue value) => value.AsBoolean();
 
-    public JSValue From<T>(T value)
+    // Cast JSValue to Int8 using AsInt8() call.
+    public static explicit operator sbyte(JSValue value) => value.AsInt8();
+
+    // Cast JSValue to Int16 using AsInt16() call.
+    public static explicit operator short(JSValue value) => value.AsInt16();
+
+    // Cast JSValue to Int32 using AsInt32() call.
+    public static explicit operator int(JSValue value) => value.AsInt32();
+
+    // Cast JSValue to Int64 using AsInt64() call.
+    public static explicit operator long(JSValue value) => value.AsInt64();
+
+    // Cast JSValue to UInt8 using AsUInt8() call.
+    public static explicit operator byte(JSValue value) => value.AsUInt8();
+
+    // Cast JSValue to UInt16 using AsUInt16() call.
+    public static explicit operator ushort(JSValue value) => value.AsUInt16();
+
+    // Cast JSValue to UInt32 using AsUInt32() call.
+    public static explicit operator uint(JSValue value) => value.AsUInt32();
+
+    // Cast JSValue to UInt64 using AsUInt64() call.
+    public static explicit operator ulong(JSValue value) => value.AsUInt64();
+
+    // Cast JSValue to Single using AsSingle() call.
+    public static explicit operator float(JSValue value) => value.AsSingle();
+
+    // Cast JSValue to Double using AsDouble() call.
+    public static explicit operator double(JSValue value) => value.AsDouble();
+
+    // Return a String representation of JSValue. It is equivalent to JavaScript String(value) result.
+    public string AsJSString()
     {
-      var writer = new JSValueTreeWriter();
-      writer.WriteValue(value);
-      return writer.TakeValue();
+      StringBuilder WriteValue(StringBuilder sb, JSValue node)
+      {
+        switch (node.Type)
+        {
+          case JSValueType.Null: return sb.Append(JSConverter.NullString);
+          case JSValueType.Object: return sb.Append(JSConverter.ObjectString);
+          case JSValueType.Array:
+            {
+              bool start = true;
+              foreach (var item in node.ArrayValue)
+              {
+                if (start)
+                {
+                  start = false;
+                }
+                else
+                {
+                  sb.Append(',');
+                }
+
+                WriteValue(sb, item);
+              }
+              return sb;
+            }
+          case JSValueType.String: return sb.Append(node.StringValue);
+          case JSValueType.Boolean: return sb.Append(JSConverter.ToJSString(node.BooleanValue));
+          case JSValueType.Int64: return sb.Append(node.Int64Value);
+          case JSValueType.Double: return sb.Append(JSConverter.ToJSString(node.DoubleValue));
+          default: return sb;
+        }
+      }
+
+      switch (Type)
+      {
+        case JSValueType.Null: return JSConverter.NullString;
+        case JSValueType.Object: return JSConverter.ObjectString;
+        case JSValueType.Array:
+          {
+            StringBuilder sb = new StringBuilder();
+            WriteValue(sb, this);
+            return sb.ToString();
+          }
+        case JSValueType.String: return StringValue;
+        case JSValueType.Boolean: return JSConverter.ToJSString(BooleanValue);
+        case JSValueType.Int64: return Int64Value.ToString();
+        case JSValueType.Double: return JSConverter.ToJSString(DoubleValue);
+        default: return "";
+      }
     }
 
+    // Return a Boolean representation of JSValue. It is equivalent to JavaScript Boolean(value) result.
+    public bool AsJSBoolean()
+    {
+      switch (Type)
+      {
+        case JSValueType.Object:
+        case JSValueType.Array: return true;
+        case JSValueType.String: return !string.IsNullOrEmpty(StringValue);
+        case JSValueType.Boolean: return BooleanValue;
+        case JSValueType.Int64: return Int64Value != 0;
+        case JSValueType.Double: return !double.IsNaN(DoubleValue) && DoubleValue != 0;
+        default: return false;
+      }
+    }
+
+    // Return a Double representation of JSValue. It is equivalent to JavaScript Number(value) result.
+    public double AsJSNumber()
+    {
+      switch (Type)
+      {
+        case JSValueType.Object:
+        case JSValueType.Array:
+        case JSValueType.String: return JSConverter.ToJSNumber(AsJSString());
+        case JSValueType.Boolean: return BooleanValue ? 1 : 0;
+        case JSValueType.Int64: return Int64Value;
+        case JSValueType.Double: return DoubleValue;
+        default: return 0;
+      }
+    }
+
+    // Convert JSValue to a readable string that can be used for logging and debugging.
     public override string ToString()
     {
       switch (Type)
       {
-        case JSValueType.Null: return "null";
+        case JSValueType.Null: return JSConverter.NullString;
         case JSValueType.Object:
           {
             var sb = new StringBuilder();
             sb.Append("{");
-            foreach (var prop in Object)
+            bool start = true;
+            foreach (var prop in ObjectValue)
             {
+              if (start)
+              {
+                start = false;
+              }
+              else
+              {
+                sb.Append(", ");
+              }
+
               sb.Append(prop.Key);
               sb.Append(": ");
               sb.Append(prop.Value.ToString());
-              sb.Append(", ");
             }
-            sb.Length -= 2;
+
             sb.Append("}");
             return sb.ToString();
           }
@@ -219,26 +655,52 @@ namespace Microsoft.ReactNative.Managed
           {
             var sb = new StringBuilder();
             sb.Append("[");
-            foreach (var item in Array)
+            bool start = true;
+            foreach (var item in ArrayValue)
             {
+              if (start)
+              {
+                start = false;
+              }
+              else
+              {
+                sb.Append(", ");
+              }
+
               sb.Append(item.ToString());
-              sb.Append(", ");
             }
-            sb.Length -= 2;
+
             sb.Append("]");
             return sb.ToString();
           }
-        case JSValueType.String: return "\"" + String + "\"";
-        case JSValueType.Boolean: return Boolean ? "true": "false";
-        case JSValueType.Int64: return Int64.ToString();
-        case JSValueType.Double: return Double.ToString();
+        case JSValueType.String: return "\"" + StringValue + "\"";
+        case JSValueType.Boolean: return JSConverter.ToJSString(BooleanValue);
+        case JSValueType.Int64: return Int64Value.ToString();
+        case JSValueType.Double: return JSConverter.ToJSString(DoubleValue);
         default: return "<Unexpected>";
       }
     }
 
+    // Return value T that is created from JSValue using a ReadValue extension function.
+    // Default T is constructed by using default constructor.
+    public T To<T>() => new JSValueTreeReader(this).ReadValue<T>();
+
+    // Create JSValue from a type that has WriteValue extension method defined to write to IJSValueWriter.
+    public JSValue From<T>(T value)
+    {
+      var writer = new JSValueTreeWriter();
+      writer.WriteValue(value);
+      return writer.TakeValue();
+    }
+
+    // Return property count if JSValue is Object, or 0 otherwise.
+    public int PropertyCount => Type == JSValueType.Object ? ObjectValue.Count : 0;
+
+    // Try to get an object property value if JSValue type is Object and the property is found.
+    // It returns false and outputs JSValue.Null otherwise.
     public bool TryGetObjectProperty(string propertyName, out JSValue value)
     {
-      if (Type == JSValueType.Object && Object.TryGetValue(propertyName, out value))
+      if (TryGetObject(out var objectValue) && objectValue.TryGetValue(propertyName, out value))
       {
         return true;
       }
@@ -247,213 +709,200 @@ namespace Microsoft.ReactNative.Managed
       return false;
     }
 
+    // Get an object property value if JSValue type is Object and the property is found,
+    // or JSValue.Null otherwise.
     public JSValue GetObjectProperty(string propertyName)
     {
-      return (Type == JSValueType.Object && Object.TryGetValue(propertyName, out JSValue value)) ? value : Null;
+      TryGetObjectProperty(propertyName, out JSValue result);
+      return result;
     }
 
-    public JSValue GetArrayItem(int index)
-    {
-      return (Type == JSValueType.Array && index < Array.Count) ? Array[index] : Null; 
-    }
+    // Get an object property value if JSValue type is Object and the property is found,
+    // or JSValue.Null otherwise.
+    public JSValue this[string propertyName] => GetObjectProperty(propertyName);
 
-    public JSValue this[string propertyName]
-    {
-      get { return GetObjectProperty(propertyName); }
-    }
+    // Return item count if JSValue is Array, or 0 otherwise.
+    public int ItemCount => Type == JSValueType.Array ? ArrayValue.Count : 0;
 
-    public JSValue this[int index]
+    // Try to get an array item if JSValue type is Array and the index is in bounds.
+    // It returns false and outputs JSValue.Null otherwise.
+    public bool TryGetArrayItem(int index, out JSValue value)
     {
-      get { return GetArrayItem(index); }
-    }
-
-    public static bool operator ==(JSValue lhs, JSValue rhs)
-    {
-      return lhs.ValueEquals(rhs);
-    }
-
-    public static bool operator !=(JSValue lhs, JSValue rhs)
-    {
-      return !lhs.ValueEquals(rhs);
-    }
-
-    public bool Equals(JSValue other)
-    {
-      return ValueEquals(other);
-    }
-
-    private bool ValueEquals(JSValue other)
-    {
-      if (Type == other.Type)
+      if (index >= 0 && TryGetArray(out var arrayValue) && index < arrayValue.Count)
       {
-        switch (Type)
-        {
-          case JSValueType.Null: return true;
-          case JSValueType.Object: return ObjectEquals(other.Object);
-          case JSValueType.Array: return ArrayEquals(other.Array);
-          case JSValueType.String: return String == other.String;
-          case JSValueType.Boolean: return Boolean == other.Boolean;
-          case JSValueType.Int64: return Int64 == other.Int64;
-          case JSValueType.Double: return Double == other.Double;
-          default: return false;
-        }
+        value = arrayValue[index];
+        return true;
       }
 
+      value = Null;
       return false;
     }
 
-    private bool ObjectEquals(IReadOnlyDictionary<string, JSValue> other)
+    // Get an array item if JSValue type is Array and the index is in bounds,
+    // or JSValue.Null otherwise.
+    public JSValue GetArrayItem(int index)
     {
-      var obj = Object;
-      if (obj.Count != other.Count)
+      TryGetArrayItem(index, out JSValue result);
+      return result;
+    }
+
+    // Get an array item if JSValue type is Array and the index is in bounds,
+    // or JSValue.Null otherwise.
+    public JSValue this[int index] => GetArrayItem(index);
+
+    // Return true if this JSValue is strictly equal to JSValue.
+    // Compared values must have the same type and value.
+    //
+    // The behavior is similar to JavaScript === operator except for Object and Array where
+    // this functions does a deep structured comparison instead of pointer equality.
+    public bool Equals(JSValue other)
+    {
+      if (Type != other.Type)
       {
         return false;
       }
 
-      foreach (var entry in obj)
+      switch (Type)
       {
-        if (!other.TryGetValue(entry.Key, out var value) || !value.ValueEquals(entry.Value))
-        {
-          return false;
-        }
+        case JSValueType.Null: return true;
+        case JSValueType.Object: return JSValueObject.Equals(ObjectValue, other.ObjectValue);
+        case JSValueType.Array: return JSValueArray.Equals(ArrayValue, other.ArrayValue);
+        case JSValueType.String: return StringValue == other.StringValue;
+        case JSValueType.Boolean: return BooleanValue == other.BooleanValue;
+        case JSValueType.Int64: return Int64Value == other.Int64Value;
+        case JSValueType.Double: return DoubleValue == other.DoubleValue;
+        default: return false;
       }
-
-      return true;
     }
 
-    private bool ArrayEquals(IReadOnlyList<JSValue> other)
-    {
-      var arr = Array;
-      if (arr.Count != other.Count)
-      {
-        return false;
-      }
-
-      for (int i = 0; i < arr.Count; ++i)
-      {
-        if (!arr[i].ValueEquals(other[i]))
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
+    // Return true if obj is a JSValue it is strictly equal to this JSValue. 
     public override bool Equals(object obj)
     {
       return (obj is JSValue) && Equals((JSValue)obj);
     }
 
+    // True if left.Equals(right)
+    public static bool operator ==(JSValue left, JSValue right)
+    {
+      return left.Equals(right);
+    }
+
+    //! True if !left.Equals(right)
+    public static bool operator !=(JSValue left, JSValue right)
+    {
+      return !left.Equals(right);
+    }
+
+    // Return true if this JSValue is strictly equal to JSValue after they are converted to the same type.
+    //
+    // Null is not converted to any other type before comparison.
+    // Object and Array types are converted first to a String type using AsString() before comparing
+    // with other types, and then we apply the same rules as for the String type.
+    // String is converted to Double before comparing with Boolean, Int64, or Double.
+    // Boolean is converted to 1.0 and +0.0 when comparing with String, Int64, or Double.
+    // Int64 is converted to Double before comparing with other types.
+    //
+    // The behavior is similar to JavaScript == operator except for Object and Array for which
+    // this functions does a deep structured comparison using JSEquals instead
+    // of pointer equality.
+    public bool JSEquals(JSValue other)
+    {
+      if (Type == other.Type)
+      {
+        switch (Type)
+        {
+          case JSValueType.Object:
+            return JSValueObject.JSEquals(ObjectValue, other.ObjectValue);
+          case JSValueType.Array:
+            return JSValueArray.JSEquals(ArrayValue, other.ArrayValue);
+          default:
+            return Equals(other);
+        }
+      }
+      else if (Type == JSValueType.Null || other.Type == JSValueType.Null)
+      {
+        return false;
+      }
+
+      // If one of the types Boolean, Int64, or Double, then compare as Numbers,
+      // otherwise compare as strings.
+      JSValueType greatestType = Type > other.Type ? Type : other.Type;
+      if (greatestType >= JSValueType.Boolean)
+      {
+        return AsJSNumber() == other.AsJSNumber();
+      }
+      else
+      {
+        return AsJSString() == other.AsJSString();
+      }
+    }
+
+    // Calculation of the JSValue hash code is quite expensive.
+    // It is not implemented.
     public override int GetHashCode()
     {
       throw new NotImplementedException("JSValue currently does not support hash codes");
     }
 
+    // Create JSValue from IJSValueReader.
     public static JSValue ReadFrom(IJSValueReader reader)
     {
-      var treeReader = reader as IJSValueTreeReader;
-      if (treeReader != null)
+      if (reader is IJSValueTreeReader treeReader)
       {
         return treeReader.Current;
       }
 
-      return ReadValue(reader);
+      return InternalReadFrom(reader);
     }
 
-    public static Dictionary<string, JSValue> ReadObjectPropertiesFrom(IJSValueReader reader)
+    // Create JSValueObject from IJSValueReader.
+    public static JSValueObject ReadObjectFrom(IJSValueReader reader)
     {
       if (reader.ValueType == JSValueType.Object)
       {
-        var treeReader = reader as IJSValueTreeReader;
-        if (treeReader != null)
+        if (reader is IJSValueTreeReader treeReader)
         {
-          return new Dictionary<string, JSValue>(treeReader.Current.Object as IDictionary<string, JSValue>);
+          return JSValueObject.CopyFrom(treeReader.Current.ObjectValue);
         }
 
-        return ReadObjectProperties(reader);
+        return InternalReadObjectFrom(reader);
       }
 
-      return new Dictionary<string, JSValue>();
+      return new JSValueObject();
     }
 
-    public static List<JSValue> ReadArrayItemsFrom(IJSValueReader reader)
+    // Create JSValueArray from IJSValueReader.
+    public static JSValueArray ReadArrayFrom(IJSValueReader reader)
     {
       if (reader.ValueType == JSValueType.Array)
       {
-        var treeReader = reader as IJSValueTreeReader;
-        if (treeReader != null)
+        if (reader is IJSValueTreeReader treeReader)
         {
-          return new List<JSValue>(treeReader.Current.Array as IList<JSValue>);
+          return JSValueArray.CopyFrom(treeReader.Current.ArrayValue);
         }
 
-        return ReadArrayItems(reader);
+        return InternalReadArrayFrom(reader);
       }
 
-      return new List<JSValue>();
+      return new JSValueArray();
     }
 
-    private static JSValue ReadValue(IJSValueReader reader)
-    {
-      switch (reader.ValueType)
-      {
-        case JSValueType.Null: return Null;
-        case JSValueType.Object: return ReadObject(reader);
-        case JSValueType.Array: return ReadArray(reader);
-        case JSValueType.String: return new JSValue(reader.GetString());
-        case JSValueType.Boolean: return new JSValue(reader.GetBoolean());
-        case JSValueType.Int64: return new JSValue(reader.GetInt64());
-        case JSValueType.Double: return new JSValue(reader.GetDouble());
-        default: throw new ReactException("Unexpected JSValueType");
-      }
-    }
-
-    private static JSValue ReadObject(IJSValueReader reader)
-    {
-      return new JSValue(new ReadOnlyDictionary<string, JSValue>(ReadObjectProperties(reader)));
-    }
-
-    private static JSValue ReadArray(IJSValueReader reader)
-    {
-      return new JSValue(new ReadOnlyCollection<JSValue>(ReadArrayItems(reader)));
-    }
-
-    private static Dictionary<string, JSValue> ReadObjectProperties(IJSValueReader reader)
-    {
-      var properties = new Dictionary<string, JSValue>();
-      while (reader.GetNextObjectProperty(out string propertyName))
-      {
-        properties.Add(propertyName, ReadValue(reader));
-      }
-
-      return properties;
-    }
-
-    private static List<JSValue> ReadArrayItems(IJSValueReader reader)
-    {
-      var items = new List<JSValue>();
-      while (reader.GetNextArrayItem())
-      {
-        items.Add(ReadValue(reader));
-      }
-
-      return items;
-    }
-
+    // Write this JSValue to IJSValueWriter.
     public void WriteTo(IJSValueWriter writer)
     {
       switch (Type)
       {
         case JSValueType.Null: writer.WriteNull(); break;
-        case JSValueType.Object: WriteObject(writer, Object); break;
-        case JSValueType.Array: WriteArray(writer, Array); break;
-        case JSValueType.String: writer.WriteString(String); break;
-        case JSValueType.Boolean: writer.WriteBoolean(Boolean); break;
-        case JSValueType.Int64: writer.WriteInt64(Int64); break;
-        case JSValueType.Double: writer.WriteDouble(Double); break;
+        case JSValueType.Object: WriteObject(writer, ObjectValue); break;
+        case JSValueType.Array: WriteArray(writer, ArrayValue); break;
+        case JSValueType.String: writer.WriteString(StringValue); break;
+        case JSValueType.Boolean: writer.WriteBoolean(BooleanValue); break;
+        case JSValueType.Int64: writer.WriteInt64(Int64Value); break;
+        case JSValueType.Double: writer.WriteDouble(DoubleValue); break;
       }
     }
 
+    // Write JSValueObject key-value pairs to IJSValueWriter.
     public static void WriteObject(IJSValueWriter writer, IEnumerable<KeyValuePair<string, JSValue>> value)
     {
       writer.WriteObjectBegin();
@@ -462,9 +911,11 @@ namespace Microsoft.ReactNative.Managed
         writer.WritePropertyName(keyValue.Key);
         keyValue.Value.WriteTo(writer);
       }
+
       writer.WriteObjectEnd();
     }
 
+    // Write JSValueArray items to IJSValueWriter.
     public static void WriteArray(IJSValueWriter writer, IEnumerable<JSValue> value)
     {
       writer.WriteArrayBegin();
@@ -472,8 +923,76 @@ namespace Microsoft.ReactNative.Managed
       {
         item.WriteTo(writer);
       }
+
       writer.WriteArrayEnd();
     }
+
+    private static JSValue InternalReadFrom(IJSValueReader reader)
+    {
+      switch (reader.ValueType)
+      {
+        case JSValueType.Null: return Null;
+        case JSValueType.Object: return new JSValue(InternalReadObjectFrom(reader));
+        case JSValueType.Array: return new JSValue(InternalReadArrayFrom(reader));
+        case JSValueType.String: return new JSValue(reader.GetString());
+        case JSValueType.Boolean: return new JSValue(reader.GetBoolean());
+        case JSValueType.Int64: return new JSValue(reader.GetInt64());
+        case JSValueType.Double: return new JSValue(reader.GetDouble());
+        default: throw new ReactException("Unexpected JSValueType");
+      }
+    }
+
+    private static JSValueObject InternalReadObjectFrom(IJSValueReader reader)
+    {
+      var jsObject = new JSValueObject();
+      while (reader.GetNextObjectProperty(out string propertyName))
+      {
+        jsObject.Add(propertyName, InternalReadFrom(reader));
+      }
+
+      return jsObject;
+    }
+
+    private static JSValueArray InternalReadArrayFrom(IJSValueReader reader)
+    {
+      var jsArray = new JSValueArray();
+      while (reader.GetNextArrayItem())
+      {
+        jsArray.Add(InternalReadFrom(reader));
+      }
+
+      return jsArray;
+    }
+
+    #region Obsolete members
+
+    [Obsolete("Use TryGetObject or AsObject")] public IReadOnlyDictionary<string, JSValue> Object => (IReadOnlyDictionary<string, JSValue>)m_objValue;
+    [Obsolete("Use TryGetArray or AsArray")] public IReadOnlyList<JSValue> Array => (IReadOnlyList<JSValue>)m_objValue;
+    [Obsolete("Use TryGetString, AsString, or AsJSString")] public string String => (string)m_objValue;
+    [Obsolete("Use TryGetBoolean, AsBoolean, or AsJSBoolean")] public bool Boolean => m_simpleValue.BooleanValue;
+    [Obsolete("Use TryGetInt64 or AsInt64")] public long Int64 => m_simpleValue.Int64Value;
+    [Obsolete("Use TryGetDouble, AsDouble, or AsJSNumber")] public double Double => m_simpleValue.DoubleValue;
+
+    [Obsolete("Use ReadObjectFrom")]
+    public static Dictionary<string, JSValue> ReadObjectPropertiesFrom(IJSValueReader reader)
+    {
+      return ReadObjectFrom(reader);
+    }
+
+    [Obsolete("Use ReadArrayFrom")]
+    public static List<JSValue> ReadArrayItemsFrom(IJSValueReader reader)
+    {
+      return ReadArrayFrom(reader);
+    }
+
+    #endregion
+
+    private IReadOnlyDictionary<string, JSValue> ObjectValue => (IReadOnlyDictionary<string, JSValue>)m_objValue;
+    private IReadOnlyList<JSValue> ArrayValue => (IReadOnlyList<JSValue>)m_objValue;
+    private string StringValue => (string)m_objValue;
+    private bool BooleanValue => m_simpleValue.BooleanValue;
+    private long Int64Value => m_simpleValue.Int64Value;
+    private double DoubleValue => m_simpleValue.DoubleValue;
 
     // This is a 'union' type that may store in the same location bool, long, or double.
     [StructLayout(LayoutKind.Explicit)]
@@ -483,21 +1002,53 @@ namespace Microsoft.ReactNative.Managed
       [FieldOffset(0)] public long Int64Value;
       [FieldOffset(0)] public double DoubleValue;
     }
-  }
 
-  class JSValueObject : Dictionary<string, JSValue>
-  {
-    public static implicit operator JSValue(JSValueObject properties)
+    private static class JSConverter
     {
-      return new JSValue(new ReadOnlyDictionary<string, JSValue>(properties));
-    }
-  }
+      public static readonly string NullString = "null";
+      public static readonly string ObjectString = "[object Object]";
 
-  class JSValueArray : List<JSValue>
-  {
-    public static implicit operator JSValue(JSValueArray items)
-    {
-      return new JSValue(new ReadOnlyCollection<JSValue>(items));
+      public static string ToJSString(bool value)
+      {
+        return value ? "true" : "false";
+      }
+
+      public static string ToJSString(double value)
+      {
+        if (double.IsNaN(value))
+        {
+          return "NaN";
+        }
+        else if (double.IsPositiveInfinity(value))
+        {
+          return "Infinity";
+        }
+        else if (double.IsNegativeInfinity(value))
+        {
+          return "-Infinity";
+        }
+        else
+        {
+          return value.ToString();
+        }
+      }
+
+      public static double ToJSNumber(string value)
+      {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+          return 0;
+        }
+
+        // NumberStyles.Float does not allow numbers to have thousand's commas insider. 
+        return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue)
+          ? doubleValue : double.NaN;
+      }
+
+      public static long ToInt64(double value) =>
+        (long.MinValue <= value && value <= long.MaxValue) ? unchecked((long)value) : 0;
     }
   }
 }
+

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueGenerator.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueGenerator.cs
@@ -250,8 +250,7 @@ namespace Microsoft.ReactNative.Managed
 
       public MethodCallExpression CallExt(MethodInfo method, params object[] arguments)
       {
-        var args = new List<Expression>();
-        args.Add(AsExpression);
+        var args = new List<Expression> { AsExpression };
 
         void ParseArgs(object[] argObjects)
         {

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueReader.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueReader.cs
@@ -135,72 +135,72 @@ namespace Microsoft.ReactNative.Managed
 
     public static void ReadValue(this IJSValueReader reader, out Dictionary<string, JSValue> value)
     {
-      value = JSValue.ReadObjectPropertiesFrom(reader);
+      value = JSValue.ReadObjectFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out IDictionary<string, JSValue> value)
     {
-      value = JSValue.ReadObjectPropertiesFrom(reader);
+      value = JSValue.ReadObjectFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out ICollection<KeyValuePair<string, JSValue>> value)
     {
-      value = JSValue.ReadObjectPropertiesFrom(reader);
+      value = JSValue.ReadObjectFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out IEnumerable<KeyValuePair<string, JSValue>> value)
     {
-      value = JSValue.ReadObjectPropertiesFrom(reader);
+      value = JSValue.ReadObjectFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out ReadOnlyDictionary<string, JSValue> value)
     {
-      value = new ReadOnlyDictionary<string, JSValue>(JSValue.ReadObjectPropertiesFrom(reader));
+      value = new ReadOnlyDictionary<string, JSValue>(JSValue.ReadObjectFrom(reader));
     }
 
     public static void ReadValue(this IJSValueReader reader, out IReadOnlyDictionary<string, JSValue> value)
     {
-      value = new ReadOnlyDictionary<string, JSValue>(JSValue.ReadObjectPropertiesFrom(reader));
+      value = new ReadOnlyDictionary<string, JSValue>(JSValue.ReadObjectFrom(reader));
     }
 
     public static void ReadValue(this IJSValueReader reader, out IReadOnlyCollection<KeyValuePair<string, JSValue>> value)
     {
-      value = new ReadOnlyDictionary<string, JSValue>(JSValue.ReadObjectPropertiesFrom(reader));
+      value = new ReadOnlyDictionary<string, JSValue>(JSValue.ReadObjectFrom(reader));
     }
 
     public static void ReadValue(this IJSValueReader reader, out List<JSValue> value)
     {
-      value = JSValue.ReadArrayItemsFrom(reader);
+      value = JSValue.ReadArrayFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out IList<JSValue> value)
     {
-      value = JSValue.ReadArrayItemsFrom(reader);
+      value = JSValue.ReadArrayFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out ICollection<JSValue> value)
     {
-      value = JSValue.ReadArrayItemsFrom(reader);
+      value = JSValue.ReadArrayFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out IEnumerable<JSValue> value)
     {
-      value = JSValue.ReadArrayItemsFrom(reader);
+      value = JSValue.ReadArrayFrom(reader);
     }
 
     public static void ReadValue(this IJSValueReader reader, out ReadOnlyCollection<JSValue> value)
     {
-      value = new ReadOnlyCollection<JSValue>(JSValue.ReadArrayItemsFrom(reader));
+      value = new ReadOnlyCollection<JSValue>(JSValue.ReadArrayFrom(reader));
     }
 
     public static void ReadValue(this IJSValueReader reader, out IReadOnlyList<JSValue> value)
     {
-      value = new ReadOnlyCollection<JSValue>(JSValue.ReadArrayItemsFrom(reader));
+      value = new ReadOnlyCollection<JSValue>(JSValue.ReadArrayFrom(reader));
     }
 
     public static void ReadValue(this IJSValueReader reader, out IReadOnlyCollection<JSValue> value)
     {
-      value = new ReadOnlyCollection<JSValue>(JSValue.ReadArrayItemsFrom(reader));
+      value = new ReadOnlyCollection<JSValue>(JSValue.ReadArrayFrom(reader));
     }
 
     public static void ReadValue<T>(this IJSValueReader reader, out T? value) where T : struct
@@ -510,8 +510,10 @@ namespace Microsoft.ReactNative.Managed
         if (readerDelegates != s_readerDelegates) continue;
 
         // Clone the dictionary, update the clone, and try to replace the s_readerDelegates.
-        var updatedReaderDelegates = new Dictionary<Type, Delegate>(readerDelegates as IDictionary<Type, Delegate>);
-        updatedReaderDelegates.Add(valueType, newDelegate);
+        var updatedReaderDelegates = new Dictionary<Type, Delegate>(readerDelegates as IDictionary<Type, Delegate>)
+        {
+          [valueType] = newDelegate
+        };
         Interlocked.CompareExchange(ref s_readerDelegates, updatedReaderDelegates, readerDelegates);
       }
     }

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueTreeReader.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueTreeReader.cs
@@ -26,9 +26,9 @@ namespace Microsoft.ReactNative.Managed
     {
       if (!m_isIterating)
       {
-        if (Current.Type == JSValueType.Object)
+        if (Current.TryGetObject(out var currentObject))
         {
-          var properties = Current.Object.GetEnumerator();
+          var properties = currentObject.GetEnumerator();
           if (properties.MoveNext())
           {
             m_stack.Push(StackEntry.ObjectProperty(Current, properties));
@@ -70,9 +70,9 @@ namespace Microsoft.ReactNative.Managed
     {
       if (!m_isIterating)
       {
-        if (Current.Type == JSValueType.Array)
+        if (Current.TryGetArray(out var currentArray))
         {
-          var items = Current.Array.GetEnumerator();
+          var items = currentArray.GetEnumerator();
           if (items.MoveNext())
           {
             m_stack.Push(StackEntry.ArrayItem(Current, items));
@@ -125,22 +125,22 @@ namespace Microsoft.ReactNative.Managed
 
     public string GetString()
     {
-      return (Current.Type == JSValueType.String) ? Current.String : "";
+      return Current.TryGetString(out var stringValue) ? stringValue : "";
     }
 
     public bool GetBoolean()
     {
-      return (Current.Type == JSValueType.Boolean) ? Current.Boolean : false;
+      return Current.TryGetBoolean(out var booleanValue) ? booleanValue : false;
     }
 
     public long GetInt64()
     {
-      return (Current.Type == JSValueType.Int64) ? Current.Int64 : 0;
+      return Current.TryGetInt64(out var int64Value) ? int64Value : 0;
     }
 
     public double GetDouble()
     {
-      return (Current.Type == JSValueType.Double) ? Current.Double : 0;
+      return Current.TryGetDouble(out var doubleValue) ? doubleValue : 0;
     }
 
     private struct StackEntry

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueTreeWriter.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueTreeWriter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ReactNative.Managed
   class JSValueTreeWriter : IJSValueWriter
   {
     private State m_state = State.Start;
-    private Stack<StackEntry> m_stack = new Stack<StackEntry>();
+    private readonly Stack<StackEntry> m_stack = new Stack<StackEntry>();
     private object m_dynamic;
     private string m_propertyName;
     private JSValue m_result;

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueWriterGenerator.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueWriterGenerator.cs
@@ -103,22 +103,6 @@ namespace Microsoft.ReactNative.Managed
       return writeArgsMethod.First();
     }
 
-    public static MethodInfo WriteErrorOf(Type typeArg)
-    {
-      var writeErrorMethod =
-        from member in typeof(JSValueWriter).GetMember(
-          nameof(JSValueWriter.WriteError), BindingFlags.Static | BindingFlags.Public)
-        let method = member as MethodInfo
-        let isGeneric = method.IsGenericMethod
-        where method != null
-          && method.IsDefined(typeof(ExtensionAttribute), inherit: false)
-        let parameters = method.GetParameters()
-        where parameters.Length == 2
-          && parameters[0].ParameterType == typeof(IJSValueWriter)
-        select method.MakeGenericMethod(typeArg);
-      return writeErrorMethod.First();
-    }
-
     private static MethodInfo MethodOf(string methodName, params Type[] typeArgs) =>
       typeof(JSValueWriterGenerator).GetMethod(methodName).MakeGenericMethod(typeArgs);
 

--- a/vnext/Microsoft.ReactNative.SharedManaged/ReactConstantProvider.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/ReactConstantProvider.cs
@@ -15,6 +15,6 @@ namespace Microsoft.ReactNative.Managed
       m_writer.WriteObjectProperty(constantName, value);
     }
 
-    private IJSValueWriter m_writer;
+    private readonly IJSValueWriter m_writer;
   }
 }

--- a/vnext/Microsoft.ReactNative.SharedManaged/ReactModuleInfo.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/ReactModuleInfo.cs
@@ -11,15 +11,15 @@ namespace Microsoft.ReactNative.Managed
 {
   class ReactModuleInfo
   {
-    private static object s_moduleInfoMutex = new object();
+    private static readonly object s_moduleInfoMutex = new object();
     private static Dictionary<Type, ReactModuleInfo> s_moduleInfos;
-    private Lazy<List<ReactInitializerInfo>> m_initializerInfos;
-    private Lazy<List<ReactConstantInfo>> m_constantInfos;
-    private Lazy<List<ReactConstantProviderInfo>> m_constantProviderInfos;
-    private Lazy<List<ReactMethodInfo>> m_methodInfos;
-    private Lazy<List<ReactSyncMethodInfo>> m_syncMethodInfos;
-    private Lazy<List<ReactFunctionInfo>> m_functionInfos;
-    private Lazy<List<ReactEventInfo>> m_eventInfos;
+    private readonly Lazy<List<ReactInitializerInfo>> m_initializerInfos;
+    private readonly Lazy<List<ReactConstantInfo>> m_constantInfos;
+    private readonly Lazy<List<ReactConstantProviderInfo>> m_constantProviderInfos;
+    private readonly Lazy<List<ReactMethodInfo>> m_methodInfos;
+    private readonly Lazy<List<ReactSyncMethodInfo>> m_syncMethodInfos;
+    private readonly Lazy<List<ReactFunctionInfo>> m_functionInfos;
+    private readonly Lazy<List<ReactEventInfo>> m_eventInfos;
 
     public ReactModuleInfo(Type moduleType) : this(moduleType, moduleType.GetTypeInfo().GetCustomAttribute<ReactModuleAttribute>())
     {
@@ -60,8 +60,7 @@ namespace Microsoft.ReactNative.Managed
           s_moduleInfos = new Dictionary<Type, ReactModuleInfo>();
         }
 
-        ReactModuleInfo moduleInfo;
-        if (s_moduleInfos.TryGetValue(moduleType, out moduleInfo))
+        if (s_moduleInfos.TryGetValue(moduleType, out ReactModuleInfo moduleInfo))
         {
           return moduleInfo;
         }


### PR DESCRIPTION
In PR https://github.com/microsoft/react-native-windows/pull/4260 we have changed C++ JSValue implementation to deprecate methods that access typed values stored in JSValue because of their unclear semantic and replaced them with `TryGetXXX` methods that return specified type and `AsXXX` methods that do JavaScript-like conversion. 

In this PR we are completing the set of changes that originally started to address issue https://github.com/microsoft/react-native-windows/issues/4181. In this PR we do the following changes:
- Updated C# JSValue implementation to match changes to C++ JSValue.
- All JavaScript-like conversions are now named `AsJSString`, `AsJSBoolean`, and `AsJSNumber` methods. They match to the JavaScript `String()`, `Boolean()`, and `Number()` methods.
- The `AsXXX` conversion methods are changed to have a little bit more predictable semantic. E.g. `AsJSBoolean()` converts any non-empty string to `true`, while the `AsBoolean()` function returns true only for a small set of case-insensitive strings: `"true", "1", "yes", "y", "on"`.
- The `As<T>()` is renamed back to `To<T>()`.
- `JSValueObjectFrom` and `JSValueArrayFrom` are not deprecated anymore.
- Renamed `EqualsAfterConversion` to `JSEquals`. It compares JSValue using JavaScript-like equality operator `==`. The only difference is that it does structural match of `JSValueObject` and `JSValueArray` instead of comparing their pointers if both JSValue of the same type.
- Added more unit tests.
- Fixed all C# compiler warnings.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4358)