### PR TITLE
Use new init package instead of legacy rnpm one in CI

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -51,9 +51,14 @@ steps:
     displayName: Publish packages to verdaccio
 
   - task: CmdLine@2
+    displayName: Install react-native cli
+    inputs:
+      script: npm install -g react-native-cli
+
+  - task: CmdLine@2
     displayName: Init new project
     inputs:
-      script: npx react-native init testcli --version ${{ parameters.version }}
+      script: react-native init testcli --version ${{ parameters.version }}
       workingDirectory: $(Agent.BuildDirectory)
 
   - task: CmdLine@2
@@ -108,5 +113,5 @@ steps:
   - task: CmdLine@2
     displayName: Create bundle testcli
     inputs:
-      script: npx react-native bundle --entry-file index.js platform windows --bundle-output test.bundle
+      script: react-native bundle --entry-file index.js platform windows --bundle-output test.bundle
       workingDirectory: $(Agent.BuildDirectory)\testcli

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -51,26 +51,15 @@ steps:
     displayName: Publish packages to verdaccio
 
   - task: CmdLine@2
-    displayName: Install react-native cli
-    inputs:
-      script: npm install -g react-native-cli
-
-  - task: CmdLine@2
     displayName: Init new project
     inputs:
-      script: react-native init testcli --version ${{ parameters.version }}
+      script: npx react-native init testcli --version ${{ parameters.version }}
       workingDirectory: $(Agent.BuildDirectory)
-
-  - task: CmdLine@2
-    displayName: Install rnpm-plugin-windows
-    inputs:
-      script: yarn add rnpm-plugin-windows
-      workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: react-native windows --template beta --overwrite --language ${{ parameters.language }}
+      script: npx react-native-windows-init --version beta --overwrite --language ${{ parameters.language }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: NuGetCommand@2
@@ -119,5 +108,5 @@ steps:
   - task: CmdLine@2
     displayName: Create bundle testcli
     inputs:
-      script: react-native bundle --entry-file index.js platform windows --bundle-output test.bundle
+      script: npx react-native bundle --entry-file index.js platform windows --bundle-output test.bundle
       workingDirectory: $(Agent.BuildDirectory)\testcli

--- a/packages/microsoft-reactnative-sampleapps/index.windows.js
+++ b/packages/microsoft-reactnative-sampleapps/index.windows.js
@@ -18,6 +18,8 @@ import {
 
 import { NativeModules, NativeEventEmitter } from 'react-native';
 
+import {MyComp} from './myComp';
+
 // Creating event emitters
 const SampleModuleCSEmitter = new NativeEventEmitter(NativeModules.SampleModuleCS);
 const SampleModuleCppEmitter = new NativeEventEmitter(NativeModules.SampleModuleCpp);
@@ -63,7 +65,7 @@ class SampleApp extends Component {
 
     Linking.getInitialURL()
       .then(url => log('Initial URL is: ' + url))
-      .catch(err => log('An error occurred: '+ err));
+      .catch(err => log('An error occurred: ' + err));
   }
 
   componentWillUnmount() {
@@ -267,6 +269,8 @@ class SampleApp extends Component {
   render() {
     return (
       <View style={styles.container}>
+
+        <MyComp/>
         <Text style={styles.welcome}>
           SampleApp
         </Text>

--- a/packages/microsoft-reactnative-sampleapps/myComp.js
+++ b/packages/microsoft-reactnative-sampleapps/myComp.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+
+class MyComp extends Component {
+
+    render() {
+        return (
+        <View style={styles.container}>
+          <Text style={styles.welcome}>
+            My Component!
+          </Text>
+        </View>
+      );
+    }
+  }
+
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 0,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: '#F5FCFF',
+    },
+    welcome: {
+      fontSize: 20,
+      textAlign: 'center',
+      color: 'green',
+      margin: 10,
+    },
+});
+
+module.exports = {
+    MyComp,
+};


### PR DESCRIPTION
This moves our CI task to use the new method of creating a new app. 

OLD:

```cmd
npx react-native init <myproject> --version 0.61.5
cd <myproject>
yarn add rpnm-react-native-windows
npx react-native windows
```

NEW:

```cmd
npx react-native init <myproject> --version 0.61.5
cd <myproject>
npx react-native-windows-init
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4437)