### PR TITLE
Rework more publish logic - produce nugets in PRs

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -157,6 +157,7 @@ jobs:
           layoutHeaders: eq('true', variables['LayoutHeaders'])
           contents: |
             ReactUWP\**
+            Microsoft.ReactNative\**
 
     # Disable for now, not sure this works on github projects anyway.
     # - task: PublishSymbols@2

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -6,6 +6,7 @@ parameters:
   desktopId: 'OfficeReact.Win32'
   microsoftRNId: 'Microsoft.ReactNative'
   universalId: 'OfficeReact.UWP'
+  slices: '("x64.Release", "x64.Debug", "x86.Release", "x86.Debug", "ARM.Release", "ARM.Debug", "ARM64.Release", "ARM64.Debug")'
 
 steps:
   - task: DownloadBuildArtifacts@0
@@ -13,6 +14,19 @@ steps:
     inputs:
       artifactName: ReactWindows
       downloadPath: $(System.DefaultWorkingDirectory)
+
+    # Strip down the binaries from nuget because we may not have built all the flavours.
+    - task: PowerShell@2
+      displayName: Strip slices from ReactUwp.nuspec
+      inputs:
+        targetType: filePath
+        filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+
+    - task: PowerShell@2
+      displayName: Strip slices from Microsoft.ReactNative.nuspec
+      inputs:
+        targetType: filePath
+        filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack Desktop'
@@ -36,4 +50,4 @@ steps:
       command: pack
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
-      buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.microsoftRNId}};nugetroot=${{parameters.nugetroot}}
+      buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.microsoftRNId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -15,18 +15,18 @@ steps:
       artifactName: ReactWindows
       downloadPath: $(System.DefaultWorkingDirectory)
 
-    # Strip down the binaries from nuget because we may not have built all the flavours.
-    - task: PowerShell@2
-      displayName: Strip slices from ReactUwp.nuspec
-      inputs:
-        targetType: filePath
-        filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+  # Strip down the binaries from nuget because we may not have built all the flavours.
+  - task: PowerShell@2
+    displayName: Strip slices from ReactUwp.nuspec
+    inputs:
+      targetType: filePath
+      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
 
-    - task: PowerShell@2
-      displayName: Strip slices from Microsoft.ReactNative.nuspec
-      inputs:
-        targetType: filePath
-        filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+  - task: PowerShell@2
+    displayName: Strip slices from Microsoft.ReactNative.nuspec
+    inputs:
+      targetType: filePath
+      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack Desktop'

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -50,6 +50,6 @@ steps:
     displayName: 'NuGet pack Microsoft.ReactNative'
     inputs:
       command: pack
-      packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec
+      packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
       buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.microsoftRNId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -20,13 +20,15 @@ steps:
     displayName: Strip slices from ReactUwp.nuspec
     inputs:
       targetType: filePath
-      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1
+      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/ReactUWP.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
 
   - task: PowerShell@2
     displayName: Strip slices from Microsoft.ReactNative.nuspec
     inputs:
       targetType: filePath
-      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1 -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1
+      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack Desktop'

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -28,7 +28,7 @@ steps:
     inputs:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1
-      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsot.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack Desktop'

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -62,7 +62,7 @@ steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download TestMSRNNuget Artifact'
     inputs:
-      artifactName: TestMSRNNuget.$(BuildPlatform).$(BuildConfiguration)
+      artifactName: TestMSRNNuget.${{ parameters.platform }}.${{ parameters.configuration }}
       downloadPath: $(System.DefaultWorkingDirectory)
     condition: eq('true', ${{ parameters.experimentalNugetDependency }})
 
@@ -83,7 +83,7 @@ steps:
     inputs:
       targetType: inline
       script: |
