### PR TITLE
[0.61] Do Not Override NPM Tag Based on Branch Name (#4434)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -39,16 +39,9 @@ jobs:
           script: yarn build
 
       - task: CmdLine@2
-        displayName: Beachball Publish (for master)
+        displayName: Beachball Publish
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js publish -n $(npmAuthToken) --yes -m "applying package updates ***NO_CI***" --bump-deps --access public
-        condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
-
-      - task: CmdLine@2
-        displayName: Beachball Publish (for other branches)
-        inputs:
-          script: node ./node_modules/beachball/bin/beachball.js publish --tag v$(Build.SourceBranchName) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
-        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
+          script: node ./node_modules/beachball/bin/beachball.js publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
 
       - task: CmdLine@2
         displayName: Set Version Env Vars

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -47,7 +47,7 @@ steps:
     displayName: Add npm user to verdaccio
 
   - script: |
-      npx --no-install beachball publish --branch origin/0.61-stable --no-push --registry http://localhost:4873 --yes --access public
+      npx --no-install beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public
     displayName: Publish packages to verdaccio
 
   - task: CmdLine@2

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -494,7 +494,7 @@ jobs:
       - task: CmdLine@2
         displayName: Check for change files
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js check --changehint "Run `yarn change` from root of repo to generate a change file." -b 0.61-stable
+          script: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(System.PullRequest.TargetBranch) --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn format:verify


### PR DESCRIPTION
* Do not Override NPM Tag Based on Branch Name

Even the legacy CLI doesn't seem to rely on `v${branch}` tags (or current ore master), and they trample over anything we set in package.json. Stop tagging these so we an clean up npm tags.

While we're here, we try to inject the current branch name into more brachball logic in CI so we can avoid more changes while branching to stable releases.

Will cherry-pick this into 0.60-stable and 0.61-stable once in master.

* Try massaging PR target branch var for Beachball

* Echo CI info

* Use System.PullRequest.TargetBranch without massaging

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4441)