### PR TITLE
Fixed Mso test crash

### DIFF
--- a/change/react-native-windows-2020-04-01-05-05-07-FixMsoTest.json
+++ b/change/react-native-windows-2020-04-01-05-05-07-FixMsoTest.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed Mso test crash",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T12:05:07.771Z"
+}

--- a/vnext/Mso.UnitTests/future/arrayViewTest.cpp
+++ b/vnext/Mso.UnitTests/future/arrayViewTest.cpp
@@ -26,11 +26,13 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
   }
 
   TEST_METHOD(ArrayView_ctor_initializer_list) {
-    Mso::Async::ArrayView<int> a1({1, 2, 3});
-    TestCheckEqual(3, a1.Size());
-    TestCheckEqual(1, a1[0]);
-    TestCheckEqual(2, a1[1]);
-    TestCheckEqual(3, a1[2]);
+    // We use lambda to avoid ArrayView use temporary objects.
+    [](Mso::Async::ArrayView<int> a1) {
+      TestCheckEqual(3, a1.Size());
+      TestCheckEqual(1, a1[0]);
+      TestCheckEqual(2, a1[1]);
+      TestCheckEqual(3, a1[2]);
+    }({1, 2, 3});
   }
 
   TEST_METHOD(ArrayView_ctor_vector) {


### PR DESCRIPTION
Mso ArrayView unit test was failing because it was using a reference to a temporary variable. The test is fixed by making sure that temporary is not destroyed while used.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4470)