### PR TITLE
[0.60] Prevent reference cycles between WebSocketModule and React Instance.

### DIFF
--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -53,7 +53,7 @@ steps:
     displayName: Install react-native-cli
     inputs:
       script: npm install -g react-native-cli
-      
+
   - task: CmdLine@2
     displayName: yarn ${{ parameters.yarnBuildCmd }}
     inputs:
@@ -80,3 +80,7 @@ steps:
       targetType: inline # filePath | inline
       script: |
         Get-WmiObject Win32_LogicalDisk
+
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: ">=4.6.0"

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -374,6 +374,11 @@ jobs:
         inputs:
           version: '10.x'
 
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: ">=4.6.0"
+
       - template: templates/react-native-init.yml
         parameters:
           version: 0.60.6
@@ -395,6 +400,11 @@ jobs:
         lfs: false # whether to download Git-LFS files
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: ">=4.6.0"
 
       - task: CmdLine@2
         displayName: yarn install
@@ -472,6 +482,11 @@ jobs:
         lfs: false # whether to download Git-LFS files
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: ">=4.6.0"
 
       - task: UseNode@1
         inputs:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -21,6 +21,11 @@ jobs:
           targetType: filePath
           filePath: .ado/shouldSkipPRBuild.ps1
 
+      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: ">=4.6.0"
+
   - job: RNWUniversalPR
     displayName: Universal PR
     dependsOn: Setup
@@ -108,7 +113,7 @@ jobs:
       - checkout: self
         clean: false
         submodules: false
-        
+
       - template: templates/prepare-env.yml
         parameters:
           useRnFork: $(UseRNFork)
@@ -167,7 +172,7 @@ jobs:
         condition: and(succeeded(), eq(variables['UseRNFork'], 'true'), ne(variables['BuildPlatform'], 'x86'), false) # Disabled. issue #3670  Unable to resolve module `warnOnce`
 
       # Possible related to https://social.msdn.microsoft.com/Forums/vstudio/en-US/23c8df57-9c50-476c-9f56-1fe058e75a9d/uwp-app-builds-on-local-machine-fails-on-build-agent-systemprivatecorelib-not-found
-      # use X86 msbuild to avoid ##[error]...Microsoft.AppXPackage.Targets(1248,5): Error MSB3816: Loading assembly "\runtime.win7-x86.microsoft.netcore.runtime.coreclr\1.0.2\runtimes\win7-x86\lib\netstandard1.0\mscorlib.dll" failed. 
+      # use X86 msbuild to avoid ##[error]...Microsoft.AppXPackage.Targets(1248,5): Error MSB3816: Loading assembly "\runtime.win7-x86.microsoft.netcore.runtime.coreclr\1.0.2\runtimes\win7-x86\lib\netstandard1.0\mscorlib.dll" failed.
       # System.ArgumentException: A BadImageFormatException has been thrown while parsing the signature.
       # This is likely due to lack of a generic context. Ensure genericTypeArguments and genericMethodArguments are provided and contain enough context.
       - task: MSBuild@1

--- a/change/react-native-windows-2020-04-06-15-55-46-winapi_ws_0.60-weakInstance.json
+++ b/change/react-native-windows-2020-04-06-15-55-46-winapi_ws_0.60-weakInstance.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Make WS callbacks capture weak instance instead of strong instance pointer",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "commit": "f9231ef1758e686f6cf2ea5133b8e7eb692a6d74",
+  "dependentChangeType": "patch",
+  "date": "2020-04-06T22:55:46.289Z"
+}

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -148,26 +148,42 @@ std::shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_
   {
     auto ws = IWebSocketResource::Make(std::move(url));
     auto weakInstance = this->getInstance();
-    ws->SetOnError([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), instance = weakInstance.lock()](const IWebSocketResource::Error& err)
+    ws->SetOnError([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance](const IWebSocketResource::Error& err)
     {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
       auto strongWs = weakWs.lock();
       auto errorObj = dynamic::object("id", id)("message", err.Message);
       this->SendEvent("websocketFailed", std::move(errorObj));
     });
-    ws->SetOnConnect([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), instance = weakInstance.lock()]()
+    ws->SetOnConnect([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance]()
     {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
       auto strongWs = weakWs.lock();
       auto args = dynamic::object("id", id);
       this->SendEvent("websocketOpen", std::move(args));
     });
-    ws->SetOnMessage([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), instance = weakInstance.lock()](size_t length, const string& message)
+    ws->SetOnMessage([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance](size_t length, const string& message)
     {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
       auto strongWs = weakWs.lock();
       auto args = dynamic::object("id", id)("data", message)("type", "text");
       this->SendEvent("websocketMessage", std::move(args));
     });
-    ws->SetOnClose([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), instance = weakInstance.lock()](IWebSocketResource::CloseCode code, const string& reason)
+    ws->SetOnClose([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance](IWebSocketResource::CloseCode code, const string& reason)
     {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
       auto strongWs = weakWs.lock();
       auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
       this->SendEvent("websocketClosed", std::move(args));

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -148,43 +148,39 @@ std::shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_
   {
     auto ws = IWebSocketResource::Make(std::move(url));
     auto weakInstance = this->getInstance();
-    ws->SetOnError([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance](const IWebSocketResource::Error& err)
+    ws->SetOnError([this, id, weakInstance](const IWebSocketResource::Error& err)
     {
       auto strongInstance = weakInstance.lock();
       if (!strongInstance)
         return;
 
-      auto strongWs = weakWs.lock();
       auto errorObj = dynamic::object("id", id)("message", err.Message);
       this->SendEvent("websocketFailed", std::move(errorObj));
     });
-    ws->SetOnConnect([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance]()
+    ws->SetOnConnect([this, id, weakInstance]()
     {
       auto strongInstance = weakInstance.lock();
       if (!strongInstance)
         return;
 
-      auto strongWs = weakWs.lock();
       auto args = dynamic::object("id", id);
       this->SendEvent("websocketOpen", std::move(args));
     });
-    ws->SetOnMessage([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance](size_t length, const string& message)
+    ws->SetOnMessage([this, id, weakInstance](size_t length, const string& message)
     {
       auto strongInstance = weakInstance.lock();
       if (!strongInstance)
         return;
 
-      auto strongWs = weakWs.lock();
       auto args = dynamic::object("id", id)("data", message)("type", "text");
       this->SendEvent("websocketMessage", std::move(args));
     });
-    ws->SetOnClose([this, id, weakWs = weak_ptr<IWebSocketResource>(ws), weakInstance](IWebSocketResource::CloseCode code, const string& reason)
+    ws->SetOnClose([this, id, weakInstance](IWebSocketResource::CloseCode code, const string& reason)
     {
       auto strongInstance = weakInstance.lock();
       if (!strongInstance)
         return;
 
-      auto strongWs = weakWs.lock();
       auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
       this->SendEvent("websocketClosed", std::move(args));
     });

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -275,6 +275,11 @@ fire_and_forget WinRTWebSocketResource::PerformClose()
       {
         message = Utf16ToUtf8(e.message());
       }
+      // BSTR's allocated memory must be explicitly released.
+      // See https://docs.microsoft.com/en-us/cpp/atl-mfc-shared/allocating-and-releasing-memory-for-a-bstr
+      SysFreeString(description);
+      SysFreeString(restrictedDesc);
+      SysFreeString(capabilitySid);
 
       m_errorHandler({ std::move(message), ErrorType::Close });
     }


### PR DESCRIPTION
Capture a weak reference to the Instance in the WebSocket resource's callback lambda and bail if it's not available.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4510)