### PR TITLE
Directory Logic and CI Fixes

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -102,7 +102,6 @@ steps:
       msbuildArgs:
         /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
         /p:PlatformToolset=$(MSBuildPlatformToolset)
-        /p:BaseIntDir=$(BaseIntDir)
         /p:AppxGeneratePrisForPortableLibrariesEnabled=false
 
   - task: PublishBuildArtifacts@1

--- a/change/react-native-windows-2020-04-06-19-51-02-no-specialize.json
+++ b/change/react-native-windows-2020-04-06-19-51-02-no-specialize.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Clean up normalization",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-07T02:51:02.164Z"
+}

--- a/vnext/PropertySheets/ReactDirectories.props
+++ b/vnext/PropertySheets/ReactDirectories.props
@@ -3,11 +3,16 @@
 
 
   <!--
-    We should move all of these to the vnext Directory.build.props once we no longer have to support ReactUwp playground
+    We should move all of these to the vnext Directory.build.props once we no longer have to support ReactUwp playground.
+
+    IMPORTANT: Traversals left in a directory will break some tools like midl, but we also cannot call
+    [MSBuild]::NormalizeDirectory on relative paths since cwd is not always correct. This logic should prfer to operate
+    on full paths annd avoid extra normalization.
   -->
   <PropertyGroup>
-
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$(MSBuildThisFileDirectory)\..\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir>$([MSBuild]::NormalizeDirectory($(ReactNativeWindowsDir)))</ReactNativeWindowsDir>
+
     <ReactNativePackageDir Condition="'$(ReactNativePackageDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativePackageDir>
 
     <!-- Visual Studio forces using 'Win32' for the 'x86' platform. -->
@@ -20,22 +25,15 @@
     <OutDir>$(BaseOutDir)\$(ProjectName)\</OutDir>
 
     <GeneratedFilesDir>$(IntDir)Generated Files\</GeneratedFilesDir>
-
     <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$(IntDir)\react-native-patched\</ReactNativeDir>
 
-    <!-- For relative paths, make it relative to MSBuildProjectDirectory not CurrentWorkingDirectory. -->
-    <ReactNativeDir>$([MSBuild]::NormalizeDirectory( $([System.IO.Path]::Combine( $(MSBuildProjectDirectory), $(ReactNativeDir) )) ))</ReactNativeDir>
-
     <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)\ReactCommon\yoga</YogaDir>
+
     <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
+    <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
+
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Normalize the directory names -->
-    <ReactNativeWindowsDir>$([MSBuild]::NormalizeDirectory($(ReactNativeWindowsDir)))</ReactNativeWindowsDir>
-    <ReactNativePackageDir>$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)))</ReactNativePackageDir>
-    <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
-  </PropertyGroup>
 
 </Project>
 

--- a/vnext/PropertySheets/ReactDirectories.props
+++ b/vnext/PropertySheets/ReactDirectories.props
@@ -31,9 +31,7 @@
 
     <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
     <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
-
   </PropertyGroup>
-
 
 </Project>
 


### PR DESCRIPTION
This should be as close as possible to what users run. Use the default IntDir in this job (Hopefully we shouldn't run into disk space issues with a single slice).

Fix some normalization behavior which seems to cause midl to fail due to having a directory traversal in one of its arguments.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4506)