### PR TITLE
CLI behaves erratically when there is more than one SLN file

### DIFF
--- a/change/react-native-windows-2020-04-24-00-38-58-cli_sln.json
+++ b/change/react-native-windows-2020-04-24-00-38-58-cli_sln.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Detect when we have more than one SLN as it may not be obvious to the user. Add --sln option to CLI.",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T07:38:58.412Z"
+}

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -43,7 +43,7 @@ async function runWindows(config, args, options) {
     autolink.updateAutoLink(verbose);
   }
   if (options.build) {
-    const slnFile = build.getSolutionFile(options);
+    const slnFile = options.sln || build.getSolutionFile(options);
     if (!slnFile) {
       newError(
         'Visual Studio Solution file not found. Maybe run "react-native windows" first?',
@@ -129,6 +129,7 @@ runWindows({
  *    no-launch: Boolean - Do not launch the app after deployment
  *    no-build: Boolean - Do not build the solution
  *    no-deploy: Boolean - Do not deploy the app
+ *    sln: String - Solution file to build
  *    msBuildProps: String - Comma separated props to pass to msbuild, eg: prop1=value1,prop2=value2
  *    direct-debugging: Number - Enable direct debugging on specified port
  */
@@ -199,13 +200,18 @@ module.exports = {
       default: false,
     },
     {
+      command: '--sln [string]',
+      description: 'Solution file to build, e.g. windows\\myApp.sln',
+      default: undefined,
+    },
+    {
       command: '--msbuildprops [string]',
       description:
         'Comma separated props to pass to msbuild, eg: prop1=value1,prop2=value2',
     },
     {
       command: '--info',
-      description: 'Dump enviroment information',
+      description: 'Dump environment information',
       default: false,
     },
     {

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -15,6 +15,7 @@ const MSBuildTools = require('./msbuildtools');
 const Version = require('./version');
 const {commandWithProgress, newSpinner} = require('./commandWithProgress');
 const util = require('util');
+const chalk = require('chalk');
 const existsAsync = util.promisify(fs.exists);
 
 async function buildSolution(
@@ -112,7 +113,17 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
 }
 
 function getSolutionFile(options) {
-  return glob.sync(path.join(options.root, 'windows/*.sln'))[0];
+  const solutions = glob.sync(path.join(options.root, 'windows/*.sln'));
+  if (solutions.length == 0) {
+    return null;
+  } else if (solutions.length == 1) {
+    return solutions[0];
+  } else {
+    console.log(chalk.red('More than one solution file found:'));
+    console.log(chalk.bold(solutions.map(x => fs.realpathSync(x)).join('\n')));
+    console.log('Use --sln {slnFile} to specify which one to build');
+    return null;
+  }
 }
 
 function parseMsBuildProps(options) {


### PR DESCRIPTION
I ran into this trying to use the CLI on Playground which has 2 SLN (UWP and Win32)

Detect when we have more than one SLN as it may not be obvious to the user. 
Add --sln option to CLI.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4704)