### PR TITLE
Fixing ExceptionsManagerModule

### DIFF
--- a/change/react-native-windows-2020-04-17-02-58-34-khosany-exceptionsmanager.json
+++ b/change/react-native-windows-2020-04-17-02-58-34-khosany-exceptionsmanager.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing ExceptionsManagerModule",
+  "packageName": "react-native-windows",
+  "email": "khosany@microsoft.com",
+  "commit": "5349aeb14874490a3c910d85287e98f1a7510d9e",
+  "date": "2020-04-17T09:58:34.258Z"
+}

--- a/vnext/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/ExceptionsManagerModule.cpp
@@ -110,12 +110,12 @@ std::string ExceptionsManagerModule::RetrieveValueFromMap(
   std::string value;
   auto iterator = map.find(key);
   if (iterator != map.items().end()) {
+    if (iterator->second.isNull()) {
+      return "<Unknown>";
+    }
     if (type == folly::dynamic::STRING) {
       value = iterator->second.asString();
     } else {
-      if (iterator->second.isNull()) {
-        return "<Unknown>";
-      }
       assert(iterator->second.isNumber());
       std::stringstream stream;
       stream << static_cast<int64_t>(iterator->second.asDouble());


### PR DESCRIPTION
A crash is happening on line 114 because we are receiving a callstack from the JS side where the filename is null. Actual callstack contains some internal code, so I am not sharing here.

Fix is to return "<Unknown>" in that case.

This change is going to 0.60-stable only as this code is gone in newer branches.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4626)