### PR TITLE
Implement accessibilityState

### DIFF
--- a/change/react-native-windows-2020-04-15-15-25-43-AccessibilityState.json
+++ b/change/react-native-windows-2020-04-15-15-25-43-AccessibilityState.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "implement accessibilityState",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T22:25:43.418Z"
+}

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -152,9 +152,10 @@ static folly::dynamic GetAccessibilityStateProps() {
 folly::dynamic FrameworkElementViewManager::GetNativeProps() const {
   folly::dynamic props = Super::GetNativeProps();
   props.update(folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")(
-      "accessibilityState", GetAccessibilityStateProps())("accessibilityHint", "string")(
-      "accessibilityLabel", "string")("accessibilityPosInSet", "number")("accessibilitySetSize", "number")(
-      "testID", "string")("tooltip", "string")("accessibilityActions", "array")("accessibilityLiveRegion", "string"));
+      "accessibilityStates", "array")("accessibilityState", GetAccessibilityStateProps())(
+      "accessibilityHint", "string")("accessibilityLabel", "string")("accessibilityPosInSet", "number")(
+      "accessibilitySetSize", "number")("testID", "string")("tooltip", "string")("accessibilityActions", "array")(
+      "accessibilityLiveRegion", "string"));
   return props;
 }
 
@@ -393,6 +394,45 @@ bool FrameworkElementViewManager::UpdateProperty(
       } else if (propertyValue.isNull()) {
         element.ClearValue(DynamicAutomationProperties::AccessibilityRoleProperty());
       }
+    } else if (propertyName == "accessibilityStates") {
+      bool states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::CountStates)] = {};
+
+      if (propertyValue.isArray()) {
+        for (const auto &state : propertyValue) {
+          if (!state.isString())
+            continue;
+
+          if (state.getString() == "selected")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)] = true;
+          else if (state.getString() == "disabled")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)] = true;
+          else if (state.getString() == "checked")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)] = true;
+          else if (state.getString() == "unchecked")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)] = true;
+          else if (state.getString() == "busy")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Busy)] = true;
+          else if (state.getString() == "expanded")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Expanded)] = true;
+          else if (state.getString() == "collapsed")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Collapsed)] = true;
+        }
+      }
+
+      DynamicAutomationProperties::SetAccessibilityStateSelected(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)]);
+      DynamicAutomationProperties::SetAccessibilityStateDisabled(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)]);
+      DynamicAutomationProperties::SetAccessibilityStateChecked(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)]);
+      DynamicAutomationProperties::SetAccessibilityStateUnchecked(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)]);
+      DynamicAutomationProperties::SetAccessibilityStateBusy(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Busy)]);
+      DynamicAutomationProperties::SetAccessibilityStateExpanded(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Expanded)]);
+      DynamicAutomationProperties::SetAccessibilityStateCollapsed(
+          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Collapsed)]);
     } else if (propertyName == "accessibilityState") {
       bool states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::CountStates)] = {};
 

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -152,9 +152,9 @@ static folly::dynamic GetAccessibilityStateProps() {
 folly::dynamic FrameworkElementViewManager::GetNativeProps() const {
   folly::dynamic props = Super::GetNativeProps();
   props.update(folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")(
-      "accessibilityState", GetAccessibilityStateProps())("accessibilityHint", "string")("accessibilityLabel", "string")(
-      "accessibilityPosInSet", "number")("accessibilitySetSize", "number")("testID", "string")("tooltip", "string")(
-      "accessibilityActions", "array")("accessibilityLiveRegion", "string"));
+      "accessibilityState", GetAccessibilityStateProps())("accessibilityHint", "string")(
+      "accessibilityLabel", "string")("accessibilityPosInSet", "number")("accessibilitySetSize", "number")(
+      "testID", "string")("tooltip", "string")("accessibilityActions", "array")("accessibilityLiveRegion", "string"));
   return props;
 }
 

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -149,6 +149,7 @@ static folly::dynamic GetAccessibilityStateProps() {
       "busy", "boolean")("expanded", "boolean"));
   return props;
 }
