### PR TITLE
Allow NativeModules event handlers to have 0..n arguments

### DIFF
--- a/change/react-native-windows-2020-03-25-20-43-02-FixReactEvent.json
+++ b/change/react-native-windows-2020-03-25-20-43-02-FixReactEvent.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow NativeModules events to have 0..n arguments",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-26T03:43:02.397Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -543,6 +543,14 @@ struct SimpleNativeModule {
   REACT_EVENT(OnIntEvent)
   std::function<void(int)> OnIntEvent;
 
+  // An event without arguments
+  REACT_EVENT(OnNoArgEvent)
+  std::function<void()> OnNoArgEvent;
+
+  // An event with two arguments
+  REACT_EVENT(OnTwoArgsEvent)
+  std::function<void(Point const &, Point const &)> OnTwoArgsEvent;
+
   // Specify event name different from the field name.
   REACT_EVENT(OnPointEvent, L"onPointEvent")
   std::function<void(Point const &)> OnPointEvent;
@@ -567,6 +575,10 @@ struct SimpleNativeModule {
   // Use two arguments. Specify JS function name different from the field name.
   REACT_FUNCTION(JSLineFunction, L"lineFunc")
   std::function<void(Point const &, Point const &)> JSLineFunction;
+
+  // Use no arguments.
+  REACT_FUNCTION(NoArgFunction)
+  std::function<void()> NoArgFunction;
 
   // By default we use the module name from REACT_MODULE which is by default the struct name.
   // Here we specify module name local for this function.
@@ -1327,22 +1339,51 @@ TEST_CLASS (NativeModuleTest) {
 
   TEST_METHOD(TestEvent_IntEventField) {
     bool eventRaised = false;
-    m_builderMock.ExpectEvent(L"RCTDeviceEventEmitter", L"OnIntEvent", [&eventRaised](JSValue const &arg) noexcept {
-      TestCheck(arg == 42);
-      eventRaised = true;
-    });
+    m_builderMock.ExpectEvent(
+        L"RCTDeviceEventEmitter", L"OnIntEvent", [&eventRaised](JSValueArray const &args) noexcept {
+          TestCheck(args[0] == 42);
+          eventRaised = true;
+        });
 
     m_module->OnIntEvent(42);
     TestCheck(eventRaised);
   }
 
+  TEST_METHOD(TestEvent_OnNoArgEventField) {
+    bool eventRaised = false;
+    m_builderMock.ExpectEvent(
+        L"RCTDeviceEventEmitter", L"OnNoArgEvent", [&eventRaised](JSValueArray const &args) noexcept {
+          TestCheckEqual(0, args.size());
+          eventRaised = true;
+        });
+
+    m_module->OnNoArgEvent();
+    TestCheck(eventRaised);
+  }
+
+  TEST_METHOD(TestEvent_TwoArgsEventField) {
+    bool eventRaised = false;
+    m_builderMock.ExpectEvent(
+        L"RCTDeviceEventEmitter", L"OnTwoArgsEvent", [&eventRaised](JSValueArray const &args) noexcept {
+          TestCheckEqual(4, args[0]["X"]);
+          TestCheckEqual(2, args[0]["Y"]);
+          TestCheckEqual(12, args[1]["X"]);
+          TestCheckEqual(18, args[1]["Y"]);
+          eventRaised = true;
+        });
+
+    m_module->OnTwoArgsEvent(Point{/*X =*/4, /*Y =*/2}, Point{/*X =*/12, /*Y =*/18});
+    TestCheck(eventRaised);
+  }
+
   TEST_METHOD(TestEvent_JSNameEventField) {
     bool eventRaised = false;
-    m_builderMock.ExpectEvent(L"RCTDeviceEventEmitter", L"onPointEvent", [&eventRaised](JSValue const &arg) noexcept {
-      TestCheck(arg["X"] == 4);
-      TestCheck(arg["Y"] == 2);
-      eventRaised = true;
-    });
+    m_builderMock.ExpectEvent(
+        L"RCTDeviceEventEmitter", L"onPointEvent", [&eventRaised](JSValueArray const &args) noexcept {
+          TestCheck(args[0]["X"] == 4);
+          TestCheck(args[0]["Y"] == 2);
+          eventRaised = true;
+        });
 
     m_module->OnPointEvent(Point{/*X =*/4, /*Y =*/2});
     TestCheck(eventRaised == true);
@@ -1350,8 +1391,8 @@ TEST_CLASS (NativeModuleTest) {
 
   TEST_METHOD(TestEvent_JSEventEmitterEventField) {
     bool eventRaised = false;
-    m_builderMock.ExpectEvent(L"MyEventEmitter", L"onStringEvent", [&eventRaised](JSValue const &arg) noexcept {
-      TestCheck(arg == "Hello World!");
+    m_builderMock.ExpectEvent(L"MyEventEmitter", L"onStringEvent", [&eventRaised](JSValueArray const &args) noexcept {
+      TestCheckEqual("Hello World!", args[0]);
       eventRaised = true;
     });
 
@@ -1362,9 +1403,9 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestEvent_JSValueObjectEventField) {
     bool eventRaised = false;
     m_builderMock.ExpectEvent(
-        L"RCTDeviceEventEmitter", L"OnJSValueEvent", ([&eventRaised](JSValue const &arg) noexcept {
-          TestCheck(arg["X"] == 4);
-          TestCheck(arg["Y"] == 2);
+        L"RCTDeviceEventEmitter", L"OnJSValueEvent", ([&eventRaised](JSValueArray const &args) noexcept {
+          TestCheck(args[0]["X"] == 4);
+          TestCheck(args[0]["Y"] == 2);
           eventRaised = true;
         }));
 
@@ -1375,11 +1416,11 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestEvent_JSValueArrayEventField) {
     bool eventRaised = false;
     m_builderMock.ExpectEvent(
-        L"RCTDeviceEventEmitter", L"OnJSValueEvent", ([&eventRaised](JSValue const &arg) noexcept {
-          TestCheck(arg[0] == "X");
-          TestCheck(arg[1] == 4);
-          TestCheck(arg[2] == true);
-          TestCheck(arg[3]["Id"] == 42);
+        L"RCTDeviceEventEmitter", L"OnJSValueEvent", ([&eventRaised](JSValueArray const &args) noexcept {
+          TestCheck(args[0][0] == "X");
+          TestCheck(args[0][1] == 4);
+          TestCheck(args[0][2] == true);
+          TestCheck(args[0][3]["Id"] == 42);
           eventRaised = true;
         }));
 
@@ -1390,8 +1431,8 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestEvent_JSValueArray1EventField) {
     bool eventRaised = false;
     m_builderMock.ExpectEvent(
-        L"RCTDeviceEventEmitter", L"OnJSValueEvent", ([&eventRaised](JSValue const &arg) noexcept {
-          TestCheck(arg[0] == 4);
+        L"RCTDeviceEventEmitter", L"OnJSValueEvent", ([&eventRaised](JSValueArray const &args) noexcept {
+          TestCheck(args[0][0] == 4);
           eventRaised = true;
         }));
 
@@ -1437,6 +1478,18 @@ TEST_CLASS (NativeModuleTest) {
 
     m_module->JSLineFunction(Point{/*X =*/4, /*Y =*/2}, Point{/*X =*/12, /*Y =*/18});
     TestCheck(functionCalled == true);
+  }
+
+  TEST_METHOD(TestFunction_NoArgFunctionField) {
+    bool functionCalled = false;
+    m_builderMock.ExpectFunction(
+        L"SimpleNativeModule", L"NoArgFunction", [&functionCalled](JSValueArray const &args) noexcept {
+          TestCheckEqual(0, args.size());
+          functionCalled = true;
+        });
+
+    m_module->NoArgFunction();
+    TestCheck(functionCalled);
   }
 
   TEST_METHOD(TestFunction_JSModuleNameFunctionField) {

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -58,7 +58,7 @@ struct ReactModuleBuilderMock {
   void ExpectEvent(
       std::wstring_view eventEmitterName,
       std::wstring_view eventName,
-      Mso::Functor<void(JSValue const &)> &&checkValue) noexcept;
+      Mso::Functor<void(JSValueArray const &)> &&checkValues) noexcept;
 
   void ExpectFunction(
       std::wstring_view moduleName,

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -424,14 +424,7 @@ template <class... TArgs>
 inline void ReadArgs(IJSValueReader const &reader, /*out*/ TArgs &... args) noexcept {
   // Read as many arguments as we can or return default values.
   bool success = reader.ValueType() == JSValueType::Array;
-
-  if constexpr (sizeof...(args) != 0) {
-    // To read variadic template arguments in natural order we must use them in an initializer list.
-    // TODO: can we fold expression instead?
-    [[maybe_unused]] int dummy[] = {
-        (success = success && reader.GetNextArrayItem(), args = success ? ReadValue<TArgs>(reader) : TArgs{}, 0)...};
-  }
-
+  ((success = success && reader.GetNextArrayItem(), args = success ? ReadValue<TArgs>(reader) : TArgs{}), ...);
   success = success && SkipArrayToEnd(reader);
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -250,10 +250,7 @@ inline void WriteProperties(IJSValueWriter const &writer, T const &value) noexce
 template <class... TArgs>
 inline void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexcept {
   writer.WriteArrayBegin();
-  if constexpr (sizeof...(args) > 0) {
-    // To write variadic template arguments in natural order we must use them in an initializer list.
-    [[maybe_unused]] int dummy[] = {(WriteValue(writer, args), 0)...};
-  }
+  (WriteValue(writer, args), ...);
   writer.WriteArrayEnd();
 }
 

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
@@ -456,6 +456,14 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [ReactEvent]
     public Action<int> OnIntEvent = null;
 
+    // An event without arguments
+    [ReactEvent]
+    public Action OnNoArgEvent = null;
+
+    // An event with two arguments
+    [ReactEvent]
+    public Action<Point, Point> OnTwoArgsEvent = null;
+
     // Specify event name different from the field name.
     [ReactEvent("onPointEvent")]
     public Action<Point> OnPointEvent = null;
@@ -472,6 +480,14 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     // Property that allows to emit native module events.
     [ReactEvent]
     public Action<int> OnIntEventProp { get; set; }
+
+    // An event without arguments
+    [ReactEvent]
+    public Action OnNoArgEventProp { get; set; }
+
+    // An event with two arguments
+    [ReactEvent]
+    public Action<Point, Point> OnTwoArgsEventProp { get; set; }
 
     // Specify event name different from the property name.
     [ReactEvent("onPointEventProp")]
@@ -498,6 +514,10 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [ReactFunction("lineFunc")]
     public Action<Point, Point> JSLineFunction = null;
 
+    // Use no arguments.
+    [ReactFunction]
+    public Action NoArgFunction = null;
+
     // By default we use the module name from ReactModuleAttribute which is by default the class name.
     // Here we specify module name local for this function.
     [ReactFunction("stringFunc", ModuleName = "MyModule")]
@@ -518,6 +538,10 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     // Use two arguments. Specify JS function name different from the property name.
     [ReactFunction("lineFuncProp")]
     public Action<Point, Point> JSLineFunctionProp { get; set; }
+
+    // Use no arguments.
+    [ReactFunction]
+    public Action NoArgFunctionProp { get; set; }
 
     // By default we use the module name from ReactModuleAttribute which is by default the class name.
     // Here we specify module name local for this function.
@@ -1075,9 +1099,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_IntEventField()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnIntEvent", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnIntEvent", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(42, arg);
+        Assert.AreEqual(42, args[0]);
         eventRaised = true;
       });
 
@@ -1086,13 +1110,44 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     }
 
     [TestMethod]
+    public void TestEvent_NoArgEventField()
+    {
+      bool eventRaised = false;
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnNoArgEvent", (IReadOnlyList<JSValue> args) =>
+      {
+        Assert.AreEqual(0, args.Count);
+        eventRaised = true;
+      });
+
+      m_module.OnNoArgEvent();
+      Assert.IsTrue(eventRaised);
+    }
+
+    [TestMethod]
+    public void TestEvent_TwoArgsEventField()
+    {
+      bool eventRaised = false;
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnTwoArgsEvent", (IReadOnlyList<JSValue> args) =>
+      {
+        Assert.AreEqual(4, args[0]["X"]);
+        Assert.AreEqual(2, args[0]["Y"]);
+        Assert.AreEqual(12, args[1]["X"]);
+        Assert.AreEqual(18, args[1]["Y"]);
+        eventRaised = true;
+      });
+
+      m_module.OnTwoArgsEvent(new Point { X = 4, Y = 2 }, new Point { X = 12, Y = 18 });
+      Assert.IsTrue(eventRaised);
+    }
+
+    [TestMethod]
     public void TestEvent_JSNameEventField()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "onPointEvent", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "onPointEvent", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(4, arg["X"]);
-        Assert.AreEqual(2, arg["Y"]);
+        Assert.AreEqual(4, args[0]["X"]);
+        Assert.AreEqual(2, args[0]["Y"]);
         eventRaised = true;
       });
 
@@ -1104,9 +1159,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSEventEmitterEventField()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("MyEventEmitter", "onStringEvent", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("MyEventEmitter", "onStringEvent", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual("Hello World!", arg);
+        Assert.AreEqual("Hello World!", args[0]);
         eventRaised = true;
       });
 
@@ -1118,10 +1173,10 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSValueObjectEventField()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEvent", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEvent", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(4, arg["X"]);
-        Assert.AreEqual(2, arg["Y"]);
+        Assert.AreEqual(4, args[0]["X"]);
+        Assert.AreEqual(2, args[0]["Y"]);
         eventRaised = true;
       });
 
@@ -1133,12 +1188,12 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSValueArrayEventField()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEvent", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEvent", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual("X", arg[0]);
-        Assert.AreEqual(4, arg[1]);
-        Assert.AreEqual(true, arg[2]);
-        Assert.AreEqual(42, arg[3]["Id"]);
+        Assert.AreEqual("X", args[0][0]);
+        Assert.AreEqual(4, args[0][1]);
+        Assert.AreEqual(true, args[0][2]);
+        Assert.AreEqual(42, args[0][3]["Id"]);
         eventRaised = true;
       });
 
@@ -1150,9 +1205,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSValueArray1EventField()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEvent", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEvent", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(42, arg[0]);
+        Assert.AreEqual(42, args[0][0]);
         eventRaised = true;
       });
 
@@ -1164,9 +1219,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_IntEventProperty()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnIntEventProp", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnIntEventProp", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(42, arg);
+        Assert.AreEqual(42, args[0]);
         eventRaised = true;
       });
 
@@ -1174,14 +1229,46 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       Assert.IsTrue(eventRaised);
     }
 