-        Install-Package Microsoft.ReactNative -Source $(System.DefaultWorkingDirectory)/TestMSRNNuget.$(BuildPlatform).$(BuildConfiguration) -Destination $(Agent.BuildDirectory)\testcli\windows\packages
+        Install-Package Microsoft.ReactNative -Source $(System.DefaultWorkingDirectory)/TestMSRNNuget.${{ parameters.platform }}.${{ parameters.configuration }} -Destination $(Agent.BuildDirectory)\testcli\windows\packages
     condition: eq('true', ${{ parameters.experimentalNugetDependency }})
 
   - task: NuGetCommand@2

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -62,7 +62,7 @@ steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download TestMSRNNuget Artifact'
     inputs:
-      artifactName: TestMSRNNuget
+      artifactName: TestMSRNNuget.${{ parameters.platform }}.${{ parameters.configuration }}
       downloadPath: $(System.DefaultWorkingDirectory)
     condition: eq('true', ${{ parameters.experimentalNugetDependency }})
 

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -62,7 +62,7 @@ steps:
   - task: DownloadBuildArtifacts@0
     displayName: 'Download TestMSRNNuget Artifact'
     inputs:
-      artifactName: TestMSRNNuget.${{ parameters.platform }}.${{ parameters.configuration }}
+      artifactName: TestMSRNNuget.$(BuildPlatform).$(BuildConfiguration)
       downloadPath: $(System.DefaultWorkingDirectory)
     condition: eq('true', ${{ parameters.experimentalNugetDependency }})
 
@@ -83,7 +83,7 @@ steps:
     inputs:
       targetType: inline
       script: |
-        Install-Package Microsoft.ReactNative -Source $(System.DefaultWorkingDirectory)/TestMSRNNuget -Destination $(Agent.BuildDirectory)\testcli\windows\packages
+        Install-Package Microsoft.ReactNative -Source $(System.DefaultWorkingDirectory)/TestMSRNNuget.$(BuildPlatform).$(BuildConfiguration) -Destination $(Agent.BuildDirectory)\testcli\windows\packages
     condition: eq('true', ${{ parameters.experimentalNugetDependency }})
 
   - task: NuGetCommand@2

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -35,10 +35,10 @@ jobs:
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
-          TestMSRNNuget: True
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
+          TestMSRNNuget: True
         #X86Release:
         #  BuildConfiguration: Release
         #  BuildPlatform: x86
@@ -101,6 +101,7 @@ jobs:
           layoutHeaders: eq('true', variables['LayoutHeaders'])
           contents: |
             ReactUWP\**
+            Microsoft.ReactNative\**
 
       - script: |
           npx --no-install beachball bump
@@ -114,15 +115,15 @@ jobs:
           script: |
             $pkgJson = Get-Content -Raw -Path .\vnext\package.json | ConvertFrom-Json
             $pkgVersion = $pkgJson.version
-            $(Build.SourcesDirectory)\vnext\Scripts\StripAdditionalPlatformsFromNuspec.ps1
+            $(Build.SourcesDirectory)\vnext\Scripts\StripAdditionalPlatformsFromNuspec.ps1 -slices ("$(BuildPlatform).$(BuildConfiguration)")
             Copy-Item -Force -Path vnext\Scripts\Microsoft.ReactNative.targets -Destination $(Build.SourcesDirectory)\vnext\target
-            nuget pack $(Build.SourcesDirectory)\vnext\Scripts\Microsoft.ReactNative.PR.nuspec -NonInteractive -OutputDirectory $(Build.StagingDirectory)/TestMSRNNuget -Properties "Configuration=Release;CommitId=0;version=$pkgVersion;id=Microsoft.ReactNative;nugetroot=$(Build.SourcesDirectory)\vnext\target" -Verbosity Detailed
+            nuget pack $(Build.SourcesDirectory)\vnext\Scripts\Microsoft.ReactNative.PR.nuspec -NonInteractive -OutputDirectory $(Build.StagingDirectory)/TestMSRNNuget -Properties "Configuration=Release;CommitId=0;version=$pkgVersion;id=Microsoft.ReactNative;nugetroot=$(Build.SourcesDirectory)\vnext\target;baseplatform=$(BuildPlatform);baseconfiguration=$(BuildConfiguration)" -Verbosity Detailed
         condition: eq('true', variables['TestMSRNNuget'])
 
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: TestMSRNNuget"
         inputs:
