### PR TITLE
Make JSValueReader.h compile with Clang [RFC]

### DIFF
--- a/change/react-native-windows-2020-04-03-04-18-37-JSValueReader.h.patch.json
+++ b/change/react-native-windows-2020-04-03-04-18-37-JSValueReader.h.patch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Make JSValueReader.h compile with Clang [RFC] I have spent quite some time on this but I can't make it compile as a static assert prevents compilation using Clang.",
+  "packageName": "react-native-windows",
+  "email": "christophpurrer@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-03T11:18:37.745Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -149,6 +149,8 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ std::string &value) 
       break;
     case JSValueType::Double:
       value = std::to_string(reader.GetDouble());
+      value.erase(value.find_last_not_of('0') + 1, std::string::npos);
+      value.erase(value.find_last_not_of('.') + 1, std::string::npos);
       break;
     default:
       value = "";
@@ -169,6 +171,8 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ std::wstring &value)
       break;
     case JSValueType::Double:
       value = std::to_wstring(reader.GetDouble());
+      value.erase(value.find_last_not_of('0') + 1, std::wstring::npos);
+      value.erase(value.find_last_not_of('.') + 1, std::wstring::npos);
       break;
     default:
       value = L"";

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -11,6 +11,8 @@
 
 #include "winrt/Microsoft.ReactNative.h"
 
+#include <string>
+
 namespace winrt::Microsoft::ReactNative {
 
 // A value can be read from IJSValueReader in one of three ways:
@@ -134,29 +136,6 @@ inline void ReadValue(TJSValue const &jsValue, /*out*/ T &value) noexcept {
   ReadValue(reader, /*out*/ value);
 }
 
-template <typename TChar, typename TValue>
-inline std::basic_string<TChar> basic_string_convert(TValue value) {
-  static_assert(std::is_arithmetic_v<TValue>);
-  char temp[32];
-  std::to_chars_result result;
-  if constexpr (std::is_integral_v<TValue>) {
-    result = std::to_chars(std::begin(temp), std::end(temp), value);
-  } else {
-    // Floating point
-    result = std::to_chars(std::begin(temp), std::end(temp), value, std::chars_format::general);
-  }
-  WINRT_ASSERT(result.ec == std::errc{});
-  if constexpr (std::is_same_v<TChar, wchar_t>) {
-    wchar_t buffer[32];
-    auto end = std::copy(std::begin(temp), result.ptr, buffer);
-    return std::wstring{buffer, static_cast<std::size_t>(end - buffer)};
-  } else if constexpr (std::is_same_v<TChar, char>) {
-    return std::string{temp, static_cast<std::size_t>(result.ptr - temp)};
-  } else {
-    static_assert(false, "Unsupported char type");
-  }
-}
-
 inline void ReadValue(IJSValueReader const &reader, /*out*/ std::string &value) noexcept {
   switch (reader.ValueType()) {
     case JSValueType::String:
@@ -166,10 +145,10 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ std::string &value) 
       value = reader.GetBoolean() ? "true" : "false";
       break;
     case JSValueType::Int64:
-      value = basic_string_convert<char>(reader.GetInt64());
+      value = std::to_string(reader.GetInt64());
       break;
     case JSValueType::Double:
-      value = basic_string_convert<char>(reader.GetDouble());
+      value = std::to_string(reader.GetDouble());
       break;
     default:
       value = "";
@@ -186,10 +165,10 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ std::wstring &value)
       value = reader.GetBoolean() ? L"true" : L"false";
       break;
     case JSValueType::Int64:
-      value = basic_string_convert<wchar_t>(reader.GetInt64());
+      value = std::to_wstring(reader.GetInt64());
       break;
     case JSValueType::Double:
-      value = basic_string_convert<wchar_t>(reader.GetDouble());
+      value = std::to_wstring(reader.GetDouble());      
       break;
     default:
       value = L"";

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -168,7 +168,7 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ std::wstring &value)
       value = std::to_wstring(reader.GetInt64());
       break;
     case JSValueType::Double:
-      value = std::to_wstring(reader.GetDouble());      
+      value = std::to_wstring(reader.GetDouble());
       break;
     default:
       value = L"";


### PR DESCRIPTION
I have spent quite some time on this but I can't make it compile with Clang 9.0.1 or Clang 10.0.0 as a static assert prevents compilation.
```
In file included from react-native-windows_MicrosoftReactNativeCxx_targetWindows#header-mode-symlink-tree-only,headers\NativeModules.h:8:
react-native-windows_MicrosoftReactNativeCxx_targetWindows#header-mode-symlink-tree-only,headers/JSValueReader.h:160:5: error: static_assert failed "Unsupported char type"
    static_assert(false, "Unsupported char type");
    ^             ~~~~~
1 error generated.
```
This happens on https://github.com/microsoft/react-native-windows/blob/react-native-windows_v0.60.0-vnext.133/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h - but it seems the same code is still in master

The problem happens here > https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h#L156

But we only pass in ```char``` and ```wchar_t```  > https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h#L168-L192

I looked at https://docs.microsoft.com/en-us/cpp/build/reference/zc-wchar-t-wchar-t-is-native-type?view=vs-2019 but it did help me either.

Also tried to treat ```unsigned short as wchar_t```
https://docs.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=vs-2019 ... no luck

The ```basic_string_convert``` is only used with ```char``` and ```wchar_t``` and the only arguments passed in are ```Int64_t``` and ```double``` so maybe we can just use the built-in ```std::to_string``` / ```std::to_wstring``` functions instead

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4481)