### PR TITLE
Fix crash when calling measure on non-framework element

### DIFF
--- a/change/react-native-windows-2020-04-01-13-40-22-devtoolscrash.json
+++ b/change/react-native-windows-2020-04-01-13-40-22-devtoolscrash.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash when calling measure on non-framework element",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T20:40:22.490Z"
+}

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -907,7 +907,7 @@ void NativeUIManager::measure(
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
   auto view = node.GetView();
 
-  auto feView = view.as<winrt::FrameworkElement>();
+  auto feView = view.try_as<winrt::FrameworkElement>();
   if (feView == nullptr) {
     callback(args);
     return;


### PR DESCRIPTION
This currently makes using the react-devtools inspector very challenging, as if you click on any component that is not backed by a framework element you crash the app.

With this fix, you can happily click around the inspector crash free.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4473)