### PR TITLE
Backport various fixes to 0.61

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -149,7 +149,6 @@ jobs:
       - template: templates/build-rnw.yml
         parameters:
           project: vnext/ReactWindows-Universal.sln
-          msBuildArchitecture: x86 # Necessary to build C# unit tests
           vsComponents: $(VsComponents),Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
 
       - template: templates/publish-build-artifacts-for-nuget.yml

--- a/.ado/setVersionEnvVars.js
+++ b/.ado/setVersionEnvVars.js
@@ -8,7 +8,8 @@ const pkgJsonPath = path.resolve(__dirname, "../vnext/package.json");
 // Helper to format npmVersion in a way that the Version.rc resource files want it
 function npmVersionToRcVersion(npmVersion) {
   let groups = npmVersion.split(/[\.-]/);
-  return `${groups[0]},${groups[1]},${groups[2]},${groups[4]}`;
+  const [major,minor,patch,_junk,prerelease] = groups;
+  return `${major},${minor},${patch},${prerelease ? prerelease : '0'}`;
 }
 
 let pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -34,17 +34,20 @@ steps:
       restoreDirectory: packages/
       verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-  - task: MSBuild@1
-    displayName: MSBuild ${{parameters.project}}
+  - task: VSBuild@1
+    displayName: VSBuild ${{parameters.project}}
     inputs:
       solution: ${{parameters.project }}
-      msbuildVersion: ${{parameters.msbuildVersion}}
+      vsVersion: ${{parameters.msbuildVersion}}
       msbuildArchitecture: ${{parameters.msBuildArchitecture}}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
+      clean: false # Optional
+      maximumCpuCount: false # Optional
+      restoreNugetPackages: false # Optional
       createLogFile: true
       logFileVerbosity: detailed
-      msbuildArguments:
+      msbuildArgs:
         /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
         /p:BaseIntDir=$(BaseIntDir)

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -93,20 +93,24 @@ steps:
         -Components ${{ parameters.vsComponents }}
     condition: and(ne('${{parameters.vsComponents}}', ''), eq(variables['VmImage'], 'windows-2019'))
 
-  - task: MSBuild@1
-    displayName: MSBuild - testcli
+  - task: VSBuild@1
+    displayName: VSBuild - testcli
     inputs:
       solution: $(Agent.BuildDirectory)\testcli\windows\testcli.sln
-      msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-      msbuildArchitecture: x86 # $(MSBuildArchitecture) # Optional. Options: x86, x64
+      vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+      msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
       platform: ${{ parameters.platform }} # Optional
       configuration: ${{ parameters.configuration }} # Optional
+      clean: false # Optional
+      maximumCpuCount: false # Optional
+      restoreNugetPackages: false # Optional
       createLogFile: true
       logFileVerbosity: detailed
-      msbuildArguments:
+      msbuildArgs:
         /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
         /p:PlatformToolset=$(MSBuildPlatformToolset)
         /p:BaseIntDir=$(BaseIntDir)
+        /p:AppxGeneratePrisForPortableLibrariesEnabled=false
 
   - task: PublishBuildArtifacts@1
     condition:  succeededOrFailed()

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -70,7 +70,6 @@ jobs:
         parameters:
           yarnBuildCmd: build
           project: vnext/ReactWindows-Universal.sln
-          msBuildArchitecture: x86 # Necessary to build C# unit tests
           vsComponents: $(VsComponents),Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
 
       - task: VSTest@2
@@ -134,19 +133,21 @@ jobs:
           restoreSolution: packages/playground/windows/Playground.sln
           verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-      - task: MSBuild@1
-        displayName: MSBuild - Playground
+      - task: VSBuild@1
+        displayName: VSBuild - Playground
         inputs:
           solution: packages/playground/windows/Playground.sln
-          msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+          vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
           msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
-          msbuildArguments:
+          clean: true # Optional
+          maximumCpuCount: false # Optional
+          restoreNugetPackages: false # Optional
+          msbuildArgs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
-          clean: true # Optional
 
       - task: NuGetCommand@2
         displayName: NuGet restore - Playground Win32
@@ -155,19 +156,21 @@ jobs:
           restoreSolution: packages/playground/windows/Playground-Win32.sln
           verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-      - task: MSBuild@1
