### PR TITLE
Fix fast refresh in playground app

### DIFF
--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -40,7 +40,7 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().UseWebDebugger(x_UseWebDebuggerCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseDirectDebugger(x_UseDirectDebuggerCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
-  host.InstanceSettings().UseFastRefresh(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
+  host.InstanceSettings().UseFastRefresh(x_UseFastRefreshCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerPort(static_cast<uint16_t>(std::stoi(std::wstring(x_DebuggerPort().Text()))));
 
   // Nudge the ReactNativeHost to create the instance and wrapping context


### PR DESCRIPTION
In a rewrite from codereview I had a typo where the FastRefresh setting was based on the Break On First line checkbox instead of the fast refresh one.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4580)