### PR TITLE
Deploy from layout in Debug builds

### DIFF
--- a/change/react-native-windows-2020-04-24-01-46-24-cli_deployFromLayout.json
+++ b/change/react-native-windows-2020-04-24-01-46-24-cli_deployFromLayout.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Install from layout in Debug builds",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T08:46:24.668Z"
+}


### PR DESCRIPTION
In Debug builds we should just use appx layout registration instead of installing APPX. This speeds up the CLI loop for debug and lets you rebuild without having to reinstall the app.

Fixes: #4673 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4705)