### PR TITLE
Pass XamlViews through ReactUwp View Managers by Const Ref

### DIFF
--- a/change/react-native-windows-2020-04-22-15-24-14-const-ref.json
+++ b/change/react-native-windows-2020-04-22-15-24-14-const-ref.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Pass XamlView's through ReactUwp View Managers by Const Ref",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-22T22:24:14.912Z"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -130,7 +130,7 @@ folly::dynamic ABIViewManager::GetCommands() const {
 }
 
 void ABIViewManager::DispatchCommand(
-    winrt::Windows::UI::Xaml::DependencyObject viewToUpdate,
+    const winrt::Windows::UI::Xaml::DependencyObject &viewToUpdate,
     int64_t commandId,
     const folly::dynamic &commandArgs) {
   if (m_viewManagerWithCommands) {
@@ -185,8 +185,8 @@ folly::dynamic ABIViewManager::GetExportedCustomDirectEventTypeConstants() const
 }
 
 void ABIViewManager::AddView(
-    winrt::Windows::UI::Xaml::DependencyObject parent,
-    winrt::Windows::UI::Xaml::DependencyObject child,
+    const winrt::Windows::UI::Xaml::DependencyObject &parent,
+    const winrt::Windows::UI::Xaml::DependencyObject &child,
     int64_t index) {
   if (m_viewManagerWithChildren) {
     m_viewManagerWithChildren.AddView(parent.as<winrt::FrameworkElement>(), child.as<winrt::UIElement>(), index);
@@ -195,7 +195,7 @@ void ABIViewManager::AddView(
   }
 }
 
-void ABIViewManager::RemoveAllChildren(winrt::Windows::UI::Xaml::DependencyObject parent) {
+void ABIViewManager::RemoveAllChildren(const winrt::Windows::UI::Xaml::DependencyObject &parent) {
   if (m_viewManagerWithChildren) {
     m_viewManagerWithChildren.RemoveAllChildren(parent.as<winrt::FrameworkElement>());
   } else {
@@ -203,7 +203,7 @@ void ABIViewManager::RemoveAllChildren(winrt::Windows::UI::Xaml::DependencyObjec
   }
 }
 
-void ABIViewManager::RemoveChildAt(winrt::Windows::UI::Xaml::DependencyObject parent, int64_t index) {
+void ABIViewManager::RemoveChildAt(const winrt::Windows::UI::Xaml::DependencyObject &parent, int64_t index) {
   if (m_viewManagerWithChildren) {
     m_viewManagerWithChildren.RemoveChildAt(parent.as<winrt::FrameworkElement>(), index);
   } else {
@@ -212,9 +212,9 @@ void ABIViewManager::RemoveChildAt(winrt::Windows::UI::Xaml::DependencyObject pa
 }
 
 void ABIViewManager::ReplaceChild(
-    winrt::Windows::UI::Xaml::DependencyObject parent,
-    winrt::Windows::UI::Xaml::DependencyObject oldChild,
-    winrt::Windows::UI::Xaml::DependencyObject newChild) {
+    const winrt::Windows::UI::Xaml::DependencyObject &parent,
+    const winrt::Windows::UI::Xaml::DependencyObject &oldChild,
+    const winrt::Windows::UI::Xaml::DependencyObject &newChild) {
   if (m_viewManagerWithChildren) {
     m_viewManagerWithChildren.ReplaceChild(
         parent.as<winrt::FrameworkElement>(), oldChild.as<winrt::UIElement>(), newChild.as<winrt::UIElement>());

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -39,7 +39,7 @@ class ABIViewManager : public react::uwp::FrameworkElementViewManager {
   folly::dynamic GetCommands() const override;
 
   void DispatchCommand(
-      winrt::Windows::UI::Xaml::DependencyObject viewToUpdate,
+      const winrt::Windows::UI::Xaml::DependencyObject &viewToUpdate,
       int64_t commandId,
       const folly::dynamic &commandArgs) override;
 
@@ -48,15 +48,15 @@ class ABIViewManager : public react::uwp::FrameworkElementViewManager {
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
 
   void AddView(
-      winrt::Windows::UI::Xaml::DependencyObject parent,
-      winrt::Windows::UI::Xaml::DependencyObject child,
+      const winrt::Windows::UI::Xaml::DependencyObject &parent,
+      const winrt::Windows::UI::Xaml::DependencyObject &child,
       int64_t index) override;
-  void RemoveAllChildren(winrt::Windows::UI::Xaml::DependencyObject parent) override;
-  void RemoveChildAt(winrt::Windows::UI::Xaml::DependencyObject parent, int64_t index) override;
+  void RemoveAllChildren(const winrt::Windows::UI::Xaml::DependencyObject &parent) override;
+  void RemoveChildAt(const winrt::Windows::UI::Xaml::DependencyObject &parent, int64_t index) override;
   void ReplaceChild(
-      winrt::Windows::UI::Xaml::DependencyObject parent,
-      winrt::Windows::UI::Xaml::DependencyObject oldChild,
-      winrt::Windows::UI::Xaml::DependencyObject newChild) override;
+      const winrt::Windows::UI::Xaml::DependencyObject &parent,
+      const winrt::Windows::UI::Xaml::DependencyObject &oldChild,
+      const winrt::Windows::UI::Xaml::DependencyObject &newChild) override;
 
  protected:
   winrt::Windows::UI::Xaml::DependencyObject CreateViewCore(int64_t) override;

--- a/vnext/ReactUWP/Polyester/ButtonContentViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ButtonContentViewManager.cpp
@@ -24,14 +24,14 @@ namespace polyester {
 ButtonContentViewManager::ButtonContentViewManager(const std::shared_ptr<IReactInstance> &reactInstance)
     : Super(reactInstance) {}
 
-void ButtonContentViewManager::AddView(XamlView parent, XamlView child, int64_t index) {
+void ButtonContentViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
   auto stackPanel(parent.as<StackPanel>());
   if (stackPanel != nullptr) {
     stackPanel.Children().InsertAt(static_cast<uint32_t>(index), child.as<UIElement>());
   }
 }
 
-void ButtonContentViewManager::RemoveAllChildren(XamlView parent) {
+void ButtonContentViewManager::RemoveAllChildren(const XamlView &parent) {
   auto stackPanel(parent.as<StackPanel>());
   if (stackPanel != nullptr) {
     stackPanel.Children().Clear();
@@ -40,7 +40,7 @@ void ButtonContentViewManager::RemoveAllChildren(XamlView parent) {
   }
 }
 
-void ButtonContentViewManager::RemoveChildAt(XamlView parent, int64_t index) {
+void ButtonContentViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
   auto stackPanel(parent.as<StackPanel>());
   if (stackPanel != nullptr) {
     stackPanel.Children().RemoveAt(static_cast<uint32_t>(index));

--- a/vnext/ReactUWP/Polyester/ButtonContentViewManager.h
+++ b/vnext/ReactUWP/Polyester/ButtonContentViewManager.h
@@ -17,9 +17,9 @@ class ButtonContentViewManager : public FrameworkElementViewManager {
 
   const char *GetName() const override;
 
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
-  void RemoveAllChildren(XamlView parent) override;
-  void RemoveChildAt(XamlView parent, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
+  void RemoveAllChildren(const XamlView &parent) override;
+  void RemoveChildAt(const XamlView &parent, int64_t index) override;
 
  protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
@@ -58,7 +58,7 @@ facebook::react::ShadowNode *ContentControlViewManager::createShadow() const {
   return new ContentControlShadowNode();
 }
 
-void ContentControlViewManager::AddView(XamlView parent, XamlView child, int64_t index) {
+void ContentControlViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
   // ContentControl holds a single child, so should never insert after
   if (index != 0) {
     // ASSERT: Currently considering any index other than 0 as ignorable since
@@ -72,13 +72,13 @@ void ContentControlViewManager::AddView(XamlView parent, XamlView child, int64_t
     contentControl.Content(child.as<winrt::IInspectable>());
 }
 
-void ContentControlViewManager::RemoveAllChildren(XamlView parent) {
+void ContentControlViewManager::RemoveAllChildren(const XamlView &parent) {
   auto contentControl(parent.as<winrt::ContentControl>());
   if (contentControl != nullptr)
     contentControl.Content(nullptr);
 }
 
-void ContentControlViewManager::RemoveChildAt(XamlView parent, int64_t index) {
+void ContentControlViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
   if (index != 0)
     return;
 

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.h
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.h
@@ -41,9 +41,9 @@ class ContentControlViewManager : public ControlViewManager {
 
   facebook::react::ShadowNode *createShadow() const override;
 
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
-  void RemoveAllChildren(XamlView parent) override;
-  void RemoveChildAt(XamlView parent, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
+  void RemoveAllChildren(const XamlView &parent) override;
+  void RemoveChildAt(const XamlView &parent, int64_t index) override;
 };
 
 } // namespace polyester

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -18,7 +18,7 @@ folly::dynamic ControlViewManager::GetNativeProps() const {
   props.update(folly::dynamic::object("tabIndex", "number"));
   return props;
 }
-void ControlViewManager::TransferProperties(XamlView oldView, XamlView newView) {
+void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
   TransferProperty(oldView, newView, winrt::Control::FontSizeProperty());
   TransferProperty(oldView, newView, winrt::Control::FontFamilyProperty());
   TransferProperty(oldView, newView, winrt::Control::FontWeightProperty());

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -442,7 +442,7 @@ folly::dynamic FlyoutViewManager::GetExportedCustomDirectEventTypeConstants() co
 
 void FlyoutViewManager::SetLayoutProps(
     ShadowNodeBase &nodeToUpdate,
-    XamlView /*viewToUpdate*/,
+    const XamlView & /*viewToUpdate*/,
     float /*left*/,
     float /*top*/,
     float width,

--- a/vnext/ReactUWP/Views/FlyoutViewManager.h
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.h
@@ -21,7 +21,7 @@ class FlyoutViewManager : public FrameworkElementViewManager {
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,
-      XamlView viewToUpdate,
+      const XamlView &viewToUpdate,
       float left,
       float top,
       float width,

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -74,13 +74,13 @@ namespace uwp {
 FrameworkElementViewManager::FrameworkElementViewManager(const std::shared_ptr<IReactInstance> &reactInstance)
     : Super(reactInstance) {}
 
-void FrameworkElementViewManager::TransferProperty(XamlView oldView, XamlView newView, winrt::DependencyProperty dp) {
+void FrameworkElementViewManager::TransferProperty(const XamlView &oldView, const XamlView &newView, winrt::DependencyProperty dp) {
   TransferProperty(oldView, newView, dp, dp);
 }
 
 void FrameworkElementViewManager::TransferProperty(
-    XamlView oldView,
-    XamlView newView,
+    const XamlView &oldView,
+    const XamlView &newView,
     winrt::DependencyProperty oldViewDP,
     winrt::DependencyProperty newViewDP) {
   auto oldValue = oldView.ReadLocalValue(oldViewDP);
@@ -90,7 +90,7 @@ void FrameworkElementViewManager::TransferProperty(
   }
 }
 
-void FrameworkElementViewManager::TransferProperties(XamlView oldView, XamlView newView) {
+void FrameworkElementViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
   // Render Properties
   TransferProperty(oldView, newView, winrt::UIElement::OpacityProperty());
 

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -74,7 +74,10 @@ namespace uwp {
 FrameworkElementViewManager::FrameworkElementViewManager(const std::shared_ptr<IReactInstance> &reactInstance)
     : Super(reactInstance) {}
 
-void FrameworkElementViewManager::TransferProperty(const XamlView &oldView, const XamlView &newView, winrt::DependencyProperty dp) {
+void FrameworkElementViewManager::TransferProperty(
+    const XamlView &oldView,
+    const XamlView &newView,
+    winrt::DependencyProperty dp) {
   TransferProperty(oldView, newView, dp, dp);
 }
 

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -326,7 +326,7 @@ XamlView PopupViewManager::CreateViewCore(int64_t /*tag*/) {
 
 void PopupViewManager::SetLayoutProps(
     ShadowNodeBase &nodeToUpdate,
-    XamlView viewToUpdate,
+    const XamlView &viewToUpdate,
     float left,
     float top,
     float width,

--- a/vnext/ReactUWP/Views/PopupViewManager.h
+++ b/vnext/ReactUWP/Views/PopupViewManager.h
@@ -22,7 +22,7 @@ class PopupViewManager : public FrameworkElementViewManager {
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,
-      XamlView viewToUpdate,
+      const XamlView &viewToUpdate,
       float left,
       float top,
       float width,

--- a/vnext/ReactUWP/Views/RawTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/RawTextViewManager.cpp
@@ -84,7 +84,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(IReactInstance *instance, Sh
 
 void RawTextViewManager::SetLayoutProps(
     ShadowNodeBase & /*nodeToUpdate*/,
-    XamlView /*viewToUpdate*/,
+    const XamlView & /*viewToUpdate*/,
     float /*left*/,
     float /*top*/,
     float /*width*/,

--- a/vnext/ReactUWP/Views/RawTextViewManager.h
+++ b/vnext/ReactUWP/Views/RawTextViewManager.h
@@ -20,7 +20,7 @@ class RawTextViewManager : public ViewManagerBase {
 
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,
-      XamlView viewToUpdate,
+      const XamlView &viewToUpdate,
       float left,
       float top,
       float width,

--- a/vnext/ReactUWP/Views/RefreshControlManager.cpp
+++ b/vnext/ReactUWP/Views/RefreshControlManager.cpp
@@ -95,7 +95,7 @@ XamlView RefreshControlViewManager::CreateViewCore(int64_t /*tag*/) {
   }
 }
 
-void RefreshControlViewManager::AddView(XamlView parent, XamlView child, int64_t /*index*/) {
+void RefreshControlViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t /*index*/) {
   if (auto refreshContainer = parent.try_as<winrt::RefreshContainer>()) {
     refreshContainer.Content(child.as<winrt::ScrollViewer>());
   } else if (auto grid = parent.try_as<winrt::Grid>()) {

--- a/vnext/ReactUWP/Views/RefreshControlManager.h
+++ b/vnext/ReactUWP/Views/RefreshControlManager.h
@@ -22,7 +22,7 @@ class RefreshControlViewManager : public FrameworkElementViewManager {
 
  protected:
   XamlView CreateViewCore(int64_t tag) override;
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/Views/RootViewManager.cpp
+++ b/vnext/ReactUWP/Views/RootViewManager.cpp
@@ -30,19 +30,19 @@ XamlView RootViewManager::CreateViewCore(int64_t /*tag*/) {
   return nullptr;
 }
 
-void RootViewManager::AddView(XamlView parent, XamlView child, int64_t index) {
+void RootViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
   auto panel(parent.as<winrt::Panel>());
   if (panel != nullptr)
     panel.Children().InsertAt(static_cast<uint32_t>(index), child.as<winrt::UIElement>());
 }
 
-void RootViewManager::RemoveAllChildren(XamlView parent) {
+void RootViewManager::RemoveAllChildren(const XamlView &parent) {
   auto panel(parent.as<winrt::Panel>());
   if (panel != nullptr)
     panel.Children().Clear();
 }
 
-void RootViewManager::RemoveChildAt(XamlView parent, int64_t index) {
+void RootViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
   auto panel(parent.as<winrt::Panel>());
   if (panel != nullptr)
     panel.Children().RemoveAt(static_cast<uint32_t>(index));
@@ -50,7 +50,7 @@ void RootViewManager::RemoveChildAt(XamlView parent, int64_t index) {
 
 void RootViewManager::SetLayoutProps(
     ShadowNodeBase & /*nodeToUpdate*/,
-    XamlView /*nodeToUpdate*/,
+    const XamlView & /*nodeToUpdate*/,
     float /*left*/,
     float /*top*/,
     float /*width*/,

--- a/vnext/ReactUWP/Views/RootViewManager.h
+++ b/vnext/ReactUWP/Views/RootViewManager.h
@@ -16,13 +16,13 @@ class RootViewManager : public FrameworkElementViewManager {
 
   const char *GetName() const override;
 
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
-  void RemoveAllChildren(XamlView parent) override;
-  void RemoveChildAt(XamlView parent, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
+  void RemoveAllChildren(const XamlView &parent) override;
+  void RemoveChildAt(const XamlView &parent, int64_t index) override;
 
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,
-      XamlView viewToUpdate,
+      const XamlView &viewToUpdate,
       float left,
       float top,
       float width,

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -462,7 +462,7 @@ XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/) {
   return scrollViewer;
 }
 
-void ScrollViewManager::AddView(XamlView parent, XamlView child, [[maybe_unused]] int64_t index) {
+void ScrollViewManager::AddView(const XamlView &parent, const XamlView &child, [[maybe_unused]] int64_t index) {
   assert(index == 0);
 
   auto scrollViewer = parent.as<winrt::ScrollViewer>();
@@ -470,18 +470,18 @@ void ScrollViewManager::AddView(XamlView parent, XamlView child, [[maybe_unused]
   snapPointManager->Content(child);
 }
 
-void ScrollViewManager::RemoveAllChildren(XamlView parent) {
+void ScrollViewManager::RemoveAllChildren(const XamlView &parent) {
   auto scrollViewer = parent.as<winrt::ScrollViewer>();
   auto snapPointManager = scrollViewer.Content().as<SnapPointManagingContentControl>();
   snapPointManager->Content(nullptr);
 }
 
-void ScrollViewManager::RemoveChildAt(XamlView parent, [[maybe_unused]] int64_t index) {
+void ScrollViewManager::RemoveChildAt(const XamlView &parent, [[maybe_unused]] int64_t index) {
   assert(index == 0);
   RemoveAllChildren(parent);
 }
 
-void ScrollViewManager::SnapToInterval(XamlView parent, float interval) {
+void ScrollViewManager::SnapToInterval(const XamlView &parent, float interval) {
   if (parent) {
     if (const auto scrollViewer = parent.as<winrt::ScrollViewer>()) {
       ScrollViewUWPImplementation(scrollViewer).SnapToInterval(interval);
@@ -489,7 +489,7 @@ void ScrollViewManager::SnapToInterval(XamlView parent, float interval) {
   }
 }
 
-void ScrollViewManager::SnapToOffsets(XamlView parent, const winrt::IVectorView<float> &offsets) {
+void ScrollViewManager::SnapToOffsets(const XamlView &parent, const winrt::IVectorView<float> &offsets) {
   if (parent) {
     if (const auto scrollViewer = parent.as<winrt::ScrollViewer>()) {
       ScrollViewUWPImplementation(scrollViewer).SnapToOffsets(offsets);

--- a/vnext/ReactUWP/Views/ScrollViewManager.h
+++ b/vnext/ReactUWP/Views/ScrollViewManager.h
@@ -22,12 +22,12 @@ class ScrollViewManager : public ControlViewManager {
 
   facebook::react::ShadowNode *createShadow() const override;
 
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
-  void RemoveAllChildren(XamlView parent) override;
-  void RemoveChildAt(XamlView parent, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
+  void RemoveAllChildren(const XamlView &parent) override;
+  void RemoveChildAt(const XamlView &parent, int64_t index) override;
 
-  void SnapToInterval(XamlView parent, float interval);
-  void SnapToOffsets(XamlView parent, const winrt::IVectorView<float> &offsets);
+  void SnapToInterval(const XamlView &parent, float interval);
+  void SnapToOffsets(const XamlView &parent, const winrt::IVectorView<float> &offsets);
 
  protected:
   XamlView CreateViewCore(int64_t tag) override;

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -75,7 +75,7 @@ void ShadowNodeBase::ReplaceView(XamlView view) {
   }
 }
 
-void ShadowNodeBase::ReplaceChild(XamlView oldChildView, XamlView newChildView) {
+void ShadowNodeBase::ReplaceChild(const XamlView &oldChildView, const XamlView &newChildView) {
   GetViewManager()->ReplaceChild(m_view, oldChildView, newChildView);
 }
 

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -628,7 +628,10 @@ YGMeasureFunc TextInputViewManager::GetYogaCustomMeasureFunc() const {
   return DefaultYogaSelfMeasureFunc;
 }
 
-void TextInputViewManager::TransferInputScope(const XamlView &oldView, const XamlView &newView, const bool copyToPasswordBox) {
+void TextInputViewManager::TransferInputScope(
+    const XamlView &oldView,
+    const XamlView &newView,
+    const bool copyToPasswordBox) {
   // transfer input scope, only common keyboardType between secureTextEntry
   // on/off is numeric, so only need to transfer input scope "Number" <=>
   // "NumericPin", everything else leave it as default.

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -628,7 +628,7 @@ YGMeasureFunc TextInputViewManager::GetYogaCustomMeasureFunc() const {
   return DefaultYogaSelfMeasureFunc;
 }
 
-void TextInputViewManager::TransferInputScope(XamlView oldView, XamlView newView, const bool copyToPasswordBox) {
+void TextInputViewManager::TransferInputScope(const XamlView &oldView, const XamlView &newView, const bool copyToPasswordBox) {
   // transfer input scope, only common keyboardType between secureTextEntry
   // on/off is numeric, so only need to transfer input scope "Number" <=>
   // "NumericPin", everything else leave it as default.
@@ -656,7 +656,7 @@ void TextInputViewManager::TransferInputScope(XamlView oldView, XamlView newView
   }
 }
 
-void TextInputViewManager::TransferProperties(XamlView oldView, XamlView newView) {
+void TextInputViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
   if ((oldView.try_as<winrt::TextBox>() != nullptr && newView.try_as<winrt::PasswordBox>() != nullptr) ||
       (oldView.try_as<winrt::PasswordBox>() != nullptr && newView.try_as<winrt::TextBox>() != nullptr)) {
     bool copyToPasswordBox = oldView.try_as<winrt::TextBox>() != nullptr;

--- a/vnext/ReactUWP/Views/TextInputViewManager.h
+++ b/vnext/ReactUWP/Views/TextInputViewManager.h
@@ -20,14 +20,14 @@ class TextInputViewManager : public ControlViewManager {
   facebook::react::ShadowNode *createShadow() const override;
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
-  virtual void TransferProperties(XamlView oldView, XamlView newView) override;
+  virtual void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
  protected:
   XamlView CreateViewCore(int64_t tag) override;
   friend class TextInputShadowNode;
 
  private:
-  void TransferInputScope(XamlView oldView, XamlView newView, const bool copyToPasswordBox);
+  void TransferInputScope(const XamlView &oldView, const XamlView &newView, const bool copyToPasswordBox);
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -142,18 +142,18 @@ bool TextViewManager::UpdateProperty(
   return true;
 }
 
-void TextViewManager::AddView(XamlView parent, XamlView child, int64_t index) {
+void TextViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
   auto textBlock(parent.as<winrt::TextBlock>());
   auto childInline(child.as<winrt::Inline>());
   textBlock.Inlines().InsertAt(static_cast<uint32_t>(index), childInline);
 }
 
-void TextViewManager::RemoveAllChildren(XamlView parent) {
+void TextViewManager::RemoveAllChildren(const XamlView &parent) {
   auto textBlock(parent.as<winrt::TextBlock>());
   textBlock.Inlines().Clear();
 }
 
-void TextViewManager::RemoveChildAt(XamlView parent, int64_t index) {
+void TextViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
   auto textBlock(parent.as<winrt::TextBlock>());
   return textBlock.Inlines().RemoveAt(static_cast<uint32_t>(index));
 }

--- a/vnext/ReactUWP/Views/TextViewManager.h
+++ b/vnext/ReactUWP/Views/TextViewManager.h
@@ -18,9 +18,9 @@ class TextViewManager : public FrameworkElementViewManager {
 
   const char *GetName() const override;
 
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
-  void RemoveAllChildren(XamlView parent) override;
-  void RemoveChildAt(XamlView parent, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
+  void RemoveAllChildren(const XamlView &parent) override;
+  void RemoveChildAt(const XamlView &parent, int64_t index) override;
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -198,19 +198,19 @@ XamlView ViewManagerBase::CreateView(int64_t tag) {
   return view;
 }
 
-void ViewManagerBase::AddView(XamlView /*parent*/, XamlView /*child*/, int64_t /*index*/) {
+void ViewManagerBase::AddView(const XamlView & /*parent*/, const XamlView & /*child*/, int64_t /*index*/) {
   // ASSERT: Child must either implement or not allow children.
   assert(false);
 }
 
-void ViewManagerBase::RemoveChildAt(XamlView /*parent*/, int64_t /*index*/) {
+void ViewManagerBase::RemoveChildAt(const XamlView & /*parent*/, int64_t /*index*/) {
   // ASSERT: Child must either implement or not allow children.
   assert(false);
 }
 
-void ViewManagerBase::RemoveAllChildren(XamlView parent) {}
+void ViewManagerBase::RemoveAllChildren(const XamlView &parent) {}
 
-void ViewManagerBase::ReplaceChild(XamlView parent, XamlView oldChild, XamlView newChild) {
+void ViewManagerBase::ReplaceChild(const XamlView &parent, const XamlView &oldChild, const XamlView &newChild) {
   // ASSERT: Child must either implement or not allow children.
   assert(false);
 }
@@ -251,10 +251,10 @@ bool ViewManagerBase::UpdateProperty(
   return true;
 }
 
-void ViewManagerBase::TransferProperties(XamlView /*oldView*/, XamlView /*newView*/) {}
+void ViewManagerBase::TransferProperties(const XamlView & /*oldView*/, const XamlView & /*newView*/) {}
 
 void ViewManagerBase::DispatchCommand(
-    XamlView /*viewToUpdate*/,
+    const XamlView & /*viewToUpdate*/,
     int64_t /*commandId*/,
     const folly::dynamic & /*commandArgs*/) {
   assert(false); // View did not handle its command
@@ -316,7 +316,7 @@ void ViewManagerBase::TestHook::NotifyUnimplementedProperty(
 
 void ViewManagerBase::SetLayoutProps(
     ShadowNodeBase &nodeToUpdate,
-    XamlView viewToUpdate,
+    const XamlView &viewToUpdate,
     float left,
     float top,
     float width,

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -135,7 +135,7 @@ class ViewShadowNode : public ShadowNodeBase {
     }
   }
 
-  void ReplaceChild(XamlView oldChildView, XamlView newChildView) override {
+  void ReplaceChild(const XamlView &oldChildView, const XamlView &newChildView) override {
     auto pPanel = GetViewPanel();
     if (pPanel != nullptr) {
       uint32_t index;
@@ -513,7 +513,7 @@ void ViewViewManager::TryUpdateView(
 
 void ViewViewManager::SetLayoutProps(
     ShadowNodeBase &nodeToUpdate,
-    XamlView viewToUpdate,
+    const XamlView &viewToUpdate,
     float left,
     float top,
     float width,

--- a/vnext/ReactUWP/Views/ViewViewManager.h
+++ b/vnext/ReactUWP/Views/ViewViewManager.h
@@ -30,7 +30,7 @@ class ViewViewManager : public FrameworkElementViewManager {
   // Yoga Layout
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,
-      XamlView viewToUpdate,
+      const XamlView &viewToUpdate,
       float left,
       float top,
       float width,

--- a/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
@@ -53,18 +53,18 @@ bool VirtualTextViewManager::UpdateProperty(
   return true;
 }
 
-void VirtualTextViewManager::AddView(XamlView parent, XamlView child, int64_t index) {
+void VirtualTextViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
   auto span(parent.as<winrt::Span>());
   auto childInline(child.as<winrt::Inline>());
   span.Inlines().InsertAt(static_cast<uint32_t>(index), childInline);
 }
 
-void VirtualTextViewManager::RemoveAllChildren(XamlView parent) {
+void VirtualTextViewManager::RemoveAllChildren(const XamlView &parent) {
   auto span(parent.as<winrt::Span>());
   span.Inlines().Clear();
 }
 
-void VirtualTextViewManager::RemoveChildAt(XamlView parent, int64_t index) {
+void VirtualTextViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
   auto span(parent.as<winrt::Span>());
   return span.Inlines().RemoveAt(static_cast<uint32_t>(index));
 }

--- a/vnext/ReactUWP/Views/VirtualTextViewManager.h
+++ b/vnext/ReactUWP/Views/VirtualTextViewManager.h
@@ -16,9 +16,9 @@ class VirtualTextViewManager : public ViewManagerBase {
 
   const char *GetName() const override;
 
-  void AddView(XamlView parent, XamlView child, int64_t index) override;
-  void RemoveAllChildren(XamlView parent) override;
-  void RemoveChildAt(XamlView parent, int64_t index) override;
+  void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
+  void RemoveAllChildren(const XamlView &parent) override;
+  void RemoveChildAt(const XamlView &parent, int64_t index) override;
 
   bool RequiresYogaNode() const override;
 

--- a/vnext/include/ReactUWP/Views/ControlViewManager.h
+++ b/vnext/include/ReactUWP/Views/ControlViewManager.h
@@ -21,7 +21,7 @@ class REACTWINDOWS_EXPORT ControlViewManager : public FrameworkElementViewManage
       ShadowNodeBase *nodeToUpdate,
       const std::string &propertyName,
       const folly::dynamic &propertyValue) override;
-  void TransferProperties(XamlView oldView, XamlView newView) override;
+  void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
  protected:
   void OnViewCreated(XamlView view) override;

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -31,7 +31,8 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const folly::dynamic &propertyValue) override;
 
-  void TransferProperty(const XamlView &oldView, const XamlView &newView, winrt::Windows::UI::Xaml::DependencyProperty dp);
+  void
+  TransferProperty(const XamlView &oldView, const XamlView &newView, winrt::Windows::UI::Xaml::DependencyProperty dp);
 
   void TransferProperty(
       const XamlView &oldView,

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -23,7 +23,7 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       winrt::UIElement uielement,
       winrt::Windows::UI::Composition::CompositionPropertySet transformPS);
 
-  virtual void TransferProperties(XamlView oldView, XamlView newView) override;
+  virtual void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
  protected:
   bool UpdateProperty(
@@ -31,11 +31,11 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const folly::dynamic &propertyValue) override;
 
-  void TransferProperty(XamlView oldView, XamlView newView, winrt::Windows::UI::Xaml::DependencyProperty dp);
+  void TransferProperty(const XamlView &oldView, const XamlView &newView, winrt::Windows::UI::Xaml::DependencyProperty dp);
 
   void TransferProperty(
-      XamlView oldView,
-      XamlView newView,
+      const XamlView &oldView,
+      const XamlView &newView,
       winrt::DependencyProperty oldViewDP,
       winrt::DependencyProperty newViewDP);
 

--- a/vnext/include/ReactUWP/Views/ShadowNodeBase.h
+++ b/vnext/include/ReactUWP/Views/ShadowNodeBase.h
@@ -63,7 +63,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
 
   virtual void updateProperties(const folly::dynamic &&props) override;
 
-  virtual void ReplaceChild(XamlView oldChildView, XamlView newChildView);
+  virtual void ReplaceChild(const XamlView &oldChildView, const XamlView &newChildView);
   virtual bool ImplementsPadding() {
     return false;
   }

--- a/vnext/include/ReactUWP/Views/ViewManagerBase.h
+++ b/vnext/include/ReactUWP/Views/ViewManagerBase.h
@@ -55,18 +55,18 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public facebook::react::IViewManager
   folly::dynamic GetExportedCustomBubblingEventTypeConstants() const override;
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
 
-  virtual void AddView(XamlView parent, XamlView child, int64_t index);
-  virtual void RemoveAllChildren(XamlView parent);
-  virtual void RemoveChildAt(XamlView parent, int64_t index);
-  virtual void ReplaceChild(XamlView parent, XamlView oldChild, XamlView newChild);
+  virtual void AddView(const XamlView &parent, const XamlView &child, int64_t index);
+  virtual void RemoveAllChildren(const XamlView &parent);
+  virtual void RemoveChildAt(const XamlView &parent, int64_t index);
+  virtual void ReplaceChild(const XamlView &parent, const XamlView &oldChild, const XamlView &newChild);
 
   virtual void UpdateProperties(ShadowNodeBase *nodeToUpdate, const folly::dynamic &reactDiffMap);
 
-  virtual void DispatchCommand(XamlView viewToUpdate, int64_t commandId, const folly::dynamic &commandArgs);
+  virtual void DispatchCommand(const XamlView &viewToUpdate, int64_t commandId, const folly::dynamic &commandArgs);
 
   // Yoga Layout
   virtual void
-  SetLayoutProps(ShadowNodeBase &nodeToUpdate, XamlView viewToUpdate, float left, float top, float width, float height);
+  SetLayoutProps(ShadowNodeBase &nodeToUpdate, const XamlView &viewToUpdate, float left, float top, float width, float height);
   virtual YGMeasureFunc GetYogaCustomMeasureFunc() const;
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;
@@ -75,7 +75,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public facebook::react::IViewManager
     return m_wkReactInstance;
   }
 
-  virtual void TransferProperties(XamlView oldView, XamlView newView);
+  virtual void TransferProperties(const XamlView &oldView, const XamlView &newView);
 
  protected:
   virtual XamlView CreateViewCore(int64_t tag) = 0;

--- a/vnext/include/ReactUWP/Views/ViewManagerBase.h
+++ b/vnext/include/ReactUWP/Views/ViewManagerBase.h
@@ -65,8 +65,13 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public facebook::react::IViewManager
   virtual void DispatchCommand(const XamlView &viewToUpdate, int64_t commandId, const folly::dynamic &commandArgs);
 
   // Yoga Layout
-  virtual void
-  SetLayoutProps(ShadowNodeBase &nodeToUpdate, const XamlView &viewToUpdate, float left, float top, float width, float height);
+  virtual void SetLayoutProps(
+      ShadowNodeBase &nodeToUpdate,
+      const XamlView &viewToUpdate,
+      float left,
+      float top,
+      float width,
+      float height);
   virtual YGMeasureFunc GetYogaCustomMeasureFunc() const;
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;


### PR DESCRIPTION
Passing by values means extra copies + extra atomic AddRef and Release. Pass by ref instead.

This was a quick find/replace, inspect, and see if we compile deal. I didn't bother trying to catch everything in every view manager, and just fixed the main interface. Much of this will likely get nuked when ABIViewManager becomes the sole source of goodness.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4681)