### PR TITLE
[0.60] Do Not Override NPM Tag Based on Branch Name (#4434)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -38,16 +38,9 @@ jobs:
           script: yarn build
 
       - task: CmdLine@2
-        displayName: Beachball Publish (for master)
+        displayName: Beachball Publish
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js publish -n $(npmAuthToken) --yes -m "applying package updates ***NO_CI***" --bump-deps --access public
-        condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
-
-      - task: CmdLine@2
-        displayName: Beachball Publish (for other branches)
-        inputs:
-          script: node ./node_modules/beachball/bin/beachball.js publish --tag v$(Build.SourceBranchName) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
-        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
+          script: node ./node_modules/beachball/bin/beachball.js publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
 
       - task: CmdLine@2
         displayName: Set Version Env Vars

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -399,7 +399,7 @@ jobs:
       - task: CmdLine@2
         displayName: Check for change files
         inputs:
-          script: node ./node_modules/beachball/bin/beachball.js check --changehint "Run `yarn change` from root of repo to generate a change file." -b 0.60-stable
+          script: node ./node_modules/beachball/bin/beachball.js check --branch origin/$(System.PullRequest.TargetBranch) --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn format:verify

--- a/change/@office-iss-react-native-win32-2020-03-27-15-10-36-no-tag-60.json
+++ b/change/@office-iss-react-native-win32-2020-03-27-15-10-36-no-tag-60.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Do Not Override NPM Tag Based on Branch Name (#4434)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "commit": "5933a05f87a12eaf4a483b12e339131128531962",
+  "dependentChangeType": "patch",
+  "date": "2020-03-27T22:10:29.063Z"
+}

--- a/change/react-native-windows-2020-03-27-15-10-36-no-tag-60.json
+++ b/change/react-native-windows-2020-03-27-15-10-36-no-tag-60.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Do Not Override NPM Tag Based on Branch Name (#4434)",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "5933a05f87a12eaf4a483b12e339131128531962",
+  "dependentChangeType": "patch",
+  "date": "2020-03-27T22:10:36.851Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -58,5 +58,13 @@
   "peerDependencies": {
     "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
     "react": "16.8.6"
+  },
+  "beachball": {
+    "defaultNpmTag": "v0.60-stable",
+    "disallowedChangeTypes": [
+      "major",
+      "minor",
+      "patch"
+    ]
   }
 }

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -60,7 +60,6 @@
     "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
-    "defaultNpmTag": "vnext",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -60,6 +60,7 @@
     "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
+    "defaultNpmTag": "v0.60-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
* Do not Override NPM Tag Based on Branch Name

Even the legacy CLI doesn't seem to rely on `v${branch}` tags (or current ore master), and they trample over anything we set in package.json. Stop tagging these so we an clean up npm tags.

While we're here, we try to inject the current branch name into more brachball logic in CI so we can avoid more changes while branching to stable releases.

Will cherry-pick this into 0.60-stable and 0.61-stable once in master.

* Try massaging PR target branch var for Beachball

* Echo CI info

* Use System.PullRequest.TargetBranch without massaging

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4442)