### PR TITLE
react-native-windows-init should support npm tags for --version parameter

### DIFF
--- a/change/react-native-windows-init-2020-04-20-13-55-48-tagininit.json
+++ b/change/react-native-windows-init-2020-04-20-13-55-48-tagininit.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix react-native-windows-init to work with tags (@master)",
+  "packageName": "react-native-windows-init",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-20T20:55:48.747Z"
+}


### PR DESCRIPTION
We had code to try to support npm tags for the --version parameter on `react-native-windows-init`, and are even using it in our CI loops to installed the test version.  But there appears to be a difference in behavior between npmjs.org and verdaccio which causes it to work when running against verdaccio  but it still doesn't work against npmjs.org.

This should enable instructions to run against latest master to be:
```cmd
npx react-native init <myproj> --template react-native@^0.62
cd <myproj>
npx react-native-windows-init --version master
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4647)