### PR TITLE
[0.60] Make IWebSocketResource as shared_ptr

### DIFF
--- a/change/react-native-windows-2020-03-24-20-28-28-winapi_ws_0.60_sharedwsr.json
+++ b/change/react-native-windows-2020-03-24-20-28-28-winapi_ws_0.60_sharedwsr.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Merge from winapi_ws: Make IWebSocketResource shared_ptr",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "commit": "ffaf762782a0bcd0ca02f41f5602cef27d9b710f",
+  "dependentChangeType": "patch",
+  "date": "2020-03-25T03:28:28.784Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UEBA?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SA?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QEAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YA?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QEB_WI@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SG?AV?$unique_ptr@UIWebSocketResource@React@Microsoft@@U?$default_delete@UIWebSocketResource@React@Microsoft@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -284,6 +284,9 @@ TEST_CLASS (WebSocketIntegrationTest)
     server->Stop();
   }
 
+  BEGIN_TEST_METHOD_ATTRIBUTE(SendReceiveSsl)
+    TEST_IGNORE()
+  END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(SendReceiveSsl)
   {
     SendReceiveCloseBase(/*isSecure*/ true);

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -16,76 +16,76 @@
 using namespace Microsoft::React;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
+using std::shared_ptr;
 using std::string;
-using std::unique_ptr;
 using std::vector;
 
-TEST_CLASS(WebSocketResourcePerformanceTest){// See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
-                                             int32_t GetCurrentThreadCount(){DWORD procId = GetCurrentProcessId();
-HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
+TEST_CLASS (WebSocketResourcePerformanceTest) { // See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
+  int32_t GetCurrentThreadCount() {
+    DWORD procId = GetCurrentProcessId();
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
 
-PROCESSENTRY32 entry = {0};
-entry.dwSize = sizeof(entry);
+    PROCESSENTRY32 entry = {0};
+    entry.dwSize = sizeof(entry);
 
-BOOL procFound = true;
-procFound = Process32First(snapshot, &entry);
-while (procFound && entry.th32ProcessID != procId)
-  procFound = Process32Next(snapshot, &entry);
-CloseHandle(snapshot);
+    BOOL procFound = true;
+    procFound = Process32First(snapshot, &entry);
+    while (procFound && entry.th32ProcessID != procId)
+      procFound = Process32Next(snapshot, &entry);
+    CloseHandle(snapshot);
 
-if (procFound)
-  return entry.cntThreads;
+    if (procFound)
+      return entry.cntThreads;
 
-return -1;
-}
-
-///
-/// Spawn a number of WebSocket resources, have it write and read a message
-/// several times, then measure the amount of allocated threads. Important. This
-/// test must be run in isolation (no other tests running concurrently).
-///
-TEST_METHOD(ProcessThreadsPerResource) {
-  const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
-  // increase this value to 100.
-  const int maxWriteCount = 10;
-  const int expectedThreadsPerResource = 3;
-  const int startThreadCount = GetCurrentThreadCount();
-
-  std::atomic_int32_t threadCount = 0;
-
-  // WebSocket resources scope.
-  {
-    vector<unique_ptr<IWebSocketResource>> resources;
-    for (int i = 0; i < resourceTotal; i++) {
-      auto ws = IWebSocketResource::Make("ws://localhost:5556/");
-      ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
-        auto count = this->GetCurrentThreadCount();
-        if (count > threadCount.load())
-          threadCount.store(count);
-      });
-      ws->SetOnSend([this, &threadCount](size_t) {
-        auto count = this->GetCurrentThreadCount();
-        if (count > threadCount.load())
-          threadCount.store(count);
-      });
-      ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
-        auto count = this->GetCurrentThreadCount();
-        if (count > threadCount.load())
-          threadCount.store(count);
-      });
-      ws->Connect();
-
-      resources.push_back(std::move(ws));
-    } // Create and store WS resources.
-
-    // Send messages.
-    for (auto &ws : resources) {
-      ws->Send("some message");
-    }
+    return -1;
   }
 
-  int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
-  Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
-}
-}
-;
+  ///
+  /// Spawn a number of WebSocket resources, have it write and read a message
+  /// several times, then measure the amount of allocated threads. Important. This
+  /// test must be run in isolation (no other tests running concurrently).
+  ///
+  TEST_METHOD(ProcessThreadsPerResource) {
+    const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
+    // increase this value to 100.
+    const int maxWriteCount = 10;
+    const int expectedThreadsPerResource = 3;
+    const int startThreadCount = GetCurrentThreadCount();
+
+    std::atomic_int32_t threadCount = 0;
+
+    // WebSocket resources scope.
+    {
+      vector<shared_ptr<IWebSocketResource>> resources;
+      for (int i = 0; i < resourceTotal; i++) {
+        auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+        ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
+          auto count = this->GetCurrentThreadCount();
+          if (count > threadCount.load())
+            threadCount.store(count);
+        });
+        ws->SetOnSend([this, &threadCount](size_t) {
+          auto count = this->GetCurrentThreadCount();
+          if (count > threadCount.load())
+            threadCount.store(count);
+        });
+        ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
+          auto count = this->GetCurrentThreadCount();
+          if (count > threadCount.load())
+            threadCount.store(count);
+        });
+        ws->Connect();
+
+        resources.push_back(std::move(ws));
+      } // Create and store WS resources.
+
+      // Send messages.
+      for (auto &ws : resources) {
+        ws->Send("some message");
+      }
+    }
+
+    int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
+    Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
+  }
+};

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -20,72 +20,72 @@ using std::shared_ptr;
 using std::string;
 using std::vector;
 
