### PR TITLE
Don't set readyState on connection error

### DIFF
--- a/change/react-native-windows-2020-04-09-21-13-41-wsrc_openfails_nochangestate.json
+++ b/change/react-native-windows-2020-04-09-21-13-41-wsrc_openfails_nochangestate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't set readyState on connection error",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T04:13:41.955Z"
+}

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -122,7 +122,6 @@ IAsyncAction WinRTWebSocketResource::PerformConnect()
   }
   catch (hresult_error const& e)
   {
-    self->m_readyState = ReadyState::Closed;
     if (self->m_errorHandler)
     {
       self->m_errorHandler({ Utf16ToUtf8(e.message()), ErrorType::Connection });


### PR DESCRIPTION
Setting this may prevent `PerformClose` from getting called, which leads to a hang.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4562)