### PR TITLE
Remove Folly Unzipping ContinueOnError

### DIFF
--- a/change/react-native-windows-2020-04-13-09-02-10-no-folly-suppress.json
+++ b/change/react-native-windows-2020-04-13-09-02-10-no-folly-suppress.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Folly ContinueOnError",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-13T16:02:10.402Z"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -274,8 +274,7 @@
   </Target>
   <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
     <Message Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
-    <!-- Using ContinueOnError due to https://github.com/Microsoft/msbuild/issues/3884, https://github.com/microsoft/msbuild/pull/4935, We will still succeed, and this will be fixed in a newer version of MSBuild  -->
-    <Unzip Condition="!Exists('$(FollyDir)')" ContinueOnError="true" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
+    <Unzip Condition="!Exists('$(FollyDir)')" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
   </Target>
   <ItemGroup>
     <TemporaryFollyPatchFiles Include="$(MSBuildThisFileDirectory)\TEMP_UntilFollyUpdate\**\*.*"/>


### PR DESCRIPTION
After upgrading to v142 build tools we no longer see MSBuild throwing up while unzipping files. Remove ContinueOnError from the build task.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4581)