### PR TITLE
Revert #4487 in 0.61-stable

### DIFF
--- a/change/react-native-windows-2020-04-03-16-53-54-fix-publish-61.json
+++ b/change/react-native-windows-2020-04-03-16-53-54-fix-publish-61.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Revert #4487 in 0.61-stable",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-03T23:53:54.845Z"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -13,9 +13,6 @@
 
   </PropertyGroup>
 
-  <!-- Initialize $(ReactNativeWindowsDir) before it is used below. -->
-  <Import Project="PropertySheets\ReactPackageDirectories.props" />
-
   <PropertyGroup Label="Configuration">
     <ProjectName Condition="'$(ProjectName)'==''">$(MSBuildProjectName)</ProjectName>
     <!-- Visual Studio forces using 'Win32' for the 'x86' platform. -->


### PR DESCRIPTION
This change ended up causing patched react native to land outside of the intermediate build directory, causing publish to fail. Revert it, since we seemed to not need it earlier (I think build logic after the branch changed where we defined ReactNativeWindowsDir). react-native-init CI will confirm whether this is okay to check in. Will need to follow-up to make sure publishing starts working after.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4497)