-          artifactName: TestMSRNNuget
+          artifactName: TestMSRNNuget.$(BuildPlatform).$(BuildConfiguration)
           pathtoPublish: $(Build.StagingDirectory)/TestMSRNNuget
         condition: eq('true', variables['TestMSRNNuget'])
 
@@ -612,12 +613,6 @@ jobs:
         inputs:
           versionSpec: ">=4.6.0"
 
-      # Exclude ReactUWP from nuget because we didn't build all the flavours.
-      - task: PowerShell@2
-        displayName: Exclude ReactUWP from ReactUwp.nuspec
-        inputs:
-          targetType: inline # filePath | inline
-          script: |
-            ((Get-Content -path vnext\Scripts\ReactUwp.nuspec -Raw) -replace ".*ReactUWP\\React.UWP.*","") | Set-Content -Path vnext\Scripts\ReactUwp.nuspec
-
       - template: templates/prep-and-pack-nuget.yml
+        parameters:
+          slices: '("x64.Release", "x86.Debug", "ARM.Debug")'

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -38,7 +38,8 @@ jobs:
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
-          TestMSRNNuget: True
+          TestMSRNNuget: true
+          LayoutHeaders: true
         #X86Release:
         #  BuildConfiguration: Release
         #  BuildPlatform: x86
@@ -526,8 +527,8 @@ jobs:
       - template: templates/react-native-init.yml
         parameters:
           language: cpp
-          configuration: Release
-          platform: x64
+          configuration: Debug
+          platform: x86
           version: $(reactNativeVersion)
           vsComponents: $(VsComponents)
           experimentalNugetDependency: true

--- a/change/react-native-windows-2020-04-07-14-22-47-pubmsrn2.json
+++ b/change/react-native-windows-2020-04-07-14-22-47-pubmsrn2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rework more publish logic - produce nugets in PRs",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-07T21:22:47.793Z"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -15,7 +15,7 @@
 
     <file src="$nugetroot$\Microsoft.ReactNative.targets" target="build\native"/>
 
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.winmd"   target="lib\uap10.0"/>
+    <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative\Microsoft.ReactNative.winmd"   target="lib\uap10.0"/>
     <!-- 
     Uncomment once we are producing doc xml file
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml"   target="lib\uap10.0"/> 
@@ -25,17 +25,33 @@
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
 
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
+
     <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
     <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
     <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
+
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
 
     <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
     <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
     <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
 
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
+
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
+
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
 
   </files>
 </package>

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -101,7 +101,11 @@ Get-ChildItem -Path $ReactWindowsRoot\Desktop.Test.DLL -Name -Recurse -Include $
 Copy-Item -Force -Recurse -Path $ReactWindowsRoot\include -Destination $TargetRoot\inc
 
 # NUSPEC
-Copy-Item -Force -Path $ReactWindowsRoot\Scripts\React*.nuspec -Destination $TargetRoot
+Copy-Item -Force -Path $ReactWindowsRoot\Scripts\*.nuspec -Destination $TargetRoot
+
+#Copy StripAdditionalPlatformsFromNuspec.ps1 for use by publish task
+Copy-Item -Force -Path $ReactWindowsRoot\Scripts\StripAdditionalPlatformsFromNuspec.ps1 -Destination $TargetRoot
+
 
 # Microsoft.ReactNative.targets
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.targets -Destination $TargetRoot


### PR DESCRIPTION
Currently nuget creation isn't really getting any test coverage during PRs.  This should get them building again.

Also moved the logic for the experimental nuget init package to the x86 debug build, since that is the quicker of the slices.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4524)