### PR TITLE
Do not enter loaded state when an error occurs during web bundle loadJSBundles

### DIFF
--- a/change/react-native-windows-2020-03-23-14-20-35-acoates-loadcrash.json
+++ b/change/react-native-windows-2020-03-23-14-20-35-acoates-loadcrash.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Do not enter loaded state when an error occurs during web bundle loadJSBundles",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "25f261101a22ff2fa8ac2f17b6f4d4115a6e67a6",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T21:20:35.420Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -269,7 +269,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
             LoadJSBundles();
 
-            if (m_options.DeveloperSettings.IsDevModeEnabled) {
+            if (m_options.DeveloperSettings.IsDevModeEnabled && State() != ReactInstanceState::HasError) {
               folly::dynamic params = folly::dynamic::array(
                   STRING(RN_PLATFORM),
                   m_options.DeveloperSettings.SourceBundlePath.empty() ? m_options.Identity
@@ -349,8 +349,9 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
       loadCallbackGuard = Mso::MakeMoveOnCopyWrapper(LoadedCallbackGuard{*this})
     ]() noexcept {
       if (auto strongThis = weakThis.GetStrongPtr()) {
-        // All JS bundles successfully loaded.
-        strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
+        if (strongThis->State() != ReactInstanceState::HasError) {
+          strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
+        }
       }
     });
   }


### PR DESCRIPTION
In the code path where we try to load the bundle from a bundle server, but the server isn't running, the instance currently gets an error back in loadBundle, but then still puts the instance into a loaded state afterwards.  This leaves the instance in a loaded state, but with no JS loaded.  Which causes crashes in various native modules when they try to call into the instance.

I also changed the fast refresh call to check for error state before being called. -- I think there is a deeper issue of potential lost JS calls from native modules, as callJSFunction checks for the loaded state, otherwise drops the call.  But if a native module was to make a call while the instance is in the loading state, I think it should probably be queued up for later delivery once the instance loads?  (Not handling that as part of this PR)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4402)