+
 folly::dynamic FrameworkElementViewManager::GetNativeProps() const {
   folly::dynamic props = Super::GetNativeProps();
   props.update(folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")(

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -141,10 +141,18 @@ void FrameworkElementViewManager::TransferProperties(XamlView oldView, XamlView 
   }
 }
 
+static folly::dynamic GetAccessibilityStateProps() {
+  folly::dynamic props = folly::dynamic::object();
+
+  // TODO:  "checked" is spec'd as being either a boolean or the string "mixed".  How do we handle "mixed"?
+  props.update(folly::dynamic::object("selected", "boolean")("disabled", "boolean")("checked", "boolean")(
+      "busy", "boolean")("expanded", "boolean"));
+  return props;
+}
 folly::dynamic FrameworkElementViewManager::GetNativeProps() const {
   folly::dynamic props = Super::GetNativeProps();
   props.update(folly::dynamic::object("accessible", "boolean")("accessibilityRole", "string")(
-      "accessibilityStates", "array")("accessibilityHint", "string")("accessibilityLabel", "string")(
+      "accessibilityState", GetAccessibilityStateProps())("accessibilityHint", "string")("accessibilityLabel", "string")(
       "accessibilityPosInSet", "number")("accessibilitySetSize", "number")("testID", "string")("tooltip", "string")(
       "accessibilityActions", "array")("accessibilityLiveRegion", "string"));
   return props;
@@ -385,28 +393,27 @@ bool FrameworkElementViewManager::UpdateProperty(
       } else if (propertyValue.isNull()) {
         element.ClearValue(DynamicAutomationProperties::AccessibilityRoleProperty());
       }
-    } else if (propertyName == "accessibilityStates") {
+    } else if (propertyName == "accessibilityState") {
       bool states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::CountStates)] = {};
 
-      if (propertyValue.isArray()) {
-        for (const auto &state : propertyValue) {
-          if (!state.isString())
-            continue;
+      if (propertyValue.isObject()) {
+        for (const auto &pair : propertyValue.items()) {
+          const std::string &innerName = pair.first.getString();
+          const folly::dynamic &innerValue = pair.second;
 
-          if (state.getString() == "selected")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)] = true;
-          else if (state.getString() == "disabled")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)] = true;
-          else if (state.getString() == "checked")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)] = true;
-          else if (state.getString() == "unchecked")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)] = true;
-          else if (state.getString() == "busy")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Busy)] = true;
-          else if (state.getString() == "expanded")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Expanded)] = true;
-          else if (state.getString() == "collapsed")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Collapsed)] = true;
+          if (innerName == "selected")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)] = innerValue.getBool();
+          else if (innerName == "disabled")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)] = innerValue.getBool();
+          else if (innerName == "checked") {
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)] = innerValue.getBool();
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)] = !innerValue.getBool();
+          } else if (innerName == "busy")
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Busy)] = innerValue.getBool();
+          else if (innerName == "expanded") {
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Expanded)] = innerValue.getBool();
+            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Collapsed)] = !innerValue.getBool();
+          }
         }
       }
 

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -445,7 +445,7 @@ bool FrameworkElementViewManager::UpdateProperty(
             states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)] = innerValue.getBool();
           else if (innerName == "disabled")
             states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)] = innerValue.getBool();
-          else if (innerName == "checked") { 
+          else if (innerName == "checked") {
             states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)] =
                 innerValue.isBool() && innerValue.getBool();
             states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)] =

