### PR TITLE
Disable copying V8 dll to target output for UWP projects

### DIFF
--- a/change/react-native-windows-2020-04-24-19-55-04-master.json
+++ b/change/react-native-windows-2020-04-24-19-55-04-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Disable copying V8 dll to target output; we need a clearer way to distinguish uwp vs. win32 in the build system but this will do for now to unblock #4475",
+  "packageName": "react-native-windows",
+  "email": "tudorm@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-25T02:55:04.378Z"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -155,6 +155,9 @@
       </PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
+  <PropertyGroup>
+    <V8JSI_NODLLCOPY />
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />

--- a/vnext/Desktop/packages.config
+++ b/vnext/Desktop/packages.config
@@ -4,6 +4,6 @@
   <package id="ChakraCore.Debugger" version="0.0.0.43" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.2.5" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.2.7" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />
 </packages>

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -140,7 +140,9 @@
       <Project>{700A84FD-F92A-43F1-8D06-B0E0745DF9B5}</Project>
     </ProjectReference>
   </ItemGroup>
-  <ItemDefinitionGroup />
+  <PropertyGroup>
+    <V8JSI_NODLLCOPY />
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -28,7 +28,7 @@
     <HERMES_Package Condition="'$(HERMES_Package)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HERMES_Version)</HERMES_Package>
 
     <USE_V8 Condition="'$(USE_V8)' == '' AND '$(Platform)' != 'ARM' AND '$(Platform)' != 'ARM64'">true</USE_V8>
-    <V8_Version Condition="'$(V8_Version)' == ''">0.2.5</V8_Version>
+    <V8_Version Condition="'$(V8_Version)' == ''">0.2.7</V8_Version>
     <V8_Package Condition="'$(V8_Package)' == ''">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
 
     <!-- Enables React-Native-Windows ETW Provider : React-Native-Windows-Provider  -->
@@ -57,6 +57,9 @@
     <!-- This prop is used for JSI code that may be overridden in external JSI implementations -->
     <JSI_SourcePath Condition="'$(JSI_SourcePath)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_SourcePath>
     <JSI_SourcePath Condition="'$(USE_V8)' == 'true'">$(V8_Package)\build\native\include</JSI_SourcePath>
+
+    <!-- This disables copying the v8 DLL to outputs; it is re-enabled locally in win32 projects -->
+    <V8JSI_NODLLCOPY>true</V8JSI_NODLLCOPY>
   </PropertyGroup>
 
   <ImportGroup Label="Defaults">

--- a/vnext/ReactWindowsCore/packages.config
+++ b/vnext/ReactWindowsCore/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.1.6" targetFramework="native" Condition="$(USE_HERMES)' == 'true'" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.2.5" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.2.7" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
 </packages>


### PR DESCRIPTION
Disable copying V8 dll to target output for UWP projects; we need a clearer way to distinguish uwp vs. win32 in the build system but this will do for now to unblock #4475

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4712)