### PR TITLE
Teach React Native CLI about master and 0.61 versions

### DIFF
--- a/change/rnpm-plugin-windows-2020-03-23-15-44-43-cli-versions.json
+++ b/change/rnpm-plugin-windows-2020-03-23-15-44-43-cli-versions.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Teach React Native CLI about master and 0.61 versions",
+  "packageName": "rnpm-plugin-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "89e1071abb6ec12023ae422bda3e948f5cc5c2ea",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T22:44:43.124Z"
+}

--- a/packages/rnpm-plugin-windows/src/common.js
+++ b/packages/rnpm-plugin-windows/src/common.js
@@ -92,6 +92,23 @@ function getLatestMatchingVersion(versionRange, tag) {
   });
 }
 
+/**
+ * Matches a version range to a version of react-native-windows to install. This is a hairy process
+ * with a few different cases. Note that we will not run this at all if an exact version was given
+ * for --windowsVersion.
+ *
+ * - If no version was specified we are passed a range based on React Native version. E.g. "0.61.*".
+ *   We will try to match this against available packages, but need special rules for prerelease
+ *   tags since we use them for even stable releases for several versions. Because of that we cannot
+ *   use the semver range directly.
+ *
+ * - If our tag is "master", we grab the latest master label builds, since our RN version may not
+ *   correspond to our RNW version. This will change once we're aligned to Facebook's master builds.
+ *
+ * - Users can pass in a range to --windowsVersion and we will try to respect it according to above
+ *   matching logic. We likely do not do the right thing here in many cases sine we do not query the
+ *   registry for the range directly, instead using custom logic to also ensure tag matches.
+ */
 async function getMatchingVersion(versionRange, tag) {
   const versionStr = tag === 'master' ? 'master' : versionRange;
   console.log(`Checking for react-native-windows version matching ${versionStr}...`);

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -21,38 +21,52 @@ const REACT_NATIVE_WINDOWS_GENERATE_PATH = function() {
   );
 };
 
