### PR TITLE
Microsoft.ReactNative Nuget only contains debug bits

### DIFF
--- a/change/react-native-windows-2020-04-22-08-27-16-pubrel.json
+++ b/change/react-native-windows-2020-04-22-08-27-16-pubrel.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Publish ship and debug bits in the nuget",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-22T15:27:16.797Z"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -25,33 +25,33 @@
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
 
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native" />
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\debug" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\debug" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\debug" />
 
     <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
     <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
     <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
 
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native\debug" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native\debug" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native\debug" />
 
     <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
     <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
     <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
 
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native\debug" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native\debug" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native\debug" />
 
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
 
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native\debug" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native\debug" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native\debug" />
 
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -21,33 +21,33 @@
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml"   target="lib\uap10.0"/> 
     -->
 
-    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native" />
-    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
-    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\release" />
+    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\release" />
+    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\release" />
 
     <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\debug" />
     <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\debug" />
     <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\debug" />
 
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native\release" />
+    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native\release" />
+    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native\release" />
 
     <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native\debug" />
     <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native\debug" />
     <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native\debug" />
 
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native\release" />
+    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native\release" />
+    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native\release" />
 
     <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native\debug" />
     <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native\debug" />
     <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native\debug" />
 
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native\release" />
+    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native\release" />
+    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native\release" />
 
     <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native\debug" />
     <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native\debug" />

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -8,7 +8,9 @@
         <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ReactNative.winmd">
             <Implementation>Microsoft.ReactNative.dll</Implementation>
         </Reference>
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="${Configuration) == 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\Microsoft.ReactNative.dll" />
+    <ReferenceCopyLocalPaths Condition="${Configuration) == 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="${Configuration) != 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ReactNative.dll" />
+    <ReferenceCopyLocalPaths Condition="${Configuration) != 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ReactNative.pri" />
     </ItemGroup>
 </Project>

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -8,9 +8,9 @@
         <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ReactNative.winmd">
             <Implementation>Microsoft.ReactNative.dll</Implementation>
         </Reference>
-    <ReferenceCopyLocalPaths Condition="${Configuration) == 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="${Configuration) == 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\Microsoft.ReactNative.pri" />
-    <ReferenceCopyLocalPaths Condition="${Configuration) != 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="${Configuration) != 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\Microsoft.ReactNative.dll" />
+    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="$(Configuration) != 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\release\Microsoft.ReactNative.dll" />
+    <ReferenceCopyLocalPaths Condition="$(Configuration) != 'Debug'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\release\Microsoft.ReactNative.pri" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I accidently had the release and debug bits overwrite each other in the nuspec.  This fixes the nuget to publish both ship and debug, and modifies the default project to use the debug dll when building debug.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4674)