### PR TITLE
Fix template specialization error in FrameworkElementViewManager.cpp

### DIFF
--- a/change/react-native-windows-2020-04-03-03-43-11-FrameworkElementViewManager.cpp.patch.json
+++ b/change/react-native-windows-2020-04-03-03-43-11-FrameworkElementViewManager.cpp.patch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix template specialization error in FrameworkElementViewManager.cpp",
+  "packageName": "react-native-windows",
+  "email": "christophpurrer@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-03T10:43:11.729Z"
+}

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -35,9 +35,6 @@ using namespace Windows::UI::Xaml::Automation::Peers;
 using namespace Windows::Foundation::Collections;
 } // namespace winrt
 
-namespace react {
-namespace uwp {
-
 template <>
 struct json_type_traits<winrt::react::uwp::AccessibilityAction> {
   static winrt::react::uwp::AccessibilityAction parseJson(const folly::dynamic &json) {
@@ -70,6 +67,9 @@ struct json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>> 
     return vector;
   }
 };
+
+namespace react {
+namespace uwp {
 
 FrameworkElementViewManager::FrameworkElementViewManager(const std::shared_ptr<IReactInstance> &reactInstance)
     : Super(reactInstance) {}


### PR DESCRIPTION
Does not compile with Clang 9.0.1 or with Clang 10.0.0
```
react-native-windows\vnext\ReactUWP\Views\FrameworkElementViewManager.cpp:41:8: error: class template specialization of 'json_type_traits' must occur at global scope
struct json_type_traits<winrt::react::uwp::AccessibilityAction> {
       ^
buck-out/gen/ec45211b/third-party/microsoft-fork-of-react-native/react-native-windows_MicrosoftReactNativeWindows#private-headers,windows-x86_64\Utils/PropertyHandlerUtils.h:55:8: note: explicitly specialized declaration is here
struct json_type_traits;
       ^
react-native-windows\vnext\ReactUWP\Views\FrameworkElementViewManager.cpp:57:8: error: class template specialization of 'json_type_traits' must occur at global scope
struct json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>> {
       ^
buck-out/gen/ec45211b/third-party/microsoft-fork-of-react-native/react-native-windows_MicrosoftReactNativeWindows#private-headers,windows-x86_64\Utils/PropertyHandlerUtils.h:55:8: note: explicitly specialized declaration is here
struct json_type_traits;
```

It might not be desirable having templates in the global namespace, but this changes is at least consistent with usage in other files as: https://github.com/microsoft/react-native-windows/blob/master/vnext/ReactUWP/Views/FlyoutViewManager.cpp#L52-L67

## Test plan
Compiles with Clang 9.0.1
Compiles with VS 2019

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4478)