### PR TITLE
Small CLI fix

### DIFF
--- a/change/rnpm-plugin-windows-2020-03-24-23-34-25-fix-cli.json
+++ b/change/rnpm-plugin-windows-2020-03-24-23-34-25-fix-cli.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "allow CLI to install from file:",
+  "packageName": "rnpm-plugin-windows",
+  "email": "kmelmon@microsoft.com",
+  "commit": "6919a19f4678028678be0ae4f41dfcf2a60218c2",
+  "dependentChangeType": "patch",
+  "date": "2020-03-25T06:34:24.942Z"
+}

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -70,9 +70,12 @@ module.exports = async function (config, args, options) {
     const name = args[0] || Common.getReactNativeAppName();
     const ns = options.namespace || name;
     const version = options.windowsVersion || Common.getReactNativeVersion();
-    const versionTag = options.template || await getDefaultVersionTag(version);
+    let rnwPackage = version;
+    if (!version.startsWith("file:")) {
+      const versionTag = options.template || await getDefaultVersionTag(version);
 
-    const rnwPackage = await Common.getInstallPackage(version, versionTag);
+      rnwPackage = await Common.getInstallPackage(version, versionTag);
+    }
 
     console.log(`Installing ${rnwPackage}...`);
     const pkgmgr = Common.isGlobalCliUsingYarn(process.cwd()) ? 'yarn add' : 'npm install --save';

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -72,6 +72,7 @@ module.exports = async function (config, args, options) {
     const version = options.windowsVersion || Common.getReactNativeVersion();
     let rnwPackage = version;
     // If the version is a file: link, there's no need to compute what package to install.
+    // This is useful when testing local changes to the repo that haven't been published yet.
     if (!version.startsWith("file:")) {
       const versionTag = options.template || await getDefaultVersionTag(version);
 

--- a/packages/rnpm-plugin-windows/src/windows.js
+++ b/packages/rnpm-plugin-windows/src/windows.js
@@ -71,6 +71,7 @@ module.exports = async function (config, args, options) {
     const ns = options.namespace || name;
     const version = options.windowsVersion || Common.getReactNativeVersion();
     let rnwPackage = version;
+    // If the version is a file: link, there's no need to compute what package to install.
     if (!version.startsWith("file:")) {
       const versionTag = options.template || await getDefaultVersionTag(version);
 


### PR DESCRIPTION
This fixes a small regression that came in with:
https://github.com/microsoft/react-native-windows/pull/4403

With this change you can no longer install react-native-windows with --windowsVersion file:<path>

This change fixes that.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4419)