### PR TITLE
Clean Up Directory Logic to Fix Publish

### DIFF
--- a/change/react-native-windows-2020-04-03-16-21-58-fix-publish.json
+++ b/change/react-native-windows-2020-04-03-16-21-58-fix-publish.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Clean Up Directory Logic to Fix Publish",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-03T23:21:58.354Z"
+}

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -9,10 +9,7 @@
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup>
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-  </PropertyGroup>
-  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPackageDirectories.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactDirectories.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -43,10 +43,7 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <PropertyGroup>
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-  </PropertyGroup>
-  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPackageDirectories.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactDirectories.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -10,24 +10,12 @@
 
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-
   </PropertyGroup>
-
-  <!-- Initialize $(ReactNativeWindowsDir) before it is used below. -->
-  <Import Project="$(MSBuildThisFileDirectory)\PropertySheets\ReactPackageDirectories.props" />
 
   <PropertyGroup Label="Configuration">
     <ProjectName Condition="'$(ProjectName)'==''">$(MSBuildProjectName)</ProjectName>
-    <!-- Visual Studio forces using 'Win32' for the 'x86' platform. -->
-    <BaseIntDir Condition="'$(Platform)' != 'Win32'">$(ReactNativeWindowsDir)build\$(Platform)\$(Configuration)</BaseIntDir>
-    <BaseIntDir Condition="'$(Platform)' == 'Win32'">$(ReactNativeWindowsDir)build\x86\$(Configuration)</BaseIntDir>
-    <BaseOutDir Condition="'$(Platform)' != 'Win32'">$(ReactNativeWindowsDir)target\$(Platform)\$(Configuration)</BaseOutDir>
-    <BaseOutDir Condition="'$(Platform)' == 'Win32'">$(ReactNativeWindowsDir)target\x86\$(Configuration)</BaseOutDir>
-
-    <IntDir>$(BaseIntDir)\$(ProjectName)\</IntDir>
-    <OutDir>$(BaseOutDir)\$(ProjectName)\</OutDir>
-
-    <GeneratedFilesDir>$(IntDir)Generated Files\</GeneratedFilesDir>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)\PropertySheets\ReactDirectories.props" />
 
 </Project>

--- a/vnext/PropertySheets/ReactDirectories.props
+++ b/vnext/PropertySheets/ReactDirectories.props
@@ -1,21 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+
   <!--
-   Projects should include the following code in their project file before importing this file:
-
-  <PropertyGroup>
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-  </PropertyGroup>
-
-  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactPackageDirectories.props" />
+    We should move all of these to the vnext Directory.build.props once we no longer have to support ReactUwp playground
   -->
-
   <PropertyGroup>
+
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$(MSBuildThisFileDirectory)\..\</ReactNativeWindowsDir>
     <ReactNativePackageDir Condition="'$(ReactNativePackageDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativePackageDir>
+
+    <!-- Visual Studio forces using 'Win32' for the 'x86' platform. -->
+    <BaseIntDir Condition="'$(Platform)' != 'Win32'">$(ReactNativeWindowsDir)build\$(Platform)\$(Configuration)</BaseIntDir>
+    <BaseIntDir Condition="'$(Platform)' == 'Win32'">$(ReactNativeWindowsDir)build\x86\$(Configuration)</BaseIntDir>
+    <BaseOutDir Condition="'$(Platform)' != 'Win32'">$(ReactNativeWindowsDir)target\$(Platform)\$(Configuration)</BaseOutDir>
+    <BaseOutDir Condition="'$(Platform)' == 'Win32'">$(ReactNativeWindowsDir)target\x86\$(Configuration)</BaseOutDir>
+
+    <IntDir>$(BaseIntDir)\$(ProjectName)\</IntDir>
+    <OutDir>$(BaseOutDir)\$(ProjectName)\</OutDir>
+
+    <GeneratedFilesDir>$(IntDir)Generated Files\</GeneratedFilesDir>
+
     <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$(IntDir)\react-native-patched\</ReactNativeDir>
-    
+
     <!-- For relative paths, make it relative to MSBuildProjectDirectory not CurrentWorkingDirectory. -->
     <ReactNativeDir>$([MSBuild]::NormalizeDirectory( $([System.IO.Path]::Combine( $(MSBuildProjectDirectory), $(ReactNativeDir) )) ))</ReactNativeDir>
 

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -91,9 +91,6 @@
         $(FollyDir);
         $(ReactNativeWindowsDir)\ReactWindowsCore\pch;
         $(ReactNativeWindowsDir)\ReactWindowsCore\tracing;
-        $(ProjectDir);
-        $(GeneratedFilesDir);
-        $(IntDir);
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
#4469 reordered build logic to define ReactNativeWindowsDir before it was seemingly used. This actually made it so we no longer correctly put patched react native sources in the right intermediate build output directory, since we don't define IntDir before including directory logic.

Seemingly the previous documented assumption was that we should define ReactNativeWindowsDir before including ReactPackageDirectories.props. This is oddd/error prone. This change combines logic so we can correctly interleave dependencies. It has the side effect of forcing anything including ReactPackageDirectories to include out intermediate output dir. This should only affect ReactUwp projects, which we will no longer be supporting for 0.62.

We can't actually test that this fixes publish because of #3889, but this should theoretically fix the issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4496)