+async function getDefaultVersionTag(version) {
+  const validVersion = semver.valid(version);
+  const validRange = semver.validRange(version);
+  if (!validVersion && !validRange) {
+    console.error(chalk.red(`'${version}' is not a valid version`));
+    process.exit(1);
+  }
+
+  // Prefer rc builds before 0.59 (See #2559)
+  if ((validVersion && semver.lt(validVersion, '0.59.0'))
+    || (validRange && semver.gtr('0.59.0', validRange))) {
+    return 'rc';
+  }
+
+  // Ask for vnext or legacy for 0.59
+  if ((validVersion && semver.lt(validVersion, '0.60.0'))
+    || (validRange && semver.gtr('0.60.0', validRange))) {
+    return  (await prompts({
+      type: 'select',
+      name: 'template',
+      message: 'What version of react-native-windows would you like to install?',
+      choices: [
+        { value: 'vnext', title: ' [1mLatest[22m      - High performance react-native-windows built on a shared C++ core from facebook (supports C++ or C#).' },
+        { value: 'legacy', title: ' [1mLegacy[22m      - Older react-native-windows implementation - (C# only, react-native <= 0.59 only)' },
+      ],
+    })).template;
+  }
+
+  // 0.60 releases use the vnext tag
+  if ((validVersion && semver.lt(validVersion, '0.61.0'))
+    || (validRange && semver.gtr('0.61.0', validRange))) {
+    return 'vnext';
+  }
+
+  // 0.61 and after don't tag stable releases
+  return null;
+}
+
 module.exports = async function (config, args, options) {
   try {
-    const name = args[0] ? args[0] : Common.getReactNativeAppName();
-    const ns = options.namespace ? options.namespace : name;
-    let version = options.windowsVersion ? options.windowsVersion : Common.getReactNativeVersion();
+    const name = args[0] || Common.getReactNativeAppName();
+    const ns = options.namespace || name;
+    let version = options.windowsVersion || Common.getReactNativeVersion();
+    const versionTag = options.template || await getDefaultVersionTag(version);
 
-    let template = options.template;
-    if (!template) {
-      const validVersion = semver.valid(version);
-      const validRange = semver.validRange(version);
-      // If the RN version is >= 0.60 we know they have to use vnext
-      if ((validVersion && semver.gte(validVersion, '0.60')) ||
-          (!validVersion && validRange && semver.ltr('0.59.1000', validRange))) {
-            template = 'vnext';
-          }
-
-      // If the RN version is >= 0.59 then we need to query which version the user wants
-      if (!template && ((validVersion && semver.gte(validVersion, '0.59.0')) ||
-          (!validVersion && validRange && semver.ltr('0.58.1000', validRange)))) {
-            template = (await prompts({
-              type: 'select',
-              name: 'template',
-              message: 'What version of react-native-windows would you like to install?',
-              choices: [
-                { value: 'vnext', title: ' [1mLatest[22m      - High performance react-native-windows built on a shared C++ core from facebook (supports C++ or C#).' },
-                { value: 'legacy', title: ' [1mLegacy[22m      - Older react-native-windows implementation - (C# only, react-native <= 0.59 only)' },
-              ],
-            })).template;
-      }
-    }
-
-    let rnwPackage = await Common.getInstallPackage(version, template, !!template);
+    let rnwPackage = await Common.getInstallPackage(version, versionTag);
 
     console.log(`Installing ${rnwPackage}...`);
     const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';
@@ -66,5 +80,6 @@ module.exports = async function (config, args, options) {
   } catch (error) {
     console.error(chalk.red(error.message));
     console.error(error);
+    process.exit(1);
   }
 };

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -69,10 +69,10 @@ module.exports = async function (config, args, options) {
   try {
     const name = args[0] || Common.getReactNativeAppName();
     const ns = options.namespace || name;
-    let version = options.windowsVersion || Common.getReactNativeVersion();
+    const version = options.windowsVersion || Common.getReactNativeVersion();
     const versionTag = options.template || await getDefaultVersionTag(version);
 
-    let rnwPackage = await Common.getInstallPackage(version, versionTag);
+    const rnwPackage = await Common.getInstallPackage(version, versionTag);
 
     console.log(`Installing ${rnwPackage}...`);
     const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -31,8 +31,8 @@ async function getDefaultVersionTag(version) {
 
   // 0.57 and below had stable untagged releases
   if ((validVersion && semver.lt(validVersion, '0.58.0'))
-  || (validRange && semver.gtr('0.58.0', validRange))) {
-  return null;
+    || (validRange && semver.gtr('0.58.0', validRange))) {
+    return null;
   }
 
   // 0.58 went to RC (See #2559)

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -29,13 +29,19 @@ async function getDefaultVersionTag(version) {
     process.exit(1);
   }
 
-  // Prefer rc builds before 0.59 (See #2559)
+  // 0.57 and below had stable untagged releases
+  if ((validVersion && semver.lt(validVersion, '0.58.0'))
+  || (validRange && semver.gtr('0.58.0', validRange))) {
+  return null;
+  }
+
+  // 0.58 went to RC (See #2559)
   if ((validVersion && semver.lt(validVersion, '0.59.0'))
     || (validRange && semver.gtr('0.59.0', validRange))) {
     return 'rc';
   }
 
-  // Ask for vnext or legacy for 0.59
+  // 0.59 tags releases as "legacy" or "vnext"
   if ((validVersion && semver.lt(validVersion, '0.60.0'))
     || (validRange && semver.gtr('0.60.0', validRange))) {
     return  (await prompts({
@@ -49,7 +55,7 @@ async function getDefaultVersionTag(version) {
     })).template;
   }
 
-  // 0.60 releases use the vnext tag
+  // 0.60 releases all use the vnext tag
   if ((validVersion && semver.lt(validVersion, '0.61.0'))
     || (validRange && semver.gtr('0.61.0', validRange))) {
     return 'vnext';

--- a/packages/rnpm-plugin-windows/src/wpf.js
+++ b/packages/rnpm-plugin-windows/src/wpf.js
@@ -26,9 +26,8 @@ module.exports = function (config, args, options) {
 
   // If the template is not set, look for a stable or 'rc' version
   const template = options.template ? options.template : 'rc';
-  const ignoreStable = !!options.template;
 
-  return Common.getInstallPackage(version, template, ignoreStable)
+  return Common.getInstallPackage(version, template)
     .then(rnwPackage => {
       console.log(`Installing ${rnwPackage}...`);
       const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';


### PR DESCRIPTION
Add special rules for the master template to rnpm-plugin-windows to allow 0.0.0 versions of React Native Windows to match to non 0.0.0 versions of React Native, while we're not caught up yet.

Do not force the "vnext" tag for 0.61 builds without a template. We also rewrite some of the fuzzy logic added in #2559, which was allowing prereleases to be matched when we didn't force a tag. We didn't run into this in 0.59 or 0.60 given forcing vnext or legacy.

Part of the master logic was tested end-to-end in the 0.62 branch, but I plan to revalidate before checkin. Behavior was tested for different versions of RN by using the "--windowsVersion" flag to simulate different installed RN versions, and observing the package we try to install. Will verify this works as expected in 0.61-stable before checkin.

Will cherry-pick this into 0.61-stable and submit in the same change as the publish change. This should also allow us to change master to 0.0.0 scheme shortly after publishing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4403)