### PR TITLE
[0.60] Implement WinRTWebSocketResource

### DIFF
--- a/change/react-native-windows-2020-03-22-18-29-34-winapi_ws_0.60.json
+++ b/change/react-native-windows-2020-03-22-18-29-34-winapi_ws_0.60.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Merge from branch winapi_ws",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "commit": "b32cb8dc25311b5a9cbb1c2d630695b51f0e681a",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T01:29:34.400Z"
+}

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -137,14 +137,18 @@
   <ItemGroup>
     <ClInclude Include="MessageQueueShim.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -39,4 +39,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/vnext/Desktop.ABITests/packages.config
+++ b/vnext/Desktop.ABITests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
+</packages>

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -54,7 +54,7 @@
         BOOST_ASIO_HAS_IOCP - Force unique layout/size for boost::asio::basic_stream_socket<> subtypes.
         REACTWINDOWS_BUILD - building with REACTWINDOWS_API as dll exports
       -->
-      <PreprocessorDefinitions>REACTWINDOWS_BUILD;BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;_USRDLL;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REACTWINDOWS_BUILD;BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN8;WIN32;_WINDOWS;_USRDLL;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>%(AdditionalOptions) /Zc:strictStrings</AdditionalOptions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -62,7 +62,16 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalOptions>-minpdbpathlen:256</AdditionalOptions>
-      <AdditionalDependencies>Shlwapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!--
+        comsuppw.lib  - _com_util::ConvertStringToBSTR
+        Winhttp.lib   - WebSocket resource implementation
+      -->
+      <AdditionalDependencies>
+        comsuppw.lib;
+        Shlwapi.lib;
+        Version.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
       <!--
       Replaces the WindowsApp.lib link reference in Microsoft.Windows.CppWinRT.props until
       we have a better solution for handling the absence of WinRT string and error DLLs on Win7.
@@ -73,7 +82,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <Link>
-      <ModuleDefinitionFile>react-native-win32.x64.def</ModuleDefinitionFile>	
+      <ModuleDefinitionFile>react-native-win32.x64.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="('$(Platform)'=='Win32' OR '$(Platform)'=='x86')">

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UEBA?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
-?Make@IWebSocket@React@Microsoft@@SA?AV?$unique_ptr@UIWebSocket@React@Microsoft@@U?$default_delete@UIWebSocket@React@Microsoft@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QEAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YA?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QEB_WI@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocket@React@Microsoft@@SG?AV?$unique_ptr@UIWebSocket@React@Microsoft@@U?$default_delete@UIWebSocket@React@Microsoft@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -21,6 +22,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E0D269B4-D7F0-4C4E-92CD-B2C06109A2BB}</ProjectGuid>
     <ProjectName>React.Windows.Desktop.IntegrationTests</ProjectName>
+    <CppWinRTOptimized>true</CppWinRTOptimized>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
@@ -47,14 +49,25 @@
     <ClCompile>
       <SDLCheck>true</SDLCheck>
       <!-- See https://stackoverflow.com/questions/42847103/stdtr1-with-visual-studio-2017. -->
-      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_PLATFORM=windesktop;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;_WIN32_WINNT=_WIN32_WINNT_WIN8;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_PLATFORM=windesktop;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <UseFullPaths>true</UseFullPaths>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Shlwapi.lib;Version.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!--
+        comsuppw.lib  - _com_util::ConvertStringToBSTR
+        delayimp.lib  -
+        Winhttp.lib   - WebSocket resource implementation
+      -->
+      <AdditionalDependencies>
+        comsuppw.lib;
+        delayimp.lib;
+        Shlwapi.lib;
+        Version.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -109,6 +122,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -119,6 +133,8 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>
   <Target Name="Test">

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -373,7 +373,9 @@ TEST_CLASS (WebSocketIntegrationTest)
     // The WebSocket implementation can't handle multiple write operations
     // concurrently.
     for (int i = 0; i < writes; i++)
+    {
       ws->Send("suffixme");
+    }
 
     // Block until response is received. Fail in case of a remote endpoint failure.
     auto future = response.get_future();

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// clang-format off
 #include <CppUnitTest.h>
-#include <IWebSocket.h>
+#include <IWebSocketResource.h>
 #include <Test/WebSocketServer.h>
 
 #include <condition_variable>
@@ -20,321 +21,370 @@ using std::string;
 using std::unique_lock;
 using std::chrono::milliseconds;
 
-using CloseCode = IWebSocket::CloseCode;
+using CloseCode = IWebSocketResource::CloseCode;
+using Error = IWebSocketResource::Error;
 
