### PR TITLE
Added inline to REACT_STRUCT's GetStructInfo to use in header files

### DIFF
--- a/change/react-native-windows-2020-04-21-09-24-21-Fix_REACT_STRUCT_inline_issue.json
+++ b/change/react-native-windows-2020-04-21-09-24-21-Fix_REACT_STRUCT_inline_issue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Added inline to REACT_STRUCT's GetStructInfo to use in header files",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-21T16:24:21.711Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -9,7 +9,7 @@
 
 #define REACT_STRUCT(type)                                                           \
   struct type;                                                                       \
-  winrt::Microsoft::ReactNative::FieldMap GetStructInfo(type *) noexcept {           \
+  inline winrt::Microsoft::ReactNative::FieldMap GetStructInfo(type *) noexcept {    \
     winrt::Microsoft::ReactNative::FieldMap fieldMap{};                              \
     winrt::Microsoft::ReactNative::CollectStructFields<type, __COUNTER__>(fieldMap); \
     return fieldMap;                                                                 \


### PR DESCRIPTION
The changes is targeting the 0.61-stable branch. It is already fixed in master in PR #4656.
This PR Closes #4631.

The issue is that the `REACT_STRUCT` implements a `GetStructInfo` function and it does not have the `inline` keyword. It causes a linker error if a header file with such `REACT_STRUCT` code is included in multiple .cpp files.

In this PR we add the missing `inline` keyword to fix the issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4659)