### PR TITLE
Implemented Linking module protocol activation

### DIFF
--- a/change/react-native-windows-2020-03-21-08-39-47-MS_LinkingModule.json
+++ b/change/react-native-windows-2020-03-21-08-39-47-MS_LinkingModule.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Implemented Linking module protocol activation",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "commit": "f880a99a915a334670ded6125096ca2868f271f6",
+  "dependentChangeType": "patch",
+  "date": "2020-03-21T15:39:47.241Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/index.windows.js
+++ b/packages/microsoft-reactnative-sampleapps/index.windows.js
@@ -13,6 +13,7 @@ import {
   Text,
   UIManager,
   View,
+  Linking,
 } from 'react-native';
 
 import { NativeModules, NativeEventEmitter } from 'react-native';
@@ -56,13 +57,19 @@ global.__fbBatchedBridge.registerLazyCallableModule('SampleModuleCpp', () => new
 
 class SampleApp extends Component {
   componentDidMount() {
-    this._TimedEventCSSub = SampleModuleCSEmitter.addListener('TimedEventCS', getCallback('SampleModuleCS.TimedEventCS() => '));
-    this._TimedEventCppSub = SampleModuleCppEmitter.addListener('TimedEventCpp', getCallback('SampleModuleCpp.TimedEventCpp() => '));
+    this.timedEventCSSub = SampleModuleCSEmitter.addListener('TimedEventCS', getCallback('SampleModuleCS.TimedEventCS() => '));
+    this.timedEventCppSub = SampleModuleCppEmitter.addListener('TimedEventCpp', getCallback('SampleModuleCpp.TimedEventCpp() => '));
+    this.openURLSub = Linking.addListener('url', (event) => log('Open URL => ' + event.url));
+
+    Linking.getInitialURL()
+      .then(url => log('Initial URL is: ' + url))
+      .catch(err => log('An error occurred: '+ err));
   }
 
   componentWillUnmount() {
-    this._TimedEventCSSub.remove();
-    this._TimedEventCppSub.remove();
+    this.timedEventCSSub.remove();
+    this.timedEventCppSub.remove();
+    this.openURLSub.remove();
   }
 
   onPressSampleModuleCS() {

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/Package.appxmanifest
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/Package.appxmanifest
@@ -24,6 +24,13 @@
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="rn-sample-app-cpp">
+            <uap:DisplayName>RN Sample URI Scheme</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/Package.appxmanifest
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/Package.appxmanifest
@@ -20,6 +20,13 @@
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="rn-sample-app-cs">
+            <uap:DisplayName>RN Sample URI Scheme</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -9,6 +9,8 @@
 namespace winrt::Microsoft::ReactNative::implementation {
 
 struct ReactApplication : ReactApplicationT<ReactApplication> {
+  using Super = ReactApplicationT<ReactApplication>;
+
  public: // ReactApplication ABI API
   ReactApplication() noexcept;
 
@@ -33,11 +35,10 @@ struct ReactApplication : ReactApplicationT<ReactApplication> {
   void JavaScriptBundleFile(hstring const &value) noexcept;
 
  public:
-  virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &);
-  virtual void OnSuspending(IInspectable const &, Windows::ApplicationModel::SuspendingEventArgs const &);
-  virtual void OnNavigationFailed(
-      IInspectable const &,
-      Windows::UI::Xaml::Navigation::NavigationFailedEventArgs const &);
+  void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
+  void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &e);
+  void OnSuspending(IInspectable const &, Windows::ApplicationModel::SuspendingEventArgs const &);
+  void OnNavigationFailed(IInspectable const &, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs const &);
 
  protected:
   virtual ReactApplicationDelegate __stdcall CreateReactApplicationDelegate();
@@ -49,7 +50,7 @@ struct ReactApplication : ReactApplicationT<ReactApplication> {
 
   ReactApplicationDelegate m_delegate{nullptr};
 
-  void OnCreate(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &e);
+  void OnCreate(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/ReactUWP/Modules/LinkingManagerModule.cpp
+++ b/vnext/ReactUWP/Modules/LinkingManagerModule.cpp
@@ -21,28 +21,28 @@
 
 using Callback = facebook::xplat::module::CxxModule::Callback;
 
-namespace react {
-namespace uwp {
+using namespace winrt;
+using namespace Windows::Foundation;
+using namespace Windows::System;
+using namespace ::Microsoft::Common::Unicode;
+
+namespace react::uwp {
 
 //
 // LinkingManagerModule helpers
 //
 
-static winrt::fire_and_forget openURLAsync(winrt::Windows::Foundation::Uri uri, Callback success, Callback error) {
-  if (co_await winrt::Windows::System::Launcher::LaunchUriAsync(uri)) {
+static fire_and_forget openURLAsync(Uri uri, Callback success, Callback error) {
+  if (co_await Launcher::LaunchUriAsync(uri)) {
     success({true});
   } else {
-    error({folly::dynamic::object("code", 1)(
-        "message", "Unable to open URL:" + Microsoft::Common::Unicode::Utf16ToUtf8(uri.DisplayUri()))});
+    error({folly::dynamic::object("code", 1)("message", "Unable to open URL: " + Utf16ToUtf8(uri.DisplayUri()))});
   }
 }
 
-static winrt::fire_and_forget
-canOpenURLAsync(winrt::Windows::Foundation::Uri uri, Callback success, Callback /*error*/) {
-  winrt::Windows::System::LaunchQuerySupportStatus status =
-      co_await winrt::Windows::System::Launcher::QueryUriSupportAsync(
-          uri, winrt::Windows::System::LaunchQuerySupportType::Uri);
-  if (status == winrt::Windows::System::LaunchQuerySupportStatus::Available) {
+static fire_and_forget canOpenURLAsync(Uri uri, Callback success, Callback /*error*/) {
+  auto status = co_await Launcher::QueryUriSupportAsync(uri, LaunchQuerySupportType::Uri);
+  if (status == LaunchQuerySupportStatus::Available) {
     success({true});
   } else {
     success({false});
@@ -53,10 +53,45 @@ canOpenURLAsync(winrt::Windows::Foundation::Uri uri, Callback success, Callback 
 // LinkingManagerModule
 //
 const char *LinkingManagerModule::name = "LinkingManager";
+/*static*/ std::mutex LinkingManagerModule::s_mutex;
+/*static*/ Uri LinkingManagerModule::s_initialUri{nullptr};
+/*static*/ std::vector<LinkingManagerModule *> LinkingManagerModule::s_linkingModules;
 
-LinkingManagerModule::LinkingManagerModule() {}
+LinkingManagerModule::LinkingManagerModule() noexcept {
+  std::scoped_lock lock{s_mutex};
+  s_linkingModules.push_back(this);
+}
 
-LinkingManagerModule::~LinkingManagerModule() = default;
+LinkingManagerModule::~LinkingManagerModule() noexcept {
+  std::scoped_lock lock{s_mutex};
+  auto it = std::find(s_linkingModules.begin(), s_linkingModules.end(), this);
+  if (it != s_linkingModules.end()) {
+    s_linkingModules.erase(it);
+  }
+}
+
+/*static*/ void LinkingManagerModule::OpenUri(winrt::Windows::Foundation::Uri const &uri) noexcept {
+  if (!s_initialUri) {
+    s_initialUri = uri;
+  }
+
+  std::vector<LinkingManagerModule *> modules;
+  {
+    std::scoped_lock lock{s_mutex};
+    modules = s_linkingModules;
+  }
+
+  for (auto &module : modules) {
+    module->HandleOpenUri(uri.AbsoluteUri());
+  }
+}
+
+void LinkingManagerModule::HandleOpenUri(winrt::hstring const &uri) noexcept {
+  if (auto instance = getInstance().lock()) {
+    instance->callJSFunction(
+        "RCTDeviceEventEmitter", "emit", folly::dynamic::array("url", folly::dynamic::object("url", to_string(uri))));
+  }
+}
 
 std::string LinkingManagerModule::getName() {
   return name;
@@ -71,24 +106,25 @@ auto LinkingManagerModule::getMethods() -> std::vector<Method> {
       Method(
           "openURL",
           [](folly::dynamic args, Callback successCallback, Callback errorCallback) {
-            winrt::Windows::Foundation::Uri uri(
-                Microsoft::Common::Unicode::Utf8ToUtf16(facebook::xplat::jsArgAsString(args, 0)));
+            winrt::Windows::Foundation::Uri uri(Utf8ToUtf16(facebook::xplat::jsArgAsString(args, 0)));
             openURLAsync(uri, successCallback, errorCallback);
           }),
       Method(
           "canOpenURL",
           [](folly::dynamic args, Callback successCallback, Callback errorCallback) {
-            winrt::Windows::Foundation::Uri uri(
-                Microsoft::Common::Unicode::Utf8ToUtf16(facebook::xplat::jsArgAsString(args, 0)));
+            winrt::Windows::Foundation::Uri uri(Utf8ToUtf16(facebook::xplat::jsArgAsString(args, 0)));
             canOpenURLAsync(uri, successCallback, errorCallback);
           }),
       Method(
           "getInitialURL",
           [](folly::dynamic /*args*/, Callback successCallback, Callback /*errorCallback*/) {
-            successCallback({nullptr});
+            if (s_initialUri) {
+              successCallback({to_string(s_initialUri.AbsoluteUri())});
+            } else {
+              successCallback({nullptr});
+            }
           }),
   };
 }
 
-} // namespace uwp
-} // namespace react
+} // namespace react::uwp

--- a/vnext/ReactUWP/Modules/LinkingManagerModule.h
+++ b/vnext/ReactUWP/Modules/LinkingManagerModule.h
@@ -6,20 +6,26 @@
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
 
-namespace react {
-namespace uwp {
+namespace react::uwp {
 
-class LinkingManagerModule final : public facebook::xplat::module::CxxModule {
- public:
-  LinkingManagerModule();
-  virtual ~LinkingManagerModule();
+struct LinkingManagerModule final : facebook::xplat::module::CxxModule {
+  LinkingManagerModule() noexcept;
+  ~LinkingManagerModule() noexcept override;
 
-  // CxxModule
+  static void OpenUri(winrt::Windows::Foundation::Uri const &uri) noexcept;
+  void HandleOpenUri(winrt::hstring const &uri) noexcept;
+
+ public: // CxxModule
   std::string getName() override;
   std::map<std::string, folly::dynamic> getConstants() override;
-  auto getMethods() -> std::vector<Method> override;
+  std::vector<Method> getMethods() override;
 
   static const char *name;
+
+ private:
+  static std::mutex s_mutex;
+  static winrt::Windows::Foundation::Uri s_initialUri;
+  static std::vector<LinkingManagerModule *> s_linkingModules;
 };
-} // namespace uwp
-} // namespace react
+
+} // namespace react::uwp


### PR DESCRIPTION
In RNW we already had Linking module implemented. The part that was missing is the implementation of the `getInitialURL()` method and raising events when application is asked to navigate to new a URL.

In this PR we are implementing the missing functionality:
- `ReactApplication` is changed to show RN UI on protocol activation and to notify  `LinkingManagerModule` about new URL activations.
- The sample applications are changed to respond to `rn-sample-app-cpp:` and `rn-sample-app-cs` protocols.
- Sample JS file changed to log the initial URL and subscribe to Open URL notifications and show them in the log.

To manually test the new functionality, developers can call run window `Win+R` and type there `rn-sample-app-cpp:Hello` or some other URL that uses the `rn-sample-app-cpp:` or `rn-sample-app-cs` protocols depending on whether they test C++ or C# based apps.
For the new activations the apps will log a non-null initial URL. The running apps will log the 'Open URL' event. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4392)