### PR TITLE
Enable WebSocketModule unit tests

### DIFF
--- a/change/react-native-windows-2020-04-09-16-51-25-wsmodule_unittests.json
+++ b/change/react-native-windows-2020-04-09-16-51-25-wsmodule_unittests.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "dependentChangeType": "none",
+  "date": "2020-04-09T23:51:25.594Z"
+}

--- a/change/react-native-windows-2020-04-09-16-51-56-wsmodule_unittests.json
+++ b/change/react-native-windows-2020-04-09-16-51-56-wsmodule_unittests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Allow WebSocketModule to use custom resource factory",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "dependentChangeType": "none",
+  "date": "2020-04-09T23:51:56.846Z"
+}

--- a/vnext/Desktop.UnitTests/InstanceMocks.cpp
+++ b/vnext/Desktop.UnitTests/InstanceMocks.cpp
@@ -1,0 +1,100 @@
+#include "InstanceMocks.h"
+
+#include <cxxreact/ModuleRegistry.h>
+
+using namespace facebook::react;
+
+using folly::dynamic;
+using std::function;
+using std::make_unique;
+using std::make_shared;
+using std::shared_ptr;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+namespace Microsoft::React::Test
+{
+#pragma region MockMessageQueueThread
+  void MockMessageQueueThread::runOnQueue(function<void()>&& work) /*override*/
+  {
+    work();
+  }
+
+  void MockMessageQueueThread::runOnQueueSync(function<void()>&& work) /*override*/
+  {
+    work();
+  }
+
+  void MockMessageQueueThread::quitSynchronous() /*override*/ {}
+#pragma endregion // MockMessageQueueThread
+
+#pragma region MockInstanceCallback
+
+  void MockInstanceCallback::onBatchComplete() /*override*/ {}
+  void MockInstanceCallback::incrementPendingJSCalls() /*override*/ {}
+  void MockInstanceCallback::decrementPendingJSCalls() /*override*/ {}
+
+#pragma endregion // MockInstanceCallback
+
+#pragma region MockJSExecutor
+
+  void MockJSExecutor::loadApplicationScript(unique_ptr<const JSBigString> script, string sourceURL) {}
+  void MockJSExecutor::setBundleRegistry(unique_ptr<RAMBundleRegistry> bundleRegistry) {}
+  void MockJSExecutor::registerBundle(uint32_t bundleId, const string& bundlePath) {}
+
+
+void MockJSExecutor::callFunction(const string& moduleId, const string& methodId, const dynamic& arguments) {
+  if (CallFunctionMock) {
+    CallFunctionMock(moduleId, methodId, arguments);
+  }
+}
+
+void MockJSExecutor::invokeCallback(const double callbackId, const dynamic& arguments) {}
+void MockJSExecutor::setGlobalVariable(string propName, unique_ptr<const JSBigString> jsonValue) {}
+void* MockJSExecutor::getJavaScriptContext() {
+  return nullptr;
+}
+
+bool MockJSExecutor::isInspectable() {
+  return false;
+}
+std::string MockJSExecutor::getDescription() {
+  return {};
+}
+void MockJSExecutor::handleMemoryPressure(__unused int pressureLevel) {}
+void MockJSExecutor::destroy() {}
+void MockJSExecutor::flush() {}
+
+#pragma endregion // MockJSExecutor
+
+#pragma region MockJSExecutorFactory
+
+unique_ptr<JSExecutor> MockJSExecutorFactory::createJSExecutor(
+  shared_ptr<ExecutorDelegate> delegate,
+  shared_ptr<MessageQueueThread> jsQueue) /*override*/
+{
+  if (CreateJSExecutorMock) {
+    return CreateJSExecutorMock(delegate, jsQueue);
+  }
+
+  return make_unique<MockJSExecutor>();
+}
+
+#pragma endregion // MockJSExecutorFactory
+
+shared_ptr<Instance> CreateMockInstance(shared_ptr<JSExecutorFactory> jsef) {
+  auto instance = make_shared<Instance>();
+  auto callback = make_unique<MockInstanceCallback>();
+  auto jsQueue = make_shared<MockMessageQueueThread>();
+  auto moduleRegistry = make_shared<ModuleRegistry>(
+    vector<unique_ptr<NativeModule>>(), // modules
+    nullptr // moduleNotFoundCallback
+    );
+
+  instance->initializeBridge(std::move(callback), jsef, jsQueue, moduleRegistry);
+
+  return instance;
+}
+
+} // namespace Microsoft::React::Test

--- a/vnext/Desktop.UnitTests/InstanceMocks.cpp
+++ b/vnext/Desktop.UnitTests/InstanceMocks.cpp
@@ -6,53 +6,51 @@ using namespace facebook::react;
 
 using folly::dynamic;
 using std::function;
-using std::make_unique;
 using std::make_shared;
+using std::make_unique;
 using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
 using std::vector;
 
