### PR TITLE
Fix co_routine in ReactImage.cpp

### DIFF
--- a/change/react-native-windows-2020-04-03-04-48-03-ReactImage.cpp.patch.json
+++ b/change/react-native-windows-2020-04-03-04-48-03-ReactImage.cpp.patch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix co_routine in ReactImage.cpp",
+  "packageName": "react-native-windows",
+  "email": "christophpurrer@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-03T11:48:03.462Z"
+}

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -125,7 +125,7 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> ReactImage::GetImageMe
     ReactImageSource source) {
   switch (source.sourceType) {
     case ImageSourceType::Download:
-      return co_await GetImageStreamAsync(source);
+      co_return co_await GetImageStreamAsync(source);
     case ImageSourceType::InlineData:
       co_return co_await GetImageInlineDataAsync(source);
     default: // ImageSourceType::Uri
@@ -326,18 +326,18 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageStreamAsync(Re
       co_await winrt::RandomAccessStream::CopyAsync(inputStream, memoryStream);
       memoryStream.Seek(0);
 
-      return memoryStream;
+      co_return memoryStream;
     }
   } catch (winrt::hresult_error const &) {
   }
 
-  return nullptr;
+  co_return nullptr;
 }
 
 winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageInlineDataAsync(ReactImageSource source) {
   size_t start = source.uri.find(',');
   if (start == std::string::npos || start + 1 > source.uri.length())
-    return nullptr;
+    co_return nullptr;
 
   try {
     co_await winrt::resume_background();
@@ -350,12 +350,12 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageInlineDataAsyn
     co_await memoryStream.WriteAsync(buffer);
     memoryStream.Seek(0);
 
-    return memoryStream;
+    co_return memoryStream;
   } catch (winrt::hresult_error const &) {
     // Base64 decode failed
   }
 
-  return nullptr;
+  co_return nullptr;
 }
 } // namespace uwp
 } // namespace react


### PR DESCRIPTION
Does not follow specification: https://en.cppreference.com/w/cpp/language/coroutines

Does not compile with Clang 9.0.1 or with Clang 10.0.0
```
stderr: react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:120:14: error: no viable conversion from returned value of type 'winrt::Windows::Storage::Streams::InMemoryRandomAccessStream' to function return type 'winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream>'
      return co_await GetImageStreamAsync(source);
             ^~~~~~~~
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'winrt::Windows::Storage::Streams::InMemoryRandomAccessStream' to 'const winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> &' for 1st argument
    struct __declspec(empty_bases) IAsyncOperation :
                                   ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'winrt::Windows::Storage::Streams::InMemoryRandomAccessStream' to 'winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> &&' for 1st argument
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:52:9: note: candidate constructor not viable: no known conversion from 'winrt::Windows::Storage::Streams::InMemoryRandomAccessStream' to 'std::nullptr_t' (aka 'nullptr_t') for 1st argument
        IAsyncOperation(std::nullptr_t = nullptr) noexcept {}
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
        operator I() const noexcept
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:321:14: error: no viable conversion from returned value of type 'winrt::InMemoryRandomAccessStream' to function return type 'winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream>'
      return memoryStream;
             ^~~~~~~~~~~~
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'winrt::InMemoryRandomAccessStream' to 'const winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> &' for 1st argument
    struct __declspec(empty_bases) IAsyncOperation :
                                   ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'winrt::InMemoryRandomAccessStream' to 'winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> &&' for 1st argument
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:52:9: note: candidate constructor not viable: no known conversion from 'winrt::InMemoryRandomAccessStream' to 'std::nullptr_t' (aka 'nullptr_t') for 1st argument
        IAsyncOperation(std::nullptr_t = nullptr) noexcept {}
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
        operator I() const noexcept
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:326:3: error: return statement not allowed in coroutine; did you mean 'co_return'?
  return nullptr;
  ^
react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:292:5: note: function is a coroutine due to use of 'co_await' here
    co_await winrt::resume_background();
    ^
react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:345:12: error: no viable conversion from returned value of type 'winrt::InMemoryRandomAccessStream' to function return type 'winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream>'
    return memoryStream;
           ^~~~~~~~~~~~
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'winrt::InMemoryRandomAccessStream' to 'const winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> &' for 1st argument
    struct __declspec(empty_bases) IAsyncOperation :
                                   ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:46:36: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'winrt::InMemoryRandomAccessStream' to 'winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream> &&' for 1st argument
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/impl/Windows.Foundation.1.h:52:9: note: candidate constructor not viable: no known conversion from 'winrt::InMemoryRandomAccessStream' to 'std::nullptr_t' (aka 'nullptr_t') for 1st argument
        IAsyncOperation(std::nullptr_t = nullptr) noexcept {}
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
        operator I() const noexcept
        ^
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
cppwinrt/winrt_generated_filesWindows#header-mode-symlink-tree-only,headers\winrt/base.h:629:9: note: candidate function
react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:332:5: error: return statement not allowed in coroutine; did you mean 'co_return'?
    return nullptr;
    ^
react-native-windows\vnext\ReactUWP\Views\Image\ReactImage.cpp:335:5: note: function is a coroutine due to use of 'co_await' here
    co_await winrt::resume_background();
    ^
5 errors generated.
```

## Test plan
Compiles with Clang 9.0.1
Compiles with VS 2019

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4482)