### PR TITLE
Ensure sequential writes in WinRTWebSocketResource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,8 @@ node_modules
 ipch/
 [Oo]bj/
 [Bb]in
-[Dd]ebug*/
-[Rr]elease*/
+[Dd]ebug/
+[Rr]elease/
 *.tlog/
 Ankh.NoLoad
 UpgradeLog.htm

--- a/change/react-native-windows-2020-03-23-20-55-53-winapi_ws_0.60_changegate.json
+++ b/change/react-native-windows-2020-03-23-20-55-53-winapi_ws_0.60_changegate.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Merge from winapi_ws",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "commit": "85fc67bcb9494dbc0f62e759c051a8ea023d8dd5",
+  "dependentChangeType": "patch",
+  "date": "2020-03-24T03:55:53.564Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UEBA?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SA?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QEAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YA?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QEB_WI@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SG?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -36,7 +36,7 @@ TEST_CLASS (WebSocketIntegrationTest)
     string scheme = "ws";
     if (isSecure)
       scheme += "s";
-    auto ws = IWebSocketResource::Make(scheme + "://localhost:5556/", true);
+    auto ws = IWebSocketResource::Make(scheme + "://localhost:5556/", false, true);
     promise<size_t> sentSizePromise;
     ws->SetOnSend([&sentSizePromise](size_t size)
     {

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -41,6 +41,7 @@
   <ImportGroup Label="Shared">
     <Import Project="..\Shared\Shared.vcxitems" Label="Shared" />
     <Import Project="..\Chakra\Chakra.vcxitems" Label="Shared" />
+    <Import Project="..\Mso\Mso.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -59,6 +60,7 @@
       <AdditionalOptions>%(AdditionalOptions) /Zc:strictStrings /bigobj</AdditionalOptions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -15,9 +15,9 @@ namespace Microsoft::React
 {
 #pragma region IWebSocketResource static members
 
-/*static*/ unique_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString, bool acceptSelfSigned)
+/*static*/ unique_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned)
 {
-  if (true) //TODO: Feature-gate this.
+  if (!legacyImplementation)
   {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (acceptSelfSigned)

--- a/vnext/Mso/debugAssertApi/debugAssertApi.h
+++ b/vnext/Mso/debugAssertApi/debugAssertApi.h
@@ -1,0 +1,284 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+#ifndef MSO_DEBUGASSERTAPI_DEBUGASSERTAPI_H
+#define MSO_DEBUGASSERTAPI_DEBUGASSERTAPI_H
+
+/**
+  API for debug asserts. Must support C callers
+*/
+#ifndef RC_INVOKED
+#pragma pack(push, 8)
+
+#include <compilerAdapters/cppMacros.h>
+#include <compilerAdapters/functionDecorations.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <tagUtils/tagTypes.h>
+
+/**
+Basic debug assert macros to use.
+
+Assert:        evaluate in debug, call the debug handler on failure
+AssertDo:    always evaluate, call the debug handler on failure
+*/
+#define Assert(f) AssertTag(f, UNTAGGED)
+#define AssertSz(f, _sz) AssertSzTag(f, _sz, UNTAGGED)
+#define AssertSz0(f, _sz) AssertSzTag(f, _sz, UNTAGGED)
+#define AssertSz1(f, _sz, a) AssertSz1Tag(f, _sz, a, UNTAGGED)
+#define AssertSz2(f, _sz, a, b) AssertSz2Tag(f, _sz, a, b, UNTAGGED)
+#define AssertSz3(f, _sz, a, b, c) AssertSz3Tag(f, _sz, a, b, c, UNTAGGED)
+#define AssertSz4(f, _sz, a, b, c, d) AssertSz4Tag(f, _sz, a, b, c, d, UNTAGGED)
+#define AssertSz5(f, _sz, a, b, c, d, e) AssertSz5Tag(f, _sz, a, b, c, d, e, UNTAGGED)
+
+#define AssertDo(f) AssertDoTag(f, UNTAGGED)
+#define AssertDoSz(f, _sz) AssertDoSzTag(f, _sz, UNTAGGED)
+#define AssertDoSz1(f, _sz, a) AssertDoSz1Tag(f, _sz, a, UNTAGGED)
+#define AssertDoSz2(f, _sz, a, b) AssertDoSz2Tag(f, _sz, a, b, UNTAGGED)
+#define AssertDoSz3(f, _sz, a, b, c) AssertDoSz3Tag(f, _sz, a, b, c, UNTAGGED)
+#define AssertDoSz4(f, _sz, a, b, c, d) AssertDoSz4Tag(f, _sz, a, b, c, d, UNTAGGED)
+#define AssertDoSz5(f, _sz, a, b, c, d, e) AssertDoSz5Tag(f, _sz, a, b, c, d, e, UNTAGGED)
+
+/**
+The following macros can be used to assert inside an expression.
+Note: Always returns (f), the assert is purely a side-effect.
+LATER: add more if needed or ShipAssert versions.
+
+if (FAssertDo(f)) { ... } // same as "if (f) { ... } else Assert(false);"
+*/
+#define FAssertDo(f) FAssertDoTag(f, UNTAGGED)
+#define FAssertDoSz(f, _sz) FAssertDoSzTag(f, _sz, UNTAGGED)
+#define FAssertDoSz1(f, _sz, a) FAssertDoSz1Tag(f, _sz, a, UNTAGGED)
+#define FAssertDoSz2(f, _sz, a, b) FAssertDoSz2Tag(f, _sz, a, b, UNTAGGED)
+
+#ifdef __cplusplus
+#define AssertDetails_SzCast(sz) static_cast<const char *>(sz)
+#else
+#define AssertDetails_SzCast(sz) (const char *)(sz)
+#endif
+
+/**
+Suppressed warnings in Assert macros:
+  C4127 - if/while loop condition is a constant
+  C4018 - signed/unsigned compare was converted to unsigned/unsigned compare
+  C4389 - operation involved signed/unsigned variables
+   6239 - OACR left expression is always false
+  25011 - OACR missing 'break' or '__fallthrough' statement
+  25037 - OACR expression is always false
+  25038 - OACR expression is always false
+  25039 - OACR expression is always true
+  25041 - OACR if/while loop condition is true
+  25042 - OACR if/while loop condition is false
+  25064 - OACR function called twice in macro
+*/
+#define AssertDetails_Statement_Begin \
+  __pragma(warning(push))             \
+      __pragma(warning(disable : 4127 4018 4389 6239 25037 25038 25039 25041 25042 25064 25306)) do {
+#define AssertDetails_Statement_End \
+  }                                 \
+  while (0)                         \
+  __pragma(warning(suppress : 25011)) __pragma(warning(pop))
+
+// NOTE: OACR_ASSUME uses the Assert macro, so oacr.h must be included after Assert is defined
+#include "oacr/oacr.h"
+
+/**
+Return Address
+FUTURE: get rid of this and just use void*
+*/
+typedef struct _MSORADDR {
+  void *pfnCaller;
+} MSORADDR;
+
+/**
+Ugly workarounds to support C callers, essentially:
+C++: pass by reference, use constructor
+C  : pass by pointer, use initializer list
+*/
+#if defined(__cplusplus)
+using MsoAssertParamsType = const struct _MsoAssertParams &;
+#ifdef DEBUG
+#define DeclareMsoAssertParams(...) MsoAssertParams params(__VA_ARGS__)
+#else
+#define DeclareMsoAssertParams(...)
+#endif // DEBUG
+#define AccessMsoAssertParams(_p) (&(_p))
+#define InlineMsoAssertParams(...) MsoAssertParams(__VA_ARGS__)
+#define DeclareInlineMsoAssertParams(_p)
+#define PassMsoAssertParams(_p) _p
+#else // __cplusplus
+typedef struct _MsoAssertParams *MsoAssertParamsType;
+#ifdef DEBUG
+#define DeclareMsoAssertParams(...) (__pragma(warning(suppress : 4204)) MsoAssertParams params = {__VA_ARGS__})
+#else
+#define DeclareMsoAssertParams(...)
+#endif // DEBUG
+#define AccessMsoAssertParams(_p) _p
+#define InlineMsoAssertParams(szCondition, ...) DeclareMsoAssertParams(__VA_ARGS__)
+#define DeclareInlineMsoAssertParamsUnwrap(...) __VA_ARGS__
+#define DeclareInlineMsoAssertParams(_p) DeclareInlineMsoAssertParamsUnwrap _p
+#define PassMsoAssertParams(_p) &params
+#endif // __cplusplus
+
+#ifdef DEBUG
+/**
+Various parameters that can be passed to the assert functions.
+This structure is duplicated in MotifTest project.
+*/
+typedef struct _MsoAssertParams {
+  uint32_t dwTag;
+  const char *szFile;
+  uint32_t iLine;
+  const char *szTitle;
+  const MSORADDR *rgCallstack;
+  uint32_t cCallstack;
+  const char *szCondition;
+
+  // Skip this many frames if a callstack is generated.
+#ifdef __cplusplus
+  mutable
+#endif // __cplusplus
+      uint32_t framesToSkip;
+
+#ifdef __cplusplus
+  explicit _MsoAssertParams(
+      uint32_t dwTagLocal = UNTAGGED,
+      _In_z_ const char *szFileLocal = __FILE__,
+      uint32_t iLineLocal = __LINE__,
+      _In_opt_z_ const char *szTitleLocal = nullptr,
+      _In_opt_count_(cCallstackLocal) const MSORADDR *rgCallstackLocal = nullptr,
+      uint32_t cCallstackLocal = 0,
+      _In_opt_z_ const char *szConditionLocal = "false") MSONOEXCEPT : dwTag(dwTagLocal),
+                                                                       szFile(szFileLocal),
+                                                                       iLine(iLineLocal),
+                                                                       szTitle(szTitleLocal),
+                                                                       rgCallstack(rgCallstackLocal),
+                                                                       cCallstack(cCallstackLocal),
+                                                                       szCondition(szConditionLocal),
+                                                                       framesToSkip(0) {}
+
+  explicit _MsoAssertParams(
+      _In_z_ const char *szConditionLocal,
+      uint32_t dwTagLocal,
+      _In_z_ const char *szFileLocal,
+      int32_t iLineLocal) MSONOEXCEPT : dwTag(dwTagLocal),
+                                        szFile(szFileLocal),
+                                        iLine(static_cast<uint32_t>(iLineLocal)),
+                                        szTitle(nullptr),
+                                        rgCallstack(nullptr),
+                                        cCallstack(0),
+                                        szCondition(szConditionLocal),
+                                        framesToSkip(0) {}
+#endif // __cplusplus
+} MsoAssertParams;
+
+/**
+  Function for handling asserts with strings. Return value is AssertResult.
+  Note: this function has to be callable from C code
+*/
+#if defined(__cplusplus)
+extern "C" {
+#endif // C++
+LIBLET_PUBLICAPI int32_t
+MsoAssertSzTagProc(MsoAssertParamsType params, _Printf_format_string_ const char *szFmt, va_list argList) MSONOEXCEPT;
+#if defined(__cplusplus)
+}
+#endif // C++
+
+#endif // DEBUG
+
+#include "debugAssertDetails.h"
+
+#ifdef DEBUG
+#ifdef __cplusplus
+namespace Mso {
+namespace DebugAsserts {
+
+using AssertIgnorer = bool (*)(const MsoAssertParams &params, const char *szMsg);
+
+/**
+  Add an assert ignorer for this process.
+  Note: this API is not thread-safe.
+*/
+LIBLET_PUBLICAPI void AddAssertIgnorer(AssertIgnorer ignorer) noexcept;
+
+/**
+  Remove an assert ignorer for this process.
+  Note: this API is not thread-safe.
+*/
+LIBLET_PUBLICAPI void RemoveAssertIgnorer(AssertIgnorer ignorer) noexcept;
+
+struct AutoRegisterAssertIgnorer {
+  AutoRegisterAssertIgnorer(AssertIgnorer ignorer) noexcept : m_ignorer(ignorer) {
+    AddAssertIgnorer(m_ignorer);
+  }
+
+  ~AutoRegisterAssertIgnorer() noexcept {
+    RemoveAssertIgnorer(m_ignorer);
+  }
+
+ private:
+  AssertIgnorer m_ignorer;
+};
+
+using AssertListener = void (*)(const MsoAssertParams &params, const char *szMsg);
+
+/**
+  Add an assert listener for this process.
+  Note: this API is not thread-safe.
+*/
+LIBLET_PUBLICAPI void AddAssertListener(AssertListener listener) noexcept;
+
+/**
+  Remove a previously registered assert listener for this process.
+  Note: this API is not thread-safe.
+*/
+LIBLET_PUBLICAPI void RemoveAssertListener(AssertListener listener) noexcept;
+
+struct AutoRegisterAssertListener {
+  AutoRegisterAssertListener(AssertListener listener) noexcept : m_listener(listener) {
+    AddAssertListener(m_listener);
+  }
+
+  ~AutoRegisterAssertListener() noexcept {
+    RemoveAssertListener(m_listener);
+  }
+
+ private:
+  AssertListener m_listener;
+};
+
+using AssertHandler = AssertResult (*)(const MsoAssertParams &params, const char *szMsg);
+
+/**
+  Set the assert handler for this process. The previous handler is returned.
+  Note: this API is not thread-safe.
+*/
+LIBLET_PUBLICAPI AssertHandler SetAssertHandler(AssertHandler handler) noexcept;
+
+/**
+  Get the current assert handler for this process.
+*/
+LIBLET_PUBLICAPI AssertHandler GetAssertHandler() noexcept;
+
+struct AutoRegisterAssertHandler {
+  AutoRegisterAssertHandler(AssertHandler handler) noexcept : m_previous(SetAssertHandler(handler)) {}
+
+  ~AutoRegisterAssertHandler() noexcept {
+    SetAssertHandler(m_previous);
+  }
+
+ private:
+  AssertHandler m_previous;
+};
+
+} // namespace DebugAsserts
+} // namespace Mso
+#endif // __cplusplus
+#endif // DEBUG
+
+#pragma pack(pop)
+#endif // RC_INVOKED
+
+#endif // MSO_DEBUGASSERTAPI_DEBUGASSERTAPI_H

--- a/vnext/Mso/debugAssertApi/debugAssertDetails.h
+++ b/vnext/Mso/debugAssertApi/debugAssertDetails.h
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+#ifndef MSO_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
+#define MSO_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
+
+/**
+  Private implementation details for debug assert macros
+  This header should not be included directly - only through debugAssertApi.h
+
+   Note that C4706 is purposely left enabled. Assignments in inside Assert
+  statements are almost always a bug (e.g. Assert(m_foo = fooBar))
+*/
+
+#include <cstdarg>
+#include <cstdint>
+
+/**
+Mappings for core Debug asserts.
+*/
+#pragma warning(suppress : 4005) // macro redefinition :(
+#define AssertTag(f, tag) \
+  AssertAnnotatedSzNTagImpl(f, L## #f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), "%s", #f)
+#define AssertSzTag(f, sz, tag) \
+  AssertSzNTagImpl(f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), "%s", AssertDetails_SzCast(sz))
+#define AssertSz1Tag(f, sz, a, tag) AssertSzNTagImpl(f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), sz, a)
+#define AssertSz2Tag(f, sz, a, b, tag) AssertSzNTagImpl(f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), sz, a, b)
+#define AssertSz3Tag(f, sz, a, b, c, tag) \
+  AssertSzNTagImpl(f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), sz, a, b, c)
+#define AssertSz4Tag(f, sz, a, b, c, d, tag) \
+  AssertSzNTagImpl(f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), sz, a, b, c, d)
+#define AssertSz5Tag(f, sz, a, b, c, d, e, tag) \
+  AssertSzNTagImpl(f, InlineMsoAssertParams(#f, tag, __FILE__, __LINE__), sz, a, b, c, d, e)
+
+#define FAssertDoTag(f, tag) FAssertDoSzNTagImpl(f, tag, __FILE__, __LINE__, L## #f, "%s", #f)
+#define FAssertDoSzTag(f, sz, tag) \
+  FAssertDoSzNTagImpl(f, tag, __FILE__, __LINE__, L##sz, "%s", AssertDetails_SzCast(sz))
+#define FAssertDoSz1Tag(f, sz, a, tag) FAssertDoSzNTagImpl(f, tag, __FILE__, __LINE__, L##sz, sz, a)
+#define FAssertDoSz2Tag(f, sz, a, b, tag) FAssertDoSzNTagImpl(f, tag, __FILE__, __LINE__, L##sz, sz, a, b)
+
+/**
+Return values from MsoAssertSzTagProc(Inline)(2)
+*/
+static const uint32_t c_assertIgnore = 0;
+static const uint32_t c_assertDebugBreak = 1;
+static const uint32_t c_assertAlwaysIgnore = 2;
+
+#ifdef __cplusplus
+#ifdef DEBUG
+namespace Mso {
+namespace DebugAsserts {
+
+/**
+  Return values from MsoAssertSzTagProc(Inline)(2)
+*/
+__pragma(warning(suppress : 4472)) enum class AssertResult : uint32_t {
+  Ignore = c_assertIgnore,
+  Break = c_assertDebugBreak,
+  AlwaysIgnore = c_assertAlwaysIgnore,
+};
+
+} // namespace DebugAsserts
+} // namespace Mso
+#endif // DEBUG
+#endif // C++
+
+// TODO: move this abstraction into compilerAdapters? Except it depends on windows - hmm
+#if defined(__clang__) || defined(__cplusplus_cli) || defined(__INTELLISENSE__)
+#define AssertBreak(wzMsg) __debugbreak()
+#elif defined(_DBGRAISEASSERTIONFAILURE_)
+#define AssertBreak(wzMsg) (__annotation(L"Debug", L"AssertFail", wzMsg), DbgRaiseAssertionFailure())
+#else
+#define AssertBreak(wzMsg) (__annotation(L"Debug", L"AssertFail", wzMsg), __debugbreak())
+#endif
+
+#if DEBUG
+/**
+  MsoAssertSzTagProcInline
+
+  Converts variable arguments into the arg list format
+*/
+#ifndef __cplusplus
+static
+#endif
+    __inline int32_t
+    MsoAssertSzTagProcInline(MsoAssertParamsType params, _Printf_format_string_ const char *szFmt, ...) MSONOEXCEPT {
+  va_list argList;
+  va_start(argList, szFmt);
+  AccessMsoAssertParams(params)->framesToSkip++;
+  return MsoAssertSzTagProc(params, szFmt, argList);
+}
+
+#ifdef __cplusplus
+/**
+  MsoAssertSzTagProcInline2
+
+  Converts variable arguments into the arg list format
+
+  Use a lamba function to generate a unique function providing storage of
+  _fIgnore_ (for in-proc based assert management) and unique break address.
+*/
+#define MsoAssertSzTagProcInline2(dwTag, szFile, iLine, wzAnnotation, szFmt, ...)                               \
+  [&]() -> int32_t {                                                                                            \
+    __pragma(warning(suppress : 4456)) /* declaration of '_fIgnore_' hides previous local declaration */        \
+        static int32_t _fIgnore_ = false;                                                                       \
+    if (!_fIgnore_) {                                                                                           \
+      __pragma(warning(suppress : 4456)) /* declaration of 'params' hides previous local declaration */         \
+          DeclareMsoAssertParams(dwTag, szFile, iLine);                                                         \
+      params.framesToSkip++;                                                                                    \
+      const int32_t _assertResult_ = MsoAssertSzTagProcInline(PassMsoAssertParams(params), szFmt, __VA_ARGS__); \
+      __pragma(warning(suppress : 4700)) /* MSVC is unhappy with this used in a loop conditional */             \
+          if (_assertResult_ == c_assertDebugBreak) {                                                           \
+        AssertBreak(wzAnnotation);                                                                              \
+      }                                                                                                         \
+      _fIgnore_ = (_assertResult_ == c_assertAlwaysIgnore);                                                     \
+    }                                                                                                           \
+    return FALSE;                                                                                               \
+  }()
+#endif // __cplusplus
+
+#else
+#define MsoAssertSzTagProcInline(params, szFmt, ...) (0)
+#endif // DEBUG
+
+/**
+  Hide the debug assert 'f' condition from OACR so it acts more like a ship build
+*/
+#if OACR
+#define AssertDetails_ShouldRaiseDebugAssert(f, fIgnore) 0
+#else
+#define AssertDetails_ShouldRaiseDebugAssert(f, fIgnore) (!(f) && !(fIgnore))
+#endif
+
+#if DEBUG
+
+/**
+  AssertSzNTagImpl - all debug asserts funnel into here
+  TODO: need to move the Ignore logic, should it be on params?
+  Params is MsoAssertParams, only C callers need to do something weird.
+
+  Note: be aware that ... requires at least one argument
+*/
+#define AssertSzNTagImpl(f, params, sz, ...) AssertAnnotatedSzNTagImpl(f, L## #f, params, sz, __VA_ARGS__)
+
+#define AssertAnnotatedSzNTagImpl(f, wzAnnotation, params, sz, ...)                                        \
+  AssertDetails_Statement_Begin static int32_t _fIgnore_ = 0;                                              \
+  if (AssertDetails_ShouldRaiseDebugAssert(f, _fIgnore_)) {                                                \
+    DeclareInlineMsoAssertParams(params);                                                                  \
+    const int32_t _assertResult_ = MsoAssertSzTagProcInline(PassMsoAssertParams(params), sz, __VA_ARGS__); \
+    if (_assertResult_ == c_assertDebugBreak)                                                              \
+      AssertBreak(wzAnnotation);                                                                           \
+    _fIgnore_ = (_assertResult_ == c_assertAlwaysIgnore);                                                  \
+  }                                                                                                        \
+  AssertDetails_Statement_End
+
+#else
+
+#define AssertSzNTagImpl(f, params, _sz, ...) __noop()
+#define AssertAnnotatedSzNTagImpl(f, annotation, params, sz, ...) __noop()
+
+#endif // DEBUG
+
+#if DEBUG && !OACR // OACR can't understand FAssertDoSzNTagImpl
+
+/**
+  FAssertDoSzNTagImpl - all debug FAsserts funnel into here
+  <condition> || <assertResult && false>
+
+  TODO: need to move the Ignore logic, handle these differently?
+  Note: be aware that ... requires at least one argument
+*/
+
+#define FAssertDoSzNTagImpl(f, dwTag, szFile, iLine, wzAnnotation, sz, ...) \
+  ((f) || (MsoAssertSzTagProcInline2(dwTag, szFile, iLine, wzAnnotation, sz, __VA_ARGS__)))
+
+#else
+
+// REVIEW: (f) because sometimes f defines to nothing. But assuming here seems wrong.
+#define FAssertDoSzNTagImpl(f, dwTag, szFile, iLine, wzAnnotation, _sz, ...) (f)
+
+#endif // DEBUG && !OACR
+
+// Note: AssertDo may contain assignments so I'm using the != 0 syntax which allows that.
+#define AssertDoTag(f, tag) Statement(if ((f) == 0) { AssertSzTag(0, #f, tag); })
+#define AssertDoSzTag(f, sz, tag) Statement(if ((f) == 0) { AssertSzTag(0, sz, tag); })
+#define AssertDoSz1Tag(f, sz, a, tag) Statement(if ((f) == 0) { AssertSz1Tag(0, sz, a, tag); })
+#define AssertDoSz2Tag(f, sz, a, b, tag) Statement(if ((f) == 0) { AssertSz2Tag(0, sz, a, b, tag); })
+#define AssertDoSz3Tag(f, sz, a, b, c, tag) Statement(if ((f) == 0) { AssertSz3Tag(0, sz, a, b, c, tag); })
+#define AssertDoSz4Tag(f, sz, a, b, c, d, tag) Statement(if ((f) == 0) { AssertSz4Tag(0, sz, a, b, c, d, tag); })
+#define AssertDoSz5Tag(f, sz, a, b, c, d, e, tag) Statement(if ((f) == 0) { AssertSz5Tag(0, sz, a, b, c, d, e, tag); })
+
+/**
+  Helpers for debug HRESULT asserts.
+
+  Ship versions are not supported; consider VerifySucceededElseCrash
+*/
+#if DEBUG
+
+#define AssertDoSucceededTag(expr, tag)                                       \
+  AssertDetails_Statement_Begin HRESULT _hr_ = (expr);                        \
+  AssertAnnotatedSzNTagImpl(                                                  \
+      SUCCEEDED(_hr_),                                                        \
+      L#expr L" success. Check local variable _hr_.",                         \
+      InlineMsoAssertParams("SUCCEEDED(" #expr ")", tag, __FILE__, __LINE__), \
+      "%s failed with 0x%08x",                                                \
+      #expr,                                                                  \
+      _hr_);                                                                  \
+  AssertDetails_Statement_End
+
+#define FAssertDoSucceededTag(expr, tag)                                              \
+  [&]() noexcept->bool {                                                              \
+    HRESULT _hr_ = (expr);                                                            \
+    if (FAILED(_hr_)) {                                                               \
+      if (MsoAssertSzTagProcInline(                                                   \
+              InlineMsoAssertParams("SUCCEEDED(" #expr ")", tag, __FILE__, __LINE__), \
+              "%s failed with 0x%08x",                                                \
+              #expr,                                                                  \
+              _hr_) == c_assertDebugBreak) {                                          \
+        AssertBreak(L#expr L" success. Check local variable _hr_.");                  \
+      }                                                                               \
+    }                                                                                 \
+    return SUCCEEDED(_hr_);                                                           \
+    OACR_WARNING_SUPPRESS(NOEXCEPT_FUNC_THROWS, "Ignore whether expr throws.");       \
+  }                                                                                   \
+  ()
+
+#else
+
+#define AssertDoSucceededTag(expr, tag) ((void)(expr))
+#define FAssertDoSucceededTag(expr, tag) (SUCCEEDED(expr))
+
+#endif // DEBUG
+
+/**
+  Random other deprecated assert macros
+*/
+#define AssertImpliesTag(a, b, tag) AssertSzTag(FImplies(a, b), #a " => " #b, tag)
+#define AssertBiImpliesTag(a, b, tag) AssertSzTag(FBiImplies(a, b), #a " <==> " #b, tag)
+
+#endif // MSO_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H

--- a/vnext/Mso/src/debugAssertApi/debugAssertApi.cpp
+++ b/vnext/Mso/src/debugAssertApi/debugAssertApi.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "debugAssertApi/debugAssertApi.h"
+#include <algorithm>
+#include <memory>
+#include <set>
+#include "compilerAdapters/cppMacrosDebug.h"
+#include "cppExtensions/autoRestore.h"
+
+#ifdef DEBUG
+
+namespace Mso {
+namespace DebugAsserts {
+
+struct Data {
+  std::set<uint32_t> DisabledTags;
+  std::set<AssertIgnorer> Ignorers;
+  std::set<AssertListener> Listeners;
+  AssertHandler Handler = nullptr;
+
+  static Data &Get() noexcept {
+    // To avoid static initializer ordering issues, this object is created on demand and purposely leaked
+    static auto s_data = Construct();
+    return *s_data;
+  }
+
+ private:
+  static Data *Construct() noexcept {
+    // xlsrv doesn't allow calling new from static initializers. Using std::allocator instead, which has been modified
+    // to call malloc.
+    std::allocator<Data> alloc;
+    auto p = alloc.allocate(1);
+    alloc.construct(p);
+    return p;
+  }
+};
+
+void DisableAssertTag(uint32_t tag) noexcept {
+  Data::Get().DisabledTags.insert(tag);
+}
+
+void EnableAssertTag(uint32_t tag) noexcept {
+  Data::Get().DisabledTags.erase(tag);
+}
+
+bool IsAssertTagDisabled(uint32_t tag) noexcept {
+  const auto &disabledTags = Data::Get().DisabledTags;
+  return (disabledTags.find(tag) != std::end(disabledTags));
+}
+
+void AddAssertIgnorer(AssertIgnorer ignorer) noexcept {
+  Data::Get().Ignorers.insert(ignorer);
+}
+
+void RemoveAssertIgnorer(AssertIgnorer ignorer) noexcept {
+  Data::Get().Ignorers.erase(ignorer);
+}
+
+void AddAssertListener(AssertListener listener) noexcept {
+  Data::Get().Listeners.insert(listener);
+}
+
+void RemoveAssertListener(AssertListener listener) noexcept {
+  Data::Get().Listeners.erase(listener);
+}
+
+AssertHandler GetAssertHandler() noexcept {
+  return Data::Get().Handler;
+}
+
+AssertHandler SetAssertHandler(AssertHandler handler) noexcept {
+  std::swap(Data::Get().Handler, handler);
+  return handler;
+}
+
+static bool v_isInAssertHandler;
+
+extern "C" int32_t MsoAssertSzTagProc(
+    const MsoAssertParams &params,
+    _Printf_format_string_ const char *szFormat,
+    va_list argList) noexcept {
+  if (IsAssertTagDisabled(params.dwTag))
+    return c_assertIgnore;
+
+  char assertMessage[4096];
+  (void)vsnprintf(assertMessage, sizeof(assertMessage), szFormat, argList);
+  params.framesToSkip++;
+
+  const auto &data = Data::Get();
+  for (const auto &ignorer : data.Ignorers) {
+    if (ignorer(params, assertMessage))
+      return c_assertIgnore;
+  }
+
+  for (const auto &listener : data.Listeners) {
+    listener(params, assertMessage);
+  }
+
+  if (data.Handler) {
+    Mso::TRestorer<bool> restoreInAssertHandler(v_isInAssertHandler, true);
+    return static_cast<int32_t>(data.Handler(params, assertMessage));
+  }
+
+  return c_assertIgnore;
+}
+
+bool IsInAssertHandler() noexcept {
+  return v_isInAssertHandler;
+}
+
+} // namespace DebugAsserts
+} // namespace Mso
+
+// LIBLET_PUBLICAPI_APPLE MSOAPI_(void) MsoFAddIgnoredAssertTag(uint32_t tag) noexcept
+//{
+//	Mso::DebugAsserts::DisableAssertTag(tag);
+//}
+//
+// LIBLET_PUBLICAPI_APPLE MSOAPI_(void) MsoFRemoveIgnoredAssertTag(uint32_t tag) noexcept
+//{
+//	Mso::DebugAsserts::EnableAssertTag(tag);
+//}
+
+#endif // DEBUG

--- a/vnext/ReactWindows-Desktop.sln
+++ b/vnext/ReactWindows-Desktop.sln
@@ -111,6 +111,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JSI.Desktop", "JSI\Desktop\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "Common\Common.vcxproj", "{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso.UnitTests", "Mso.UnitTests\Mso.UnitTests.vcxproj", "{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mso", "Mso", "{4DE630AE-EC50-4F21-942E-7B811A1C5FA3}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
@@ -119,11 +121,13 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
 		JSI\Shared\JSI.Shared.vcxitems*{17dd1b17-3094-40dd-9373-ac2497932eca}*SharedItemsImports = 4
+		Mso\Mso.vcxitems*{1958ceaa-fbe0-44e3-8a99-90ad85531ffe}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
 		Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
+		Mso\Mso.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
 		include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
@@ -253,6 +257,14 @@ Global
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x64.Build.0 = Release|x64
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x86.ActiveCfg = Release|Win32
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x86.Build.0 = Release|Win32
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x64.ActiveCfg = Debug|x64
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x64.Build.0 = Debug|x64
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x86.ActiveCfg = Debug|Win32
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x86.Build.0 = Debug|Win32
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x64.ActiveCfg = Release|x64
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x64.Build.0 = Release|x64
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x86.ActiveCfg = Release|Win32
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -266,6 +278,7 @@ Global
 		{2EB5E646-7EB4-4FED-B1A8-0AEEF2D32268} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
 		{F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
 		{41F31595-2F20-4D6B-A6CF-60444415012A} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
+		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE} = {4DE630AE-EC50-4F21-942E-7B811A1C5FA3}
 		{4DE630AE-EC50-4F21-942E-7B811A1C5FA3} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
 		{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E} = {4DE630AE-EC50-4F21-942E-7B811A1C5FA3}
 	EndGlobalSection

--- a/vnext/ReactWindows-Desktop.sln
+++ b/vnext/ReactWindows-Desktop.sln
@@ -111,8 +111,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JSI.Desktop", "JSI\Desktop\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "Common\Common.vcxproj", "{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso.UnitTests", "Mso.UnitTests\Mso.UnitTests.vcxproj", "{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mso", "Mso", "{4DE630AE-EC50-4F21-942E-7B811A1C5FA3}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
@@ -121,7 +119,6 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
 		JSI\Shared\JSI.Shared.vcxitems*{17dd1b17-3094-40dd-9373-ac2497932eca}*SharedItemsImports = 4
-		Mso\Mso.vcxitems*{1958ceaa-fbe0-44e3-8a99-90ad85531ffe}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
@@ -257,14 +254,6 @@ Global
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x64.Build.0 = Release|x64
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x86.ActiveCfg = Release|Win32
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x86.Build.0 = Release|Win32
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x64.ActiveCfg = Debug|x64
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x64.Build.0 = Debug|x64
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x86.ActiveCfg = Debug|Win32
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Debug|x86.Build.0 = Debug|Win32
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x64.ActiveCfg = Release|x64
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x64.Build.0 = Release|x64
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x86.ActiveCfg = Release|Win32
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -278,7 +267,6 @@ Global
 		{2EB5E646-7EB4-4FED-B1A8-0AEEF2D32268} = {6F24927E-EE45-4DB2-91DA-DCC6E98B0C42}
 		{F90FDFD1-2C76-4DCD-B248-F6FB2BB15BDF} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
 		{41F31595-2F20-4D6B-A6CF-60444415012A} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
-		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE} = {4DE630AE-EC50-4F21-942E-7B811A1C5FA3}
 		{4DE630AE-EC50-4F21-942E-7B811A1C5FA3} = {978A75A5-B8D2-4306-9AEF-D00793F33F5F}
 		{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E} = {4DE630AE-EC50-4F21-942E-7B811A1C5FA3}
 	EndGlobalSection

--- a/vnext/ReactWindowsCore/IWebSocketResource.h
+++ b/vnext/ReactWindowsCore/IWebSocketResource.h
@@ -85,7 +85,8 @@ struct IWebSocketResource {
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::unique_ptr<IWebSocketResource> Make(const std::string &url, bool acceptSelfSigned = false);
+  static std::unique_ptr<IWebSocketResource>
+  Make(const std::string &url, bool legacyImplementation = false, bool acceptSelfSigned = false);
 
   virtual ~IWebSocketResource() {}
 

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -78,7 +78,7 @@
       -->
       <PreprocessorDefinitions>REACTWINDOWS_BUILD;NOMINMAX;FOLLY_NO_CONFIG;WIN32=0;RN_EXPORT=;CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(USE_HERMES)'=='true'">USE_HERMES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)Mso;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <PreprocessToFile>false</PreprocessToFile>

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.h
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <dispatchQueue/dispatchQueue.h>
 #include <winrt/Windows.Networking.Sockets.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <IWebSocketResource.h>
@@ -26,6 +27,7 @@ class WinRTWebSocketResource : public IWebSocketResource
   winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_revoker;
   winrt::Windows::Storage::Streams::DataWriter m_writer{ m_socket.OutputStream() };
 
+  Mso::DispatchQueue m_dispatchQueue;
   std::atomic_bool m_connectRequested;
   std::promise<void> m_connectPerformedPromise;
   winrt::handle m_connectPerformed{ CreateEvent(/*attributes*/ nullptr, /*manual reset*/ true, /*state*/ false, /*name*/ nullptr) };


### PR DESCRIPTION
See #4330.

Use an `Mso::DispatchQueue` to avoid race conditions on background WebSocket writes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4410)