-namespace Microsoft::React::Test
-{
+namespace Microsoft::React::Test {
 #pragma region MockMessageQueueThread
-  void MockMessageQueueThread::runOnQueue(function<void()>&& work) /*override*/
-  {
-    work();
-  }
+void MockMessageQueueThread::runOnQueue(function<void()> &&work) /*override*/
+{
+  work();
+}
 
-  void MockMessageQueueThread::runOnQueueSync(function<void()>&& work) /*override*/
-  {
-    work();
-  }
+void MockMessageQueueThread::runOnQueueSync(function<void()> &&work) /*override*/
+{
+  work();
+}
 
-  void MockMessageQueueThread::quitSynchronous() /*override*/ {}
+void MockMessageQueueThread::quitSynchronous() /*override*/ {}
 #pragma endregion // MockMessageQueueThread
 
 #pragma region MockInstanceCallback
 
-  void MockInstanceCallback::onBatchComplete() /*override*/ {}
-  void MockInstanceCallback::incrementPendingJSCalls() /*override*/ {}
-  void MockInstanceCallback::decrementPendingJSCalls() /*override*/ {}
+void MockInstanceCallback::onBatchComplete() /*override*/ {}
+void MockInstanceCallback::incrementPendingJSCalls() /*override*/ {}
+void MockInstanceCallback::decrementPendingJSCalls() /*override*/ {}
 
 #pragma endregion // MockInstanceCallback
 
 #pragma region MockJSExecutor
 
-  void MockJSExecutor::loadApplicationScript(unique_ptr<const JSBigString> script, string sourceURL) {}
-  void MockJSExecutor::setBundleRegistry(unique_ptr<RAMBundleRegistry> bundleRegistry) {}
-  void MockJSExecutor::registerBundle(uint32_t bundleId, const string& bundlePath) {}
+void MockJSExecutor::loadApplicationScript(unique_ptr<const JSBigString> script, string sourceURL) {}
+void MockJSExecutor::setBundleRegistry(unique_ptr<RAMBundleRegistry> bundleRegistry) {}
+void MockJSExecutor::registerBundle(uint32_t bundleId, const string &bundlePath) {}
 
-
-void MockJSExecutor::callFunction(const string& moduleId, const string& methodId, const dynamic& arguments) {
+void MockJSExecutor::callFunction(const string &moduleId, const string &methodId, const dynamic &arguments) {
   if (CallFunctionMock) {
     CallFunctionMock(moduleId, methodId, arguments);
   }
 }
 
-void MockJSExecutor::invokeCallback(const double callbackId, const dynamic& arguments) {}
+void MockJSExecutor::invokeCallback(const double callbackId, const dynamic &arguments) {}
 void MockJSExecutor::setGlobalVariable(string propName, unique_ptr<const JSBigString> jsonValue) {}
-void* MockJSExecutor::getJavaScriptContext() {
+void *MockJSExecutor::getJavaScriptContext() {
   return nullptr;
 }
 
@@ -71,8 +69,8 @@ void MockJSExecutor::flush() {}
 #pragma region MockJSExecutorFactory
 
 unique_ptr<JSExecutor> MockJSExecutorFactory::createJSExecutor(
-  shared_ptr<ExecutorDelegate> delegate,
-  shared_ptr<MessageQueueThread> jsQueue) /*override*/
+    shared_ptr<ExecutorDelegate> delegate,
+    shared_ptr<MessageQueueThread> jsQueue) /*override*/
 {
   if (CreateJSExecutorMock) {
     return CreateJSExecutorMock(delegate, jsQueue);
@@ -88,9 +86,9 @@ shared_ptr<Instance> CreateMockInstance(shared_ptr<JSExecutorFactory> jsef) {
   auto callback = make_unique<MockInstanceCallback>();
   auto jsQueue = make_shared<MockMessageQueueThread>();
   auto moduleRegistry = make_shared<ModuleRegistry>(
-    vector<unique_ptr<NativeModule>>(), // modules
-    nullptr // moduleNotFoundCallback
-    );
+      vector<unique_ptr<NativeModule>>(), // modules
+      nullptr // moduleNotFoundCallback
+  );
 
   instance->initializeBridge(std::move(callback), jsef, jsQueue, moduleRegistry);
 

--- a/vnext/Desktop.UnitTests/InstanceMocks.h
+++ b/vnext/Desktop.UnitTests/InstanceMocks.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cxxreact/Instance.h>
+#include <cxxreact/JSBigString.h>
+#include <cxxreact/JSExecutor.h>
+#include <cxxreact/MessageQueueThread.h>
+#include <cxxreact/RAMBundleRegistry.h>
+
+namespace Microsoft::React::Test
+{
+std::shared_ptr<facebook::react::Instance> CreateMockInstance(std::shared_ptr<facebook::react::JSExecutorFactory> jsef);
+
+class MockMessageQueueThread : public facebook::react::MessageQueueThread {
+public:
+#pragma region MessageQueueThread overrides
+
+  void runOnQueue(std::function<void()>&&) override;
+
+  void runOnQueueSync(std::function<void()>&&) override;
+
+  void quitSynchronous() override;
+
+#pragma endregion // MessageQueueThread overrides
+};
+
+class MockInstanceCallback : public facebook::react::InstanceCallback {
+public:
+#pragma region InstanceCallback overrides
+
+  void onBatchComplete() override;
+  void incrementPendingJSCalls() override;
+  void decrementPendingJSCalls() override;
+
+#pragma endregion // InstanceCallback overrides
+};
+
+class MockJSExecutor : public facebook::react::JSExecutor {
+public:
+  std::function<void(const std::string&, const std::string&, const folly::dynamic&)> CallFunctionMock;
+
+#pragma region JSExecutor overrides
+
+  void loadApplicationScript(std::unique_ptr<const facebook::react::JSBigString> script, std::string sourceURL) override;
+
+  void setBundleRegistry(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry) override;
+
+  void registerBundle(uint32_t bundleId, const std::string& bundlePath) override;
+
+  void callFunction(const std::string& moduleId, const std::string& methodId, const folly::dynamic& arguments) override;
+
+  void invokeCallback(const double callbackId, const folly::dynamic& arguments) override;
+
+  void setGlobalVariable(std::string propName, std::unique_ptr<const facebook::react::JSBigString> jsonValue) override;
+
+  void* getJavaScriptContext() override;
+
+  bool isInspectable() override;
+
+  std::string getDescription() override;
+
+  void handleMemoryPressure(__unused int pressureLevel) override;
+
+  void destroy() override;
+
+  void flush() override;
+
+#pragma endregion // JSExecutor overrides
+};
+
+class MockJSExecutorFactory : public facebook::react::JSExecutorFactory {
+public:
+  std::function<std::unique_ptr<facebook::react::JSExecutor>(std::shared_ptr<facebook::react::ExecutorDelegate>, std::shared_ptr<facebook::react::MessageQueueThread>)>
+    CreateJSExecutorMock;
+
+#pragma region JSExecutorFactory overrides
+
+  std::unique_ptr<facebook::react::JSExecutor> createJSExecutor(
+    std::shared_ptr<facebook::react::ExecutorDelegate> delegate,
+    std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) override;
+
+#pragma endregion // JSExecutorFactory overrides
+};
+
+} // namespace Microsoft::React::Test

--- a/vnext/Desktop.UnitTests/InstanceMocks.h
+++ b/vnext/Desktop.UnitTests/InstanceMocks.h
@@ -6,17 +6,16 @@
 #include <cxxreact/MessageQueueThread.h>
 #include <cxxreact/RAMBundleRegistry.h>
 
-namespace Microsoft::React::Test
-{
+namespace Microsoft::React::Test {
 std::shared_ptr<facebook::react::Instance> CreateMockInstance(std::shared_ptr<facebook::react::JSExecutorFactory> jsef);
 
 class MockMessageQueueThread : public facebook::react::MessageQueueThread {
-public:
+ public:
 #pragma region MessageQueueThread overrides
 
-  void runOnQueue(std::function<void()>&&) override;
+  void runOnQueue(std::function<void()> &&) override;
 
-  void runOnQueueSync(std::function<void()>&&) override;
+  void runOnQueueSync(std::function<void()> &&) override;
 
   void quitSynchronous() override;
 
@@ -24,7 +23,7 @@ public:
 };
 
 class MockInstanceCallback : public facebook::react::InstanceCallback {
-public:
+ public:
 #pragma region InstanceCallback overrides
 
   void onBatchComplete() override;
@@ -35,24 +34,25 @@ public:
 };
 
 class MockJSExecutor : public facebook::react::JSExecutor {
-public:
-  std::function<void(const std::string&, const std::string&, const folly::dynamic&)> CallFunctionMock;
+ public:
+  std::function<void(const std::string &, const std::string &, const folly::dynamic &)> CallFunctionMock;
 
 #pragma region JSExecutor overrides
 
-  void loadApplicationScript(std::unique_ptr<const facebook::react::JSBigString> script, std::string sourceURL) override;
+  void loadApplicationScript(std::unique_ptr<const facebook::react::JSBigString> script, std::string sourceURL)
+      override;
 
   void setBundleRegistry(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry) override;
 
-  void registerBundle(uint32_t bundleId, const std::string& bundlePath) override;
+  void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
 
-  void callFunction(const std::string& moduleId, const std::string& methodId, const folly::dynamic& arguments) override;
+  void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments) override;
 
-  void invokeCallback(const double callbackId, const folly::dynamic& arguments) override;
+  void invokeCallback(const double callbackId, const folly::dynamic &arguments) override;
 
   void setGlobalVariable(std::string propName, std::unique_ptr<const facebook::react::JSBigString> jsonValue) override;
 
-  void* getJavaScriptContext() override;
+  void *getJavaScriptContext() override;
 
   bool isInspectable() override;
 
@@ -68,15 +68,17 @@ public:
 };
 
 class MockJSExecutorFactory : public facebook::react::JSExecutorFactory {
-public:
-  std::function<std::unique_ptr<facebook::react::JSExecutor>(std::shared_ptr<facebook::react::ExecutorDelegate>, std::shared_ptr<facebook::react::MessageQueueThread>)>
-    CreateJSExecutorMock;
+ public:
+  std::function<std::unique_ptr<facebook::react::JSExecutor>(
+      std::shared_ptr<facebook::react::ExecutorDelegate>,
+      std::shared_ptr<facebook::react::MessageQueueThread>)>
+      CreateJSExecutorMock;
 
 #pragma region JSExecutorFactory overrides
 
   std::unique_ptr<facebook::react::JSExecutor> createJSExecutor(
-    std::shared_ptr<facebook::react::ExecutorDelegate> delegate,
-    std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) override;
+      std::shared_ptr<facebook::react::ExecutorDelegate> delegate,
+      std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) override;
 
 #pragma endregion // JSExecutorFactory overrides
 };

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -87,12 +87,14 @@
     <ClCompile Include="EmptyUIManagerModule.cpp" />
     <ClCompile Include="LayoutAnimationTests.cpp" />
     <ClCompile Include="MemoryMappedBufferTests.cpp" />
+    <ClCompile Include="InstanceMocks.cpp" />
     <ClCompile Include="UnicodeConversionTest.cpp" />
     <ClCompile Include="UnicodeTestStrings.cpp" />
     <ClCompile Include="StringConversionTest_Desktop.cpp" />
     <ClCompile Include="UIManagerModuleTest.cpp" />
     <ClCompile Include="UtilsTest.cpp" />
     <ClCompile Include="WebSocketJSExecutorTest.cpp" />
+    <ClCompile Include="WebSocketMocks.cpp" />
     <ClCompile Include="WebSocketModuleTest.cpp" />
     <ClCompile Include="WebSocketTest.cpp" />
   </ItemGroup>
@@ -104,7 +106,9 @@
   <ItemGroup>
     <ClInclude Include="AsyncStorageTestClass.h" />
     <ClInclude Include="EmptyUIManagerModule.h" />
+    <ClInclude Include="InstanceMocks.h" />
     <ClInclude Include="UnicodeTestStrings.h" />
+    <ClInclude Include="WebSocketMocks.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Desktop\React.Windows.Desktop.vcxproj">

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj.filters
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj.filters
@@ -46,6 +46,12 @@
     <ClCompile Include="MemoryMappedBufferTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="WebSocketMocks.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="InstanceMocks.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -66,6 +72,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="UnicodeTestStrings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="WebSocketMocks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="InstanceMocks.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vnext/Desktop.UnitTests/WebSocketMocks.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.cpp
@@ -1,0 +1,44 @@
+#include "WebSocketMocks.h"
+
+using std::function;
+using std::string;
+
+namespace Microsoft::React::Test
+{
+#pragma region IWebSocketResource overrides
+
+void MockWebSocketResource::Connect(const Protocols&, const Options&) /*override*/
+{
+  m_onConnect();
+}
+
+void MockWebSocketResource::Ping() /*override*/ {}
+
+void MockWebSocketResource::Send(const string&) /*override*/ {}
+
+void MockWebSocketResource::SendBinary(const string&) /*override*/ {}
+
+void MockWebSocketResource::Close(CloseCode, const string&) /*override*/ {}
+
+IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const /*override*/
+{
+  return ReadyState::Open;
+}
+
+void MockWebSocketResource::SetOnConnect(function<void()>&& onConnect) /*override*/
+{
+  m_onConnect = std::move(onConnect);
+}
+
+void MockWebSocketResource::SetOnPing(function<void()>&&) /*override*/ {}
+
+void MockWebSocketResource::SetOnSend(function<void(size_t)>&&) /*override*/ {}
+
+void MockWebSocketResource::SetOnMessage(function<void(size_t, const string&)>&&) /*override*/ {}
+
+void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string&)>&&) /*override*/ {}
+
+void MockWebSocketResource::SetOnError(function<void(Error&&)>&&) /*override*/ {}
+
+#pragma endregion IWebSocketResource overrides
+}

--- a/vnext/Desktop.UnitTests/WebSocketMocks.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.cpp
@@ -3,42 +3,41 @@
 using std::function;
 using std::string;
 
-namespace Microsoft::React::Test
-{
+namespace Microsoft::React::Test {
 #pragma region IWebSocketResource overrides
 
-void MockWebSocketResource::Connect(const Protocols&, const Options&) /*override*/
+void MockWebSocketResource::Connect(const Protocols &, const Options &) /*override*/
 {
   m_onConnect();
 }
 
 void MockWebSocketResource::Ping() /*override*/ {}
 
-void MockWebSocketResource::Send(const string&) /*override*/ {}
+void MockWebSocketResource::Send(const string &) /*override*/ {}
 
-void MockWebSocketResource::SendBinary(const string&) /*override*/ {}
+void MockWebSocketResource::SendBinary(const string &) /*override*/ {}
 
-void MockWebSocketResource::Close(CloseCode, const string&) /*override*/ {}
+void MockWebSocketResource::Close(CloseCode, const string &) /*override*/ {}
 
 IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const /*override*/
 {
   return ReadyState::Open;
 }
 
-void MockWebSocketResource::SetOnConnect(function<void()>&& onConnect) /*override*/
+void MockWebSocketResource::SetOnConnect(function<void()> &&onConnect) /*override*/
 {
   m_onConnect = std::move(onConnect);
 }
 
-void MockWebSocketResource::SetOnPing(function<void()>&&) /*override*/ {}
+void MockWebSocketResource::SetOnPing(function<void()> &&) /*override*/ {}
 
-void MockWebSocketResource::SetOnSend(function<void(size_t)>&&) /*override*/ {}
+void MockWebSocketResource::SetOnSend(function<void(size_t)> &&) /*override*/ {}
 
-void MockWebSocketResource::SetOnMessage(function<void(size_t, const string&)>&&) /*override*/ {}
+void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> &&) /*override*/ {}
 
-void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string&)>&&) /*override*/ {}
+void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)> &&) /*override*/ {}
 
