### PR TITLE
Consistency [with upstream] in instructions

### DIFF
--- a/change/react-native-windows-2020-04-14-16-58-37-consistency-in-instructions.json
+++ b/change/react-native-windows-2020-04-14-16-58-37-consistency-in-instructions.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "[generator] Use `npx` for consistency",
+  "packageName": "react-native-windows",
+  "email": "eloy.de.enige@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-14T14:58:37.541Z"
+}

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -128,7 +128,7 @@ function copyProjectTemplateAndReplace(
   copyAndReplaceAll(path.join(srcPath, 'src'), destPath, path.join(windowsDir, newProjectName), templateVars, options.overwrite);
 
   console.log(chalk.white.bold('To run your app on UWP:'));
-  console.log(chalk.white('   react-native run-windows'));
+  console.log(chalk.white('   npx react-native run-windows'));
 }
 
 function installDependencies(options) {


### PR DESCRIPTION
Very minor change to bring this in line with upstream instructions, which always prefix `react-native` with `npx`. E.g. https://github.com/react-native-community/cli/blob/04537d5693e6780c3f177fa5bfe21109b6b80fb3/packages/cli/src/commands/init/printRunInstructions.ts#L29

PS: Wasn't sure if this needed a changelog entry, mostly because of the notion of it requiring a “pre-release”, which felt unnecessary to me 🤷‍♂️ 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4601)