### PR TITLE
Publish 0.61-stable Without Prerelease Tag

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: react-native windows --template beta --overwrite --language ${{ parameters.language }}
+      script: react-native windows --overwrite --language ${{ parameters.language }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: NuGetCommand@2

--- a/change/@office-iss-react-native-win32-2020-03-20-17-06-01-0.61-stable.json
+++ b/change/@office-iss-react-native-win32-2020-03-20-17-06-01-0.61-stable.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Make package changes",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "commit": "1f68f4ecd7b7abcd882ba104b376acf5b94ce9db",
+  "dependentChangeType": "patch",
+  "date": "2020-03-21T00:05:51.381Z"
+}

--- a/change/react-native-windows-2020-03-20-17-06-01-0.61-stable.json
+++ b/change/react-native-windows-2020-03-20-17-06-01-0.61-stable.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Make package changes",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "1f68f4ecd7b7abcd882ba104b376acf5b94ce9db",
+  "dependentChangeType": "patch",
+  "date": "2020-03-21T00:06:01.702Z"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "lerna run lint:fix --stream -- --color",
     "api": "lerna run api --stream -- --color",
     "buildci": "lerna run build --stream -- --ci",
-    "change": "beachball change",
+    "change": "beachball change -b 0.61-stable",
     "clean": "lerna run clean --stream -- --color",
     "format": "node packages/scripts/formatFiles.js -i -style=file -assume-filename=../.clang-format",
     "format:verify": "node packages/scripts/formatFiles.js -i -style=file -assume-filename=../.clang-format -verify",

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -64,11 +64,9 @@
     "react-native": "0.61.5"
   },
   "beachball": {
-    "defaultNpmTag": "beta",
     "disallowedChangeTypes": [
       "major",
-      "minor",
-      "patch"
+      "minor"
     ]
   }
 }

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -62,11 +62,9 @@
     "react-native": "0.61.5"
   },
   "beachball": {
-    "defaultNpmTag": "beta",
     "disallowedChangeTypes": [
       "major",
-      "minor",
-      "patch"
+      "minor"
     ]
   }
 }


### PR DESCRIPTION
According to @acoates-ms Beachball should automatically strip the tag when specifying a patch change. This has the other package and CLI changes needed to no longer count as a beta (thanks Andrew). CI should pick this up automatically since it's using wildcards to work for any stable branches now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4391)