### PR TITLE
Hitting 'r' in the packager should reload the instance

### DIFF
--- a/change/react-native-windows-2020-04-21-14-06-12-master.json
+++ b/change/react-native-windows-2020-04-21-14-06-12-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Hook up to packager websocket to allow 'r' to reload instance",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-21T21:06:12.961Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -513,7 +513,7 @@ std::shared_ptr<IRedBoxHandler> ReactInstanceWin::GetRedBoxHandler() noexcept {
 
 std::function<void()> ReactInstanceWin::GetLiveReloadCallback() noexcept {
   // Live reload is enabled if we provide a callback function.
-  if (m_options.DeveloperSettings.UseLiveReload) {
+  if (m_options.DeveloperSettings.UseLiveReload || m_options.DeveloperSettings.UseFastRefresh) {
     return Mso::MakeWeakMemberStdFunction(this, &ReactInstanceWin::OnLiveReload);
   }
   return std::function<void()>{};

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
@@ -95,12 +95,10 @@ std::future<void> DevSupportManager::CreatePackagerConnection(const facebook::re
 
             auto version = (int)json.GetNamedNumber(L"version", 0.0);
             if (version != 2) {
-              AssertSz(false, "Message with incompatible or missing version of protocol received");
               return;
             }
             auto method = std::wstring(json.GetNamedString(L"method", L""));
             if (method.empty()) {
-              AssertSz(false, "No method provided");
               return;
             }
 
@@ -108,7 +106,6 @@ std::future<void> DevSupportManager::CreatePackagerConnection(const facebook::re
               reloadCallback();
             } else if (!method.compare(L"devMenu")) {
               // TODO showDevMenu
-              ;
             } else if (!method.compare(L"captureHeap")) {
               // TODO captureHeap
             }

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.cpp
@@ -16,6 +16,7 @@
 #include "Utilities.h"
 
 #include <Utils/CppWinrtLessExceptions.h>
+#include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Web.Http.Filters.h>
 #include <winrt/Windows.Web.Http.Headers.h>
@@ -73,12 +74,67 @@ void DevSupportManager::LaunchDevTools(const facebook::react::DevSettings &setti
   DownloadFromAsync(facebook::react::DevServerHelper::get_LaunchDevToolsCommandUrl(settings.debugHost)).get();
 }
 
+std::future<void> DevSupportManager::CreatePackagerConnection(const facebook::react::DevSettings &settings) {
+  m_ws = winrt::Windows::Networking::Sockets::MessageWebSocket();
+
+  m_wsMessageRevoker = m_ws.MessageReceived(
+      winrt::auto_revoke, [reloadCallback = settings.liveReloadCallback](auto && /*sender*/, auto &&args) noexcept {
+        try {
+          auto reader = args.GetDataReader();
+
+          uint32_t len = reader.UnconsumedBufferLength();
+          if (args.MessageType() == winrt::Windows::Networking::Sockets::SocketMessageType::Utf8) {
+            reader.UnicodeEncoding(winrt::Windows::Storage::Streams::UnicodeEncoding::Utf8);
+            std::vector<uint8_t> data(len);
+            reader.ReadBytes(data);
+
+            auto response =
+                std::string(Microsoft::Common::Utilities::CheckedReinterpretCast<char *>(data.data()), data.size());
+            auto json =
+                winrt::Windows::Data::Json::JsonObject::Parse(Microsoft::Common::Unicode::Utf8ToUtf16(response));
+
+            auto version = (int)json.GetNamedNumber(L"version", 0.0);
+            if (version != 2) {
+              AssertSz(false, "Message with incompatible or missing version of protocol received");
+              return;
+            }
+            auto method = std::wstring(json.GetNamedString(L"method", L""));
+            if (method.empty()) {
+              AssertSz(false, "No method provided");
+              return;
+            }
+
+            if (!method.compare(L"reload")) {
+              reloadCallback();
+            } else if (!method.compare(L"devMenu")) {
+              // TODO showDevMenu
+              ;
+            } else if (!method.compare(L"captureHeap")) {
+              // TODO captureHeap
+            }
+          }
+        } catch (winrt::hresult_error const &e) {
+        }
+      });
+
+  winrt::Windows::Foundation::Uri uri(
+      Microsoft::Common::Unicode::Utf8ToUtf16("ws://" + settings.debugHost + "/message"));
+  auto async = m_ws.ConnectAsync(uri);
+
+#ifdef DEFAULT_CPPWINRT_EXCEPTIONS
+  co_await async;
+#else
+  co_await lessthrow_await_adapter<winrt::Windows::Foundation::IAsyncAction>{async};
+#endif
+}
+
 facebook::react::JSECreator DevSupportManager::LoadJavaScriptInProxyMode(const facebook::react::DevSettings &settings) {
   // Reset exception state since client is requesting new service
   m_exceptionCaught = false;
 
   try {
     LaunchDevTools(settings);
+    CreatePackagerConnection(settings);
 
     return [this, settings](
                std::shared_ptr<facebook::react::ExecutorDelegate> delegate,

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
@@ -7,6 +7,7 @@
 
 #include <DevServerHelper.h>
 
+#include <winrt/Windows.Networking.Sockets.h>
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -39,8 +40,11 @@ class DevSupportManager : public facebook::react::IDevSupportManager {
 
  private:
   void LaunchDevTools(const facebook::react::DevSettings &settings);
+  std::future<void> CreatePackagerConnection(const facebook::react::DevSettings &settings);
 
  private:
+  winrt::Windows::Networking::Sockets::MessageWebSocket m_ws{nullptr};
+  winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_wsMessageRevoker;
   bool m_exceptionCaught = false;
   std::atomic_bool m_cancellation_token;
 };

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -661,7 +661,7 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
 
 void InstanceImpl::RegisterForReloadIfNecessary() noexcept {
   // setup polling for live reload
-  if (!m_devManager->HasException() && m_devSettings->liveReloadCallback != nullptr) {
+  if (!m_devManager->HasException() && !m_devSettings->useFastRefresh && m_devSettings->liveReloadCallback != nullptr) {
     m_devManager->StartPollingLiveReload(m_devSettings->debugHost, m_devSettings->liveReloadCallback);
   }
 }


### PR DESCRIPTION
The packager implements a websocket that allows apps to be recieve commands from the packager.  Two obvious commands are 'reload' and 'show devmenu'.

This PR makes the instance connect to this websocket and see the commands.  It hooks up reload.  The dev menu command is left as a todo for now, as the dev menu is currently tied to the root view, which is probably incorrect and will require some more refactoring.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4665)