-        displayName: MSBuild - Playground Win32
+      - task: VSBuild@1
+        displayName: VSBuild - Playground Win32
         inputs:
           solution: packages/playground/windows/Playground-Win32.sln
-          msbuildVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+          vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
           msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
-          msbuildArguments:
+          clean: true # Optional
+          maximumCpuCount: false # Optional
+          restoreNugetPackages: false # Optional
+          msbuildArgs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
-          clean: true # Optional
 
       - task: CmdLine@2
         displayName: Create Playground bundle

--- a/change/react-native-windows-2020-03-26-09-13-41-certtimeout.json
+++ b/change/react-native-windows-2020-03-26-09-13-41-certtimeout.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Add a timeout to catch hangs during cert generation",
   "packageName": "react-native-windows",
   "email": "acoates@microsoft.com",

--- a/change/react-native-windows-2020-03-26-09-13-41-certtimeout.json
+++ b/change/react-native-windows-2020-03-26-09-13-41-certtimeout.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add a timeout to catch hangs during cert generation",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-26T16:13:40.983Z"
+}

--- a/change/react-native-windows-2020-03-27-11-52-38-dd.json
+++ b/change/react-native-windows-2020-03-27-11-52-38-dd.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Fix direct debugging",
   "packageName": "react-native-windows",
   "email": "acoates@microsoft.com",

--- a/change/react-native-windows-2020-03-27-11-52-38-dd.json
+++ b/change/react-native-windows-2020-03-27-11-52-38-dd.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix direct debugging",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-27T18:52:38.219Z"
+}

--- a/change/react-native-windows-2020-03-31-10-16-02-msbuildx64.json
+++ b/change/react-native-windows-2020-03-31-10-16-02-msbuildx64.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update MSBuild Tasks to use MSBuild x64",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-03-31T17:16:02.126Z"
+}

--- a/change/react-native-windows-2020-03-31-10-16-02-msbuildx64.json
+++ b/change/react-native-windows-2020-03-31-10-16-02-msbuildx64.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Update MSBuild Tasks to use MSBuild x64",
   "packageName": "react-native-windows",
   "email": "jthysell@microsoft.com",

--- a/change/react-native-windows-2020-03-31-20-25-48-FixNewProjectBuild.json
+++ b/change/react-native-windows-2020-03-31-20-25-48-FixNewProjectBuild.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Set $(ReactNativeWindowsDir) before it is used",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T03:25:48.573Z"
+}

--- a/change/react-native-windows-2020-03-31-20-25-48-FixNewProjectBuild.json
+++ b/change/react-native-windows-2020-03-31-20-25-48-FixNewProjectBuild.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Set $(ReactNativeWindowsDir) before it is used",
   "packageName": "react-native-windows",
   "email": "vmorozov@microsoft.com",

--- a/change/react-native-windows-2020-04-01-13-40-22-devtoolscrash.json
+++ b/change/react-native-windows-2020-04-01-13-40-22-devtoolscrash.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash when calling measure on non-framework element",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T20:40:22.490Z"
+}

--- a/change/react-native-windows-2020-04-01-13-40-22-devtoolscrash.json
+++ b/change/react-native-windows-2020-04-01-13-40-22-devtoolscrash.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Fix crash when calling measure on non-framework element",
   "packageName": "react-native-windows",
   "email": "acoates@microsoft.com",

--- a/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -20,6 +20,7 @@
     <PackageCertificateThumbprint>FCDD40CD2A4E90DD1F10E5C04D5A958E6B5311CA</PackageCertificateThumbprint>
     <PackageCertificateKeyFile>ReactUWPTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
@@ -18,6 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -13,6 +13,9 @@
 
   </PropertyGroup>
 
