### PR TITLE
Improve inner loop and error reporting (local CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ packages/
 #Other files
 *.DotSettings
 .vs/
+.vscode/
 *project.lock.json
 jsconfig.json
 package-lock.json

--- a/change/react-native-windows-2020-04-08-19-30-11-fork-localCLI.json
+++ b/change/react-native-windows-2020-04-08-19-30-11-fork-localCLI.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Improve inner loop and error reporting (local CLI)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-09T02:30:11.182Z"
+}

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -12,6 +12,17 @@ const {newError, newInfo} = require('./utils/commandWithProgress');
 const info = require('./utils/info');
 const msbuildtools = require('./utils/msbuildtools');
 const autolink = require('./utils/autolink');
+const fs = require('fs');
+
+function unique(arr) {
+  let arrOut = [];
+  for (let i = 0; i < arr.length; i++) {
+    if (!arrOut.find(x => x === arr[i])) {
+      arrOut.push(arr[i]);
+    }
+  }
+  return arrOut;
+}
 
 async function runWindows(config, args, options) {
   const verbose = options.logging;
@@ -70,6 +81,9 @@ async function runWindows(config, args, options) {
         verbose,
       );
     } catch (e) {
+      if (!e) {
+        e = unique(fs.readFileSync('msbuild.err').toString().split('\n'));
+      }
       newError(
         `Build failed with message ${e}. Check your build configuration.`,
       );
@@ -89,7 +103,7 @@ async function runWindows(config, args, options) {
         await deploy.deployToDesktop(options, verbose);
       }
     } catch (e) {
-      newError(`Failed to deploy: ${e.message}`);
+      newError(`Failed to deploy${e ? `: ${e.message}` : ''}`);
       process.exit(1);
     }
   } else {

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -12,6 +12,7 @@ const {newError, newInfo} = require('./utils/commandWithProgress');
 const info = require('./utils/info');
 const msbuildtools = require('./utils/msbuildtools');
 const autolink = require('./utils/autolink');
+const chalk = require('chalk');
 
 async function runWindows(config, args, options) {
   const verbose = options.logging;
@@ -75,6 +76,9 @@ async function runWindows(config, args, options) {
           e.message
         }. Check your build configuration.`,
       );
+      if (e.logfile) {
+        console.log('See', chalk.bold(e.logfile));
+      }
       process.exit(1);
     }
   } else {

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -12,17 +12,6 @@ const {newError, newInfo} = require('./utils/commandWithProgress');
 const info = require('./utils/info');
 const msbuildtools = require('./utils/msbuildtools');
 const autolink = require('./utils/autolink');
-const fs = require('fs');
-
-function unique(arr) {
-  let arrOut = [];
-  for (let i = 0; i < arr.length; i++) {
-    if (!arrOut.find(x => x === arr[i])) {
-      arrOut.push(arr[i]);
-    }
-  }
-  return arrOut;
-}
 
 async function runWindows(config, args, options) {
   const verbose = options.logging;
@@ -81,11 +70,10 @@ async function runWindows(config, args, options) {
         verbose,
       );
     } catch (e) {
-      if (!e) {
-        e = unique(fs.readFileSync('msbuild.err').toString().split('\n'));
-      }
       newError(
-        `Build failed with message ${e}. Check your build configuration.`,
+        `Build failed with message ${
+          e.message
+        }. Check your build configuration.`,
       );
       process.exit(1);
     }

--- a/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -88,7 +88,7 @@ function EnableDevmode {
         New-Item -Path $RegistryKeyPath -ItemType Directory -Force
     }
 
-    Set-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -Value 1
+    Set-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -Value 1 -ErrorAction Stop
 }
 
 #

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -92,10 +92,9 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
     );
   } catch (e) {
     if (!options.isRetryingNuget) {
-      options.isRetryingNuget = true;
+      const retryOptions = Object.assign({isRetryingNuget: true}, options);
       fs.unlinkSync(nugetPath);
-      await restoreNuGetPackages(options, slnFile, verbose);
-      return;
+      return restoreNuGetPackages(retryOptions, slnFile, verbose);
     }
     throw e;
   }

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -42,7 +42,7 @@ async function buildSolution(
 }
 
 async function nugetRestore(nugetPath, slnFile, verbose, msbuildVersion) {
-  const text = 'Restoring NuGets';
+  const text = 'Restoring NuGet packages ';
   const spinner = newSpinner(text);
   console.log(nugetPath);
   await commandWithProgress(
@@ -74,7 +74,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
       ensureNugetSpinner,
       dlNugetText,
       'powershell',
-      `Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe -outfile ${nugetPath}`.split(
+      `$progressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue; Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe -outfile ${nugetPath}`.split(
         ' ',
       ),
       verbose,
@@ -83,12 +83,22 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
   ensureNugetSpinner.succeed('Found NuGet Binary');
 
   const msbuildTools = MSBuildTools.findAvailableVersion('x86', verbose);
-  await nugetRestore(
-    nugetPath,
-    slnFile,
-    verbose,
-    msbuildTools.installationVersion,
-  );
+  try {
+    await nugetRestore(
+      nugetPath,
+      slnFile,
+      verbose,
+      msbuildTools.installationVersion,
+    );
+  } catch (e) {
+    if (!options.isRetryingNuget) {
+      options.isRetryingNuget = true;
+      fs.unlinkSync(nugetPath);
+      await restoreNuGetPackages(options, slnFile, verbose);
+      return;
+    }
+    throw e;
+  }
 }
 
 function getSolutionFile(options) {

--- a/vnext/local-cli/runWindows/utils/commandWithProgress.js
+++ b/vnext/local-cli/runWindows/utils/commandWithProgress.js
@@ -41,11 +41,16 @@ function newSpinner(text) {
   return ora(options).start();
 }
 
-async function runPowerShellScriptFunction(text, script, funcName, verbose) {
+async function runPowerShellScriptFunction(
+  taskDescription,
+  script,
+  funcName,
+  verbose,
+) {
   try {
     await commandWithProgress(
-      newSpinner(text),
-      text,
+      newSpinner(taskDescription),
+      taskDescription,
       'powershell',
       [
         '-NoProfile',
@@ -58,7 +63,7 @@ async function runPowerShellScriptFunction(text, script, funcName, verbose) {
   } catch {
     // The error output from the process will be shown if verbose is set.
     // We don't capture the process output if verbose is set, but at least we have the task name in text, so throw that.
-    throw new Error(text);
+    throw new Error(taskDescription);
   }
 }
 
@@ -71,7 +76,7 @@ function commandWithProgress(spinner, taskDoingName, command, args, verbose) {
     }
 
     const cp = child_process.spawn(command, args, spawnOptions);
-    var error = null;
+    let firstErrorLine = null;
     if (!verbose) {
       cp.stdout.on('data', chunk => {
         const text = chunk.toString();
@@ -79,14 +84,14 @@ function commandWithProgress(spinner, taskDoingName, command, args, verbose) {
       });
       cp.stderr.on('data', chunk => {
         const text = chunk.toString();
-        if (!error) {
-          error = text;
+        if (!firstErrorLine) {
+          firstErrorLine = text;
         }
         if (verbose) {
           console.error(chalk.red(text));
         }
         if (text) {
-          setSpinnerText(spinner, taskDoingName + ': ERROR: ', error);
+          setSpinnerText(spinner, taskDoingName + ': ERROR: ', firstErrorLine);
         }
       });
     }

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -20,6 +20,7 @@ const {
   newWarn,
   newSpinner,
   commandWithProgress,
+  runPowerShellScriptFunction,
 } = require('./commandWithProgress');
 
 function pushd(pathArg) {
@@ -166,36 +167,24 @@ async function deployToDesktop(options, verbose) {
 
   const popd = pushd(options.root);
 
-  const removingText = 'Removing old version of the app';
-  await commandWithProgress(
-    newSpinner(removingText),
-    removingText,
-    'powershell',
-    `-NoProfile -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}" ; Uninstall-App ${appName}`.split(
-      ' ',
-    ),
+  await runPowerShellScriptFunction(
+    'Removing old version of the app',
+    windowsStoreAppUtils,
+    `Uninstall-App ${appName}`,
     verbose,
   );
 