+
+    [TestMethod]
+    public void TestEvent_NoArgEventProperty()
+    {
+      bool eventRaised = false;
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnNoArgEventProp", (IReadOnlyList<JSValue> args) =>
+      {
+        Assert.AreEqual(0, args.Count);
+        eventRaised = true;
+      });
+
+      m_module.OnNoArgEventProp();
+      Assert.IsTrue(eventRaised);
+    }
+
+    [TestMethod]
+    public void TestEvent_TwoArgsEventProperty()
+    {
+      bool eventRaised = false;
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnTwoArgsEventProp", (IReadOnlyList<JSValue> args) =>
+      {
+        Assert.AreEqual(4, args[0]["X"]);
+        Assert.AreEqual(2, args[0]["Y"]);
+        Assert.AreEqual(12, args[1]["X"]);
+        Assert.AreEqual(18, args[1]["Y"]);
+        eventRaised = true;
+      });
+
+      m_module.OnTwoArgsEventProp(new Point { X = 4, Y = 2 }, new Point { X = 12, Y = 18 });
+      Assert.IsTrue(eventRaised);
+    }
+
     [TestMethod]
     public void TestEvent_JSNameEventProperty()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "onPointEventProp", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "onPointEventProp", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(4, arg["X"]);
-        Assert.AreEqual(2, arg["Y"]);
+        Assert.AreEqual(4, args[0]["X"]);
+        Assert.AreEqual(2, args[0]["Y"]);
         eventRaised = true;
       });
 
