### PR TITLE
Update MSBuild ADO Tasks to use MSBuild x64

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -149,7 +149,6 @@ jobs:
       - template: templates/build-rnw.yml
         parameters:
           project: vnext/ReactWindows-Universal.sln
-          msBuildArchitecture: x86 # Necessary to build C# unit tests
           vsComponents: $(VsComponents),Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
 
       - template: templates/publish-build-artifacts-for-nuget.yml

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -34,17 +34,20 @@ steps:
       restoreDirectory: packages/
       verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-  - task: MSBuild@1
-    displayName: MSBuild ${{parameters.project}}
+  - task: VSBuild@1
+    displayName: VSBuild ${{parameters.project}}
     inputs:
       solution: ${{parameters.project }}
-      msbuildVersion: ${{parameters.msbuildVersion}}
+      vsVersion: ${{parameters.msbuildVersion}}
       msbuildArchitecture: ${{parameters.msBuildArchitecture}}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
+      clean: false # Optional
+      maximumCpuCount: false # Optional
+      restoreNugetPackages: false # Optional
       createLogFile: true
       logFileVerbosity: detailed
-      msbuildArguments:
+      msbuildArgs:
         /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
         /p:BaseIntDir=$(BaseIntDir)

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -104,6 +104,7 @@ steps:
         /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
         /p:PlatformToolset=$(MSBuildPlatformToolset)
         /p:BaseIntDir=$(BaseIntDir)
+        /p:AppxGeneratePrisForPortableLibrariesEnabled=false
 
   - task: PublishBuildArtifacts@1
     condition:  succeededOrFailed()

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -92,7 +92,7 @@ steps:
     inputs:
       solution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
       msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-      msbuildArchitecture: x86 # $(MSBuildArchitecture) # Optional. Options: x86, x64
+      msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
       platform: ${{ parameters.platform }} # Optional
       configuration: ${{ parameters.configuration }} # Optional
       createLogFile: true

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -87,17 +87,20 @@ steps:
         -Components ${{ parameters.vsComponents }}
     condition: and(ne('${{parameters.vsComponents}}', ''), eq(variables['VmImage'], 'windows-2019'))
 
-  - task: MSBuild@1
-    displayName: MSBuild - testcli
+  - task: VSBuild@1
+    displayName: VSBuild - testcli
     inputs:
       solution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
-      msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+      vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
       msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
       platform: ${{ parameters.platform }} # Optional
       configuration: ${{ parameters.configuration }} # Optional
+      clean: false # Optional
+      maximumCpuCount: false # Optional
+      restoreNugetPackages: false # Optional
       createLogFile: true
       logFileVerbosity: detailed
-      msbuildArguments:
+      msbuildArgs:
         /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
         /p:PlatformToolset=$(MSBuildPlatformToolset)
         /p:BaseIntDir=$(BaseIntDir)

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -70,7 +70,6 @@ jobs:
         parameters:
           yarnBuildCmd: build
           project: vnext/ReactWindows-Universal.sln
-          msBuildArchitecture: x86 # Necessary to build C# unit tests
           vsComponents: $(VsComponents),Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
 
       - task: VSTest@2

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -133,15 +133,18 @@ jobs:
           restoreSolution: packages/playground/windows/Playground.sln
           verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-      - task: MSBuild@1
-        displayName: MSBuild - Playground
+      - task: VSBuild@1
+        displayName: VSBuild - Playground
         inputs:
           solution: packages/playground/windows/Playground.sln
-          msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+          vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
           msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
-          msbuildArguments:
+          clean: false # Optional
+          maximumCpuCount: false # Optional
+          restoreNugetPackages: false # Optional
+          msbuildArgs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
@@ -154,15 +157,18 @@ jobs:
           restoreSolution: packages/playground/windows/Playground-Win32.sln
           verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-      - task: MSBuild@1
-        displayName: MSBuild - Playground Win32
+      - task: VSBuild@1
+        displayName: VSBuild - Playground Win32
         inputs:
           solution: packages/playground/windows/Playground-Win32.sln
-          msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+          vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
           msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
-          msbuildArguments:
+          clean: false # Optional
+          maximumCpuCount: false # Optional
+          restoreNugetPackages: false # Optional
+          msbuildArgs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -141,14 +141,13 @@ jobs:
           msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
-          clean: false # Optional
+          clean: true # Optional
           maximumCpuCount: false # Optional
           restoreNugetPackages: false # Optional
           msbuildArgs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
-          clean: true # Optional
 
       - task: NuGetCommand@2
         displayName: NuGet restore - Playground Win32
@@ -165,14 +164,13 @@ jobs:
           msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
-          clean: false # Optional
+          clean: true # Optional
           maximumCpuCount: false # Optional
           restoreNugetPackages: false # Optional
           msbuildArgs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
-          clean: true # Optional
 
       - task: CmdLine@2
         displayName: Create Playground bundle

--- a/change/react-native-windows-2020-03-31-10-16-02-msbuildx64.json
+++ b/change/react-native-windows-2020-03-31-10-16-02-msbuildx64.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update MSBuild Tasks to use MSBuild x64",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-31T17:16:02.126Z"
+}

--- a/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -20,6 +20,7 @@
     <PackageCertificateThumbprint>FCDD40CD2A4E90DD1F10E5C04D5A958E6B5311CA</PackageCertificateThumbprint>
     <PackageCertificateKeyFile>ReactUWPTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
@@ -18,6 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
@@ -18,6 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
+++ b/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
@@ -23,6 +23,7 @@
     <PackageCertificateKeyFile><%=name%>_TemporaryKey.pfx</PackageCertificateKeyFile>
     <%=certificateThumbprint%>
     <PackageCertificatePassword>password</PackageCertificatePassword>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
+++ b/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
@@ -2,9 +2,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <SomeKey>SomeValue</SomeKey>
-  </PropertyGroup>
-  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{<%=projectGuidUpper%>}</ProjectGuid>


### PR DESCRIPTION
* Removed x86 override for msbuild tasks in CI, publish
* Switch from MSBuild to VSBuild
* Added `<AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>` to C# app projects to fix build issues with msbuild x64
* Added `/p:AppxGeneratePrisForPortableLibrariesEnabled=false` for testcli build task

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4462)