-void MockWebSocketResource::SetOnError(function<void(Error&&)>&&) /*override*/ {}
+void MockWebSocketResource::SetOnError(function<void(Error &&)> &&) /*override*/ {}
 
 #pragma endregion IWebSocketResource overrides
-}
+} // namespace Microsoft::React::Test

--- a/vnext/Desktop.UnitTests/WebSocketMocks.h
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.h
@@ -2,39 +2,37 @@
 
 #include <IWebSocketResource.h>
 
-namespace Microsoft::React::Test
-{
+namespace Microsoft::React::Test {
 struct MockWebSocketResource : public IWebSocketResource {
-
 #pragma region IWebSocketResource overrides
 
-  void Connect(const Protocols&, const Options&) override;
+  void Connect(const Protocols &, const Options &) override;
 
   void Ping() override;
 
-  void Send(const std::string&) override;
+  void Send(const std::string &) override;
 
-  void SendBinary(const std::string&) override;
+  void SendBinary(const std::string &) override;
 
-  void Close(CloseCode, const std::string&) override;
+  void Close(CloseCode, const std::string &) override;
 
   ReadyState GetReadyState() const override;
 
-  void SetOnConnect(std::function<void()>&& onConnect) override;
+  void SetOnConnect(std::function<void()> &&onConnect) override;
 
-  void SetOnPing(std::function<void()>&&) override;
+  void SetOnPing(std::function<void()> &&) override;
 
-  void SetOnSend(std::function<void(size_t)>&&) override;
+  void SetOnSend(std::function<void(size_t)> &&) override;
 
-  void SetOnMessage(std::function<void(size_t, const std::string&)>&&) override;
+  void SetOnMessage(std::function<void(size_t, const std::string &)> &&) override;
 
-  void SetOnClose(std::function<void(CloseCode, const std::string&)>&&) override;
+  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&) override;
 
-  void SetOnError(std::function<void(Error&&)>&&) override;
+  void SetOnError(std::function<void(Error &&)> &&) override;
 
 #pragma endregion IWebSocketResource overrides
 
-private:
+ private:
   std::function<void()> m_onConnect;
 };
 

--- a/vnext/Desktop.UnitTests/WebSocketMocks.h
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <IWebSocketResource.h>
+
+namespace Microsoft::React::Test
+{
+struct MockWebSocketResource : public IWebSocketResource {
+
+#pragma region IWebSocketResource overrides
+
+  void Connect(const Protocols&, const Options&) override;
+
+  void Ping() override;
+
+  void Send(const std::string&) override;
+
+  void SendBinary(const std::string&) override;
+
+  void Close(CloseCode, const std::string&) override;
+
+  ReadyState GetReadyState() const override;
+
+  void SetOnConnect(std::function<void()>&& onConnect) override;
+
+  void SetOnPing(std::function<void()>&&) override;
+
+  void SetOnSend(std::function<void(size_t)>&&) override;
+
+  void SetOnMessage(std::function<void(size_t, const std::string&)>&&) override;
+
+  void SetOnClose(std::function<void(CloseCode, const std::string&)>&&) override;
+
+  void SetOnError(std::function<void(Error&&)>&&) override;
+
+#pragma endregion IWebSocketResource overrides
+
+private:
+  std::function<void()> m_onConnect;
+};
+
+} // namespace Microsoft::React::Test

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -95,6 +95,7 @@ class MockJSExecutorFactory : public JSExecutorFactory {
 using folly::dynamic;
 using std::function;
 using std::string;
+using std::unique_ptr;
 
 void MockMessageQueueThread::runOnQueue(function<void()> &&) /*override*/ {}
 void MockMessageQueueThread::runOnQueueSync(function<void()> &&work) /*override*/

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -175,8 +175,8 @@ shared_ptr<Instance> CreateMockInstance(shared_ptr<JSExecutorFactory> jsef) {
 #pragma endregion // Move
 
 TEST_CLASS (WebSocketModuleTest) {
-
-  const char *MethodName[static_cast<size_t>(WebSocketModule::MethodId::SIZE)]{"connect", "close", "send", "sendBinary", "ping"};
+  const char *MethodName[static_cast<size_t>(WebSocketModule::MethodId::SIZE)]{
+      "connect", "close", "send", "sendBinary", "ping"};
   TEST_METHOD(WebSocketModuleTest_CreateModule) {
     auto module = make_unique<WebSocketModule>();
 

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -175,10 +175,8 @@ shared_ptr<Instance> CreateMockInstance(shared_ptr<JSExecutorFactory> jsef) {
 #pragma endregion // Move
 
 TEST_CLASS (WebSocketModuleTest) {
-  enum class MethodId : size_t { Connect = 0, Close = 1, Send = 2, SendBinary = 3, Ping = 4, SIZE = 5 };
 
-  const char *MethodName[static_cast<size_t>(MethodId::SIZE)]{"connect", "close", "send", "sendBinary", "ping"};
-
+  const char *MethodName[static_cast<size_t>(WebSocketModule::MethodId::SIZE)]{"connect", "close", "send", "sendBinary", "ping"};
   TEST_METHOD(WebSocketModuleTest_CreateModule) {
     auto module = make_unique<WebSocketModule>();
 
@@ -186,7 +184,7 @@ TEST_CLASS (WebSocketModuleTest) {
     Assert::AreEqual(string("WebSocketModule"), module->getName());
 
     auto methods = module->getMethods();
-    for (size_t i = 0; i < static_cast<size_t>(MethodId::SIZE); i++) {
+    for (size_t i = 0; i < static_cast<size_t>(WebSocketModule::MethodId::SIZE); i++) {
       Assert::AreEqual(string(MethodName[i]), string(methods[i].name));
     }
 

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -58,9 +58,9 @@ TEST_CLASS (WebSocketModuleTest) {
     };
 
     auto instance = CreateMockInstance(jsef);
-    auto module =
-        make_unique<WebSocketModule>([](const string &, bool, bool) { return make_shared<MockWebSocketResource>(); });
+    auto module = make_unique<WebSocketModule>();
     module->setInstance(instance);
+    module->SetResourceFactory([](const string &, bool, bool) { return make_shared<MockWebSocketResource>(); });
 
     // Execute module method
     auto connect = module->getMethods().at(WebSocketModule::MethodId::Connect);

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -4,11 +4,143 @@
 #include <CppUnitTest.h>
 #include <Modules/WebSocketModule.h>
 
+// TODO: Move out
+#include <cxxreact/Instance.h>
+#include <cxxreact/JSBigString.h>
+#include <cxxreact/JSExecutor.h>
+#include <cxxreact/MessageQueueThread.h>
+#include <cxxreact/ModuleRegistry.h>
+#include <cxxreact/RAMBundleRegistry.h>
+
 using namespace facebook::react;
 using namespace facebook::xplat::module;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace Microsoft::React::Test {
+
+class MockMessageQueueThread : public MessageQueueThread {
+ public:
+#pragma region MessageQueueThread overrides
+
+  void runOnQueue(std::function<void()> &&) override;
+
+  void runOnQueueSync(std::function<void()> &&) override;
+
+  void quitSynchronous() override;
+
+#pragma endregion // MessageQueueThread overrides
+};
+
+class MockInstanceCallback : public InstanceCallback {
+ public:
+#pragma region InstanceCallback overrides
+
+  void onBatchComplete() override;
+  void incrementPendingJSCalls() override;
+  void decrementPendingJSCalls() override;
+
+#pragma endregion // InstanceCallback overrides
+};
+
+class MockJSExecutor : public JSExecutor {
+ public:
+#pragma region JSExecutor overrides
+
+  void loadApplicationScript(std::unique_ptr<const JSBigString> script, std::string sourceURL) override;
+
+  void setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) override;
+
+  void registerBundle(uint32_t bundleId, const std::string &bundlePath) override;
+
+  void callFunction(const std::string &moduleId, const std::string &methodId, const folly::dynamic &arguments) override;
+
+  void invokeCallback(const double callbackId, const folly::dynamic &arguments) override;
+
+  void setGlobalVariable(std::string propName, std::unique_ptr<const JSBigString> jsonValue) override;
+
+  void *getJavaScriptContext() override;
+
+  bool isInspectable() override;
+
+  std::string getDescription() override;
+
+  void handleMemoryPressure(__unused int pressureLevel) override;
+
+  void destroy() override;
+
+  void flush() override;
+
+#pragma endregion // JSExecutor overrides
+};
+
+class MockJSExecutorFactory : public JSExecutorFactory {
+#pragma region JSExecutorFactory overrides
+ public:
+  std::unique_ptr<JSExecutor> createJSExecutor(
+      std::shared_ptr<ExecutorDelegate> delegate,
+      std::shared_ptr<MessageQueueThread> jsQueue) override;
+
+#pragma endregion // JSExecutorFactory overrides
+};
+
+#pragma region Move
+
+// MockMessageQueueThread
+using std::function;
+
+void MockMessageQueueThread::runOnQueue(function<void()> &&) /*override*/ {}
+void MockMessageQueueThread::runOnQueueSync(function<void()> &&work) /*override*/
+{
+  work();
+}
+
+void MockMessageQueueThread::quitSynchronous() /*override*/ {}
+
+// MockInstanceCallback
+void MockInstanceCallback::onBatchComplete() /*override*/ {}
+void MockInstanceCallback::incrementPendingJSCalls() /*override*/ {}
+void MockInstanceCallback::decrementPendingJSCalls() /*override*/ {}
+
+// MockJSExecutor
+void MockJSExecutor::loadApplicationScript(std::unique_ptr<const JSBigString> script, std::string sourceURL) {}
+void MockJSExecutor::setBundleRegistry(std::unique_ptr<RAMBundleRegistry> bundleRegistry) {}
+void MockJSExecutor::registerBundle(uint32_t bundleId, const std::string &bundlePath) {}
+void MockJSExecutor::callFunction(
+    const std::string &moduleId,
+    const std::string &methodId,
+    const folly::dynamic &arguments) {}
+void MockJSExecutor::invokeCallback(const double callbackId, const folly::dynamic &arguments) {}
+void MockJSExecutor::setGlobalVariable(std::string propName, std::unique_ptr<const JSBigString> jsonValue) {}
+void *MockJSExecutor::getJavaScriptContext() {
+  return nullptr;
+}
+
+bool MockJSExecutor::isInspectable() {
+  return false;
+}
+std::string MockJSExecutor::getDescription() {
+  return {};
+}
+void MockJSExecutor::handleMemoryPressure(__unused int pressureLevel) {}
+void MockJSExecutor::destroy() {}
+void MockJSExecutor::flush() {}
+
+// MockJSExecutorFactory
+
+using std::make_shared;
+using std::make_unique;
+using std::shared_ptr;
+using std::unique_ptr;
+
+unique_ptr<JSExecutor> MockJSExecutorFactory::createJSExecutor(
+    shared_ptr<ExecutorDelegate> delegate,
+    shared_ptr<MessageQueueThread> jsQueue) /*override*/
+{
+  std::vector<unique_ptr<NativeModule>> modules{};
+  return make_unique<MockJSExecutor>();
+}
+
+#pragma endregion // Move
 
 TEST_CLASS (WebSocketModuleTest) {
   enum class MethodId : size_t { Connect = 0, Close = 1, Send = 2, SendBinary = 3, Ping = 4, SIZE = 5 };
@@ -27,6 +159,24 @@ TEST_CLASS (WebSocketModuleTest) {
     }
 
     Assert::AreEqual(static_cast<size_t>(0), module->getConstants().size());
+  }
+
+  TEST_METHOD(WebSocketModuleDummyRemove) {
+    auto instance = std::make_shared<Instance>();
+    auto callback = std::make_unique<MockInstanceCallback>();
+    auto jsef = std::make_shared<MockJSExecutorFactory>();
+    auto jsQueue = std::make_shared<MockMessageQueueThread>();
+    auto moduleRegistry = std::make_shared<ModuleRegistry>(
+        std::vector<unique_ptr<NativeModule>>(), // modules
+        nullptr // moduleNotFoundCallback
+    );
+
+    instance->initializeBridge(
+        std::move(callback), // callback
+        jsef, // jsef
+        jsQueue, // jsQueue
+        moduleRegistry // moduleRegistry
+    );
   }
 };
 

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -44,7 +44,7 @@ class MockInstanceCallback : public InstanceCallback {
 
 class MockJSExecutor : public JSExecutor {
  public:
-  std::function<void(const std::string &, const std::string &, const folly::dynamic &)> CallFunctionImpl;
+  std::function<void(const std::string &, const std::string &, const folly::dynamic &)> CallFunctionMock;
 
 #pragma region JSExecutor overrides
 
@@ -78,7 +78,7 @@ class MockJSExecutor : public JSExecutor {
 class MockJSExecutorFactory : public JSExecutorFactory {
  public:
   std::function<std::unique_ptr<JSExecutor>(std::shared_ptr<ExecutorDelegate>, std::shared_ptr<MessageQueueThread>)>
-      CreateJSExecutorImpl;
+      CreateJSExecutorMock;
 
 #pragma region JSExecutorFactory overrides
 
@@ -120,8 +120,8 @@ void MockJSExecutor::setBundleRegistry(unique_ptr<RAMBundleRegistry> bundleRegis
 void MockJSExecutor::registerBundle(uint32_t bundleId, const string &bundlePath) {}
 
 void MockJSExecutor::callFunction(const string &moduleId, const string &methodId, const dynamic &arguments) {
-  if (CallFunctionImpl) {
-    CallFunctionImpl(moduleId, methodId, arguments);
+  if (CallFunctionMock) {
+    CallFunctionMock(moduleId, methodId, arguments);
   }
 }
 
@@ -153,8 +153,8 @@ unique_ptr<JSExecutor> MockJSExecutorFactory::createJSExecutor(
     shared_ptr<ExecutorDelegate> delegate,
     shared_ptr<MessageQueueThread> jsQueue) /*override*/
 {
-  if (CreateJSExecutorImpl) {
-    return CreateJSExecutorImpl(delegate, jsQueue);
+  if (CreateJSExecutorMock) {
+    return CreateJSExecutorMock(delegate, jsQueue);
   }
 
   return make_unique<MockJSExecutor>();
@@ -202,10 +202,10 @@ TEST_CLASS (WebSocketModuleTest) {
     string eventName;
     string moduleName;
     string methodName;
-    jsef->CreateJSExecutorImpl = [&eventName, &moduleName, &methodName](
+    jsef->CreateJSExecutorMock = [&eventName, &moduleName, &methodName](
                                      shared_ptr<ExecutorDelegate>, shared_ptr<MessageQueueThread>) {
       auto jse = make_unique<MockJSExecutor>();
-      jse->CallFunctionImpl = [&eventName, &moduleName, &methodName](
+      jse->CallFunctionMock = [&eventName, &moduleName, &methodName](
                                   const string &module, const string &method, const dynamic &args) {
         moduleName = module;
         methodName = method;

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -25,15 +25,14 @@ constexpr char moduleName[] = "WebSocketModule";
 
 namespace Microsoft::React {
 
-WebSocketModule::WebSocketModule(
+WebSocketModule::WebSocketModule()
+    : m_resourceFactory{[](const string &url, bool legacyImplementation, bool acceptSelfSigned) {
+        return IWebSocketResource::Make(url, legacyImplementation, acceptSelfSigned);
+      }} {}
+
+void WebSocketModule::SetResourceFactory(
     std::function<shared_ptr<IWebSocketResource>(const string &, bool, bool)> &&resourceFactory) {
-  if (resourceFactory) {
-    m_resourceFactory = std::move(resourceFactory);
-  } else {
-    m_resourceFactory = [](const string &url, bool legacyImplementation, bool acceptSelfSigned) {
-      return IWebSocketResource::Make(url, legacyImplementation, acceptSelfSigned);
-    };
-  }
+  m_resourceFactory = std::move(resourceFactory);
 }
 
 string WebSocketModule::getName() {

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -15,6 +15,7 @@ using namespace folly;
 
 using Microsoft::Common::Unicode::Utf8ToUtf16;
 
+using std::shared_ptr;
 using std::string;
 using std::weak_ptr;
 
@@ -24,7 +25,16 @@ constexpr char moduleName[] = "WebSocketModule";
 
 namespace Microsoft::React {
 
-WebSocketModule::WebSocketModule() {}
+WebSocketModule::WebSocketModule(
+    std::function<shared_ptr<IWebSocketResource>(const string &, bool, bool)> &&resourceFactory) {
+  if (resourceFactory) {
+    m_resourceFactory = std::move(resourceFactory);
+  } else {
+    m_resourceFactory = [](const string &url, bool legacyImplementation, bool acceptSelfSigned) {
+      return IWebSocketResource::Make(url, legacyImplementation, acceptSelfSigned);
+    };
+  }
+}
 
 string WebSocketModule::getName() {
   return moduleName;
@@ -146,7 +156,7 @@ std::shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_
   auto itr = m_webSockets.find(id);
   if (itr == m_webSockets.end())
   {
-    auto ws = IWebSocketResource::Make(std::move(url));
+    auto ws = m_resourceFactory(std::move(url), /*legacyImplementation*/ false, /*acceptSelfSigned*/ false);
     auto weakInstance = this->getInstance();
     ws->SetOnError([this, id, weakInstance](const IWebSocketResource::Error& err)
     {

--- a/vnext/ReactWindowsCore/Modules/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/Modules/WebSocketModule.h
@@ -21,18 +21,18 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getName" />
   /// </summary>
-  std::string getName();
+  std::string getName() override;
 
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getConstants" />
   /// </summary>
-  virtual std::map<std::string, folly::dynamic> getConstants();
+  std::map<std::string, folly::dynamic> getConstants() override;
 
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getMethods" />
   /// </summary>
   /// <remarks>See See react-native/Libraries/WebSocket/WebSocket.js</remarks>
-  virtual std::vector<Method> getMethods();
+  std::vector<Method> getMethods() override;
 
  private:
   /// <summary>

--- a/vnext/ReactWindowsCore/Modules/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/Modules/WebSocketModule.h
@@ -16,8 +16,9 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
  public:
   enum MethodId { Connect = 0, Close = 1, Send = 2, SendBinary = 3, Ping = 4, SIZE = 5 };
 
-  WebSocketModule(
-      std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> &&resourceFactory = nullptr);
+  WebSocketModule();
+
+#pragma region CxxModule overrides
 
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getName" />
@@ -34,6 +35,11 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// </summary>
   /// <remarks>See See react-native/Libraries/WebSocket/WebSocket.js</remarks>
   std::vector<Method> getMethods() override;
+
+#pragma endregion CxxModule overrides
+
+  void SetResourceFactory(
+      std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> &&resourceFactory = nullptr);
 
  private:
   /// <summary>

--- a/vnext/ReactWindowsCore/Modules/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/Modules/WebSocketModule.h
@@ -16,7 +16,8 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
  public:
   enum MethodId { Connect = 0, Close = 1, Send = 2, SendBinary = 3, Ping = 4, SIZE = 5 };
 
-  WebSocketModule();
+  WebSocketModule(
+      std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> &&resourceFactory = nullptr);
 
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getName" />
@@ -50,6 +51,11 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// As defined in WebSocket.js.
   /// </summary>
   std::map<int64_t, std::shared_ptr<IWebSocketResource>> m_webSockets;
+
+  /// <summary>
+  /// Generates IWebSocketResource instances, defaulting to IWebSocketResource::Make.
+  /// </summary>
+  std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> m_resourceFactory;
 };
 
 } // namespace Microsoft::React


### PR DESCRIPTION
- Add initial set of tests for class `WebSocketModule`.
- Define mocking support types.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4538)