@@ -1193,9 +1280,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSEventEmitterEventProperty()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("MyEventEmitter", "onStringEventProp", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("MyEventEmitter", "onStringEventProp", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual("Hello World!", arg);
+        Assert.AreEqual("Hello World!", args[0]);
         eventRaised = true;
       });
 
@@ -1207,10 +1294,10 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSValueObjectEventProperty()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEventProp", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEventProp", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(4, arg["X"]);
-        Assert.AreEqual(2, arg["Y"]);
+        Assert.AreEqual(4, args[0]["X"]);
+        Assert.AreEqual(2, args[0]["Y"]);
         eventRaised = true;
       });
 
@@ -1222,12 +1309,12 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSValueArrayEventProperty()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEventProp", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEventProp", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual("X", arg[0]);
-        Assert.AreEqual(4, arg[1]);
-        Assert.AreEqual(true, arg[2]);
-        Assert.AreEqual(42, arg[3]["Id"]);
+        Assert.AreEqual("X", args[0][0]);
+        Assert.AreEqual(4, args[0][1]);
+        Assert.AreEqual(true, args[0][2]);
+        Assert.AreEqual(42, args[0][3]["Id"]);
         eventRaised = true;
       });
 
@@ -1239,9 +1326,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void TestEvent_JSValueArray1EventProperty()
     {
       bool eventRaised = false;
-      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEventProp", (JSValue arg) =>
+      m_moduleBuilderMock.ExpectEvent("RCTDeviceEventEmitter", "OnJSValueEventProp", (IReadOnlyList<JSValue> args) =>
       {
-        Assert.AreEqual(42, arg[0]);
+        Assert.AreEqual(42, args[0][0]);
         eventRaised = true;
       });
 
@@ -1279,7 +1366,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     }
 
     [TestMethod]
