### PR TITLE
Fixed .Net Native crash for custom struct deserialization

### DIFF
--- a/change/react-native-windows-2020-04-23-11-35-11-MS_FixDotNetNative.json
+++ b/change/react-native-windows-2020-04-23-11-35-11-MS_FixDotNetNative.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed .Net Native crash for custom struct deserialization",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-23T18:35:11.572Z"
+}

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueReaderGenerator.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueReaderGenerator.cs
@@ -260,7 +260,7 @@ namespace Microsoft.ReactNative.Managed
       // }
 
       var fields =
-              from field in classType.GetFields(BindingFlags.Public | BindingFlags.Instance)
+        from field in classType.GetFields(BindingFlags.Public | BindingFlags.Instance)
         where !field.IsInitOnly
         select new { field.Name, Type = field.FieldType };
       var properties =


### PR DESCRIPTION
The investigation has shown that the .Net Native does not allow to have a parameter passed as 'ref' in a dynamically generated lambda. It was causing a crash when we generate ReadValue lambda to read custom class or struct where we pass the type by 'ref'.

In this PR we work around this issue by having a different delegate signature used for generating custom class reader. It uses return value instead of 'ref' parameter.

This change only affect the internal implementation of the Microsoft.ReactNative.SharedManaged code. There are no changes in user code required.

Closes #3838 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4696)