### PR TITLE
Improve redbox formatting and inner loop experience

### DIFF
--- a/change/react-native-windows-2020-04-10-16-49-23-redbox.json
+++ b/change/react-native-windows-2020-04-10-16-49-23-redbox.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Improve RedBox ux, and don't require elevation unless it's the first time running the build (and need to enable dev mode)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T23:49:23.308Z"
+}

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -80,8 +80,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
         winrt::Windows::UI::Xaml::Markup::XamlReader::Load(xamlString));
     m_errorMessageText =
         m_redboxContent.FindName(L"ErrorMessageText").as<winrt::Windows::UI::Xaml::Controls::TextBlock>();
-    m_errorStackText = 
-      m_redboxContent.FindName(L"ErrorStackText").as<winrt::Windows::UI::Xaml::Controls::TextBlock>();
+    m_errorStackText = m_redboxContent.FindName(L"ErrorStackText").as<winrt::Windows::UI::Xaml::Controls::TextBlock>();
     m_stackPanel = m_redboxContent.FindName(L"StackPanel").as<winrt::Windows::UI::Xaml::Controls::StackPanel>();
     m_dismissButton = m_redboxContent.FindName(L"DismissButton").as<winrt::Windows::UI::Xaml::Controls::Button>();
     m_reloadButton = m_redboxContent.FindName(L"ReloadButton").as<winrt::Windows::UI::Xaml::Controls::Button>();
@@ -144,7 +143,8 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 
  private:
   void UpdateErorrMessageUI() noexcept {
-    const std::regex colorsRegex("\\x1b\\[[0-9;]*m"); // strip out console colors which is often added to JS error messages
+    const std::regex colorsRegex(
+        "\\x1b\\[[0-9;]*m"); // strip out console colors which is often added to JS error messages
     std::string formated = std::regex_replace(m_errorInfo.Message, colorsRegex, "");
 
     auto json = folly::parseJson(m_errorInfo.Message);
@@ -154,8 +154,8 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
       m_errorMessageText.Text(Microsoft::Common::Unicode::Utf8ToUtf16(message));
       m_errorStackText.Text(Microsoft::Common::Unicode::Utf8ToUtf16(stack));
     } else {
-      m_errorMessageText.Text(
-          Microsoft::Common::Unicode::Utf8ToUtf16(formated));
+      m_errorMessageText.Text(Microsoft::Common::Unicode::Utf8ToUtf16(formated));
+      m_errorStackText.Text(L"");
     }
   }
 

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -64,9 +64,11 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
         L"  </Grid.RowDefinitions>"
         L"  <ScrollViewer Grid.Row='0' Grid.ColumnSpan='2' HorizontalAlignment='Stretch'>"
         L"    <StackPanel HorizontalAlignment='Stretch'>"
-        L"      <Grid Background='#EECC0000' HorizontalAlignment='Stretch' Padding='15,35,15,15'>"
-        L"        <TextBlock x:Name='ErrorMessageText' FontSize='20' Foreground='White' TextWrapping='Wrap'/>"
-        L"      </Grid>"
+        L"      <StackPanel Background='#EECC0000' HorizontalAlignment='Stretch' Padding='15,35,15,15'>"
+        L"        <TextBlock x:Name='ErrorMessageText' FontSize='14' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>"
+        L"        <Border Padding='15,15,15,0'/>"
+        L"        <TextBlock x:Name='ErrorStackText' FontSize='12' FontFamily='Consolas' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>"
+        L"      </StackPanel>"
         L"      <StackPanel HorizontalAlignment='Stretch' x:Name='StackPanel' Margin='15' />"
         L"    </StackPanel>"
         L"  </ScrollViewer>"
@@ -78,6 +80,8 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
         winrt::Windows::UI::Xaml::Markup::XamlReader::Load(xamlString));
     m_errorMessageText =
         m_redboxContent.FindName(L"ErrorMessageText").as<winrt::Windows::UI::Xaml::Controls::TextBlock>();
