### PR TITLE
Some Direct Debugging fixes

### DIFF
--- a/change/react-native-windows-2020-03-27-11-52-38-dd.json
+++ b/change/react-native-windows-2020-03-27-11-52-38-dd.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix direct debugging",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-27T18:52:38.219Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -319,15 +319,16 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
     auto instanceWrapper = m_instanceWrapper.LoadWithLock();
     instanceWrapper->loadBundle(Mso::Copy(m_options.Identity));
 
-    m_jsMessageThread.Load()->runOnQueue(
-        [weakThis = Mso::WeakPtr{this},
-         loadCallbackGuard = Mso::MakeMoveOnCopyWrapper(LoadedCallbackGuard{*this})]() noexcept {
-          if (auto strongThis = weakThis.GetStrongPtr()) {
-            if (strongThis->State() != ReactInstanceState::HasError) {
-              strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
-            }
-          }
-        });
+    m_jsMessageThread.Load()->runOnQueue([
+      weakThis = Mso::WeakPtr{this},
+      loadCallbackGuard = Mso::MakeMoveOnCopyWrapper(LoadedCallbackGuard{*this})
+    ]() noexcept {
+      if (auto strongThis = weakThis.GetStrongPtr()) {
+        if (strongThis->State() != ReactInstanceState::HasError) {
+          strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
+        }
+      }
+    });
   } else {
     m_jsMessageThread.Load()->runOnQueue([
       weakThis = Mso::WeakPtr{this},

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -519,6 +519,7 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
           m_useWebDebugger = !m_useWebDebugger;
+          m_directDebugging = false; // Remote debugging is incompatible with direct debugging
           ReloadHost();
         });
 
@@ -527,11 +528,12 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
           m_directDebugging = !m_directDebugging;
+          m_useWebDebugger = false; // Remote debugging is incompatible with direct debugging
           ReloadHost();
         });
 
     breakOnNextLineText.Text(m_breakOnNextLine ? L"Disable Break on First Line" : L"Enable Break on First Line");
-    m_breakOnNextLineRevoker = directDebugButton.Click(
+    m_breakOnNextLineRevoker = breakOnNextLineButton.Click(
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
           m_breakOnNextLine = !m_breakOnNextLine;

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -81,6 +81,8 @@ struct DevSettings {
   /// is loaded.
   bool useWebDebugger{false};
 
+  bool useFastRefresh{false};
+
   // Enables ChakraCore console redirection to debugger
   bool debuggerConsoleRedirection{false};
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -510,7 +510,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       m_devSettings->errorCallback(e.what());
       return;
     }
-  } else if (m_devSettings->liveReloadCallback != nullptr) {
+  } else if (m_devSettings->liveReloadCallback != nullptr || m_devSettings->useFastRefresh) {
     auto jsBundleString = m_devManager->GetJavaScriptFromServer(
         m_devSettings->debugHost, jsBundleRelativePath, m_devSettings->platformName);
 


### PR DESCRIPTION
### Fix crash when enabling direct debugging at run-time using the dev menu
This was caused by a bad hook up the UI buttons, where the break at next statement and direct debugging callback were both hooked up to the direct debugging button.

### Direct debugging does not work with FastRefresh
Currently either webdebugging or livereload are the conditions to get the bundle from the metro server.  We should include fastRefresh in that logic.

### Before using direct debugging, the user has to disable remote debugging
Direct Debugging is fundamentally incompatible with remote debugging.  Previously the user had to manually disable one before enabling the other.  This PR toggles the other one for you.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4440)