-TEST_CLASS (WebSocketResourcePerformanceTest) { // See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
-  int32_t GetCurrentThreadCount() {
-    DWORD procId = GetCurrentProcessId();
-    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
+TEST_CLASS(WebSocketResourcePerformanceTest){// See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
+                                             int32_t GetCurrentThreadCount(){DWORD procId = GetCurrentProcessId();
+HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0 /*th32ProcessID*/);
 
-    PROCESSENTRY32 entry = {0};
-    entry.dwSize = sizeof(entry);
+PROCESSENTRY32 entry = {0};
+entry.dwSize = sizeof(entry);
 
-    BOOL procFound = true;
-    procFound = Process32First(snapshot, &entry);
-    while (procFound && entry.th32ProcessID != procId)
-      procFound = Process32Next(snapshot, &entry);
-    CloseHandle(snapshot);
+BOOL procFound = true;
+procFound = Process32First(snapshot, &entry);
+while (procFound && entry.th32ProcessID != procId)
+  procFound = Process32Next(snapshot, &entry);
+CloseHandle(snapshot);
 
-    if (procFound)
-      return entry.cntThreads;
+if (procFound)
+  return entry.cntThreads;
 
-    return -1;
-  }
+return -1;
+}
 
-  ///
-  /// Spawn a number of WebSocket resources, have it write and read a message
-  /// several times, then measure the amount of allocated threads. Important. This
-  /// test must be run in isolation (no other tests running concurrently).
-  ///
-  TEST_METHOD(ProcessThreadsPerResource) {
-    const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
-    // increase this value to 100.
-    const int maxWriteCount = 10;
-    const int expectedThreadsPerResource = 3;
-    const int startThreadCount = GetCurrentThreadCount();
+///
+/// Spawn a number of WebSocket resources, have it write and read a message
+/// several times, then measure the amount of allocated threads. Important. This
+/// test must be run in isolation (no other tests running concurrently).
+///
+TEST_METHOD(ProcessThreadsPerResource) {
+  const int resourceTotal = 50; // About 3 seconds total running time. 6 if we
+  // increase this value to 100.
+  const int maxWriteCount = 10;
+  const int expectedThreadsPerResource = 3;
+  const int startThreadCount = GetCurrentThreadCount();
 
-    std::atomic_int32_t threadCount = 0;
+  std::atomic_int32_t threadCount = 0;
 
-    // WebSocket resources scope.
-    {
-      vector<shared_ptr<IWebSocketResource>> resources;
-      for (int i = 0; i < resourceTotal; i++) {
-        auto ws = IWebSocketResource::Make("ws://localhost:5556/");
-        ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
-          auto count = this->GetCurrentThreadCount();
-          if (count > threadCount.load())
-            threadCount.store(count);
-        });
-        ws->SetOnSend([this, &threadCount](size_t) {
-          auto count = this->GetCurrentThreadCount();
-          if (count > threadCount.load())
-            threadCount.store(count);
-        });
-        ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
-          auto count = this->GetCurrentThreadCount();
-          if (count > threadCount.load())
-            threadCount.store(count);
-        });
-        ws->Connect();
+  // WebSocket resources scope.
+  {
+    vector<shared_ptr<IWebSocketResource>> resources;
+    for (int i = 0; i < resourceTotal; i++) {
+      auto ws = IWebSocketResource::Make("ws://localhost:5556/");
+      ws->SetOnMessage([this, &threadCount](size_t size, const string &message) {
+        auto count = this->GetCurrentThreadCount();
+        if (count > threadCount.load())
+          threadCount.store(count);
+      });
+      ws->SetOnSend([this, &threadCount](size_t) {
+        auto count = this->GetCurrentThreadCount();
+        if (count > threadCount.load())
+          threadCount.store(count);
+      });
+      ws->SetOnClose([this, &threadCount](IWebSocketResource::CloseCode, const string & /*reason*/) {
+        auto count = this->GetCurrentThreadCount();
+        if (count > threadCount.load())
+          threadCount.store(count);
+      });
+      ws->Connect();
 
-        resources.push_back(std::move(ws));
-      } // Create and store WS resources.
+      resources.push_back(std::move(ws));
+    } // Create and store WS resources.
 
-      // Send messages.
-      for (auto &ws : resources) {
-        ws->Send("some message");
-      }
+    // Send messages.
+    for (auto &ws : resources) {
+      ws->Send("some message");
     }
-
-    int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
-    Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
   }
