### PR TITLE
Fixup direction == 'rtl'

### DIFF
--- a/change/react-native-windows-2020-04-22-16-22-32-direction-rtl.json
+++ b/change/react-native-windows-2020-04-22-16-22-32-direction-rtl.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix RTL",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-22T23:22:32.344Z"
+}

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -507,13 +507,12 @@ static void StyleYogaNode(ShadowNodeBase &shadowNode, const YGNodeRef yogaNode, 
 
       YGNodeStyleSetDisplay(yogaNode, display);
     } else if (key == "direction") {
-      YGDirection direction = YGDirectionInherit;
-      if (value == "inherit" || value.isNull())
-        direction = YGDirectionInherit;
-      else if (value == "ltr" || value.isNull())
-        direction = YGDirectionLTR;
-      else if (value == "rtl")
-        direction = YGDirectionRTL;
+      // https://github.com/microsoft/react-native-windows/issues/4668
+      // In order to support the direction property, we tell yoga to always layout
+      // in LTR direction, then push the appropriate FlowDirection into XAML.
+      // This way XAML handles flipping in RTL mode, which works both for RN components
+      // as well as native components that have purely XAML sub-trees (eg ComboBox).
+      YGDirection direction = YGDirectionLTR;
 
       YGNodeStyleSetDirection(yogaNode, direction);
     } else if (key == "aspectRatio") {

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -40,12 +40,10 @@ static const std::unordered_map<std::string, ShadowEdges> edgeTypeMap = {
     {"borderWidth", ShadowEdges::AllEdges},
 };
 
-inline winrt::Windows::UI::Xaml::Thickness GetThickness(double thicknesses[ShadowEdges::CountEdges], bool isRTL) {
+inline winrt::Windows::UI::Xaml::Thickness GetThickness(double thicknesses[ShadowEdges::CountEdges]) {
   const double defaultWidth = std::max<double>(0, thicknesses[ShadowEdges::AllEdges]);
   double startWidth = DefaultOrOverride(thicknesses[ShadowEdges::Left], thicknesses[ShadowEdges::Start]);
   double endWidth = DefaultOrOverride(thicknesses[ShadowEdges::Right], thicknesses[ShadowEdges::End]);
-  if (isRTL)
-    std::swap(startWidth, endWidth);
 
   // Compute each edge.  Most specific setting wins, so fill from broad to
   // narrow: all, horiz/vert, start/end, left/right
@@ -69,8 +67,7 @@ inline winrt::Windows::UI::Xaml::Thickness GetThickness(double thicknesses[Shado
 }
 
 inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(
-    double cornerRadii[ShadowCorners::CountCorners],
-    bool isRTL) {
+    double cornerRadii[ShadowCorners::CountCorners]) {
   winrt::Windows::UI::Xaml::CornerRadius cornerRadius;
   const double defaultRadius = std::max<double>(0, cornerRadii[ShadowCorners::AllCorners]);
   double topStartRadius = DefaultOrOverride(cornerRadii[ShadowCorners::TopLeft], cornerRadii[ShadowCorners::TopStart]);
@@ -79,10 +76,6 @@ inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(
       DefaultOrOverride(cornerRadii[ShadowCorners::BottomLeft], cornerRadii[ShadowCorners::BottomStart]);
   double bottomEndRadius =
       DefaultOrOverride(cornerRadii[ShadowCorners::BottomRight], cornerRadii[ShadowCorners::BottomEnd]);
-  if (isRTL) {
-    std::swap(topStartRadius, topEndRadius);
-    std::swap(bottomStartRadius, bottomEndRadius);
-  }
 
   cornerRadius.TopLeft = DefaultOrOverride(defaultRadius, topStartRadius);
   cornerRadius.TopRight = DefaultOrOverride(defaultRadius, topEndRadius);
@@ -96,7 +89,7 @@ template <class T>
 void UpdatePadding(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
   node->m_padding[edge] = margin;
   winrt::Thickness thickness =
-      GetThickness(node->m_padding, element.FlowDirection() == winrt::FlowDirection::RightToLeft);
+      GetThickness(node->m_padding);
   element.Padding(thickness);
 }
 
@@ -104,7 +97,7 @@ template <class T>
 void SetBorderThickness(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
   node->m_border[edge] = margin;
   winrt::Thickness thickness =
-      GetThickness(node->m_border, element.FlowDirection() == winrt::FlowDirection::RightToLeft);
+      GetThickness(node->m_border);
   element.BorderThickness(thickness);
 }
 
@@ -142,7 +135,7 @@ UpdateCornerRadiusValueOnNode(ShadowNodeBase *node, ShadowCorners corner, const 
 template <class T>
 void UpdateCornerRadiusOnElement(ShadowNodeBase *node, const T &element) {
   winrt::CornerRadius cornerRadius =
-      GetCornerRadius(node->m_cornerRadius, element.FlowDirection() == winrt::FlowDirection::RightToLeft);
+      GetCornerRadius(node->m_cornerRadius);
   element.CornerRadius(cornerRadius);
 }
 

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -66,8 +66,7 @@ inline winrt::Windows::UI::Xaml::Thickness GetThickness(double thicknesses[Shado
   return thickness;
 }
 
-inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(
-    double cornerRadii[ShadowCorners::CountCorners]) {
+inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(double cornerRadii[ShadowCorners::CountCorners]) {
   winrt::Windows::UI::Xaml::CornerRadius cornerRadius;
   const double defaultRadius = std::max<double>(0, cornerRadii[ShadowCorners::AllCorners]);
   double topStartRadius = DefaultOrOverride(cornerRadii[ShadowCorners::TopLeft], cornerRadii[ShadowCorners::TopStart]);
@@ -88,16 +87,14 @@ inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(
 template <class T>
 void UpdatePadding(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
   node->m_padding[edge] = margin;
-  winrt::Thickness thickness =
-      GetThickness(node->m_padding);
+  winrt::Thickness thickness = GetThickness(node->m_padding);
   element.Padding(thickness);
 }
 
 template <class T>
 void SetBorderThickness(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
   node->m_border[edge] = margin;
-  winrt::Thickness thickness =
-      GetThickness(node->m_border);
+  winrt::Thickness thickness = GetThickness(node->m_border);
   element.BorderThickness(thickness);
 }
 
@@ -134,8 +131,7 @@ UpdateCornerRadiusValueOnNode(ShadowNodeBase *node, ShadowCorners corner, const 
 
 template <class T>
 void UpdateCornerRadiusOnElement(ShadowNodeBase *node, const T &element) {
-  winrt::CornerRadius cornerRadius =
-      GetCornerRadius(node->m_cornerRadius);
+  winrt::CornerRadius cornerRadius = GetCornerRadius(node->m_cornerRadius);
   element.CornerRadius(cornerRadius);
 }
 

--- a/vnext/src/RNTester/js/examples/RTL/RTLExample.windows.js
+++ b/vnext/src/RNTester/js/examples/RTL/RTLExample.windows.js
@@ -1,0 +1,749 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const React = require('react');
+
+const {
+  Alert,
+  Animated,
+  I18nManager,
+  Image,
+  PixelRatio,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableWithoutFeedback,
+  Switch,
+  View,
+  Button,
+} = require('react-native');
+
+type State = {
+  toggleStatus: any,
+  pan: Object,
+  linear: Object,
+  isRTL: boolean,
+  ...
+};
+
+type RTLToggleState = {isRTL: boolean, ...};
+
+type AnimationState = {
+  toggleStatus: any,
+  linear: Object,
+  windowWidth: number,
+  ...
+};
+
+const SCALE = PixelRatio.get();
+const IMAGE_DIMENSION = 100 * SCALE;
+const IMAGE_SIZE = [IMAGE_DIMENSION, IMAGE_DIMENSION];
+
+const IS_RTL = I18nManager.isRTL;
+
+function ListItem(props) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.column1}>
+        <Image source={props.imageSource} style={styles.icon} />
+      </View>
+      <View style={styles.column2}>
+        <View style={styles.textBox}>
+          <Text>Text Text Text</Text>
+        </View>
+      </View>
+      <View style={styles.column3}>
+        <View style={styles.smallButton}>
+          <Text style={styles.fontSizeSmall}>Button</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const TextAlignmentExample = withRTLState(({isRTL, setRTL, ...props}) => {
+  return (
+    <View>
+      <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+      <View style={directionStyle(isRTL)}>
+        <Text style={props.style}>
+          Left-to-Right language without text alignment.
+        </Text>
+        <Text style={props.style}>
+          {'\u0645\u0646 \u0627\u0644\u064A\u0645\u064A\u0646 ' +
+            '\u0625\u0644\u0649 \u0627\u0644\u064A\u0633\u0627\u0631 ' +
+            '\u0627\u0644\u0644\u063A\u0629 \u062F\u0648\u0646 ' +
+            '\u0645\u062D\u0627\u0630\u0627\u0629 \u0627\u0644\u0646\u0635'}
+        </Text>
+        <Text style={props.style}>
+          {'\u05DE\u05D9\u05DE\u05D9\u05DF \u05DC\u05E9\u05DE\u05D0\u05DC ' +
+            '\u05D4\u05E9\u05E4\u05D4 \u05D1\u05DC\u05D9 ' +
+            '\u05D9\u05D9\u05E9\u05D5\u05E8 \u05D8\u05E7\u05E1\u05D8'}
+        </Text>
+      </View>
+    </View>
+  );
+});
+
+const IconsExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+      <View style={[styles.flexDirectionRow, directionStyle(isRTL)]}>
+        <View>
+          <Image
+            source={require('../../assets/like.png')}
+            style={styles.image}
+          />
+          <Text style={styles.fontSizeExtraSmall}>
+            Without directional meaning
+          </Text>
+        </View>
+        <View style={styles.rightAlignStyle}>
+          <Image
+            source={require('../../assets/poke.png')}
+            style={[styles.image, styles.withRTLStyle]}
+          />
+          <Text style={styles.fontSizeExtraSmall}>
+            With directional meaning
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+function AnimationBlock(props) {
+  return (
+    <View style={styles.block}>
+      <TouchableWithoutFeedback onPress={props.onPress}>
+        <Animated.Image
+          style={[styles.img, props.imgStyle]}
+          source={require('../../assets/poke.png')}
+        />
+      </TouchableWithoutFeedback>
+    </View>
+  );
+}
+
+type RTLSwitcherComponentState = {|
+  isRTL: boolean,
+|};
+
+function withRTLState(Component) {
+  return class extends React.Component<*, RTLSwitcherComponentState> {
+    constructor(...args) {
+      super(...args);
+      this.state = {
+        isRTL: IS_RTL,
+      };
+    }
+
+    render() {
+      const setRTL = isRTL => this.setState({isRTL: isRTL});
+      return (
+        <Component isRTL={this.state.isRTL} setRTL={setRTL} {...this.props} />
+      );
+    }
+  };
+}
+
+const RTLToggler = ({isRTL, setRTL}) => {
+  if (Platform.OS === 'android') {
+    return <Text style={styles.rtlToggler}>{isRTL ? 'RTL' : 'LTR'}</Text>;
+  }
+
+  const toggleRTL = () => setRTL(!isRTL);
+  return (
+    <Button
+      onPress={toggleRTL}
+      title={isRTL ? 'RTL' : 'LTR'}
+      color="gray"
+      accessibilityLabel="Change layout direction"
+    />
+  );
+};
+
+class RTLToggleExample extends React.Component<any, RTLToggleState> {
+  constructor(props: Object) {
+    super(props);
+
+    this.state = {
+      isRTL: IS_RTL,
+    };
+  }
+
+  render() {
+    return (
+      <View>
+        <View style={styles.directionBox}>
+          <Text style={styles.directionText}>
+            {this.state.isRTL ? 'Right-to-Left' : 'Left-to-Right'}
+          </Text>
+        </View>
+        <View style={styles.flexDirectionRow}>
+          <Text style={styles.switchRowTextView}>forceRTL</Text>
+          <View style={styles.switchRowSwitchView}>
+            <Switch
+              onValueChange={this._onDirectionChange}
+              style={styles.rightAlignStyle}
+              value={this.state.isRTL}
+            />
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  _onDirectionChange = () => {
+    I18nManager.forceRTL(!this.state.isRTL);
+    this.setState({isRTL: !this.state.isRTL});
+    Alert.alert(
+      'Reload this page',
+      'Please reload this page to change the UI direction! ' +
+        'All examples in this app will be affected. ' +
+        'Check them out to see what they look like in RTL layout.',
+    );
+  };
+}
+
+const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+      <View style={[styles.list, directionStyle(isRTL)]}>
+        <ListItem imageSource={require('../../assets/like.png')} />
+        <ListItem imageSource={require('../../assets/poke.png')} />
+      </View>
+    </View>
+  );
+});
+
+const AnimationContainer = withRTLState(({isRTL, setRTL}) => {
+  return <AnimationExample isRTL={isRTL} setRTL={setRTL} />;
+});
+
+class AnimationExample extends React.Component<any, AnimationState> {
+  constructor(props: Object) {
+    super(props);
+
+    this.state = {
+      toggleStatus: {},
+      linear: new Animated.Value(0),
+      windowWidth: 0,
+    };
+  }
+
+  render() {
+    return (
+      <View>
+        <RTLToggler setRTL={this.props.setRTL} isRTL={this.props.isRTL} />
+        <View style={styles.view} onLayout={this._onLayout}>
+          <AnimationBlock
+            onPress={this._linearTap}
+            imgStyle={{
+              transform: [
+                {translateX: this.state.linear},
+                {scaleX: this.props.isRTL ? -1 : 1},
+              ],
+            }}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  _onLayout = (e: Object) => {
+    this.setState({
+      windowWidth: e.nativeEvent.layout.width,
+    });
+  };
+
+  _linearTap = (e: Object) => {
+    this.setState({
+      toggleStatus: {
+        ...this.state.toggleStatus,
+        [e]: !this.state.toggleStatus[e],
+      },
+    });
+    const offset = IMAGE_SIZE[0] / SCALE / 2 + 10;
+    const toMaxDistance =
+      (this.props.isRTL ? -1 : 1) * (this.state.windowWidth / 2 - offset);
+    Animated.timing(this.state.linear, {
+      toValue: this.state.toggleStatus[e] ? toMaxDistance : 0,
+      duration: 2000,
+      useNativeDriver: true,
+    }).start();
+  };
+}
+
+const PaddingExample = withRTLState(({isRTL, setRTL}) => {
+  const color = 'teal';
+
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>paddingStart: 50,</Text>
+      <Text>paddingEnd: 10</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <Text>The {color} is padding.</Text>
+      <View
+        style={{
+          backgroundColor: color,
+          paddingStart: 50,
+          paddingEnd: 10,
+          borderWidth: 1,
+          borderColor: color,
+          direction: isRTL ? 'rtl' : 'ltr',
+        }}>
+        <View
+          style={{
+            backgroundColor: 'white',
+            paddingTop: 5,
+            paddingBottom: 5,
+            borderLeftWidth: 1,
+            borderRightWidth: 1,
+            borderColor: 'gray',
+          }}>
+          <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const MarginExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>marginStart: 50,</Text>
+      <Text>marginEnd: 10</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <Text>The green is margin.</Text>
+      <View
+        style={{
+          backgroundColor: 'green',
+          borderWidth: 1,
+          borderColor: 'green',
+          direction: isRTL ? 'rtl' : 'ltr',
+        }}>
+        <View
+          style={{
+            backgroundColor: 'white',
+            paddingTop: 5,
+            paddingBottom: 5,
+            marginStart: 50,
+            marginEnd: 10,
+            borderLeftWidth: 1,
+            borderRightWidth: 1,
+            borderColor: 'gray',
+          }}>
+          <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const PositionExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>start: 50</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <Text>The orange is position.</Text>
+      <View
+        style={{
+          backgroundColor: 'orange',
+          borderWidth: 1,
+          borderColor: 'orange',
+          direction: isRTL ? 'rtl' : 'ltr',
+        }}>
+        <View
+          style={{
+            backgroundColor: 'white',
+            start: 50,
+            borderColor: 'gray',
+          }}>
+          <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+        </View>
+      </View>
+      <Text />
+      <Text style={styles.bold}>Styles</Text>
+      <Text>end: 50</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <Text>The orange is position.</Text>
+      <View
+        style={{
+          backgroundColor: 'orange',
+          borderWidth: 1,
+          borderColor: 'orange',
+          direction: isRTL ? 'rtl' : 'ltr',
+        }}>
+        <View
+          style={{
+            backgroundColor: 'white',
+            end: 50,
+            borderColor: 'gray',
+          }}>
+          <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const BorderWidthExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>borderStartWidth: 10,</Text>
+      <Text>borderEndWidth: 50</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <View style={directionStyle(isRTL)}>
+        <View
+          style={{
+            borderColor: 'black', // [Windows] specify a color
+            borderStartWidth: 10,
+            borderEndWidth: 50,
+          }}>
+          <View>
+            <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const BorderColorExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>borderStartColor: 'red',</Text>
+      <Text>borderEndColor: 'green',</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <View style={directionStyle(isRTL)}>
+        <View
+          style={{
+            borderStartColor: 'red',
+            borderEndColor: 'green',
+            borderLeftWidth: 20,
+            borderRightWidth: 20,
+            padding: 10,
+          }}>
+          <View>
+            <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const BorderRadiiExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>borderTopStartRadius: 10,</Text>
+      <Text>borderTopEndRadius: 20,</Text>
+      <Text>borderBottomStartRadius: 30,</Text>
+      <Text>borderBottomEndRadius: 40</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <View style={directionStyle(isRTL)}>
+        <View
+          style={{
+            borderColor: 'black',  // [Windows] specify a color
+            borderWidth: 10,
+            borderTopStartRadius: 10,
+            borderTopEndRadius: 20,
+            borderBottomStartRadius: 30,
+            borderBottomEndRadius: 40,
+            padding: 10,
+          }}>
+          <View>
+            <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const BorderExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <View>
+      <Text style={styles.bold}>Styles</Text>
+      <Text>borderStartColor: 'red',</Text>
+      <Text>borderEndColor: 'green',</Text>
+      <Text>borderStartWidth: 10,</Text>
+      <Text>borderEndWidth: 50,</Text>
+      <Text>borderTopStartRadius: 10,</Text>
+      <Text>borderTopEndRadius: 20,</Text>
+      <Text>borderBottomStartRadius: 30,</Text>
+      <Text>borderBottomEndRadius: 40</Text>
+      <Text />
+      <Text style={styles.bold}>Demo: </Text>
+      <View style={directionStyle(isRTL)}>
+        <View
+          style={{
+            borderStartColor: 'red',
+            borderEndColor: 'green',
+            borderStartWidth: 10,
+            borderEndWidth: 50,
+            borderTopStartRadius: 10,
+            borderTopEndRadius: 20,
+            borderBottomStartRadius: 30,
+            borderBottomEndRadius: 40,
+            padding: 10,
+          }}>
+          <View>
+            <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const directionStyle = isRTL =>
+  Platform.OS !== 'android' ? {direction: isRTL ? 'rtl' : 'ltr'} : null;    // [Windows] Don't explicitly check for iOS 
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#e9eaed',
+    paddingTop: 15,
+  },
+  directionBox: {
+    flex: 1,
+    backgroundColor: '#f8f8f8',
+    borderWidth: 0.5,
+    borderColor: 'black',
+    marginBottom: 15,
+  },
+  directionText: {
+    padding: 10,
+    fontSize: 16,
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+  switchRowTextView: {
+    flex: 1,
+    marginBottom: 5,
+    marginTop: 5,
+    textAlign: 'center',
+  },
+  switchRowSwitchView: {
+    flex: 3,
+  },
+  rightAlignStyle: {
+    right: 10,
+    position: 'absolute',
+  },
+  list: {
+    height: 120,
+    marginBottom: 5,
+    borderTopWidth: 0.5,
+    borderLeftWidth: 0.5,
+    borderRightWidth: 0.5,
+    borderColor: '#e5e5e5',
+  },
+  row: {
+    height: 60,
+    flexDirection: 'row',
+    borderBottomWidth: 0.5,
+    borderColor: '#e5e5e5',
+  },
+  column1: {
+    width: 60,
+  },
+  column2: {
+    flex: 2.5,
+    padding: 6,
+  },
+  column3: {
+    flex: 1.5,
+  },
+  icon: {
+    width: 48,
+    height: 48,
+    margin: 6,
+    borderWidth: 0.5,
+    borderColor: '#e5e5e5',
+  },
+  withRTLStyle: {
+    transform: [{scaleX: IS_RTL ? -1 : 1}],
+  },
+  image: {
+    left: 30,
+    width: 48,
+    height: 48,
+  },
+  img: {
+    width: IMAGE_SIZE[0] / SCALE,
+    height: IMAGE_SIZE[1] / SCALE,
+  },
+  view: {
+    flex: 1,
+  },
+  block: {
+    padding: 10,
+    alignItems: 'center',
+  },
+  smallButton: {
+    top: 18,
+    borderRadius: 5,
+    height: 24,
+    width: 64,
+    backgroundColor: '#e5e5e5',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fontSizeSmall: {
+    fontSize: 10,
+  },
+  fontSizeExtraSmall: {
+    fontSize: 8,
+  },
+  textAlignLeft: {
+    textAlign: 'left',
+  },
+  textAlignRight: {
+    textAlign: 'right',
+  },
+  textBox: {
+    width: 28,
+  },
+  flexDirectionRow: {
+    flexDirection: 'row',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  rtlToggler: {
+    color: 'gray',
+    padding: 8,
+    textAlign: 'center',
+    fontWeight: '500',
+  },
+});
+
+exports.title = 'RTLExample';
+exports.description = 'Examples to show how to apply components to RTL layout.';
+exports.examples = [
+  {
+    title: 'Current Layout Direction',
+    render: function(): React.Element<any> {
+      return <RTLToggleExample />;
+    },
+  },
+  {
+    title: 'A Simple List Item Layout',
+    render: function(): React.Element<any> {
+      return <SimpleListItemExample />;
+    },
+  },
+  {
+    title: 'Default Text Alignment',
+    description: ('In iOS, it depends on active language. ' +
+      'In Android, it depends on the text content.': string),
+    render: function(): React.Element<any> {
+      return <TextAlignmentExample style={styles.fontSizeSmall} />;
+    },
+  },
+  {
+    title: "Using textAlign: 'left'",
+    description: ('In iOS/Android, text alignment flips regardless of ' +
+      'languages or text content.': string),
+    render: function(): React.Element<any> {
+      return (
+        <TextAlignmentExample
+          style={[styles.fontSizeSmall, styles.textAlignLeft]}
+        />
+      );
+    },
+  },
+  {
+    title: "Using textAlign: 'right'",
+    description: ('In iOS/Android, text alignment flips regardless of ' +
+      'languages or text content.': string),
+    render: function(): React.Element<any> {
+      return (
+        <TextAlignmentExample
+          style={[styles.fontSizeSmall, styles.textAlignRight]}
+        />
+      );
+    },
+  },
+  {
+    title: 'Working With Icons',
+    render: function(): React.Element<any> {
+      return <IconsExample />;
+    },
+  },
+  {
+    title: 'Controlling Animation',
+    description: 'Animation direction according to layout',
+    render: function(): React.Element<any> {
+      return <AnimationContainer />;
+    },
+  },
+  {
+    title: 'Padding Start/End',
+    render: function(): React.Element<any> {
+      return <PaddingExample />;
+    },
+  },
+  {
+    title: 'Margin Start/End',
+    render: function(): React.Element<any> {
+      return <MarginExample />;
+    },
+  },
+  {
+    title: 'Position Start/End',
+    render: function(): React.Element<any> {
+      return <PositionExample />;
+    },
+  },
+  {
+    title: 'Border Width Start/End',
+    render: function(): React.Element<any> {
+      return <BorderWidthExample />;
+    },
+  },
+  {
+    title: 'Border Color Start/End',
+    render: function(): React.Element<any> {
+      return <BorderColorExample />;
+    },
+  },
+  {
+    title: 'Border Radii Start/End',
+    render: function(): React.Element<any> {
+      return <BorderRadiiExample />;
+    },
+  },
+  {
+    title: 'Border',
+    render: function(): React.Element<any> {
+      return <BorderExample />;
+    },
+  },
+];

--- a/vnext/src/RNTester/js/examples/RTL/RTLExample.windows.js
+++ b/vnext/src/RNTester/js/examples/RTL/RTLExample.windows.js
@@ -469,7 +469,7 @@ const BorderRadiiExample = withRTLState(({isRTL, setRTL}) => {
       <View style={directionStyle(isRTL)}>
         <View
           style={{
-            borderColor: 'black',  // [Windows] specify a color
+            borderColor: 'black', // [Windows] specify a color
             borderWidth: 10,
             borderTopStartRadius: 10,
             borderTopEndRadius: 20,
@@ -523,7 +523,7 @@ const BorderExample = withRTLState(({isRTL, setRTL}) => {
 });
 
 const directionStyle = isRTL =>
-  Platform.OS !== 'android' ? {direction: isRTL ? 'rtl' : 'ltr'} : null;    // [Windows] Don't explicitly check for iOS 
+  Platform.OS !== 'android' ? {direction: isRTL ? 'rtl' : 'ltr'} : null; // [Windows] Don't explicitly check for iOS
 
 const styles = StyleSheet.create({
   container: {

--- a/vnext/src/overrides.json
+++ b/vnext/src/overrides.json
@@ -816,6 +816,14 @@
     },
     {
       "type": "patch",
+      "file": "RNTester\\js\\examples\\RTL\\RTLExample.windows.js",
+      "baseFile": "RNTester\\js\\examples\\RTL\\RTLExample.js",
+      "baseVersion": "0.62.2",
+      "baseHash": "70a65dc896406e7ad971f0a9a770b7ea30f43b9e",
+      "issue": 678
+    },
+    {
+      "type": "patch",
       "file": "RNTester\\js\\examples\\ScrollView\\ScrollViewExample.windows.js",
       "baseFile": "RNTester\\js\\examples\\ScrollView\\ScrollViewExample.js",
       "baseVersion": "0.62.0-rc.3",

--- a/vnext/src/overrides.json
+++ b/vnext/src/overrides.json
@@ -820,7 +820,7 @@
       "baseFile": "RNTester\\js\\examples\\RTL\\RTLExample.js",
       "baseVersion": "0.62.2",
       "baseHash": "70a65dc896406e7ad971f0a9a770b7ea30f43b9e",
-      "issue": 678
+      "issue": 4678
     },
     {
       "type": "patch",


### PR DESCRIPTION
Fixes #4668 
Fixes #4646 
Fixes #4645 
Fixes #4499 

This change fixes multiple RTL related issues.  At the most basic level, our implementation of direction == 'rtl' was incorrect.  The problem here was that we would do two things:
1) Yoga would see the direction == 'rtl' and do layout in an RTL fashion.  This results in absolute positions in a "flipped" coordinate space, which we would then push into XAML.
2) We also mapped the direction property to the XAML FlowDirection property and set this on the backing XAML element.  When FlowDirection == RightToLeft, XAML flips everything.

These two cancel each other out in the most basic scenario (a container with children stacked horizontally), so you'd end up with an LTR layout instead of RTL.

Also, there was code in place which tried to manually flip certain properties (padding, margin, and border), but this code was also incorrect.  Most importantly, this code is unnecessary.  It appears there was just a misunderstanding about how XAML applies these properties - it already flips these properties when in an RTL mode.  I manually verified each of these properties is supposed to flip in RTL mode, and XAML does flip them in RTL.  Also, after debugging some scenarios, I realized this code was buggy.  It was manually querying the FlowDirection of the element having its properties set, which isn't reliable.  The FlowDirection property inherits down the tree, so at the time a XAML element is being created, it hasn't inherited the property yet.  But later, after it is in the tree, and XAML layout runs, it will.  So the result of querying for FlowDirection varies depending on when we update the properties.  Yikes!  This caused the symptoms we saw in bug #4499, where the corner radius was sometimes flipped, depending on exactly when the property was applied.

This change fixes both sets of issues by doing the following:
1) Do not let yoga layout anything in RTL.  Always run yoga layout in LTR.
2) Push FlowDirection into XAML, and let XAML be the one and only place we flip into RTL.  This will do the correct thing for flexbox layout, and also allow native controls like ComboBox to pick up the correct FlowDirection as yoga doesn't do the layout of these controls, XAML does.

As a result of the above, I was able to also remove the code that was trying to manually flip certain properties as it's totally unnecessary.

Also, I noticed the RTLExample RNTester page essentially does nothing on Windows, as the page only actually applies direction == 'rtl' if the Platform is iOS.  This is because rtl isn't supported on Android.  The fix was simple - just check for "not Android".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4683)