### PR TITLE
Fix co_routine in LocationObserverModule.cpp

### DIFF
--- a/change/react-native-windows-2020-04-03-03-53-34-LocationObserverModule.cpp.patch.json
+++ b/change/react-native-windows-2020-04-03-03-53-34-LocationObserverModule.cpp.patch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "# Fix co_routine in LocationObserverModule.cpp",
+  "packageName": "react-native-windows",
+  "email": "christophpurrer@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-03T10:53:34.312Z"
+}

--- a/vnext/ReactUWP/Modules/LocationObserverModule.cpp
+++ b/vnext/ReactUWP/Modules/LocationObserverModule.cpp
@@ -103,7 +103,7 @@ winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Devices::Geolocation
     LocationObserverOptions &options) {
   auto location =
       co_await geoLocator.GetGeopositionAsync(TimeSpanFromMs(options.maxAge), TimeSpanFromMs(options.timeout));
-  return location;
+  co_return location;
 }
 
 void LocationObserverModule::LocationObserver::getCurrentPosition(


### PR DESCRIPTION
Does not follow specification: https://en.cppreference.com/w/cpp/language/coroutines

Does not compile with Clang 9.0.1 or with Clang 10.0.0
```
react-native-windows\vnext\ReactUWP\Modules\LocationObserverModule.cpp:106:10: error: no viable conversion from returned value of type 'winrt::Windows::Devices::Geolocation::Geoposition' to function return type 'winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Devices::Geolocation::Geoposition>'
  return location;
         ^~~~~~~~
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'winrt::Windows::Devices::Geolocation::Geoposition' to 'const winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Devices::Geolocation::Geoposition> &' for 1st argument
    struct __declspec(empty_bases) IAsyncOperation :
                                   ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'winrt::Windows::Devices::Geolocation::Geoposition' to 'winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Devices::Geolocation::Geoposition> &&' for 1st argument
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:52:9: note: candidate constructor not viable: no known conversion from 'winrt::Windows::Devices::Geolocation::Geoposition' to 'std::nullptr_t' (aka 'nullptr_t') for 1st argument
        IAsyncOperation(std::nullptr_t = nullptr) noexcept {}
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
        operator I() const noexcept
```

## Test plan
Compiles with Clang 9.0.1
Compiles with VS 2019

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4479)