### PR TITLE
turn off signing on Playground vcrurrent

### DIFF
--- a/current/ReactWindows/Playground/Playground.csproj
+++ b/current/ReactWindows/Playground/Playground.csproj
@@ -19,6 +19,7 @@
     <PackageCertificateKeyFile>Playground_TemporaryKey.pfx</PackageCertificateKeyFile>
     <DependencyConfiguration>Debug</DependencyConfiguration>
     <PackageCertificateThumbprint>218F5339D3F55118F3F99818E3D252192FEA960C</PackageCertificateThumbprint>
+    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'DebugBundle'">
     <DependencyConfiguration>Debug</DependencyConfiguration>

--- a/current/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
+++ b/current/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
@@ -20,6 +20,7 @@
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">14.0</UnitTestPlatformVersion>
     <DependencyConfiguration>Debug</DependencyConfiguration>
     <PackageCertificateThumbprint>F983A63678123AECBF104DEBC8E7B2B3080F1C01</PackageCertificateThumbprint>
+    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'DebugBundle'">
     <DependencyConfiguration>Debug</DependencyConfiguration>


### PR DESCRIPTION
vcurrent still exists in the 60 stable branch, and has a Playground app, its certificate just expired.
We don't need to sign this package, turning this off.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4370)