### PR TITLE
Fix typo causing activity indicators to be sad and colorless

### DIFF
--- a/change/react-native-windows-2020-04-24-16-02-17-4700.json
+++ b/change/react-native-windows-2020-04-24-16-02-17-4700.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix typo causing activity indicators to be sad and colorless",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T23:02:17.176Z"
+}

--- a/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
@@ -45,7 +45,7 @@ bool ActivityIndicatorViewManager::UpdateProperty(
     else if (propertyValue.isNull())
       progressRing.ClearValue(winrt::ProgressRing::IsActiveProperty());
   } else {
-    return Super::UpdateProperty(nodeToUpdate, propertyName, propertyName);
+    return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }
   return true;
 }


### PR DESCRIPTION
Fixes #4700 

![image](https://user-images.githubusercontent.com/22989529/80263319-23d13500-8645-11ea-882d-f1720828f468.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4710)