### PR TITLE
Remove PreferredToolArchitecture Specialization

### DIFF
--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -6,8 +6,6 @@ parameters:
   # NuGet & MSBuild
   project:
   msbuildVersion: $(MSBuildVersion)
-  msBuildArchitecture: $(MSBuildArchitecture)
-  preferredToolArchitecture: $(MSBuildPreferredToolArchitecture)
   platformToolset: $(MSBuildPlatformToolset)
   msbuildArguments: ''
   yarnBuildCmd: build
@@ -41,7 +39,6 @@ steps:
     inputs:
       solution: ${{parameters.project }}
       vsVersion: ${{parameters.msbuildVersion}}
-      msbuildArchitecture: ${{parameters.msBuildArchitecture}}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
       clean: false # Optional
@@ -50,7 +47,6 @@ steps:
       createLogFile: true
       logFileVerbosity: detailed
       msbuildArgs:
-        /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
         /p:BaseIntDir=$(BaseIntDir)
         ${{parameters.msbuildArguments}}

--- a/.ado/variables/msbuild.yml
+++ b/.ado/variables/msbuild.yml
@@ -1,6 +1,4 @@
 variables:
-  MSBuildArchitecture: x64
-  MSBuildPreferredToolArchitecture: x64
   MSBuildPlatformToolset: v142
   TargetPlatformVersion: 10.0.18362.0
   Win10Version: 18362

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -171,14 +171,12 @@ jobs:
         inputs:
           solution: packages/playground/windows/Playground.sln
           vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-          msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
           clean: true # Optional
           maximumCpuCount: false # Optional
           restoreNugetPackages: false # Optional
           msbuildArgs:
-            /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
             /p:AppxPackageSigningEnabled=false
@@ -195,14 +193,12 @@ jobs:
         inputs:
           solution: packages/playground/windows/Playground-Win32.sln
           vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-          msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
           platform: $(BuildPlatform) # Optional
           configuration: $(BuildConfiguration) # Optional
           clean: true # Optional
           maximumCpuCount: false # Optional
           restoreNugetPackages: false # Optional
           msbuildArgs:
-            /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             /p:BaseIntDir=$(BaseIntDir)
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,13 +39,13 @@ jobs:
         run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory vnext/packages/ -Verbosity Detailed -NonInteractive
 
       - name: Build ReactWindows-UWP.sln
-        run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug"
+        run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /p:platform="x86" /p:configuration="Debug"
 
       - name: NuGet restore Playground.sln
         run: nuget.exe restore packages/playground/windows/Playground.sln -Verbosity Detailed -NonInteractive
 
       - name: Build Playground.sln
-        run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+        run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /p:platform="x86" /p:configuration="Debug" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
 
       # todo work out how to specify working-directory for run command
       - name: Create Playground bundle
@@ -56,7 +56,7 @@ jobs:
       #  run: nuget.exe restore packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln -Verbosity Detailed -NonInteractive
 
       #- name: Build SampleApps.sln
-      #  run: msbuild packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+      #  run: msbuild packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln /nologo /nr:false /p:platform="x86" /p:configuration="Debug" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
 
       # todo work out how to specify working-directory for run command
       - name: Create SampleApp bundle
@@ -99,7 +99,7 @@ jobs:
         run: nuget.exe restore vnext\ReactWindows-UWP.sln -PackagesDirectory vnext/packages/ -Verbosity Detailed -NonInteractive
 
       - name: Build ReactWindows-UWP.sln
-        run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+        run: msbuild vnext\ReactWindows-UWP.sln /nologo /nr:false /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
         env:
           BUILDPLATFORM: ${{ matrix.BuildPlatform }}
           BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
@@ -108,7 +108,7 @@ jobs:
         run: nuget.exe restore packages/playground/windows/Playground.sln -Verbosity Detailed -NonInteractive
 
       - name: Build Playground.sln
-        run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+        run: msbuild packages/playground/windows/Playground.sln /nologo /nr:false /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
         env:
           BUILDPLATFORM: ${{ matrix.BuildPlatform }}
           BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
@@ -122,7 +122,7 @@ jobs:
       #  run: nuget.exe restore packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln -Verbosity Detailed -NonInteractive
 
       #- name: Build SampleApps.sln
-      #  run: msbuild packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
+      #  run: msbuild packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln /nologo /nr:false /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%"
       #  env:
       #    BUILDPLATFORM: ${{ matrix.BuildPlatform }}
       #    BUILDCONFIGURATION: ${{ matrix.BuildConfiguration }}
@@ -183,7 +183,7 @@ jobs:
         run: nuget restore ${{ runner.temp }}\testcli\windows\testcli.sln
 
       - name: Build testcli.sln
-        run: msbuild ${{ runner.temp }}\testcli\windows\testcli.sln /nologo /nr:false /p:PreferredToolArchitecture=x86 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+        run: msbuild ${{ runner.temp }}\testcli\windows\testcli.sln /nologo /nr:false /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
         env:
           BUILDPLATFORM: x64
           BUILDCONFIGURATION: Debug
@@ -253,7 +253,7 @@ jobs:
         uses: warrenbuckley/Setup-MSBuild@v1
 
       - name: Build ReactNative.sln
-        run: msbuild current/ReactWindows/ReactNative.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+        run: msbuild current/ReactWindows/ReactNative.sln /nologo /nr:false /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
         env:
           BUILDPLATFORM: ${{ matrix.BuildPlatform }}
           BUILDCONFIGURATION: Debug
@@ -312,7 +312,7 @@ jobs:
         uses: warrenbuckley/Setup-MSBuild@v1
 
       - name: Build ReactWindows.sln
-        run: msbuild vnext\ReactWindows.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="${{ matrix.BuildPlatform }}" /p:configuration="${{ matrix.BuildConfiguration}}" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+        run: msbuild vnext\ReactWindows.sln /nologo /nr:false /p:platform="${{ matrix.BuildPlatform }}" /p:configuration="${{ matrix.BuildConfiguration}}" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
 
       - name: Run Desktop Unit Tests
         if: matrix.BuildPlatform != 'arm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
         uses: warrenbuckley/Setup-MSBuild@v1
 
       - name: Build ReactWindows.sln
-        run: msbuild vnext\ReactWindows.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="${{ matrix.BuildPlatform }}" /p:configuration="${{ matrix.BuildConfiguration}}" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
+        run: msbuild vnext\ReactWindows.sln /nologo /nr:false /p:platform="${{ matrix.BuildPlatform }}" /p:configuration="${{ matrix.BuildConfiguration}}" /clp:NoSummary;NoItemAndPropertyList;Verbosity=normal
 
       - name: "Copy Nuget source files"
         if: matrix.BuildConfiguration == 'Debug' && matrix.BuildPlatform == 'x86'


### PR DESCRIPTION
We see OOM issues during compilation resolved when adding more physical memory. This means toolset bitness is unlilkely to affect our builds. Remove this property, since specializing the build in CI has been leading to bugs we can't catch.

IIRC we were still seeing failures in the 0.61 branch after porting the change. I don't think it's doing what's intended, but we can revert this is we see failures come back up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4653)