+    m_errorStackText = 
+      m_redboxContent.FindName(L"ErrorStackText").as<winrt::Windows::UI::Xaml::Controls::TextBlock>();
     m_stackPanel = m_redboxContent.FindName(L"StackPanel").as<winrt::Windows::UI::Xaml::Controls::StackPanel>();
     m_dismissButton = m_redboxContent.FindName(L"DismissButton").as<winrt::Windows::UI::Xaml::Controls::Button>();
     m_reloadButton = m_redboxContent.FindName(L"ReloadButton").as<winrt::Windows::UI::Xaml::Controls::Button>();
@@ -140,9 +144,19 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 
  private:
   void UpdateErorrMessageUI() noexcept {
-    std::regex colorsreg("\\x1b\\[[0-9;]*m"); // strip out console colors which is often added to JS error messages
-    m_errorMessageText.Text(
-        Microsoft::Common::Unicode::Utf8ToUtf16(std::regex_replace(m_errorInfo.Message, colorsreg, "")));
+    const std::regex colorsRegex("\\x1b\\[[0-9;]*m"); // strip out console colors which is often added to JS error messages
+    std::string formated = std::regex_replace(m_errorInfo.Message, colorsRegex, "");
+
+    auto json = folly::parseJson(m_errorInfo.Message);
+    if (json.count("name") && json["name"] == "Error") {
+      auto message = json["message"].asString();
+      auto stack = json["stack"].asString().substr(ARRAYSIZE("Error: ") + message.length());
+      m_errorMessageText.Text(Microsoft::Common::Unicode::Utf8ToUtf16(message));
+      m_errorStackText.Text(Microsoft::Common::Unicode::Utf8ToUtf16(stack));
+    } else {
+      m_errorMessageText.Text(
+          Microsoft::Common::Unicode::Utf8ToUtf16(formated));
+    }
   }
 
   void PopulateFrameStackUI() noexcept {
@@ -215,6 +229,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
   winrt::Windows::UI::Xaml::Controls::Button m_dismissButton{nullptr};
   winrt::Windows::UI::Xaml::Controls::Button m_reloadButton{nullptr};
   winrt::Windows::UI::Xaml::Controls::TextBlock m_errorMessageText{nullptr};
+  winrt::Windows::UI::Xaml::Controls::TextBlock m_errorStackText{nullptr};
 
   bool m_showing = false;
   Mso::Functor<void(uint32_t)> m_onClosedCallback;

--- a/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -88,7 +88,10 @@ function EnableDevmode {
         New-Item -Path $RegistryKeyPath -ItemType Directory -Force
     }
 
-    Set-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -Value 1 -ErrorAction Stop
+    $value = get-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -ErrorAction SilentlyContinue
+    if (($value -eq $null) -or ($value.AllowDevelopmentWithoutDevLicense -ne 1)) {
+        Set-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -Value 1 -ErrorAction Stop
+    }
 }
 
 #

--- a/vnext/local-cli/runWindows/utils/commandWithProgress.js
+++ b/vnext/local-cli/runWindows/utils/commandWithProgress.js
@@ -93,6 +93,7 @@ function commandWithProgress(spinner, taskDoingName, command, args, verbose) {
         if (text) {
           setSpinnerText(spinner, taskDoingName + ': ERROR: ', firstErrorLine);
         }
+        reject();
       });
     }
     cp.on('error', e => {

--- a/vnext/local-cli/runWindows/utils/commandWithProgress.js
+++ b/vnext/local-cli/runWindows/utils/commandWithProgress.js
@@ -93,7 +93,7 @@ function commandWithProgress(spinner, taskDoingName, command, args, verbose) {
         if (text) {
           setSpinnerText(spinner, taskDoingName + ': ERROR: ', firstErrorLine);
         }
-        reject();
+        reject(new Error(firstErrorLine));
       });
     }
     cp.on('error', e => {


### PR DESCRIPTION
- Improve RedBox ux. Shows formatted error message and stack trace
- Don't require elevation if dev mode is already on (we only need to elevate to turn on Dev Mode). 

New redbox (we can now select text for easy copy/paste):
![image](https://user-images.githubusercontent.com/22989529/79029698-5e69a680-7b4a-11ea-9caa-a62c3cf466f3.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4570)