### PR TITLE
Fix new project build

### DIFF
--- a/change/react-native-windows-2020-03-31-20-25-48-FixNewProjectBuild.json
+++ b/change/react-native-windows-2020-03-31-20-25-48-FixNewProjectBuild.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Set $(ReactNativeWindowsDir) before it is used",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T03:25:48.573Z"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -13,6 +13,9 @@
 
   </PropertyGroup>
 
+  <!-- Initialize $(ReactNativeWindowsDir) before it is used below. -->
+  <Import Project="PropertySheets\ReactPackageDirectories.props" />
+
   <PropertyGroup Label="Configuration">
     <ProjectName Condition="'$(ProjectName)'==''">$(MSBuildProjectName)</ProjectName>
     <!-- Visual Studio forces using 'Win32' for the 'x86' platform. -->


### PR DESCRIPTION
When we create a new project using the 'react-native init' we have a build error.
It says that it cannot find Microsoft.ReactNative.winmd file.
The issue was that the target destination of this file is reported as a relative path instead of an absolute one. This is because the $(ReactNativeWindowsDir) variable is not initialized since the Directory.Build.props file from our repo root folder is not deployed.

In this PR we ensure that we properly initialize the $(ReactNativeWindowsDir) before it is used for the build and target folder creation. It fixes the issue with the new project builds.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4469)