### PR TITLE
[0.60] Fix crash in timers during instance shutdown, and in systrace (#4291)

### DIFF
--- a/change/react-native-windows-2020-03-10-22-14-59-reloadcrashes.json
+++ b/change/react-native-windows-2020-03-10-22-14-59-reloadcrashes.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in timers during instance shutdown, and in systrace",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "d8cf799a2df255fd3c590ba9df5319368cc6f682",
+  "dependentChangeType": "patch",
+  "date": "2020-03-11T05:14:59.356Z"
+}

--- a/vnext/ReactUWP/Modules/TimingModule.cpp
+++ b/vnext/ReactUWP/Modules/TimingModule.cpp
@@ -76,6 +76,7 @@ Timing::Timing(TimingModule *parent) : m_parent(parent) {}
 
 void Timing::Disconnect() {
   m_parent = nullptr;
+  m_rendering.revoke();
 }
 
 std::weak_ptr<facebook::react::Instance> Timing::getInstance() noexcept {
@@ -85,7 +86,7 @@ std::weak_ptr<facebook::react::Instance> Timing::getInstance() noexcept {
   return m_parent->getInstance();
 }
 
-void Timing::OnRendering(const winrt::IInspectable &, const winrt::IInspectable &args) {
+void Timing::OnRendering() {
   std::vector<int64_t> readyTimers;
   auto now = winrt::DateTime::clock::now();
 
@@ -132,8 +133,14 @@ void Timing::createTimer(int64_t id, double duration, double jsSchedulingTime, b
 
   if (m_timerQueue.IsEmpty()) {
     m_rendering.revoke();
-    m_rendering =
-        winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering(winrt::auto_revoke, {this, &Timing::OnRendering});
+    m_rendering = winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering(
+        winrt::auto_revoke,
+        [wkThis = std::weak_ptr(this->shared_from_this())](
+            const winrt::IInspectable &, const winrt::IInspectable & /*args*/) {
+          if (auto pThis = wkThis.lock()) {
+            pThis->OnRendering();
+          }
+        });
   }
 
   // Convert double duration in ms to TimeSpan

--- a/vnext/ReactUWP/Modules/TimingModule.h
+++ b/vnext/ReactUWP/Modules/TimingModule.h
@@ -58,7 +58,7 @@ class TimerQueue {
   std::vector<Timer> m_timerVector;
 };
 
-class Timing {
+class Timing : public std::enable_shared_from_this<Timing> {
  public:
   Timing(TimingModule *parent);
   void Disconnect();
@@ -69,9 +69,7 @@ class Timing {
 
  private:
   std::weak_ptr<facebook::react::Instance> getInstance() noexcept;
-  void OnRendering(
-      const winrt::Windows::Foundation::IInspectable &,
-      const winrt::Windows::Foundation::IInspectable &args);
+  void OnRendering();
 
  private:
   TimingModule *m_parent;

--- a/vnext/ReactWindowsCore/tracing/tracing.cpp
+++ b/vnext/ReactWindowsCore/tracing/tracing.cpp
@@ -33,6 +33,7 @@ std::mutex g_pages_mutex;
 }
 
 /*static */ void FbSystraceAsyncFlow::end(uint64_t tag, const char *name, int cookie) {
+  std::lock_guard<std::mutex> guard(s_tracker_mutex_);
   auto search = s_tracker_.find(cookie);
   double duration = -1;
 
@@ -42,7 +43,6 @@ std::mutex g_pages_mutex;
                    .count();
 
     // Flow has ended. Clear the cookie tracker.
-    std::lock_guard<std::mutex> guard(s_tracker_mutex_);
     s_tracker_.erase(cookie);
   }
 


### PR DESCRIPTION
* Fix crash in timers during instance shutdown

* Fix crash in systrace

* Change files

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4458)