-    public void TestFunction_TwoArgFunctionField()
+    public void TestFunction_TwoArgsFunctionField()
     {
       bool functionCalled = false;
       m_moduleBuilderMock.ExpectFunction("SimpleNativeModule", "lineFunc", (IReadOnlyList<JSValue> args) =>
@@ -1292,6 +1379,20 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       });
 
       m_module.JSLineFunction(new Point { X = 4, Y = 2 }, new Point { X = 12, Y = 18 });
+      Assert.IsTrue(functionCalled);
+    }
+
+    [TestMethod]
+    public void TestFunction_NoArgFunctionField()
+    {
+      bool functionCalled = false;
+      m_moduleBuilderMock.ExpectFunction("SimpleNativeModule", "NoArgFunction", (IReadOnlyList<JSValue> args) =>
+      {
+        Assert.AreEqual(0, args.Count);
+        functionCalled = true;
+      });
+
+      m_module.NoArgFunction();
       Assert.IsTrue(functionCalled);
     }
 
@@ -1371,7 +1472,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     }
 
     [TestMethod]
-    public void TestFunction_TwoArgFunctionProperty()
+    public void TestFunction_TwoArgsFunctionProperty()
     {
       bool functionCalled = false;
       m_moduleBuilderMock.ExpectFunction("SimpleNativeModule", "lineFuncProp", (IReadOnlyList<JSValue> args) =>
@@ -1384,6 +1485,20 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       });
 
       m_module.JSLineFunctionProp(new Point { X = 4, Y = 2 }, new Point { X = 12, Y = 18 });
