### PR TITLE
Rename DeveloperSettings.SourceBundlePath -> SourceBundleName

### DIFF
--- a/change/react-native-windows-2020-04-15-00-20-55-sbp.json
+++ b/change/react-native-windows-2020-04-15-00-20-55-sbp.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rename DeveloperSettings.SourceBundlePath -> SourceBundleName",
+  "packageName": "react-native-windows",
+  "email": "rezha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T07:20:55.380Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -125,9 +125,9 @@ struct ReactDevOptions {
   //! {NAME} = "index.{PLATFORM}" where {PLATFORM} = "ios", "android", "win32", etc.
   //! {EXTENSION} = ".bundle"
   //! Specify a value for a component, or leave empty to use the default.
-  std::string SourceBundleHost;      // Host domain (without port) for the bundler server. Default: "localhost".
-  std::string SourceBundlePort;      // Host port for the bundler server. Default: "8081".
-  std::string SourceBundleName;      // Bundle name without any extension (e.g. "index.win32"). Default: "index.{PLATFORM}"
+  std::string SourceBundleHost; // Host domain (without port) for the bundler server. Default: "localhost".
+  std::string SourceBundlePort; // Host port for the bundler server. Default: "8081".
+  std::string SourceBundleName; // Bundle name without any extension (e.g. "index.win32"). Default: "index.{PLATFORM}"
   std::string SourceBundleExtension; // Bundle name extension. Default: ".bundle".
 
   //! Module name used for loading the debug bundle.

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -118,17 +118,17 @@ struct ReactDevOptions {
   std::string DebugHost;
 
   //! When using web debugging and/or live reload, the source is obtained from the packager.
-  //! The source url for the bundle is "http://{HOST}:{PORT}/{PATH}{EXTENSION}?platform=..."
+  //! The source url for the bundle is "http://{HOST}:{PORT}/{NAME}{EXTENSION}?platform=..."
   //! which defaults to:
   //! {HOST} = "localhost",
   //! {PORT} = "8081",
-  //! {PATH} = "index.{PLATFORM}" where {PLATFORM} = "ios", "android", "win32", etc.
+  //! {NAME} = "index.{PLATFORM}" where {PLATFORM} = "ios", "android", "win32", etc.
   //! {EXTENSION} = ".bundle"
   //! Specify a value for a component, or leave empty to use the default.
-  std::string SourceBundleHost; // {HOST}
-  std::string SourceBundlePort; // {PORT}
-  std::string SourceBundlePath; // {PATH}
-  std::string SourceBundleExtension; // {EXTENSION}
+  std::string SourceBundleHost;      // Host domain (without port) for the bundler server. Default: "localhost".
+  std::string SourceBundlePort;      // Host port for the bundler server. Default: "8081".
+  std::string SourceBundleName;      // Bundle name without any extension (e.g. "index.win32"). Default: "index.{PLATFORM}"
+  std::string SourceBundleExtension; // Bundle name extension. Default: ".bundle".
 
   //! Module name used for loading the debug bundle.
   //! e.g. The modules name registered in the jsbundle via AppRegistry.registerComponent('ModuleName', () =>

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -161,7 +161,7 @@ void ReactInstanceWin::Initialize() noexcept {
           auto devSettings = std::make_shared<facebook::react::DevSettings>();
           devSettings->useJITCompilation = m_options.EnableJITCompilation;
           devSettings->debugHost = GetDebugHost();
-          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundlePath;
+          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName;
           devSettings->liveReloadCallback = GetLiveReloadCallback();
           devSettings->errorCallback = GetErrorCallback();
           devSettings->loggingCallback = GetLoggingCallback();
@@ -273,8 +273,8 @@ void ReactInstanceWin::Initialize() noexcept {
             if (m_options.DeveloperSettings.IsDevModeEnabled && State() != ReactInstanceState::HasError) {
               folly::dynamic params = folly::dynamic::array(
                   STRING(RN_PLATFORM),
-                  m_options.DeveloperSettings.SourceBundlePath.empty() ? m_options.Identity
-                                                                       : m_options.DeveloperSettings.SourceBundlePath,
+                  m_options.DeveloperSettings.SourceBundleName.empty() ? m_options.Identity
+                                                                       : m_options.DeveloperSettings.SourceBundleName,
                   GetSourceBundleHost(),
                   GetSourceBundlePort(),
                   m_options.DeveloperSettings.UseFastRefresh);

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -80,7 +80,7 @@ void ReactNativeHost::ReloadInstance() noexcept {
 
   Mso::React::ReactOptions reactOptions{};
   reactOptions.DeveloperSettings.IsDevModeEnabled = legacySettings.EnableDeveloperMenu;
-  reactOptions.DeveloperSettings.SourceBundlePath = legacySettings.DebugBundlePath;
+  reactOptions.DeveloperSettings.SourceBundleName = legacySettings.DebugBundlePath;
   reactOptions.DeveloperSettings.UseWebDebugger = legacySettings.UseWebDebugger;
   reactOptions.DeveloperSettings.UseDirectDebugger = legacySettings.UseDirectDebugger;
   reactOptions.DeveloperSettings.DebuggerBreakOnNextLine = legacySettings.DebuggerBreakOnNextLine;

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -277,7 +277,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
           std::string stackFrameUri = "http://";
           stackFrameUri.append(devSettings.SourceBundleHost.empty() ? "localhost" : devSettings.SourceBundleHost);
           stackFrameUri.append(":");
-          stackFrameUri.append(devSettings.SourceBundlePath.empty() ? "8081" : devSettings.SourceBundlePort);
+          stackFrameUri.append(devSettings.SourceBundlePort.empty() ? "8081" : devSettings.SourceBundlePort);
           stackFrameUri.append("/open-stack-frame");
 
           Uri uri{Microsoft::Common::Unicode::Utf8ToUtf16(stackFrameUri)};


### PR DESCRIPTION
When using web debugging and/or live reload, source bundle is obtained from the packager.
The source url for the bundle is `http://{HOST}:{PORT}/{NAME}{EXTENSION}?platform={PLATFORM}` where:
```
{HOST} = "localhost",
{PORT} = "8081",
{NAME} = "index.{PLATFORM}" where {PLATFORM} = "ios", "android", "win32", etc.
{EXTENSION} = ".bundle"
```
Currently, the `NAME` field is named `SourceBundlePath`, which incorrectly implies file path. This CR renames it to `SourceBundleName`.

(There seems to be a typo in `RedBox.cpp`. Also fixed that.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4608)