### PR TITLE
[0.60] Ensure React Instance reference lifetime in WebSocketModule

### DIFF
--- a/change/react-native-windows-2020-04-03-13-24-27-winapi_ws_0.60-modulesharedref.json
+++ b/change/react-native-windows-2020-04-03-13-24-27-winapi_ws_0.60-modulesharedref.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent invalid access to WebSocketModule::getInstance",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "commit": "80b568f8a3916bf4a694ed11be8ffc1c554c8536",
+  "dependentChangeType": "patch",
+  "date": "2020-04-03T20:24:27.807Z"
+}

--- a/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// clang-format off
 #include <CppUnitTest.h>
 
 #include <Modules/WebSocketModule.h>
@@ -14,8 +13,8 @@ using std::make_unique;
 using std::unique_ptr;
 using std::vector;
 
-TEST_CLASS (WebSocketModuleIntegrationTest)
-{
+TEST_CLASS (WebSocketModuleIntegrationTest) {
+  // clang-format off
   TEST_METHOD(WebSocketModule_Ping)
   {
     auto module = make_unique<WebSocketModule>();
@@ -32,7 +31,9 @@ TEST_CLASS (WebSocketModuleIntegrationTest)
     auto close = module->getMethods().at(WebSocketModule::MethodId::Close);
     close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
   }
+  // clang-format on
 
+  // clang-format off
   TEST_METHOD(WebSocketModule_SendMultiple)
   {
     auto module = make_unique<WebSocketModule>();
@@ -57,4 +58,5 @@ TEST_CLASS (WebSocketModuleIntegrationTest)
     close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
     close.func(dynamic::array(0, "closing", /*id*/ 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
   }
+  // clang-format on
 };

--- a/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
@@ -13,8 +13,8 @@ using std::make_unique;
 using std::unique_ptr;
 using std::vector;
 
-TEST_CLASS (WebSocketModuleIntegrationTest) {
-  // clang-format off
+TEST_CLASS(WebSocketModuleIntegrationTest){
+    // clang-format off
   TEST_METHOD(WebSocketModule_Ping)
   {
     auto module = make_unique<WebSocketModule>();
@@ -31,9 +31,9 @@ TEST_CLASS (WebSocketModuleIntegrationTest) {
     auto close = module->getMethods().at(WebSocketModule::MethodId::Close);
     close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
   }
-  // clang-format on
+// clang-format on
 
-  // clang-format off
+// clang-format off
   TEST_METHOD(WebSocketModule_SendMultiple)
   {
     auto module = make_unique<WebSocketModule>();
@@ -58,5 +58,6 @@ TEST_CLASS (WebSocketModuleIntegrationTest) {
     close.func(dynamic::array(0, "closing", /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
     close.func(dynamic::array(0, "closing", /*id*/ 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
   }
-  // clang-format on
-};
+// clang-format on
+}
+;

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -148,35 +148,27 @@ std::shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_
   {
     auto ws = IWebSocketResource::Make(std::move(url));
     auto weakInstance = this->getInstance();
-    ws->SetOnError([this, id, ws, instance = weakInstance.lock()](const IWebSocketResource::Error& err)
-    {
-      if (!instance)
-        return;
+    auto instance = weakInstance.lock();
+    if (!instance)
+      return;
 
+    ws->SetOnError([this, id, ws, instance](const IWebSocketResource::Error& err)
+    {
       auto errorObj = dynamic::object("id", id)("message", err.Message);
       this->SendEvent("websocketFailed", std::move(errorObj));
     });
-    ws->SetOnConnect([this, id, ws, instance = weakInstance.lock()]()
+    ws->SetOnConnect([this, id, ws, instance]()
     {
-      if (!instance)
-        return;
-
       auto args = dynamic::object("id", id);
       this->SendEvent("websocketOpen", std::move(args));
     });
-    ws->SetOnMessage([this, id, ws, instance = weakInstance.lock()](size_t length, const string& message)
+    ws->SetOnMessage([this, id, ws, instance](size_t length, const string& message)
     {
-      if (!instance)
-        return;
-
       auto args = dynamic::object("id", id)("data", message)("type", "text");
       this->SendEvent("websocketMessage", std::move(args));
     });
-    ws->SetOnClose([this, id, ws, instance = weakInstance.lock()](IWebSocketResource::CloseCode code, const string& reason)
+    ws->SetOnClose([this, id, ws, instance](IWebSocketResource::CloseCode code, const string& reason)
     {
-      if (!instance)
-        return;
-
       auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
       this->SendEvent("websocketClosed", std::move(args));
     });

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -1,58 +1,48 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// clang-format off
 #include "pch.h"
 
 #include <WinRTWebSocketResource.h>
 #include "BeastWebSocketResource.h"
 
 using std::make_shared;
-using std::string;
 using std::shared_ptr;
+using std::string;
 
-namespace Microsoft::React
-{
+namespace Microsoft::React {
 #pragma region IWebSocketResource static members
 
 /*static*/
 shared_ptr<IWebSocketResource>
-IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned)
-{
-  if (!legacyImplementation)
-  {
+IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned) {
+  if (!legacyImplementation) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
-    if (acceptSelfSigned)
-    {
-      certExceptions.emplace_back(winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::Untrusted);
-      certExceptions.emplace_back(winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
+    if (acceptSelfSigned) {
+      certExceptions.emplace_back(
+          winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::Untrusted);
+      certExceptions.emplace_back(
+          winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
     }
     return make_shared<WinRTWebSocketResource>(urlString, certExceptions);
-  }
-  else
-  {
+  } else {
     Url url(urlString);
 
-    if (url.scheme == "ws")
-    {
+    if (url.scheme == "ws") {
       if (url.port.empty())
         url.port = "80";
 
       return make_shared<Beast::WebSocketResource>(std::move(url));
-    }
-    else if (url.scheme == "wss")
-    {
+    } else if (url.scheme == "wss") {
       if (url.port.empty())
         url.port = "443";
 
       return make_shared<Beast::SecureWebSocket>(std::move(url));
-    }
-    else
-    {
+    } else {
       throw std::invalid_argument((string("Incorrect URL scheme: ") + url.scheme).c_str());
     }
   }
 }
 
 #pragma endregion IWebSocketResource static members
-}
+} // namespace Microsoft::React

--- a/vnext/ReactWindowsCore/Modules/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/Modules/WebSocketModule.h
@@ -43,7 +43,7 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// <summary>
   /// Creates or retrieves a raw <c>IWebSocketResource</c> pointer.
   /// </summary>
-  std::weak_ptr<IWebSocketResource> GetOrCreateWebSocket(std::int64_t id, std::string &&url = {});
+  std::shared_ptr<IWebSocketResource> GetOrCreateWebSocket(std::int64_t id, std::string &&url = {});
 
   /// <summary>
   /// Keeps <c>IWebSocketResource</c> instances identified by <c>id</c>.

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -178,7 +178,6 @@ fire_and_forget WinRTWebSocketResource::PerformWrite()
   auto self = shared_from_this();
   if (self->m_writeQueue.empty())
   {
-    self = nullptr;
     co_return;
   }
 


### PR DESCRIPTION
See #4330 .

Ensures `Instance` referenced by `WebSocketModule` stays valid.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4495)