### PR TITLE
Enable basic V8 direct debugging

### DIFF
--- a/change/react-native-windows-2020-03-25-16-16-54-HEAD.json
+++ b/change/react-native-windows-2020-03-25-16-16-54-HEAD.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Enable basic V8 direct debugging",
+  "packageName": "react-native-windows",
+  "email": "tudorm@microsoft.com",
+  "commit": "0b6e5cd38488a9e5f5214a66c822d62c6dc066df",
+  "dependentChangeType": "patch",
+  "date": "2020-03-25T23:16:54.732Z"
+}

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.cpp
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.cpp
@@ -164,6 +164,11 @@ std::shared_ptr<facebook::jsi::Runtime> V8JSIRuntimeHolder::getRuntime() noexcep
 void V8JSIRuntimeHolder::initRuntime() noexcept {
   v8runtime::V8RuntimeArgs args{};
 
+  if (debuggerPort_ > 0) {
+    args.inspectorPort = debuggerPort_;
+  }
+  args.enableInspector = useDirectDebugger_;
+
   args.foreground_task_runner =
       std::make_unique<TaskRunnerAdapter>(std::make_shared<ReactQueueBackedTaskRunner>(jsQueue_));
   args.scriptStore = std::move(scriptStore_);

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.cpp
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.cpp
@@ -164,9 +164,9 @@ std::shared_ptr<facebook::jsi::Runtime> V8JSIRuntimeHolder::getRuntime() noexcep
 void V8JSIRuntimeHolder::initRuntime() noexcept {
   v8runtime::V8RuntimeArgs args{};
 
-  if (debuggerPort_ > 0) {
+  if (debuggerPort_ > 0)
     args.inspectorPort = debuggerPort_;
-  }
+
   args.enableInspector = useDirectDebugger_;
 
   args.foreground_task_runner =

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
@@ -19,7 +19,9 @@ class V8JSIRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
       std::unique_ptr<facebook::jsi::ScriptStore> &&scriptStore,
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept
-      : jsQueue_(std::move(jsQueue)),
+      : useDirectDebugger_(devSettings->useDirectDebugger),
+        debuggerPort_(devSettings->debuggerPort),
+        jsQueue_(std::move(jsQueue)),
         scriptStore_(std::move(scriptStore)),
         preparedScriptStore_(std::move(preparedScriptStore)) {}
 
@@ -34,6 +36,9 @@ class V8JSIRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
 
   std::once_flag once_flag_;
   std::thread::id own_thread_id_;
+
+  uint16_t debuggerPort_;
+  bool useDirectDebugger_;
 };
 
 } // namespace react


### PR DESCRIPTION
The V8 JSI inspector supports only limited scenarios, will always break on first line and will crash the process on detach.
This is just an early preview to enable basic debugging and profiling of the V8JSI runtime.

(This cherry picks the changes already submitted to 0.60-stable)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4427)