### PR TITLE
Password box bug

### DIFF
--- a/change/react-native-windows-2020-04-14-22-41-42-PasswordBoxBug.json
+++ b/change/react-native-windows-2020-04-14-22-41-42-PasswordBoxBug.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix bug where not specifying height on TextInput causes 0 height",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T05:41:41.940Z"
+}

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -134,7 +134,6 @@ const styles = StyleSheet.create({
   },
   input: {
     margin: 5,
-    height: 40,
     width: 700,
     borderColor: '#7a42f4',
     borderWidth: 1,

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -793,6 +793,7 @@ void NativeUIManager::ReplaceView(facebook::react::ShadowNode &shadowNode) {
         auto context = std::make_unique<YogaContext>(node.GetView());
         YGNodeSetContext(yogaNode, reinterpret_cast<void *>(context.get()));
 
+        m_tagsToYogaContext.erase(node.m_tag);
         m_tagsToYogaContext.emplace(node.m_tag, std::move(context));
       }
     } else {

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -92,6 +92,12 @@ void ShadowNodeBase::ReparentView(XamlView view) {
     }
   }
   ReplaceView(view);
+
+  // Let the UIManager know about this so it can update the yoga context.
+  if (const auto instance = GetViewManager()->GetReactInstance().lock()) {
+    auto pNativeUiManager = static_cast<NativeUIManager *>(instance->NativeUIManager());
+    pNativeUiManager->ReplaceView(*static_cast<ShadowNode *>(this));
+  }
 }
 
 winrt::Windows::UI::Composition::CompositionPropertySet ShadowNodeBase::EnsureTransformPS() {

--- a/vnext/include/Include.vcxitems.filters
+++ b/vnext/include/Include.vcxitems.filters
@@ -86,6 +86,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactUWP\Utils\UwpScriptStore.h">
       <Filter>ReactUWP\Utils</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)ReactWindowsCore\cdebug.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ReactUWP">


### PR DESCRIPTION
This fixes a bug in TextInput.  If you don't specify a height and also set secureTextEntry = true, the PasswordBox ends up with a 0 height.

The bug was caused by some missing logic in the code that swaps the TextBox out for a PasswordBox.  This code replaces the backing XAML element, but forgot to notify the UIManager which maintains a mapping from ShadowNode => XAML element.  Thus, after the swap, bad stuff happens in layout, causing us to push a 0 height into the PasswordBox.

The fix is straightforward - after swapping the control, notify the UIManager so it can update its mapping to the new XAML element.

Also changed our existing Playground test page to not specify a height, this exposes the issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4607)