### PR TITLE
Fix calling winrt::TimeSpan constructor in ValueUtils.cpp

### DIFF
--- a/change/react-native-windows-2020-04-03-03-58-46-ValueUtils.cpp.patch.json
+++ b/change/react-native-windows-2020-04-03-03-58-46-ValueUtils.cpp.patch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix calling winrt::TimeSpan constructor in ValueUtils.cpp",
+  "packageName": "react-native-windows",
+  "email": "christophpurrer@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-03T10:58:46.529Z"
+}

--- a/vnext/ReactUWP/Utils/ValueUtils.cpp
+++ b/vnext/ReactUWP/Utils/ValueUtils.cpp
@@ -198,7 +198,7 @@ REACTWINDOWS_API_(bool) IsValidColorValue(const folly::dynamic &d) {
 
 REACTWINDOWS_API_(winrt::TimeSpan) TimeSpanFromMs(double ms) {
   std::chrono::milliseconds dur((int64_t)ms);
-  return winrt::TimeSpan::duration(dur);
+  return winrt::TimeSpan(dur);
 }
 
 } // namespace uwp


### PR DESCRIPTION
Does not compile with Clang 9.0.1 or with Clang 10.0.0
```
stderr: react-native-windows\vnext\ReactUWP\Utils\ValueUtils.cpp:201:27: error: qualified reference to 'duration' is a constructor name rather than a type in this context
  return winrt::TimeSpan::duration(dur);
````

## Test plan
Compiles with Clang 9.0.1
Compiles with VS 2019

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4480)