-TEST_CLASS(WebSocketIntegrationTest){TEST_METHOD(ConnectClose){auto server = make_shared<Test::WebSocketServer>(5556);
-auto ws = IWebSocket::Make("ws://localhost:5556/");
-Assert::IsFalse(nullptr == ws);
-bool connected = false;
-string message;
-ws->SetOnConnect([&connected]() { connected = true; });
-
-server->Start();
-ws->Connect();
-ws->Close(CloseCode::Normal, "Closing");
-server->Stop();
-
-Assert::IsTrue(connected);
-}
-
-TEST_METHOD(ConnectNoClose) {
-  bool connected = false;
-  auto server = make_shared<Test::WebSocketServer>(5556);
-  server->Start();
-
-  // IWebSocket scope. Ensures object is closed implicitly by destructor.
+TEST_CLASS (WebSocketIntegrationTest)
+{
+  void SendReceiveCloseBase(bool isSecure)
   {
-    auto ws = IWebSocket::Make("ws://localhost:5556/");
-    ws->SetOnConnect([&connected]() { connected = true; });
+    auto server = make_shared<Test::WebSocketServer>(5556, isSecure);
+    server->SetMessageFactory([](string&& message)
+    {
+      return message + "_response";
+    });
+    string scheme = "ws";
+    if (isSecure)
+      scheme += "s";
+    auto ws = IWebSocketResource::Make(scheme + "://localhost:5556/", true);
+    promise<size_t> sentSizePromise;
+    ws->SetOnSend([&sentSizePromise](size_t size)
+    {
+      sentSizePromise.set_value(size);
+    });
+    promise<string> receivedPromise;
+    ws->SetOnMessage([&receivedPromise](size_t size, const string& message)
+    {
+      receivedPromise.set_value(message);
+    });
+    string errorMessage;
+    ws->SetOnError([&errorMessage](IWebSocketResource::Error err)
+    {
+      errorMessage = err.Message;
+    });
+
+    server->Start();
+    string sent = "prefix";
+    ws->Connect();
+    ws->Send(sent);
+
+    // Block until response is received. Fail in case of a remote endpoint failure.
+    auto sentSizeFuture = sentSizePromise.get_future();
+    sentSizeFuture.wait();
+    auto sentSize = sentSizeFuture.get();
+    auto receivedFuture = receivedPromise.get_future();
+    receivedFuture.wait();
+    string received = receivedFuture.get();
+    Assert::AreEqual({}, errorMessage);
+
+    ws->Close(CloseCode::Normal, "Closing after reading");
+    server->Stop();
+
+    Assert::AreEqual({}, errorMessage);
+    Assert::AreEqual(sent.length(), sentSize);
+    Assert::AreEqual({"prefix_response"}, received);
+  }
+
+  TEST_METHOD(ConnectClose)
+  {
+    auto server = make_shared<Test::WebSocketServer>(5556);
+    auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+    Assert::IsFalse(nullptr == ws);
+    bool connected = false;
+    bool closed = false;
+    bool error = false;
+    ws->SetOnConnect([&connected]()
+    {
+      connected = true;
+    });
+    ws->SetOnClose([&closed](CloseCode code, const string& reason)
+    {
+      closed = true;
+    });
+    ws->SetOnError([&error](Error&& e)
+    {
+      error = true;
+    });
+
+    server->Start();
+    ws->Connect();
+    ws->Close(CloseCode::Normal, "Closing");
+    server->Stop();
+
+    Assert::IsFalse(error);
+    Assert::IsTrue(connected);
+    Assert::IsTrue(closed);
+  }
+
+  TEST_METHOD(ConnectNoClose)
+  {
+    bool connected = false;
+    bool error = false;
+    auto server = make_shared<Test::WebSocketServer>(5556);
+    server->Start();
+
+    // IWebSocketResource scope. Ensures object is closed implicitly by destructor.
+    {
+      auto ws = IWebSocketResource::Make("ws://localhost:5556");
+      ws->SetOnConnect([&connected]()
+      {
+        connected = true;
+      });
+      ws->SetOnError([&error](IWebSocketResource::Error &&)
+      {
+        error = true;
+      });
+
+      ws->Connect();
+    }
+
+    server->Stop();
+
+    Assert::IsFalse(error);
+    Assert::IsTrue(connected);
+  }
+
+  TEST_METHOD(PingClose)
+  {
+    auto server = make_shared<Test::WebSocketServer>(5556);
+    server->Start();
+
+    auto ws = IWebSocketResource::Make("ws://localhost:5556");
+    promise<bool> pingPromise;
+    ws->SetOnPing([&pingPromise]()
+    {
+      pingPromise.set_value(true);
+    });
+    string errorString;
+    ws->SetOnError([&errorString](IWebSocketResource::Error err)
+    {
+      errorString = err.Message;
+    });
 
     ws->Connect();
+    ws->Ping();
+    auto pingFuture = pingPromise.get_future();
+    pingFuture.wait();
+    bool pinged = pingFuture.get();
+    ws->Close(CloseCode::Normal, "Closing after reading");
+
+    server->Stop();
+
+    Assert::IsTrue(pinged);
+    Assert::AreEqual({}, errorString);
   }
 
-  server->Stop();
+  // Emulate promise/future functionality.
+  // Fails when connecting to stock package bundler.
+  BEGIN_TEST_METHOD_ATTRIBUTE(WaitForBundlerResponseNoClose)
+  TEST_IGNORE()
+  END_TEST_METHOD_ATTRIBUTE()
+  TEST_METHOD(WaitForBundlerResponseNoClose) {
+    string url = "ws://localhost:8081/debugger-proxy?role=client";
+    // string url = "ws://localhost:5555/";
+    auto ws = IWebSocketResource::Make(url);
+    string json =
+        "{\"inject\":{},\"id\":1,\"method\":\"executeApplicationScript\",\"url\":\"http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=ios&dev=true\"}";
+    // string json = "{}";
+    std::mutex mutex;
+    condition_variable condition;
+    bool read = false;
+    bool connected = false;
+    bool wrote = false;
+    ws->SetOnConnect([&connected]() { connected = true; });
+    ws->SetOnSend([&wrote](size_t size) { wrote = true; });
+    ws->SetOnMessage([&mutex, &condition, &read](size_t size, const string &message) {
+      lock_guard<std::mutex> guard(mutex);
+      read = true;
+      condition.notify_all();
+    });
 
-  Assert::IsTrue(connected);
-}
+    ws->Connect();
+    ws->Send(json);
 
-TEST_METHOD(PingClose) {
-  auto server = make_shared<Test::WebSocketServer>(5556);
-  server->Start();
+    unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock);
 
-  auto ws = IWebSocket::Make("ws://localhost:5556");
-  promise<bool> pingPromise;
-  ws->SetOnPing([&pingPromise]() { pingPromise.set_value(true); });
-  string errorString;
-  ws->SetOnError([&errorString](IWebSocket::Error err) { errorString = err.Message; });
+    Assert::IsTrue(connected);
+    Assert::IsTrue(wrote);
+    Assert::IsTrue(read);
+  }
 
-  ws->Connect();
-  ws->Ping();
-  auto pingFuture = pingPromise.get_future();
-  pingFuture.wait();
-  bool pinged = pingFuture.get();
-  ws->Close(CloseCode::Normal, "Closing after reading");
+  TEST_METHOD(SendReceiveClose)
+  {
+    SendReceiveCloseBase(/*isSecure*/ false);
+  }
 
-  server->Stop();
+  TEST_METHOD(SendReceiveLargeMessage) {
+    auto server = make_shared<Test::WebSocketServer>(5556);
+    server->SetMessageFactory([](string &&message) { return message + "_response"; });
+    auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+    promise<string> response;
+    ws->SetOnMessage([&response](size_t size, const string &message) { response.set_value(message); });
+    string errorMessage;
+    ws->SetOnError([&errorMessage](IWebSocketResource::Error err) { errorMessage = err.Message; });
 
-  Assert::IsTrue(pinged);
-  Assert::AreEqual({}, errorString);
-}
+    server->Start();
+    ws->Connect();
 
-// Emulate promise/future functionality.
-// Fails when connecting to stock package bundler.
-BEGIN_TEST_METHOD_ATTRIBUTE(WaitForBundlerResponseNoClose)
-TEST_IGNORE()
-END_TEST_METHOD_ATTRIBUTE()
-TEST_METHOD(WaitForBundlerResponseNoClose) {
-  string url = "ws://localhost:8081/debugger-proxy?role=client";
-  // string url = "ws://localhost:5555/";
-  auto ws = IWebSocket::Make(url);
-  string json =
-      "{\"inject\":{},\"id\":1,\"method\":\"executeApplicationScript\",\"url\":\"http://localhost:8081/IntegrationTests/IntegrationTestsAppWin.bundle?platform=ios&dev=true\"}";
-  // string json = "{}";
-  std::mutex mutex;
-  condition_variable condition;
-  bool read = false;
-  bool connected = false;
-  bool wrote = false;
-  ws->SetOnConnect([&connected]() { connected = true; });
-  ws->SetOnSend([&wrote](size_t size) { wrote = true; });
-  ws->SetOnMessage([&mutex, &condition, &read](size_t size, const string &message) {
-    lock_guard<std::mutex> guard(mutex);
-    read = true;
-    condition.notify_all();
-  });
-
-  ws->Connect();
-  ws->Send(json);
-
-  unique_lock<std::mutex> lock(mutex);
-  condition.wait(lock);
-
-  Assert::IsTrue(connected);
-  Assert::IsTrue(wrote);
-  Assert::IsTrue(read);
-}
-
-TEST_METHOD(SendReceiveClose) {
-  auto server = make_shared<Test::WebSocketServer>(5556);
-  server->SetMessageFactory([](string &&message) { return message + "_response"; });
-  auto ws = IWebSocket::Make("ws://localhost:5556/");
-  promise<size_t> sentSizePromise;
-  ws->SetOnSend([&sentSizePromise](size_t size) { sentSizePromise.set_value(size); });
-  promise<string> receivedPromise;
-  ws->SetOnMessage([&receivedPromise](size_t size, const string &message) { receivedPromise.set_value(message); });
-  string errorMessage;
-  ws->SetOnError([&errorMessage](IWebSocket::Error err) { errorMessage = err.Message; });
-
-  server->Start();
-  string sent = "prefix";
-  ws->Connect();
-  ws->Send(sent);
-
-  // Block until respone is received. Fail in case of a remote endpoint failure.
-  auto sentSizeFuture = sentSizePromise.get_future();
-  sentSizeFuture.wait();
-  auto sentSize = sentSizeFuture.get();
-  auto receivedFuture = receivedPromise.get_future();
-  receivedFuture.wait();
-  string received = receivedFuture.get();
-  Assert::AreEqual({}, errorMessage);
-
-  ws->Close(CloseCode::Normal, "Closing after reading");
-  server->Stop();
-
-  Assert::AreEqual({}, errorMessage);
-  Assert::AreEqual(sent.length(), sentSize);
-  Assert::AreEqual({"prefix_response"}, received);
-}
-
-TEST_METHOD(SendReceiveLargeMessage) {
-  auto server = make_shared<Test::WebSocketServer>(5556);
-  server->SetMessageFactory([](string &&message) { return message + "_response"; });
-  auto ws = IWebSocket::Make("ws://localhost:5556/");
-  promise<string> response;
-  ws->SetOnMessage([&response](size_t size, const string &message) { response.set_value(message); });
-  string errorMessage;
-  ws->SetOnError([&errorMessage](IWebSocket::Error err) { errorMessage = err.Message; });
-
-  server->Start();
-  ws->Connect();
-
-  char digits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    char digits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 #define LEN 4096 + 4096 * 2 + 1
-  char chars[LEN + 1];
-  for (int i = 0; i < LEN; i++) {
-    chars[i] = digits[i % 16];
-  }
-  chars[LEN] = '\0';
-  string large(chars);
-  ws->Send(large);
+    char chars[LEN + 1];
+    for (int i = 0; i < LEN; i++) {
+      chars[i] = digits[i % 16];
+    }
+    chars[LEN] = '\0';
+    string large(chars);
+    ws->Send(large);
 
-  // Block until respone is received. Fail in case of a remote endpoint failure.
-  auto future = response.get_future();
-  future.wait();
-  string result = future.get();
-
-  ws->Close(CloseCode::Normal, "Closing after reading");
-  server->Stop();
-
-  Assert::AreEqual({}, errorMessage);
-  Assert::AreEqual(static_cast<size_t>(LEN + string("_response").length()), result.length());
-}
-
-/*
-  Currently, this test requires a modified websocket test server.
-  TODO: Write an in-place werver with this behavior:
-
- server.on('connection', (ws) => {
-   ws.on('message', (message) => {
-     for (var propName in ws.upgradeReq.headers) {
-       console.log(`${propName}: [${ws.upgradeReq.headers[propName]}]`);
-     }
-
-     // Send the cookie back to the client.
-     ws.send(ws.upgradeReq.headers.cookie);
-   });
- });
-
-  Test passes, otherwise.
- */
-BEGIN_TEST_METHOD_ATTRIBUTE(AdditionalHeaders)
-TEST_IGNORE()
-END_TEST_METHOD_ATTRIBUTE()
-TEST_METHOD(AdditionalHeaders) {
-  string cookie;
-  auto server = make_shared<Test::WebSocketServer>(5556);
-  server->SetOnHandshake([server](boost::beast::websocket::response_type &response) {
-    auto cookie = response[boost::beast::http::field::cookie].to_string();
-    server->SetMessageFactory([cookie](string &&) { return cookie; });
-  });
-  auto ws = IWebSocket::Make("ws://localhost:5556/");
-  promise<string> response;
-  ws->SetOnMessage([&response](size_t size, const string &message) { response.set_value(message); });
-
-  server->Start();
-  ws->Connect({}, {{L"Cookie", "JSESSIONID=AD9A320CC4034641997FF903F1D10906"}});
-  ws->Send("");
-
-  auto future = response.get_future();
-  future.wait();
-  string result = future.get();
-
-  Assert::AreEqual({"JSESSIONID=AD9A320CC4034641997FF903F1D10906"}, result);
-
-  ws->Close(CloseCode::Normal, "No reason");
-  server->Stop();
-}
-
-TEST_METHOD(SendReceiveSsl) {
-  auto server = make_shared<Test::WebSocketServer>(5556, /*isSecure*/ true);
-  server->SetMessageFactory([](string &&message) { return message + "_response"; });
-  auto ws = IWebSocket::Make("wss://localhost:5556");
-  promise<string> response;
-  ws->SetOnMessage([&response](size_t size, const string &messageIn) { response.set_value(messageIn); });
-
-  server->Start();
-  ws->Connect();
-  ws->Send("suffixme");
-
-  auto result = response.get_future();
-  result.wait();
-
-  ws->Close(CloseCode::Normal, "Closing after reading");
-  server->Stop();
-
-  Assert::AreEqual({"suffixme_response"}, result.get());
-}
-
-// TODO: Use Test::WebSocketServer!!!
-BEGIN_TEST_METHOD_ATTRIBUTE(SendBinary)
-TEST_IGNORE()
-END_TEST_METHOD_ATTRIBUTE()
-TEST_METHOD(SendBinary) {
-  auto ws = IWebSocket::Make("ws://localhost:5555/");
-
-  std::vector<string> messages{
-      // Empty
-      "", // []
-
-      // Text
-      "MQ==", // "1"
-      "MTI=", // "12"
-      "MTIz", // "123"
-      "MTIzNA==", // "1230"
-
-      // Binary
-      "AQ==", // [ 01 ]
-      "AQI=", // [ 01 02 ]
-      "AQID", // [ 01 02 03 ]
-      "AQIDAA==" // [ 00, 01, 02, 03, 00 ]
-  };
-
-  string errorMessage;
-  promise<string> responsePromise;
-  ws->SetOnMessage([&responsePromise](size_t size, const string &messageIn) {
-    // Ignore on-connect greeting.
-    if (messageIn == "hello")
-      return;
-
-    responsePromise.set_value(messageIn);
-  });
-  ws->SetOnError([&errorMessage](IWebSocket::Error error) { errorMessage = error.Message; });
-
-  ws->Connect();
-
-  for (size_t i = 0; i < messages.size(); i++) {
-    ws->SendBinary(messages[i]);
-    auto future = responsePromise.get_future();
+    // Block until response is received. Fail in case of a remote endpoint failure.
+    auto future = response.get_future();
     future.wait();
-    string response = future.get();
-    responsePromise = promise<string>(); // Reset promise.
+    string result = future.get();
 
-    // Expect same message.
-    Assert::AreEqual(messages[i], response);
+    ws->Close(CloseCode::Normal, "Closing after reading");
+    server->Stop();
+
+    Assert::AreEqual({}, errorMessage);
+    Assert::AreEqual(static_cast<size_t>(LEN + string("_response").length()), result.length());
   }
 
-  ws->Close(CloseCode::Normal, "Closing after reading");
+  /*
+    Currently, this test requires a modified websocket test server.
+    TODO: Write an in-place werver with this behavior:
 
-  Assert::AreEqual({}, errorMessage);
-}
+   server.on('connection', (ws) => {
+     ws.on('message', (message) => {
+       for (var propName in ws.upgradeReq.headers) {
+         console.log(`${propName}: [${ws.upgradeReq.headers[propName]}]`);
+       }
 
-TEST_METHOD(SendConsecutive) {
-  auto server = make_shared<Test::WebSocketServer>(5556);
-  server->SetMessageFactory([](string &&message) { return message + "_response"; });
-  auto ws = IWebSocket::Make("ws://localhost:5556/");
-  promise<string> response;
-  const int writes = 10;
-  int count = 0;
-  ws->SetOnMessage([&response, &count, writes](size_t size, const string &message) {
-    if (++count < writes)
-      return;
+       // Send the cookie back to the client.
+       ws.send(ws.upgradeReq.headers.cookie);
+     });
+   });
 
-    response.set_value(message);
-  });
-  string errorMessage;
-  ws->SetOnError([&errorMessage](IWebSocket::Error err) { errorMessage = err.Message; });
+    Test passes, otherwise.
+   */
+  BEGIN_TEST_METHOD_ATTRIBUTE(AdditionalHeaders)
+  TEST_IGNORE()
+  END_TEST_METHOD_ATTRIBUTE()
+  TEST_METHOD(AdditionalHeaders) {
+    string cookie;
+    auto server = make_shared<Test::WebSocketServer>(5556);
+    server->SetOnHandshake([server](boost::beast::websocket::response_type &response) {
+      auto cookie = response[boost::beast::http::field::cookie].to_string();
+      server->SetMessageFactory([cookie](string &&) { return cookie; });
+    });
+    auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+    promise<string> response;
+    ws->SetOnMessage([&response](size_t size, const string &message) { response.set_value(message); });
 
-  server->Start();
-  ws->Connect();
+    server->Start();
+    ws->Connect({}, {{L"Cookie", "JSESSIONID=AD9A320CC4034641997FF903F1D10906"}});
+    ws->Send("");
 
-  // Consecutive immediate writes should be enqueued.
-  // The WebSocket implementation can't handle multiple write operations
-  // concurrently.
-  for (int i = 0; i < writes; i++)
-    ws->Send("suffixme");
+    auto future = response.get_future();
+    future.wait();
+    string result = future.get();
 
-  // Block until respone is received. Fail in case of a remote endpoint failure.
-  auto future = response.get_future();
-  future.wait();
-  string result = future.get();
+    Assert::AreEqual({"JSESSIONID=AD9A320CC4034641997FF903F1D10906"}, result);
 
-  ws->Close(CloseCode::Normal, "Closing");
-  server->Stop();
+    ws->Close(CloseCode::Normal, "No reason");
+    server->Stop();
+  }
 
-  Assert::AreEqual({}, errorMessage);
-  Assert::AreEqual(writes, count);
-  Assert::AreEqual({"suffixme_response"}, result);
-}
-}
-;
+  TEST_METHOD(SendReceiveSsl)
+  {
+    SendReceiveCloseBase(/*isSecure*/ true);
+  }
+
+  // TODO: Use Test::WebSocketServer!!!
+  BEGIN_TEST_METHOD_ATTRIBUTE(SendBinary)
+  TEST_IGNORE()
+  END_TEST_METHOD_ATTRIBUTE()
+  TEST_METHOD(SendBinary) {
+    auto ws = IWebSocketResource::Make("ws://localhost:5555/");
+
+    std::vector<string> messages{
+        // Empty
+        "", // []
+
+        // Text
+        "MQ==", // "1"
+        "MTI=", // "12"
+        "MTIz", // "123"
+        "MTIzNA==", // "1230"
+
+        // Binary
+        "AQ==", // [ 01 ]
+        "AQI=", // [ 01 02 ]
+        "AQID", // [ 01 02 03 ]
+        "AQIDAA==" // [ 00, 01, 02, 03, 00 ]
+    };
+
+    string errorMessage;
+    promise<string> responsePromise;
+    ws->SetOnMessage([&responsePromise](size_t size, const string &messageIn) {
+      // Ignore on-connect greeting.
+      if (messageIn == "hello")
+        return;
+
+      responsePromise.set_value(messageIn);
+    });
+    ws->SetOnError([&errorMessage](IWebSocketResource::Error error) { errorMessage = error.Message; });
+
+    ws->Connect();
+
+    for (size_t i = 0; i < messages.size(); i++) {
+      ws->SendBinary(messages[i]);
+      auto future = responsePromise.get_future();
+      future.wait();
+      string response = future.get();
+      responsePromise = promise<string>(); // Reset promise.
+
+      // Expect same message.
+      Assert::AreEqual(messages[i], response);
+    }
+
+    ws->Close(CloseCode::Normal, "Closing after reading");
+
+    Assert::AreEqual({}, errorMessage);
+  }
+
+  TEST_METHOD(SendConsecutive)
+  {
+    auto server = make_shared<Test::WebSocketServer>(5556);
+    server->SetMessageFactory([](string&& message)
+    {
+      return message + "_response";
+    });
+    auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+    promise<string> response;
+    const int writes = 10;
+    int count = 0;
+    ws->SetOnMessage([&response, &count, writes](size_t size, const string& message)
+    {
+      if (++count < writes)
+        return;
+
+      response.set_value(message);
+    });
+    string errorMessage;
+    ws->SetOnError([&errorMessage](IWebSocketResource::Error err)
+    {
+      errorMessage = err.Message;
+    });
+
+    server->Start();
+    ws->Connect();
+
+    // Consecutive immediate writes should be enqueued.
+    // The WebSocket implementation can't handle multiple write operations
+    // concurrently.
+    for (int i = 0; i < writes; i++)
+      ws->Send("suffixme");
+
+    // Block until response is received. Fail in case of a remote endpoint failure.
+    auto future = response.get_future();
+    future.wait();
+    string result = future.get();
+
+    ws->Close(CloseCode::Normal, "Closing");
+    server->Stop();
+
+    Assert::AreEqual({}, errorMessage);
+    Assert::AreEqual(writes, count);
+    Assert::AreEqual({"suffixme_response"}, result);
+  }
+};

