### PR TITLE
Fixed crash when trying to load invalid image uri

### DIFF
--- a/change/react-native-windows-2020-03-23-11-27-39-playground3738.json
+++ b/change/react-native-windows-2020-03-23-11-27-39-playground3738.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed crash when trying to load invalid image uri",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "commit": "d99cb1ea2ffb7b29b36f4a47539fa038c7b76e83",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T18:27:39.628Z"
+}


### PR DESCRIPTION
Rather than crashing the entire app if the image uri is invalid (not actually a uri), just don't set the source.

Fixes issue #3738

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4400)