--- a/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
+++ b/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
@@ -140,7 +140,6 @@ const ReactNativeViewConfig = {
     accessibilityLabel: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
-    accessibilityStates: true, // TODO: Can be removed after next release
     accessibilityState: true,
     accessibilityValue: true,
     accessibilityViewIsModal: true,

--- a/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
+++ b/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
@@ -140,6 +140,7 @@ const ReactNativeViewConfig = {
     accessibilityLabel: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
+    accessibilityStates: true, // TODO: Can be removed after next release
     accessibilityState: true,
     accessibilityValue: true,
     accessibilityViewIsModal: true,

--- a/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -270,7 +270,7 @@ class AccessibilityStateExamples extends React.Component {
   public state = {
     viewDisabled: false,
     itemsSelected: [false, false, false],
-    viewChecked: false,
+    viewChecked: 0,
     viewBusy: false,
     viewCollapsed: false,
   };
@@ -332,8 +332,8 @@ class AccessibilityStateExamples extends React.Component {
           keyExtractor={(item, index) => index.toString()}
         />
         <Text>
-          The following TouchableHighlight toggles accessibilityState.checked
-          and accessibilityState.unchecked for the View under it:
+          The following TouchableHighlight cycles accessibilityState.checked
+          through unchecked/checked/mixed for the View under it:
         </Text>
         <TouchableHighlight
           style={{width: 100, height: 50, backgroundColor: 'blue'}}
@@ -343,21 +343,21 @@ class AccessibilityStateExamples extends React.Component {
         </TouchableHighlight>
         <View
           style={{
-            backgroundColor: this.state.viewChecked ? 'gray' : 'lightskyblue',
+            backgroundColor: this.state.viewChecked === 0 ? 'green' : this.state.viewChecked === 1 ? 'gray' : 'lightskyblue',
           }}
           //@ts-ignore
           accessibilityRole="checkbox"
           //@ts-ignore
           accessibilityState={{
-            checked: this.state.viewChecked,
+            checked: this.state.viewChecked === 0 ? false : this.state.viewChecked === 1 ? true : 'mixed',
           }}>
           <Text>
             This View should be{' '}
-            {this.state.viewChecked ? 'Checked' : 'Unchecked'} according to UIA
+            {this.state.viewChecked === 0 ? 'Unchecked' : this.state.viewChecked === 1 ? 'Checked' : 'Mixed'} according to UIA
           </Text>
         </View>
         <Text>
-          The following TouchableHighlight toggles accessibilityState.busy for
+          The following TouchableHighlight toggles the acessibilityState.busy for
           the View under it:
         </Text>
         <TouchableHighlight
@@ -419,7 +419,11 @@ class AccessibilityStateExamples extends React.Component {
   };
 
   private checkedPress = () => {
-    this.setState({viewChecked: !this.state.viewChecked});
+    let newChecked = this.state.viewChecked + 1;
+    if (newChecked === 3) {
+      newChecked = 0;
+    }
+    this.setState({viewChecked: newChecked});
   };
 
   private busyPress = () => {

--- a/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -294,7 +294,7 @@ class AccessibilityStateExamples extends React.Component {
             backgroundColor: this.state.viewDisabled ? 'gray' : 'lightskyblue',
           }}
           accessibilityRole="none"
-          accessibilityStates={this.state.viewDisabled ? ['disabled'] : []}>
+          accessibilityState={{disabled:this.state.viewDisabled}}>
           <Text>
             This View should be{' '}
             {this.state.viewDisabled ? 'disabled' : 'enabled'} according to UIA
@@ -318,9 +318,9 @@ class AccessibilityStateExamples extends React.Component {
               }}
               accessibilityRole="button"
               accessibilityLabel={'Selectable item ' + (item.index + 1)}
-              accessibilityStates={
-                this.state.itemsSelected[item.index] ? ['selected'] : []
-              }
+              accessibilityState={{
+                selected: this.state.itemsSelected[item.index] 
+              }}
               onPress={() => this.selectPress(item.index)}>
               <Text>
                 {this.state.itemsSelected[item.index]
@@ -348,9 +348,9 @@ class AccessibilityStateExamples extends React.Component {
           //@ts-ignore
           accessibilityRole="checkbox"
           //@ts-ignore
-          accessibilityStates={
-            this.state.viewChecked ? ['checked'] : ['unchecked']
-          }>
+          accessibilityState={{
+            checked: this.state.viewChecked
+          }}>
           <Text>
             This View should be{' '}
             {this.state.viewChecked ? 'Checked' : 'Unchecked'} according to UIA
@@ -372,7 +372,7 @@ class AccessibilityStateExamples extends React.Component {
           }}
           accessibilityRole="none"
           //@ts-ignore
-          accessibilityStates={this.state.viewBusy ? ['busy'] : []}>
+          accessibilityState={{busy: this.state.viewBusy}}>
           <Text>
             This View should be {this.state.viewBusy ? 'Busy' : 'Not Busy'}{' '}
             according to UIA
@@ -395,9 +395,9 @@ class AccessibilityStateExamples extends React.Component {
           }}
           accessibilityRole="none"
           //@ts-ignore
-          accessibilityStates={
-            this.state.viewCollapsed ? ['collapsed'] : ['expanded']
-          }>
+          accessibilityState={{
+            expanded: !this.state.viewCollapsed
+          }}>
           <Text>
             This View should be{' '}
             {this.state.viewCollapsed ? 'Collapsed' : 'Expanded'} according to

--- a/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -294,7 +294,7 @@ class AccessibilityStateExamples extends React.Component {
             backgroundColor: this.state.viewDisabled ? 'gray' : 'lightskyblue',
           }}
           accessibilityRole="none"
-          accessibilityState={{disabled:this.state.viewDisabled}}>
+          accessibilityState={{disabled: this.state.viewDisabled}}>
           <Text>
             This View should be{' '}
             {this.state.viewDisabled ? 'disabled' : 'enabled'} according to UIA
@@ -319,7 +319,7 @@ class AccessibilityStateExamples extends React.Component {
               accessibilityRole="button"
               accessibilityLabel={'Selectable item ' + (item.index + 1)}
               accessibilityState={{
-                selected: this.state.itemsSelected[item.index] 
+                selected: this.state.itemsSelected[item.index],
               }}
               onPress={() => this.selectPress(item.index)}>
               <Text>
@@ -349,7 +349,7 @@ class AccessibilityStateExamples extends React.Component {
           accessibilityRole="checkbox"
           //@ts-ignore
           accessibilityState={{
-            checked: this.state.viewChecked
+            checked: this.state.viewChecked,
           }}>
           <Text>
             This View should be{' '}
@@ -396,7 +396,7 @@ class AccessibilityStateExamples extends React.Component {
           accessibilityRole="none"
           //@ts-ignore
           accessibilityState={{
-            expanded: !this.state.viewCollapsed
+            expanded: !this.state.viewCollapsed,
           }}>
           <Text>
             This View should be{' '}

--- a/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -343,22 +343,37 @@ class AccessibilityStateExamples extends React.Component {
         </TouchableHighlight>
         <View
           style={{
-            backgroundColor: this.state.viewChecked === 0 ? 'green' : this.state.viewChecked === 1 ? 'gray' : 'lightskyblue',
+            backgroundColor:
+              this.state.viewChecked === 0
+                ? 'green'
+                : this.state.viewChecked === 1
+                ? 'gray'
+                : 'lightskyblue',
           }}
           //@ts-ignore
           accessibilityRole="checkbox"
           //@ts-ignore
           accessibilityState={{
-            checked: this.state.viewChecked === 0 ? false : this.state.viewChecked === 1 ? true : 'mixed',
+            checked:
+              this.state.viewChecked === 0
+                ? false
+                : this.state.viewChecked === 1
+                ? true
+                : 'mixed',
           }}>
           <Text>
             This View should be{' '}
-            {this.state.viewChecked === 0 ? 'Unchecked' : this.state.viewChecked === 1 ? 'Checked' : 'Mixed'} according to UIA
+            {this.state.viewChecked === 0
+              ? 'Unchecked'
+              : this.state.viewChecked === 1
+              ? 'Checked'
+              : 'Mixed'}{' '}
+            according to UIA
           </Text>
         </View>
         <Text>
-          The following TouchableHighlight toggles the acessibilityState.busy for
-          the View under it:
+          The following TouchableHighlight toggles the acessibilityState.busy
+          for the View under it:
         </Text>
         <TouchableHighlight
           style={{width: 100, height: 50, backgroundColor: 'blue'}}


### PR DESCRIPTION
Fixes #4042 

In version 0.61, accessibilityState was introduced and accessibilityStates was marked as deprecated.
In version 0.62, accessibilityStates was removed.

This change implements accessibilityState and removes accessibilityStates.

The change is straightforward - instead of an array, the property is an object with fields.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4617)