### PR TITLE
Remove extra blank lines in windows generator templates.

### DIFF
--- a/change/react-native-windows-2020-03-27-17-22-39-remove-blank-lines.json
+++ b/change/react-native-windows-2020-03-27-17-22-39-remove-blank-lines.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove blank lines in templates",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "commit": "09f8b38ce8d8d6f1515bd9417d2d4153bf0f4d35",
+  "dependentChangeType": "patch",
+  "date": "2020-03-28T00:22:39.475Z"
+}

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
@@ -2,9 +2,7 @@
 
 #include "App.h"
 #include "ReactPackageProvider.h"
-
 // clang-format off
-
 using namespace winrt::<%=ns%>;
 using namespace winrt::<%=ns%>::implementation;
 

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "App.xaml.g.h"
-
 // clang-format off
-
 namespace winrt::<%=ns%>::implementation
 {
     struct App : AppT<App>

--- a/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.cpp
@@ -1,10 +1,7 @@
 #include "pch.h"
 #include "ReactPackageProvider.h"
-
 #include "NativeModules.h"
-
 // clang-format off
-
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::<%=ns%>::implementation

--- a/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "winrt/Microsoft.ReactNative.h"
-
 // clang-format off
-
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::<%=ns%>::implementation


### PR DESCRIPTION
Too many blank lines in the generated files, cleaning up.

<img src="https://user-images.githubusercontent.com/4424330/77810182-6573bd80-7050-11ea-8e21-c07ffbf35dec.png" width=300/>


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4445)