+      Assert.IsTrue(functionCalled);
+    }
+
+    [TestMethod]
+    public void TestFunction_NoArgFunctionProperty()
+    {
+      bool functionCalled = false;
+      m_moduleBuilderMock.ExpectFunction("SimpleNativeModule", "NoArgFunctionProp", (IReadOnlyList<JSValue> args) =>
+      {
+        Assert.AreEqual(0, args.Count);
+        functionCalled = true;
+      });
+
+      m_module.NoArgFunctionProp();
       Assert.IsTrue(functionCalled);
     }
 

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -226,13 +226,14 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       return constantWriter.TakeValue().AsObject();
     }
 
-    public void ExpectEvent(string eventEmitterName, string eventName, Action<JSValue> checkValue)
+    public void ExpectEvent(string eventEmitterName, string eventName, Action<IReadOnlyList<JSValue>> checkValues)
     {
       m_jsEventHandler = (string actualEventEmitterName, string actualEventName, JSValue value) =>
       {
         Assert.AreEqual(eventEmitterName, actualEventEmitterName);
         Assert.AreEqual(eventName, actualEventName);
-        checkValue(value);
+        Assert.AreEqual(JSValueType.Array, value.Type);
+        checkValues(value.AsArray());
       };
     }
 
@@ -257,7 +258,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public void EmitJSEvent(string eventEmitterName, string eventName, JSValueArgWriter paramsArgWriter)
     {
       var writer = new JSValueTreeWriter();
+      writer.WriteArrayBegin();
       paramsArgWriter(writer);
+      writer.WriteArrayEnd();
       m_jsEventHandler(eventEmitterName, eventName, writer.TakeValue());
     }
   }

