### PR TITLE
Add timeout to certificate generation on project init

### DIFF
--- a/change/react-native-windows-2020-03-26-09-13-41-certtimeout.json
+++ b/change/react-native-windows-2020-03-26-09-13-41-certtimeout.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add a timeout to catch hangs during cert generation",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-26T16:13:40.983Z"
+}

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -21,11 +21,12 @@ function generateCertificate(srcPath, destPath, newProjectName, currentUser) {
   let toCopyTempKey = false;
   if (os.platform() === 'win32') {
     try {
-      const thumbprint = childProcess.execSync(`powershell -command "Write-Output (New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject 'CN=${currentUser}' -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}Subject Type:End Entity') -CertStoreLocation 'Cert:\\CurrentUser\\My').Thumbprint"`).toString().trim();
+      const timeout = 10000; // 10 seconds;
+      const thumbprint = childProcess.execSync(`powershell -command "Write-Output (New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject 'CN=${currentUser}' -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}Subject Type:End Entity') -CertStoreLocation 'Cert:\\CurrentUser\\My').Thumbprint"`, {timeout}).toString().trim();
       if (!fs.existsSync(path.join(windowsDir, newProjectName))) {
         fs.createDir(path.join(windowsDir, newProjectName));
       }
-      childProcess.execSync(`powershell -command "$pwd = (ConvertTo-SecureString -String password -Force -AsPlainText); Export-PfxCertificate -Cert 'cert:\\CurrentUser\\My\\${thumbprint}' -FilePath ${path.join(windowsDir, newProjectName, newProjectName)}_TemporaryKey.pfx -Password $pwd"`);
+      childProcess.execSync(`powershell -command "$pwd = (ConvertTo-SecureString -String password -Force -AsPlainText); Export-PfxCertificate -Cert 'cert:\\CurrentUser\\My\\${thumbprint}' -FilePath ${path.join(windowsDir, newProjectName, newProjectName)}_TemporaryKey.pfx -Password $pwd"`, {timeout});
       console.log(chalk.green('Self-signed certificate generated successfully.'));
       return thumbprint;
       } catch (err) {


### PR DESCRIPTION
Fixes #3930 

Another attempt at ensuring that project init doesn't hang.  #4423 helped on my local machine at least.  But user feedback is that that didn't prevent all the hangs.  -- So I'm adding a 15 second timeout to the certificate generation.  If it timesout it will fallback to the placeholder cert, as it does on other failures, or when generating from a non-windows box.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4430)