### PR TITLE
Explicitly disallow prerelease changes in 0.61-stable

### DIFF
--- a/change/@office-iss-react-native-win32-2020-03-30-16-03-07-disallow-pre61.json
+++ b/change/@office-iss-react-native-win32-2020-03-30-16-03-07-disallow-pre61.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Explicitly disallow prerelease changes in 0.61-stable",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "commit": "63b17a71b8e2aaa7c8f6b5b7084deabf6618d683",
+  "dependentChangeType": "patch",
+  "date": "2020-03-30T23:03:05.067Z"
+}

--- a/change/react-native-windows-2020-03-30-16-03-07-disallow-pre61.json
+++ b/change/react-native-windows-2020-03-30-16-03-07-disallow-pre61.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Explicitly disallow prerelease changes in 0.61-stable",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "commit": "63b17a71b8e2aaa7c8f6b5b7084deabf6618d683",
+  "dependentChangeType": "patch",
+  "date": "2020-03-30T23:03:07.152Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -67,7 +67,8 @@
     "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
-      "minor"
+      "minor",
+      "prerelease"
     ]
   }
 }

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,7 +65,8 @@
     "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
-      "minor"
+      "minor",
+      "prerelease"
     ]
   }
 }


### PR DESCRIPTION
Beachball behavior without this change is to add to the prerelease section to our version if we backport a change from master. E.g. "0.61.0-0". This is dangerous given the workflow of cherry-picking already committed changes.

This change ends up leading Beachball to effectively no-op during publish. ideally this would instead be a human readable error. This is tracked as an issue at https://github.com/microsoft/beachball/issues/301

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4457)