### PR TITLE
Provide better feedback when RN version has no matching RNW version

### DIFF
--- a/change/react-native-windows-init-2020-03-26-12-07-31-newerrn.json
+++ b/change/react-native-windows-init-2020-03-26-12-07-31-newerrn.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Provide better feedback when RN version has no matching RNW version",
+  "packageName": "react-native-windows-init",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-26T19:07:31.483Z"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -231,7 +231,12 @@ function isProjectUsingYarn(cwd: string) {
     const rnwResolvedVersion = await getLatestMatchingRNWVersion(version);
 
     if (!rnwResolvedVersion) {
-      if (!argv.version) {
+      if (argv.version) {
+        console.error(
+          `Error: No version of react-native-windows@${argv.version} found`,
+        );
+        process.exit(EXITCODE_NO_MATCHING_RNW);
+      } else {
         const rnwLatestVersion = await getLatestRNWVersion();
         console.error(
           `
@@ -251,11 +256,6 @@ Please modify your application to use ${chalk.green(
 `,
         );
         process.exit(EXITCODE_NO_AUTO_MATCHING_RNW);
-      } else {
-        console.error(
-          `Error: No version of react-native-windows@${argv.version} found`,
-        );
-        process.exit(EXITCODE_NO_MATCHING_RNW);
       }
     }
 


### PR DESCRIPTION
With the publication of RN 0.62, we now get into a case where there isn't a matching version of RNW for the latest RN.

This PR improves the error message when you install RN 0.62 and try to init RNW:

```
>npx react-native init myproject
>cd myproject
>npx react-native-windows-init
No compatible version of react-native-windows found.
The latest supported version is react-native-windows@0.61.0.
Please modify your application to use react-native@^0.61 or another supported version of react-native and try again.
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4433)