-};
+
+  int64_t threadsPerResource = (threadCount.load() - startThreadCount) / resourceTotal;
+  Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
+}
+}
+;

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.cpp
@@ -118,7 +118,8 @@ std::future<bool> WebSocketJSExecutor::ConnectAsync(
   promise<bool> resultPromise;
   m_errorCallback = std::move(errorCallback);
 
-  m_webSocket = IWebSocketResource::Make(webSocketServerUrl);
+  m_webSocket =
+      IWebSocketResource::Make(webSocketServerUrl, /*legacyImplementation*/ true); // TODO: Deprecate legacy impl.
   m_webSocket->SetOnMessage([this](size_t /*length*/, const string &message) { this->OnMessageReceived(message); });
   m_webSocket->SetOnError([this](const IWebSocketResource::Error &err) { this->SetState(State::Error); });
 

--- a/vnext/Desktop/Executors/WebSocketJSExecutor.h
+++ b/vnext/Desktop/Executors/WebSocketJSExecutor.h
@@ -60,7 +60,7 @@ class WebSocketJSExecutor : public JSExecutor {
 
   std::shared_ptr<ExecutorDelegate> m_delegate;
   std::shared_ptr<MessageQueueThread> m_messageQueueThread;
-  std::unique_ptr<IWebSocketResource> m_webSocket;
+  std::shared_ptr<IWebSocketResource> m_webSocket;
   folly::dynamic m_injectedObjects = folly::dynamic::object;
   std::function<void(std::string)> m_errorCallback;
 

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// clang-format off
 #include "pch.h"
 
 #include <WebSocketModule.h>
@@ -13,123 +14,155 @@
 using namespace facebook::xplat;
 using namespace folly;
 
+using Microsoft::Common::Unicode::Utf8ToUtf16;
+
+using std::shared_ptr;
 using std::string;
 
-namespace {
-
+namespace
+{
 constexpr char moduleName[] = "WebSocketModule";
-
 } // anonymous namespace
 
-namespace Microsoft::React {
+namespace Microsoft::React
+{
 
-WebSocketModule::WebSocketModule() {}
+  WebSocketModule::WebSocketModule() {}
 
-string WebSocketModule::getName() {
+string WebSocketModule::getName()
+{
   return moduleName;
 }
 
-std::map<string, dynamic> WebSocketModule::getConstants() {
+std::map<string, dynamic> WebSocketModule::getConstants()
+{
   return {};
 }
 
-std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMethods() {
-  return {Method(
-              "connect",
-              [this](dynamic args) // const string& url, folly::dynamic protocols,
-                                   // folly::dynamic options, int64_t id
-              {
-                IWebSocketResource::Protocols protocols;
-                dynamic protocolsDynamic = jsArgAsDynamic(args, 1);
-                if (!protocolsDynamic.empty()) {
-                  for (const auto &protocol : protocolsDynamic.items()) {
-                    protocols.push_back(protocol.first.getString());
-                  }
-                }
+std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMethods()
+{
+  return
+  {
+    Method(
+      "connect",
+      [this](dynamic args) // const string& url, dynamic protocols, dynamic options, int64_t id
+      {
+        IWebSocketResource::Protocols protocols;
+        dynamic protocolsDynamic = jsArgAsDynamic(args, 1);
+        if (!protocolsDynamic.empty())
+        {
+          for (const auto& protocol : protocolsDynamic.items())
+          {
+            protocols.push_back(protocol.first.getString());
+          }
+        }
 
-                IWebSocketResource::Options options;
-                dynamic optionsDynamic = jsArgAsDynamic(args, 2);
-                if (!optionsDynamic.empty() && !optionsDynamic["headers"].empty()) {
-                  dynamic headersDynamic = optionsDynamic["headers"];
-                  for (const auto &header : headersDynamic.items()) {
-                    options.emplace(
-                        Microsoft::Common::Unicode::Utf8ToUtf16(header.first.getString()), header.second.getString());
-                  }
-                }
+        IWebSocketResource::Options options;
+        dynamic optionsDynamic = jsArgAsDynamic(args, 2);
+        if (!optionsDynamic.empty() && !optionsDynamic["headers"].empty())
+        {
+          dynamic headersDynamic = optionsDynamic["headers"];
+          for (const auto& header : headersDynamic.items())
+          {
+            options.emplace(Utf8ToUtf16(header.first.getString()), header.second.getString());
+          }
+        }
 
-                this->GetOrCreateWebSocket(jsArgAsInt(args, 3), jsArgAsString(args, 0))->Connect(protocols, options);
-              }),
-          Method(
-              "close",
-              [this](dynamic args) // [int64_t code, string reason,] int64_t id
-              {
-                // See react-native\Libraries\WebSocket\WebSocket.js:_close
-                if (args.size() == 3) // WebSocketModule.close(statusCode,
-                                      // closeReason, this._socketId);
-                  this->GetOrCreateWebSocket(jsArgAsInt(args, 2))
-                      ->Close(static_cast<IWebSocketResource::CloseCode>(jsArgAsInt(args, 0)), jsArgAsString(args, 1));
-                else if (args.size() == 1) // WebSocketModule.close(this._socketId);
-                  this->GetOrCreateWebSocket(jsArgAsInt(args, 0))->Close(IWebSocketResource::CloseCode::Normal, {});
-                else {
-                  auto errorObj = dynamic::object("id", -1)("message", "Incorrect number of parameters");
-                  this->SendEvent("websocketFailed", std::move(errorObj));
-                }
-              }),
-          Method(
-              "send",
-              [this](dynamic args) // const string& message, int64_t id
-              { this->GetOrCreateWebSocket(jsArgAsInt(args, 1))->Send(jsArgAsString(args, 0)); }),
-          Method(
-              "sendBinary",
-              [this](dynamic args) // const string& base64String, int64_t id
-              { this->GetOrCreateWebSocket(jsArgAsInt(args, 1))->SendBinary(jsArgAsString(args, 0)); }),
-          Method(
-              "ping",
-              [this](dynamic args) // int64_t id
-              { this->GetOrCreateWebSocket(jsArgAsInt(args, 0))->Ping(); })};
+        this->GetOrCreateWebSocket(jsArgAsInt(args, 3), jsArgAsString(args, 0))->Connect(protocols, options);
+      }),
+    Method(
+      "close",
+      [this](dynamic args) // [int64_t code, string reason,] int64_t id
+      {
+        // See react-native\Libraries\WebSocket\WebSocket.js:_close
+        if (args.size() == 3) // WebSocketModule.close(statusCode, closeReason, this._socketId);
+        {
+          this->GetOrCreateWebSocket(jsArgAsInt(args, 2))
+            ->Close(static_cast<IWebSocketResource::CloseCode>(jsArgAsInt(args, 0)), jsArgAsString(args, 1));
+        }
+        else if (args.size() == 1) // WebSocketModule.close(this._socketId);
+        {
+          this->GetOrCreateWebSocket(jsArgAsInt(args, 0))->Close(IWebSocketResource::CloseCode::Normal, {});
+        }
+        else
+        {
+          auto errorObj = dynamic::object("id", -1)("message", "Incorrect number of parameters");
+          this->SendEvent("websocketFailed", std::move(errorObj));
+        }
+      }),
+    Method(
+      "send",
+      [this](dynamic args) // const string& message, int64_t id
+      {
+        this->GetOrCreateWebSocket(jsArgAsInt(args, 1))->Send(jsArgAsString(args, 0));
+      }),
+    Method(
+      "sendBinary",
+      [this](dynamic args) // const string& base64String, int64_t id
+      {
+        this->GetOrCreateWebSocket(jsArgAsInt(args, 1))->SendBinary(jsArgAsString(args, 0));
+      }),
+    Method(
+      "ping",
+      [this](dynamic args) // int64_t id
+      {
+        this->GetOrCreateWebSocket(jsArgAsInt(args, 0))->Ping();
+      })
+  };
 } // getMethods
 
 #pragma region private members
 
-void WebSocketModule::SendEvent(string &&eventName, dynamic &&args) {
+void WebSocketModule::SendEvent(string&& eventName, dynamic&& args)
+{
   auto instance = this->getInstance().lock();
   if (instance)
+  {
     instance->callJSFunction("RCTDeviceEventEmitter", "emit", dynamic::array(std::move(eventName), std::move(args)));
+  }
 }
 
-IWebSocketResource *WebSocketModule::GetOrCreateWebSocket(int64_t id, string &&url) {
-  IWebSocketResource *ptr = nullptr;
-  if (m_webSockets.find(id) == m_webSockets.end()) {
+shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id, string&& url)
+{
+  if (m_webSockets.find(id) == m_webSockets.end())
+  {
     auto ws = IWebSocketResource::Make(std::move(url));
-    ws->SetOnError([this, id](const IWebSocketResource::Error &err) {
+    ws->SetOnError([this, id, ws](const IWebSocketResource::Error& err)
+    {
+      auto wsRef = ws;
       auto errorObj = dynamic::object("id", id)("message", err.Message);
       this->SendEvent("websocketFailed", std::move(errorObj));
     });
-    ws->SetOnConnect([this, id]() {
-      dynamic args = dynamic::object("id", id);
+    ws->SetOnConnect([this, id, ws]()
+    {
+      auto wsRef = ws;
+      auto args = dynamic::object("id", id);
       this->SendEvent("websocketOpen", std::move(args));
     });
-    ws->SetOnMessage([this, id](size_t length, const string &message) {
-      dynamic args = dynamic::object("id", id)("data", message)("type", "text");
+    ws->SetOnMessage([this, id, ws](size_t length, const string& message)
+    {
+      auto wsRef = ws;
+      auto args = dynamic::object("id", id)("data", message)("type", "text");
       this->SendEvent("websocketMessage", std::move(args));
     });
-    ws->SetOnClose([this, id](IWebSocketResource::CloseCode code, const string &reason) {
-      dynamic args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
+    ws->SetOnClose([this, id, ws](IWebSocketResource::CloseCode code, const string& reason)
+    {
+      auto wsRef = ws;
+      auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
       this->SendEvent("websocketClosed", std::move(args));
     });
 
-    ptr = ws.get();
-    m_webSockets.emplace(id, std::move(ws));
-  } else {
-    ptr = m_webSockets.at(id).get();
+    m_webSockets.emplace(id, ws);
+    return ws;
   }
 
-  return ptr;
+  return m_webSockets.at(id);
 }
 
 #pragma endregion private members
 
-std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule() noexcept {
+/*extern*/ std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule() noexcept
+{
   return std::make_unique<WebSocketModule>();
 }
 

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -16,7 +16,6 @@ using namespace folly;
 
 using Microsoft::Common::Unicode::Utf8ToUtf16;
 
-using std::shared_ptr;
 using std::string;
 
 namespace
@@ -68,7 +67,11 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
           }
         }
 
-        this->GetOrCreateWebSocket(jsArgAsInt(args, 3), jsArgAsString(args, 0))->Connect(protocols, options);
+        auto weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 3), jsArgAsString(args, 0));
+        if (auto sharedWs = weakWs.lock())
+        {
+          sharedWs->Connect(protocols, options);
+        }
       }),
     Method(
       "close",
@@ -77,12 +80,19 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
         // See react-native\Libraries\WebSocket\WebSocket.js:_close
         if (args.size() == 3) // WebSocketModule.close(statusCode, closeReason, this._socketId);
         {
-          this->GetOrCreateWebSocket(jsArgAsInt(args, 2))
-            ->Close(static_cast<IWebSocketResource::CloseCode>(jsArgAsInt(args, 0)), jsArgAsString(args, 1));
+          auto weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 2));
+          if (auto sharedWs = weakWs.lock())
+          {
+            sharedWs->Close(static_cast<IWebSocketResource::CloseCode>(jsArgAsInt(args, 0)), jsArgAsString(args, 1));
+          }
         }
         else if (args.size() == 1) // WebSocketModule.close(this._socketId);
         {
-          this->GetOrCreateWebSocket(jsArgAsInt(args, 0))->Close(IWebSocketResource::CloseCode::Normal, {});
+          auto weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 0));
+          if (auto sharedWs = weakWs.lock())
+          {
+            sharedWs->Close(IWebSocketResource::CloseCode::Normal, {});
+          }
         }
         else
         {
@@ -94,19 +104,31 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
       "send",
       [this](dynamic args) // const string& message, int64_t id
       {
-        this->GetOrCreateWebSocket(jsArgAsInt(args, 1))->Send(jsArgAsString(args, 0));
+        auto weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 1));
+        if (auto sharedWs = weakWs.lock())
+        {
+          sharedWs->Send(jsArgAsString(args, 0));
+        }
       }),
     Method(
       "sendBinary",
       [this](dynamic args) // const string& base64String, int64_t id
       {
-        this->GetOrCreateWebSocket(jsArgAsInt(args, 1))->SendBinary(jsArgAsString(args, 0));
+        auto weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 1));
+        if (auto sharedWs = weakWs.lock())
+        {
+          sharedWs->SendBinary(jsArgAsString(args, 0));
+        }
       }),
     Method(
       "ping",
       [this](dynamic args) // int64_t id
       {
-        this->GetOrCreateWebSocket(jsArgAsInt(args, 0))->Ping();
+        auto weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 0));
+        if (auto sharedWs = weakWs.lock())
+        {
+          sharedWs->Ping();
+        }
       })
   };
 } // getMethods
@@ -122,7 +144,7 @@ void WebSocketModule::SendEvent(string&& eventName, dynamic&& args)
   }
 }
 
-shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id, string&& url)
+std::weak_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id, string&& url)
 {
   if (m_webSockets.find(id) == m_webSockets.end())
   {

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -151,25 +151,21 @@ std::weak_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t 
     auto ws = IWebSocketResource::Make(std::move(url));
     ws->SetOnError([this, id, ws](const IWebSocketResource::Error& err)
     {
-      auto wsRef = ws;
       auto errorObj = dynamic::object("id", id)("message", err.Message);
       this->SendEvent("websocketFailed", std::move(errorObj));
     });
     ws->SetOnConnect([this, id, ws]()
     {
-      auto wsRef = ws;
       auto args = dynamic::object("id", id);
       this->SendEvent("websocketOpen", std::move(args));
     });
     ws->SetOnMessage([this, id, ws](size_t length, const string& message)
     {
-      auto wsRef = ws;
       auto args = dynamic::object("id", id)("data", message)("type", "text");
       this->SendEvent("websocketMessage", std::move(args));
     });
     ws->SetOnClose([this, id, ws](IWebSocketResource::CloseCode code, const string& reason)
     {
-      auto wsRef = ws;
       auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
       this->SendEvent("websocketClosed", std::move(args));
     });

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -7,15 +7,17 @@
 #include <WinRTWebSocketResource.h>
 #include "BeastWebSocketResource.h"
 
-using std::make_unique;
+using std::make_shared;
 using std::string;
-using std::unique_ptr;
+using std::shared_ptr;
 
 namespace Microsoft::React
 {
 #pragma region IWebSocketResource static members
 
-/*static*/ unique_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned)
+/*static*/
+shared_ptr<IWebSocketResource>
+IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned)
 {
   if (!legacyImplementation)
   {
@@ -25,26 +27,30 @@ namespace Microsoft::React
       certExceptions.emplace_back(winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::Untrusted);
       certExceptions.emplace_back(winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
     }
-    return make_unique<WinRTWebSocketResource>(urlString, certExceptions);
+    return make_shared<WinRTWebSocketResource>(urlString, certExceptions);
   }
   else
   {
     Url url(urlString);
 
-    if (url.scheme == "ws") {
+    if (url.scheme == "ws")
+    {
       if (url.port.empty())
         url.port = "80";
 
-      return make_unique<Beast::WebSocketResource>(std::move(url));
+      return make_shared<Beast::WebSocketResource>(std::move(url));
     }
-    else if (url.scheme == "wss") {
+    else if (url.scheme == "wss")
+    {
       if (url.port.empty())
         url.port = "443";
 
-      return make_unique<Beast::SecureWebSocket>(std::move(url));
+      return make_shared<Beast::SecureWebSocket>(std::move(url));
     }
     else
+    {
       throw std::invalid_argument((string("Incorrect URL scheme: ") + url.scheme).c_str());
+    }
   }
 }
 

--- a/vnext/ReactWindowsCore/IWebSocketResource.h
+++ b/vnext/ReactWindowsCore/IWebSocketResource.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// clang-format off
 #pragma once
 
 #include <functional>
@@ -8,16 +9,18 @@
 #include <string>
 #include <vector>
 
-namespace Microsoft::React {
+namespace Microsoft::React
+{
 
 /// <summary>
 /// Defines the core functionality for a native WebSocket client resource.
 /// </summary>
-struct IWebSocketResource {
+struct IWebSocketResource
+{
 #pragma region Aliases
 
   using Protocols = std::vector<std::string>;
-  using Options = std::map<std::wstring, std::string>;
+  using Options   = std::map<std::wstring, std::string>;
 
 #pragma endregion Aliases
 
@@ -26,52 +29,56 @@ struct IWebSocketResource {
   /// <summary>
   /// As defined in RFC6455.
   /// </summary>
-  enum class ReadyState : std::uint16_t {
-    Connecting = 0, // Handle initialized
-    Open = 1, // Ready to send
-    Closing = 2, // Currently closing
-    Closed = 3, // Closed or failed to open
-    Size = 4 // Metavalue representing the number of entries in this enum.
+  enum class ReadyState : std::uint16_t
+  {
+    Connecting  = 0, // Handle initialized
+    Open        = 1, // Ready to send
+    Closing     = 2, // Currently closing
+    Closed      = 3, // Closed or failed to open
+    Size        = 4 // Metavalue representing the number of entries in this enum.
   };
 
-  enum class ErrorType : size_t {
-    None = 0,
-    Resolution = 1,
-    Connection = 2,
-    Handshake = 3,
-    Ping = 4,
-    Send = 5,
-    Receive = 6,
-    Close = 7,
-    Size = 8 // Metavalue representing the number of entries in this enum.
+  enum class ErrorType : std::size_t
+  {
+    None        = 0,
+    Resolution  = 1,
+    Connection  = 2,
+    Handshake   = 3,
+    Ping        = 4,
+    Send        = 5,
+    Receive     = 6,
+    Close       = 7,
+    Size        = 8 // Metavalue representing the number of entries in this enum.
   };
 
   /// <summary>
   /// As defined in https://tools.ietf.org/html/rfc6455#section-7.4
   /// </summary>
-  enum class CloseCode : std::uint16_t {
+  enum class CloseCode : std::uint16_t
+  {
     // Keep in sync with RFC 6455 specification
-    None = 0,
-    Normal = 1000,
-    GoingAway = 1001,
-    ProtocolError = 1002,
-    UnknownData = 1003,
-    Reserved1 = 1004,
-    NoStatus = 1005,
-    Abnormal = 1006,
-    BadPayload = 1007,
-    PolicyError = 1008,
-    TooBig = 1009,
-    NeedsExtension = 1010,
-    InternalError = 1011,
-    ServiceRestart = 1012,
-    TryAgainLater = 1013,
-    Reserved2 = 1014,
-    Reserved3 = 1015,
-    Size = 17 // Metavalue representing the number of entries in this enum.
+    None            = 0,
+    Normal          = 1000,
+    GoingAway       = 1001,
+    ProtocolError   = 1002,
+    UnknownData     = 1003,
+    Reserved1       = 1004,
+    NoStatus        = 1005,
+    Abnormal        = 1006,
+    BadPayload      = 1007,
+    PolicyError     = 1008,
+    TooBig          = 1009,
+    NeedsExtension  = 1010,
+    InternalError   = 1011,
+    ServiceRestart  = 1012,
+    TryAgainLater   = 1013,
+    Reserved2       = 1014,
+    Reserved3       = 1015,
+    Size            = 17 // Metavalue representing the number of entries in this enum.
   };
 
-  struct Error {
+  struct Error
+  {
     std::string Message;
     const ErrorType Type;
   };
@@ -85,8 +92,8 @@ struct IWebSocketResource {
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::unique_ptr<IWebSocketResource>
-  Make(const std::string &url, bool legacyImplementation = false, bool acceptSelfSigned = false);
+  static std::shared_ptr<IWebSocketResource>
+  Make(const std::string& url, bool legacyImplementation = false, bool acceptSelfSigned = false);
 
   virtual ~IWebSocketResource() {}
 
@@ -100,7 +107,7 @@ struct IWebSocketResource {
   /// HTTP header fields passed by the remote endpoint, to be used in the
   /// handshake process.
   /// </param>
-  virtual void Connect(const Protocols &protocols = {}, const Options &options = {}) = 0;
+  virtual void Connect(const Protocols& protocols = {}, const Options& options = {}) = 0;
 
   /// <summary>
   /// Sends a ping frame to the remote endpoint.
@@ -113,7 +120,7 @@ struct IWebSocketResource {
   /// <param name="message">
   /// UTF8-encoded string of arbitrary length.
   /// </param>
-  virtual void Send(const std::string &message) = 0;
+  virtual void Send(const std::string& message) = 0;
 
   /// <summary>
   /// Sends a non-plain-text message to the remote endpoint.
@@ -121,7 +128,7 @@ struct IWebSocketResource {
   /// <param name="base64String">
   /// Binary message encoded in Base64 format.
   /// </param>
-  virtual void SendBinary(const std::string &base64String) = 0;
+  virtual void SendBinary(const std::string& base64String) = 0;
 
   /// <summary>
   /// Terminates this resource's connection to the remote endpoint.
@@ -131,7 +138,7 @@ struct IWebSocketResource {
   /// </param>
   /// <param name="reason">
   /// </param>
-  virtual void Close(CloseCode code, const std::string &reason) = 0;
+  virtual void Close(CloseCode code, const std::string& reason) = 0;
 
   /// <returns>
   /// Current public state as defined in the <c>ReadyState</c> enum.
@@ -143,7 +150,7 @@ struct IWebSocketResource {
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnConnect(std::function<void()> &&handler) = 0;
+  virtual void SetOnConnect(std::function<void()>&& handler) = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on a successful ping to the remote
@@ -151,14 +158,14 @@ struct IWebSocketResource {
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnPing(std::function<void()> &&handler) = 0;
+  virtual void SetOnPing(std::function<void()>&& handler) = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on a message sending.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnSend(std::function<void(std::size_t)> &&handler) = 0;
+  virtual void SetOnSend(std::function<void(std::size_t)>&& handler) = 0;
 
   /// <summary>
   /// Sets the optional custom behavior to run when there is an incoming
@@ -166,28 +173,21 @@ struct IWebSocketResource {
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) = 0;
+  virtual void SetOnMessage(std::function<void(std::size_t, const std::string&)>&& handler) = 0;
 
   /// <summary>
   /// Sets the optional custom behavior to run when this instance is closed.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) = 0;
+  virtual void SetOnClose(std::function<void(CloseCode, const std::string&)>&& handler) = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on an error condition.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnError(std::function<void(Error &&)> &&handler) = 0;
+  virtual void SetOnError(std::function<void(Error&&)>&& handler) = 0;
 };
 
 } // namespace Microsoft::React
-
-// Deprecated. Keeping for compatibility with dependent code.
-namespace facebook::react {
-
-using IWebSocket = Microsoft::React::IWebSocketResource;
-
-} // namespace facebook::react

--- a/vnext/ReactWindowsCore/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/WebSocketModule.h
@@ -43,7 +43,7 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// <summary>
   /// Creates or retrieves a raw <c>IWebSocketResource</c> pointer.
   /// </summary>
-  std::shared_ptr<IWebSocketResource> GetOrCreateWebSocket(std::int64_t id, std::string &&url = {});
+  std::weak_ptr<IWebSocketResource> GetOrCreateWebSocket(std::int64_t id, std::string &&url = {});
 
   /// <summary>
   /// Keeps <c>IWebSocketResource</c> instances identified by <c>id</c>.

--- a/vnext/ReactWindowsCore/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/WebSocketModule.h
@@ -43,20 +43,13 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// <summary>
   /// Creates or retrieves a raw <c>IWebSocketResource</c> pointer.
   /// </summary>
-  IWebSocketResource *GetOrCreateWebSocket(int64_t id, std::string &&url = std::string());
+  std::shared_ptr<IWebSocketResource> GetOrCreateWebSocket(std::int64_t id, std::string &&url = {});
 
   /// <summary>
   /// Keeps <c>IWebSocketResource</c> instances identified by <c>id</c>.
   /// As defined in WebSocket.js.
   /// </summary>
-  std::map<int64_t, std::unique_ptr<IWebSocketResource>> m_webSockets;
+  std::map<int64_t, std::shared_ptr<IWebSocketResource>> m_webSockets;
 };
 
 } // namespace Microsoft::React
-
-// Deprecated. Keeping for compatibility.
-namespace facebook::react {
-
-using WebSocketModule = Microsoft::React::WebSocketModule;
-
-} // namespace facebook::react

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -56,6 +56,8 @@
 #include "ChakraRuntimeHolder.h"
 #endif
 
+using Microsoft::React::WebSocketModule;
+
 // forward declaration.
 namespace facebook::react::tracing {
 void initializeETW();

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -28,6 +28,7 @@
 
 #if (defined(_MSC_VER) && !defined(WINRT))
 #include <WebSocketModule.h>
+using Microsoft::React::WebSocketModule;
 #endif
 #include <Modules/ExceptionsManagerModule.h>
 #include <SourceCodeModule.h>
@@ -55,8 +56,6 @@
 #endif
 #include "ChakraRuntimeHolder.h"
 #endif
-
-using Microsoft::React::WebSocketModule;
 
 // forward declaration.
 namespace facebook::react::tracing {


### PR DESCRIPTION
See #4330 .

Changes `IWebSocketResource::Make` to return `std::shared_ptr` to ensure its lifetime when ran asynchronously.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4418)