### PR TITLE
Publish Master Using "0.0.0-master.x" Version Scheme

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: react-native windows --template beta --overwrite --language ${{ parameters.language }}
+      script: react-native windows --template master --overwrite --language ${{ parameters.language }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: NuGetCommand@2

--- a/change/@office-iss-react-native-win32-2020-03-23-16-12-52-master-versioning.json
+++ b/change/@office-iss-react-native-win32-2020-03-23-16-12-52-master-versioning.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "0.0.0 Master Versioning Scheme",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "commit": "92fed98e0286502c8c4eaf5871f42dff1160b0a1",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T23:12:50.384Z"
+}

--- a/change/react-native-windows-2020-03-23-16-12-52-master-versioning.json
+++ b/change/react-native-windows-2020-03-23-16-12-52-master-versioning.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "0.0.0 Master Versioning Scheme",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "92fed98e0286502c8c4eaf5871f42dff1160b0a1",
+  "dependentChangeType": "patch",
+  "date": "2020-03-23T23:12:52.131Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-windows": "0.61.0-beta.74",
+    "react-native-windows": "0.0.0-master.0",
     "rnpm-plugin-windows": "^0.6.1"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-windows": "0.61.0-beta.74",
+    "react-native-windows": "0.0.0-master.0",
     "rnpm-plugin-windows": "^0.6.1"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-windows": "0.61.0-beta.74",
+    "react-native-windows": "0.0.0-master.0",
     "rnpm-plugin-windows": "^0.6.1"
   },
   "devDependencies": {

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -64,7 +64,7 @@
     "react-native": "0.61.5"
   },
   "beachball": {
-    "defaultNpmTag": "beta",
+    "defaultNpmTag": "master",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-iss/react-native-win32",
-  "version": "0.61.0-beta.16",
+  "version": "0.0.0-master.0",
   "description": "Implementation of react native on top of Office's Win32 platform.",
   "license": "MIT",
   "main": "./Libraries/react-native/react-native-implementation.win32.js",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows",
-  "version": "0.61.0-beta.74",
+  "version": "0.0.0-master.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -62,7 +62,7 @@
     "react-native": "0.61.5"
   },
   "beachball": {
-    "defaultNpmTag": "beta",
+    "defaultNpmTag": "master",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
This change will start publishing our master branch using the 0.0.0 versioning scheme (with the next release being 0.0.0-master.1). 0.61 has been forked to stable, so it makes sense to do this now to avoid overlapping beta and stable releases.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4435)