### PR TITLE
Fix Build Break Due To Missing Include in DevSupportManagerUwp

### DIFF
--- a/change/react-native-windows-2020-04-23-08-43-34-fix-build.json
+++ b/change/react-native-windows-2020-04-23-08-43-34-fix-build.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Missing Include in DevSupportManagerUwp",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-23T15:43:34.454Z"
+}

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
@@ -10,6 +10,7 @@
 #include <winrt/Windows.Networking.Sockets.h>
 #include <atomic>
 #include <functional>
+#include <future>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
This is causing failures in publish and locally. Possibly a silent merge conflict that got past CI?


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4693)