+  <!-- Initialize $(ReactNativeWindowsDir) before it is used below. -->
+  <Import Project="PropertySheets\ReactPackageDirectories.props" />
+
   <PropertyGroup Label="Configuration">
     <ProjectName Condition="'$(ProjectName)'==''">$(MSBuildProjectName)</ProjectName>
     <!-- Visual Studio forces using 'Win32' for the 'x86' platform. -->

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
@@ -18,6 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -171,6 +171,7 @@ void ReactInstanceWin::Initialize() noexcept {
           devSettings->debuggerPort = m_options.DeveloperSettings.DebuggerPort;
           devSettings->debuggerRuntimeName = m_options.DeveloperSettings.DebuggerRuntimeName;
           devSettings->useWebDebugger = m_options.DeveloperSettings.UseWebDebugger;
+          devSettings->useFastRefresh = m_options.DeveloperSettings.UseFastRefresh;
           // devSettings->memoryTracker = GetMemoryTracker();
           devSettings->bundleRootPath =
               m_options.BundleRootPath.empty() ? "ms-appx:///Bundle/" : m_options.BundleRootPath;
@@ -313,7 +314,22 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
   // The OnReactInstanceLoaded internally only accepts the first call and ignores others.
   //
 
-  if (!m_options.DeveloperSettings.UseWebDebugger) {
+  if (m_options.DeveloperSettings.UseWebDebugger || m_options.DeveloperSettings.UseFastRefresh) {
+    // Getting bundle from the packager, so do everything async.
+    auto instanceWrapper = m_instanceWrapper.LoadWithLock();
+    instanceWrapper->loadBundle(Mso::Copy(m_options.Identity));
+
+    m_jsMessageThread.Load()->runOnQueue([
+      weakThis = Mso::WeakPtr{this},
+      loadCallbackGuard = Mso::MakeMoveOnCopyWrapper(LoadedCallbackGuard{*this})
+    ]() noexcept {
+      if (auto strongThis = weakThis.GetStrongPtr()) {
+        if (strongThis->State() != ReactInstanceState::HasError) {
+          strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
+        }
+      }
+    });
+  } else {
     m_jsMessageThread.Load()->runOnQueue([
       weakThis = Mso::WeakPtr{this},
       loadCallbackGuard = Mso::MakeMoveOnCopyWrapper(LoadedCallbackGuard{*this})
@@ -337,21 +353,6 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
 
         // All JS bundles successfully loaded.
         strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
-      }
-    });
-  } else {
-    // Web Debugging
-    auto instanceWrapper = m_instanceWrapper.LoadWithLock();
-    instanceWrapper->loadBundle(Mso::Copy(m_options.Identity));
-
-    m_jsMessageThread.Load()->runOnQueue([
-      weakThis = Mso::WeakPtr{this},
-      loadCallbackGuard = Mso::MakeMoveOnCopyWrapper(LoadedCallbackGuard{*this})
-    ]() noexcept {
-      if (auto strongThis = weakThis.GetStrongPtr()) {
-        if (strongThis->State() != ReactInstanceState::HasError) {
-          strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
-        }
       }
     });
   }

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -519,6 +519,7 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
           m_useWebDebugger = !m_useWebDebugger;
+          m_directDebugging = false; // Remote debugging is incompatible with direct debugging
           ReloadHost();
         });
 
@@ -527,11 +528,12 @@ void ReactRootControl::ShowDeveloperMenu() noexcept {
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
           m_directDebugging = !m_directDebugging;
+          m_useWebDebugger = false; // Remote debugging is incompatible with direct debugging
           ReloadHost();
         });
 
     breakOnNextLineText.Text(m_breakOnNextLine ? L"Disable Break on First Line" : L"Enable Break on First Line");
