### PR TITLE
[0.60] Don't set readyState on connection error

### DIFF
--- a/change/react-native-windows-2020-04-09-21-13-37-wsrc_openfails_nochangestate-0.60.json
+++ b/change/react-native-windows-2020-04-09-21-13-37-wsrc_openfails_nochangestate-0.60.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Don't set readyState on connection error",
+  "packageName": "react-native-windows",
+  "email": "julio@rochsquadron.net",
+  "commit": "83e71956a206c16b5d26d82b403f9c870f4ea634",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T04:13:37.103Z"
+}

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -122,7 +122,6 @@ IAsyncAction WinRTWebSocketResource::PerformConnect()
   }
   catch (hresult_error const& e)
   {
-    self->m_readyState = ReadyState::Closed;
     if (self->m_errorHandler)
     {
       self->m_errorHandler({ Utf16ToUtf8(e.message()), ErrorType::Connection });


### PR DESCRIPTION
Backport of #4562.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4563)