--- a/vnext/Microsoft.ReactNative.SharedManaged/ReactContextExtensions.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/ReactContextExtensions.cs
@@ -56,9 +56,90 @@ namespace Microsoft.ReactNative.Managed
       reactContext.CallJSFunction(moduleName, methodName, (IJSValueWriter writer) => writer.WriteArgs(arg1, arg2, arg3, arg4, arg5, arg6, arg7));
     }
 
-    public static void EmitJSEvent<T>(this IReactContext reactContext, string eventEmitterName, string eventName, T arg)
+    public static void EmitJSEvent(this IReactContext reactContext, string eventEmitterName, string eventName)
     {
-      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) => writer.WriteValue(arg));
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) => {});
+    }
+
+    public static void EmitJSEvent<T1>(this IReactContext reactContext, string eventEmitterName, string eventName, T1 arg1)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+      });
+    }
+
+    public static void EmitJSEvent<T1, T2>(this IReactContext reactContext, string eventEmitterName, string eventName, T1 arg1, T2 arg2)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+        writer.WriteValue(arg2);
+      });
+    }
+
+    public static void EmitJSEvent<T1, T2, T3>(this IReactContext reactContext, string eventEmitterName, string eventName, T1 arg1, T2 arg2, T3 arg3)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+        writer.WriteValue(arg2);
+        writer.WriteValue(arg3);
+      });
+    }
+
+    public static void EmitJSEvent<T1, T2, T3, T4>(this IReactContext reactContext,
+      string eventEmitterName, string eventName, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+        writer.WriteValue(arg2);
+        writer.WriteValue(arg3);
+        writer.WriteValue(arg4);
+      });
+    }
+
+    public static void EmitJSEvent<T1, T2, T3, T4, T5>(this IReactContext reactContext,
+      string eventEmitterName, string eventName, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+        writer.WriteValue(arg2);
+        writer.WriteValue(arg3);
+        writer.WriteValue(arg4);
+        writer.WriteValue(arg5);
+      });
+    }
+
+    public static void EmitJSEvent<T1, T2, T3, T4, T5, T6>(this IReactContext reactContext,
+      string eventEmitterName, string eventName, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+        writer.WriteValue(arg2);
+        writer.WriteValue(arg3);
+        writer.WriteValue(arg4);
+        writer.WriteValue(arg5);
+        writer.WriteValue(arg6);
+      });
+    }
+
+    public static void EmitJSEvent<T1, T2, T3, T4, T5, T6, T7>(this IReactContext reactContext,
+      string eventEmitterName, string eventName, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+    {
+      reactContext.EmitJSEvent(eventEmitterName, eventName, (IJSValueWriter writer) =>
+      {
+        writer.WriteValue(arg1);
+        writer.WriteValue(arg2);
+        writer.WriteValue(arg3);
+        writer.WriteValue(arg4);
+        writer.WriteValue(arg5);
+        writer.WriteValue(arg6);
+        writer.WriteValue(arg7);
+      });
     }
   }
 }


### PR DESCRIPTION
In the previous implementation of REACT_EVENT we only supported one argument for event handlers. It seemed to be the most common case. According to the issue #4401, the ReactNative events could support a variadic set of arguments 0..n. In this PR we are addressing this issue for C++ and C# code.
New unit tests are added to verify new scenarios.

Minor related change: start using C++17 folding expressions instead of array initializers to implement variadic argument reading/writing.

Closes #4401 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4426)