-    m_breakOnNextLineRevoker = directDebugButton.Click(
+    m_breakOnNextLineRevoker = breakOnNextLineButton.Click(
         winrt::auto_revoke, [this](auto const & /*sender*/, winrt::RoutedEventArgs const & /*args*/) noexcept {
           DismissDeveloperMenu();
           m_breakOnNextLine = !m_breakOnNextLine;

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -907,7 +907,7 @@ void NativeUIManager::measure(
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
   auto view = node.GetView();
 
-  auto feView = view.as<winrt::FrameworkElement>();
+  auto feView = view.try_as<winrt::FrameworkElement>();
   if (feView == nullptr) {
     callback(args);
     return;

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -81,6 +81,8 @@ struct DevSettings {
   /// is loaded.
   bool useWebDebugger{false};
 
+  bool useFastRefresh{false};
+
   // Enables ChakraCore console redirection to debugger
   bool debuggerConsoleRedirection{false};
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -510,7 +510,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       m_devSettings->errorCallback(e.what());
       return;
     }
-  } else if (m_devSettings->liveReloadCallback != nullptr) {
+  } else if (m_devSettings->liveReloadCallback != nullptr || m_devSettings->useFastRefresh) {
     auto jsBundleString = m_devManager->GetJavaScriptFromServer(
         m_devSettings->debugHost, jsBundleRelativePath, m_devSettings->platformName);
 

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -20,24 +20,20 @@ function generateCertificate(srcPath, destPath, newProjectName, currentUser) {
   console.log('Generating self-signed certificate...');
   let toCopyTempKey = false;
   if (os.platform() === 'win32') {
-    const certGenCommand = [
-      `$cert = New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject "CN=${currentUser}" -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}Subject Type:End Entity") -CertStoreLocation "Cert:\\CurrentUser\\My"`,
-      '$pwd = ConvertTo-SecureString -String password -Force -AsPlainText',
-      `New-Item -ErrorAction Ignore -ItemType directory -Path ${path.join(windowsDir, newProjectName)}`,
-      `Export-PfxCertificate -Cert "cert:\\CurrentUser\\My\\$($cert.Thumbprint)" -FilePath ${path.join(windowsDir, newProjectName, newProjectName)}_TemporaryKey.pfx -Password $pwd`,
-      '$cert.Thumbprint',
-    ];
-    const certGenProcess = childProcess.spawnSync('powershell', ['-command', certGenCommand.join(';')]);
-
-    if (certGenProcess.status === 0) {
-      const certGenProcessOutput = certGenProcess.stdout.toString().trim().split('\n');
+    try {
+      const timeout = 10000; // 10 seconds;
+      const thumbprint = childProcess.execSync(`powershell -command "Write-Output (New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject 'CN=${currentUser}' -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}Subject Type:End Entity') -CertStoreLocation 'Cert:\\CurrentUser\\My').Thumbprint"`, {timeout}).toString().trim();
+      if (!fs.existsSync(path.join(windowsDir, newProjectName))) {
+        fs.createDir(path.join(windowsDir, newProjectName));
+      }
+      childProcess.execSync(`powershell -command "$pwd = (ConvertTo-SecureString -String password -Force -AsPlainText); Export-PfxCertificate -Cert 'cert:\\CurrentUser\\My\\${thumbprint}' -FilePath ${path.join(windowsDir, newProjectName, newProjectName)}_TemporaryKey.pfx -Password $pwd"`, {timeout});
       console.log(chalk.green('Self-signed certificate generated successfully.'));
-      return certGenProcessOutput[certGenProcessOutput.length - 1];
+      return thumbprint;
+      } catch (err) {
+        console.log(chalk.yellow('Failed to generate Self-signed certificate. Using Default Certificate. Use Visual Studio to renew it.'));
+        toCopyTempKey = true;
+      }
     } else {
-      console.log(chalk.yellow('Failed to generate Self-signed certificate. Using Default Certificate. Use Visual Studio to renew it.'));
-      toCopyTempKey = true;
-    }
-  } else {
     console.log(chalk.yellow('Using Default Certificate. Use Visual Studio to renew it.'));
     toCopyTempKey = true;
   }

--- a/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
+++ b/vnext/local-cli/generator-windows/templates/cs/proj/MyApp.csproj
@@ -2,9 +2,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <SomeKey>SomeValue</SomeKey>
-  </PropertyGroup>
-  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{<%=projectGuidUpper%>}</ProjectGuid>
@@ -23,6 +20,7 @@
     <PackageCertificateKeyFile><%=name%>_TemporaryKey.pfx</PackageCertificateKeyFile>
     <%=certificateThumbprint%>
     <PackageCertificatePassword>password</PackageCertificatePassword>
+    <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This backports the following changes:
- Fix crash when calling measure on non-framework element #4473
- Fix new project build #4469
- Update MSBuild ADO Tasks to use MSBuild x64 #4462
- Some Direct Debugging fixes #4440
- Add timeout to certificate generation on project init #4430
- Handle publishing versions without pre-release versions #4489

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4487)