--- a/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
@@ -22,7 +22,7 @@ TEST_CLASS (WebSocketModuleIntegrationTest)
 
     auto connect = module->getMethods().at(WebSocketModule::MethodId::Connect);
     connect.func(
-        dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 0),
+        dynamic::array("ws://localhost:5556/", dynamic(), dynamic(), /*id*/ 0),
         [](vector<dynamic>) {},
         [](vector<dynamic>) {});
 
@@ -39,11 +39,11 @@ TEST_CLASS (WebSocketModuleIntegrationTest)
 
     auto connect = module->getMethods().at(WebSocketModule::MethodId::Connect);
     connect.func(
-        dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 0),
+        dynamic::array("ws://localhost:5556/", dynamic(), dynamic(), /*id*/ 0),
         [](vector<dynamic>) {},
         [](vector<dynamic>) {});
     connect.func(
-        dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 1),
+        dynamic::array("ws://localhost:5556/", dynamic(), dynamic(), /*id*/ 1),
         [](vector<dynamic>) {},
         [](vector<dynamic>) {});
 

--- a/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
@@ -1,56 +1,60 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// clang-format off
 #include <CppUnitTest.h>
 
 #include <WebSocketModule.h>
 
-using namespace facebook::react;
 using namespace folly;
+using namespace Microsoft::React;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using std::make_unique;
 using std::unique_ptr;
 using std::vector;
 