-  const devmodeText = 'Enabling Developer Mode';
-  const devmodeEnable = `-NoProfile -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; EnableDevmode "${script}"`;
-
-  await commandWithProgress(
-    newSpinner(devmodeText),
-    devmodeText,
-    'powershell',
-    devmodeEnable.split(' '),
+  await runPowerShellScriptFunction(
+    'Enabling Developer Mode',
+    windowsStoreAppUtils,
+    `EnableDevMode "${script}"`,
     verbose,
   );
 
-  const installingText = 'Installing new version of the app';
-  const installApp = `-NoProfile -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Install-App "${script}" -Force`;
-
-  await commandWithProgress(
-    newSpinner(installingText),
-    installingText,
-    'powershell',
-    installApp.split(' '),
+  await runPowerShellScriptFunction(
+    'Installing new version of the app',
+    windowsStoreAppUtils,
+    `Install-App "${script}" -Force`,
     verbose,
   );
 
@@ -223,14 +212,10 @@ async function deployToDesktop(options, verbose) {
   );
 
   if (shouldLaunchApp(options)) {
-    const startingText = 'Starting the app';
-    await commandWithProgress(
-      newSpinner(startingText),
-      startingText,
-      'powershell',
-      `-ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} ${args}`.split(
-        ' ',
-      ),
+    await runPowerShellScriptFunction(
+      'Starting the app',
+      windowsStoreAppUtils,
+      `Start-Locally ${appName} ${args}`,
       verbose,
     );
   } else {

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -22,16 +22,6 @@ const {
 } = require('./commandWithProgress');
 const execSync = require('child_process').execSync;
 
-function unique(arr) {
-  let arrOut = [];
-  for (let i = 0; i < arr.length; i++) {
-    if (!arrOut.find(x => x === arr[i])) {
-      arrOut.push(arr[i]);
-    }
-  }
-  return arrOut;
-}
-
 const MSBUILD_VERSIONS = ['16.0'];
 
 class MSBuildTools {
@@ -61,7 +51,7 @@ class MSBuildTools {
     newInfo(`Build configuration: ${buildType}`);
     newInfo(`Build platform: ${buildArch}`);
 
-    const verbosityOption = verbose ? 'normal' : 'quiet';
+    const verbosityOption = verbose ? 'normal' : 'minimal';
     const errorLog = path.join(process.env.temp, `msbuild_${process.pid}.err`);
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,
@@ -86,7 +76,9 @@ class MSBuildTools {
       throw e;
     }
 
-    console.log(`Running MSBuild with args ${args.join(' ')}`);
+    if (verbose) {
+      console.log(`Running MSBuild with args ${args.join(' ')}`);
+    }
 
     const progressName = 'Building Solution';
     const spinner = newSpinner(progressName);
@@ -102,13 +94,12 @@ class MSBuildTools {
       let error = e;
       if (!e) {
         error = new Error(
-          unique(
-            fs
-              .readFileSync(errorLog)
-              .toString()
-              .split('\n'),
-          )[0],
+          fs
+            .readFileSync(errorLog)
+            .toString()
+            .split(EOL)[0],
         );
+        error.logfile = errorLog;
       }
       throw error;
     }

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -93,19 +93,17 @@ class MSBuildTools {
     } catch (e) {
       let error = e;
       if (!e) {
-        error = new Error(
-          fs
-            .readFileSync(errorLog)
-            .toString()
-            .split(EOL)[0],
-        );
+        const firstMessage = (await fs.promises.readFile(errorLog))
+          .toString()
+          .split(EOL)[0];
+        error = new Error(firstMessage);
         error.logfile = errorLog;
       }
       throw error;
     }
     // If we have no errors, delete the error log when we're done
-    if (fs.statSync(errorLog).size === 0) {
-      fs.unlinkSync(errorLog);
+    if ((await fs.promises.stat(errorLog)).size === 0) {
+      await fs.promises.unlink(errorLog);
     }
   }
 }

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -51,17 +51,16 @@ class MSBuildTools {
     newInfo(`Build configuration: ${buildType}`);
     newInfo(`Build platform: ${buildArch}`);
 
-    //const verbosityOption = verbose ? 'normal' : 'quiet';
-    const verbosityOption = 'normal';
+    const verbosityOption = verbose ? 'normal' : 'quiet';
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,
       '/nologo',
       `/p:Configuration=${buildType}`,
       `/p:Platform=${buildArch}`,
       '/p:AppxBundle=Never',
+      '/bl',
+      '/flp1:errorsonly;logfile=msbuild.err'
     ];
-
-    args.push('/bl');
 
     if (msBuildProps) {
       Object.keys(msBuildProps).forEach(function(key) {
@@ -73,7 +72,7 @@ class MSBuildTools {
       checkRequirements.isWinSdkPresent('10.0');
     } catch (e) {
       newError(e.message);
-      return;
+      throw e;
     }
 
     console.log(`Running MSBuild with args ${args.join(' ')}`);


### PR DESCRIPTION
- Surface msbuild errors (shows as undefined right now)
- downloading nuget with Invoke-WebRequest will usually take a long time because of the PS progress bar (which sadly gets updated for every byte), so I'm disabling the progress bar (it only takes a second to download when the progress bar is turned off)
- retry once if nuget failed since if you cancel at just the right time, you could end up with a truncated nuget.exe and are wedged unless you know which file to delete. Learned that the hard way.
- factor out calling onto powershell functions
- we were not exposing whether the function failed or not


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4536)