### PR TITLE
Do Not Override NPM Tag Based on Branch Name

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -40,16 +40,9 @@ jobs:
           script: yarn build
 
       - task: CmdLine@2
-        displayName: Beachball Publish (for master)
+        displayName: Beachball Publish
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js publish -n $(npmAuthToken) --yes -m "applying package updates ***NO_CI***" --bump-deps --access public
-        condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
-
-      - task: CmdLine@2
-        displayName: Beachball Publish (for other branches)
-        inputs:
-          script: node ./node_modules/beachball/bin/beachball.js publish --tag v$(Build.SourceBranchName) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
-        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
+          script: node ./node_modules/beachball/bin/beachball.js publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
 
       - task: CmdLine@2
         displayName: Set Version Env Vars

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -46,9 +46,13 @@ steps:
       node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
     displayName: Add npm user to verdaccio
 
-  - script: |
-      npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) --no-push --registry http://localhost:4873 --yes --access public
+  - task: PowerShell@2
     displayName: Publish packages to verdaccio
+    inputs:
+      targetType: inline
+      script: |
+        $env:SYSTEM_PULLREQUEST_TARGETBRANCH -match 'refs/heads/(.*)'
+        npx --no-install beachball publish --branch $Matches[1] --no-push --registry http://localhost:4873 --yes --access public
 
   - task: CmdLine@2
     displayName: Install react-native cli

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -47,7 +47,7 @@ steps:
     displayName: Add npm user to verdaccio
 
   - script: |
-      npx --no-install beachball publish --no-push --registry http://localhost:4873 --yes --access public
+      npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) --no-push --registry http://localhost:4873 --yes --access public
     displayName: Publish packages to verdaccio
 
   - task: CmdLine@2

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -46,13 +46,9 @@ steps:
       node .ado/npmAddUser.js user pass mail@nomail.com http://localhost:4873
     displayName: Add npm user to verdaccio
 
-  - task: PowerShell@2
+  - script: |
+      npx --no-install beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
     displayName: Publish packages to verdaccio
-    inputs:
-      targetType: inline
-      script: |
-        $env:SYSTEM_PULLREQUEST_TARGETBRANCH -match 'refs/heads/(.*)'
-        npx --no-install beachball publish --branch $Matches[1] --no-push --registry http://localhost:4873 --yes --access public
 
   - task: CmdLine@2
     displayName: Install react-native cli

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -440,10 +440,13 @@ jobs:
         inputs:
           script: yarn install --frozen-lockfile
 
-      - task: CmdLine@2
+      - task: PowerShell@2
         displayName: Check for change files
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(Build.SourceBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+          targetType: inline
+          script: |
+            $env:SYSTEM_PULLREQUEST_TARGETBRANCH -match 'refs/heads/(.*)'
+            node ./node_modules/beachball/bin/beachball.js check --branch $Matches[1] --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn format:verify

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -440,14 +440,10 @@ jobs:
         inputs:
           script: yarn install --frozen-lockfile
 
-      - task: PowerShell@2
+      - task: CmdLine@2
         displayName: Check for change files
         inputs:
-          targetType: inline
-          script: |
-            echo $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-            $env:SYSTEM_PULLREQUEST_TARGETBRANCH -match 'refs/heads/(.*)'
-            node ./node_modules/beachball/bin/beachball.js check --branch $Matches[1] --changehint "Run `yarn change` from root of repo to generate a change file."
+          script: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(System.PullRequest.TargetBranch) --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn format:verify

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -445,6 +445,7 @@ jobs:
         inputs:
           targetType: inline
           script: |
+            echo $env:SYSTEM_PULLREQUEST_TARGETBRANCH
             $env:SYSTEM_PULLREQUEST_TARGETBRANCH -match 'refs/heads/(.*)'
             node ./node_modules/beachball/bin/beachball.js check --branch $Matches[1] --changehint "Run `yarn change` from root of repo to generate a change file."
 

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -443,7 +443,7 @@ jobs:
       - task: CmdLine@2
         displayName: Check for change files
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js check --changehint "Run `yarn change` from root of repo to generate a change file."
+          script: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(Build.SourceBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn format:verify

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -205,7 +205,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Check for change files
-        run: node ./node_modules/beachball/bin/beachball.js check --changehint "Run `yarn change` from root of repo to generate a change file."
+        run: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(Build.SourceBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - run: yarn format:verify
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -205,7 +205,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Check for change files
-        run: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(Build.SourceBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+        run: node ./node_modules/beachball/bin/beachball.js check --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - run: yarn format:verify
 


### PR DESCRIPTION
Even the legacy CLI doesn't seem to rely on `v${branch}` tags (or current ore master), and they trample over anything we set in package.json. Stop tagging these so we an clean up npm tags.

While we're here, we try to inject the current branch name into more brachball logic in CI so we can avoid more changes while branching to stable releases.

Will cherry-pick this into 0.60-stable and 0.61-stable once in master.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4434)