-TEST_CLASS(WebSocketModuleIntegrationTest){
-    TEST_METHOD(WebSocketModule_Ping){auto module = make_unique<WebSocketModule>();
+TEST_CLASS (WebSocketModuleIntegrationTest)
+{
+  TEST_METHOD(WebSocketModule_Ping)
+  {
+    auto module = make_unique<WebSocketModule>();
 
-auto connect = module -> getMethods().at(WebSocketModule::MethodId::Connect);
-connect.func(
-    dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 0),
-    [](vector<dynamic>) {},
-    [](vector<dynamic>) {});
+    auto connect = module->getMethods().at(WebSocketModule::MethodId::Connect);
+    connect.func(
+        dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 0),
+        [](vector<dynamic>) {},
+        [](vector<dynamic>) {});
 
-auto ping = module -> getMethods().at(WebSocketModule::MethodId::Ping);
-ping.func(dynamic::array(0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+    auto ping = module->getMethods().at(WebSocketModule::MethodId::Ping);
+    ping.func(dynamic::array(0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
 
-auto close = module -> getMethods().at(WebSocketModule::MethodId::Close);
-close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
-}
+    auto close = module->getMethods().at(WebSocketModule::MethodId::Close);
+    close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+  }
 
-TEST_METHOD(WebSocketModule_SendMultiple) {
-  auto module = make_unique<WebSocketModule>();
+  TEST_METHOD(WebSocketModule_SendMultiple)
+  {
+    auto module = make_unique<WebSocketModule>();
 
-  auto connect = module->getMethods().at(WebSocketModule::MethodId::Connect);
-  connect.func(
-      dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 0),
-      [](vector<dynamic>) {},
-      [](vector<dynamic>) {});
-  connect.func(
-      dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 1),
-      [](vector<dynamic>) {},
-      [](vector<dynamic>) {});
+    auto connect = module->getMethods().at(WebSocketModule::MethodId::Connect);
+    connect.func(
+        dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 0),
+        [](vector<dynamic>) {},
+        [](vector<dynamic>) {});
+    connect.func(
+        dynamic::array("ws://localhost:5555/", dynamic(), dynamic(), /*id*/ 1),
+        [](vector<dynamic>) {},
+        [](vector<dynamic>) {});
 
-  auto send = module->getMethods().at(WebSocketModule::MethodId::Send);
-  send.func(dynamic::array("request1", 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
-  send.func(dynamic::array("request2", 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
-  send.func(dynamic::array("request3", 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
-  send.func(dynamic::array("request4", 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+    auto send = module->getMethods().at(WebSocketModule::MethodId::Send);
+    send.func(dynamic::array("request1", 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+    send.func(dynamic::array("request2", 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+    send.func(dynamic::array("request3", 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+    send.func(dynamic::array("request4", 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
 
-  auto close = module->getMethods().at(WebSocketModule::MethodId::Close);
-  close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
-  close.func(dynamic::array(0, "closing", /*id*/ 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
-}
-}
-;
+    auto close = module->getMethods().at(WebSocketModule::MethodId::Close);
+    close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+    close.func(dynamic::array(0, "closing", /*id*/ 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+  }
+};

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -20,72 +20,72 @@ using std::string;
 using std::unique_ptr;
 using std::vector;
 
-TEST_CLASS(WebSocketResourcePerformanceTest){// See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
-                                             int32_t GetCurrentThreadCount(){DWORD procId = GetCurrentProcessId();
-HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
+TEST_CLASS (WebSocketResourcePerformanceTest) { // See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
+  int32_t GetCurrentThreadCount() {
+    DWORD procId = GetCurrentProcessId();
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
 
-PROCESSENTRY32 entry = {0};
-entry.dwSize = sizeof(entry);
+    PROCESSENTRY32 entry = {0};
+    entry.dwSize = sizeof(entry);
 
-BOOL procFound = true;
-procFound = Process32First(snapshot, &entry);
-while (procFound && entry.th32ProcessID != procId)
-  procFound = Process32Next(snapshot, &entry);
-CloseHandle(snapshot);
+    BOOL procFound = true;
+    procFound = Process32First(snapshot, &entry);
+    while (procFound && entry.th32ProcessID != procId)
+      procFound = Process32Next(snapshot, &entry);
+    CloseHandle(snapshot);
 
-if (procFound)
-  return entry.cntThreads;
+    if (procFound)
+      return entry.cntThreads;
 
-return -1;
-}
-
-///
-/// Spawn a number of WebSocket resources, have it write and read a message
-/// several times, then measure the amount of allocated threads. Important. This
-/// test must be run in isolation (no other tests running concurrently).
-///
-TEST_METHOD(ProcessThreadsPerResource) {
-  const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
-  // increase this value to 100.
-  const int maxWriteCount = 10;
-  const int expectedThreadsPerResource = 3;
-  const int startThreadCount = GetCurrentThreadCount();
-
-  std::atomic_int32_t threadCount = 0;
-
-  // WebSocket resources scope.
-  {
-    vector<unique_ptr<IWebSocketResource>> resources;
-    for (int i = 0; i < resourceTotal; i++) {
-      auto ws = IWebSocketResource::Make("ws://localhost:5555/");
-      ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
-        auto count = this->GetCurrentThreadCount();
-        if (count > threadCount.load())
-          threadCount.store(count);
-      });
-      ws->SetOnSend([this, &threadCount](size_t) {
-        auto count = this->GetCurrentThreadCount();
-        if (count > threadCount.load())
-          threadCount.store(count);
-      });
-      ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
-        auto count = this->GetCurrentThreadCount();
-        if (count > threadCount.load())
-          threadCount.store(count);
-      });
-      ws->Connect();
-
-      resources.push_back(std::move(ws));
-    } // Create and store WS resources.
-
-    // Send messages.
-    for (auto &ws : resources) {
-      ws->Send("some message");
-    }
+    return -1;
   }
 
-  int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
-  Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
-}
-}
-;
+  ///
+  /// Spawn a number of WebSocket resources, have it write and read a message
+  /// several times, then measure the amount of allocated threads. Important. This
+  /// test must be run in isolation (no other tests running concurrently).
+  ///
+  TEST_METHOD(ProcessThreadsPerResource) {
+    const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
+    // increase this value to 100.
+    const int maxWriteCount = 10;
+    const int expectedThreadsPerResource = 3;
+    const int startThreadCount = GetCurrentThreadCount();
+
+    std::atomic_int32_t threadCount = 0;
+
+    // WebSocket resources scope.
+    {
+      vector<unique_ptr<IWebSocketResource>> resources;
+      for (int i = 0; i < resourceTotal; i++) {
+        auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+        ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
+          auto count = this->GetCurrentThreadCount();
+          if (count > threadCount.load())
+            threadCount.store(count);
+        });
+        ws->SetOnSend([this, &threadCount](size_t) {
+          auto count = this->GetCurrentThreadCount();
+          if (count > threadCount.load())
+            threadCount.store(count);
+        });
+        ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
+          auto count = this->GetCurrentThreadCount();
+          if (count > threadCount.load())
+            threadCount.store(count);
+        });
+        ws->Connect();
+
+        resources.push_back(std::move(ws));
+      } // Create and store WS resources.
+
+      // Send messages.
+      for (auto &ws : resources) {
+        ws->Send("some message");
+      }
+    }
+
+    int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
+    Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
+  }
+};

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -20,72 +20,72 @@ using std::string;
 using std::unique_ptr;
 using std::vector;
 
-TEST_CLASS (WebSocketResourcePerformanceTest) { // See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
-  int32_t GetCurrentThreadCount() {
-    DWORD procId = GetCurrentProcessId();
-    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
+TEST_CLASS(WebSocketResourcePerformanceTest){// See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
+                                             int32_t GetCurrentThreadCount(){DWORD procId = GetCurrentProcessId();
+HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
 
-    PROCESSENTRY32 entry = {0};
-    entry.dwSize = sizeof(entry);
+PROCESSENTRY32 entry = {0};
+entry.dwSize = sizeof(entry);
 
-    BOOL procFound = true;
-    procFound = Process32First(snapshot, &entry);
-    while (procFound && entry.th32ProcessID != procId)
-      procFound = Process32Next(snapshot, &entry);
-    CloseHandle(snapshot);
+BOOL procFound = true;
+procFound = Process32First(snapshot, &entry);
+while (procFound && entry.th32ProcessID != procId)
+  procFound = Process32Next(snapshot, &entry);
+CloseHandle(snapshot);
 
-    if (procFound)
-      return entry.cntThreads;
+if (procFound)
+  return entry.cntThreads;
 
-    return -1;
-  }
+return -1;
+}
 
-  ///
-  /// Spawn a number of WebSocket resources, have it write and read a message
-  /// several times, then measure the amount of allocated threads. Important. This
-  /// test must be run in isolation (no other tests running concurrently).
-  ///
-  TEST_METHOD(ProcessThreadsPerResource) {
-    const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
-    // increase this value to 100.
-    const int maxWriteCount = 10;
-    const int expectedThreadsPerResource = 3;
-    const int startThreadCount = GetCurrentThreadCount();
+///
+/// Spawn a number of WebSocket resources, have it write and read a message
+/// several times, then measure the amount of allocated threads. Important. This
+/// test must be run in isolation (no other tests running concurrently).
+///
+TEST_METHOD(ProcessThreadsPerResource) {
+  const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
+  // increase this value to 100.
+  const int maxWriteCount = 10;
+  const int expectedThreadsPerResource = 3;
+  const int startThreadCount = GetCurrentThreadCount();
 
-    std::atomic_int32_t threadCount = 0;
+  std::atomic_int32_t threadCount = 0;
 
-    // WebSocket resources scope.
-    {
-      vector<unique_ptr<IWebSocketResource>> resources;
-      for (int i = 0; i < resourceTotal; i++) {
-        auto ws = IWebSocketResource::Make("ws://localhost:5556/");
-        ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
-          auto count = this->GetCurrentThreadCount();
-          if (count > threadCount.load())
-            threadCount.store(count);
-        });
-        ws->SetOnSend([this, &threadCount](size_t) {
-          auto count = this->GetCurrentThreadCount();
-          if (count > threadCount.load())
-            threadCount.store(count);
-        });
-        ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
-          auto count = this->GetCurrentThreadCount();
-          if (count > threadCount.load())
-            threadCount.store(count);
-        });
-        ws->Connect();
+  // WebSocket resources scope.
+  {
+    vector<unique_ptr<IWebSocketResource>> resources;
+    for (int i = 0; i < resourceTotal; i++) {
+      auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+      ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
+        auto count = this->GetCurrentThreadCount();
+        if (count > threadCount.load())
+          threadCount.store(count);
+      });
+      ws->SetOnSend([this, &threadCount](size_t) {
+        auto count = this->GetCurrentThreadCount();
+        if (count > threadCount.load())
+          threadCount.store(count);
+      });
+      ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
+        auto count = this->GetCurrentThreadCount();
+        if (count > threadCount.load())
+          threadCount.store(count);
+      });
+      ws->Connect();
 
-        resources.push_back(std::move(ws));
-      } // Create and store WS resources.
+      resources.push_back(std::move(ws));
+    } // Create and store WS resources.
 
-      // Send messages.
-      for (auto &ws : resources) {
-        ws->Send("some message");
-      }
+    // Send messages.
+    for (auto &ws : resources) {
+      ws->Send("some message");
     }
-
-    int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
-    Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
   }
-};
+
+  int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
+  Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
+}
+}
+;

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <CppUnitTest.h>
-#include <IWebSocket.h>
+#include <IWebSocketResource.h>
 
 #include <Windows.h>
 
@@ -13,7 +13,7 @@
 #include <atomic>
 #include <future>
 
-using namespace facebook::react;
+using namespace Microsoft::React;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using std::string;
@@ -55,9 +55,9 @@ TEST_METHOD(ProcessThreadsPerResource) {
 
   // WebSocket resources scope.
   {
-    vector<unique_ptr<IWebSocket>> resources;
+    vector<unique_ptr<IWebSocketResource>> resources;
     for (int i = 0; i < resourceTotal; i++) {
-      auto ws = IWebSocket::Make("ws://localhost:5555/");
+      auto ws = IWebSocketResource::Make("ws://localhost:5555/");
       ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
         auto count = this->GetCurrentThreadCount();
         if (count > threadCount.load())
@@ -68,7 +68,7 @@ TEST_METHOD(ProcessThreadsPerResource) {
         if (count > threadCount.load())
           threadCount.store(count);
       });
-      ws->SetOnClose([this, &threadCount](IWebSocket::CloseCode, const string & /*reason*/) {
+      ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
         auto count = this->GetCurrentThreadCount();
         if (count > threadCount.load())
           threadCount.store(count);

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x64.def
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x64.def
@@ -7,7 +7,7 @@ EXPORTS
 ?OnAccept@WebSocketServer@Test@React@Microsoft@@AEAAXVerror_code@system@boost@@@Z
 ?SetMessageFactory@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6A?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@$$QEAV12@@Z@std@@@Z
 ?SetOnConnection@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXXZ@std@@@Z
-?SetOnError@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AX$$QEAUError@IWebSocket@React@Microsoft@@@Z@std@@@Z
+?SetOnError@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AX$$QEAUError@IWebSocketResource@React@Microsoft@@@Z@std@@@Z
 ?SetOnHandshake@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXAEAU?$message@$0A@U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@@Z@std@@@Z
 ?SetOnMessage@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z@std@@@Z
 ?Start@WebSocketServer@Test@React@Microsoft@@QEAAXXZ

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x86.def
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x86.def
@@ -7,7 +7,7 @@ EXPORTS
 ?OnAccept@WebSocketServer@Test@React@Microsoft@@AAEXVerror_code@system@boost@@@Z
 ?SetMessageFactory@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6G?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@$$QAV12@@Z@std@@@Z
 ?SetOnConnection@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXXZ@std@@@Z
-?SetOnError@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GX$$QAUError@IWebSocket@React@Microsoft@@@Z@std@@@Z
+?SetOnError@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GX$$QAUError@IWebSocketResource@React@Microsoft@@@Z@std@@@Z
 ?SetOnHandshake@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXAAU?$message@$0A@U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@@Z@std@@@Z
 ?SetOnMessage@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z@std@@@Z
 ?Start@WebSocketServer@Test@React@Microsoft@@QAEXXZ

--- a/vnext/Desktop.UnitTests/BaseWebSocketTests.cpp
+++ b/vnext/Desktop.UnitTests/BaseWebSocketTests.cpp
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <BeastWebSocketResource.h>
 #include <CppUnitTest.h>
-#include <WebSocket.h>
 #include <future>
 
 using namespace boost::beast;
-using namespace facebook::react;
-using namespace Microsoft::React::Test;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using boost::system::error_code;
+using Microsoft::React::Beast::Test::TestWebSocket;
 using std::future;
 using std::make_unique;
 using std::promise;
@@ -18,8 +17,8 @@ using std::string;
 
 namespace Microsoft::React::Test {
 
-using CloseCode = IWebSocket::CloseCode;
-using Error = IWebSocket::Error;
+using CloseCode = IWebSocketResource::CloseCode;
+using Error = IWebSocketResource::Error;
 
 // We turn clang format off here because it does not work with some of the
 // test macros.

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -46,11 +47,19 @@
     <ClCompile>
       <SDLCheck>true</SDLCheck>
       <!-- See //https://stackoverflow.com/questions/42847103/stdtr1-with-visual-studio-2017. -->
-      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;GTEST_LANG_CXX11=1;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;GTEST_LANG_CXX11=1;_WIN32_WINNT=_WIN32_WINNT_WIN8;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!--
+        comsuppw.lib  - _com_util::ConvertStringToBSTR
+        Winhttp.lib   - WebSocket resource implementation
+      -->
+      <AdditionalDependencies>
+        comsuppw.lib;
+        Shlwapi.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
@@ -91,6 +100,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -99,6 +109,8 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
   <Target Name="Test">
     <Exec Command="$(OutDir)$(TargetFileName)" IgnoreStandardErrorWarningFormat="true" />

--- a/vnext/Desktop.UnitTests/WebSocketTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketTest.cpp
@@ -3,7 +3,7 @@
 
 #include <CppUnitTest.h>
 
-#include <WebSocket.h>
+#include <BeastWebSocketResource.h>
 
 using namespace boost::beast;
 using namespace Microsoft::React;
@@ -19,26 +19,26 @@ namespace Microsoft::React::Test {
 
 TEST_CLASS(WebSocketTest) {
   TEST_METHOD(WebSocketTest_CreateAndSetHandlers) {
-    auto ws = std::make_shared<WebSocket>(Url("ws://validurl:0/"));
+    auto ws = std::make_shared<Beast::WebSocketResource>(Url("ws://validurl:0/"));
     Assert::IsFalse(nullptr == ws);
     ws->SetOnConnect([]() {});
     ws->SetOnPing([]() {});
     ws->SetOnSend([](size_t length) {});
     ws->SetOnMessage([](std::size_t length, const string &buffer) {});
-    ws->SetOnClose([](IWebSocket::CloseCode, const string &) {});
-    ws->SetOnError([](const IWebSocket::Error &error) {});
+    ws->SetOnClose([](IWebSocketResource::CloseCode, const string &) {});
+    ws->SetOnError([](const IWebSocketResource::Error &error) {});
   }
 
   // TODO: Implement Protocol and Socket mocks.
   void ConnectAndClose()
   // TEST_METHOD(WebSocketTest_ConnectAndClose)
   {
-    auto ws = std::make_shared<WebSocket>(Url("ws://localhost:5555/"));
+    auto ws = std::make_shared<Beast::WebSocketResource>(Url("ws://localhost:5555/"));
     bool connected = false;
     ws->SetOnConnect([&connected]() { connected = true; });
 
     ws->Connect({}, {});
-    ws->Close(IWebSocket::CloseCode::Normal, "BECAUSE!");
+    ws->Close(IWebSocketResource::CloseCode::Normal, "BECAUSE!");
 
     Assert::IsTrue(connected);
   }
@@ -47,7 +47,7 @@ TEST_CLASS(WebSocketTest) {
   void SendAndReceive()
   // TEST_METHOD(WebSocketTest_SendAndReceive)
   {
-    auto ws = std::make_shared<WebSocket>(Url("ws://localhost:5555/"));
+    auto ws = std::make_shared<Beast::WebSocketResource>(Url("ws://localhost:5555/"));
     ws->SetOnMessage([](size_t size, const string &message) {
       // EXPECT_EQ("uppercaseme_response", ss.str());//TODO: Check test server.
       // Sending back "hello".
@@ -58,7 +58,7 @@ TEST_CLASS(WebSocketTest) {
 
     ws->Connect({}, {});
     ws->Send("uppercaseme");
-    ws->Close(IWebSocket::CloseCode::Normal, "");
+    ws->Close(IWebSocketResource::CloseCode::Normal, "");
   }
 };
 

--- a/vnext/Desktop.UnitTests/packages.config
+++ b/vnext/Desktop.UnitTests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />
 </packages>

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -6,7 +6,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4996) // std::copy::_Unchecked_iterators::_Deprecate
 
-#include "WebSocket.h"
+#include "BeastWebSocketResource.h"
 
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
@@ -33,13 +33,16 @@ using boostecr = boost::system::error_code const &;
 
 namespace Microsoft::React {
 
-#pragma region BaseWebSocket members
+namespace Beast {
+
+#pragma region BaseWebSocketResource members
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::BaseWebSocket(Url &&url) : m_url{std::move(url)} {}
+BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::BaseWebSocketResource(Url &&url)
+    : m_url{std::move(url)} {}
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::~BaseWebSocket() {
+BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::~BaseWebSocketResource() {
   if (!m_context.stopped()) {
     if (!m_closeRequested)
       Close(CloseCode::GoingAway, "Terminating instance");
@@ -49,7 +52,8 @@ BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::~BaseWebSocket() {
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Handshake(const IWebSocket::Options &options) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Handshake(
+    const IWebSocketResource::Options &options) {
   m_stream->async_handshake_ex(
       m_url.host,
       m_url.Target(),
@@ -91,7 +95,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Handshake(const IWe
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformRead() {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformRead() {
   if (ReadyState::Closing == m_readyState || ReadyState::Closed == m_readyState) {
     return;
   }
@@ -132,7 +136,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformRead() {
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformWrite() {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformWrite() {
   assert(!m_writeRequests.empty());
   assert(!m_writeInProgress);
   m_writeInProgress = true;
@@ -164,7 +168,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformWrite() {
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformPing() {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformPing() {
   assert(m_pingRequests > 0);
   assert(!m_pingInProgress);
   m_pingInProgress = true;
@@ -186,7 +190,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformPing() {
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformClose() {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformClose() {
   m_closeInProgress = true;
   m_readyState = ReadyState::Closing;
 
@@ -207,7 +211,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::PerformClose() {
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Stop() {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Stop() {
   if (m_workGuard)
     m_workGuard->reset();
 
@@ -216,7 +220,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Stop() {
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::EnqueueWrite(const string &message, bool binary) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::EnqueueWrite(const string &message, bool binary) {
   post(m_context, [this, message = std::move(message), binary]() {
     m_writeRequests.emplace(std::move(message), binary);
 
@@ -226,79 +230,83 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::EnqueueWrite(const 
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-websocket::close_code BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::ToBeastCloseCode(
-    IWebSocket::CloseCode closeCode) {
+websocket::close_code BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::ToBeastCloseCode(
+    IWebSocketResource::CloseCode closeCode) {
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::Abnormal) == static_cast<uint16_t>(websocket::close_code::abnormal),
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::Abnormal) ==
+          static_cast<uint16_t>(websocket::close_code::abnormal),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::BadPayload) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::BadPayload) ==
           static_cast<uint16_t>(websocket::close_code::bad_payload),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::GoingAway) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::GoingAway) ==
           static_cast<uint16_t>(websocket::close_code::going_away),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::InternalError) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::InternalError) ==
           static_cast<uint16_t>(websocket::close_code::internal_error),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::NeedsExtension) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::NeedsExtension) ==
           static_cast<uint16_t>(websocket::close_code::needs_extension),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::None) == static_cast<uint16_t>(websocket::close_code::none),
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::None) == static_cast<uint16_t>(websocket::close_code::none),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::Normal) == static_cast<uint16_t>(websocket::close_code::normal),
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::Normal) ==
+          static_cast<uint16_t>(websocket::close_code::normal),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::NoStatus) == static_cast<uint16_t>(websocket::close_code::no_status),
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::NoStatus) ==
+          static_cast<uint16_t>(websocket::close_code::no_status),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::PolicyError) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::PolicyError) ==
           static_cast<uint16_t>(websocket::close_code::policy_error),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::ProtocolError) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::ProtocolError) ==
           static_cast<uint16_t>(websocket::close_code::protocol_error),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::Reserved1) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::Reserved1) ==
           static_cast<uint16_t>(websocket::close_code::reserved1),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::Reserved2) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::Reserved2) ==
           static_cast<uint16_t>(websocket::close_code::reserved2),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::Reserved3) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::Reserved3) ==
           static_cast<uint16_t>(websocket::close_code::reserved3),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::ServiceRestart) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::ServiceRestart) ==
           static_cast<uint16_t>(websocket::close_code::service_restart),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::TooBig) == static_cast<uint16_t>(websocket::close_code::too_big),
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::TooBig) ==
+          static_cast<uint16_t>(websocket::close_code::too_big),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::TryAgainLater) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::TryAgainLater) ==
           static_cast<uint16_t>(websocket::close_code::try_again_later),
       "Exception type enums don't match");
   static_assert(
-      static_cast<uint16_t>(IWebSocket::CloseCode::UnknownData) ==
+      static_cast<uint16_t>(IWebSocketResource::CloseCode::UnknownData) ==
           static_cast<uint16_t>(websocket::close_code::unknown_data),
       "Exception type enums don't match");
 
   return static_cast<websocket::close_code>(closeCode);
 }
 
-#pragma region IWebSocket members
+#pragma region IWebSocketResource members
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Connect(
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Connect(
     const Protocols &protocols,
     const Options &options) {
   // "Cannot call Connect more than once");
@@ -344,7 +352,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Connect(
 } // void Connect
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Close(CloseCode code, const string &reason) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Close(CloseCode code, const string &reason) {
   if (m_closeRequested)
     return;
 
@@ -361,12 +369,12 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Close(CloseCode cod
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Send(const string &message) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Send(const string &message) {
   EnqueueWrite(std::move(message), false);
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SendBinary(const string &base64String) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SendBinary(const string &base64String) {
   m_stream->binary(true);
 
   string message;
@@ -388,7 +396,7 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SendBinary(const st
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Ping() {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Ping() {
   if (ReadyState::Closed == m_readyState)
     return;
 
@@ -397,54 +405,54 @@ void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::Ping() {
     PerformPing();
 }
 
-#pragma endregion IWebSocket members
+#pragma endregion IWebSocketResource members
 
 #pragma region Handler setters
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SetOnConnect(function<void()> &&handler) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnConnect(function<void()> &&handler) {
   m_connectHandler = handler;
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SetOnPing(function<void()> &&handler) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnPing(function<void()> &&handler) {
   m_pingHandler = handler;
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SetOnSend(function<void(size_t)> &&handler) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnSend(function<void(size_t)> &&handler) {
   m_writeHandler = handler;
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SetOnMessage(
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnMessage(
     function<void(size_t, const string &)> &&handler) {
   m_readHandler = handler;
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SetOnClose(
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnClose(
     function<void(CloseCode, const string &)> &&handler) {
   m_closeHandler = handler;
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::SetOnError(function<void(Error &&)> &&handler) {
+void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnError(function<void(Error &&)> &&handler) {
   m_errorHandler = handler;
 }
 
 template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-IWebSocket::ReadyState BaseWebSocket<Protocol, SocketLayer, Stream, Resolver>::GetReadyState() const {
+IWebSocketResource::ReadyState BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::GetReadyState() const {
   return m_readyState;
 }
 
 #pragma endregion Handler setters
 
-#pragma endregion BaseWebSocket members
+#pragma endregion BaseWebSocketResource members
 
-#pragma region WebSocket members
+#pragma region WebSocketResource members
 
-WebSocket::WebSocket(Url &&url) : BaseWebSocket(std::move(url)) {
+WebSocketResource::WebSocketResource(Url &&url) : BaseWebSocketResource(std::move(url)) {
   this->m_stream = make_unique<websocket::stream<basic_stream_socket<tcp>>>(this->m_context);
   this->m_stream->auto_fragment(false); // ISS:2906963 Re-enable message fragmenting.
 }
@@ -453,45 +461,24 @@ WebSocket::WebSocket(Url &&url) : BaseWebSocket(std::move(url)) {
 
 #pragma region SecureWebSocket members
 
-SecureWebSocket::SecureWebSocket(Url &&url) : BaseWebSocket(std::move(url)) {
+SecureWebSocket::SecureWebSocket(Url &&url) : BaseWebSocketResource(std::move(url)) {
   auto ssl = ssl::context(ssl::context::sslv23_client);
   this->m_stream = make_unique<websocket::stream<ssl::stream<tcp::socket>>>(this->m_context, ssl);
   this->m_stream->auto_fragment(false); // ISS:2906963 Re-enable message fragmenting.
 }
 
-void SecureWebSocket::Handshake(const IWebSocket::Options &options) {
+void SecureWebSocket::Handshake(const IWebSocketResource::Options &options) {
   this->m_stream->next_layer().async_handshake(
       ssl::stream_base::client, [this, options = std::move(options)](boostecr ec) {
         if (ec && this->m_errorHandler) {
-          this->m_errorHandler({ec.message(), IWebSocket::ErrorType::Connection});
+          this->m_errorHandler({ec.message(), IWebSocketResource::ErrorType::Connection});
         } else {
-          BaseWebSocket::Handshake(std::move(options));
+          BaseWebSocketResource::Handshake(std::move(options));
         }
       });
 }
 
 #pragma endregion SecureWebSocket members
-
-#pragma region IWebSocket static members
-
-/*static*/ unique_ptr<IWebSocket> IWebSocket::Make(const string &urlString) {
-  Url url(urlString);
-
-  if (url.scheme == "ws") {
-    if (url.port.empty())
-      url.port = "80";
-
-    return unique_ptr<IWebSocket>(new WebSocket(std::move(url)));
-  } else if (url.scheme == "wss") {
-    if (url.port.empty())
-      url.port = "443";
-
-    return unique_ptr<IWebSocket>(new SecureWebSocket(std::move(url)));
-  } else
-    throw std::exception((string("Incorrect url protocol: ") + url.scheme).c_str());
-}
-
-#pragma endregion IWebSocket static members
 
 namespace Test {
 
@@ -595,7 +582,7 @@ MockStream::async_close(websocket::close_reason const &cr, CloseHandler &&handle
 
 #pragma region TestWebSocket
 
-TestWebSocket::TestWebSocket(Url &&url) : BaseWebSocket(std::move(url)) {
+TestWebSocket::TestWebSocket(Url &&url) : BaseWebSocketResource(std::move(url)) {
   m_stream = make_unique<MockStream>(m_context);
 }
 
@@ -614,6 +601,8 @@ void TestWebSocket::SetCloseResult(function<error_code()> &&resultFunc) {
 #pragma endregion TestWebSocket
 } // namespace Test
 
+} // namespace Beast
+
 } // namespace Microsoft::React
 
 namespace boost::asio {
@@ -622,7 +611,7 @@ namespace boost::asio {
 template <typename Iterator, typename IteratorConnectHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(IteratorConnectHandler, void(error_code, Iterator))
 async_connect(
-    Microsoft::React::Test::MockStream &s,
+    Microsoft::React::Beast::Test::MockStream &s,
     Iterator begin,
     Iterator end,
     BOOST_ASIO_MOVE_ARG(IteratorConnectHandler) handler) {

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -7,17 +7,17 @@
 #include <boost/beast/websocket/ssl.hpp>
 #include <queue>
 #include <thread>
-#include "IWebSocket.h"
+#include "IWebSocketResource.h"
 #include "Utils.h"
 
-namespace Microsoft::React {
+namespace Microsoft::React::Beast {
 
 template <
     typename Protocol = boost::asio::ip::tcp,
     typename SocketLayer = boost::asio::basic_stream_socket<Protocol>,
     typename Stream = boost::beast::websocket::stream<SocketLayer>,
     typename Resolver = boost::asio::ip::basic_resolver<Protocol>>
-class BaseWebSocket : public IWebSocket {
+class BaseWebSocketResource : public IWebSocketResource {
   std::function<void()> m_connectHandler;
   std::function<void()> m_pingHandler;
   std::function<void(std::size_t)> m_writeHandler;
@@ -90,7 +90,7 @@ class BaseWebSocket : public IWebSocket {
   /// </summary>
   void Stop();
 
-  boost::beast::websocket::close_code ToBeastCloseCode(IWebSocket::CloseCode closeCode);
+  boost::beast::websocket::close_code ToBeastCloseCode(IWebSocketResource::CloseCode closeCode);
 
  protected:
   /// <summary>
@@ -110,9 +110,7 @@ class BaseWebSocket : public IWebSocket {
   std::unique_ptr<Stream> m_stream;
   std::function<void(Error &&)> m_errorHandler;
 
-  BaseWebSocket(Url &&url);
-
-  ~BaseWebSocket() override;
+  BaseWebSocketResource(Url &&url);
 
   /// <summary>
   /// Finalizes the connection setup to the remote endpoint.
@@ -127,81 +125,83 @@ class BaseWebSocket : public IWebSocket {
   /// <param name="options">
   /// Map of HTTP header fields sent by the remote endpoint.
   /// </param>
-  virtual void Handshake(const IWebSocket::Options &options);
+  virtual void Handshake(const IWebSocketResource::Options &options);
 
  public:
-#pragma region IWebSocket
+  ~BaseWebSocketResource() override;
+
+#pragma region IWebSocketResource
 
   /// <summary>
-  /// <see cref="IWebSocket::Connect" />
+  /// <see cref="IWebSocketResource::Connect" />
   /// </summary>
   void Connect(const Protocols &protocols, const Options &options) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::Ping" />
+  /// <see cref="IWebSocketResource::Ping" />
   /// </summary>
   void Ping() override;
 
   /// <summary>
-  /// <see cref="IWebSocket::Send" />
+  /// <see cref="IWebSocketResource::Send" />
   /// </summary>
   void Send(const std::string &message) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SendBinary" />
+  /// <see cref="IWebSocketResource::SendBinary" />
   /// </summary>
   void SendBinary(const std::string &base64String) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::Close" />
+  /// <see cref="IWebSocketResource::Close" />
   /// </summary>
   void Close(CloseCode code, const std::string &reason) override;
 
   ReadyState GetReadyState() const override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SetOnConnect" />
+  /// <see cref="IWebSocketResource::SetOnConnect" />
   /// </summary>
   void SetOnConnect(std::function<void()> &&handler) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SetOnPing" />
+  /// <see cref="IWebSocketResource::SetOnPing" />
   /// </summary>
   void SetOnPing(std::function<void()> &&handler) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SetOnSend" />
+  /// <see cref="IWebSocketResource::SetOnSend" />
   /// </summary>
   void SetOnSend(std::function<void(std::size_t)> &&handler) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SetOnMessage" />
+  /// <see cref="IWebSocketResource::SetOnMessage" />
   /// </summary>
   void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SetOnClose" />
+  /// <see cref="IWebSocketResource::SetOnClose" />
   /// </summary>
   void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) override;
 
   /// <summary>
-  /// <see cref="IWebSocket::SetOnError" />
+  /// <see cref="IWebSocketResource::SetOnError" />
   /// </summary>
   void SetOnError(std::function<void(Error &&)> &&handler) override;
 
-#pragma endregion IWebSocket
+#pragma endregion IWebSocketResource
 };
 
-class WebSocket : public BaseWebSocket<> {
+class WebSocketResource : public BaseWebSocketResource<> {
  public:
-  WebSocket(Url &&url);
+  WebSocketResource(Url &&url);
 };
 
 class SecureWebSocket
-    : public BaseWebSocket<boost::asio::ip::tcp, boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> {
-#pragma region BaseWebSocket overrides
+    : public BaseWebSocketResource<boost::asio::ip::tcp, boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> {
+#pragma region BaseWebSocketResource overrides
 
-  void Handshake(const IWebSocket::Options &options) override;
+  void Handshake(const IWebSocketResource::Options &options) override;
 
 #pragma endregion
 
@@ -276,7 +276,7 @@ class MockStream {
   std::function<boost::system::error_code()> CloseResult;
 };
 
-class TestWebSocket : public BaseWebSocket<
+class TestWebSocket : public BaseWebSocketResource<
                           boost::asio::ip::tcp, // TODO: Mock this and Resolver.
                           std::nullptr_t, // Unused. MockStream works as its own
                                           // next/lowest layer.
@@ -291,4 +291,4 @@ class TestWebSocket : public BaseWebSocket<
 
 } // namespace Test
 
-} // namespace Microsoft::React
+} // namespace Microsoft::React::Beast

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -105,7 +105,7 @@ void WebSocketJSExecutor::handleMemoryPressure(int pressureLevel) {}
 
 void WebSocketJSExecutor::destroy() {
   if (State::Connected == m_state || State::Running == m_state)
-    m_webSocket->Close(IWebSocket::CloseCode::GoingAway, "Disposed");
+    m_webSocket->Close(IWebSocketResource::CloseCode::GoingAway, "Disposed");
 
   SetState(State::Disposed);
 }
@@ -118,9 +118,9 @@ std::future<bool> WebSocketJSExecutor::ConnectAsync(
   promise<bool> resultPromise;
   m_errorCallback = std::move(errorCallback);
 
-  m_webSocket = IWebSocket::Make(webSocketServerUrl);
+  m_webSocket = IWebSocketResource::Make(webSocketServerUrl);
   m_webSocket->SetOnMessage([this](size_t /*length*/, const string &message) { this->OnMessageReceived(message); });
-  m_webSocket->SetOnError([this](const IWebSocket::Error &err) { this->SetState(State::Error); });
+  m_webSocket->SetOnError([this](const IWebSocketResource::Error &err) { this->SetState(State::Error); });
 
   try {
     promise<void> connectPromise;
@@ -135,7 +135,7 @@ std::future<bool> WebSocketJSExecutor::ConnectAsync(
     auto status = connectPromise.get_future().wait_for(std::chrono::milliseconds(ConnectTimeoutMilliseconds));
     if (std::future_status::ready != status) {
       m_errorCallback("Timeout: Failed to connect to the dev server");
-      m_webSocket->Close(IWebSocket::CloseCode::ProtocolError, "Timed out");
+      m_webSocket->Close(IWebSocketResource::CloseCode::ProtocolError, "Timed out");
 
       resultPromise.set_value(false);
       return resultPromise.get_future();
@@ -152,7 +152,7 @@ std::future<bool> WebSocketJSExecutor::ConnectAsync(
     m_errorCallback(IsConnected() ? "Timeout: preparing JS runtime" : "Timeout: Failed to connect to the dev server");
 
     try {
-      m_webSocket->Close(IWebSocket::CloseCode::ProtocolError, "Timed out");
+      m_webSocket->Close(IWebSocketResource::CloseCode::ProtocolError, "Timed out");
     } catch (const std::exception &) {
       // Nothing left to do. Aborting operation.
     }

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.h
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <IWebSocket.h>
+#include <IWebSocketResource.h>
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/JSModulesUnbundle.h>
 
@@ -60,7 +60,7 @@ class WebSocketJSExecutor : public JSExecutor {
 
   std::shared_ptr<ExecutorDelegate> m_delegate;
   std::shared_ptr<MessageQueueThread> m_messageQueueThread;
-  std::unique_ptr<IWebSocket> m_webSocket;
+  std::unique_ptr<IWebSocketResource> m_webSocket;
   folly::dynamic m_injectedObjects = folly::dynamic::object;
   std::function<void(std::string)> m_errorCallback;
 

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -55,7 +55,7 @@
       <!--
         BOOST_ASIO_HAS_IOCP - Force unique layout/size for boost::asio::basic_stream_socket<> subtypes.
       -->
-      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_PLATFORM=win32;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN8;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_PLATFORM=win32;RN_EXPORT=;JSI_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>%(AdditionalOptions) /Zc:strictStrings /bigobj</AdditionalOptions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -106,8 +106,9 @@
     <ClCompile Include="Sandbox\NamedPipeEndpoint.cpp" />
     <ClCompile Include="Sandbox\SandboxJSExecutor.cpp" />
     <ClCompile Include="HttpResource.cpp" />
-    <ClCompile Include="WebSocket.cpp" />
+    <ClCompile Include="BeastWebSocketResource.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="WebSocketResourceFactory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABI\MemoryTracker.h">
@@ -134,7 +135,7 @@
     <ClInclude Include="Sandbox\NamedPipeEndpoint.h" />
     <ClInclude Include="Sandbox\SandboxJSExecutor.h" />
     <ClInclude Include="HttpResource.h" />
-    <ClInclude Include="WebSocket.h" />
+    <ClInclude Include="BeastWebSocketResource.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
@@ -104,12 +104,15 @@
     <ClCompile Include="LazyDevSupportManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="WebSocket.cpp">
+    <ClCompile Include="BeastWebSocketResource.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp">
       <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WebSocketResourceFactory.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -161,7 +164,7 @@
     <ClInclude Include="NativeModuleFactories.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="WebSocket.h">
+    <ClInclude Include="BeastWebSocketResource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// clang-format off
+#include "pch.h"
+
+#include <WinRTWebSocketResource.h>
+#include "BeastWebSocketResource.h"
+
+using std::make_unique;
+using std::string;
+using std::unique_ptr;
+
+namespace Microsoft::React
+{
+#pragma region IWebSocketResource static members
+
+/*static*/ unique_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString, bool acceptSelfSigned)
+{
+  if (true) //TODO: Feature-gate this.
+  {
+    std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
+    if (acceptSelfSigned)
+    {
+      certExceptions.emplace_back(winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::Untrusted);
+      certExceptions.emplace_back(winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
+    }
+    return make_unique<WinRTWebSocketResource>(urlString, certExceptions);
+  }
+  else
+  {
+    Url url(urlString);
+
+    if (url.scheme == "ws") {
+      if (url.port.empty())
+        url.port = "80";
+
+      return make_unique<Beast::WebSocketResource>(std::move(url));
+    }
+    else if (url.scheme == "wss") {
+      if (url.port.empty())
+        url.port = "443";
+
+      return make_unique<Beast::SecureWebSocket>(std::move(url));
+    }
+    else
+      throw std::invalid_argument((string("Incorrect URL scheme: ") + url.scheme).c_str());
+  }
+}
+
+#pragma endregion IWebSocketResource static members
+}

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -44,7 +45,7 @@
         BOOST_ASIO_HAS_IOCP - Force unique layout/size for boost::asio::basic_stream_socket<> subtypes.
         REACTWINDOWS_BUILD - building with REACTWINDOWS_API as dll exports
       -->
-      <PreprocessorDefinitions>REACTWINDOWS_BUILD;BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN7;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;GTEST_LANG_CXX11;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REACTWINDOWS_BUILD;BOOST_ASIO_HAS_IOCP;_WINSOCK_DEPRECATED_NO_WARNINGS;_WIN32_WINNT=_WIN32_WINNT_WIN8;WIN32;_WINDOWS;REACTNATIVEWIN32_EXPORTS;FOLLY_NO_CONFIG;NOMINMAX;GLOG_NO_ABBREVIATED_SEVERITIES;_HAS_AUTO_PTR_ETC;CHAKRACORE;RN_EXPORT=;GTEST_LANG_CXX11;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- /Zc:strictStrings enforces the standard C++ const qualifications for
       string literals. It prevents code like
         wchar_t* str = L"hello";
@@ -55,7 +56,17 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>-minpdbpathlen:256</AdditionalOptions>
-      <AdditionalDependencies>Shlwapi.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!--
+        comsuppw.lib  - _com_util::ConvertStringToBSTR
+        delayimp.lib  -
+        Winhttp.lib   - WebSocket resource implementation
+      -->
+      <AdditionalDependencies>
+        comsuppw.lib;
+        delayimp.lib;
+        Shlwapi.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -121,6 +132,7 @@
     <Import Project="$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -132,5 +144,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/vnext/JSI.Desktop.UnitTests/packages.config
+++ b/vnext/JSI.Desktop.UnitTests/packages.config
@@ -4,5 +4,6 @@
   <package id="ChakraCore.Debugger" version="0.0.0.43" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />
 </packages>

--- a/vnext/ReactWindows-Desktop.sln
+++ b/vnext/ReactWindows-Desktop.sln
@@ -85,8 +85,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Desktop", "De
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Desktop.IntegrationTests", "Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.vcxproj", "{E0D269B4-D7F0-4C4E-92CD-B2C06109A2BB}"
 EndProject
-Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "IntegrationTests", "IntegrationTestScripts\IntegrationTests.njsproj", "{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.IntegrationTests", "IntegrationTests\React.Windows.IntegrationTests.vcxproj", "{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra", "Chakra\Chakra.vcxitems", "{C38970C0-5FBF-4D69-90D8-CBAC225AE895}"
@@ -113,6 +111,10 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JSI.Desktop", "JSI\Desktop\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "Common\Common.vcxproj", "{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mso", "Mso", "{4DE630AE-EC50-4F21-942E-7B811A1C5FA3}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
@@ -120,6 +122,7 @@ Global
 		Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
+		Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
@@ -196,10 +199,6 @@ Global
 		{E0D269B4-D7F0-4C4E-92CD-B2C06109A2BB}.Release|x64.Build.0 = Release|x64
 		{E0D269B4-D7F0-4C4E-92CD-B2C06109A2BB}.Release|x86.ActiveCfg = Release|Win32
 		{E0D269B4-D7F0-4C4E-92CD-B2C06109A2BB}.Release|x86.Build.0 = Release|Win32
-		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Release|x64.ActiveCfg = Release|Any CPU
-		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32}.Release|x86.ActiveCfg = Release|Any CPU
 		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x64.ActiveCfg = Debug|x64
 		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x64.Build.0 = Debug|x64
 		{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}.Debug|x86.ActiveCfg = Debug|Win32
@@ -265,9 +264,10 @@ Global
 		{43A78B84-278B-4B99-8887-4029D551173E} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
 		{102E37B8-4BE5-4DC1-A650-16706EFB3306} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
 		{2EB5E646-7EB4-4FED-B1A8-0AEEF2D32268} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
-		{956D7AE7-0C64-44A1-B5BC-0936B23A3A32} = {F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF}
 		{F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
 		{41F31595-2F20-4D6B-A6CF-60444415012A} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
+		{4DE630AE-EC50-4F21-942E-7B811A1C5FA3} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
+		{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E} = {4DE630AE-EC50-4F21-942E-7B811A1C5FA3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C1055EEE-3785-4C0E-8934-FBAA21BFF90C}

--- a/vnext/ReactWindowsCore/IWebSocketResource.h
+++ b/vnext/ReactWindowsCore/IWebSocketResource.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace Microsoft::React {
@@ -12,7 +13,7 @@ namespace Microsoft::React {
 /// <summary>
 /// Defines the core functionality for a native WebSocket client resource.
 /// </summary>
-struct IWebSocket {
+struct IWebSocketResource {
 #pragma region Aliases
 
   using Protocols = std::vector<std::string>;
@@ -78,15 +79,15 @@ struct IWebSocket {
 #pragma endregion Inner types
 
   /// <summary>
-  /// Creates an <c>IWebSocket</c> instance.
+  /// Creates an <c>IWebSocketResource</c> instance.
   /// </summary>
   /// <param name="url">
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::unique_ptr<IWebSocket> Make(const std::string &url);
+  static std::unique_ptr<IWebSocketResource> Make(const std::string &url, bool acceptSelfSigned = false);
 
-  virtual ~IWebSocket() {}
+  virtual ~IWebSocketResource() {}
 
   /// <summary>
   /// Establishes a continuous connection with the remote endpoint.
@@ -186,6 +187,6 @@ struct IWebSocket {
 // Deprecated. Keeping for compatibility with dependent code.
 namespace facebook::react {
 
-using IWebSocket = Microsoft::React::IWebSocket;
+using IWebSocket = Microsoft::React::IWebSocketResource;
 
 } // namespace facebook::react

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -80,6 +80,7 @@
       <PreprocessorDefinitions Condition="'$(USE_HERMES)'=='true'">USE_HERMES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <PreprocessToFile>false</PreprocessToFile>
     </ClCompile>
     <Link>
@@ -112,7 +113,7 @@
     <ClInclude Include="InstanceManager.h" />
     <ClInclude Include="IReactRootView.h" />
     <ClInclude Include="IUIManager.h" />
-    <ClInclude Include="IWebSocket.h" />
+    <ClInclude Include="IWebSocketResource.h" />
     <ClInclude Include="IHttpResource.h" />
     <ClInclude Include="JSBigAbiString.h" />
     <ClInclude Include="LayoutAnimation.h" />
@@ -136,6 +137,7 @@
     <ClInclude Include="Utils.h" />
     <ClInclude Include="WebSocketJSExecutorFactory.h" />
     <ClInclude Include="WebSocketModule.h" />
+    <ClInclude Include="WinRTWebSocketResouce.h" />
     <ClInclude Include="ChakraRuntimeHolder.h" Condition="'$(PATCH_RN)' == 'true'" />
     <ClInclude Include="HermesRuntimeHolder.h" Condition="'$(PATCH_RN)' == 'true' AND '$(USE_HERMES)' == 'true'" />
     <ClInclude Include="V8JSIRuntimeHolder.h" Condition="'$(PATCH_RN)' == 'true' AND '$(USE_V8)' == 'true'" />
@@ -164,6 +166,7 @@
     <ClCompile Include="tracing\tracing.cpp" />
     <ClCompile Include="Utils.cpp" />
     <ClCompile Include="ViewManager.cpp" />
+    <ClCompile Include="WinRTWebSocketResource.cpp" />
     <ClCompile Include="ChakraRuntimeHolder.cpp" Condition="'$(PATCH_RN)' == 'true'" />
     <ClCompile Include="HermesRuntimeHolder.cpp" Condition="'$(PATCH_RN)' == 'true' AND '$(USE_HERMES)' == 'true'" />
     <ClCompile Include="V8JSIRuntimeHolder.cpp" Condition="'$(PATCH_RN)' == 'true' AND '$(USE_V8)' == 'true'" />

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj.filters
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj.filters
@@ -161,7 +161,7 @@
     <ClInclude Include="IUIManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="IWebSocket.h">
+    <ClInclude Include="IWebSocketResource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="JSBigAbiString.h">
@@ -228,6 +228,10 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="WebSocketModule.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+    <ClInclude Include="WinRTWebSocketResource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vnext/ReactWindowsCore/Utils.cpp
+++ b/vnext/ReactWindowsCore/Utils.cpp
@@ -4,17 +4,17 @@
 #include "Utils.h"
 #include <regex>
 
-using namespace std;
+using std::string;
 
 namespace Microsoft::React {
 
 Url::Url(const string &source) {
-  //      ( 1 )              ( 2 )   ( 3 (4) )   ( 5 )    ( 6 (7) )
-  regex expression("(http|https|ws|wss)://([^:/\\?]+)(:(\\d+))?(/[^\\?]*)?(\\?(.*))?$");
-  //     protocol             host       port     path        query
-  cmatch match;
+  //                           ( 1 )              ( 2 )   ( 3 (4) )   ( 5 )    ( 6 (7) )
+  std::regex expression("(http|https|ws|wss)://([^:/\\?]+)(:(\\d+))?(/[^\\?]*)?(\\?(.*))?$");
+  //                          scheme              host       port      path      query
+  std::cmatch match;
   int index = 0;
-  if (regex_match(source.c_str(), match, expression)) {
+  if (std::regex_match(source.c_str(), match, expression)) {
     ++index;
     this->scheme = string(match[index].first, match[index].second);
 

--- a/vnext/ReactWindowsCore/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/WebSocketModule.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <cxxreact/CxxModule.h>
-#include "IWebSocket.h"
+#include "IWebSocketResource.h"
 
 namespace Microsoft::React {
 
@@ -41,15 +41,15 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   void SendEvent(std::string &&eventName, folly::dynamic &&parameters);
 
   /// <summary>
-  /// Creates or retrieves a raw <c>IWebSocket</c> pointer.
+  /// Creates or retrieves a raw <c>IWebSocketResource</c> pointer.
   /// </summary>
-  IWebSocket *GetOrCreateWebSocket(int64_t id, std::string &&url = std::string());
+  IWebSocketResource *GetOrCreateWebSocket(int64_t id, std::string &&url = std::string());
 
   /// <summary>
-  /// Keeps <c>IWebSocket</c> instances identified by <c>id</c>.
+  /// Keeps <c>IWebSocketResource</c> instances identified by <c>id</c>.
   /// As defined in WebSocket.js.
   /// </summary>
-  std::map<int64_t, std::unique_ptr<IWebSocket>> m_webSockets;
+  std::map<int64_t, std::unique_ptr<IWebSocketResource>> m_webSockets;
 };
 
 } // namespace Microsoft::React

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// clang-format off
+#include "WinRTWebSocketResource.h"
+
+#include <winrt/Windows.Security.Cryptography.h>
+#include <Unicode.h>
+#include <Utilities.h>
+
+// Standard Library
+#include <future>
+
+using Microsoft::Common::Unicode::Utf8ToUtf16;
+using Microsoft::Common::Unicode::Utf16ToUtf8;
+using Microsoft::Common::Utilities::CheckedReinterpretCast;
+
+using std::function;
+using std::size_t;
+using std::string;
+using std::vector;
+
+using winrt::fire_and_forget;
+using winrt::hresult;
+using winrt::hresult_error;
+using winrt::resume_background;
+using winrt::Windows::Foundation::IAsyncAction;
+using winrt::Windows::Foundation::Uri;
+using winrt::Windows::Networking::Sockets::IWebSocket;
+using winrt::Windows::Networking::Sockets::MessageWebSocket;
+using winrt::Windows::Networking::Sockets::MessageWebSocketMessageReceivedEventArgs;
+using winrt::Windows::Networking::Sockets::SocketMessageType;
+using winrt::Windows::Networking::Sockets::WebSocketClosedEventArgs;
+using winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult;
+using winrt::Windows::Security::Cryptography::CryptographicBuffer;
+using winrt::Windows::Storage::Streams::DataReader;
+using winrt::Windows::Storage::Streams::DataWriter;
+using winrt::Windows::Storage::Streams::UnicodeEncoding;
+
+namespace Microsoft::React
+{
+WinRTWebSocketResource::WinRTWebSocketResource(Uri&& uri, vector<ChainValidationResult> certExeptions)
+  : m_uri{ std::move(uri) }
+{
+  m_socket.MessageReceived({ this, &WinRTWebSocketResource::OnMessageReceived });
+  m_socket.Closed({ this, &WinRTWebSocketResource::OnClosed });
+
+  for (auto certException : certExeptions)
+  {
+    m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
+  }
+}
+
+WinRTWebSocketResource::WinRTWebSocketResource(const string& urlString, vector<ChainValidationResult> certExeptions)
+  : WinRTWebSocketResource(Uri{ Utf8ToUtf16(urlString) }, certExeptions)
+{
+}
+
+WinRTWebSocketResource::~WinRTWebSocketResource() /*override*/
+{
+  Stop();
+}
+
+#pragma region Private members
+
+IAsyncAction WinRTWebSocketResource::PerformConnect()
+{
+  try
+  {
+    co_await resume_background();
+
+    co_await m_socket.ConnectAsync(m_uri);
+
+    if (m_connectHandler)
+    {
+      m_connectHandler();
+    }
+  }
+  catch (hresult_error const& e)
+  {
+    if (m_errorHandler)
+    {
+      m_errorHandler({ Utf16ToUtf8(e.message()), ErrorType::Connection });
+    }
+  }
+
+  m_connectPerformed.set_value();
+  m_connectRequested = false;
+}
+
+fire_and_forget WinRTWebSocketResource::PerformPing()
+{
+  try
+  {
+    co_await resume_background();
+
+    co_await m_connectAction;
+
+    m_socket.Control().MessageType(SocketMessageType::Utf8);
+
+    string s{};
+    winrt::array_view<const uint8_t> arr(
+      CheckedReinterpretCast<const uint8_t*>(s.c_str()),
+      CheckedReinterpretCast<const uint8_t*>(s.c_str()) + s.length());
+    m_writer.WriteBytes(arr);
+
+    co_await m_writer.StoreAsync();
+
+    if (m_pingHandler)
+    {
+      m_pingHandler();
+    }
+  }
+  catch (hresult_error const& e)
+  {
+    if (m_errorHandler)
+    {
+      m_errorHandler({ Utf16ToUtf8(e.message()), ErrorType::Ping });
+    }
+  }
+}
+
+fire_and_forget WinRTWebSocketResource::PerformWrite()
+{
+  if (m_writeQueue.empty())
+  {
+    co_return;
+  }
+
+  try
+  {
+    co_await resume_background();
+
+    co_await m_connectAction; //TODO: EnqueueWrite()
+
+    size_t length;
+    auto [message, isBinary] = std::move(m_writeQueue.front());
+    m_writeQueue.pop();
+
+    if (isBinary)
+    {
+      m_socket.Control().MessageType(SocketMessageType::Binary);
+
+      auto buffer = CryptographicBuffer::DecodeFromBase64String(Utf8ToUtf16(std::move(message)));
+      length = buffer.Length();
+      m_writer.WriteBuffer(buffer);
+    }
+    else
+    {
+      m_socket.Control().MessageType(SocketMessageType::Utf8);
+
+      //TODO: Use char_t instead of uint8_t?
+      length = message.size();
+      winrt::array_view<const uint8_t> arr(
+        CheckedReinterpretCast<const uint8_t*>(message.c_str()),
+        CheckedReinterpretCast<const uint8_t*>(message.c_str()) + message.length());
+      m_writer.WriteBytes(arr);
+    }
+
+    co_await m_writer.StoreAsync();
+
+    if (m_writeHandler)
+    {
+      m_writeHandler(length);
+    }
+
+    if (!m_writeQueue.empty())
+    {
+      PerformWrite();
+    }
+  }
+  catch (hresult_error const& e)
+  {
+    if (m_errorHandler)
+    {
+      m_errorHandler({ Utf16ToUtf8(e.message()), ErrorType::Ping });
+    }
+  }
+}
+
+fire_and_forget WinRTWebSocketResource::PerformClose()
+{
+  co_await resume_background();
+
+  co_await m_connectAction;
+
+  m_socket.Close(static_cast<uint16_t>(m_closeCode), Utf8ToUtf16(m_closeReason));
+  m_closePerformed.set_value();
+
+  co_return;
+}
+
+void WinRTWebSocketResource::OnMessageReceived(IWebSocket const& sender, MessageWebSocketMessageReceivedEventArgs const& args)
+{
+  try
+  {
+    string response;
+    DataReader reader = args.GetDataReader();
+    auto len = reader.UnconsumedBufferLength();
+    if (args.MessageType() == SocketMessageType::Utf8)
+    {
+      reader.UnicodeEncoding(UnicodeEncoding::Utf8);
+      vector<uint8_t> data(len);
+      reader.ReadBytes(data);
+
+      response = string(CheckedReinterpretCast<char*>(data.data()), data.size());
+    }
+    else
+    {
+      auto buffer = reader.ReadBuffer(len);
+      winrt::hstring data = CryptographicBuffer::EncodeToBase64String(buffer);
+
+      response = Utf16ToUtf8(std::wstring_view(data));
+    }
+
+    if (m_readHandler)
+      m_readHandler(response.length(), response);//TODO: move?
+  }
+  catch (hresult_error const& e)
+  {
+    if (m_errorHandler)
+    {
+      m_errorHandler({ Utf16ToUtf8(e.message()), ErrorType::Receive });
+    }
+  }
+}
+
+void WinRTWebSocketResource::OnClosed(IWebSocket const& sender, WebSocketClosedEventArgs const& args)
+{
+  if (m_closeHandler)
+  {
+    //TODO: Parameterize (pass via member variables?)
+    m_closeHandler(CloseCode::Normal, "Closing");
+  }
+
+  m_closePerformed.set_value();
+}
+
+void WinRTWebSocketResource::Stop()
+{
+  // Ensure sequence of other operations
+  if (m_connectRequested)
+  {
+    m_connectPerformed.get_future().wait();
+  }
+}
+
+#pragma endregion Private members
+
+#pragma region IWebSocketResource
+
+void WinRTWebSocketResource::Connect(const Protocols& protocols, const Options& options)
+{
+  for (const auto& header : options)
+  {
+    m_socket.SetRequestHeader(header.first, Utf8ToUtf16(header.second));
+  }
+
+  winrt::Windows::Foundation::Collections::IVector<winrt::hstring> supportedProtocols =
+    m_socket.Control().SupportedProtocols();
+  for (const auto& protocol : protocols)
+  {
+    supportedProtocols.Append(Utf8ToUtf16(protocol));
+  }
+
+  m_connectRequested = true;
+  m_connectAction = PerformConnect();
+}
+
+void WinRTWebSocketResource::Ping()
+{
+  PerformPing();
+}
+
+void WinRTWebSocketResource::Send(const string& message)
+{
+  m_writeQueue.emplace(message, false);
+
+  PerformWrite();
+}
+
+void WinRTWebSocketResource::SendBinary(const string& base64String)
+{
+  m_writeQueue.emplace(base64String, true);
+
+  PerformWrite();
+}
+
+void WinRTWebSocketResource::Close(CloseCode code, const string& reason)
+{
+  Stop();
+
+  m_closeCode = code;
+  m_closeReason = reason;
+
+  PerformClose();
+}
+
+IWebSocketResource::ReadyState WinRTWebSocketResource::GetReadyState() const
+{
+  return ReadyState::Closed;
+}
+
+void WinRTWebSocketResource::SetOnConnect(function<void()>&& handler)
+{
+  m_connectHandler = std::move(handler);
+}
+
+void WinRTWebSocketResource::SetOnPing(function<void()>&& handler)
+{
+  m_pingHandler = std::move(handler);
+}
+
+void WinRTWebSocketResource::SetOnSend(function<void(size_t)>&& handler)
+{
+  m_writeHandler = std::move(handler);
+}
+
+void WinRTWebSocketResource::SetOnMessage(function<void(size_t, const string&)>&& handler)
+{
+  m_readHandler = std::move(handler);
+}
+
+void WinRTWebSocketResource::SetOnClose(function<void(CloseCode, const string&)>&& handler)
+{
+  m_closeHandler = std::move(handler);
+}
+
+void WinRTWebSocketResource::SetOnError(function<void(Error&&)>&& handler)
+{
+  m_errorHandler = std::move(handler);
+}
+
+#pragma endregion IWebSocketResource
+
+}// namespace Microsoft::React

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.h
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.h
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// clang-format off
+
+#pragma once
+
+#include <winrt/Windows.Networking.Sockets.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <IWebSocketResource.h>
+
+#include <future>
+#include <queue>
+
+namespace Microsoft::React
+{
+
+class WinRTWebSocketResource : public IWebSocketResource
+{
+  winrt::Windows::Foundation::Uri m_uri;
+  winrt::Windows::Networking::Sockets::MessageWebSocket m_socket;
+  winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_revoker;
+  winrt::Windows::Storage::Streams::DataWriter m_writer{ m_socket.OutputStream() };
+
+  std::atomic_bool m_connectRequested;
+  std::atomic_bool m_sendRequested;
+  std::promise<void> m_connectPerformed;
+  std::promise<void> m_closePerformed;
+  winrt::Windows::Foundation::IAsyncAction m_connectAction;
+
+  CloseCode m_closeCode{ CloseCode::None };
+  std::string m_closeReason;
+  std::queue<std::pair<std::string, bool>> m_writeQueue;
+
+  std::function<void()> m_connectHandler;
+  std::function<void()> m_pingHandler;
+  std::function<void(std::size_t)> m_writeHandler;
+  std::function<void(std::size_t, const std::string&)> m_readHandler;
+  std::function<void(CloseCode, const std::string&)> m_closeHandler;
+  std::function<void(Error&&)> m_errorHandler;
+
+  WinRTWebSocketResource(
+    winrt::Windows::Foundation::Uri&& uri,
+    std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions);
+
+  winrt::Windows::Foundation::IAsyncAction PerformConnect();
+  winrt::fire_and_forget PerformPing();
+  winrt::fire_and_forget PerformWrite();
+  winrt::fire_and_forget PerformClose();
+
+  void OnMessageReceived(
+    winrt::Windows::Networking::Sockets::IWebSocket const& sender,
+    winrt::Windows::Networking::Sockets::MessageWebSocketMessageReceivedEventArgs const& args);
+  void OnClosed(
+    winrt::Windows::Networking::Sockets::IWebSocket const& sender,
+    winrt::Windows::Networking::Sockets::WebSocketClosedEventArgs const& args);
+
+  void Stop();
+
+public:
+  WinRTWebSocketResource(
+    const std::string& urlString,
+    std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions);
+  ~WinRTWebSocketResource() override;
+
+#pragma region IWebSocketResource
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Connect" />
+  /// </summary>
+  void Connect(const Protocols& protocols, const Options& options) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Ping" />
+  /// </summary>
+  void Ping() override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Send" />
+  /// </summary>
+  void Send(const std::string& message) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SendBinary" />
+  /// </summary>
+  void SendBinary(const std::string& base64String) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Close" />
+  /// </summary>
+  void Close(CloseCode code, const std::string& reason) override;
+
+  ReadyState GetReadyState() const override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnConnect" />
+  /// </summary>
+  void SetOnConnect(std::function<void()>&& handler) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnPing" />
+  /// </summary>
+  void SetOnPing(std::function<void()>&& handler) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnSend" />
+  /// </summary>
+  void SetOnSend(std::function<void(std::size_t)>&& handler) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnMessage" />
+  /// </summary>
+  void SetOnMessage(std::function<void(std::size_t, const std::string&)>&& handler) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnClose" />
+  /// </summary>
+  void SetOnClose(std::function<void(CloseCode, const std::string&)>&& handler) override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnError" />
+  /// </summary>
+  void SetOnError(std::function<void(Error&&)>&& handler) override;
+
+#pragma endregion IWebSocketResource
+};
+
+} // namespace Microsoft::React

--- a/vnext/Scripts/ReactUwp.nuspec
+++ b/vnext/Scripts/ReactUwp.nuspec
@@ -24,7 +24,7 @@
     <file src="$nugetroot$\inc\ReactWindowsCore\InstanceManager.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\IReactRootView.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\IUIManager.h" target="inc"/>
-    <file src="$nugetroot$\inc\ReactWindowsCore\IWebSocket.h" target="inc"/>
+    <file src="$nugetroot$\inc\ReactWindowsCore\IWebSocketResource.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\JSBigAbiString.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\LayoutAnimation.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\Logging.h" target="inc"/>

--- a/vnext/Scripts/ReactWin32.nuspec
+++ b/vnext/Scripts/ReactWin32.nuspec
@@ -35,7 +35,7 @@
     <file src="$nugetroot$\inc\ReactWindowsCore\InstanceManager.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\IReactRootView.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\IUIManager.h" target="inc"/>
-    <file src="$nugetroot$\inc\ReactWindowsCore\IWebSocket.h" target="inc"/>
+    <file src="$nugetroot$\inc\ReactWindowsCore\IWebSocketResource.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\JSBigAbiString.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\LayoutAnimation.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWindowsCore\Logging.h" target="inc"/>

--- a/vnext/Test/WebSocketServer.cpp
+++ b/vnext/Test/WebSocketServer.cpp
@@ -350,7 +350,7 @@ void WebSocketServer::SetMessageFactory(function<string(string &&)> &&func) {
   m_callbacks.MessageFactory = std::move(func);
 }
 
-void WebSocketServer::SetOnError(function<void(IWebSocket::Error &&)> &&func) {
+void WebSocketServer::SetOnError(function<void(IWebSocketResource::Error &&)> &&func) {
   m_callbacks.OnError = std::move(func);
 }
 

--- a/vnext/Test/WebSocketServer.h
+++ b/vnext/Test/WebSocketServer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <IWebSocket.h>
+#include <IWebSocketResource.h>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
@@ -13,7 +13,7 @@ struct WebSocketServiceCallbacks {
   std::function<void(boost::beast::websocket::response_type &)> OnHandshake;
   std::function<void(std::string)> OnMessage;
   std::function<std::string(std::string &&)> MessageFactory;
-  std::function<void(IWebSocket::Error &&)> OnError;
+  std::function<void(IWebSocketResource::Error &&)> OnError;
 };
 
 struct IWebSocketSession {
@@ -31,7 +31,7 @@ class BaseWebSocketSession : public IWebSocketSession {
   WebSocketServiceCallbacks &m_callbacks;
   State m_state;
 
-  std::function<void(IWebSocket::Error &&)> m_errorHandler;
+  std::function<void(IWebSocketResource::Error &&)> m_errorHandler;
 
   void Read();
 
@@ -106,7 +106,7 @@ class WebSocketServer : public std::enable_shared_from_this<WebSocketServer> {
   void SetOnHandshake(std::function<void(boost::beast::websocket::response_type &)> &&func);
   void SetOnMessage(std::function<void(std::string)> &&func);
   void SetMessageFactory(std::function<std::string(std::string &&)> &&func);
-  void SetOnError(std::function<void(IWebSocket::Error &&)> &&func);
+  void SetOnError(std::function<void(IWebSocketResource::Error &&)> &&func);
 };
 
 } // namespace Microsoft::React::Test


### PR DESCRIPTION
See #4330.

- Replaces `Microsoft::React::BeastWebSocket`
- Implemented using `C++/WinRT` and `Windows::Networking::Sockets`
- Supported on Windows 8 and later


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4393)