### PR TITLE
Implemented C++ TurboModule compile time spec validation

### DIFF
--- a/change/react-native-windows-2020-04-21-06-23-19-MS_CppTurboModules.json
+++ b/change/react-native-windows-2020-04-21-06-23-19-MS_CppTurboModules.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implemented C++ TurboModule compile time spec validation",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-21T13:23:19.348Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -112,6 +112,7 @@
     <ClInclude Include="JsonJSValueReader.h" />
     <ClInclude Include="JsonReader.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="Point.h" />
     <ClInclude Include="ReactModuleBuilderMock.h" />
   </ItemGroup>
   <ItemGroup>
@@ -126,6 +127,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="ReactModuleBuilderMock.cpp" />
+    <ClCompile Include="TurboModuleTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
@@ -507,7 +507,7 @@ struct SimpleNativeModule2 {
 
 /*static*/ std::string SimpleNativeModule2::StaticMessage;
 
-void RegisterModule(ReactModuleBuilder<SimpleNativeModule2> &moduleBuilder) noexcept {
+void GetReactModuleInfo(SimpleNativeModule2 *, ReactModuleBuilder<SimpleNativeModule2> &moduleBuilder) noexcept {
   moduleBuilder.RegisterModuleName(L"SimpleNativeModule2");
   moduleBuilder.RegisterInitMethod(&SimpleNativeModule2::Initialize);
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::Add, L"Add");
@@ -577,8 +577,8 @@ void RegisterModule(ReactModuleBuilder<SimpleNativeModule2> &moduleBuilder) noex
   moduleBuilder.RegisterConstantField(&SimpleNativeModule2::Constant2, L"const2");
   moduleBuilder.RegisterConstantField(&SimpleNativeModule2::Constant3, L"const3");
   moduleBuilder.RegisterConstantField(&SimpleNativeModule2::Constant4, L"Constant4");
-  moduleBuilder.RegisterConstantMethod(&SimpleNativeModule2::Constant5, L"Constant5");
-  moduleBuilder.RegisterConstantMethod(&SimpleNativeModule2::Constant6, L"Constant6");
+  moduleBuilder.RegisterConstantMethod(&SimpleNativeModule2::Constant5);
+  moduleBuilder.RegisterConstantMethod(&SimpleNativeModule2::Constant6);
   moduleBuilder.RegisterEventField(&SimpleNativeModule2::OnIntEvent, L"OnIntEvent");
   moduleBuilder.RegisterEventField(&SimpleNativeModule2::OnNoArgEvent, L"OnNoArgEvent");
   moduleBuilder.RegisterEventField(&SimpleNativeModule2::OnTwoArgsEvent, L"OnTwoArgsEvent");

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Point.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Point.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "NativeModules.h"
+
+namespace ReactNativeTests {
+
+REACT_STRUCT(Point)
+struct Point {
+  REACT_FIELD(X)
+  int X;
+
+  REACT_FIELD(Y)
+  int Y;
+};
+
+} // namespace ReactNativeTests

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -112,8 +112,8 @@ struct ReactModuleBuilderMock {
   std::vector<ConstantProviderDelegate> m_constantProviders;
   std::map<std::wstring, std::tuple<MethodReturnType, MethodDelegate>> m_methods;
   std::map<std::wstring, SyncMethodDelegate> m_syncMethods;
-  bool m_isResolveCallbackCalled;
-  bool m_isRejectCallbackCalled;
+  bool m_isResolveCallbackCalled{false};
+  bool m_isRejectCallbackCalled{false};
   Mso::Functor<void(std::wstring_view, std::wstring_view, JSValue const &)> m_jsFunctionHandler;
   Mso::Functor<void(std::wstring_view, std::wstring_view, JSValue const &)> m_jsEventHandler;
 };

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -9,9 +9,8 @@
 #include "future/futureWait.h"
 
 namespace ReactNativeTests {
-
-REACT_MODULE(SimpleNativeModule)
-struct SimpleNativeModule {
+REACT_MODULE(MyTurboModule)
+struct MyTurboModule {
   REACT_INIT(Initialize)
   void Initialize(React::IReactContext const &context) noexcept {
     IsInitialized = true;
@@ -71,9 +70,9 @@ struct SimpleNativeModule {
     Message = ss.str();
   }
 
-  REACT_METHOD(StaticSayHello1)
-  static void StaticSayHello1() noexcept {
-    StaticMessage = "Hello_1";
+  REACT_METHOD(StaticSayHello0)
+  static void StaticSayHello0() noexcept {
+    StaticMessage = "Hello_0";
   }
 
   REACT_METHOD(StaticPrintPoint)
@@ -586,24 +585,544 @@ struct SimpleNativeModule {
   static std::string StaticMessage;
 };
 
-/*static*/ std::string SimpleNativeModule::StaticMessage;
+/*static*/ std::string MyTurboModule::StaticMessage;
 
-TEST_CLASS (NativeModuleTest) {
-  React::ReactModuleBuilderMock m_builderMock{};
-  React::IReactModuleBuilder m_moduleBuilder;
+// The TurboModule spec is going to be generated from the Flow spec file.
+// It verifies that:
+// - module methods names are unique;
+// - method names are matching to the module spec method names;
+// - method signatures match the spec method signatures.
+struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto methods = std::tuple{
+      Method<void(int, int, Callback<int>) noexcept>{0, L"Add"},
+      Method<void(int, Callback<int>) noexcept>{1, L"Negate"},
+      Method<void(Callback<std::string>) noexcept>{2, L"SayHello"},
+      Method<void(int, int, Callback<int>) noexcept>{3, L"StaticAdd"},
+      Method<void(int, Callback<int>) noexcept>{4, L"StaticNegate"},
+      Method<void(Callback<std::string>) noexcept>{5, L"StaticSayHello"},
+      Method<void() noexcept>{6, L"SayHello0"},
+      Method<void(Point) noexcept>{7, L"PrintPoint"},
+      Method<void(Point, Point) noexcept>{8, L"PrintLine"},
+      Method<void() noexcept>{9, L"StaticSayHello0"},
+      Method<void(Point) noexcept>{10, L"StaticPrintPoint"},
+      Method<void(Point, Point) noexcept>{11, L"StaticPrintLine"},
+      Method<void(int, int, Callback<int>) noexcept>{12, L"AddCallback"},
+      Method<void(int, Callback<int>) noexcept>{13, L"NegateCallback"},
+      Method<void(int, Callback<int>) noexcept>{14, L"NegateAsyncCallback"},
+      Method<void(int, Callback<int>) noexcept>{15, L"NegateDispatchQueueCallback"},
+      Method<void(int, Callback<int>) noexcept>{16, L"NegateFutureCallback"},
+      Method<void(Callback<std::string>) noexcept>{17, L"SayHelloCallback"},
+      Method<void(int, int, Callback<int>) noexcept>{18, L"StaticAddCallback"},
+      Method<void(int, Callback<int>) noexcept>{19, L"StaticNegateCallback"},
+      Method<void(int, Callback<int>) noexcept>{20, L"StaticNegateAsyncCallback"},
+      Method<void(int, Callback<int>) noexcept>{21, L"StaticNegateDispatchQueueCallback"},
+      Method<void(int, Callback<int>) noexcept>{22, L"StaticNegateFutureCallback"},
+      Method<void(Callback<std::string>) noexcept>{23, L"StaticSayHelloCallback"},
+      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{24, L"DivideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{25, L"NegateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{26, L"NegateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{27, L"NegateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{28, L"NegateFutureCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{29, L"ResolveSayHelloCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{30, L"RejectSayHelloCallbacks"},
+      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{31, L"StaticDivideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{32, L"StaticNegateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{33, L"StaticNegateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{34, L"StaticNegateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{35, L"StaticNegateFutureCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{36, L"StaticResolveSayHelloCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{37, L"StaticRejectSayHelloCallbacks"},
+      Method<void(int, int, Promise<int>) noexcept>{38, L"DividePromise"},
+      Method<void(int, Promise<int>) noexcept>{39, L"NegatePromise"},
+      Method<void(int, Promise<int>) noexcept>{40, L"NegateAsyncPromise"},
+      Method<void(int, Promise<int>) noexcept>{41, L"NegateDispatchQueuePromise"},
+      Method<void(int, Promise<int>) noexcept>{42, L"NegateFuturePromise"},
+      Method<void(int, Promise<void>) noexcept>{43, L"voidPromise"},
+      Method<void(Promise<std::string>) noexcept>{44, L"ResolveSayHelloPromise"},
+      Method<void(Promise<std::string>) noexcept>{45, L"RejectSayHelloPromise"},
+      Method<void(int, int, Promise<int>) noexcept>{46, L"StaticDividePromise"},
+      Method<void(int, Promise<int>) noexcept>{47, L"StaticNegatePromise"},
+      Method<void(int, Promise<int>) noexcept>{48, L"StaticNegateAsyncPromise"},
+      Method<void(int, Promise<int>) noexcept>{49, L"StaticNegateDispatchQueuePromise"},
+      Method<void(int, Promise<int>) noexcept>{50, L"StaticNegateFuturePromise"},
+      Method<void(int, Promise<void>) noexcept>{51, L"staticVoidPromise"},
+      Method<void(Promise<std::string>) noexcept>{52, L"StaticResolveSayHelloPromise"},
+      Method<void(Promise<std::string>) noexcept>{53, L"StaticRejectSayHelloPromise"},
+      SyncMethod<int(int, int) noexcept>{54, L"AddSync"},
+      SyncMethod<int(int) noexcept>{55, L"NegateSync"},
+      SyncMethod<std::string() noexcept>{56, L"SayHelloSync"},
+      SyncMethod<int(int, int) noexcept>{57, L"StaticAddSync"},
+      SyncMethod<int(int) noexcept>{58, L"StaticNegateSync"},
+      SyncMethod<std::string() noexcept>{59, L"StaticSayHelloSync"},
+  };
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        0,
+        "Add",
+        "    REACT_METHOD(Add) int Add(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) winrt::fire_and_forget Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) static int Add(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) static void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) static React::Coroutine Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        1,
+        "Negate",
+        "    REACT_METHOD(Negate) int Negate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) void Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) winrt::fire_and_forget Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) static int Negate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) static void Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) static winrt::fire_and_forget Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        2,
+        "SayHello",
+        "    REACT_METHOD(SayHello) std::string SayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) void SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) winrt::fire_and_forget SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) static std::string SayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) static void SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) static winrt::fire_and_forget SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        3,
+        "StaticAdd",
+        "    REACT_METHOD(StaticAdd) int StaticAdd(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) void StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) winrt::fire_and_forget StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) static int StaticAdd(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) static void StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) static winrt::fire_and_forget StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        4,
+        "StaticNegate",
+        "    REACT_METHOD(StaticNegate) int StaticNegate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) void StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) winrt::fire_and_forget StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) static int StaticNegate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) static void StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) static winrt::fire_and_forget StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        5,
+        "StaticSayHello",
+        "    REACT_METHOD(StaticSayHello) std::string StaticSayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) void StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) winrt::fire_and_forget StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) static std::string StaticSayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) static void StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) static winrt::fire_and_forget StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        6,
+        "SayHello0",
+        "    REACT_METHOD(SayHello0) void SayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello0) winrt::fire_and_forget SayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello0) static void SayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello0) static winrt::fire_and_forget SayHello0() noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        7,
+        "PrintPoint",
+        "    REACT_METHOD(PrintPoint) void PrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) winrt::fire_and_forget PrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static void PrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static winrt::fire_and_forget PrintPoint(Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        8,
+        "PrintLine",
+        "    REACT_METHOD(PrintPoint) void PrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) winrt::fire_and_forget PrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static void PrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static winrt::fire_and_forget PrintLine(Point, Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        9,
+        "StaticSayHello0",
+        "    REACT_METHOD(StaticSayHello0) void StaticSayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello0) winrt::fire_and_forget StaticSayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello0) static void StaticSayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello0) static winrt::fire_and_forget StaticSayHello0() noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        10,
+        "StaticPrintPoint",
+        "    REACT_METHOD(StaticPrintPoint) void StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) winrt::fire_and_forget StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static void StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static winrt::fire_and_forget StaticPrintPoint(Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        11,
+        "StaticPrintLine",
+        "    REACT_METHOD(StaticPrintPoint) void StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) winrt::fire_and_forget StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static void StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static winrt::fire_and_forget StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        12,
+        "AddCallback",
+        "    REACT_METHOD(AddCallback) int AddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) void AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) winrt::fire_and_forget AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) static int AddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) static void AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) static winrt::fire_and_forget AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        13,
+        "NegateCallback",
+        "    REACT_METHOD(NegateCallback) int NegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) void NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) winrt::fire_and_forget NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) static int NegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) static void NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) static winrt::fire_and_forget NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        14,
+        "NegateAsyncCallback",
+        "    REACT_METHOD(NegateAsyncCallback) int NegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) void NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) winrt::fire_and_forget NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) static int NegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) static void NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) static winrt::fire_and_forget NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        15,
+        "NegateDispatchQueueCallback",
+        "    REACT_METHOD(NegateDispatchQueueCallback) int NegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) void NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) winrt::fire_and_forget NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) static int NegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) static void NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) static winrt::fire_and_forget NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        16,
+        "NegateFutureCallback",
+        "    REACT_METHOD(NegateFutureCallback) int NegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) void NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) winrt::fire_and_forget NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) static int NegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) static void NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) static winrt::fire_and_forget NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        17,
+        "SayHelloCallback",
+        "    REACT_METHOD(SayHelloCallback) std::string SayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) void SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) winrt::fire_and_forget SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) static std::string SayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) static void SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) static winrt::fire_and_forget SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        18,
+        "StaticAddCallback",
+        "    REACT_METHOD(StaticAddCallback) int StaticAddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) void StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) winrt::fire_and_forget StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) static int StaticAddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) static void StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) static winrt::fire_and_forget StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        19,
+        "StaticNegateCallback",
+        "    REACT_METHOD(StaticNegateCallback) int StaticNegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) void StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) winrt::fire_and_forget StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) static int StaticNegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) static void StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) static winrt::fire_and_forget StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        20,
+        "StaticNegateAsyncCallback",
+        "    REACT_METHOD(StaticNegateAsyncCallback) int StaticNegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) void StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) winrt::fire_and_forget StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) static int StaticNegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) static void StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) static winrt::fire_and_forget StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        21,
+        "StaticNegateDispatchQueueCallback",
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) int StaticNegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) void StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) winrt::fire_and_forget StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static int StaticNegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static void StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static winrt::fire_and_forget StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        22,
+        "StaticNegateFutureCallback",
+        "    REACT_METHOD(StaticNegateFutureCallback) int StaticNegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) void StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) winrt::fire_and_forget StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) static int StaticNegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) static void StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) static winrt::fire_and_forget StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        23,
+        "StaticSayHelloCallback",
+        "    REACT_METHOD(StaticSayHelloCallback) std::string StaticSayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) void StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) static std::string StaticSayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) static void StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) static winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        24,
+        "DivideCallbacks",
+        "    REACT_METHOD(DivideCallbacks) void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DivideCallbacks) winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DivideCallbacks) static void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DivideCallbacks) static winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        25,
+        "NegateCallbacks",
+        "    REACT_METHOD(NegateCallbacks) void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallbacks) winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallbacks) static void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallbacks) static winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        26,
+        "NegateAsyncCallbacks",
+        "    REACT_METHOD(NegateAsyncCallbacks) void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallbacks) winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallbacks) static void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallbacks) static winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        27,
+        "NegateDispatchQueueCallbacks",
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) static void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) static winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        28,
+        "NegateFutureCallbacks",
+        "    REACT_METHOD(NegateFutureCallbacks) void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallbacks) winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallbacks) static void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallbacks) static winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        29,
+        "ResolveSayHelloCallbacks",
+        "    REACT_METHOD(ResolveSayHelloCallbacks) void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloCallbacks) winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloCallbacks) static void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloCallbacks) static winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        30,
+        "RejectSayHelloCallbacks",
+        "    REACT_METHOD(RejectSayHelloCallbacks) void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloCallbacks) winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloCallbacks) static void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloCallbacks) static winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        31,
+        "StaticDivideCallbacks",
+        "    REACT_METHOD(StaticDivideCallbacks) void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDivideCallbacks) winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDivideCallbacks) static void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDivideCallbacks) static winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        32,
+        "StaticNegateCallbacks",
+        "    REACT_METHOD(StaticNegateCallbacks) void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallbacks) winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallbacks) static void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallbacks) static winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        33,
+        "StaticNegateAsyncCallbacks",
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) static void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) static winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        34,
+        "StaticNegateDispatchQueueCallbacks",
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        35,
+        "StaticNegateFutureCallbacks",
+        "    REACT_METHOD(StaticNegateFutureCallbacks) void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallbacks) winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallbacks) static void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallbacks) static winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        36,
+        "StaticResolveSayHelloCallbacks",
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) static void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) static winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        37,
+        "StaticRejectSayHelloCallbacks",
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) static void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) static winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        38,
+        "DividePromise",
+        "    REACT_METHOD(DividePromise) void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DividePromise) winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DividePromise) static void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DividePromise) static winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        39,
+        "NegatePromise",
+        "    REACT_METHOD(NegatePromise) void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegatePromise) winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegatePromise) static void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegatePromise) static winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        40,
+        "NegateAsyncPromise",
+        "    REACT_METHOD(NegateAsyncPromise) void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncPromise) winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncPromise) static void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncPromise) static winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        41,
+        "NegateDispatchQueuePromise",
+        "    REACT_METHOD(NegateDispatchQueuePromise) void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueuePromise) winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueuePromise) static void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueuePromise) static winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        42,
+        "NegateFuturePromise",
+        "    REACT_METHOD(NegateFuturePromise) void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFuturePromise) winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFuturePromise) static void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFuturePromise) static winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        43,
+        "voidPromise",
+        "    REACT_METHOD(voidPromise) void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(voidPromise) winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(voidPromise) static void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(voidPromise) static winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        44,
+        "ResolveSayHelloPromise",
+        "    REACT_METHOD(ResolveSayHelloPromise) void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloPromise) winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloPromise) static void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloPromise) static winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        45,
+        "RejectSayHelloPromise",
+        "    REACT_METHOD(RejectSayHelloPromise) void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloPromise) winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloPromise) static void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloPromise) static winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        46,
+        "StaticDividePromise",
+        "    REACT_METHOD(StaticDividePromise) void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDividePromise) winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDividePromise) static void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDividePromise) static winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        47,
+        "StaticNegatePromise",
+        "    REACT_METHOD(StaticNegatePromise) void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegatePromise) winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegatePromise) static void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegatePromise) static winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        48,
+        "StaticNegateAsyncPromise",
+        "    REACT_METHOD(StaticNegateAsyncPromise) void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncPromise) winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncPromise) static void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncPromise) static winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        49,
+        "StaticNegateDispatchQueuePromise",
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) static void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) static winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        50,
+        "StaticNegateFuturePromise",
+        "    REACT_METHOD(StaticNegateFuturePromise) void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFuturePromise) winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFuturePromise) static void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFuturePromise) static winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        51,
+        "staticVoidPromise",
+        "    REACT_METHOD(staticVoidPromise) void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(staticVoidPromise) winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(staticVoidPromise) static void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(staticVoidPromise) static winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        52,
+        "StaticResolveSayHelloPromise",
+        "    REACT_METHOD(StaticResolveSayHelloPromise) void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloPromise) winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloPromise) static void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloPromise) static winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        53,
+        "StaticRejectSayHelloPromise",
+        "    REACT_METHOD(StaticRejectSayHelloPromise) void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloPromise) winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloPromise) static void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloPromise) static winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        54,
+        "AddSync",
+        "    REACT_METHOD(AddSync) int AddSync(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddSync) static int AddSync(int, int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        55,
+        "NegateSync",
+        "    REACT_METHOD(NegateSync) int NegateSync(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateSync) static int NegateSync(int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        56,
+        "SayHelloSync",
+        "    REACT_METHOD(SayHelloSync) std::string SayHelloSync() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloSync) static std::string SayHelloSync() noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        57,
+        "StaticAddSync",
+        "    REACT_METHOD(StaticAddSync) int StaticAddSync(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddSync) static int StaticAddSync(int, int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        58,
+        "StaticNegateSync",
+        "    REACT_METHOD(StaticNegateSync) int StaticNegateSync(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateSync) static int StaticNegateSync(int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        59,
+        "StaticSayHelloSync",
+        "    REACT_METHOD(StaticSayHelloSync) std::string StaticSayHelloSync() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloSync) static std::string StaticSayHelloSync() noexcept {/*implementation*/}\n");
+  }
+};
+
+TEST_CLASS (TurboModuleTest) {
+  winrt::Microsoft::ReactNative::ReactModuleBuilderMock m_builderMock{};
+  winrt::Microsoft::ReactNative::IReactModuleBuilder m_moduleBuilder;
   Windows::Foundation::IInspectable m_moduleObject{nullptr};
-  SimpleNativeModule *m_module;
+  MyTurboModule *m_module;
 
-  NativeModuleTest() {
-    m_moduleBuilder = winrt::make<React::ReactModuleBuilderImpl>(m_builderMock);
-    auto provider = React::MakeModuleProvider<SimpleNativeModule>();
+  TurboModuleTest() {
+    m_moduleBuilder = winrt::make<winrt::Microsoft::ReactNative::ReactModuleBuilderImpl>(m_builderMock);
+    auto provider = winrt::Microsoft::ReactNative::MakeTurboModuleProvider<MyTurboModule, MyTurboModuleSpec>();
     m_moduleObject = m_builderMock.CreateModule(provider, m_moduleBuilder);
-    auto reactModule = m_moduleObject.as<React::IBoxedValue>();
-    m_module = &React::BoxedValue<SimpleNativeModule>::GetImpl(reactModule);
+    auto reactModule = m_moduleObject.as<winrt::Microsoft::ReactNative::IBoxedValue>();
+    m_module = &winrt::Microsoft::ReactNative::BoxedValue<MyTurboModule>::GetImpl(reactModule);
   }
 
   TEST_METHOD(TestMethodCall_Add) {
-    m_builderMock.Call1(L"Add", std::function<void(int)>([](int result) noexcept { TestCheck(result == 8); }), 3, 5);
+    m_builderMock.Call1(L"Add", std::function<void(int)>([](int result) noexcept { TestCheckEqual(8, result); }), 3, 5);
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -652,19 +1171,19 @@ TEST_CLASS (NativeModuleTest) {
     TestCheck(m_module->Message == "Line: (3, 5)-(6, 8)");
   }
 
-  TEST_METHOD(TestMethodCall_StaticSayHello1) {
-    m_builderMock.Call0(L"StaticSayHello1");
-    TestCheck(SimpleNativeModule::StaticMessage == "Hello_1");
+  TEST_METHOD(TestMethodCall_StaticSayHello0) {
+    m_builderMock.Call0(L"StaticSayHello0");
+    TestCheck(MyTurboModule::StaticMessage == "Hello_0");
   }
 
   TEST_METHOD(TestMethodCall_StaticPrintPoint) {
     m_builderMock.Call0(L"StaticPrintPoint", Point{/*X =*/13, /*Y =*/15});
-    TestCheck(SimpleNativeModule::StaticMessage == "Static Point: (13, 15)");
+    TestCheck(MyTurboModule::StaticMessage == "Static Point: (13, 15)");
   }
 
   TEST_METHOD(TestMethodCall_StaticPrintLine) {
     m_builderMock.Call0(L"StaticPrintLine", Point{/*X =*/13, /*Y =*/15}, Point{/*X =*/16, /*Y =*/18});
-    TestCheck(SimpleNativeModule::StaticMessage == "Static Line: (13, 15)-(16, 18)");
+    TestCheck(MyTurboModule::StaticMessage == "Static Line: (13, 15)-(16, 18)");
   }
 
   TEST_METHOD(TestMethodCall_AddCallback) {
@@ -1434,7 +1953,7 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestFunction_JSIntFunctionField) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
-        L"SimpleNativeModule", L"JSIntFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
+        L"MyTurboModule", L"JSIntFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
           TestCheck(args[0] == 42);
           functionCalled = true;
         });
@@ -1446,7 +1965,7 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestFunction_JSNameFunctionField) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
-        L"SimpleNativeModule", L"pointFunc", [&functionCalled](React::JSValueArray const &args) noexcept {
+        L"MyTurboModule", L"pointFunc", [&functionCalled](React::JSValueArray const &args) noexcept {
           TestCheck(args[0]["X"] == 4);
           TestCheck(args[0]["Y"] == 2);
           functionCalled = true;
@@ -1459,7 +1978,7 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestFunction_TwoArgFunctionField) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
-        L"SimpleNativeModule", L"lineFunc", [&functionCalled](React::JSValueArray const &args) noexcept {
+        L"MyTurboModule", L"lineFunc", [&functionCalled](React::JSValueArray const &args) noexcept {
           TestCheck(args[0]["X"] == 4);
           TestCheck(args[0]["Y"] == 2);
           TestCheck(args[1]["X"] == 12);
@@ -1474,7 +1993,7 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestFunction_NoArgFunctionField) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
-        L"SimpleNativeModule", L"JSNoArgFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
+        L"MyTurboModule", L"JSNoArgFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
           TestCheckEqual(0, args.size());
           functionCalled = true;
         });
@@ -1498,7 +2017,7 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestFunction_JSValueObjectFunctionField) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
-        L"SimpleNativeModule", L"JSValueFunction", ([&functionCalled](React::JSValueArray const &args) noexcept {
+        L"MyTurboModule", L"JSValueFunction", ([&functionCalled](React::JSValueArray const &args) noexcept {
           TestCheck(args[0]["X"] == 4);
           TestCheck(args[0]["Y"] == 2);
           functionCalled = true;
@@ -1511,7 +2030,7 @@ TEST_CLASS (NativeModuleTest) {
   TEST_METHOD(TestFunction_JSValueArrayFunctionField) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
-        L"SimpleNativeModule", L"JSValueFunction", ([&functionCalled](React::JSValueArray const &args) noexcept {
+        L"MyTurboModule", L"JSValueFunction", ([&functionCalled](React::JSValueArray const &args) noexcept {
           TestCheck(args[0][0] == "X");
           TestCheck(args[0][1] == 4);
           TestCheck(args[0][2] == true);

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -9,6 +9,7 @@
 #include "ModuleRegistration.h"
 #include "ReactPromise.h"
 
+#include <functional>
 #include <type_traits>
 
 // REACT_MODULE(moduleStruct, [opt] moduleName, [opt] eventEmitterName)
@@ -47,7 +48,7 @@
 // - Return non-void value. In JavaScript it is treated as a method with one Callback. Return std::pair<Error, Value> to
 //   be able to communicate error condition.
 // It can be an instance or static method.
-#define REACT_METHOD(/* method, [opt] methodName */...) INTERNAL_REACT_MEMBER(__VA_ARGS__)(Method, __VA_ARGS__)
+#define REACT_METHOD(/* method, [opt] methodName */...) INTERNAL_REACT_MEMBER(__VA_ARGS__)(AsyncMethod, __VA_ARGS__)
 
 // REACT_SYNC_METHOD(method, [opt] methodName)
 // Arguments:
@@ -105,38 +106,164 @@
 #define REACT_FUNCTION(/* field, [opt] functionName, [opt] moduleName */...) \
   INTERNAL_REACT_MEMBER(__VA_ARGS__)(FunctionField, __VA_ARGS__)
 
+#define REACT_SHOW_METHOD_SIGNATURES(methodName, signatures)                      \
+  " (see details below in output).\n"                                             \
+  "  It must be one of the following:\n" signatures                               \
+  "  The C++ method name could be different. In that case add the L\"" methodName \
+  "\" to the attribute:\n"                                                        \
+  "    REACT_METHOD(method, L\"" methodName "\")\n...\n"
+
+#define REACT_SHOW_SYNC_METHOD_SIGNATURES(methodName, signatures)                 \
+  " (see details below in output).\n"                                             \
+  "  It must be one of the following:\n" signatures                               \
+  "  The C++ method name could be different. In that case add the L\"" methodName \
+  "\" to the attribute:\n"                                                        \
+  "    REACT_SYNC_METHOD(method, L\"" methodName "\")\n...\n"
+
+#define REACT_SHOW_METHOD_SPEC_ERRORS(index, methodName, signatures)                                        \
+  static_assert(methodCheckResults[index].IsUniqueName, "Name '" methodName "' used for multiple methods"); \
+  static_assert(                                                                                            \
+      methodCheckResults[index].IsMethodFound,                                                              \
+      "Method '" methodName "' is not defined" REACT_SHOW_METHOD_SIGNATURES(methodName, signatures));       \
+  static_assert(                                                                                            \
+      methodCheckResults[index].IsSignatureMatching,                                                        \
+      "Method '" methodName "' does not match signature" REACT_SHOW_METHOD_SIGNATURES(methodName, signatures));
+
+#define REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(index, methodName, signatures)                                   \
+  static_assert(methodCheckResults[index].IsUniqueName, "Name '" methodName "' used for multiple methods"); \
+  static_assert(                                                                                            \
+      methodCheckResults[index].IsMethodFound,                                                              \
+      "Method '" methodName "' is not defined" REACT_SHOW_SYNC_METHOD_SIGNATURES(methodName, signatures));  \
+  static_assert(                                                                                            \
+      methodCheckResults[index].IsSignatureMatching,                                                        \
+      "Method '" methodName "' does not match signature" REACT_SHOW_SYNC_METHOD_SIGNATURES(methodName, signatures));
+
+//
+// Code below helps to register React native modules and verify method signatures
+// against specification.
+//
+
 namespace winrt::Microsoft::ReactNative {
 
-namespace Internal {
+// Often used to create a tuple with arguments or to create a method signature.
+template <class T>
+using RemoveConstRef = std::remove_const_t<std::remove_reference_t<T>>;
 
-// Checks if provided type has a callback-like signature TFunc<void(TArgs...)
+// Checks if type T has a callback-like signature TFunc<void(TArgs...)
 template <class T>
 struct IsCallback : std::false_type {};
-template <template <class...> class TFunc, class... TArgs>
+template <template <class> class TFunc, class... TArgs>
 struct IsCallback<TFunc<void(TArgs...)>> : std::true_type {};
 #if defined(__cpp_noexcept_function_type) || (_HAS_NOEXCEPT_FUNCTION_TYPES == 1)
-template <template <class...> class TFunc, class... TArgs>
+template <template <class> class TFunc, class... TArgs>
 struct IsCallback<TFunc<void(TArgs...) noexcept>> : std::true_type {};
 #endif
 
-// Finds how many callbacks the function signature has.
-template <class... TArgs>
+// Finds how many callbacks the function signature has in the end: 0, 1, or 2.
+template <class TArgsTuple>
 constexpr size_t GetCallbackCount() noexcept {
-  using TupleType = std::tuple<std::remove_const_t<std::remove_reference_t<TArgs>>...>;
-  if constexpr (sizeof...(TArgs) >= 2) {
-    return (IsCallback<std::tuple_element_t<sizeof...(TArgs) - 1u, TupleType>>::value ? 1 : 0) +
-        (IsCallback<std::tuple_element_t<sizeof...(TArgs) - 2u, TupleType>>::value ? 1 : 0);
-  } else if constexpr (sizeof...(TArgs) == 1) {
-    return IsCallback<std::tuple_element_t<0, TupleType>>::value ? 1 : 0;
+  if constexpr (std::tuple_size_v<TArgsTuple> >= 2) {
+    return (IsCallback<std::tuple_element_t<std::tuple_size_v<TArgsTuple> - 1, TArgsTuple>>::value ? 1 : 0) +
+        (IsCallback<std::tuple_element_t<std::tuple_size_v<TArgsTuple> - 2, TArgsTuple>>::value ? 1 : 0);
+  } else if constexpr (std::tuple_size_v<TArgsTuple> == 1) {
+    return IsCallback<std::tuple_element_t<0, TArgsTuple>>::value ? 1 : 0;
   } else {
     return 0;
   }
 }
 
+// Callback is any std::function<void(TArgs...)> like type.
+// For the signature comparison we want to use only input arguments.
+template <class... TArgs>
+struct CallbackSignature {};
+
+// ==== GetCallbackSignature ===================================================
+
+template <class T>
+struct GetCallbackSignatureImpl {};
+
+// Get callback signature from a callback.
+template <class TCallback>
+using GetCallbackSignature = typename GetCallbackSignatureImpl<TCallback>::Type;
+
+template <template <class> class TCallback, class... TArgs>
+struct GetCallbackSignatureImpl<TCallback<void(TArgs...)>> {
+  using Type = CallbackSignature<RemoveConstRef<TArgs>...>;
+};
+
+#if defined(__cpp_noexcept_function_type) || (_HAS_NOEXCEPT_FUNCTION_TYPES == 1)
+template <template <class> class TCallback, class... TArgs>
+struct GetCallbackSignatureImpl<TCallback<void(TArgs...) noexcept>> {
+  using Type = CallbackSignature<RemoveConstRef<TArgs>...>;
+};
+#endif
+
+// ==== CallbackCreator ========================================================
+
+template <class T>
+struct CallbackCreator;
+
+template <template <class> class TCallback, class... TArgs>
+struct CallbackCreator<TCallback<void(TArgs...)>> {
+  static TCallback<void(TArgs...)> Create(
+      IJSValueWriter const &argWriter,
+      MethodResultCallback const &callback) noexcept {
+    return TCallback([ callback, argWriter ](TArgs... args) noexcept {
+      WriteArgs(argWriter, std::move(args)...);
+      callback(argWriter);
+    });
+  }
+};
+
+template <template <class> class TCallback, class... TArgs>
+struct CallbackCreator<TCallback<void(TArgs...) noexcept>> {
+  static TCallback<void(TArgs...)> Create(
+      IJSValueWriter const &argWriter,
+      MethodResultCallback const &callback) noexcept {
+    return TCallback([ callback, argWriter ](TArgs... args) noexcept {
+      WriteArgs(argWriter, std::move(args)...);
+      callback(argWriter);
+    });
+  }
+};
+
+// ==== TupleElementOrVoid =====================================================
+
+template <bool, size_t Index, class TTuple>
+struct TupleElementOrVoidImpl {
+  using Type = void;
+};
+
+template <size_t Index, class TTuple>
+struct TupleElementOrVoidImpl<true, Index, TTuple> {
+  using Type = std::tuple_element_t<Index, TTuple>;
+};
+
+template <size_t Index, class TTuple>
+using TupleElementOrVoid = typename TupleElementOrVoidImpl<(Index < std::tuple_size_v<TTuple>), Index, TTuple>::Type;
+
+// Checks if type T is a has a ReactPromise
 template <class T>
 struct IsPromise : std::false_type {};
 template <class T>
 struct IsPromise<ReactPromise<T>> : std::true_type {};
+
+// Return 1 if last parameter is Promise, otherwise 0.
+template <class TArgsTuple>
+constexpr size_t GetPromiseCount() noexcept {
+  if constexpr (
+      std::tuple_size_v<TArgsTuple>> 0 &&
+      IsPromise<TupleElementOrVoid<std::tuple_size_v<TArgsTuple> - 1, TArgsTuple>>::value) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+template <class TResult>
+constexpr bool IsVoidResult() noexcept {
+  return std::is_void_v<TResult> || std::is_same_v<TResult, winrt::fire_and_forget>;
+}
 
 template <class TResult, class TArg>
 constexpr void ValidateCoroutineArg() noexcept {
@@ -147,7 +274,106 @@ constexpr void ValidateCoroutineArg() noexcept {
   }
 }
 
-} // namespace Internal
+// ==== TransformListItems =====================================================
+
+template <template <class...> class TFunc, class TList>
+struct TransformListItemsImpl;
+
+// TransformListItems transforms each variadic item parameter type using TFunc.
+// E.g. std::tuple<int, double> ==> std::tuple<TFunc<int>, TFunc<double>>.
+template <template <class...> class TFunc, class TList>
+using TransformListItems = typename TransformListItemsImpl<TFunc, TList>::Type;
+
+template <template <class...> class TFunc, template <class...> class TList, class... TItems>
+struct TransformListItemsImpl<TFunc, TList<TItems...>> {
+  using Type = TList<TFunc<TItems>...>;
+};
+
+// ==== TakeTupleElements ======================================================
+
+template <size_t StartIndex, class TIndexSequence, class TTuple>
+struct TakeTupleElementsImpl;
+
+// Take Count tuple type parameters starting with StartIndex from TTuple.
+template <size_t StartIndex, size_t Count, class TTuple>
+using TakeTupleElements = typename TakeTupleElementsImpl<StartIndex, std::make_index_sequence<Count>, TTuple>::Type;
+
+template <size_t StartIndex, class TTuple, size_t... Index>
+struct TakeTupleElementsImpl<StartIndex, std::index_sequence<Index...>, TTuple> {
+  using Type = std::tuple<std::tuple_element_t<StartIndex + Index, TTuple>...>;
+};
+
+//==============================================================================
+// MethodSignature is used to compare method signatures.
+//==============================================================================
+
+struct MethodSignatureMatchResult {
+  int ArgCountCompare;
+  int CallbackCountCompare;
+  bool IsResultMatching;
+  bool AreArgsMatching;
+  bool AreCallbacksMatching;
+  bool IsPromiseMathcing;
+  bool IsSucceeded;
+};
+
+template <class TResult, class TInputArgs, class TOutputCallbacks, class TOutputPromises>
+struct MethodSignature {
+  using Result = TResult;
+  using InputArgs = TInputArgs;
+  using OutputCallbacks = TOutputCallbacks;
+  using OutputPromises = TOutputPromises;
+  constexpr static size_t ArgCount = std::tuple_size_v<InputArgs>;
+  constexpr static size_t CallbackCount = std::tuple_size_v<TOutputCallbacks>;
+
+  static constexpr int CompareSize(size_t left, size_t right) noexcept {
+    if (left < right) {
+      return -1;
+    } else if (right < left) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  template <class TOtherInputArgs, size_t... I>
+  static constexpr bool MatchInputArgs(std::index_sequence<I...>) noexcept {
+    return (std::is_same_v<std::tuple_element_t<I, InputArgs>, std::tuple_element_t<I, TOtherInputArgs>> && ...);
+  }
+
+  template <class TOtherOutputCallbacks, size_t... I>
+  static constexpr bool MatchOutputCallbacks(std::index_sequence<I...>) noexcept {
+    return (
+        std::is_same_v<std::tuple_element_t<I, OutputCallbacks>, std::tuple_element_t<I, TOtherOutputCallbacks>> &&
+        ...);
+  }
+
+  template <class TOtherMethodSignature>
+  static constexpr MethodSignatureMatchResult Match() noexcept {
+    MethodSignatureMatchResult result{};
+
+    result.IsResultMatching = std::is_same_v<Result, typename TOtherMethodSignature::Result>;
+
+    result.ArgCountCompare = CompareSize(ArgCount, TOtherMethodSignature::ArgCount);
+    if (result.ArgCountCompare == 0) {
+      result.AreArgsMatching =
+          MatchInputArgs<typename TOtherMethodSignature::InputArgs>(std::make_index_sequence<ArgCount>{});
+    }
+
+    result.CallbackCountCompare = CompareSize(CallbackCount, TOtherMethodSignature::CallbackCount);
+    if (result.CallbackCountCompare == 0) {
+      result.AreCallbacksMatching = MatchOutputCallbacks<typename TOtherMethodSignature::OutputCallbacks>(
+          std::make_index_sequence<CallbackCount>{});
+    }
+
+    result.IsPromiseMathcing = std::is_same_v<OutputPromises, typename TOtherMethodSignature::OutputPromises>;
+
+    result.IsSucceeded = result.IsResultMatching && result.ArgCountCompare == 0 && result.AreArgsMatching &&
+        result.CallbackCountCompare == 0 && result.AreCallbacksMatching && result.IsPromiseMathcing;
+
+    return result;
+  }
+};
 
 //==============================================================================
 // Module registration helpers
@@ -168,381 +394,206 @@ struct ModuleInitMethodInfo<void (TModule::*)(IReactContext const &) noexcept> {
   }
 };
 
+// ==== MakeCallbackSignatures =================================================
+
+template <class TResult, class TOutputCallbackTuple>
+struct MakeCallbackSignaturesImpl {
+  using Type = std::tuple<CallbackSignature<TResult>>;
+};
+
+template <class TOutputCallbackTuple>
+struct MakeCallbackSignaturesImpl<void, TOutputCallbackTuple> {
+  using Type = TransformListItems<GetCallbackSignature, TOutputCallbackTuple>;
+};
+
+template <class TOutputCallbackTuple>
+struct MakeCallbackSignaturesImpl<winrt::fire_and_forget, TOutputCallbackTuple> {
+  using Type = TransformListItems<GetCallbackSignature, TOutputCallbackTuple>;
+};
+
+template <class TResult, class TOutputCallbackTuple>
+using MakeCallbackSignatures = typename MakeCallbackSignaturesImpl<TResult, TOutputCallbackTuple>::Type;
+
+template <class TMethodSignature, class TMethodSpecSignature>
+constexpr static bool MatchMethodSignature() noexcept {
+  constexpr MethodSignatureMatchResult matchResult = TMethodSignature::template Match<TMethodSpecSignature>();
+
+  static_assert(matchResult.IsResultMatching, "Method return type is different from the method spec.");
+
+  static_assert(matchResult.ArgCountCompare >= 0, "Method has less arguments than method spec.");
+  static_assert(matchResult.ArgCountCompare <= 0, "Method has more arguments than method spec.");
+  if constexpr (matchResult.ArgCountCompare == 0) {
+    static_assert(matchResult.AreArgsMatching, "Method argument types are different from the method spec.");
+  }
+
+  static_assert(matchResult.CallbackCountCompare >= 0, "Method has less callbacks than method spec.");
+  static_assert(matchResult.CallbackCountCompare <= 0, "Method has more callbacks than method spec.");
+  if constexpr (matchResult.CallbackCountCompare == 0) {
+    static_assert(matchResult.AreCallbacksMatching, "Method callback types are different from the method spec.");
+  }
+
+  static_assert(matchResult.IsPromiseMathcing, "Method Promise type is different from the method spec.");
+
+  return matchResult.IsSucceeded;
+}
+
+template <class TSignature>
+struct ModuleMethodInfoBase;
+
+template <class TResult, class... TArgs>
+struct ModuleMethodInfoBase<TResult(TArgs...) noexcept> {
+  constexpr static bool IsVoidResult = IsVoidResult<TResult>();
+  constexpr static size_t ArgCount = sizeof...(TArgs);
+  using ArgTuple = std::tuple<RemoveConstRef<TArgs>...>;
+  constexpr static size_t CallbackCount = GetCallbackCount<ArgTuple>();
+  constexpr static size_t PromiseCount = GetPromiseCount<ArgTuple>();
+  constexpr static size_t InputArgCount = ArgCount - CallbackCount - PromiseCount;
+  using InputArgTuple = TakeTupleElements<0, InputArgCount, ArgTuple>;
+  using OutputCallbackTuple = TakeTupleElements<InputArgCount, CallbackCount, ArgTuple>;
+  using OutputPromiseTuple = TakeTupleElements<InputArgCount, PromiseCount, ArgTuple>;
+
+  using Signature =
+      MethodSignature<void, InputArgTuple, MakeCallbackSignatures<TResult, OutputCallbackTuple>, OutputPromiseTuple>;
+
+  constexpr static MethodReturnType GetMethodReturnType() noexcept {
+    if constexpr (!IsVoidResult) {
+      return MethodReturnType::Callback;
+    } else if constexpr (PromiseCount == 1) {
+      return MethodReturnType::Promise;
+    } else if constexpr (CallbackCount == 2) {
+      return MethodReturnType::TwoCallbacks;
+    } else if constexpr (CallbackCount == 1) {
+      return MethodReturnType::Callback;
+    } else {
+      return MethodReturnType::Void;
+    }
+  }
+};
+
 template <class TFunc>
 struct ModuleMethodInfo;
 
 // Instance asynchronous method
 template <class TModule, class TResult, class... TArgs>
-struct ModuleMethodInfo<TResult (TModule::*)(TArgs...) noexcept> {
-  constexpr static bool HasPromise() noexcept {
-    if constexpr (sizeof...(TArgs) > 0) {
-      return Internal::IsPromise<std::remove_const_t<std::remove_reference_t<
-          std::tuple_element_t<sizeof...(TArgs) - 1, std::tuple<std::remove_reference_t<TArgs>...>>>>>::value;
-    }
-    return false;
-  }
-
-  constexpr static size_t CallbackCount = Internal::GetCallbackCount<TArgs...>();
+struct ModuleMethodInfo<TResult (TModule::*)(TArgs...) noexcept> : ModuleMethodInfoBase<TResult(TArgs...) noexcept> {
+  using Super = ModuleMethodInfoBase<TResult(TArgs...) noexcept>;
   using ModuleType = TModule;
   using MethodType = TResult (TModule::*)(TArgs...) noexcept;
-  using IndexSequence = std::make_index_sequence<sizeof...(TArgs) - (HasPromise() ? 1 : CallbackCount)>;
 
-  template <class>
-  struct Invoker;
-
-  template <size_t... I>
-  struct Invoker<std::index_sequence<I...>> {
-    // Fire and forget method
-    static MethodDelegate GetFunc(ModuleType *module, MethodType method, std::integral_constant<size_t, 0>) noexcept {
-      return [ module, method ](
-          IJSValueReader const &argReader,
-          IJSValueWriter const & /*argWriter*/,
-          MethodResultCallback const &,
-          MethodResultCallback const &) mutable noexcept {
-        std::tuple<std::remove_reference_t<TArgs>...> typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        (module->*method)(std::get<I>(std::move(typedArgs))...);
-      };
-    }
-
-    template <class T>
-    struct CallbackCreator;
-
-    template <template <class...> class TCallback, class... TArgs>
-    struct CallbackCreator<TCallback<void(TArgs...)>> {
-      static TCallback<void(TArgs...)> Create(
-          const IJSValueWriter &argWriter,
-          const MethodResultCallback &callback) noexcept {
-        return TCallback([ callback = std::move(callback), argWriter ](TArgs... args) noexcept {
-          WriteArgs(argWriter, std::move(args)...);
-          callback(argWriter);
-        });
-      }
-    };
-
-    template <class T, class TDummy>
-    struct RejectCallbackCreator;
-
-    template <template <class...> class TCallback, class TArg>
-    struct RejectCallbackCreator<
-        TCallback<void(TArg)>,
-        std::enable_if_t<std::is_assignable_v<std::string, TArg> || std::is_assignable_v<std::wstring, TArg>>> {
-      static TCallback<void(TArg)> Create(
-          const IJSValueWriter &argWriter,
-          const MethodResultCallback &callback) noexcept {
-        return TCallback([ callback = std::move(callback), argWriter ](TArg arg) noexcept {
-          argWriter.WriteArrayBegin();
-          argWriter.WriteObjectBegin();
-          argWriter.WritePropertyName(L"message");
-          WriteValue(argWriter, arg);
-          argWriter.WriteObjectEnd();
-          argWriter.WriteArrayEnd();
-          callback(argWriter);
-        });
-      }
-    };
-
-    template <template <class...> class TCallback>
-    struct RejectCallbackCreator<TCallback<void()>, void> : CallbackCreator<TCallback<void()>> {};
-
-    template <template <class...> class TCallback, class TArg>
-    struct RejectCallbackCreator<
-        TCallback<void(TArg)>,
-        std::enable_if_t<!std::is_assignable_v<std::string, TArg> && !std::is_assignable_v<std::wstring, TArg>>>
-        : CallbackCreator<TCallback<void(TArg)>> {};
-
-    template <template <class...> class TCallback, class TArg0, class TArg1, class... TArgs>
-    struct RejectCallbackCreator<TCallback<void(TArg0, TArg1, TArgs...)>, void>
-        : CallbackCreator<TCallback<void(TArg0, TArg1, TArgs...)>> {};
-
-    template <class T>
-    struct PromiseCreator;
-
-    template <class T>
-    struct PromiseCreator<ReactPromise<T>> {
-      static ReactPromise<T> Create(
-          const IJSValueWriter &argWriter,
-          const MethodResultCallback &resolve,
-          const MethodResultCallback &reject) noexcept {
-        return ReactPromise<T>(argWriter, resolve, reject);
-      }
-    };
-
-    // Method with one callback
-    static MethodDelegate GetFunc(ModuleType *module, MethodType method, std::integral_constant<size_t, 1>) noexcept {
-      return [ module, method ](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &callback,
-          MethodResultCallback const &) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        auto cb = CallbackCreator<std::remove_const_t<std::remove_reference_t<
-            std::tuple_element_t<sizeof...(TArgs) - 1, ArgTuple>>>>::Create(argWriter, callback);
-        (module->*method)(std::get<I>(std::move(typedArgs))..., std::move(cb));
-      };
-    }
-
-    // Method with two callbacks
-    static MethodDelegate GetFunc(ModuleType *module, MethodType method, std::integral_constant<size_t, 2>) noexcept {
-      return [ module, method ](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &resolve,
-          MethodResultCallback const &reject) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        // Some native modules use first callback as failure, others use second. We make them both to
-        // behave the same way and let developers to assign meaning to the first and second callbacks.
-        auto firstCallback = CallbackCreator<std::remove_const_t<
-            std::remove_reference_t<std::tuple_element_t<sizeof...(TArgs) - 2, ArgTuple>>>>::Create(argWriter, resolve);
-        auto secondCallback = CallbackCreator<std::remove_const_t<
-            std::remove_reference_t<std::tuple_element_t<sizeof...(TArgs) - 1, ArgTuple>>>>::Create(argWriter, reject);
-        (module->*method)(std::get<I>(std::move(typedArgs))..., std::move(firstCallback), std::move(secondCallback));
-      };
-    }
-
-    // Method with Promise
-    static MethodDelegate GetFunc(ModuleType *module, MethodType method, std::integral_constant<size_t, 3>) noexcept {
-      return [ module, method ](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &resolve,
-          MethodResultCallback const &reject) mutable noexcept {
-        using AllArgsTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        using ArgsTuple = std::tuple<std::tuple_element_t<I, AllArgsTuple>...>;
-        using PromiseArg = std::remove_const_t<std::tuple_element_t<sizeof...(TArgs) - 1, AllArgsTuple>>;
-        ArgsTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        auto promise = PromiseCreator<PromiseArg>::Create(argWriter, resolve, reject);
-        (module->*method)(std::get<I>(std::move(typedArgs))..., std::move(promise));
-      };
-    }
-
-    // Async method with return value
-    static MethodDelegate GetFunc(ModuleType *module, MethodType method, std::integral_constant<size_t, 4>) noexcept {
-      return [ module, method ](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &callback,
-          MethodResultCallback const &) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        TResult result = (module->*method)(std::get<I>(std::move(typedArgs))...);
+  template <size_t... ArgIndex, size_t... CallbackIndex, size_t... PromiseIndex>
+  static MethodDelegate GetMethodDelegate(
+      ModuleType *module,
+      MethodType method,
+      std::index_sequence<ArgIndex...>,
+      std::index_sequence<CallbackIndex...>,
+      std::index_sequence<PromiseIndex...>) noexcept {
+    return [ module, method ](
+        IJSValueReader const &argReader,
+        [[maybe_unused]] IJSValueWriter const &argWriter,
+        [[maybe_unused]] MethodResultCallback const &resolve,
+        [[maybe_unused]] MethodResultCallback const &reject) mutable noexcept {
+      typename Super::InputArgTuple inputArgs{};
+      ReadArgs(argReader, std::get<ArgIndex>(inputArgs)...);
+      if constexpr (!Super::IsVoidResult) {
+        TResult result = (module->*method)(std::get<ArgIndex>(std::move(inputArgs))...);
         WriteArgs(argWriter, result);
-        callback(argWriter);
-      };
-    }
-  };
+        resolve(argWriter);
+      } else if constexpr (Super::PromiseCount == 1) {
+        auto promises = std::tuple{
+            std::tuple_element_t<PromiseIndex, typename Super::OutputPromiseTuple>{argWriter, resolve, reject}...};
+        (module->*method)(std::get<ArgIndex>(std::move(inputArgs))..., std::get<PromiseIndex>(std::move(promises))...);
+      } else {
+        // When method uses two callbacks the order of resolve and reject can be reversed.
+        auto resultCallbacks = std::tuple{resolve, reject};
+        auto callbacks = std::tuple{
+            CallbackCreator<std::tuple_element_t<CallbackIndex, typename Super::OutputCallbackTuple>>::Create(
+                argWriter, std::get<CallbackIndex>(resultCallbacks))...};
+        (module->*method)(
+            std::get<ArgIndex>(std::move(inputArgs))..., std::get<CallbackIndex>(std::move(callbacks))...);
+      }
+    };
+  }
 
   static MethodDelegate GetMethodDelegate(void *module, MethodType method, MethodReturnType &returnType) noexcept {
-    (Internal::ValidateCoroutineArg<TResult, TArgs>(), ...);
-    constexpr bool isVoidResult = std::is_void_v<TResult> || std::is_same_v<TResult, winrt::fire_and_forget>;
-    if constexpr (!isVoidResult) {
-      returnType = MethodReturnType::Callback;
-    } else if constexpr (HasPromise()) {
-      returnType = MethodReturnType::Promise;
-    } else if constexpr (CallbackCount == 2) {
-      returnType = MethodReturnType::TwoCallbacks;
-    } else if constexpr (CallbackCount == 1) {
-      returnType = MethodReturnType::Callback;
-    } else {
-      returnType = MethodReturnType::Void;
-    }
+    (ValidateCoroutineArg<TResult, TArgs>(), ...);
+    returnType = Super::GetMethodReturnType();
+    return GetMethodDelegate(
+        static_cast<ModuleType *>(module),
+        method,
+        std::make_index_sequence<Super::InputArgCount>{},
+        std::make_index_sequence<Super::CallbackCount>{},
+        std::make_index_sequence<Super::PromiseCount>{});
+  }
 
-    constexpr int selector = !isVoidResult ? 4 : HasPromise() ? 3 : CallbackCount;
-    return Invoker<IndexSequence>::GetFunc(
-        static_cast<ModuleType *>(module), method, std::integral_constant<size_t, selector>{});
+  template <class TMethodSpec>
+  static constexpr bool Match() noexcept {
+    // Do not move this method to the ModuleMethodInfoBase for better error reporting.
+    return MatchMethodSignature<typename Super::Signature, typename TMethodSpec::Signature>();
   }
 };
 
 // Static asynchronous method
 template <class TResult, class... TArgs>
-struct ModuleMethodInfo<TResult (*)(TArgs...) noexcept> {
-  constexpr static bool HasPromise() noexcept {
-    if constexpr (sizeof...(TArgs) > 0) {
-      return Internal::IsPromise<std::remove_const_t<std::remove_reference_t<
-          std::tuple_element_t<sizeof...(TArgs) - 1, std::tuple<std::remove_reference_t<TArgs>...>>>>>::value;
-    }
-    return false;
-  }
-
-  constexpr static size_t CallbackCount = Internal::GetCallbackCount<TArgs...>();
+struct ModuleMethodInfo<TResult (*)(TArgs...) noexcept> : ModuleMethodInfoBase<TResult(TArgs...) noexcept> {
+  using Super = ModuleMethodInfoBase<TResult(TArgs...) noexcept>;
   using MethodType = TResult (*)(TArgs...) noexcept;
-  using IndexSequence = std::make_index_sequence<sizeof...(TArgs) - (HasPromise() ? 1 : CallbackCount)>;
 
-  template <class>
-  struct Invoker;
-
-  template <size_t... I>
-  struct Invoker<std::index_sequence<I...>> {
-    // Fire and forget method
-    static MethodDelegate GetFunc(MethodType method, std::integral_constant<size_t, 0>) noexcept {
-      return [method](
-          IJSValueReader const &argReader,
-          IJSValueWriter const & /*argWriter*/,
-          MethodResultCallback const &,
-          MethodResultCallback const &) mutable noexcept {
-        std::tuple<std::remove_reference_t<TArgs>...> typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        (*method)(std::get<I>(std::move(typedArgs))...);
-      };
-    }
-
-    template <class T>
-    struct CallbackCreator;
-
-    template <template <class...> class TCallback, class... TArgs>
-    struct CallbackCreator<TCallback<void(TArgs...)>> {
-      static TCallback<void(TArgs...)> Create(
-          const IJSValueWriter &argWriter,
-          const MethodResultCallback &callback) noexcept {
-        return TCallback([ callback = std::move(callback), argWriter ](TArgs... args) noexcept {
-          WriteArgs(argWriter, std::move(args)...);
-          callback(argWriter);
-        });
-      }
-    };
-
-    template <class T, class TDummy>
-    struct RejectCallbackCreator;
-
-    template <template <class...> class TCallback, class TArg>
-    struct RejectCallbackCreator<
-        TCallback<void(TArg)>,
-        std::enable_if_t<std::is_assignable_v<std::string, TArg> || std::is_assignable_v<std::wstring, TArg>>> {
-      static TCallback<void(TArg)> Create(
-          const IJSValueWriter &argWriter,
-          const MethodResultCallback &callback) noexcept {
-        return TCallback([ callback = std::move(callback), argWriter ](TArg arg) noexcept {
-          argWriter.WriteArrayBegin();
-          argWriter.WriteObjectBegin();
-          argWriter.WritePropertyName(L"message");
-          WriteValue(argWriter, arg);
-          argWriter.WriteObjectEnd();
-          argWriter.WriteArrayEnd();
-          callback(argWriter);
-        });
-      }
-    };
-
-    template <template <class...> class TCallback>
-    struct RejectCallbackCreator<TCallback<void()>, void> : CallbackCreator<TCallback<void()>> {};
-
-    template <template <class...> class TCallback, class TArg>
-    struct RejectCallbackCreator<
-        TCallback<void(TArg)>,
-        std::enable_if_t<!std::is_assignable_v<std::string, TArg> && !std::is_assignable_v<std::wstring, TArg>>>
-        : CallbackCreator<TCallback<void(TArg)>> {};
-
-    template <template <class...> class TCallback, class TArg0, class TArg1, class... TArgs>
-    struct RejectCallbackCreator<TCallback<void(TArg0, TArg1, TArgs...)>, void>
-        : CallbackCreator<TCallback<void(TArg0, TArg1, TArgs...)>> {};
-
-    template <class T>
-    struct PromiseCreator;
-
-    template <class T>
-    struct PromiseCreator<ReactPromise<T>> {
-      static ReactPromise<T> Create(
-          const IJSValueWriter &argWriter,
-          const MethodResultCallback &resolve,
-          const MethodResultCallback &reject) noexcept {
-        return ReactPromise<T>(argWriter, resolve, reject);
-      }
-    };
-
-    // Method with one callback
-    static MethodDelegate GetFunc(MethodType method, std::integral_constant<size_t, 1>) noexcept {
-      return [method](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &callback,
-          MethodResultCallback const &) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        auto cb = CallbackCreator<std::remove_const_t<std::remove_reference_t<
-            std::tuple_element_t<sizeof...(TArgs) - 1, ArgTuple>>>>::Create(argWriter, callback);
-        (*method)(std::get<I>(std::move(typedArgs))..., std::move(cb));
-      };
-    }
-
-    // Method with two callbacks
-    static MethodDelegate GetFunc(MethodType method, std::integral_constant<size_t, 2>) noexcept {
-      return [method](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &resolve,
-          MethodResultCallback const &reject) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        // Some native modules use first callback as failure, others use second. We make them both to
-        // behave the same way and let developers to assign meaning to the first and second callbacks.
-        auto firstCallback = CallbackCreator<std::remove_const_t<
-            std::remove_reference_t<std::tuple_element_t<sizeof...(TArgs) - 2, ArgTuple>>>>::Create(argWriter, resolve);
-        auto secondCallback = CallbackCreator<std::remove_const_t<
-            std::remove_reference_t<std::tuple_element_t<sizeof...(TArgs) - 1, ArgTuple>>>>::Create(argWriter, reject);
-        (*method)(std::get<I>(std::move(typedArgs))..., std::move(firstCallback), std::move(secondCallback));
-      };
-    }
-
-    // Method with Promise
-    static MethodDelegate GetFunc(MethodType method, std::integral_constant<size_t, 3>) noexcept {
-      return [method](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &resolve,
-          MethodResultCallback const &reject) mutable noexcept {
-        using AllArgsTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        using ArgsTuple = std::tuple<std::tuple_element_t<I, AllArgsTuple>...>;
-        using PromiseArg = std::remove_const_t<std::tuple_element_t<sizeof...(TArgs) - 1, AllArgsTuple>>;
-        ArgsTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        auto promise = PromiseCreator<PromiseArg>::Create(argWriter, resolve, reject);
-        (*method)(std::get<I>(std::move(typedArgs))..., std::move(promise));
-      };
-    }
-
-    // Async method with return value
-    static MethodDelegate GetFunc(MethodType method, std::integral_constant<size_t, 4>) noexcept {
-      return [method](
-          IJSValueReader const &argReader,
-          IJSValueWriter const &argWriter,
-          MethodResultCallback const &callback,
-          MethodResultCallback const &) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        TResult result = (*method)(std::get<I>(typedArgs)...);
+  template <size_t... ArgIndex, size_t... CallbackIndex, size_t... PromiseIndex>
+  static MethodDelegate GetMethodDelegate(
+      MethodType method,
+      std::index_sequence<ArgIndex...>,
+      std::index_sequence<CallbackIndex...>,
+      std::index_sequence<PromiseIndex...>) noexcept {
+    return [method](
+        IJSValueReader const &argReader,
+        [[maybe_unused]] IJSValueWriter const &argWriter,
+        [[maybe_unused]] MethodResultCallback const &resolve,
+        [[maybe_unused]] MethodResultCallback const &reject) mutable noexcept {
+      typename Super::InputArgTuple inputArgs{};
+      ReadArgs(argReader, std::get<ArgIndex>(inputArgs)...);
+      if constexpr (!Super::IsVoidResult) {
+        TResult result = (*method)(std::get<ArgIndex>(std::move(inputArgs))...);
         WriteArgs(argWriter, result);
-        callback(argWriter);
-      };
-    }
-  };
+        resolve(argWriter);
+      } else if constexpr (Super::PromiseCount == 1) {
+        auto promises = std::tuple{
+            std::tuple_element_t<PromiseIndex, typename Super::OutputPromiseTuple>{argWriter, resolve, reject}...};
+        (*method)(std::get<ArgIndex>(std::move(inputArgs))..., std::get<PromiseIndex>(std::move(promises))...);
+      } else {
+        // When method uses two callbacks the order of resolve and reject can be reversed.
+        auto resultCallbacks = std::tuple{resolve, reject};
+        auto callbacks = std::tuple{
+            CallbackCreator<std::tuple_element_t<CallbackIndex, typename Super::OutputCallbackTuple>>::Create(
+                argWriter, std::get<CallbackIndex>(resultCallbacks))...};
+        (*method)(std::get<ArgIndex>(std::move(inputArgs))..., std::get<CallbackIndex>(std::move(callbacks))...);
+      }
+    };
+  }
 
   static MethodDelegate GetMethodDelegate(void * /*module*/, MethodType method, MethodReturnType &returnType) noexcept {
-    (Internal::ValidateCoroutineArg<TResult, TArgs>(), ...);
-    constexpr bool isVoidResult = std::is_void_v<TResult> || std::is_same_v<TResult, winrt::fire_and_forget>;
-    if constexpr (!isVoidResult) {
-      returnType = MethodReturnType::Callback;
-    } else if constexpr (HasPromise()) {
-      returnType = MethodReturnType::Promise;
-    } else if constexpr (CallbackCount == 2) {
-      returnType = MethodReturnType::TwoCallbacks;
-    } else if constexpr (CallbackCount == 1) {
-      returnType = MethodReturnType::Callback;
-    } else {
-      returnType = MethodReturnType::Void;
-    }
-
-    constexpr int selector = !isVoidResult ? 4 : HasPromise() ? 3 : CallbackCount;
-    return Invoker<IndexSequence>::GetFunc(method, std::integral_constant<size_t, selector>{});
+    (ValidateCoroutineArg<TResult, TArgs>(), ...);
+    returnType = Super::GetMethodReturnType();
+    return GetMethodDelegate(
+        method,
+        std::make_index_sequence<Super::InputArgCount>{},
+        std::make_index_sequence<Super::CallbackCount>{},
+        std::make_index_sequence<Super::PromiseCount>{});
   }
+
+  template <class TMethodSpec>
+  static constexpr bool Match() noexcept {
+    // Do not move this method to the ModuleMethodInfoBase for better error reporting.
+    return MatchMethodSignature<typename Super::Signature, typename TMethodSpec::Signature>();
+  }
+};
+
+template <class TSignature>
+struct ModuleSyncMethodInfoBase;
+
+template <class TResult, class... TArgs>
+struct ModuleSyncMethodInfoBase<TResult(TArgs...) noexcept> {
+  using ArgTuple = std::tuple<RemoveConstRef<TArgs>...>;
+  using Signature = MethodSignature<TResult, ArgTuple, std::tuple<>, std::tuple<>>;
 };
 
 template <class TFunc>
@@ -550,56 +601,59 @@ struct ModuleSyncMethodInfo;
 
 // Instance synchronous method
 template <class TModule, class TResult, class... TArgs>
-struct ModuleSyncMethodInfo<TResult (TModule::*)(TArgs...) noexcept> {
+struct ModuleSyncMethodInfo<TResult (TModule::*)(TArgs...) noexcept>
+    : ModuleSyncMethodInfoBase<TResult(TArgs...) noexcept> {
+  using Super = ModuleSyncMethodInfoBase<TResult(TArgs...) noexcept>;
   using ModuleType = TModule;
   using MethodType = TResult (TModule::*)(TArgs...) noexcept;
-  using IndexSequence = std::make_index_sequence<sizeof...(TArgs)>;
-
-  template <class>
-  struct Invoker;
 
   template <size_t... I>
-  struct Invoker<std::index_sequence<I...>> {
-    static SyncMethodDelegate GetFunc(ModuleType *module, MethodType method) noexcept {
-      return [ module, method ](IJSValueReader const &argReader, IJSValueWriter const &argWriter) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        TResult result = (module->*method)(std::get<I>(std::move(typedArgs))...);
-        WriteArgs(argWriter, result);
-      };
-    }
-  };
+  static SyncMethodDelegate GetFunc(ModuleType *module, MethodType method, std::index_sequence<I...>) noexcept {
+    return [ module, method ](IJSValueReader const &argReader, IJSValueWriter const &argWriter) mutable noexcept {
+      using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
+      ArgTuple typedArgs{};
+      ReadArgs(argReader, std::get<I>(typedArgs)...);
+      TResult result = (module->*method)(std::get<I>(std::move(typedArgs))...);
+      WriteArgs(argWriter, result);
+    };
+  }
 
   static SyncMethodDelegate GetMethodDelegate(void *module, MethodType method) noexcept {
-    return Invoker<IndexSequence>::GetFunc(static_cast<ModuleType *>(module), method);
+    return GetFunc(static_cast<ModuleType *>(module), method, std::make_index_sequence<sizeof...(TArgs)>{});
+  }
+
+  template <class TMethodSpec>
+  static constexpr bool Match() noexcept {
+    // Do not move this method to the ModuleSyncMethodInfoBase for better error reporting.
+    return MatchMethodSignature<typename Super::Signature, typename TMethodSpec::Signature>();
   }
 };
 
 // Static synchronous method
 template <class TResult, class... TArgs>
-struct ModuleSyncMethodInfo<TResult (*)(TArgs...) noexcept> {
+struct ModuleSyncMethodInfo<TResult (*)(TArgs...) noexcept> : ModuleSyncMethodInfoBase<TResult(TArgs...) noexcept> {
+  using Super = ModuleSyncMethodInfoBase<TResult(TArgs...) noexcept>;
   using MethodType = TResult (*)(TArgs...) noexcept;
-  using IndexSequence = std::make_index_sequence<sizeof...(TArgs)>;
-
-  template <class>
-  struct Invoker;
 
   template <size_t... I>
-  struct Invoker<std::index_sequence<I...>> {
-    static SyncMethodDelegate GetFunc(MethodType method) noexcept {
-      return [method](IJSValueReader const &argReader, IJSValueWriter const &argWriter) mutable noexcept {
-        using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
-        ArgTuple typedArgs{};
-        ReadArgs(argReader, std::get<I>(typedArgs)...);
-        TResult result = (*method)(std::get<I>(std::move(typedArgs))...);
-        WriteArgs(argWriter, result);
-      };
-    }
-  };
+  static SyncMethodDelegate GetFunc(MethodType method, std::index_sequence<I...>) noexcept {
+    return [method](IJSValueReader const &argReader, IJSValueWriter const &argWriter) mutable noexcept {
+      using ArgTuple = std::tuple<std::remove_reference_t<TArgs>...>;
+      ArgTuple typedArgs{};
+      ReadArgs(argReader, std::get<I>(typedArgs)...);
+      TResult result = (*method)(std::get<I>(std::move(typedArgs))...);
+      WriteArgs(argWriter, result);
+    };
+  }
 
   static SyncMethodDelegate GetMethodDelegate(void * /*module*/, MethodType method) noexcept {
-    return Invoker<IndexSequence>::GetFunc(method);
+    return GetFunc(method, std::make_index_sequence<sizeof...(TArgs)>{});
+  }
+
+  template <class TMethodSpec>
+  static constexpr bool Match() noexcept {
+    // Do not move this method to the ModuleSyncMethodInfoBase for better error reporting.
+    return MatchMethodSignature<typename Super::Signature, typename TMethodSpec::Signature>();
   }
 };
 
@@ -611,9 +665,9 @@ struct ModuleConstFieldInfo<TValue TModule::*> {
   using ModuleType = TModule;
   using FieldType = TValue TModule::*;
 
-  static ConstantProviderDelegate GetConstantProvider(void *module, wchar_t const *name, FieldType field) noexcept {
-    return [ module = static_cast<ModuleType *>(module), name = std::wstring{name}, field ](
-        IJSValueWriter const &argWriter) mutable noexcept {
+  static ConstantProviderDelegate GetConstantProvider(void *module, std::wstring_view name, FieldType field) noexcept {
+    return
+        [ module = static_cast<ModuleType *>(module), name, field ](IJSValueWriter const &argWriter) mutable noexcept {
       WriteProperty(argWriter, name, module->*field);
     };
   }
@@ -624,8 +678,8 @@ struct ModuleConstFieldInfo<TValue *> {
   using FieldType = TValue *;
 
   static ConstantProviderDelegate
-  GetConstantProvider(void * /*module*/, wchar_t const *name, FieldType field) noexcept {
-    return [ name = std::wstring{name}, field ](IJSValueWriter const &argWriter) mutable noexcept {
+  GetConstantProvider(void * /*module*/, std::wstring_view name, FieldType field) noexcept {
+    return [ name, field ](IJSValueWriter const &argWriter) mutable noexcept {
       WriteProperty(argWriter, name, *field);
     };
   }
@@ -635,7 +689,7 @@ struct ReactConstantProvider {
   ReactConstantProvider(IJSValueWriter const &writer) noexcept : m_writer{writer} {}
 
   template <class T>
-  void Add(const wchar_t *name, const T &value) noexcept {
+  void Add(std::wstring_view name, const T &value) noexcept {
     WriteProperty(m_writer, name, value);
   }
 
@@ -683,8 +737,8 @@ struct ModuleEventFieldInfo<TFunc<void(TArgs...)> TModule::*> {
   static InitializerDelegate GetEventHandlerInitializer(
       void *module,
       FieldType field,
-      wchar_t const *eventName,
-      wchar_t const *eventEmitterName) noexcept {
+      std::wstring_view eventName,
+      std::wstring_view eventEmitterName) noexcept {
     return [ module = static_cast<ModuleType *>(module), field, eventName, eventEmitterName ](
         IReactContext const &reactContext) noexcept {
       module->*field = [ reactContext, eventEmitterName, eventName ](TArgs... args) noexcept {
@@ -710,8 +764,8 @@ struct ModuleFunctionFieldInfo<TFunc<void(TArgs...)> TModule::*> {
   static InitializerDelegate GetFunctionInitializer(
       void *module,
       FieldType field,
-      wchar_t const *functionName,
-      wchar_t const *moduleName) noexcept {
+      std::wstring_view functionName,
+      std::wstring_view moduleName) noexcept {
     return [ module = static_cast<ModuleType *>(module), field, functionName, moduleName ](
         IReactContext const &reactContext) noexcept {
       module->*field = [ reactContext, functionName, moduleName ](TArgs... args) noexcept {
@@ -724,7 +778,69 @@ struct ModuleFunctionFieldInfo<TFunc<void(TArgs...)> TModule::*> {
 };
 
 template <int I>
-using ReactMemberId = std::integral_constant<int, I>;
+using ReactAttributeId = std::integral_constant<int, I>;
+
+template <class TModule>
+struct ReactMemberInfoIterator {
+  template <int StartIndex, class TVisitor>
+  constexpr void ForEachMember(TVisitor &visitor) noexcept {
+    ForEachMember<StartIndex>(visitor, static_cast<std::make_index_sequence<10> *>(nullptr));
+  }
+
+  template <int I, class TVisitor>
+  constexpr void GetMemberInfo(TVisitor &visitor) noexcept {
+    if constexpr (decltype(HasGetReactMemberAttribute(visitor, ReactAttributeId<I>{}))::value) {
+      TModule::template GetReactMemberAttribute<TModule>(visitor, ReactAttributeId<I>{});
+    }
+  }
+
+ private:
+  template <class TVisitor, int I>
+  static auto HasGetReactMemberAttribute(TVisitor &visitor, ReactAttributeId<I> id)
+      -> decltype(TModule::template GetReactMemberAttribute<TModule>(visitor, id), std::true_type{});
+  static auto HasGetReactMemberAttribute(...) -> std::false_type;
+
+  // Visit members in groups of 10 to avoid deep recursion.
+  template <int StartIndex, class TVisitor, int... I>
+  constexpr void ForEachMember(TVisitor &visitor, std::index_sequence<I...> *) noexcept {
+    if constexpr (decltype(HasGetReactMemberAttribute(visitor, ReactAttributeId<StartIndex>{}))::value) {
+      (GetMemberInfo<StartIndex + I>(visitor), ...);
+      ForEachMember<StartIndex + sizeof...(I)>(visitor, static_cast<std::make_index_sequence<10> *>(nullptr));
+    }
+  }
+};
+
+enum class ReactMemberKind {
+  InitMethod,
+  AsyncMethod,
+  SyncMethod,
+  ConstantMethod,
+  ConstantField,
+  EventField,
+  FunctionField,
+};
+
+template <ReactMemberKind MemberKind>
+struct ReactMemberAttribute : std::integral_constant<ReactMemberKind, MemberKind> {
+  constexpr ReactMemberAttribute(std::wstring_view jsMemberName, std::wstring_view jsModuleName) noexcept
+      : JSMemberName{jsMemberName}, JSModuleName{jsModuleName} {}
+
+  std::wstring_view JSMemberName;
+  std::wstring_view JSModuleName;
+};
+
+using ReactInitMethodAttribute = ReactMemberAttribute<ReactMemberKind::InitMethod>;
+using ReactAsyncMethodAttribute = ReactMemberAttribute<ReactMemberKind::AsyncMethod>;
+using ReactSyncMethodAttribute = ReactMemberAttribute<ReactMemberKind::SyncMethod>;
+using ReactConstantMethodAttribute = ReactMemberAttribute<ReactMemberKind::ConstantMethod>;
+using ReactConstantFieldAttribute = ReactMemberAttribute<ReactMemberKind::ConstantField>;
+using ReactEventFieldAttribute = ReactMemberAttribute<ReactMemberKind::EventField>;
+using ReactFunctionFieldAttribute = ReactMemberAttribute<ReactMemberKind::FunctionField>;
+
+template <class T>
+struct IsReactMemberAttribute : std::false_type {};
+template <ReactMemberKind MemberKind>
+struct IsReactMemberAttribute<ReactMemberAttribute<MemberKind>> : std::true_type {};
 
 template <class TModule>
 struct ReactModuleBuilder {
@@ -732,19 +848,14 @@ struct ReactModuleBuilder {
       : m_module{module}, m_moduleBuilder{moduleBuilder} {}
 
   template <int I>
-  void RegisterModule(wchar_t const *moduleName, wchar_t const *eventEmitterName, ReactMemberId<I>) noexcept {
+  void RegisterModule(std::wstring_view moduleName, std::wstring_view eventEmitterName, ReactAttributeId<I>) noexcept {
     RegisterModuleName(moduleName, eventEmitterName);
-    RegisterMembers<I + 1>(static_cast<std::make_index_sequence<10> *>(nullptr));
+    ReactMemberInfoIterator<TModule>{}.ForEachMember<I + 1>(*this);
   }
 
-  void RegisterModuleName(wchar_t const *moduleName, wchar_t const *eventEmitterName = nullptr) noexcept {
+  void RegisterModuleName(std::wstring_view moduleName, std::wstring_view eventEmitterName = L"") noexcept {
     m_moduleName = moduleName;
-    m_eventEmitterName = eventEmitterName ? eventEmitterName : L"RCTDeviceEventEmitter";
-  }
-
-  void ModuleName(wchar_t const *moduleName, wchar_t const *eventEmitterName = nullptr) noexcept {
-    m_moduleName = moduleName;
-    m_eventEmitterName = eventEmitterName ? eventEmitterName : L"RCTDeviceEventEmitter";
+    m_eventEmitterName = !eventEmitterName.empty() ? eventEmitterName : L"RCTDeviceEventEmitter";
   }
 
   void CompleteRegistration() noexcept {
@@ -755,84 +866,238 @@ struct ReactModuleBuilder {
     }
   }
 
-  template <int I>
-  auto HasRegisterMember(ReactModuleBuilder &builder, ReactMemberId<I> id)
-      -> decltype(TModule::template RegisterMember<TModule>(builder, id), std::true_type{});
-  auto HasRegisterMember(...) -> std::false_type;
-
-  template <int I>
-  void RegisterMember() noexcept {
-    if constexpr (decltype(HasRegisterMember(*this, ReactMemberId<I>{}))::value) {
-      TModule::template RegisterMember<TModule>(*this, ReactMemberId<I>{});
-    }
-  }
-
-  // Register members in groups of 10 to avoid deep recursion.
-  template <int StartIndex, int... I>
-  void RegisterMembers(std::index_sequence<I...> *) noexcept {
-    if constexpr (decltype(HasRegisterMember(*this, ReactMemberId<StartIndex>{}))::value) {
-      (RegisterMember<StartIndex + I>(), ...);
-      RegisterMembers<StartIndex + sizeof...(I)>(static_cast<std::make_index_sequence<10> *>(nullptr));
+  template <class TMember, class TAttribute, int I>
+  void Visit(
+      [[maybe_unused]] TMember member,
+      ReactAttributeId<I> /*attributeId*/,
+      [[maybe_unused]] TAttribute attributeInfo) noexcept {
+    if constexpr (std::is_same_v<TAttribute, ReactInitMethodAttribute>) {
+      RegisterInitMethod(member);
+    } else if constexpr (std::is_same_v<TAttribute, ReactAsyncMethodAttribute>) {
+      RegisterMethod(member, attributeInfo.JSMemberName);
+    } else if constexpr (std::is_same_v<TAttribute, ReactSyncMethodAttribute>) {
+      RegisterSyncMethod(member, attributeInfo.JSMemberName);
+    } else if constexpr (std::is_same_v<TAttribute, ReactConstantMethodAttribute>) {
+      RegisterConstantMethod(member);
+    } else if constexpr (std::is_same_v<TAttribute, ReactConstantFieldAttribute>) {
+      RegisterConstantField(member, attributeInfo.JSMemberName);
+    } else if constexpr (std::is_same_v<TAttribute, ReactEventFieldAttribute>) {
+      RegisterEventField(member, attributeInfo.JSMemberName, attributeInfo.JSModuleName);
+    } else if constexpr (std::is_same_v<TAttribute, ReactFunctionFieldAttribute>) {
+      RegisterFunctionField(member, attributeInfo.JSMemberName, attributeInfo.JSModuleName);
     }
   }
 
   template <class TMethod>
-  void RegisterInitMethod(
-      TMethod method,
-      wchar_t const * /*unused*/ = nullptr,
-      wchar_t const * /*unused*/ = nullptr) noexcept {
+  void RegisterInitMethod(TMethod method) noexcept {
     auto initializer = ModuleInitMethodInfo<TMethod>::GetInitializer(m_module, method);
     m_initializers.push_back(std::move(initializer));
   }
 
   template <class TMethod>
-  void RegisterMethod(TMethod method, wchar_t const *name, wchar_t const * /*unused*/ = nullptr) noexcept {
+  void RegisterMethod(TMethod method, std::wstring_view name) noexcept {
     MethodReturnType returnType;
     auto methodDelegate = ModuleMethodInfo<TMethod>::GetMethodDelegate(m_module, method, /*out*/ returnType);
     m_moduleBuilder.AddMethod(name, returnType, methodDelegate);
   }
 
   template <class TMethod>
-  void RegisterSyncMethod(TMethod method, wchar_t const *name, wchar_t const * /*unused*/ = nullptr) noexcept {
+  void RegisterSyncMethod(TMethod method, std::wstring_view name) noexcept {
     auto syncMethodDelegate = ModuleSyncMethodInfo<TMethod>::GetMethodDelegate(m_module, method);
     m_moduleBuilder.AddSyncMethod(name, syncMethodDelegate);
   }
 
   template <class TMethod>
-  void RegisterConstantMethod(
-      TMethod method,
-      wchar_t const * /*unused*/ = nullptr,
-      wchar_t const * /*unused*/ = nullptr) noexcept {
+  void RegisterConstantMethod(TMethod method) noexcept {
     auto constantProvider = ModuleConstantInfo<TMethod>::GetConstantProvider(m_module, method);
     m_moduleBuilder.AddConstantProvider(constantProvider);
   }
 
   template <class TField>
-  void RegisterConstantField(TField field, wchar_t const *name, wchar_t const * /*unused*/ = nullptr) noexcept {
+  void RegisterConstantField(TField field, std::wstring_view name) noexcept {
     auto constantProvider = ModuleConstFieldInfo<TField>::GetConstantProvider(m_module, name, field);
     m_moduleBuilder.AddConstantProvider(constantProvider);
   }
 
   template <class TField>
-  void RegisterEventField(TField field, wchar_t const *eventName, wchar_t const *eventEmitterName = nullptr) noexcept {
+  void
+  RegisterEventField(TField field, std::wstring_view eventName, std::wstring_view eventEmitterName = L"") noexcept {
     auto eventHandlerInitializer = ModuleEventFieldInfo<TField>::GetEventHandlerInitializer(
-        m_module, field, eventName, eventEmitterName ? eventEmitterName : m_eventEmitterName);
+        m_module, field, eventName, !eventEmitterName.empty() ? eventEmitterName : m_eventEmitterName);
     m_moduleBuilder.AddInitializer(eventHandlerInitializer);
   }
 
   template <class TField>
-  void RegisterFunctionField(TField field, wchar_t const *functionName, wchar_t const *moduleName = nullptr) noexcept {
+  void RegisterFunctionField(TField field, std::wstring_view name, std::wstring_view moduleName = L"") noexcept {
     auto functionInitializer = ModuleFunctionFieldInfo<TField>::GetFunctionInitializer(
-        m_module, field, functionName, moduleName ? moduleName : m_moduleName);
+        m_module, field, name, !moduleName.empty() ? moduleName : m_moduleName);
     m_moduleBuilder.AddInitializer(functionInitializer);
   }
 
  private:
   void *m_module;
   IReactModuleBuilder m_moduleBuilder;
-  wchar_t const *m_moduleName{nullptr};
-  wchar_t const *m_eventEmitterName{nullptr};
+  std::wstring_view m_moduleName{L""};
+  std::wstring_view m_eventEmitterName{L""};
   std::vector<InitializerDelegate> m_initializers;
+};
+
+struct VerificationResult {
+  size_t MethodNameCount{0};
+  size_t MatchCount{0};
+  int MatchedMemberId{0};
+};
+
+template <class TModule>
+struct ReactModuleVerifier {
+  static constexpr VerificationResult VerifyMember(std::wstring_view name, ReactMemberKind memberKind) noexcept {
+    ReactModuleVerifier verifier{name, memberKind};
+    GetReactModuleInfo(static_cast<TModule *>(nullptr), verifier);
+    return verifier.m_result;
+  }
+
+  constexpr ReactModuleVerifier(std::wstring_view memberName, ReactMemberKind memberKind) noexcept
+      : m_memberName{memberName}, m_memberKind{memberKind} {}
+
+  template <int I>
+  constexpr void RegisterModule(std::wstring_view /*_*/, std::wstring_view /*_*/, ReactAttributeId<I>) noexcept {
+    ReactMemberInfoIterator<TModule>{}.ForEachMember<I + 1>(*this);
+  }
+
+  template <class TMember, class TAttribute, int I>
+  constexpr void Visit(
+      TMember /*member*/,
+      [[maybe_unused]] ReactAttributeId<I> attributeId,
+      [[maybe_unused]] TAttribute attributeInfo) noexcept {
+    if constexpr (IsReactMemberAttribute<TAttribute>::value) {
+      if (attributeInfo.JSMemberName == m_memberName) {
+        if (IsMethod(attributeInfo())) {
+          ++m_result.MethodNameCount;
+        }
+
+        if (attributeInfo() == m_memberKind) {
+          m_result.MatchedMemberId = attributeId();
+          ++m_result.MatchCount;
+        }
+      }
+    }
+  }
+
+  static bool constexpr IsMethod(ReactMemberKind memberKind) noexcept {
+    return memberKind == ReactMemberKind::AsyncMethod || memberKind == ReactMemberKind::SyncMethod;
+  }
+
+ private:
+  std::wstring_view m_memberName;
+  ReactMemberKind m_memberKind;
+  VerificationResult m_result;
+};
+
+template <class TModule, int I, class TMethodSpec>
+struct ReactMethodVerifier {
+  static constexpr bool Verify() noexcept {
+    ReactMethodVerifier verifier{};
+    ReactMemberInfoIterator<TModule>{}.GetMemberInfo<I>(verifier);
+    return verifier.m_result;
+  }
+
+  template <class TMember, class TAttribute, int I>
+  constexpr void
+  Visit([[maybe_unused]] TMember member, ReactAttributeId<I> /*attributeId*/, TAttribute /*attributeInfo*/) noexcept {
+    m_result = ModuleMethodInfo<TMember>::template Match<TMethodSpec>();
+  }
+
+ private:
+  bool m_result{false};
+};
+
+template <class TModule, int I, class TMethodSpec>
+struct ReactSyncMethodVerifier {
+  static constexpr bool Verify() noexcept {
+    ReactSyncMethodVerifier verifier{};
+    ReactMemberInfoIterator<TModule>{}.GetMemberInfo<I>(verifier);
+    return verifier.m_result;
+  }
+
+  template <class TMember, class TAttribute, int I>
+  constexpr void
+  Visit([[maybe_unused]] TMember member, ReactAttributeId<I> /*attributeId*/, TAttribute /*attributeInfo*/) noexcept {
+    m_result = ModuleSyncMethodInfo<TMember>::template Match<TMethodSpec>();
+  }
+
+ private:
+  bool m_result{false};
+};
+
+struct TurboModuleSpec {
+  struct BaseMethodSpec {
+    constexpr BaseMethodSpec(int index, std::wstring_view name) : Index{index}, Name{name} {}
+
+    int Index;
+    std::wstring_view Name;
+  };
+
+  template <class TSignature>
+  struct Method : BaseMethodSpec {
+    using BaseMethodSpec::BaseMethodSpec;
+    using Signature = typename ModuleMethodInfoBase<TSignature>::Signature;
+    static constexpr bool IsSynchronous = false;
+  };
+
+  template <class TSignature>
+  struct SyncMethod : BaseMethodSpec {
+    using BaseMethodSpec::BaseMethodSpec;
+    using Signature = typename ModuleSyncMethodInfoBase<TSignature>::Signature;
+    static constexpr bool IsSynchronous = true;
+  };
+
+  template <class... TArgs>
+  using Callback = std::function<void(TArgs...)>;
+
+  template <class TArg>
+  using Promise = ReactPromise<TArg>;
+
+  struct MethodCheckResult {
+    bool IsUniqueName{false};
+    bool IsMethodFound{false};
+    bool IsSignatureMatching{true};
+  };
+
+  template <class TModule, class TModuleSpec, size_t I>
+  static constexpr MethodCheckResult CheckMethod() noexcept {
+    constexpr VerificationResult verificationResult = ReactModuleVerifier<TModule>::VerifyMember(
+        std::get<I>(TModuleSpec::methods).Name,
+        std::get<I>(TModuleSpec::methods).IsSynchronous ? ReactMemberKind::SyncMethod : ReactMemberKind::AsyncMethod);
+    MethodCheckResult result{};
+    result.IsUniqueName = verificationResult.MethodNameCount <= 1;
+    result.IsMethodFound = verificationResult.MatchCount == 1;
+    if constexpr (verificationResult.MatchCount == 1) {
+      if constexpr (std::get<I>(TModuleSpec::methods).IsSynchronous) {
+        result.IsSignatureMatching = ReactSyncMethodVerifier<
+            TModule,
+            verificationResult.MatchedMemberId,
+            RemoveConstRef<decltype(std::get<I>(TModuleSpec::methods))>>::Verify();
+      } else {
+        result.IsSignatureMatching = ReactMethodVerifier<
+            TModule,
+            verificationResult.MatchedMemberId,
+            RemoveConstRef<decltype(std::get<I>(TModuleSpec::methods))>>::Verify();
+      }
+    }
+
+    return result;
+  }
+
+  template <class TModule, class TModuleSpec, size_t... I>
+  static constexpr auto CheckMethodsHelper(std::index_sequence<I...>) noexcept {
+    return std::array<MethodCheckResult, sizeof...(I)>{CheckMethod<TModule, TModuleSpec, I>()...};
+  }
+
+  template <class TModule, class TModuleSpec>
+  static constexpr auto CheckMethods() noexcept {
+    return CheckMethodsHelper<TModule, TModuleSpec>(
+        std::make_index_sequence<std::tuple_size_v<decltype(TModuleSpec::methods)>>{});
+  }
 };
 
 template <class T>
@@ -860,10 +1125,27 @@ inline ReactModuleProvider MakeModuleProvider() noexcept {
     auto moduleObject = make<BoxedValue<TModule>>();
     auto module = &BoxedValue<TModule>::GetImpl(moduleObject);
     ReactModuleBuilder builder{module, moduleBuilder};
-    RegisterModule(builder);
+    GetReactModuleInfo(module, builder);
+    builder.CompleteRegistration();
+    return moduleObject;
+  };
+}
+
+template <class TModule, class TModuleSpec>
+inline ReactModuleProvider MakeTurboModuleProvider() noexcept {
+  TModuleSpec::template ValidateModule<TModule>();
+  return [](IReactModuleBuilder const &moduleBuilder) noexcept {
+    auto moduleObject = make<BoxedValue<TModule>>();
+    auto module = &BoxedValue<TModule>::GetImpl(moduleObject);
+    ReactModuleBuilder builder{module, moduleBuilder};
+    GetReactModuleInfo(module, builder);
     builder.CompleteRegistration();
     return moduleObject;
   };
 }
 
 } // namespace winrt::Microsoft::ReactNative
+
+namespace React {
+using namespace winrt::Microsoft::ReactNative;
+}

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -20,7 +20,7 @@
 
 #define INTERNAL_REACT_STRUCT(structType)                                                  \
   struct structType;                                                                       \
-  winrt::Microsoft::ReactNative::FieldMap GetStructInfo(structType *) noexcept {           \
+  inline winrt::Microsoft::ReactNative::FieldMap GetStructInfo(structType *) noexcept {    \
     winrt::Microsoft::ReactNative::FieldMap fieldMap{};                                    \
     winrt::Microsoft::ReactNative::CollectStructFields<structType, __COUNTER__>(fieldMap); \
     return fieldMap;                                                                       \


### PR DESCRIPTION
The main difference between NativeModules and TurboModules is that the TurboModules have a module API spec written in Flow language that can be used to generate a spec in a native language such as C++ so that the API shape is the same between JavaScript and the native code.
Next time when spec is changed, the native code spec is regenerated and any API mismatch could be found at compile time.

In this PR we are introducing the shape of the C++ TurboModule spec and its match against the hand-written TurboModule code.

There are two important design decisions:
- The spec is **not** an abstract class with virtual methods to override. While working on the NativeModules 2.0 we have realized that a native module method callable from JavaScript could have completely different signature:
  - It could be an instance or static method.
  - Simple asynchronous method could return value instead of using callbacks.
  - Co-routine methods have different signatures comparing with non-co-routine methods.
  - Method name in C++ could be different from JavaScript because of coding conventions.
- The code written by developers for the TurboModule is exactly the same as the NativeModules 2.0:
  - Each exported method has a "custom attribute" `REACT_METHOD` or `REACT_SYNC_METHOD` to associate the method with a JS name.
  - Exported methods have strongly typed arguments that are converted with help of ReadValue/WriteValue methods.
  - There is no requirement for the base class or interface. The TurboModule/NativeModule is just a `struct` with custom attributes that can be inherited from any other type or not inherited at all.
  - Since TurboModules and NativeModules 2.0 have exactly the same shape, developers can always start with a simple NativeModule and then 'evolve' it to a TurboModule if they want.

What is the TurboModule spec and how it is verified?
Each TurboModule spec is a class that has two important parts: 
- a tuple with method signatures and names
- `constexpr ValidateModule` method that validates the method signatures against the provided module class.  

For example, a Turbo module with two asynchronous methods `Add` and `NegatePromise` and one synchronous method `SayHelloSync` could have the following generated code:
```C++
struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
  static constexpr auto methods = std::tuple{
      Method<void(int, int, Callback<int>) noexcept>{0, L"Add"},
      Method<void(int, Promise<int>) noexcept>{1, L"NegatePromise"},
      SyncMethod<std::string() noexcept>{2, L"SayHelloSync"},
  };

  template <class TModule>
  static constexpr void ValidateModule() noexcept {
    constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();

    REACT_SHOW_METHOD_SPEC_ERRORS(
        0,
        "Add",
        "    REACT_METHOD(Add) int Add(int, int) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(Add) void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(Add) winrt::fire_and_forget Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(Add) static int Add(int, int) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(Add) static void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(Add) static React::Coroutine Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
    REACT_SHOW_METHOD_SPEC_ERRORS(
        1,
        "NegatePromise",
        "    REACT_METHOD(NegatePromise) void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(NegatePromise) winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(NegatePromise) static void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
        "    REACT_METHOD(NegatePromise) static winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
        2,
        "SayHelloSync",
        "    REACT_METHOD(SayHelloSync) std::string SayHelloSync() noexcept {/*implementation*/}\n"
        "    REACT_METHOD(SayHelloSync) static std::string SayHelloSync() noexcept {/*implementation*/}\n");
    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
  }
};
```
Note that the biggest part of the generated code are the error messages. The goal is to help developers to write the code that matches the TurboModule specification.
Currently we do the following checks at compile time:
- There is a method with a `REACT_METHOD` or `REACT_SYNC_METHOD` custom attributes that export it with a name used in the spec. name of the C++ method could be different from the JS name. We only check the JS name.
- There are no two methods exported with the same name.
- The signature of the method is matching the spec. As you can see from the error messages, the same spec could be match multiple implementation signatures.

This is an initial change. We plan to iterate over it. The issues to be addressed in future:
- Check that all exported methods are present in the spec.
- Do we need spec validation for constants?
- Take advantage of using short `React` namespace instead of the long `winrt::Microsoft::ReactNative`.
- Better names for some classes and methods.
- Consider removing numeric indexes in the generated spec.