### PR TITLE
Start migrating WUX 👉 MUX

### DIFF
--- a/change/react-native-windows-2020-04-25-00-45-24-wuxmux.json
+++ b/change/react-native-windows-2020-04-25-00-45-24-wuxmux.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Start forking namespace and includes for WUX->MUX move",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-25T07:45:23.932Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -13,7 +13,7 @@
 #include "Windows.UI.Xaml.h"
 
 using namespace winrt;
-using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml; // C++/CX
 
 namespace winrt::Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -8,12 +8,11 @@
 
 #include <functional>
 #include "JSValue.h"
+#include "..\include\CppWinRTIncludes.h"
 
 #undef GetCurrentTime
-#include "Windows.UI.Xaml.h"
 
 using namespace winrt;
-using namespace Windows::UI::Xaml; // C++/CX
 
 namespace winrt::Microsoft::ReactNative {
 
@@ -122,7 +121,7 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
   ReactContextMock(ReactModuleBuilderMock *builderMock) noexcept;
 
   void DispatchEvent(
-      FrameworkElement const & /*view*/,
+      xaml::FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,
       JSValueArgWriter const & /*eventDataArgWriter*/) noexcept {}
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -7,8 +7,8 @@
 #include "future/future.h"
 
 #include <functional>
-#include "JSValue.h"
 #include "..\include\CppWinRTIncludes.h"
+#include "JSValue.h"
 
 #undef GetCurrentTime
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -7,7 +7,7 @@
 #include "future/future.h"
 
 #include <functional>
-#include "..\include\CppWinRTIncludes.h"
+#include "../include/CppWinRTIncludes.h"
 #include "JSValue.h"
 
 #undef GetCurrentTime

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
@@ -4,7 +4,7 @@
 #pragma once
 #ifndef MICROSOFT_REACTNATIVE_JSVALUEXAML
 #define MICROSOFT_REACTNATIVE_JSVALUEXAML
-
+#include "../include/CppWinRTIncludes.h"
 #include "JSValue.h"
 
 namespace winrt::Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
@@ -11,7 +11,7 @@ namespace winrt::Microsoft::ReactNative {
 
 #ifndef CXXUNITTESTS
 
-inline void ReadValue(JSValue const &jsValue, Windows::UI::Xaml::Media::Brush &value) noexcept {
+inline void ReadValue(JSValue const &jsValue, xaml::Media::Brush &value) noexcept {
   value = XamlHelper::BrushFrom([&jsValue](IJSValueWriter const &writer) noexcept { jsValue.WriteTo(writer); });
 }
 

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -186,10 +186,7 @@ folly::dynamic ABIViewManager::GetExportedCustomDirectEventTypeConstants() const
   return parent;
 }
 
-void ABIViewManager::AddView(
-    const xaml::DependencyObject &parent,
-    const xaml::DependencyObject &child,
-    int64_t index) {
+void ABIViewManager::AddView(const xaml::DependencyObject &parent, const xaml::DependencyObject &child, int64_t index) {
   if (m_viewManagerWithChildren) {
     m_viewManagerWithChildren.AddView(parent.as<xaml::FrameworkElement>(), child.as<xaml::UIElement>(), index);
   } else {

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -38,7 +38,7 @@ const char *ABIViewManager::GetName() const {
   return m_name.c_str();
 }
 
-winrt::Windows::UI::Xaml::DependencyObject ABIViewManager::CreateViewCore(int64_t) {
+xaml::DependencyObject ABIViewManager::CreateViewCore(int64_t) {
   auto view = m_viewManager.CreateView();
   return view;
 }
@@ -102,7 +102,7 @@ folly::dynamic ABIViewManager::GetNativeProps() const {
 
 void ABIViewManager::UpdateProperties(react::uwp::ShadowNodeBase *nodeToUpdate, const folly::dynamic &reactDiffMap) {
   if (m_viewManagerWithNativeProperties) {
-    auto view = nodeToUpdate->GetView().as<winrt::FrameworkElement>();
+    auto view = nodeToUpdate->GetView().as<xaml::FrameworkElement>();
 
     IJSValueReader propertyMapReader = winrt::make<DynamicReader>(reactDiffMap);
 
@@ -132,11 +132,11 @@ folly::dynamic ABIViewManager::GetCommands() const {
 }
 
 void ABIViewManager::DispatchCommand(
-    const winrt::Windows::UI::Xaml::DependencyObject &viewToUpdate,
+    const xaml::DependencyObject &viewToUpdate,
     const std::string &commandId,
     const folly::dynamic &commandArgs) {
   if (m_viewManagerWithCommands) {
-    auto view = viewToUpdate.as<winrt::FrameworkElement>();
+    auto view = viewToUpdate.as<xaml::FrameworkElement>();
 
     IJSValueReader argReader = winrt::make<DynamicReader>(commandArgs);
     m_viewManagerWithCommands.DispatchCommand(view, to_hstring(commandId), argReader);
@@ -187,39 +187,39 @@ folly::dynamic ABIViewManager::GetExportedCustomDirectEventTypeConstants() const
 }
 
 void ABIViewManager::AddView(
-    const winrt::Windows::UI::Xaml::DependencyObject &parent,
-    const winrt::Windows::UI::Xaml::DependencyObject &child,
+    const xaml::DependencyObject &parent,
+    const xaml::DependencyObject &child,
     int64_t index) {
   if (m_viewManagerWithChildren) {
-    m_viewManagerWithChildren.AddView(parent.as<winrt::FrameworkElement>(), child.as<winrt::UIElement>(), index);
+    m_viewManagerWithChildren.AddView(parent.as<xaml::FrameworkElement>(), child.as<xaml::UIElement>(), index);
   } else {
     Super::AddView(parent, child, index);
   }
 }
 
-void ABIViewManager::RemoveAllChildren(const winrt::Windows::UI::Xaml::DependencyObject &parent) {
+void ABIViewManager::RemoveAllChildren(const xaml::DependencyObject &parent) {
   if (m_viewManagerWithChildren) {
-    m_viewManagerWithChildren.RemoveAllChildren(parent.as<winrt::FrameworkElement>());
+    m_viewManagerWithChildren.RemoveAllChildren(parent.as<xaml::FrameworkElement>());
   } else {
     Super::RemoveAllChildren(parent);
   }
 }
 
-void ABIViewManager::RemoveChildAt(const winrt::Windows::UI::Xaml::DependencyObject &parent, int64_t index) {
+void ABIViewManager::RemoveChildAt(const xaml::DependencyObject &parent, int64_t index) {
   if (m_viewManagerWithChildren) {
-    m_viewManagerWithChildren.RemoveChildAt(parent.as<winrt::FrameworkElement>(), index);
+    m_viewManagerWithChildren.RemoveChildAt(parent.as<xaml::FrameworkElement>(), index);
   } else {
     Super::RemoveChildAt(parent, index);
   }
 }
 
 void ABIViewManager::ReplaceChild(
-    const winrt::Windows::UI::Xaml::DependencyObject &parent,
-    const winrt::Windows::UI::Xaml::DependencyObject &oldChild,
-    const winrt::Windows::UI::Xaml::DependencyObject &newChild) {
+    const xaml::DependencyObject &parent,
+    const xaml::DependencyObject &oldChild,
+    const xaml::DependencyObject &newChild) {
   if (m_viewManagerWithChildren) {
     m_viewManagerWithChildren.ReplaceChild(
-        parent.as<winrt::FrameworkElement>(), oldChild.as<winrt::UIElement>(), newChild.as<winrt::UIElement>());
+        parent.as<xaml::FrameworkElement>(), oldChild.as<xaml::UIElement>(), newChild.as<xaml::UIElement>());
   } else {
     Super::ReplaceChild(parent, oldChild, newChild);
   }

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -39,7 +39,7 @@ class ABIViewManager : public react::uwp::FrameworkElementViewManager {
   folly::dynamic GetCommands() const override;
 
   void DispatchCommand(
-      const winrt::Windows::UI::Xaml::DependencyObject &viewToUpdate,
+      const xaml::DependencyObject &viewToUpdate,
       const std::string &commandId,
       const folly::dynamic &commandArgs) override;
 
@@ -48,18 +48,18 @@ class ABIViewManager : public react::uwp::FrameworkElementViewManager {
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
 
   void AddView(
-      const winrt::Windows::UI::Xaml::DependencyObject &parent,
-      const winrt::Windows::UI::Xaml::DependencyObject &child,
+      const xaml::DependencyObject &parent,
+      const xaml::DependencyObject &child,
       int64_t index) override;
-  void RemoveAllChildren(const winrt::Windows::UI::Xaml::DependencyObject &parent) override;
-  void RemoveChildAt(const winrt::Windows::UI::Xaml::DependencyObject &parent, int64_t index) override;
+  void RemoveAllChildren(const xaml::DependencyObject &parent) override;
+  void RemoveChildAt(const xaml::DependencyObject &parent, int64_t index) override;
   void ReplaceChild(
-      const winrt::Windows::UI::Xaml::DependencyObject &parent,
-      const winrt::Windows::UI::Xaml::DependencyObject &oldChild,
-      const winrt::Windows::UI::Xaml::DependencyObject &newChild) override;
+      const xaml::DependencyObject &parent,
+      const xaml::DependencyObject &oldChild,
+      const xaml::DependencyObject &newChild) override;
 
  protected:
-  winrt::Windows::UI::Xaml::DependencyObject CreateViewCore(int64_t) override;
+  xaml::DependencyObject CreateViewCore(int64_t) override;
 
   std::string m_name;
   ReactNative::IViewManager m_viewManager;

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -47,10 +47,7 @@ class ABIViewManager : public react::uwp::FrameworkElementViewManager {
 
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
 
-  void AddView(
-      const xaml::DependencyObject &parent,
-      const xaml::DependencyObject &child,
-      int64_t index) override;
+  void AddView(const xaml::DependencyObject &parent, const xaml::DependencyObject &child, int64_t index) override;
   void RemoveAllChildren(const xaml::DependencyObject &parent) override;
   void RemoveChildAt(const xaml::DependencyObject &parent, int64_t index) override;
   void ReplaceChild(

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -10,7 +10,7 @@ namespace winrt::Microsoft::ReactNative {
 ReactContext::ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context{std::move(context)} {}
 
 void ReactContext::DispatchEvent(
-    winrt::Windows::UI::Xaml::FrameworkElement const &view,
+    xaml::FrameworkElement const &view,
     hstring const &eventName,
     JSValueArgWriter const &eventDataArgWriter) noexcept {
   folly::dynamic eventData; // default to NULLT

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -13,7 +13,7 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
 
  public: // IReactContext
   void DispatchEvent(
-      winrt::Windows::UI::Xaml::FrameworkElement const &view,
+      xaml::FrameworkElement const &view,
       hstring const &eventName,
       JSValueArgWriter const &eventDataArgWriter) noexcept;
   void CallJSFunction(

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -3,11 +3,13 @@
 
 import "IJSValueWriter.idl";
 
+#include "../Include/NamespaceRedirect.h"
+
 namespace Microsoft.ReactNative {
 
   [webhosthidden]
   interface IReactContext {
-    void DispatchEvent(Windows.UI.Xaml.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
+    void DispatchEvent(WUXMUX_TYPE(FrameworkElement) view, String eventName, JSValueArgWriter eventDataArgWriter);
     void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
   }

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -9,7 +9,7 @@ namespace Microsoft.ReactNative {
 
   [webhosthidden]
   interface IReactContext {
-    void DispatchEvent(WUXMUX_TYPE(FrameworkElement) view, String eventName, JSValueArgWriter eventDataArgWriter);
+    void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
     void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
   }

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -4,6 +4,8 @@
 import "IReactModuleBuilder.idl";
 import "IReactContext.idl";
 
+#include "../Include/NamespaceRedirect.h"
+
 namespace Microsoft.ReactNative
 {
   [webhosthidden]
@@ -22,7 +24,7 @@ namespace Microsoft.ReactNative
   {
     String Name { get; };
 
-    Windows.UI.Xaml.FrameworkElement CreateView();
+    WUXMUX_TYPE(FrameworkElement) CreateView();
   }
 
   [webhosthidden]
@@ -42,7 +44,7 @@ namespace Microsoft.ReactNative
   {
     IMapView<String, ViewManagerPropertyType> NativeProps { get; };
 
-    void UpdateProperties(Windows.UI.Xaml.FrameworkElement view, IJSValueReader propertyMapReader);
+    void UpdateProperties(WUXMUX_TYPE(FrameworkElement) view, IJSValueReader propertyMapReader);
   }
 
   [webhosthidden]
@@ -50,7 +52,7 @@ namespace Microsoft.ReactNative
   {
     IVectorView<String> Commands { get; };
 
-    void DispatchCommand(Windows.UI.Xaml.FrameworkElement view, String commandId, IJSValueReader commandArgsReader);
+    void DispatchCommand(WUXMUX_TYPE(FrameworkElement) view, String commandId, IJSValueReader commandArgsReader);
   }
 
   [webhosthidden]
@@ -64,12 +66,12 @@ namespace Microsoft.ReactNative
   [webhosthidden]
   interface IViewManagerWithChildren
   {
-    void AddView(Windows.UI.Xaml.FrameworkElement parent, Windows.UI.Xaml.UIElement child, Int64 index);
+    void AddView(WUXMUX_TYPE(FrameworkElement) parent, WUXMUX_TYPE(UIElement) child, Int64 index);
 
-    void RemoveAllChildren(Windows.UI.Xaml.FrameworkElement parent);
+    void RemoveAllChildren(WUXMUX_TYPE(FrameworkElement) parent);
 
-    void RemoveChildAt(Windows.UI.Xaml.FrameworkElement parent, Int64 index);
+    void RemoveChildAt(WUXMUX_TYPE(FrameworkElement) parent, Int64 index);
 
-    void ReplaceChild(Windows.UI.Xaml.FrameworkElement parent, Windows.UI.Xaml.UIElement oldChild, Windows.UI.Xaml.UIElement newChild);
+    void ReplaceChild(WUXMUX_TYPE(FrameworkElement) parent, WUXMUX_TYPE(UIElement) oldChild, WUXMUX_TYPE(UIElement) newChild);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -24,7 +24,7 @@ namespace Microsoft.ReactNative
   {
     String Name { get; };
 
-    WUXMUX_TYPE(FrameworkElement) CreateView();
+    XAML_NAMESPACE.FrameworkElement CreateView();
   }
 
   [webhosthidden]
@@ -44,7 +44,7 @@ namespace Microsoft.ReactNative
   {
     IMapView<String, ViewManagerPropertyType> NativeProps { get; };
 
-    void UpdateProperties(WUXMUX_TYPE(FrameworkElement) view, IJSValueReader propertyMapReader);
+    void UpdateProperties(XAML_NAMESPACE.FrameworkElement view, IJSValueReader propertyMapReader);
   }
 
   [webhosthidden]
@@ -52,7 +52,7 @@ namespace Microsoft.ReactNative
   {
     IVectorView<String> Commands { get; };
 
-    void DispatchCommand(WUXMUX_TYPE(FrameworkElement) view, String commandId, IJSValueReader commandArgsReader);
+    void DispatchCommand(XAML_NAMESPACE.FrameworkElement view, String commandId, IJSValueReader commandArgsReader);
   }
 
   [webhosthidden]
@@ -66,12 +66,12 @@ namespace Microsoft.ReactNative
   [webhosthidden]
   interface IViewManagerWithChildren
   {
-    void AddView(WUXMUX_TYPE(FrameworkElement) parent, WUXMUX_TYPE(UIElement) child, Int64 index);
+    void AddView(XAML_NAMESPACE.FrameworkElement parent, XAML_NAMESPACE.UIElement child, Int64 index);
 
-    void RemoveAllChildren(WUXMUX_TYPE(FrameworkElement) parent);
+    void RemoveAllChildren(XAML_NAMESPACE.FrameworkElement parent);
 
-    void RemoveChildAt(WUXMUX_TYPE(FrameworkElement) parent, Int64 index);
+    void RemoveChildAt(XAML_NAMESPACE.FrameworkElement parent, Int64 index);
 
-    void ReplaceChild(WUXMUX_TYPE(FrameworkElement) parent, WUXMUX_TYPE(UIElement) oldChild, WUXMUX_TYPE(UIElement) newChild);
+    void ReplaceChild(XAML_NAMESPACE.FrameworkElement parent, XAML_NAMESPACE.UIElement oldChild, XAML_NAMESPACE.UIElement newChild);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppStateData.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateData.cpp
@@ -7,7 +7,7 @@
 using namespace winrt;
 using namespace Windows::Foundation;
 using namespace Windows::ApplicationModel;
-using namespace Windows::UI::Xaml;
+using namespace xaml;
 
 namespace react::uwp {
 

--- a/vnext/Microsoft.ReactNative/Modules/AppStateData.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateData.h
@@ -6,7 +6,6 @@
 #include <Modules/AppStateModule.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.h>
 #include "ReactHost/React.h"
 #include "activeObject/activeObject.h"
 
@@ -30,8 +29,8 @@ struct AppStateData : Mso::ActiveObject<> {
   std::mutex m_stateMutex;
   char const *m_lastState{nullptr};
   Mso::CntPtr<Mso::React::IReactContext> m_reactContext;
-  winrt::Windows::UI::Xaml::Application::EnteredBackground_revoker m_enteredBackgroundRevoker;
-  winrt::Windows::UI::Xaml::Application::LeavingBackground_revoker m_leavingBackgroundRevoker;
+  xaml::Application::EnteredBackground_revoker m_enteredBackgroundRevoker;
+  xaml::Application::LeavingBackground_revoker m_leavingBackgroundRevoker;
 };
 
 // It is a temporary class that we need to keep until we remove ReactUWP

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -9,7 +9,6 @@
 
 #include <winrt/Windows.ApplicationModel.Activation.h>
 #include <winrt/Windows.UI.Core.h>
-#include <winrt/Windows.UI.Xaml.Navigation.h>
 
 using namespace winrt;
 using namespace Windows::ApplicationModel;
@@ -17,9 +16,9 @@ using namespace Windows::ApplicationModel::Activation;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 using namespace Windows::UI::Core;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Navigation;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Navigation;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -38,7 +38,7 @@ struct ReactApplication : ReactApplicationT<ReactApplication> {
   void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
   void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &e);
   void OnSuspending(IInspectable const &, Windows::ApplicationModel::SuspendingEventArgs const &);
-  void OnNavigationFailed(IInspectable const &, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs const &);
+  void OnNavigationFailed(IInspectable const &, xaml::Navigation::NavigationFailedEventArgs const &);
 
  protected:
   virtual ReactApplicationDelegate __stdcall CreateReactApplicationDelegate();

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import "ReactNativeHost.idl";
+#include "../include/NamespaceRedirect.h"
 
 namespace Microsoft.ReactNative {
 
   [webhosthidden]
   [default_interface]
-  unsealed runtimeclass ReactApplication : Windows.UI.Xaml.Application {
+  unsealed runtimeclass ReactApplication : WUXMUX_TYPE(Application) {
     ReactApplication();
 
     ReactInstanceSettings InstanceSettings { get; set; };

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -8,7 +8,7 @@ namespace Microsoft.ReactNative {
 
   [webhosthidden]
   [default_interface]
-  unsealed runtimeclass ReactApplication : WUXMUX_TYPE(Application) {
+  unsealed runtimeclass ReactApplication : XAML_NAMESPACE.Application {
     ReactApplication();
 
     ReactInstanceSettings InstanceSettings { get; set; };

--- a/vnext/Microsoft.ReactNative/ReactApplicationDelegate.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplicationDelegate.cpp
@@ -14,7 +14,7 @@
 
 using namespace winrt;
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml;
+using namespace xaml;
 using namespace Windows::ApplicationModel;
 using namespace Windows::ApplicationModel::Activation;
 

--- a/vnext/Microsoft.ReactNative/ReactApplicationDelegate.h
+++ b/vnext/Microsoft.ReactNative/ReactApplicationDelegate.h
@@ -9,10 +9,10 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 struct ReactApplicationDelegate : ReactApplicationDelegateT<ReactApplicationDelegate> {
   ReactApplicationDelegate() = default;
-  ReactApplicationDelegate(Windows::UI::Xaml::Application const &application) noexcept;
+  ReactApplicationDelegate(xaml::Application const &application) noexcept;
 
   void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &args) noexcept;
-  Windows::UI::Xaml::UIElement OnCreate(hstring const &args) noexcept;
+  xaml::UIElement OnCreate(hstring const &args) noexcept;
 
  private:
   void OnResuming(IInspectable const &sender, IInspectable const &args) noexcept;
@@ -25,7 +25,7 @@ struct ReactApplicationDelegate : ReactApplicationDelegateT<ReactApplicationDele
       Windows::ApplicationModel::EnteredBackgroundEventArgs const &args) noexcept;
 
  private:
-  Windows::UI::Xaml::Application m_application{nullptr};
+  xaml::Application m_application{nullptr};
   IReactApplication m_reactApplication{nullptr};
   winrt::com_ptr<ReactRootView> m_reactRootView{nullptr};
 };

--- a/vnext/Microsoft.ReactNative/ReactApplicationDelegate.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplicationDelegate.idl
@@ -9,8 +9,8 @@ namespace Microsoft.ReactNative {
   [webhosthidden]
   unsealed runtimeclass ReactApplicationDelegate {
     ReactApplicationDelegate();
-    ReactApplicationDelegate(WUXMUX_TYPE(Application) application);
+    ReactApplicationDelegate(XAML_NAMESPACE.Application application);
     void OnActivated(Windows.ApplicationModel.Activation.IActivatedEventArgs args);
-    WUXMUX_TYPE(UIElement) OnCreate(String args);
+    XAML_NAMESPACE.UIElement OnCreate(String args);
   }
 }

--- a/vnext/Microsoft.ReactNative/ReactApplicationDelegate.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplicationDelegate.idl
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 import "ReactApplication.idl";
+#include "../include/NamespaceRedirect.h"
 
 namespace Microsoft.ReactNative {
 
   [webhosthidden]
   unsealed runtimeclass ReactApplicationDelegate {
     ReactApplicationDelegate();
-    ReactApplicationDelegate(Windows.UI.Xaml.Application application);
+    ReactApplicationDelegate(WUXMUX_TYPE(Application) application);
     void OnActivated(Windows.ApplicationModel.Activation.IActivatedEventArgs args);
-    Windows.UI.Xaml.UIElement OnCreate(String args);
+    WUXMUX_TYPE(UIElement) OnCreate(String args);
   }
 }

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -9,8 +9,8 @@
 
 using namespace winrt;
 using namespace Windows::Foundation::Collections;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
+using namespace xaml;
+using namespace xaml::Controls;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -3,12 +3,13 @@
 
 import "IJSValueWriter.idl";
 import "ReactNativeHost.idl";
+#include "../include/NamespaceRedirect.h"
 
 namespace Microsoft.ReactNative {
 
   [default_interface]
   [webhosthidden]
-  runtimeclass ReactRootView : Windows.UI.Xaml.Controls.Grid {
+  runtimeclass ReactRootView : WUXMUX_TYPE(Controls.Grid) {
     ReactRootView();
 
     ReactNativeHost ReactNativeHost { get; set; };

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -9,7 +9,7 @@ namespace Microsoft.ReactNative {
 
   [default_interface]
   [webhosthidden]
-  runtimeclass ReactRootView : WUXMUX_TYPE(Controls.Grid) {
+  runtimeclass ReactRootView : XAML_NAMESPACE.Controls.Grid {
     ReactRootView();
 
     ReactNativeHost ReactNativeHost { get; set; };

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "RedBox.h"
+#include <boost/algorithm/string.hpp>
 #include <functional/functor.h>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.Web.Http.h>
-#include "CppWinRTIncludes.h"
-#include <boost/algorithm/string.hpp>
 #include <regex>
+#include "CppWinRTIncludes.h"
 #include "Unicode.h"
 
 using namespace winrt::Windows::Foundation;

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -12,7 +12,6 @@
 #include <regex>
 #include "Unicode.h"
 
-namespace xaml = xaml;
 using namespace winrt::Windows::Foundation;
 
 namespace Mso::React {

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -6,18 +6,13 @@
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Core.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Documents.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.Web.Http.h>
-
+#include "CppWinRTIncludes.h"
 #include <boost/algorithm/string.hpp>
 #include <regex>
 #include "Unicode.h"
 
-namespace xaml = winrt::Windows::UI::Xaml;
+namespace xaml = xaml;
 using namespace winrt::Windows::Foundation;
 
 namespace Mso::React {

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -21,12 +21,6 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Markup.h>
-#include <winrt/Windows.UI.Xaml.Media.Media3D.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 #include <ReactHost/React.h>
 #include <ReactHost/React_Win.h>
@@ -104,7 +98,7 @@ std::string ReactRootControl::JSComponentName() const noexcept {
 
 int64_t ReactRootControl::GetActualHeight() const noexcept {
   if (auto xamlRootView = m_weakXamlRootView.get()) {
-    if (auto element = xamlRootView.as<winrt::FrameworkElement>()) {
+    if (auto element = xamlRootView.as<xaml::FrameworkElement>()) {
       return static_cast<int64_t>(element.ActualHeight());
     }
   }
@@ -114,7 +108,7 @@ int64_t ReactRootControl::GetActualHeight() const noexcept {
 
 int64_t ReactRootControl::GetActualWidth() const noexcept {
   if (auto xamlRootView = m_weakXamlRootView.get()) {
-    if (auto element = xamlRootView.as<winrt::FrameworkElement>()) {
+    if (auto element = xamlRootView.as<xaml::FrameworkElement>()) {
       return static_cast<int64_t>(element.ActualWidth());
     }
   }
@@ -138,9 +132,9 @@ void ReactRootControl::blur(XamlView const &xamlView) noexcept {
   EnsureFocusSafeHarbor();
   if (m_focusSafeHarbor) {
     m_focusSafeHarbor.IsTabStop(true);
-    winrt::FocusManager::TryFocusAsync(m_focusSafeHarbor, winrt::FocusState::Pointer);
+    xaml::Input::FocusManager::TryFocusAsync(m_focusSafeHarbor, winrt::FocusState::Pointer);
   } else
-    winrt::FocusManager::TryFocusAsync(xamlView, winrt::FocusState::Pointer);
+    xaml::Input::FocusManager::TryFocusAsync(xamlView, winrt::FocusState::Pointer);
 }
 
 void ReactRootControl::InitRootView(
@@ -292,9 +286,9 @@ void ReactRootControl::ShowInstanceWaiting(Mso::React::IReactInstance & /*reactI
     if (m_waitingTextBlock == nullptr) {
       m_waitingTextBlock = winrt::TextBlock();
       m_greenBoxGrid = winrt::Grid{};
-      m_greenBoxGrid.Background(winrt::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
+      m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
       m_greenBoxGrid.Children().Append(m_waitingTextBlock);
-      m_greenBoxGrid.VerticalAlignment(winrt::Windows::UI::Xaml::VerticalAlignment::Center);
+      m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Center);
     }
 
     // Add box grid to root view
@@ -306,9 +300,9 @@ void ReactRootControl::ShowInstanceWaiting(Mso::React::IReactInstance & /*reactI
 
     // Format TextBlock
     m_waitingTextBlock.TextAlignment(winrt::TextAlignment::Center);
-    m_waitingTextBlock.TextWrapping(winrt::TextWrapping::Wrap);
+    m_waitingTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
     m_waitingTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
-    m_waitingTextBlock.Foreground(winrt::SolidColorBrush(winrt::Colors::White()));
+    m_waitingTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
     winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
     m_waitingTextBlock.Margin(margin);
   }
@@ -328,9 +322,9 @@ void ReactRootControl::ShowInstanceLoading(Mso::React::IReactInstance & /*reactI
     if (m_waitingTextBlock == nullptr) {
       m_waitingTextBlock = winrt::TextBlock();
       m_greenBoxGrid = winrt::Grid{};
-      m_greenBoxGrid.Background(winrt::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
+      m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
       m_greenBoxGrid.Children().Append(m_waitingTextBlock);
-      m_greenBoxGrid.VerticalAlignment(winrt::Windows::UI::Xaml::VerticalAlignment::Center);
+      m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Center);
     }
 
     // Add box grid to root view
@@ -342,9 +336,9 @@ void ReactRootControl::ShowInstanceLoading(Mso::React::IReactInstance & /*reactI
 
     // Format TextBlock
     m_waitingTextBlock.TextAlignment(winrt::TextAlignment::Center);
-    m_waitingTextBlock.TextWrapping(winrt::TextWrapping::Wrap);
+    m_waitingTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
     m_waitingTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
-    m_waitingTextBlock.Foreground(winrt::SolidColorBrush(winrt::Colors::White()));
+    m_waitingTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
     winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
     m_waitingTextBlock.Margin(margin);
   }
@@ -365,9 +359,9 @@ void ReactRootControl::PrepareXamlRootView(XamlView const &rootView) noexcept {
     // Xaml's default projection in 3D is orthographic (all lines are parallel)
     // However React Native's default projection is a one-point perspective.
     // Set a default perspective projection on the main control to mimic this.
-    auto perspectiveTransform3D = winrt::Windows::UI::Xaml::Media::Media3D::PerspectiveTransform3D();
+    auto perspectiveTransform3D = xaml::Media::Media3D::PerspectiveTransform3D();
     perspectiveTransform3D.Depth(850);
-    winrt::Windows::UI::Xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
+    xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
     newRootView.Transform3D(t3d);
     children.Append(newRootView);
     m_weakXamlRootView = newRootView.try_as<XamlView>();
@@ -384,7 +378,7 @@ void ReactRootControl::EnsureFocusSafeHarbor() noexcept {
     auto panel = rootView.try_as<winrt::Panel>();
     VerifyElseCrash(panel.Children().Size() == 1);
 
-    m_focusSafeHarbor = winrt::ContentControl{};
+    m_focusSafeHarbor = xaml::Controls::ContentControl{};
     m_focusSafeHarbor.Width(0.0);
     m_focusSafeHarbor.IsTabStop(false);
     panel.Children().InsertAt(0, m_focusSafeHarbor);
@@ -404,9 +398,9 @@ void ReactRootControl::InitializeDeveloperMenu() noexcept {
   m_coreDispatcherAKARevoker = coreWindow.Dispatcher().AcceleratorKeyActivated(
       winrt::auto_revoke, [this](const auto & /*sender*/, const winrt::AcceleratorKeyEventArgs &args) {
         if ((args.VirtualKey() == winrt::Windows::System::VirtualKey::D) &&
-            KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow::GetForCurrentThread(), winrt::VirtualKey::Shift) &&
+            KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
             KeyboardHelper::IsModifiedKeyPressed(
-                winrt::CoreWindow::GetForCurrentThread(), winrt::VirtualKey::Control)) {
+                winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Control)) {
           if (!IsDeveloperMenuShowing()) {
             ShowDeveloperMenu();
           }
@@ -629,18 +623,18 @@ void ReactRootControl::AttachBackHandlers(XamlView const &rootView) noexcept {
   // In addition to handling the BackRequested event, UWP suggests that we listen for other user inputs that should
   // trigger back navigation that don't fire that event:
   // https://docs.microsoft.com/en-us/windows/uwp/design/basics/navigation-history-and-backwards-navigation
-  auto rootElement(rootView.try_as<winrt::UIElement>());
+  auto rootElement(rootView.try_as<xaml::UIElement>());
   if (rootElement == nullptr) {
     assert(false);
     return;
   }
 
   // Handle keyboard "back" button press
-  winrt::KeyboardAccelerator goBack{};
-  goBack.Key(winrt::VirtualKey::GoBack);
+  xaml::Input::KeyboardAccelerator goBack{};
+  goBack.Key(winrt::Windows::System::VirtualKey::GoBack);
   goBack.Invoked(
       [weakThis](
-          winrt::KeyboardAccelerator const & /*sender*/, winrt::KeyboardAcceleratorInvokedEventArgs const &args) {
+          xaml::Input::KeyboardAccelerator const & /*sender*/, xaml::Input::KeyboardAcceleratorInvokedEventArgs const &args) {
         if (auto self = weakThis.lock()) {
           args.Handled(self->OnBackRequested());
         }
@@ -648,26 +642,26 @@ void ReactRootControl::AttachBackHandlers(XamlView const &rootView) noexcept {
   rootElement.KeyboardAccelerators().Append(goBack);
 
   // Handle Alt+Left keyboard shortcut
-  winrt::KeyboardAccelerator altLeft{};
-  altLeft.Key(winrt::VirtualKey::Left);
+  xaml::Input::KeyboardAccelerator altLeft{};
+  altLeft.Key(winrt::Windows::System::VirtualKey::Left);
   altLeft.Invoked(
       [weakThis](
-          winrt::KeyboardAccelerator const & /*sender*/, winrt::KeyboardAcceleratorInvokedEventArgs const &args) {
+          xaml::Input::KeyboardAccelerator const & /*sender*/, xaml::Input::KeyboardAcceleratorInvokedEventArgs const &args) {
         if (auto self = weakThis.lock()) {
           args.Handled(self->OnBackRequested());
         }
       });
   rootElement.KeyboardAccelerators().Append(altLeft);
-  altLeft.Modifiers(winrt::VirtualKeyModifiers::Menu);
+  altLeft.Modifiers(winrt::Windows::System::VirtualKeyModifiers::Menu);
 
   // Hide keyboard accelerator tooltips
-  rootElement.KeyboardAcceleratorPlacementMode(winrt::KeyboardAcceleratorPlacementMode::Hidden);
+  rootElement.KeyboardAcceleratorPlacementMode(xaml::Input::KeyboardAcceleratorPlacementMode::Hidden);
 }
 
 void ReactRootControl::RemoveBackHandlers() noexcept {
   m_backRequestedRevoker.revoke();
   if (auto rootView = m_weakRootView.get()) {
-    if (auto element = rootView.try_as<winrt::UIElement>()) {
+    if (auto element = rootView.try_as<xaml::UIElement>()) {
       element.KeyboardAccelerators().Clear();
     }
   }

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -398,7 +398,8 @@ void ReactRootControl::InitializeDeveloperMenu() noexcept {
   m_coreDispatcherAKARevoker = coreWindow.Dispatcher().AcceleratorKeyActivated(
       winrt::auto_revoke, [this](const auto & /*sender*/, const winrt::AcceleratorKeyEventArgs &args) {
         if ((args.VirtualKey() == winrt::Windows::System::VirtualKey::D) &&
-            KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
+            KeyboardHelper::IsModifiedKeyPressed(
+                winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
             KeyboardHelper::IsModifiedKeyPressed(
                 winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Control)) {
           if (!IsDeveloperMenuShowing()) {
@@ -632,25 +633,25 @@ void ReactRootControl::AttachBackHandlers(XamlView const &rootView) noexcept {
   // Handle keyboard "back" button press
   xaml::Input::KeyboardAccelerator goBack{};
   goBack.Key(winrt::Windows::System::VirtualKey::GoBack);
-  goBack.Invoked(
-      [weakThis](
-          xaml::Input::KeyboardAccelerator const & /*sender*/, xaml::Input::KeyboardAcceleratorInvokedEventArgs const &args) {
-        if (auto self = weakThis.lock()) {
-          args.Handled(self->OnBackRequested());
-        }
-      });
+  goBack.Invoked([weakThis](
+                     xaml::Input::KeyboardAccelerator const & /*sender*/,
+                     xaml::Input::KeyboardAcceleratorInvokedEventArgs const &args) {
+    if (auto self = weakThis.lock()) {
+      args.Handled(self->OnBackRequested());
+    }
+  });
   rootElement.KeyboardAccelerators().Append(goBack);
 
   // Handle Alt+Left keyboard shortcut
   xaml::Input::KeyboardAccelerator altLeft{};
   altLeft.Key(winrt::Windows::System::VirtualKey::Left);
-  altLeft.Invoked(
-      [weakThis](
-          xaml::Input::KeyboardAccelerator const & /*sender*/, xaml::Input::KeyboardAcceleratorInvokedEventArgs const &args) {
-        if (auto self = weakThis.lock()) {
-          args.Handled(self->OnBackRequested());
-        }
-      });
+  altLeft.Invoked([weakThis](
+                      xaml::Input::KeyboardAccelerator const & /*sender*/,
+                      xaml::Input::KeyboardAcceleratorInvokedEventArgs const &args) {
+    if (auto self = weakThis.lock()) {
+      args.Handled(self->OnBackRequested());
+    }
+  });
   rootElement.KeyboardAccelerators().Append(altLeft);
   altLeft.Modifiers(winrt::Windows::System::VirtualKeyModifiers::Menu);
 

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
@@ -6,7 +6,6 @@
 
 #include <IReactInstance.h>
 #include <object/unknownObject.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 #include "IXamlRootView.h"
 #include "ReactHost/React.h"
 #include "SIPEventHandler.h"
@@ -16,11 +15,11 @@
 namespace winrt {
 using namespace Windows::UI;
 using namespace Windows::UI::Core;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Input;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Input;
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react::uwp {
@@ -120,8 +119,8 @@ struct ReactRootControl final : std::enable_shared_from_this<ReactRootControl>, 
   winrt::weak_ref<XamlView> m_weakRootView{nullptr};
   winrt::weak_ref<XamlView> m_weakXamlRootView{nullptr};
 
-  winrt::ContentControl m_focusSafeHarbor{nullptr};
-  winrt::ContentControl::LosingFocus_revoker m_focusSafeHarborLosingFocusRevoker{};
+  xaml::Controls::ContentControl m_focusSafeHarbor{nullptr};
+  xaml::Controls::ContentControl::LosingFocus_revoker m_focusSafeHarborLosingFocusRevoker{};
   winrt::Grid m_redBoxGrid{nullptr};
   winrt::Grid m_greenBoxGrid{nullptr};
   winrt::TextBlock m_errorTextBlock{nullptr};

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -10,7 +10,7 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-Windows::UI::Xaml::Media::Brush XamlHelper::BrushFrom(JSValueArgWriter const &valueProvider) noexcept {
+xaml::Media::Brush XamlHelper::BrushFrom(JSValueArgWriter const &valueProvider) noexcept {
   auto value = GetFollyDynamicFromValueProvider(valueProvider);
   return react::uwp::IsValidColorValue(value) ? react::uwp::BrushFrom(value) : nullptr;
 }

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::ReactNative::implementation {
 struct XamlHelper : XamlHelperT<XamlHelper> {
   XamlHelper() = default;
 
-  static Windows::UI::Xaml::Media::Brush BrushFrom(JSValueArgWriter const &valueProvider) noexcept;
+  static xaml::Media::Brush BrushFrom(JSValueArgWriter const &valueProvider) noexcept;
   static Windows::UI::Color ColorFrom(JSValueArgWriter const &valueProvider) noexcept;
 
   static folly::dynamic GetFollyDynamicFromValueProvider(JSValueArgWriter const &valueProvider) noexcept;

--- a/vnext/Microsoft.ReactNative/XamlHelper.idl
+++ b/vnext/Microsoft.ReactNative/XamlHelper.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "IJSValueWriter.idl";
+#include "../include/NamespaceRedirect.h"
 
 namespace Microsoft.ReactNative {
 
@@ -9,7 +10,7 @@ namespace Microsoft.ReactNative {
   [default_interface]
   runtimeclass XamlHelper {
     XamlHelper();
-    static Windows.UI.Xaml.Media.Brush BrushFrom(JSValueArgWriter valueProvider);
+    static WUXMUX_TYPE(Media.Brush) BrushFrom(JSValueArgWriter valueProvider);
     static Windows.UI.Color ColorFrom(JSValueArgWriter valueProvider);
   };
 

--- a/vnext/Microsoft.ReactNative/XamlHelper.idl
+++ b/vnext/Microsoft.ReactNative/XamlHelper.idl
@@ -10,7 +10,7 @@ namespace Microsoft.ReactNative {
   [default_interface]
   runtimeclass XamlHelper {
     XamlHelper();
-    static WUXMUX_TYPE(Media.Brush) BrushFrom(JSValueArgWriter valueProvider);
+    static XAML_NAMESPACE.Media.Brush BrushFrom(JSValueArgWriter valueProvider);
     static Windows.UI.Color ColorFrom(JSValueArgWriter valueProvider);
   };
 

--- a/vnext/Microsoft.ReactNative/pch.h
+++ b/vnext/Microsoft.ReactNative/pch.h
@@ -21,17 +21,7 @@
 #include <unknwn.h>
 #include <windows.h>
 
-#include <winrt/Windows.ApplicationModel.Activation.h>
-#include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.Foundation.Metadata.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Storage.Streams.h>
-#include <winrt/Windows.System.h>
-#include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
+#include "CppWinRTIncludes.h"
 #include "HResult.h"
 
 #include "Base/CxxReactIncludes.h"

--- a/vnext/ReactUWP/ABI/ReactControl_rt.cpp
+++ b/vnext/ReactUWP/ABI/ReactControl_rt.cpp
@@ -112,7 +112,7 @@ void ReactControl::CreateInnerInstance() {
   Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IFrameworkElement> spFrameworkElementABI;
   spThis.As(&spFrameworkElementABI);
   ::react::uwp::XamlView pXamlView =
-      reinterpret_cast<const winrt::Windows::UI::Xaml::FrameworkElement &>(spFrameworkElementABI);
+      reinterpret_cast<const xaml::FrameworkElement &>(spFrameworkElementABI);
 
   m_pInnerControl = std::make_shared<::react::uwp::ReactControl>(this, pXamlView);
   m_pInnerControl->SetJSComponentName(std::string(m_jsComponentName));

--- a/vnext/ReactUWP/ABI/ReactControl_rt.cpp
+++ b/vnext/ReactUWP/ABI/ReactControl_rt.cpp
@@ -111,8 +111,7 @@ void ReactControl::CreateInnerInstance() {
   Microsoft::WRL::ComPtr<ABI::react::uwp::ReactControl> spThis(this);
   Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IFrameworkElement> spFrameworkElementABI;
   spThis.As(&spFrameworkElementABI);
-  ::react::uwp::XamlView pXamlView =
-      reinterpret_cast<const xaml::FrameworkElement &>(spFrameworkElementABI);
+  ::react::uwp::XamlView pXamlView = reinterpret_cast<const xaml::FrameworkElement &>(spFrameworkElementABI);
 
   m_pInnerControl = std::make_shared<::react::uwp::ReactControl>(this, pXamlView);
   m_pInnerControl->SetJSComponentName(std::string(m_jsComponentName));

--- a/vnext/ReactUWP/Modules/AlertModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AlertModuleUwp.cpp
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "AlertModuleUwp.h"
-#include <winrt/Windows.UI.Xaml.Controls.h>
 
 #include <Utils\ValueUtils.h>
 
@@ -11,8 +10,8 @@
 #include <cxxreact/JsArgumentHelpers.h>
 #pragma warning(pop)
 namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
+using namespace xaml;
+using namespace xaml::Controls;
 } // namespace winrt
 
 #if _MSC_VER <= 1913

--- a/vnext/ReactUWP/Modules/Animated/AdditionAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/AdditionAnimatedNode.cpp
@@ -18,7 +18,7 @@ AdditionAnimatedNode::AdditionAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
-    const auto anim = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
 
     anim.Expression([nodes, manager, anim]() {
       winrt::hstring expr = L"0";

--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
@@ -61,8 +61,8 @@ class AnimationDriver {
   folly::dynamic m_config{};
   std::weak_ptr<NativeAnimatedNodeManager> m_manager{};
 
-  winrt::Windows::UI::Composition::CompositionAnimation m_animation{nullptr};
-  winrt::Windows::UI::Composition::CompositionScopedBatch m_scopedBatch{nullptr};
+  comp::CompositionAnimation m_animation{nullptr};
+  comp::CompositionScopedBatch m_scopedBatch{nullptr};
   // auto revoker for scopedBatch.Completed is broken, tracked by internal bug
   // #22399779
   winrt::event_token m_scopedBatchCompletedToken{};

--- a/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/AnimationDriver.h
@@ -23,7 +23,7 @@ class AnimationDriver {
   void StartAnimation();
   void StopAnimation(bool ignoreCompletedHandlers = false);
 
-  virtual std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch> MakeAnimation(
+  virtual std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> MakeAnimation(
       const folly::dynamic & /*config*/) {
     return std::make_tuple(nullptr, nullptr);
   };

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -9,10 +9,10 @@
 namespace react {
 namespace uwp {
 
-std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch> CalculatedAnimationDriver::MakeAnimation(
+std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedAnimationDriver::MakeAnimation(
     const folly::dynamic & /*config*/) {
   const auto [scopedBatch, animation, easingFunction] = []() {
-    const auto compositor = winrt::Window::Current().Compositor();
+    const auto compositor = xaml::Window::Current().Compositor();
     return std::make_tuple(
         compositor.CreateScopedBatch(winrt::CompositionBatchTypes::AllAnimations),
         compositor.CreateScalarKeyFrameAnimation(),

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -14,7 +14,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
   const auto [scopedBatch, animation, easingFunction] = []() {
     const auto compositor = xaml::Window::Current().Compositor();
     return std::make_tuple(
-        compositor.CreateScopedBatch(winrt::CompositionBatchTypes::AllAnimations),
+        compositor.CreateScopedBatch(comp::CompositionBatchTypes::AllAnimations),
         compositor.CreateScalarKeyFrameAnimation(),
         compositor.CreateLinearEasingFunction());
   }();

--- a/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/CalculatedAnimationDriver.h
@@ -13,7 +13,7 @@ class CalculatedAnimationDriver : public AnimationDriver {
  public:
   using AnimationDriver::AnimationDriver;
 
-  std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch> MakeAnimation(
+  std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> MakeAnimation(
       const folly::dynamic &config) override;
 
  protected:

--- a/vnext/ReactUWP/Modules/Animated/DiffClampAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/DiffClampAnimatedNode.cpp
@@ -18,7 +18,7 @@ DiffClampAnimatedNode::DiffClampAnimatedNode(
   m_max = config.find(s_maxName).dereference().second.asDouble();
 
   m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, min = m_min, max = m_max, manager]() {
-    const auto anim = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
     anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
     anim.SetScalarParameter(s_minParameterName, static_cast<float>(min));
     anim.SetScalarParameter(s_maxParameterName, static_cast<float>(max));

--- a/vnext/ReactUWP/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/DivisionAnimatedNode.cpp
@@ -22,7 +22,7 @@ DivisionAnimatedNode::DivisionAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
-    const auto anim = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
 
     anim.Expression([firstNode, nodes, manager, anim]() {
       anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());

--- a/vnext/ReactUWP/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/FrameAnimationDriver.cpp
@@ -20,10 +20,10 @@ FrameAnimationDriver::FrameAnimationDriver(
   m_toValue = config.find("toValue").dereference().second.asDouble();
 }
 
-std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch> FrameAnimationDriver::MakeAnimation(
+std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimationDriver::MakeAnimation(
     const folly::dynamic & /*config*/) {
   const auto [scopedBatch, animation] = []() {
-    const auto compositor = winrt::Window::Current().Compositor();
+    const auto compositor = xaml::Window::Current().Compositor();
     return std::make_tuple(
         compositor.CreateScopedBatch(winrt::CompositionBatchTypes::AllAnimations),
         compositor.CreateScalarKeyFrameAnimation());

--- a/vnext/ReactUWP/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/ReactUWP/Modules/Animated/FrameAnimationDriver.cpp
@@ -25,7 +25,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimat
   const auto [scopedBatch, animation] = []() {
     const auto compositor = xaml::Window::Current().Compositor();
     return std::make_tuple(
-        compositor.CreateScopedBatch(winrt::CompositionBatchTypes::AllAnimations),
+        compositor.CreateScopedBatch(comp::CompositionBatchTypes::AllAnimations),
         compositor.CreateScalarKeyFrameAnimation());
   }();
 

--- a/vnext/ReactUWP/Modules/Animated/FrameAnimationDriver.h
+++ b/vnext/ReactUWP/Modules/Animated/FrameAnimationDriver.h
@@ -17,7 +17,7 @@ class FrameAnimationDriver : public AnimationDriver {
       const folly::dynamic &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
-  std::tuple<winrt::CompositionAnimation, winrt::CompositionScopedBatch> MakeAnimation(
+  std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> MakeAnimation(
       const folly::dynamic &config) override;
 
   double ToValue() override;

--- a/vnext/ReactUWP/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -70,7 +70,7 @@ void InterpolationAnimatedNode::OnAttachToNode(int64_t animatedNodeTag) {
   m_offsetAnimation = offsetAnimation;
 }
 
-winrt::ExpressionAnimation InterpolationAnimatedNode::CreateExpressionAnimation(
+comp::ExpressionAnimation InterpolationAnimatedNode::CreateExpressionAnimation(
     const winrt::Compositor &compositor,
     ValueAnimatedNode &parent) {
   const auto animation = compositor.CreateExpressionAnimation();

--- a/vnext/ReactUWP/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -43,7 +43,7 @@ void InterpolationAnimatedNode::OnAttachToNode(int64_t animatedNodeTag) {
   const auto [rawValueAnimation, offsetAnimation] = [this]() {
     if (const auto manager = m_manager.lock()) {
       if (const auto parent = manager->GetValueAnimatedNode(m_parentTag)) {
-        const auto compositor = winrt::Window::Current().Compositor();
+        const auto compositor = xaml::Window::Current().Compositor();
 
         const auto rawValueAnimation = CreateExpressionAnimation(compositor, *parent);
         rawValueAnimation.Expression(
@@ -60,7 +60,7 @@ void InterpolationAnimatedNode::OnAttachToNode(int64_t animatedNodeTag) {
         return std::make_tuple(rawValueAnimation, offsetAnimation);
       }
     }
-    return std::tuple<winrt::ExpressionAnimation, winrt::ExpressionAnimation>(nullptr, nullptr);
+    return std::tuple<comp::ExpressionAnimation, comp::ExpressionAnimation>(nullptr, nullptr);
   }();
 
   m_propertySet.StartAnimation(s_valueName, rawValueAnimation);

--- a/vnext/ReactUWP/Modules/Animated/InterpolationAnimatedNode.h
+++ b/vnext/ReactUWP/Modules/Animated/InterpolationAnimatedNode.h
@@ -24,7 +24,7 @@ class InterpolationAnimatedNode : public ValueAnimatedNode {
   static constexpr std::wstring_view ExtrapolateTypeExtend = L"extend";
 
  private:
-  winrt::ExpressionAnimation CreateExpressionAnimation(const winrt::Compositor &compositor, ValueAnimatedNode &parent);
+  comp::ExpressionAnimation CreateExpressionAnimation(const winrt::Compositor &compositor, ValueAnimatedNode &parent);
 
   winrt::hstring GetExpression(const winrt::hstring &value);
   winrt::hstring GetInterpolateExpression(
@@ -36,8 +36,8 @@ class InterpolationAnimatedNode : public ValueAnimatedNode {
   winrt::hstring GetLeftExpression(const winrt::hstring &value, const winrt::hstring &leftInterpolateExpression);
   winrt::hstring GetRightExpression(const winrt::hstring &, const winrt::hstring &rightInterpolateExpression);
 
-  winrt::ExpressionAnimation m_rawValueAnimation{nullptr};
-  winrt::ExpressionAnimation m_offsetAnimation{nullptr};
+  comp::ExpressionAnimation m_rawValueAnimation{nullptr};
+  comp::ExpressionAnimation m_offsetAnimation{nullptr};
   std::vector<double> m_inputRanges;
   std::vector<double> m_outputRanges;
   std::string m_extrapolateLeft;

--- a/vnext/ReactUWP/Modules/Animated/ModulusAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/ModulusAnimatedNode.cpp
@@ -17,7 +17,7 @@ ModulusAnimatedNode::ModulusAnimatedNode(
   m_modulus = static_cast<int64_t>(config.find(s_modulusName).dereference().second.asDouble());
 
   m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, mod = m_modulus, manager]() {
-    const auto anim = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
     anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
     anim.SetScalarParameter(s_modName, static_cast<float>(mod));
     anim.Expression(

--- a/vnext/ReactUWP/Modules/Animated/MultiplicationAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/MultiplicationAnimatedNode.cpp
@@ -18,7 +18,7 @@ MultiplicationAnimatedNode::MultiplicationAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
-    const auto anim = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
 
     anim.Expression([nodes, manager, anim]() {
       winrt::hstring expr = L"1";

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -22,18 +22,18 @@ PropsAnimatedNode::PropsAnimatedNode(
     m_propMapping.insert({entry.first.getString(), static_cast<int64_t>(entry.second.asDouble())});
   }
 
-  m_subchannelPropertySet = winrt::Window::Current().Compositor().CreatePropertySet();
+  m_subchannelPropertySet = xaml::Window::Current().Compositor().CreatePropertySet();
   m_subchannelPropertySet.InsertScalar(L"TranslationX", 0.0f);
   m_subchannelPropertySet.InsertScalar(L"TranslationY", 0.0f);
   m_subchannelPropertySet.InsertScalar(L"ScaleX", 1.0f);
   m_subchannelPropertySet.InsertScalar(L"ScaleY", 1.0f);
 
-  m_translationCombined = winrt::Window::Current().Compositor().CreateExpressionAnimation(
+  m_translationCombined = xaml::Window::Current().Compositor().CreateExpressionAnimation(
       L"Vector3(subchannels.TranslationX, subchannels.TranslationY, 0.0)");
   m_translationCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
   m_translationCombined.Target(L"Translation");
 
-  m_scaleCombined = winrt::Window::Current().Compositor().CreateExpressionAnimation(
+  m_scaleCombined = xaml::Window::Current().Compositor().CreateExpressionAnimation(
       L"Vector3(subchannels.ScaleX, subchannels.ScaleY, 1.0)");
   m_scaleCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
   m_scaleCombined.Target(L"Scale");
@@ -120,7 +120,7 @@ void PropsAnimatedNode::StartAnimations() {
       }
       if (m_needsCenterPointAnimation) {
         if (!m_centerPointAnimation) {
-          m_centerPointAnimation = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+          m_centerPointAnimation = xaml::Window::Current().Compositor().CreateExpressionAnimation();
           m_centerPointAnimation.Target(L"CenterPoint");
           m_centerPointAnimation.SetReferenceParameter(
               L"centerPointPropertySet", GetShadowNodeBase()->EnsureTransformPS());
@@ -171,7 +171,7 @@ void PropsAnimatedNode::ResumeSuspendedAnimations(int64_t valueTag) {
 void PropsAnimatedNode::MakeAnimation(int64_t valueNodeTag, FacadeType facadeType) {
   if (const auto manager = m_manager.lock()) {
     if (const auto valueNode = manager->GetValueAnimatedNode(valueNodeTag)) {
-      const auto animation = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+      const auto animation = xaml::Window::Current().Compositor().CreateExpressionAnimation();
       animation.SetReferenceParameter(L"ValuePropSet", valueNode->PropertySet());
       animation.Expression(
           static_cast<winrt::hstring>(L"ValuePropSet.") + ValueAnimatedNode::s_valueName + L" + ValuePropSet." +
@@ -250,10 +250,10 @@ ShadowNodeBase *PropsAnimatedNode::GetShadowNodeBase() {
   return nullptr;
 }
 
-winrt::UIElement PropsAnimatedNode::GetUIElement() {
+xaml::UIElement PropsAnimatedNode::GetUIElement() {
   if (const auto shadowNodeBase = GetShadowNodeBase()) {
     if (const auto shadowNodeView = shadowNodeBase->GetView()) {
-      return shadowNodeView.as<winrt::UIElement>();
+      return shadowNodeView.as<xaml::UIElement>();
     }
   }
   return nullptr;

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.h
@@ -29,7 +29,7 @@ class PropsAnimatedNode : public AnimatedNode {
  private:
   void MakeAnimation(int64_t valueNodeTag, FacadeType facadeType);
   ShadowNodeBase *GetShadowNodeBase();
-  winrt::UIElement GetUIElement();
+  xaml::UIElement GetUIElement();
 
   std::weak_ptr<IReactInstance> m_instance{};
   std::map<std::string, int64_t> m_propMapping{};

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.h
@@ -36,9 +36,9 @@ class PropsAnimatedNode : public AnimatedNode {
   folly::dynamic m_propMap{};
 
   int64_t m_connectedViewTag{s_connectedViewTagUnset};
-  std::unordered_map<int64_t, winrt::Windows::UI::Composition::CompositionAnimation> m_expressionAnimations{};
+  std::unordered_map<int64_t, comp::CompositionAnimation> m_expressionAnimations{};
   std::vector<int64_t> m_suspendedExpressionAnimationTags{};
-  winrt::Windows::UI::Composition::ExpressionAnimation m_centerPointAnimation{nullptr};
+  comp::ExpressionAnimation m_centerPointAnimation{nullptr};
   winrt::Numerics::float3 m_rotationAxis{0, 0, 1};
   bool m_needsCenterPointAnimation{false};
   winrt::CompositionPropertySet m_subchannelPropertySet{nullptr};

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.h
@@ -41,9 +41,9 @@ class PropsAnimatedNode : public AnimatedNode {
   comp::ExpressionAnimation m_centerPointAnimation{nullptr};
   winrt::Numerics::float3 m_rotationAxis{0, 0, 1};
   bool m_needsCenterPointAnimation{false};
-  winrt::CompositionPropertySet m_subchannelPropertySet{nullptr};
-  winrt::CompositionAnimation m_translationCombined{nullptr};
-  winrt::CompositionAnimation m_scaleCombined{nullptr};
+  comp::CompositionPropertySet m_subchannelPropertySet{nullptr};
+  comp::CompositionAnimation m_translationCombined{nullptr};
+  comp::CompositionAnimation m_scaleCombined{nullptr};
 
   static constexpr int64_t s_connectedViewTagUnset{-1};
 };

--- a/vnext/ReactUWP/Modules/Animated/SubtractionAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/SubtractionAnimatedNode.cpp
@@ -22,7 +22,7 @@ SubtractionAnimatedNode::SubtractionAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
-    const auto anim = winrt::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
 
     anim.Expression([firstNode, nodes, manager, anim]() {
       anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());

--- a/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.cpp
@@ -13,7 +13,7 @@ ValueAnimatedNode::ValueAnimatedNode(
     const folly::dynamic &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
-  m_propertySet = winrt::Window::Current().Compositor().CreatePropertySet();
+  m_propertySet = xaml::Window::Current().Compositor().CreatePropertySet();
   m_propertySet.InsertScalar(
       s_valueName, static_cast<float>(config.find(s_jsValueName).dereference().second.asDouble()));
   m_propertySet.InsertScalar(
@@ -22,7 +22,7 @@ ValueAnimatedNode::ValueAnimatedNode(
 
 ValueAnimatedNode::ValueAnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
-  m_propertySet = winrt::Window::Current().Compositor().CreatePropertySet();
+  m_propertySet = xaml::Window::Current().Compositor().CreatePropertySet();
   m_propertySet.InsertScalar(s_valueName, 0.0);
   m_propertySet.InsertScalar(s_offsetName, 0.0);
 }

--- a/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.h
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 
 namespace winrt {
-using namespace winrt::Windows::UI::Composition;
+using namespace comp;
 }
 
 namespace react {

--- a/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/ReactUWP/Modules/Animated/ValueAnimatedNode.h
@@ -25,7 +25,7 @@ class ValueAnimatedNode : public AnimatedNode {
   void Offset(double offset);
   void FlattenOffset();
   void ExtractOffset();
-  winrt::CompositionPropertySet PropertySet() {
+  comp::CompositionPropertySet PropertySet() {
     return m_propertySet;
   };
 
@@ -40,7 +40,7 @@ class ValueAnimatedNode : public AnimatedNode {
   static constexpr std::wstring_view s_offsetName{L"o"};
 
  protected:
-  winrt::CompositionPropertySet m_propertySet{nullptr};
+  comp::CompositionPropertySet m_propertySet{nullptr};
 
   static constexpr std::string_view s_inputName{"input"};
 

--- a/vnext/ReactUWP/Modules/AppStateModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AppStateModuleUwp.cpp
@@ -5,8 +5,6 @@
 
 #include "AppStateModuleUwp.h"
 
-#include <winrt/Windows.UI.Xaml.h>
-
 namespace react {
 namespace uwp {
 
@@ -18,9 +16,9 @@ AppState::AppState(const std::shared_ptr<IReactInstance> &reactInstance)
     : facebook::react::AppState(), m_wkReactInstance(reactInstance) {
   m_lastState = "active";
 
-  m_enteredBackgroundRevoker = winrt::Windows::UI::Xaml::Application::Current().EnteredBackground(
+  m_enteredBackgroundRevoker = xaml::Application::Current().EnteredBackground(
       winrt::auto_revoke, {this, &AppState::EnteredBackground});
-  m_leavingBackgroundRevoker = winrt::Windows::UI::Xaml::Application::Current().LeavingBackground(
+  m_leavingBackgroundRevoker = xaml::Application::Current().LeavingBackground(
       winrt::auto_revoke, {this, &AppState::LeavingBackground});
 }
 

--- a/vnext/ReactUWP/Modules/AppStateModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AppStateModuleUwp.cpp
@@ -16,10 +16,10 @@ AppState::AppState(const std::shared_ptr<IReactInstance> &reactInstance)
     : facebook::react::AppState(), m_wkReactInstance(reactInstance) {
   m_lastState = "active";
 
-  m_enteredBackgroundRevoker = xaml::Application::Current().EnteredBackground(
-      winrt::auto_revoke, {this, &AppState::EnteredBackground});
-  m_leavingBackgroundRevoker = xaml::Application::Current().LeavingBackground(
-      winrt::auto_revoke, {this, &AppState::LeavingBackground});
+  m_enteredBackgroundRevoker =
+      xaml::Application::Current().EnteredBackground(winrt::auto_revoke, {this, &AppState::EnteredBackground});
+  m_leavingBackgroundRevoker =
+      xaml::Application::Current().LeavingBackground(winrt::auto_revoke, {this, &AppState::LeavingBackground});
 }
 
 AppState::~AppState() = default;

--- a/vnext/ReactUWP/Modules/AppStateModuleUwp.h
+++ b/vnext/ReactUWP/Modules/AppStateModuleUwp.h
@@ -8,7 +8,6 @@
 
 #include <winrt/Windows.ApplicationModel.Core.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 namespace react {
 namespace uwp {
@@ -32,8 +31,8 @@ class AppState : public facebook::react::AppState {
 
   const char *m_lastState;
   std::weak_ptr<IReactInstance> m_wkReactInstance;
-  winrt::Windows::UI::Xaml::Application::EnteredBackground_revoker m_enteredBackgroundRevoker;
-  winrt::Windows::UI::Xaml::Application::LeavingBackground_revoker m_leavingBackgroundRevoker;
+  xaml::Application::EnteredBackground_revoker m_enteredBackgroundRevoker;
+  xaml::Application::LeavingBackground_revoker m_leavingBackgroundRevoker;
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.cpp
@@ -13,7 +13,7 @@
 #endif
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
+using namespace xaml;
 using namespace Windows::UI::ViewManagement;
 } // namespace winrt
 

--- a/vnext/ReactUWP/Modules/AppThemeModuleUwp.h
+++ b/vnext/ReactUWP/Modules/AppThemeModuleUwp.h
@@ -30,7 +30,7 @@ class AppTheme {
 
   std::weak_ptr<IReactInstance> m_wkReactInstance;
   std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
-  winrt::Windows::UI::Xaml::ApplicationTheme m_currentTheme{winrt::Windows::UI::Xaml::ApplicationTheme::Light};
+  xaml::ApplicationTheme m_currentTheme{xaml::ApplicationTheme::Light};
   bool m_isHighContrast;
   folly::dynamic m_highContrastColors;
 

--- a/vnext/ReactUWP/Modules/AppearanceModule.cpp
+++ b/vnext/ReactUWP/Modules/AppearanceModule.cpp
@@ -6,8 +6,8 @@
 
 #include <winrt/Windows.UI.ViewManagement.h>
 
-using Application = winrt::Windows::UI::Xaml::Application;
-using ApplicationTheme = winrt::Windows::UI::Xaml::ApplicationTheme;
+using Application = xaml::Application;
+using ApplicationTheme = xaml::ApplicationTheme;
 using UISettings = winrt::Windows::UI::ViewManagement::UISettings;
 
 using Method = facebook::xplat::module::CxxModule::Method;

--- a/vnext/ReactUWP/Modules/AppearanceModule.h
+++ b/vnext/ReactUWP/Modules/AppearanceModule.h
@@ -13,7 +13,7 @@ namespace react::uwp {
 
 // Listens for the current theme on the UI thread, storing the most recent. Will emit JS events on Appearance change.
 class AppearanceChangeListener final : public Mso::ActiveObject<> {
-  using ApplicationTheme = winrt::Windows::UI::Xaml::ApplicationTheme;
+  using ApplicationTheme = xaml::ApplicationTheme;
   using UISettings = winrt::Windows::UI::ViewManagement::UISettings;
 
  public:

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
@@ -13,7 +13,6 @@
 #include <future>
 #include <memory>
 #include <string>
-#include <future>
 
 namespace facebook {
 namespace react {

--- a/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
+++ b/vnext/ReactUWP/Modules/DevSupportManagerUwp.h
@@ -13,6 +13,7 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <future>
 
 namespace facebook {
 namespace react {

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.cpp
@@ -21,7 +21,7 @@ DeviceInfo::DeviceInfo(const std::shared_ptr<IReactInstance> &reactInstance) : m
 
 void DeviceInfo::listenToUpdates() {
   auto const &displayInfo = winrt::Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
-  auto const &window = winrt::Windows::UI::Xaml::Window::Current().CoreWindow();
+  auto const &window = xaml::Window::Current().CoreWindow();
 
   m_sizeChangedRevoker = window.SizeChanged(winrt::auto_revoke, [this](auto &&, auto &&) {
     update();
@@ -40,7 +40,7 @@ void DeviceInfo::update() {
 
   winrt::Windows::UI::ViewManagement::UISettings uiSettings;
 
-  auto const &window = winrt::Windows::UI::Xaml::Window::Current().CoreWindow();
+  auto const &window = xaml::Window::Current().CoreWindow();
 
   m_dimensions = folly::dynamic::object(
       "windowPhysicalPixels",

--- a/vnext/ReactUWP/Modules/DeviceInfoModule.h
+++ b/vnext/ReactUWP/Modules/DeviceInfoModule.h
@@ -7,7 +7,6 @@
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
 #include <winrt/Windows.Graphics.Display.h>
-#include <winrt/Windows.UI.Xaml.h>
 #include <memory>
 #include <vector>
 

--- a/vnext/ReactUWP/Modules/ImageViewManagerModule.cpp
+++ b/vnext/ReactUWP/Modules/ImageViewManagerModule.cpp
@@ -10,8 +10,6 @@
 
 #include "ImageViewManagerModule.h"
 
-#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
-
 #include <cxxreact/JsArgumentHelpers.h>
 
 #include <Views/Image/ReactImage.h>
@@ -26,7 +24,7 @@
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::Storage::Streams;
-using namespace Windows::UI::Xaml::Media::Imaging;
+using namespace xaml::Media::Imaging;
 } // namespace winrt
 
 namespace react {

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -8,17 +8,15 @@
 #include <ReactRootView.h>
 #include <Views/ShadowNodeBase.h>
 
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
+#include "CppWinRTIncludes.h"
 #include "Unicode.h"
 
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -98,7 +96,7 @@ winrt::XamlRoot NativeUIManager::tryGetXamlRoot() {
   if (m_host) {
     for (auto const tag : m_host->GetAllRootTags()) {
       if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(tag))) {
-        if (auto uiElement10 = shadowNode->GetView().try_as<winrt::IUIElement10>()) {
+        if (auto uiElement10 = shadowNode->GetView().try_as<xaml::IUIElement10>()) {
           if (auto xamlRoot = uiElement10.XamlRoot())
             return xamlRoot;
         }
@@ -108,7 +106,7 @@ winrt::XamlRoot NativeUIManager::tryGetXamlRoot() {
   return nullptr;
 }
 
-XamlView NativeUIManager::reactPeerOrContainerFrom(winrt::FrameworkElement fe) {
+XamlView NativeUIManager::reactPeerOrContainerFrom(xaml::FrameworkElement fe) {
   if (m_host) {
     while (fe) {
       if (auto value = GetTagAsPropertyValue(fe)) {
@@ -121,7 +119,7 @@ XamlView NativeUIManager::reactPeerOrContainerFrom(winrt::FrameworkElement fe) {
           }
         }
       }
-      fe = fe.Parent().try_as<winrt::FrameworkElement>();
+      fe = fe.Parent().try_as<xaml::FrameworkElement>();
     }
   }
   return nullptr;
@@ -159,7 +157,7 @@ struct RootShadowNode final : public ShadowNodeBase {
   void AddView(facebook::react::ShadowNode &child, int64_t index) override {
     auto panel(GetView().as<winrt::Panel>());
     if (panel != nullptr) {
-      auto childView = static_cast<ShadowNodeBase &>(child).GetView().as<winrt::UIElement>();
+      auto childView = static_cast<ShadowNodeBase &>(child).GetView().as<xaml::UIElement>();
       panel.Children().InsertAt(static_cast<uint32_t>(index), childView);
     }
   }
@@ -189,12 +187,12 @@ void NativeUIManager::AddRootView(
 
   m_tagsToYogaNodes.emplace(shadowNode.m_tag, make_yoga_node());
 
-  auto element = view.as<winrt::FrameworkElement>();
+  auto element = view.as<xaml::FrameworkElement>();
   element.Tag(winrt::PropertyValue::CreateInt64(shadowNode.m_tag));
 
   // Add listener to size change so we can redo the layout when that happens
   m_sizeChangedVector.push_back(
-      view.as<winrt::FrameworkElement>().SizeChanged(winrt::auto_revoke, [this](auto &&, auto &&) { DoLayout(); }));
+      view.as<xaml::FrameworkElement>().SizeChanged(winrt::auto_revoke, [this](auto &&, auto &&) { DoLayout(); }));
 }
 
 void NativeUIManager::destroy() {
@@ -837,7 +835,7 @@ void NativeUIManager::DoLayout() {
   const auto extraLayoutNodes = m_extraLayoutNodes;
   for (const int64_t tag : extraLayoutNodes) {
     ShadowNodeBase &node = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-    auto element = node.GetView().as<winrt::FrameworkElement>();
+    auto element = node.GetView().as<xaml::FrameworkElement>();
     element.UpdateLayout();
   }
   // Values need to be cleared from the vector before next call to DoLayout.
@@ -848,7 +846,7 @@ void NativeUIManager::DoLayout() {
 
     ShadowNodeBase &rootShadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(rootTag));
     YGNodeRef rootNode = GetYogaNode(rootTag);
-    auto rootElement = rootShadowNode.GetView().as<winrt::FrameworkElement>();
+    auto rootElement = rootShadowNode.GetView().as<xaml::FrameworkElement>();
 
     float actualWidth = static_cast<float>(rootElement.ActualWidth());
     float actualHeight = static_cast<float>(rootElement.ActualHeight());
@@ -878,8 +876,8 @@ void NativeUIManager::DoLayout() {
 }
 
 winrt::Windows::Foundation::Rect GetRectOfElementInParentCoords(
-    winrt::FrameworkElement element,
-    winrt::UIElement parent) {
+    xaml::FrameworkElement element,
+    xaml::UIElement parent) {
   if (parent == nullptr) {
     assert(false);
     return winrt::Windows::Foundation::Rect();
@@ -907,7 +905,7 @@ void NativeUIManager::measure(
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
   auto view = node.GetView();
 
-  auto feView = view.try_as<winrt::FrameworkElement>();
+  auto feView = view.try_as<xaml::FrameworkElement>();
   if (feView == nullptr) {
     callback(args);
     return;
@@ -915,7 +913,7 @@ void NativeUIManager::measure(
 
   // Traverse up the react node tree to find any windowed popups.
   // If there are none, then we use the top-level root provided by our caller.
-  winrt::FrameworkElement feRootView = nullptr;
+  xaml::FrameworkElement feRootView = nullptr;
   int64_t rootTag = shadowNode.m_tag;
   int64_t childTag = rootTag;
   while (true) {
@@ -925,7 +923,7 @@ void NativeUIManager::measure(
     ShadowNodeBase &rootNode = static_cast<ShadowNodeBase &>(currNode);
     if (rootNode.IsWindowed()) {
       ShadowNodeBase &childNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(childTag));
-      feRootView = childNode.GetView().try_as<winrt::FrameworkElement>();
+      feRootView = childNode.GetView().try_as<xaml::FrameworkElement>();
       break;
     }
     childTag = currNode.m_tag;
@@ -935,7 +933,7 @@ void NativeUIManager::measure(
   if (feRootView == nullptr) {
     // Retrieve the XAML element for the root view containing this view
     if (auto xamlRootView = static_cast<ShadowNodeBase &>(shadowRoot).GetView()) {
-      feRootView = xamlRootView.as<winrt::FrameworkElement>();
+      feRootView = xamlRootView.as<xaml::FrameworkElement>();
     }
     if (feRootView == nullptr) {
       callback(args);
@@ -969,8 +967,8 @@ void NativeUIManager::measureInWindow(
   std::vector<folly::dynamic> args;
 
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
-  if (auto view = node.GetView().try_as<winrt::FrameworkElement>()) {
-    auto windowTransform = view.TransformToVisual(winrt::Window::Current().Content());
+  if (auto view = node.GetView().try_as<xaml::FrameworkElement>()) {
+    auto windowTransform = view.TransformToVisual(xaml::Window::Current().Content());
     auto positionInWindow = windowTransform.TransformPoint({0, 0});
 
     // x, y
@@ -994,8 +992,8 @@ void NativeUIManager::measureLayout(
   try {
     const auto &target = static_cast<ShadowNodeBase &>(shadowNode);
     const auto &ancestor = static_cast<ShadowNodeBase &>(ancestorNode);
-    const auto targetElement = target.GetView().as<winrt::FrameworkElement>();
-    const auto ancenstorElement = ancestor.GetView().as<winrt::FrameworkElement>();
+    const auto targetElement = target.GetView().as<xaml::FrameworkElement>();
+    const auto ancenstorElement = ancestor.GetView().as<xaml::FrameworkElement>();
 
     const auto ancestorTransform = targetElement.TransformToVisual(ancenstorElement);
     const auto width = static_cast<float>(targetElement.ActualWidth());
@@ -1025,7 +1023,7 @@ void NativeUIManager::findSubviewIn(
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
   auto view = node.GetView();
 
-  auto rootUIView = view.as<winrt::UIElement>();
+  auto rootUIView = view.as<xaml::UIElement>();
   if (rootUIView == nullptr) {
     callback({});
     return;
@@ -1043,10 +1041,10 @@ void NativeUIManager::findSubviewIn(
   auto hitTestElements = winrt::VisualTreeHelper::FindElementsInHostCoordinates(pointInAppWindow, rootUIView);
 
   int64_t foundTag{};
-  winrt::FrameworkElement foundElement = nullptr;
+  xaml::FrameworkElement foundElement = nullptr;
 
   for (const auto &elem : hitTestElements) {
-    if (foundElement = elem.try_as<winrt::FrameworkElement>()) {
+    if (foundElement = elem.try_as<xaml::FrameworkElement>()) {
       auto tag = foundElement.Tag();
       if (tag != nullptr) {
         foundTag = tag.as<winrt::IPropertyValue>().GetInt64();
@@ -1074,7 +1072,7 @@ void NativeUIManager::findSubviewIn(
 
 void NativeUIManager::focus(int64_t reactTag) {
   if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(reactTag))) {
-    winrt::FocusManager::TryFocusAsync(shadowNode->GetView(), winrt::FocusState::Programmatic);
+    xaml::Input::FocusManager::TryFocusAsync(shadowNode->GetView(), winrt::FocusState::Programmatic);
   }
 }
 
@@ -1083,7 +1081,7 @@ void NativeUIManager::blur(int64_t reactTag) {
   if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(reactTag))) {
     auto view = shadowNode->GetView();
     // Only blur if current UI is focused to avoid problem described in PR #2687
-    if (view == winrt::FocusManager::GetFocusedElement().try_as<winrt::DependencyObject>()) {
+    if (view == xaml::Input::FocusManager::GetFocusedElement().try_as<xaml::DependencyObject>()) {
       if (auto reactControl = GetParentXamlReactControl(reactTag).lock()) {
         reactControl->blur(shadowNode->GetView());
       } else {

--- a/vnext/ReactUWP/Modules/NativeUIManager.h
+++ b/vnext/ReactUWP/Modules/NativeUIManager.h
@@ -85,11 +85,11 @@ class NativeUIManager : public facebook::react::INativeUIManager {
   // XamlIsland/AppWindow scenarios. Since it doesn't have parent, and all nodes
   // in the tree should have the same XamlRoot, this function iterates all roots
   // and try to get a valid XamlRoot.
-  winrt::XamlRoot tryGetXamlRoot();
+  xaml::XamlRoot tryGetXamlRoot();
 
   // Searches itself and its parent to get a valid XamlView.
   // Like Mouse/Keyboard, the event source may not have matched XamlView.
-  XamlView reactPeerOrContainerFrom(winrt::FrameworkElement fe);
+  XamlView reactPeerOrContainerFrom(xaml::FrameworkElement fe);
 
  private:
   void DoLayout();

--- a/vnext/ReactUWP/Modules/NativeUIManager.h
+++ b/vnext/ReactUWP/Modules/NativeUIManager.h
@@ -7,8 +7,6 @@
 #include <IReactRootView.h>
 #include <Views/ViewManagerBase.h>
 
-#include <winrt/Windows.UI.Xaml.h>
-
 #include <folly/dynamic.h>
 #include <yoga/yoga.h>
 
@@ -104,7 +102,7 @@ class NativeUIManager : public facebook::react::INativeUIManager {
 
   std::map<int64_t, YogaNodePtr> m_tagsToYogaNodes;
   std::map<int64_t, std::unique_ptr<YogaContext>> m_tagsToYogaContext;
-  std::vector<winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker> m_sizeChangedVector;
+  std::vector<xaml::FrameworkElement::SizeChanged_revoker> m_sizeChangedVector;
   std::vector<std::function<void()>> m_batchCompletedCallbacks;
   std::vector<int64_t> m_extraLayoutNodes;
 

--- a/vnext/ReactUWP/Modules/TimingModule.cpp
+++ b/vnext/ReactUWP/Modules/TimingModule.cpp
@@ -18,13 +18,12 @@
 #pragma warning(pop)
 
 #include <unknwnbase.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
 
 using namespace facebook::xplat;
 using namespace folly;
 namespace winrt {
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml::Media;
 } // namespace winrt
 using namespace std;
 
@@ -133,7 +132,7 @@ void Timing::createTimer(int64_t id, double duration, double jsSchedulingTime, b
 
   if (m_timerQueue.IsEmpty()) {
     m_rendering.revoke();
-    m_rendering = winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering(
+    m_rendering = xaml::Media::CompositionTarget::Rendering(
         winrt::auto_revoke,
         [wkThis = std::weak_ptr(this->shared_from_this())](
             const winrt::IInspectable &, const winrt::IInspectable & /*args*/) {

--- a/vnext/ReactUWP/Modules/TimingModule.h
+++ b/vnext/ReactUWP/Modules/TimingModule.h
@@ -11,8 +11,6 @@
 #include <vector>
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-
 namespace react {
 namespace uwp {
 
@@ -74,7 +72,7 @@ class Timing : public std::enable_shared_from_this<Timing> {
  private:
   TimingModule *m_parent;
   TimerQueue m_timerQueue;
-  winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
+  xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
 };
 
 class TimingModule : public facebook::xplat::module::CxxModule {

--- a/vnext/ReactUWP/Pch/pch.h
+++ b/vnext/ReactUWP/Pch/pch.h
@@ -29,11 +29,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.System.h>
-#include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
+#include "CppWinRTIncludes.h"
 
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/Instance.h>

--- a/vnext/ReactUWP/Polyester/ButtonContentViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ButtonContentViewManager.cpp
@@ -7,16 +7,6 @@
 
 #include <Utils/ValueUtils.h>
 
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-
-using namespace winrt;
-using namespace ::Windows::Foundation;
-using namespace ::Windows::UI;
-using namespace ::Windows::UI::Xaml;
-using namespace ::Windows::UI::Xaml::Controls;
-using namespace ::Windows::UI::Xaml::Media;
-
 namespace react {
 namespace uwp {
 namespace polyester {
@@ -25,14 +15,14 @@ ButtonContentViewManager::ButtonContentViewManager(const std::shared_ptr<IReactI
     : Super(reactInstance) {}
 
 void ButtonContentViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
-  auto stackPanel(parent.as<StackPanel>());
+  auto stackPanel(parent.as<xaml::Controls::StackPanel>());
   if (stackPanel != nullptr) {
-    stackPanel.Children().InsertAt(static_cast<uint32_t>(index), child.as<UIElement>());
+    stackPanel.Children().InsertAt(static_cast<uint32_t>(index), child.as<xaml::UIElement>());
   }
 }
 
 void ButtonContentViewManager::RemoveAllChildren(const XamlView &parent) {
-  auto stackPanel(parent.as<StackPanel>());
+  auto stackPanel(parent.as<xaml::Controls::StackPanel>());
   if (stackPanel != nullptr) {
     stackPanel.Children().Clear();
     stackPanel.InvalidateMeasure();
@@ -41,7 +31,7 @@ void ButtonContentViewManager::RemoveAllChildren(const XamlView &parent) {
 }
 
 void ButtonContentViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
-  auto stackPanel(parent.as<StackPanel>());
+  auto stackPanel(parent.as<xaml::Controls::StackPanel>());
   if (stackPanel != nullptr) {
     stackPanel.Children().RemoveAt(static_cast<uint32_t>(index));
     stackPanel.InvalidateMeasure();
@@ -54,8 +44,8 @@ const char *ButtonContentViewManager::GetName() const {
 }
 
 XamlView ButtonContentViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto stackPanel = StackPanel();
-  stackPanel.Orientation(Orientation::Horizontal);
+  auto stackPanel = xaml::Controls::StackPanel();
+  stackPanel.Orientation(xaml::Controls::Orientation::Horizontal);
   return stackPanel;
 }
 

--- a/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.cpp
@@ -10,9 +10,6 @@
 
 #include <IReactInstance.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-
 namespace react {
 namespace uwp {
 namespace polyester {

--- a/vnext/ReactUWP/Polyester/ButtonViewManager.h
+++ b/vnext/ReactUWP/Polyester/ButtonViewManager.h
@@ -6,7 +6,7 @@
 #include "ContentControlViewManager.h"
 
 namespace winrt {
-using Button = winrt::Windows::UI::Xaml::Controls::Button;
+using Button = xaml::Controls::Button;
 }
 
 namespace react {

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
@@ -8,14 +8,12 @@
 
 #include <Utils/ValueUtils.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.h>
-
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -28,7 +26,7 @@ void ContentControlShadowNode::DoExtraLayoutPrep(YGNodeRef yogaNode) {
 
   m_paddingDirty = false;
 
-  auto contentControl = GetView().try_as<winrt::ContentControl>();
+  auto contentControl = GetView().try_as<xaml::Controls::ContentControl>();
   auto padding = contentControl.Padding();
 
   YGNodeStyleSetPadding(yogaNode, YGEdgeLeft, static_cast<float>(padding.Left));
@@ -40,14 +38,14 @@ void ContentControlShadowNode::DoExtraLayoutPrep(YGNodeRef yogaNode) {
 void ContentControlShadowNode::createView() {
   Super::createView();
 
-  auto obj = GetView().try_as<winrt::DependencyObject>();
+  auto obj = GetView().try_as<xaml::DependencyObject>();
   if (obj != nullptr) {
     // Button styles may have padding Yoga is not aware of
     obj.RegisterPropertyChangedCallback(
-        winrt::Windows::UI::Xaml::Controls::Control::PaddingProperty(),
+        xaml::Controls::Control::PaddingProperty(),
         [this](
-            winrt::Windows::UI::Xaml::DependencyObject const & /*sender*/,
-            winrt::Windows::UI::Xaml::DependencyProperty const & /*dp*/) { m_paddingDirty = true; });
+            xaml::DependencyObject const & /*sender*/,
+            xaml::DependencyProperty const & /*dp*/) { m_paddingDirty = true; });
   }
 }
 
@@ -67,13 +65,13 @@ void ContentControlViewManager::AddView(const XamlView &parent, const XamlView &
     return;
   }
 
-  auto contentControl(parent.as<winrt::ContentControl>());
+  auto contentControl(parent.as<xaml::Controls::ContentControl>());
   if (contentControl != nullptr)
     contentControl.Content(child.as<winrt::IInspectable>());
 }
 
 void ContentControlViewManager::RemoveAllChildren(const XamlView &parent) {
-  auto contentControl(parent.as<winrt::ContentControl>());
+  auto contentControl(parent.as<xaml::Controls::ContentControl>());
   if (contentControl != nullptr)
     contentControl.Content(nullptr);
 }
@@ -82,7 +80,7 @@ void ContentControlViewManager::RemoveChildAt(const XamlView &parent, int64_t in
   if (index != 0)
     return;
 
-  auto contentControl(parent.as<winrt::ContentControl>());
+  auto contentControl(parent.as<xaml::Controls::ContentControl>());
   if (contentControl != nullptr)
     contentControl.Content(nullptr);
 }

--- a/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/ContentControlViewManager.cpp
@@ -43,9 +43,9 @@ void ContentControlShadowNode::createView() {
     // Button styles may have padding Yoga is not aware of
     obj.RegisterPropertyChangedCallback(
         xaml::Controls::Control::PaddingProperty(),
-        [this](
-            xaml::DependencyObject const & /*sender*/,
-            xaml::DependencyProperty const & /*dp*/) { m_paddingDirty = true; });
+        [this](xaml::DependencyObject const & /*sender*/, xaml::DependencyProperty const & /*dp*/) {
+          m_paddingDirty = true;
+        });
   }
 }
 

--- a/vnext/ReactUWP/Polyester/HyperlinkViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/HyperlinkViewManager.cpp
@@ -10,16 +10,13 @@
 
 #include <IReactInstance.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Controls::Primitives;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Controls::Primitives;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {

--- a/vnext/ReactUWP/Polyester/IconViewManager.cpp
+++ b/vnext/ReactUWP/Polyester/IconViewManager.cpp
@@ -13,14 +13,13 @@
 #include <Views/ShadowNodeBase.h>
 
 #include <winrt/Windows.UI.ViewManagement.h>
-#include <winrt/Windows.UI.Xaml.Documents.h>
 
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Documents;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Documents;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -40,7 +39,7 @@ class IconShadowNode : public ShadowNodeBase {
   void updateProperties(const folly::dynamic &&props) override;
 
  private:
-  static void UpdateFontColorProps(winrt::Windows::UI::Xaml::Documents::Glyphs glyphs);
+  static void UpdateFontColorProps(xaml::Documents::Glyphs glyphs);
 
   std::optional<double> m_emSize;
   double m_height = 24;
@@ -129,7 +128,7 @@ void IconShadowNode::updateProperties(const folly::dynamic &&props) {
   if (appDictionary.HasKey(winrt::box_value(L"SystemAccentColor")))
     color = winrt::unbox_value<winrt::Windows::UI::Color>(appDictionary.Lookup(winrt::box_value(L"SystemAccentColor")));
 
-  glyphs.Fill(winrt::SolidColorBrush(color));
+  glyphs.Fill(xaml::Media::SolidColorBrush(color));
 }
 
 //

--- a/vnext/ReactUWP/Utils/AccessibilityUtils.cpp
+++ b/vnext/ReactUWP/Utils/AccessibilityUtils.cpp
@@ -12,7 +12,8 @@ namespace uwp {
 
 REACTWINDOWS_API_(void)
 AnnounceLiveRegionChangedIfNeeded(const xaml::FrameworkElement &element) {
-  if (xaml::Automation::AutomationProperties::GetLiveSetting(element) != xaml::Automation::Peers::AutomationLiveSetting::Off &&
+  if (xaml::Automation::AutomationProperties::GetLiveSetting(element) !=
+          xaml::Automation::Peers::AutomationLiveSetting::Off &&
       !xaml::Automation::AutomationProperties::GetName(element).empty()) {
     auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element);
     if (nullptr != peer) {

--- a/vnext/ReactUWP/Utils/AccessibilityUtils.cpp
+++ b/vnext/ReactUWP/Utils/AccessibilityUtils.cpp
@@ -7,29 +7,23 @@
 
 #include <Views\DynamicAutomationProperties.h>
 
-namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Automation;
-using namespace Windows::UI::Xaml::Automation::Peers;
-} // namespace winrt
-
 namespace react {
 namespace uwp {
 
 REACTWINDOWS_API_(void)
-AnnounceLiveRegionChangedIfNeeded(const winrt::FrameworkElement &element) {
-  if (winrt::AutomationProperties::GetLiveSetting(element) != winrt::AutomationLiveSetting::Off &&
-      !winrt::AutomationProperties::GetName(element).empty()) {
-    auto peer = winrt::FrameworkElementAutomationPeer::FromElement(element);
+AnnounceLiveRegionChangedIfNeeded(const xaml::FrameworkElement &element) {
+  if (xaml::Automation::AutomationProperties::GetLiveSetting(element) != xaml::Automation::Peers::AutomationLiveSetting::Off &&
+      !xaml::Automation::AutomationProperties::GetName(element).empty()) {
+    auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element);
     if (nullptr != peer) {
-      peer.RaiseAutomationEvent(winrt::AutomationEvents::LiveRegionChanged);
+      peer.RaiseAutomationEvent(xaml::Automation::Peers::AutomationEvents::LiveRegionChanged);
     }
   }
 }
 
 REACTWINDOWS_API_(bool)
-HasDynamicAutomationProperties(const winrt::Windows::UI::Xaml::UIElement &element) {
-  static auto unsetValue = winrt::DependencyProperty::UnsetValue();
+HasDynamicAutomationProperties(const xaml::UIElement &element) {
+  static auto unsetValue = xaml::DependencyProperty::UnsetValue();
 
   if (element) {
     return (unsetValue != element.ReadLocalValue(DynamicAutomationProperties::AccessibilityRoleProperty()));

--- a/vnext/ReactUWP/Utils/Helpers.cpp
+++ b/vnext/ReactUWP/Utils/Helpers.cpp
@@ -6,11 +6,10 @@
 #include <Modules/NativeUIManager.h>
 #include <Utils/Helpers.h>
 #include <winrt/Windows.Foundation.Metadata.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
 
 namespace winrt {
-using namespace Windows::UI::Xaml::Controls::Primitives;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml::Controls::Primitives;
+using namespace xaml::Media;
 using namespace Windows::Foundation::Metadata;
 } // namespace winrt
 
@@ -27,7 +26,7 @@ namespace uwp {
 // </NavigationView>
 // Instead of deduce view id directly from FrameworkElement.Tag, this do
 // additional check by uimanager.
-ReactId getViewId(_In_ IReactInstance *instance, winrt::FrameworkElement const &fe) {
+ReactId getViewId(_In_ IReactInstance *instance, xaml::FrameworkElement const &fe) {
   ReactId reactId;
   if (auto uiManager = static_cast<NativeUIManager *>(instance->NativeUIManager())) {
     if (auto peer = uiManager->reactPeerOrContainerFrom(fe)) {
@@ -41,8 +40,8 @@ ReactId getViewId(_In_ IReactInstance *instance, winrt::FrameworkElement const &
 std::int32_t CountOpenPopups() {
   // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
   // RS6
-  winrt::Windows::Foundation::Collections::IVectorView<winrt::Popup> popups =
-      winrt::VisualTreeHelper::GetOpenPopups(winrt::Window::Current());
+  winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
+      xaml::Media::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
   return (int32_t)popups.Size();
 }
 

--- a/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
+++ b/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
@@ -6,20 +6,13 @@
 #include <Utils/ResourceBrushUtils.h>
 #include <Utils/StandardControlResourceKeyNames.h>
 
-#include <winrt/Windows.UI.Xaml.h>
-
-namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-} // namespace winrt
-
 namespace react {
 namespace uwp {
 
 void UpdateResourceBrush(
-    const winrt::FrameworkElement &element,
+    const xaml::FrameworkElement &element,
     const std::wstring &resourceName,
-    const winrt::Brush brush) {
+    const xaml::Media::Brush brush) {
   const auto resources = element.Resources();
   if (resources != nullptr) {
     if (brush != nullptr) {
@@ -30,7 +23,7 @@ void UpdateResourceBrush(
   }
 }
 
-void UpdateTextControlBackgroundResourceBrushes(const winrt::FrameworkElement &element, const winrt::Brush brush) {
+void UpdateTextControlBackgroundResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush brush) {
   UpdateResourceBrush(element, c_textControlBackground, brush);
   UpdateResourceBrush(element, c_textControlBackgroundPointerOver, brush);
   UpdateResourceBrush(element, c_textControlBackgroundFocused, brush);
@@ -39,7 +32,7 @@ void UpdateTextControlBackgroundResourceBrushes(const winrt::FrameworkElement &e
   UpdateResourceBrush(element, c_textControlButtonForegroundPressed, brush);
 }
 
-void UpdateCheckBoxBackgroundResourceBrushes(const winrt::FrameworkElement &element, const winrt::Brush brush) {
+void UpdateCheckBoxBackgroundResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush brush) {
   UpdateResourceBrush(element, c_checkBoxBackgroundUnchecked, brush);
   UpdateResourceBrush(element, c_checkBoxBackgroundUncheckedPointerOver, brush);
   UpdateResourceBrush(element, c_checkBoxBackgroundUncheckedPressed, brush);
@@ -54,7 +47,7 @@ void UpdateCheckBoxBackgroundResourceBrushes(const winrt::FrameworkElement &elem
   UpdateResourceBrush(element, c_checkBoxBackgroundIndeterminateDisabled, brush);
 }
 
-void UpdateTextControlForegroundResourceBrushes(const winrt::FrameworkElement element, const winrt::Brush brush) {
+void UpdateTextControlForegroundResourceBrushes(const xaml::FrameworkElement element, const xaml::Media::Brush brush) {
   UpdateResourceBrush(element, c_textControlForeground, brush);
   UpdateResourceBrush(element, c_textControlForegroundPointerOver, brush);
   UpdateResourceBrush(element, c_textControlForegroundFocused, brush);
@@ -65,12 +58,12 @@ void UpdateTextControlForegroundResourceBrushes(const winrt::FrameworkElement el
   UpdateResourceBrush(element, c_textControlButtonBackgroundPressed, brush);
 }
 
-void UpdateTextControlBorderResourceBrushes(const winrt::FrameworkElement &element, const winrt::Brush b) {
+void UpdateTextControlBorderResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush& b) {
   // Workaround for bug https://microsoft.visualstudio.com/OS/_workitems/edit/26118890.
   // Remove when the bug gets fixed.
-  winrt::Brush brush = b;
-  if (auto solidBrush = b.as<winrt::SolidColorBrush>()) {
-    brush = winrt::SolidColorBrush{solidBrush.Color()};
+  xaml::Media::Brush brush = b;
+  if (auto solidBrush = b.as<xaml::Media::SolidColorBrush>()) {
+    brush = xaml::Media::SolidColorBrush{solidBrush.Color()};
   }
 
   UpdateResourceBrush(element, c_textControlBorderBrush, brush);
@@ -79,7 +72,7 @@ void UpdateTextControlBorderResourceBrushes(const winrt::FrameworkElement &eleme
   UpdateResourceBrush(element, c_textControlBorderBrushDisabled, brush);
 }
 
-void UpdateToggleSwitchBorderResourceBrushes(const winrt::ToggleSwitch &toggleSwitch, const winrt::Brush brush) {
+void UpdateToggleSwitchBorderResourceBrushes(const xaml::Controls::ToggleSwitch &toggleSwitch, const xaml::Media::Brush brush) {
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOff, brush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOffPointerOver, brush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOffPressed, brush);
@@ -90,7 +83,7 @@ void UpdateToggleSwitchBorderResourceBrushes(const winrt::ToggleSwitch &toggleSw
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOnDisabled, brush);
 }
 
-void UpdateCheckBoxBorderResourceBrushes(const winrt::CheckBox &checkBox, const winrt::Brush brush) {
+void UpdateCheckBoxBorderResourceBrushes(const xaml::Controls::CheckBox &checkBox, const xaml::Media::Brush brush) {
   UpdateResourceBrush(checkBox, c_checkBoxBorderBrushUnchecked, brush);
   UpdateResourceBrush(checkBox, c_checkBoxBorderBrushUncheckedPointerOver, brush);
   UpdateResourceBrush(checkBox, c_checkBoxBorderBrushUncheckedPressed, brush);
@@ -105,7 +98,7 @@ void UpdateCheckBoxBorderResourceBrushes(const winrt::CheckBox &checkBox, const 
   UpdateResourceBrush(checkBox, c_checkBoxBorderBrushIndeterminateDisabled, brush);
 }
 
-void UpdateToggleSwitchThumbResourceBrushes(const winrt::ToggleSwitch &toggleSwitch, const winrt::Brush thumbBrush) {
+void UpdateToggleSwitchThumbResourceBrushes(const xaml::Controls::ToggleSwitch &toggleSwitch, const xaml::Media::Brush thumbBrush) {
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOff, thumbBrush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPointerOver, thumbBrush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPressed, thumbBrush);
@@ -117,9 +110,9 @@ void UpdateToggleSwitchThumbResourceBrushes(const winrt::ToggleSwitch &toggleSwi
 }
 
 void UpdateToggleSwitchTrackResourceBrushes(
-    const winrt::ToggleSwitch &toggleSwitch,
-    const winrt::Brush onTrackBrush,
-    const winrt::Brush offTrackBrush) {
+    const xaml::Controls::ToggleSwitch &toggleSwitch,
+    const xaml::Media::Brush onTrackBrush,
+    const xaml::Media::Brush offTrackBrush) {
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOn, onTrackBrush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOnPointerOver, onTrackBrush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOnPressed, onTrackBrush);
@@ -131,38 +124,38 @@ void UpdateToggleSwitchTrackResourceBrushes(
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOffDisabled, offTrackBrush);
 }
 
-bool IsObjectATextControl(const winrt::DependencyObject &object) {
-  return object.try_as<winrt::TextBox>() != nullptr || object.try_as<winrt::PasswordBox>() != nullptr ||
-      object.try_as<winrt::RichEditBox>() != nullptr || object.try_as<winrt::AutoSuggestBox>() != nullptr;
+bool IsObjectATextControl(const xaml::DependencyObject &object) {
+  return object.try_as<xaml::Controls::TextBox>() != nullptr || object.try_as<xaml::Controls::PasswordBox>() != nullptr ||
+      object.try_as<xaml::Controls::RichEditBox>() != nullptr || object.try_as<xaml::Controls::AutoSuggestBox>() != nullptr;
 }
 
 void UpdateControlBackgroundResourceBrushes(
-    const winrt::Windows::UI::Xaml::FrameworkElement &element,
-    const winrt::Media::Brush brush) {
+    const xaml::FrameworkElement &element,
+    const xaml::Media::Brush brush) {
   if (IsObjectATextControl(element)) {
     UpdateTextControlBackgroundResourceBrushes(element, brush);
-  } else if (const auto checkBox = element.try_as<winrt::CheckBox>()) {
+  } else if (const auto checkBox = element.try_as<xaml::Controls::CheckBox>()) {
     UpdateCheckBoxBackgroundResourceBrushes(checkBox, brush);
   }
 }
 
 void UpdateControlForegroundResourceBrushes(
-    const winrt::Windows::UI::Xaml::DependencyObject object,
-    const winrt::Media::Brush brush) {
+    const xaml::DependencyObject object,
+    const xaml::Media::Brush brush) {
   if (IsObjectATextControl(object)) {
-    const auto element = object.try_as<winrt::FrameworkElement>();
+    const auto element = object.try_as<xaml::FrameworkElement>();
     UpdateTextControlForegroundResourceBrushes(element, brush);
   }
 }
 
 void UpdateControlBorderResourceBrushes(
-    const winrt::Windows::UI::Xaml::FrameworkElement &element,
-    const winrt::Media::Brush brush) {
+    const xaml::FrameworkElement &element,
+    const xaml::Media::Brush brush) {
   if (IsObjectATextControl(element)) {
     UpdateTextControlBorderResourceBrushes(element, brush);
-  } else if (const auto toggleSwitch = element.try_as<winrt::ToggleSwitch>()) {
+  } else if (const auto toggleSwitch = element.try_as<xaml::Controls::ToggleSwitch>()) {
     UpdateToggleSwitchBorderResourceBrushes(toggleSwitch, brush);
-  } else if (const auto checkBox = element.try_as<winrt::CheckBox>()) {
+  } else if (const auto checkBox = element.try_as<xaml::Controls::CheckBox>()) {
     UpdateCheckBoxBorderResourceBrushes(checkBox, brush);
   }
 }

--- a/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
+++ b/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
@@ -58,7 +58,7 @@ void UpdateTextControlForegroundResourceBrushes(const xaml::FrameworkElement ele
   UpdateResourceBrush(element, c_textControlButtonBackgroundPressed, brush);
 }
 
-void UpdateTextControlBorderResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush& b) {
+void UpdateTextControlBorderResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush &b) {
   // Workaround for bug https://microsoft.visualstudio.com/OS/_workitems/edit/26118890.
   // Remove when the bug gets fixed.
   xaml::Media::Brush brush = b;
@@ -72,7 +72,9 @@ void UpdateTextControlBorderResourceBrushes(const xaml::FrameworkElement &elemen
   UpdateResourceBrush(element, c_textControlBorderBrushDisabled, brush);
 }
 
-void UpdateToggleSwitchBorderResourceBrushes(const xaml::Controls::ToggleSwitch &toggleSwitch, const xaml::Media::Brush brush) {
+void UpdateToggleSwitchBorderResourceBrushes(
+    const xaml::Controls::ToggleSwitch &toggleSwitch,
+    const xaml::Media::Brush brush) {
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOff, brush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOffPointerOver, brush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchStrokeOffPressed, brush);
@@ -98,7 +100,9 @@ void UpdateCheckBoxBorderResourceBrushes(const xaml::Controls::CheckBox &checkBo
   UpdateResourceBrush(checkBox, c_checkBoxBorderBrushIndeterminateDisabled, brush);
 }
 
-void UpdateToggleSwitchThumbResourceBrushes(const xaml::Controls::ToggleSwitch &toggleSwitch, const xaml::Media::Brush thumbBrush) {
+void UpdateToggleSwitchThumbResourceBrushes(
+    const xaml::Controls::ToggleSwitch &toggleSwitch,
+    const xaml::Media::Brush thumbBrush) {
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOff, thumbBrush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPointerOver, thumbBrush);
   UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPressed, thumbBrush);
@@ -125,13 +129,13 @@ void UpdateToggleSwitchTrackResourceBrushes(
 }
 
 bool IsObjectATextControl(const xaml::DependencyObject &object) {
-  return object.try_as<xaml::Controls::TextBox>() != nullptr || object.try_as<xaml::Controls::PasswordBox>() != nullptr ||
-      object.try_as<xaml::Controls::RichEditBox>() != nullptr || object.try_as<xaml::Controls::AutoSuggestBox>() != nullptr;
+  return object.try_as<xaml::Controls::TextBox>() != nullptr ||
+      object.try_as<xaml::Controls::PasswordBox>() != nullptr ||
+      object.try_as<xaml::Controls::RichEditBox>() != nullptr ||
+      object.try_as<xaml::Controls::AutoSuggestBox>() != nullptr;
 }
 
-void UpdateControlBackgroundResourceBrushes(
-    const xaml::FrameworkElement &element,
-    const xaml::Media::Brush brush) {
+void UpdateControlBackgroundResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush brush) {
   if (IsObjectATextControl(element)) {
     UpdateTextControlBackgroundResourceBrushes(element, brush);
   } else if (const auto checkBox = element.try_as<xaml::Controls::CheckBox>()) {
@@ -139,18 +143,14 @@ void UpdateControlBackgroundResourceBrushes(
   }
 }
 
-void UpdateControlForegroundResourceBrushes(
-    const xaml::DependencyObject object,
-    const xaml::Media::Brush brush) {
+void UpdateControlForegroundResourceBrushes(const xaml::DependencyObject object, const xaml::Media::Brush brush) {
   if (IsObjectATextControl(object)) {
     const auto element = object.try_as<xaml::FrameworkElement>();
     UpdateTextControlForegroundResourceBrushes(element, brush);
   }
 }
 
-void UpdateControlBorderResourceBrushes(
-    const xaml::FrameworkElement &element,
-    const xaml::Media::Brush brush) {
+void UpdateControlBorderResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush brush) {
   if (IsObjectATextControl(element)) {
     UpdateTextControlBorderResourceBrushes(element, brush);
   } else if (const auto toggleSwitch = element.try_as<xaml::Controls::ToggleSwitch>()) {

--- a/vnext/ReactUWP/Utils/ValueUtils.cpp
+++ b/vnext/ReactUWP/Utils/ValueUtils.cpp
@@ -104,7 +104,8 @@ SolidColorBrushFrom(const folly::dynamic &d) {
     return BrushFromColorObject(d).as<xaml::Media::SolidColorBrush>();
   }
 
-  thread_local static std::map<winrt::Color, winrt::weak_ref<xaml::Media::SolidColorBrush>, ColorComp> solidColorBrushCache;
+  thread_local static std::map<winrt::Color, winrt::weak_ref<xaml::Media::SolidColorBrush>, ColorComp>
+      solidColorBrushCache;
 
   const auto color = d.isNumber() ? ColorFrom(d) : winrt::Colors::Transparent();
   if (solidColorBrushCache.count(color) != 0) {

--- a/vnext/ReactUWP/Utils/ValueUtils.cpp
+++ b/vnext/ReactUWP/Utils/ValueUtils.cpp
@@ -4,7 +4,6 @@
 #include "pch.h"
 
 #include <Utils/ValueUtils.h>
-#include <winrt/Windows.UI.Xaml.Markup.h>
 #include "Unicode.h"
 
 #include <folly/dynamic.h>
@@ -18,9 +17,9 @@
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Input;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Input;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -47,10 +46,10 @@ struct ColorComp {
   }
 };
 
-winrt::Windows::UI::Xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {
+xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {
   winrt::hstring resourceName{winrt::to_hstring(d.find("windowsbrush")->second.asString())};
 
-  thread_local static std::map<winrt::hstring, winrt::weak_ref<winrt::SolidColorBrush>> accentColorMap = {
+  thread_local static std::map<winrt::hstring, winrt::weak_ref<xaml::Media::SolidColorBrush>> accentColorMap = {
       {L"SystemAccentColor", {nullptr}},
       {L"SystemAccentColorLight1", {nullptr}},
       {L"SystemAccentColorLight2", {nullptr}},
@@ -82,7 +81,7 @@ winrt::Windows::UI::Xaml::Media::Brush BrushFromColorObject(const folly::dynamic
 
     auto dictionary{winrt::unbox_value<winrt::ResourceDictionary>(winrt::Markup::XamlReader::Load(xamlString))};
 
-    auto brush{winrt::unbox_value<winrt::SolidColorBrush>(dictionary.Lookup(winrt::box_value(resourceName)))};
+    auto brush{winrt::unbox_value<xaml::Media::SolidColorBrush>(dictionary.Lookup(winrt::box_value(resourceName)))};
 
     accentColorMap[resourceName] = winrt::make_weak(brush);
 
@@ -99,13 +98,13 @@ REACTWINDOWS_API_(winrt::Color) ColorFrom(const folly::dynamic &d) {
   return winrt::ColorHelper::FromArgb(GetAFromArgb(argb), GetRFromArgb(argb), GetGFromArgb(argb), GetBFromArgb(argb));
 }
 
-REACTWINDOWS_API_(winrt::SolidColorBrush)
+REACTWINDOWS_API_(xaml::Media::SolidColorBrush)
 SolidColorBrushFrom(const folly::dynamic &d) {
   if (d.isObject()) {
-    return BrushFromColorObject(d).as<winrt::SolidColorBrush>();
+    return BrushFromColorObject(d).as<xaml::Media::SolidColorBrush>();
   }
 
-  thread_local static std::map<winrt::Color, winrt::weak_ref<winrt::SolidColorBrush>, ColorComp> solidColorBrushCache;
+  thread_local static std::map<winrt::Color, winrt::weak_ref<xaml::Media::SolidColorBrush>, ColorComp> solidColorBrushCache;
 
   const auto color = d.isNumber() ? ColorFrom(d) : winrt::Colors::Transparent();
   if (solidColorBrushCache.count(color) != 0) {
@@ -114,7 +113,7 @@ SolidColorBrushFrom(const folly::dynamic &d) {
     }
   }
 
-  winrt::SolidColorBrush brush(color);
+  xaml::Media::SolidColorBrush brush(color);
   solidColorBrushCache[color] = winrt::make_weak(brush);
   return brush;
 }
@@ -127,38 +126,38 @@ REACTWINDOWS_API_(winrt::Brush) BrushFrom(const folly::dynamic &d) {
   return SolidColorBrushFrom(d);
 }
 
-REACTWINDOWS_API_(winrt::HorizontalAlignment)
+REACTWINDOWS_API_(xaml::HorizontalAlignment)
 HorizontalAlignmentFrom(const folly::dynamic &d) {
   auto valueString = d.asString();
   if (valueString == "center")
-    return winrt::HorizontalAlignment::Center;
+    return xaml::HorizontalAlignment::Center;
   else if (valueString == "left")
-    return winrt::HorizontalAlignment::Left;
+    return xaml::HorizontalAlignment::Left;
   else if (valueString == "right")
-    return winrt::HorizontalAlignment::Right;
+    return xaml::HorizontalAlignment::Right;
   else if (valueString == "stretch")
-    return winrt::HorizontalAlignment::Stretch;
+    return xaml::HorizontalAlignment::Stretch;
 
   // ASSERT: Invalid value for VerticalAlignment. Shouldn't get this far.
   assert(false);
-  return winrt::HorizontalAlignment::Stretch;
+  return xaml::HorizontalAlignment::Stretch;
 }
 
-REACTWINDOWS_API_(winrt::VerticalAlignment)
+REACTWINDOWS_API_(xaml::VerticalAlignment)
 VerticalAlignmentFrom(const folly::dynamic &d) {
   auto valueString = d.asString();
   if (valueString == "bottom")
-    return winrt::VerticalAlignment::Bottom;
+    return xaml::VerticalAlignment::Bottom;
   else if (valueString == "center")
-    return winrt::VerticalAlignment::Center;
+    return xaml::VerticalAlignment::Center;
   else if (valueString == "stretch")
-    return winrt::VerticalAlignment::Stretch;
+    return xaml::VerticalAlignment::Stretch;
   else if (valueString == "top")
-    return winrt::VerticalAlignment::Top;
+    return xaml::VerticalAlignment::Top;
 
   // ASSERT: Invalid value for VerticalAlignment. Shouldn't get this far.
   assert(false);
-  return winrt::VerticalAlignment::Stretch;
+  return xaml::VerticalAlignment::Stretch;
 }
 
 REACTWINDOWS_API_(winrt::DateTime)

--- a/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/ReactUWP/Views/ActivityIndicatorViewManager.cpp
@@ -27,7 +27,7 @@ folly::dynamic ActivityIndicatorViewManager::GetNativeProps() const {
 }
 
 XamlView ActivityIndicatorViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto progressRing = winrt::ProgressRing();
+  auto progressRing = xaml::Controls::ProgressRing();
   return progressRing;
 }
 
@@ -35,7 +35,7 @@ bool ActivityIndicatorViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,
     const folly::dynamic &propertyValue) {
-  auto progressRing = nodeToUpdate->GetView().as<winrt::ProgressRing>();
+  auto progressRing = nodeToUpdate->GetView().as<xaml::Controls::ProgressRing>();
   if (progressRing == nullptr)
     return true;
 
@@ -43,7 +43,7 @@ bool ActivityIndicatorViewManager::UpdateProperty(
     if (propertyValue.isBool())
       progressRing.IsActive(propertyValue.asBool());
     else if (propertyValue.isNull())
-      progressRing.ClearValue(winrt::ProgressRing::IsActiveProperty());
+      progressRing.ClearValue(xaml::Controls::ProgressRing::IsActiveProperty());
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }

--- a/vnext/ReactUWP/Views/CheckboxViewManager.cpp
+++ b/vnext/ReactUWP/Views/CheckboxViewManager.cpp
@@ -10,10 +10,8 @@
 
 #include <IReactInstance.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-
 namespace winrt {
-using ToggleButton = Windows::UI::Xaml::Controls::Primitives::ToggleButton;
+using ToggleButton = xaml::Controls::Primitives::ToggleButton;
 }
 
 namespace react {
@@ -30,14 +28,14 @@ class CheckBoxShadowNode : public ShadowNodeBase {
  private:
   static void OnCheckedChanged(IReactInstance &instance, int64_t tag, bool newValue);
 
-  winrt::CheckBox::Checked_revoker m_checkBoxCheckedRevoker{};
-  winrt::CheckBox::Unchecked_revoker m_checkBoxUncheckedRevoker{};
+  xaml::Controls::CheckBox::Checked_revoker m_checkBoxCheckedRevoker{};
+  xaml::Controls::CheckBox::Unchecked_revoker m_checkBoxUncheckedRevoker{};
 };
 
 void CheckBoxShadowNode::createView() {
   Super::createView();
 
-  auto checkbox = GetView().as<winrt::CheckBox>();
+  auto checkbox = GetView().as<xaml::Controls::CheckBox>();
   auto wkinstance = GetViewManager()->GetReactInstance();
   m_checkBoxCheckedRevoker = checkbox.Checked(winrt::auto_revoke, [=](auto &&, auto &&) {
     auto instance = wkinstance.lock();
@@ -81,7 +79,7 @@ facebook::react::ShadowNode *CheckBoxViewManager::createShadow() const {
 }
 
 XamlView CheckBoxViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto checkbox = winrt::CheckBox();
+  auto checkbox = xaml::Controls::CheckBox();
   return checkbox;
 }
 
@@ -89,7 +87,7 @@ bool CheckBoxViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,
     const folly::dynamic &propertyValue) {
-  auto checkbox = nodeToUpdate->GetView().as<winrt::CheckBox>();
+  auto checkbox = nodeToUpdate->GetView().as<xaml::Controls::CheckBox>();
   if (checkbox == nullptr)
     return true;
 
@@ -97,7 +95,7 @@ bool CheckBoxViewManager::UpdateProperty(
     if (propertyValue.isBool())
       checkbox.IsEnabled(!propertyValue.asBool());
     else if (propertyValue.isNull())
-      checkbox.ClearValue(winrt::Control::IsEnabledProperty());
+      checkbox.ClearValue(xaml::Controls::Control::IsEnabledProperty());
   } else if (propertyName == "value") {
     if (propertyValue.isBool())
       checkbox.IsChecked(propertyValue.asBool());

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -19,22 +19,22 @@ folly::dynamic ControlViewManager::GetNativeProps() const {
   return props;
 }
 void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
-  TransferProperty(oldView, newView, winrt::Control::FontSizeProperty());
-  TransferProperty(oldView, newView, winrt::Control::FontFamilyProperty());
-  TransferProperty(oldView, newView, winrt::Control::FontWeightProperty());
-  TransferProperty(oldView, newView, winrt::Control::FontStyleProperty());
-  TransferProperty(oldView, newView, winrt::Control::CharacterSpacingProperty());
-  TransferProperty(oldView, newView, winrt::Control::IsTextScaleFactorEnabledProperty());
-  TransferProperty(oldView, newView, winrt::Control::BackgroundProperty());
-  TransferProperty(oldView, newView, winrt::Control::BorderBrushProperty());
-  TransferProperty(oldView, newView, winrt::Control::BorderThicknessProperty());
-  TransferProperty(oldView, newView, winrt::Control::PaddingProperty());
-  TransferProperty(oldView, newView, winrt::Control::ForegroundProperty());
-  TransferProperty(oldView, newView, winrt::Control::TabIndexProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::FontSizeProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::FontFamilyProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::FontWeightProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::FontStyleProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::CharacterSpacingProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::IsTextScaleFactorEnabledProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::BackgroundProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::BorderBrushProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::BorderThicknessProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::PaddingProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::ForegroundProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Control::TabIndexProperty());
   // Control.CornerRadius is only supported on >= RS5
-  if (oldView.try_as<winrt::Windows::UI::Xaml::Controls::IControl7>() &&
-      newView.try_as<winrt::Windows::UI::Xaml::Controls::IControl7>()) {
-    TransferProperty(oldView, newView, winrt::Control::CornerRadiusProperty());
+  if (oldView.try_as<xaml::Controls::IControl7>() &&
+      newView.try_as<xaml::Controls::IControl7>()) {
+    TransferProperty(oldView, newView, xaml::Controls::Control::CornerRadiusProperty());
   }
   Super::TransferProperties(oldView, newView);
 }
@@ -43,7 +43,7 @@ bool ControlViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,
     const folly::dynamic &propertyValue) {
-  auto control(nodeToUpdate->GetView().as<winrt::Control>());
+  auto control(nodeToUpdate->GetView().as<xaml::Controls::Control>());
 
   bool implementsPadding = nodeToUpdate->ImplementsPadding();
   bool finalizeBorderRadius{false};
@@ -62,21 +62,21 @@ bool ControlViewManager::UpdateProperty(
         if (tabIndex == static_cast<int32_t>(tabIndex)) {
           if (tabIndex < 0) {
             control.IsTabStop(false);
-            control.ClearValue(winrt::Control::TabIndexProperty());
+            control.ClearValue(xaml::Controls::Control::TabIndexProperty());
           } else {
             control.IsTabStop(true);
             control.TabIndex(static_cast<int32_t>(tabIndex));
           }
         }
       } else if (propertyValue.isNull()) {
-        control.ClearValue(winrt::Control::TabIndexProperty());
+        control.ClearValue(xaml::Controls::Control::TabIndexProperty());
       }
     } else {
       ret = Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
     }
   }
 
-  if (finalizeBorderRadius && control.try_as<winrt::Windows::UI::Xaml::Controls::IControl7>()) {
+  if (finalizeBorderRadius && control.try_as<xaml::Controls::IControl7>()) {
     // Control.CornerRadius is only supported on >= RS5, setting borderRadius on Controls have no effect < RS5
     UpdateCornerRadiusOnElement(nodeToUpdate, control);
   }
@@ -86,7 +86,7 @@ bool ControlViewManager::UpdateProperty(
 void ControlViewManager::OnViewCreated(XamlView view) {
   // Set the default cornerRadius to 0 for Control: WinUI usually default cornerRadius to 2
   // Only works on >= RS5 becuase Control.CornerRadius is only supported >= RS5
-  if (auto control = view.try_as<winrt::Windows::UI::Xaml::Controls::IControl7>()) {
+  if (auto control = view.try_as<xaml::Controls::IControl7>()) {
     control.CornerRadius({0});
   }
 }

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -32,8 +32,7 @@ void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlV
   TransferProperty(oldView, newView, xaml::Controls::Control::ForegroundProperty());
   TransferProperty(oldView, newView, xaml::Controls::Control::TabIndexProperty());
   // Control.CornerRadius is only supported on >= RS5
-  if (oldView.try_as<xaml::Controls::IControl7>() &&
-      newView.try_as<xaml::Controls::IControl7>()) {
+  if (oldView.try_as<xaml::Controls::IControl7>() && newView.try_as<xaml::Controls::IControl7>()) {
     TransferProperty(oldView, newView, xaml::Controls::Control::CornerRadiusProperty());
   }
   Super::TransferProperties(oldView, newView);

--- a/vnext/ReactUWP/Views/DatePickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/DatePickerViewManager.cpp
@@ -32,18 +32,18 @@ class DatePickerShadowNode : public ShadowNodeBase {
       m_minTime; // These values are expected to be in milliseconds
   int64_t m_timeZoneOffsetInSeconds = 0; // Timezone offset is expected to be in seconds
 
-  winrt::CalendarDatePicker::DateChanged_revoker m_dataPickerDateChangedRevoker{};
+  xaml::Controls::CalendarDatePicker::DateChanged_revoker m_dataPickerDateChangedRevoker{};
 };
 
 void DatePickerShadowNode::createView() {
   Super::createView();
 
-  auto datePicker = GetView().as<winrt::CalendarDatePicker>();
+  auto datePicker = GetView().as<xaml::Controls::CalendarDatePicker>();
   auto wkinstance = GetViewManager()->GetReactInstance();
 
   m_dataPickerDateChangedRevoker = datePicker.DateChanged(
       winrt::auto_revoke,
-      [=](winrt::CalendarDatePicker /*picker*/, winrt::CalendarDatePickerDateChangedEventArgs args) {
+      [=](xaml::Controls::CalendarDatePicker /*picker*/, xaml::Controls::CalendarDatePickerDateChangedEventArgs args) {
         auto instance = wkinstance.lock();
         if (!m_updating && instance != nullptr && args.NewDate() != nullptr)
           OnDateChanged(*instance, m_tag, args.NewDate().Value());
@@ -53,7 +53,7 @@ void DatePickerShadowNode::createView() {
 void DatePickerShadowNode::updateProperties(const folly::dynamic &&props) {
   m_updating = true;
 
-  auto datePicker = GetView().as<winrt::CalendarDatePicker>();
+  auto datePicker = GetView().as<xaml::Controls::CalendarDatePicker>();
   if (datePicker == nullptr)
     return;
 
@@ -69,42 +69,42 @@ void DatePickerShadowNode::updateProperties(const folly::dynamic &&props) {
       if (propertyValue.isString())
         datePicker.DayOfWeekFormat(asHstring(propertyValue));
       else if (propertyValue.isNull())
-        datePicker.ClearValue(winrt::CalendarDatePicker::DayOfWeekFormatProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::DayOfWeekFormatProperty());
     } else if (propertyName == "dateFormat") {
       if (propertyValue.isString())
         datePicker.DateFormat(asHstring(propertyValue));
       else if (propertyValue.isNull())
-        datePicker.ClearValue(winrt::CalendarDatePicker::DateFormatProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::DateFormatProperty());
     } else if (propertyName == "firstDayOfWeek") {
       if (propertyValue.isNumber())
         datePicker.FirstDayOfWeek(static_cast<winrt::DayOfWeek>(static_cast<int64_t>(propertyValue.asDouble())));
       else if (propertyValue.isNull())
-        datePicker.ClearValue(winrt::CalendarDatePicker::FirstDayOfWeekProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::FirstDayOfWeekProperty());
     } else if (propertyName == "maxDate") {
       if (propertyValue.isNumber()) {
         m_maxTime = static_cast<int64_t>(propertyValue.asDouble());
         updateMaxDate = true;
       } else if (propertyValue.isNull()) {
-        datePicker.ClearValue(winrt::CalendarDatePicker::MaxDateProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::MaxDateProperty());
       }
     } else if (propertyName == "minDate") {
       if (propertyValue.isNumber()) {
         m_minTime = static_cast<int64_t>(propertyValue.asDouble());
         updateMinDate = true;
       } else if (propertyValue.isNull()) {
-        datePicker.ClearValue(winrt::CalendarDatePicker::MinDateProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::MinDateProperty());
       }
     } else if (propertyName == "placeholderText") {
       if (propertyValue.isString())
         datePicker.PlaceholderText(asHstring(propertyValue));
       else if (propertyValue.isNull())
-        datePicker.ClearValue(winrt::CalendarDatePicker::PlaceholderTextProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::PlaceholderTextProperty());
     } else if (propertyName == "selectedDate") {
       if (propertyValue.isNumber()) {
         m_selectedTime = static_cast<int64_t>(propertyValue.asDouble());
         updateSelectedDate = true;
       } else if (propertyValue.isNull()) {
-        datePicker.ClearValue(winrt::CalendarDatePicker::DateProperty());
+        datePicker.ClearValue(xaml::Controls::CalendarDatePicker::DateProperty());
       }
     } else if (propertyName == "timeZoneOffsetInSeconds") {
       if (propertyValue.isNumber())
@@ -157,7 +157,7 @@ facebook::react::ShadowNode *DatePickerViewManager::createShadow() const {
 }
 
 XamlView DatePickerViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto datePicker = winrt::CalendarDatePicker();
+  auto datePicker = xaml::Controls::CalendarDatePicker();
   return datePicker;
 }
 

--- a/vnext/ReactUWP/Views/DynamicAutomationPeer.cpp
+++ b/vnext/ReactUWP/Views/DynamicAutomationPeer.cpp
@@ -6,9 +6,6 @@
 #include "DynamicAutomationPeer.h"
 #include "DynamicAutomationProperties.h"
 
-#include <winrt/Windows.UI.Xaml.Interop.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-
 // Needed for latest versions of C++/WinRT
 #if __has_include("DynamicAutomationPeer.g.cpp")
 #include "DynamicAutomationPeer.g.cpp"
@@ -16,18 +13,18 @@
 
 namespace winrt {
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Automation;
-using namespace Windows::UI::Xaml::Automation::Peers;
-using namespace Windows::UI::Xaml::Automation::Provider;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Interop;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Automation;
+using namespace xaml::Automation::Peers;
+using namespace xaml::Automation::Provider;
+using namespace xaml::Controls;
+using namespace xaml::Interop;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
 
-DynamicAutomationPeer::DynamicAutomationPeer(winrt::FrameworkElement const &owner) : Super(owner) {}
+DynamicAutomationPeer::DynamicAutomationPeer(xaml::FrameworkElement const &owner) : Super(owner) {}
 
 winrt::hstring DynamicAutomationPeer::GetClassNameCore() const {
   return L"DynamicAutomationPeer";
@@ -312,7 +309,7 @@ bool DynamicAutomationPeer::HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE:
           value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateCollapsedProperty());
           break;
       }
-      return (value != winrt::DependencyProperty::UnsetValue());
+      return (value != xaml::DependencyProperty::UnsetValue());
     }
   } catch (...) {
   }

--- a/vnext/ReactUWP/Views/DynamicAutomationPeer.h
+++ b/vnext/ReactUWP/Views/DynamicAutomationPeer.h
@@ -4,11 +4,6 @@
 #pragma once
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Automation.Provider.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 #include "DynamicAutomationProperties.h"
 
@@ -24,14 +19,14 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
   using Super = DynamicAutomationPeerT<DynamicAutomationPeer>;
 
   DynamicAutomationPeer() = delete;
-  DynamicAutomationPeer(winrt::Windows::UI::Xaml::FrameworkElement const &owner);
+  DynamicAutomationPeer(xaml::FrameworkElement const &owner);
 
   winrt::hstring GetClassNameCore() const;
   winrt::hstring GetNameCore() const;
 
-  winrt::Windows::UI::Xaml::Automation::Peers::AutomationControlType GetAutomationControlTypeCore() const;
+  xaml::Automation::Peers::AutomationControlType GetAutomationControlTypeCore() const;
   winrt::Windows::Foundation::IInspectable GetPatternCore(
-      winrt::Windows::UI::Xaml::Automation::Peers::PatternInterface const &patternInterface) const;
+      xaml::Automation::Peers::PatternInterface const &patternInterface) const;
 
   bool IsEnabledCore() const;
 
@@ -47,21 +42,21 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
   bool IsSelectionRequired() const {
     return false;
   }
-  winrt::com_array<winrt::Windows::UI::Xaml::Automation::Provider::IRawElementProviderSimple> GetSelection() const;
+  winrt::com_array<xaml::Automation::Provider::IRawElementProviderSimple> GetSelection() const;
 
   // ISelectionItemProvider
   bool IsSelected() const;
-  winrt::Windows::UI::Xaml::Automation::Provider::IRawElementProviderSimple SelectionContainer() const;
+  xaml::Automation::Provider::IRawElementProviderSimple SelectionContainer() const;
   void AddToSelection() const;
   void RemoveFromSelection() const;
   void Select() const;
 
   // IToggleProvider
-  winrt::Windows::UI::Xaml::Automation::ToggleState ToggleState() const;
+  xaml::Automation::ToggleState ToggleState() const;
   void Toggle() const;
 
   // IExpandCollapseProvider
-  winrt::Windows::UI::Xaml::Automation::ExpandCollapseState ExpandCollapseState() const;
+  xaml::Automation::ExpandCollapseState ExpandCollapseState() const;
   void Expand() const;
   void Collapse() const;
 
@@ -72,21 +67,21 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
   bool GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates state) const;
   winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler() const;
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty();
+  static xaml::DependencyProperty AccessibilityActionsProperty();
   static void SetAccessibilityActions(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value);
   static Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> GetAccessibilityActions(
-      Windows::UI::Xaml::UIElement const &element);
+      xaml::UIElement const &element);
   static void DispatchAccessibilityAction(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       std::wstring_view const &actionName);
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
+  static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler const &value);
   static winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
-      winrt::Windows::UI::Xaml::UIElement const &element);
+      xaml::UIElement const &element);
 };
 } // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
 

--- a/vnext/ReactUWP/Views/DynamicAutomationPeer.h
+++ b/vnext/ReactUWP/Views/DynamicAutomationPeer.h
@@ -73,9 +73,7 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
       Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value);
   static Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> GetAccessibilityActions(
       xaml::UIElement const &element);
-  static void DispatchAccessibilityAction(
-      xaml::UIElement const &element,
-      std::wstring_view const &actionName);
+  static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
   static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(
       xaml::UIElement const &element,

--- a/vnext/ReactUWP/Views/DynamicAutomationProperties.cpp
+++ b/vnext/ReactUWP/Views/DynamicAutomationProperties.cpp
@@ -5,9 +5,6 @@
 
 #include "DynamicAutomationProperties.h"
 
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Interop.h>
-
 // Needed for latest versions of C++/WinRT
 #if __has_include("DynamicAutomationProperties.g.cpp")
 #include "DynamicAutomationProperties.g.cpp"
@@ -16,8 +13,8 @@
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Interop;
+using namespace xaml;
+using namespace xaml::Interop;
 } // namespace winrt
 
 namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
@@ -25,8 +22,8 @@ namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
 const winrt::TypeName dynamicAutomationTypeName{winrt::hstring{L"DynamicAutomationProperties"},
                                                 winrt::TypeKind::Metadata};
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityRoleProperty() {
-  static winrt::DependencyProperty s_AccessibilityRoleProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityRoleProperty() {
+  static xaml::DependencyProperty s_AccessibilityRoleProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityRole",
       winrt::xaml_typename<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles>(),
       dynamicAutomationTypeName,
@@ -36,19 +33,19 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityRole(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles const &value) {
   element.SetValue(AccessibilityRoleProperty(), winrt::box_value<PROJECT_ROOT_NAMESPACE::AccessibilityRoles>(value));
 }
 
 winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles DynamicAutomationProperties::GetAccessibilityRole(
-    winrt::Windows::UI::Xaml::UIElement const &element) {
+    xaml::UIElement const &element) {
   return winrt::unbox_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles>(
       element.GetValue(AccessibilityRoleProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateSelectedProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateSelectedProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateSelectedProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateSelectedProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateSelected",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -58,17 +55,17 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateSelected(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateSelectedProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateSelected(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateSelected(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateSelectedProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateDisabledProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateDisabledProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateDisabledProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateDisabledProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateDisabled",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -78,17 +75,17 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateDisabled(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateDisabledProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateDisabled(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateDisabled(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateDisabledProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateCheckedProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateCheckedProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateCheckedProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateCheckedProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateChecked",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -98,17 +95,17 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateChecked(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateCheckedProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateChecked(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateChecked(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateCheckedProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateUncheckedProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateUncheckedProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateUncheckedProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateUncheckedProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateUnchecked",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -118,17 +115,17 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateUnchecked(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateUncheckedProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateUnchecked(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateUnchecked(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateUncheckedProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateBusyProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateBusyProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateBusyProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateBusyProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateBusy",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -138,17 +135,17 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateBusy(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateBusyProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateBusy(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateBusy(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateBusyProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateExpandedProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateExpandedProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateExpandedProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateExpandedProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateExpanded",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -158,17 +155,17 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateExpanded(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateExpandedProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateExpanded(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateExpanded(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateExpandedProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateCollapsedProperty() {
-  static winrt::DependencyProperty s_AccessibilityStateCollapsedProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateCollapsedProperty() {
+  static xaml::DependencyProperty s_AccessibilityStateCollapsedProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateCollapsed",
       winrt::xaml_typename<bool>(),
       dynamicAutomationTypeName,
@@ -178,18 +175,18 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityStateCollapsed(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     bool value) {
   element.SetValue(AccessibilityStateCollapsedProperty(), winrt::box_value<bool>(value));
 }
 
-bool DynamicAutomationProperties::GetAccessibilityStateCollapsed(winrt::Windows::UI::Xaml::UIElement const &element) {
+bool DynamicAutomationProperties::GetAccessibilityStateCollapsed(xaml::UIElement const &element) {
   return winrt::unbox_value<bool>(element.GetValue(AccessibilityStateCollapsedProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityInvokeEventHandlerProperty() {
-  static winrt::DependencyProperty s_AccessibilityInvokeEventHandlerProperty =
-      winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityInvokeEventHandlerProperty() {
+  static xaml::DependencyProperty s_AccessibilityInvokeEventHandlerProperty =
+      xaml::DependencyProperty::RegisterAttached(
           L"AccessibilityInvokeEventHandler",
           winrt::xaml_typename<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler>(),
           dynamicAutomationTypeName,
@@ -200,7 +197,7 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler const &value) {
   element.SetValue(
       AccessibilityInvokeEventHandlerProperty(),
@@ -208,13 +205,13 @@ void DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(
 }
 
 winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler
-DynamicAutomationProperties::GetAccessibilityInvokeEventHandler(winrt::Windows::UI::Xaml::UIElement const &element) {
+DynamicAutomationProperties::GetAccessibilityInvokeEventHandler(xaml::UIElement const &element) {
   return winrt::unbox_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler>(
       element.GetValue(AccessibilityInvokeEventHandlerProperty()));
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty() {
-  static winrt::DependencyProperty s_AccessibilityActionsProperty = winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty() {
+  static xaml::DependencyProperty s_AccessibilityActionsProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityActions",
       winrt::xaml_typename<Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction>>(),
       dynamicAutomationTypeName,
@@ -224,19 +221,19 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityActions(
-    Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value) {
   return element.SetValue(AccessibilityActionsProperty(), winrt::box_value(value));
 }
 
 Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction>
-DynamicAutomationProperties::GetAccessibilityActions(Windows::UI::Xaml::UIElement const &element) {
+DynamicAutomationProperties::GetAccessibilityActions(xaml::UIElement const &element) {
   return winrt::unbox_value<Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction>>(
       element.GetValue(AccessibilityActionsProperty()));
 }
 
 void DynamicAutomationProperties::DispatchAccessibilityAction(
-    Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     std::wstring_view const &actionName) {
   if (element) {
     auto vector = GetAccessibilityActions(element);
@@ -254,9 +251,9 @@ void DynamicAutomationProperties::DispatchAccessibilityAction(
   }
 }
 
-winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionEventHandlerProperty() {
-  static winrt::DependencyProperty s_AccessibilityActionEventHandlerProperty =
-      winrt::DependencyProperty::RegisterAttached(
+xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionEventHandlerProperty() {
+  static xaml::DependencyProperty s_AccessibilityActionEventHandlerProperty =
+      xaml::DependencyProperty::RegisterAttached(
           L"AccessibilityActionEventHandler",
           winrt::xaml_typename<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler>(),
           dynamicAutomationTypeName,
@@ -267,7 +264,7 @@ winrt::Windows::UI::Xaml::DependencyProperty DynamicAutomationProperties::Access
 }
 
 void DynamicAutomationProperties::SetAccessibilityActionEventHandler(
-    winrt::Windows::UI::Xaml::UIElement const &element,
+    xaml::UIElement const &element,
     winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler const &value) {
   element.SetValue(
       AccessibilityActionEventHandlerProperty(),
@@ -275,7 +272,7 @@ void DynamicAutomationProperties::SetAccessibilityActionEventHandler(
 }
 
 winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler
-DynamicAutomationProperties::GetAccessibilityActionEventHandler(winrt::Windows::UI::Xaml::UIElement const &element) {
+DynamicAutomationProperties::GetAccessibilityActionEventHandler(xaml::UIElement const &element) {
   return winrt::unbox_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler>(
       element.GetValue(AccessibilityActionEventHandlerProperty()));
 }

--- a/vnext/ReactUWP/Views/DynamicAutomationProperties.cpp
+++ b/vnext/ReactUWP/Views/DynamicAutomationProperties.cpp
@@ -54,9 +54,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateSelected
   return s_AccessibilityStateSelectedProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateSelected(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateSelected(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateSelectedProperty(), winrt::box_value<bool>(value));
 }
 
@@ -74,9 +72,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateDisabled
   return s_AccessibilityStateDisabledProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateDisabled(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateDisabled(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateDisabledProperty(), winrt::box_value<bool>(value));
 }
 
@@ -94,9 +90,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateCheckedP
   return s_AccessibilityStateCheckedProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateChecked(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateChecked(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateCheckedProperty(), winrt::box_value<bool>(value));
 }
 
@@ -114,9 +108,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateUnchecke
   return s_AccessibilityStateUncheckedProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateUnchecked(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateUnchecked(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateUncheckedProperty(), winrt::box_value<bool>(value));
 }
 
@@ -134,9 +126,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateBusyProp
   return s_AccessibilityStateBusyProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateBusy(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateBusy(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateBusyProperty(), winrt::box_value<bool>(value));
 }
 
@@ -154,9 +144,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateExpanded
   return s_AccessibilityStateExpandedProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateExpanded(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateExpanded(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateExpandedProperty(), winrt::box_value<bool>(value));
 }
 
@@ -174,9 +162,7 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateCollapse
   return s_AccessibilityStateCollapsedProperty;
 }
 
-void DynamicAutomationProperties::SetAccessibilityStateCollapsed(
-    xaml::UIElement const &element,
-    bool value) {
+void DynamicAutomationProperties::SetAccessibilityStateCollapsed(xaml::UIElement const &element, bool value) {
   element.SetValue(AccessibilityStateCollapsedProperty(), winrt::box_value<bool>(value));
 }
 

--- a/vnext/ReactUWP/Views/DynamicAutomationProperties.h
+++ b/vnext/ReactUWP/Views/DynamicAutomationProperties.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <winrt/Windows.UI.Xaml.h>
-
 #include "DynamicAutomationProperties.g.h"
 
 #ifndef PROJECT_ROOT_NAMESPACE
@@ -31,66 +29,66 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
 
   // Attached Properties
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityRoleProperty();
+  static xaml::DependencyProperty AccessibilityRoleProperty();
   static void SetAccessibilityRole(
-      winrt::Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles const &value);
-  static AccessibilityRoles GetAccessibilityRole(winrt::Windows::UI::Xaml::UIElement const &element);
+  static AccessibilityRoles GetAccessibilityRole(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateSelectedProperty();
-  static void SetAccessibilityStateSelected(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateSelected(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateSelectedProperty();
+  static void SetAccessibilityStateSelected(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateSelected(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateDisabledProperty();
-  static void SetAccessibilityStateDisabled(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateDisabled(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateDisabledProperty();
+  static void SetAccessibilityStateDisabled(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateDisabled(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateCheckedProperty();
-  static void SetAccessibilityStateChecked(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateChecked(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateCheckedProperty();
+  static void SetAccessibilityStateChecked(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateChecked(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateUncheckedProperty();
-  static void SetAccessibilityStateUnchecked(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateUnchecked(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateUncheckedProperty();
+  static void SetAccessibilityStateUnchecked(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateUnchecked(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateBusyProperty();
-  static void SetAccessibilityStateBusy(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateBusy(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateBusyProperty();
+  static void SetAccessibilityStateBusy(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateBusy(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateExpandedProperty();
-  static void SetAccessibilityStateExpanded(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateExpanded(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateExpandedProperty();
+  static void SetAccessibilityStateExpanded(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateExpanded(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityStateCollapsedProperty();
-  static void SetAccessibilityStateCollapsed(winrt::Windows::UI::Xaml::UIElement const &element, bool value);
-  static bool GetAccessibilityStateCollapsed(winrt::Windows::UI::Xaml::UIElement const &element);
+  static xaml::DependencyProperty AccessibilityStateCollapsedProperty();
+  static void SetAccessibilityStateCollapsed(xaml::UIElement const &element, bool value);
+  static bool GetAccessibilityStateCollapsed(xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityInvokeEventHandlerProperty();
+  static xaml::DependencyProperty AccessibilityInvokeEventHandlerProperty();
   static void SetAccessibilityInvokeEventHandler(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler const &value);
   static winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(
-      winrt::Windows::UI::Xaml::UIElement const &element);
+      xaml::UIElement const &element);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionsProperty();
+  static xaml::DependencyProperty AccessibilityActionsProperty();
 
   static void SetAccessibilityActions(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value);
 
   static Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> GetAccessibilityActions(
-      Windows::UI::Xaml::UIElement const &element);
+      xaml::UIElement const &element);
 
   static void DispatchAccessibilityAction(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       std::wstring_view const &actionName);
 
-  static winrt::Windows::UI::Xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
+  static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(
-      Windows::UI::Xaml::UIElement const &element,
+      xaml::UIElement const &element,
       winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler const &value);
   static winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
-      winrt::Windows::UI::Xaml::UIElement const &element);
+      xaml::UIElement const &element);
 };
 
 } // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation

--- a/vnext/ReactUWP/Views/DynamicAutomationProperties.h
+++ b/vnext/ReactUWP/Views/DynamicAutomationProperties.h
@@ -79,9 +79,7 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
   static Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> GetAccessibilityActions(
       xaml::UIElement const &element);
 
-  static void DispatchAccessibilityAction(
-      xaml::UIElement const &element,
-      std::wstring_view const &actionName);
+  static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
 
   static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(

--- a/vnext/ReactUWP/Views/ExpressionAnimationStore.cpp
+++ b/vnext/ReactUWP/Views/ExpressionAnimationStore.cpp
@@ -6,17 +6,12 @@
 #include "ExpressionAnimationStore.h"
 #include "XamlFeatures.h"
 
-namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Composition;
-} // namespace winrt
-
 namespace react {
 namespace uwp {
 
 // Expression for computing the center point of a UIElement, produces a vector3
 // with 2D translation to center.
-winrt::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpression() {
+comp::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpression() {
   /*
 
   // Because of a bug in the Composition system, we cannot cache this
@@ -30,7 +25,7 @@ winrt::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpres
 
   if (m_elementCenterPointExpression == nullptr) {
     m_elementCenterPointExpression =
-        winrt::Window::Current().Compositor().CreateExpressionAnimation(
+        xaml::Window::Current().Compositor().CreateExpressionAnimation(
             L"vector3(0.5 * uielement.ActualSize.x, 0.5 *
   uielement.ActualSize.y, 0)");
   }
@@ -45,7 +40,7 @@ winrt::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpres
   // The way we obtain the center of an element is by using the ActualSize façade. However this was only added in 19h1
   // An expression animation that refers to a non-existent property (e.g. in RS5) will crash, so use the CenterPoint as
   // a fallback. This might be wrong but at least we won't crash.
-  return winrt::Window::Current().Compositor().CreateExpressionAnimation(
+  return xaml::Window::Current().Compositor().CreateExpressionAnimation(
       g_HasActualSizeProperty == TriBit::Set
           ? L"vector3(0.5 * uielement.ActualSize.x, 0.5 * uielement.ActualSize.y, 0)"
           : L"vector3(uielement.CenterPoint.X, uielement.CenterPoint.Y, uielement.CenterPoint.Z)");
@@ -53,9 +48,9 @@ winrt::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpres
 
 // Expression for applying a TransformMatrix about the centerpoint of a
 // UIElement, produces a Matrix4x4 with overall transform.
-winrt::ExpressionAnimation ExpressionAnimationStore::GetTransformCenteringExpression() {
+comp::ExpressionAnimation ExpressionAnimationStore::GetTransformCenteringExpression() {
   if (m_transformCenteringExpression == nullptr) {
-    m_transformCenteringExpression = winrt::Window::Current().Compositor().CreateExpressionAnimation(
+    m_transformCenteringExpression = xaml::Window::Current().Compositor().CreateExpressionAnimation(
         L"Matrix4x4.CreateFromTranslation(-PS.center) * PS.transform * Matrix4x4.CreateFromTranslation(PS.center)");
   }
 

--- a/vnext/ReactUWP/Views/ExpressionAnimationStore.h
+++ b/vnext/ReactUWP/Views/ExpressionAnimationStore.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <winrt/Windows.UI.Composition.h>
-
 namespace react {
 namespace uwp {
 
@@ -16,14 +14,14 @@ namespace uwp {
 // resolved, so they can be reused.
 class ExpressionAnimationStore {
  public:
-  winrt::Windows::UI::Composition::ExpressionAnimation GetElementCenterPointExpression();
-  winrt::Windows::UI::Composition::ExpressionAnimation GetTransformCenteringExpression();
+  comp::ExpressionAnimation GetElementCenterPointExpression();
+  comp::ExpressionAnimation GetTransformCenteringExpression();
 
  private:
   // Compositor bug, see notes in GetElementCenterPointExpression()
-  //  winrt::Windows::UI::Composition::ExpressionAnimation
+  //  comp::ExpressionAnimation
   //      m_elementCenterPointExpression{nullptr};
-  winrt::Windows::UI::Composition::ExpressionAnimation m_transformCenteringExpression{nullptr};
+  comp::ExpressionAnimation m_transformCenteringExpression{nullptr};
 };
 
 } // namespace uwp

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -368,7 +368,7 @@ void FlyoutShadowNode::SetTargetFrameworkElement() {
 }
 
 void FlyoutShadowNode::AdjustDefaultFlyoutStyle(float maxWidth, float maxHeight) {
-  winrt::Style flyoutStyle({XAML_NAMESPACE L".Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
+  winrt::Style flyoutStyle({XAML_NAMESPACE_STR L".Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
   flyoutStyle.Setters().Append(winrt::Setter(xaml::FrameworkElement::MaxWidthProperty(), winrt::box_value(maxWidth)));
   flyoutStyle.Setters().Append(winrt::Setter(xaml::FrameworkElement::MaxHeightProperty(), winrt::box_value(maxHeight)));
   flyoutStyle.Setters().Append(winrt::Setter(xaml::Controls::Control::PaddingProperty(), winrt::box_value(0)));

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -368,16 +368,16 @@ void FlyoutShadowNode::SetTargetFrameworkElement() {
 }
 
 void FlyoutShadowNode::AdjustDefaultFlyoutStyle(float maxWidth, float maxHeight) {
-  winrt::Style flyoutStyle({ XAML_NAMESPACE L".Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
+  winrt::Style flyoutStyle({XAML_NAMESPACE L".Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
   flyoutStyle.Setters().Append(winrt::Setter(xaml::FrameworkElement::MaxWidthProperty(), winrt::box_value(maxWidth)));
-  flyoutStyle.Setters().Append(
-      winrt::Setter(xaml::FrameworkElement::MaxHeightProperty(), winrt::box_value(maxHeight)));
+  flyoutStyle.Setters().Append(winrt::Setter(xaml::FrameworkElement::MaxHeightProperty(), winrt::box_value(maxHeight)));
   flyoutStyle.Setters().Append(winrt::Setter(xaml::Controls::Control::PaddingProperty(), winrt::box_value(0)));
   flyoutStyle.Setters().Append(winrt::Setter(xaml::Controls::Control::BorderThicknessProperty(), winrt::box_value(0)));
   flyoutStyle.Setters().Append(
       winrt::Setter(xaml::FrameworkElement::AllowFocusOnInteractionProperty(), winrt::box_value(false)));
   flyoutStyle.Setters().Append(winrt::Setter(
-      xaml::Controls::Control::BackgroundProperty(), winrt::box_value(xaml::Media::SolidColorBrush{winrt::Colors::Transparent()})));
+      xaml::Controls::Control::BackgroundProperty(),
+      winrt::box_value(xaml::Media::SolidColorBrush{winrt::Colors::Transparent()})));
   m_flyout.FlyoutPresenterStyle(flyoutStyle);
 }
 

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -11,12 +11,11 @@
 #include <Modules/NativeUIManager.h>
 #include <Utils/Helpers.h>
 #include <Utils/PropertyHandlerUtils.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 
 namespace winrt {
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Controls::Primitives;
-using namespace Windows::UI::Xaml::Interop;
+using namespace xaml::Controls;
+using namespace xaml::Controls::Primitives;
+using namespace xaml::Interop;
 } // namespace winrt
 
 static const std::unordered_map<std::string, winrt::FlyoutPlacementMode> placementModeMinVersion = {
@@ -91,7 +90,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   winrt::Popup GetFlyoutParentPopup() const;
   winrt::FlyoutPresenter GetFlyoutPresenter() const;
 
-  winrt::FrameworkElement m_targetElement = nullptr;
+  xaml::FrameworkElement m_targetElement = nullptr;
   winrt::Flyout m_flyout = nullptr;
   bool m_isLightDismissEnabled = true;
   bool m_isOpen = false;
@@ -121,7 +120,7 @@ void FlyoutShadowNode::AddView(ShadowNode &child, int64_t /*index*/) {
   m_previewKeyboardEventHandlerOnRoot->hook(childView);
 
   if (m_flyout != nullptr) {
-    m_flyout.Content(childView.as<winrt::UIElement>());
+    m_flyout.Content(childView.as<xaml::UIElement>());
     if (winrt::FlyoutPlacementMode::Full == m_flyout.Placement()) {
       // When using FlyoutPlacementMode::Full on a Flyout with an embedded
       // Picker, the flyout is not centered correctly. Below is a temporary
@@ -129,7 +128,7 @@ void FlyoutShadowNode::AddView(ShadowNode &child, int64_t /*index*/) {
       // content by adjusting the flyout presenter max size settings prior to
       // layout. This will unblock those scenarios while the work on a more
       // exhaustive fix proceeds.  Tracked by Issue #2969
-      if (auto fe = m_flyout.Content().try_as<winrt::FrameworkElement>()) {
+      if (auto fe = m_flyout.Content().try_as<xaml::FrameworkElement>()) {
         AdjustDefaultFlyoutStyle((float)fe.Width(), (float)fe.Height());
       }
     }
@@ -165,7 +164,7 @@ void FlyoutShadowNode::createView() {
         // its anchor element to prevent cases where focus can land on
         // an outer flyout content and therefore trigger a unexpected flyout
         // dismissal
-        winrt::FocusManager::TryFocusAsync(m_targetElement, winrt::FocusState::Programmatic);
+        xaml::Input::FocusManager::TryFocusAsync(m_targetElement, winrt::FocusState::Programmatic);
       }
 
       OnFlyoutClosed(*instance, m_tag, false);
@@ -191,7 +190,7 @@ void FlyoutShadowNode::createView() {
         // z-index translation based on an elevation derived from the count
         // of open popups/flyouts. We apply this translation on open of the
         // flyout. (Translation is only supported on RS5+, eg. IUIElement9)
-        if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
+        if (auto uiElement9 = GetView().try_as<xaml::IUIElement9>()) {
           auto numOpenPopups = CountOpenPopups();
           if (numOpenPopups > 0) {
             winrt::Numerics::float3 translation{0, 0, (float)16 * numOpenPopups};
@@ -210,10 +209,10 @@ void FlyoutShadowNode::createView() {
   // expected, AllowFocusOnInteraction is turned on the content element when
   // the Content property is updated.
   m_tokenContentPropertyChangeCallback = m_flyout.RegisterPropertyChangedCallback(
-      winrt::Flyout::ContentProperty(), [=](winrt::DependencyObject sender, winrt::DependencyProperty dp) {
+      winrt::Flyout::ContentProperty(), [=](xaml::DependencyObject sender, xaml::DependencyProperty dp) {
         if (auto flyout = sender.try_as<winrt::Flyout>()) {
           if (auto content = flyout.Content()) {
-            if (auto fe = content.try_as<winrt::FrameworkElement>()) {
+            if (auto fe = content.try_as<xaml::FrameworkElement>()) {
               fe.AllowFocusOnInteraction(true);
             }
           }
@@ -361,24 +360,24 @@ void FlyoutShadowNode::SetTargetFrameworkElement() {
 
     if (pShadowNodeChild != nullptr) {
       auto targetView = pShadowNodeChild->GetView();
-      m_targetElement = targetView.as<winrt::FrameworkElement>();
+      m_targetElement = targetView.as<xaml::FrameworkElement>();
     }
   } else {
-    m_targetElement = winrt::Window::Current().Content().as<winrt::FrameworkElement>();
+    m_targetElement = xaml::Window::Current().Content().as<xaml::FrameworkElement>();
   }
 }
 
 void FlyoutShadowNode::AdjustDefaultFlyoutStyle(float maxWidth, float maxHeight) {
-  winrt::Style flyoutStyle({L"Windows.UI.Xaml.Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
-  flyoutStyle.Setters().Append(winrt::Setter(winrt::FrameworkElement::MaxWidthProperty(), winrt::box_value(maxWidth)));
+  winrt::Style flyoutStyle({ XAML_NAMESPACE L".Controls.FlyoutPresenter", winrt::TypeKind::Metadata});
+  flyoutStyle.Setters().Append(winrt::Setter(xaml::FrameworkElement::MaxWidthProperty(), winrt::box_value(maxWidth)));
   flyoutStyle.Setters().Append(
-      winrt::Setter(winrt::FrameworkElement::MaxHeightProperty(), winrt::box_value(maxHeight)));
-  flyoutStyle.Setters().Append(winrt::Setter(winrt::Control::PaddingProperty(), winrt::box_value(0)));
-  flyoutStyle.Setters().Append(winrt::Setter(winrt::Control::BorderThicknessProperty(), winrt::box_value(0)));
+      winrt::Setter(xaml::FrameworkElement::MaxHeightProperty(), winrt::box_value(maxHeight)));
+  flyoutStyle.Setters().Append(winrt::Setter(xaml::Controls::Control::PaddingProperty(), winrt::box_value(0)));
+  flyoutStyle.Setters().Append(winrt::Setter(xaml::Controls::Control::BorderThicknessProperty(), winrt::box_value(0)));
   flyoutStyle.Setters().Append(
-      winrt::Setter(winrt::FrameworkElement::AllowFocusOnInteractionProperty(), winrt::box_value(false)));
+      winrt::Setter(xaml::FrameworkElement::AllowFocusOnInteractionProperty(), winrt::box_value(false)));
   flyoutStyle.Setters().Append(winrt::Setter(
-      winrt::Control::BackgroundProperty(), winrt::box_value(winrt::SolidColorBrush{winrt::Colors::Transparent()})));
+      xaml::Controls::Control::BackgroundProperty(), winrt::box_value(xaml::Media::SolidColorBrush{winrt::Colors::Transparent()})));
   m_flyout.FlyoutPresenterStyle(flyoutStyle);
 }
 
@@ -386,7 +385,7 @@ winrt::Popup FlyoutShadowNode::GetFlyoutParentPopup() const {
   // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
   // RS6
   winrt::Windows::Foundation::Collections::IVectorView<winrt::Popup> popups =
-      winrt::VisualTreeHelper::GetOpenPopups(winrt::Window::Current());
+      winrt::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
   if (popups.Size() > 0)
     return popups.GetAt(0);
   return nullptr;

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -15,11 +15,6 @@
 #include <WindowsNumerics.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Hosting.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 #include "Utils/PropertyHandlerUtils.h"
 
@@ -28,10 +23,10 @@
 #include <Views/ViewPanel.h>
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Automation;
-using namespace Windows::UI::Xaml::Automation::Peers;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Automation;
+using namespace xaml::Automation::Peers;
 using namespace Windows::Foundation::Collections;
 } // namespace winrt
 
@@ -77,15 +72,15 @@ FrameworkElementViewManager::FrameworkElementViewManager(const std::shared_ptr<I
 void FrameworkElementViewManager::TransferProperty(
     const XamlView &oldView,
     const XamlView &newView,
-    winrt::DependencyProperty dp) {
+    xaml::DependencyProperty dp) {
   TransferProperty(oldView, newView, dp, dp);
 }
 
 void FrameworkElementViewManager::TransferProperty(
     const XamlView &oldView,
     const XamlView &newView,
-    winrt::DependencyProperty oldViewDP,
-    winrt::DependencyProperty newViewDP) {
+    xaml::DependencyProperty oldViewDP,
+    xaml::DependencyProperty newViewDP) {
   auto oldValue = oldView.ReadLocalValue(oldViewDP);
   if (oldValue != nullptr) {
     oldView.ClearValue(oldViewDP);
@@ -95,30 +90,30 @@ void FrameworkElementViewManager::TransferProperty(
 
 void FrameworkElementViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
   // Render Properties
-  TransferProperty(oldView, newView, winrt::UIElement::OpacityProperty());
+  TransferProperty(oldView, newView, xaml::UIElement::OpacityProperty());
 
   // Layout Properties
-  TransferProperty(oldView, newView, winrt::FrameworkElement::WidthProperty());
-  TransferProperty(oldView, newView, winrt::FrameworkElement::HeightProperty());
-  TransferProperty(oldView, newView, winrt::FrameworkElement::MinWidthProperty());
-  TransferProperty(oldView, newView, winrt::FrameworkElement::MinHeightProperty());
-  TransferProperty(oldView, newView, winrt::FrameworkElement::MaxWidthProperty());
-  TransferProperty(oldView, newView, winrt::FrameworkElement::MaxHeightProperty());
-  TransferProperty(oldView, newView, winrt::FrameworkElement::FlowDirectionProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::WidthProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::HeightProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MinWidthProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MinHeightProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MaxWidthProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MaxHeightProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::FlowDirectionProperty());
   TransferProperty(oldView, newView, winrt::Canvas::ZIndexProperty());
   TransferProperty(oldView, newView, ViewPanel::LeftProperty());
   TransferProperty(oldView, newView, ViewPanel::TopProperty());
 
   // Accessibility Properties
-  TransferProperty(oldView, newView, winrt::AutomationProperties::AutomationIdProperty());
-  TransferProperty(oldView, newView, winrt::AutomationProperties::NameProperty());
-  TransferProperty(oldView, newView, winrt::AutomationProperties::HelpTextProperty());
-  TransferProperty(oldView, newView, winrt::AutomationProperties::LiveSettingProperty());
-  TransferProperty(oldView, newView, winrt::AutomationProperties::PositionInSetProperty());
-  TransferProperty(oldView, newView, winrt::AutomationProperties::SizeOfSetProperty());
-  auto accessibilityView = winrt::AutomationProperties::GetAccessibilityView(oldView);
-  winrt::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
-  winrt::AutomationProperties::SetAccessibilityView(oldView, winrt::Peers::AccessibilityView::Raw);
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::AutomationIdProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::NameProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::HelpTextProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::LiveSettingProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::PositionInSetProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::SizeOfSetProperty());
+  auto accessibilityView = xaml::Automation::AutomationProperties::GetAccessibilityView(oldView);
+  xaml::Automation::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
+  xaml::Automation::AutomationProperties::SetAccessibilityView(oldView, winrt::Peers::AccessibilityView::Raw);
   TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityRoleProperty());
   TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateSelectedProperty());
   TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateDisabledProperty());
@@ -138,8 +133,8 @@ void FrameworkElementViewManager::TransferProperties(const XamlView &oldView, co
   // Clear the TransformMatrix from the old View.  The TransformMatrix will be
   // set on the new View a bit later in RefreshProperties() (as we need data
   // from the ShadowNode not available here).
-  auto oldElement = oldView.try_as<winrt::UIElement>();
-  if (oldElement && oldElement.try_as<winrt::IUIElement10>()) {
+  auto oldElement = oldView.try_as<xaml::UIElement>();
+  if (oldElement && oldElement.try_as<xaml::IUIElement10>()) {
     oldElement.TransformMatrix(winrt::Windows::Foundation::Numerics::float4x4::identity());
   }
 }
@@ -165,7 +160,7 @@ bool FrameworkElementViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,
     const folly::dynamic &propertyValue) {
-  auto element(nodeToUpdate->GetView().as<winrt::FrameworkElement>());
+  auto element(nodeToUpdate->GetView().as<xaml::FrameworkElement>());
   if (element != nullptr) {
     if (propertyName == "opacity") {
       if (propertyValue.isNumber()) {
@@ -175,10 +170,10 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::UIElement::OpacityProperty());
+        element.ClearValue(xaml::UIElement::OpacityProperty());
       }
     } else if (propertyName == "transform") {
-      if (element.try_as<winrt::IUIElement10>()) // Works on 19H1+
+      if (element.try_as<xaml::IUIElement10>()) // Works on 19H1+
       {
         if (propertyValue.isArray()) {
           assert(propertyValue.size() == 16);
@@ -213,7 +208,7 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::FrameworkElement::WidthProperty());
+        element.ClearValue(xaml::FrameworkElement::WidthProperty());
       }
 
     } else if (propertyName == "height") {
@@ -224,7 +219,7 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::FrameworkElement::HeightProperty());
+        element.ClearValue(xaml::FrameworkElement::HeightProperty());
       }
     } else if (propertyName == "minWidth") {
       if (propertyValue.isNumber()) {
@@ -234,7 +229,7 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::FrameworkElement::MinWidthProperty());
+        element.ClearValue(xaml::FrameworkElement::MinWidthProperty());
       }
     } else if (propertyName == "maxWidth") {
       if (propertyValue.isNumber()) {
@@ -244,7 +239,7 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::FrameworkElement::MaxWidthProperty());
+        element.ClearValue(xaml::FrameworkElement::MaxWidthProperty());
       }
 
     } else if (propertyName == "minHeight") {
@@ -255,7 +250,7 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::FrameworkElement::MinHeightProperty());
+        element.ClearValue(xaml::FrameworkElement::MinHeightProperty());
       }
     } else if (propertyName == "maxHeight") {
       if (propertyValue.isNumber()) {
@@ -265,7 +260,7 @@ bool FrameworkElementViewManager::UpdateProperty(
         // else
         // TODO report error
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::FrameworkElement::MaxHeightProperty());
+        element.ClearValue(xaml::FrameworkElement::MaxHeightProperty());
       }
 
     } else if (propertyName == "accessibilityHint") {
@@ -273,24 +268,24 @@ bool FrameworkElementViewManager::UpdateProperty(
         auto value = react::uwp::asHstring(propertyValue);
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
-        element.SetValue(winrt::AutomationProperties::HelpTextProperty(), boxedValue);
+        element.SetValue(xaml::Automation::AutomationProperties::HelpTextProperty(), boxedValue);
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::AutomationProperties::HelpTextProperty());
+        element.ClearValue(xaml::Automation::AutomationProperties::HelpTextProperty());
       }
     } else if (propertyName == "accessibilityLabel") {
       if (propertyValue.isString()) {
         auto value = react::uwp::asHstring(propertyValue);
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
-        element.SetValue(winrt::AutomationProperties::NameProperty(), boxedValue);
+        element.SetValue(xaml::Automation::AutomationProperties::NameProperty(), boxedValue);
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::AutomationProperties::NameProperty());
+        element.ClearValue(xaml::Automation::AutomationProperties::NameProperty());
       }
       AnnounceLiveRegionChangedIfNeeded(element);
     } else if (propertyName == "accessible") {
       if (propertyValue.isBool()) {
         if (!propertyValue.asBool())
-          winrt::AutomationProperties::SetAccessibilityView(element, winrt::Peers::AccessibilityView::Raw);
+          xaml::Automation::AutomationProperties::SetAccessibilityView(element, winrt::Peers::AccessibilityView::Raw);
       }
     } else if (propertyName == "accessibilityLiveRegion") {
       if (propertyValue.isString()) {
@@ -304,9 +299,9 @@ bool FrameworkElementViewManager::UpdateProperty(
           liveSetting = winrt::AutomationLiveSetting::Assertive;
         }
 
-        element.SetValue(winrt::AutomationProperties::LiveSettingProperty(), winrt::box_value(liveSetting));
+        element.SetValue(xaml::Automation::AutomationProperties::LiveSettingProperty(), winrt::box_value(liveSetting));
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::AutomationProperties::LiveSettingProperty());
+        element.ClearValue(xaml::Automation::AutomationProperties::LiveSettingProperty());
       }
       AnnounceLiveRegionChangedIfNeeded(element);
     } else if (propertyName == "accessibilityPosInSet") {
@@ -314,18 +309,18 @@ bool FrameworkElementViewManager::UpdateProperty(
         auto value = static_cast<int>(propertyValue.asDouble());
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateInt32(value);
 
-        element.SetValue(winrt::AutomationProperties::PositionInSetProperty(), boxedValue);
+        element.SetValue(xaml::Automation::AutomationProperties::PositionInSetProperty(), boxedValue);
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::AutomationProperties::PositionInSetProperty());
+        element.ClearValue(xaml::Automation::AutomationProperties::PositionInSetProperty());
       }
     } else if (propertyName == "accessibilitySetSize") {
       if (propertyValue.isNumber()) {
         auto value = static_cast<int>(propertyValue.asDouble());
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateInt32(value);
 
-        element.SetValue(winrt::AutomationProperties::SizeOfSetProperty(), boxedValue);
+        element.SetValue(xaml::Automation::AutomationProperties::SizeOfSetProperty(), boxedValue);
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::AutomationProperties::SizeOfSetProperty());
+        element.ClearValue(xaml::Automation::AutomationProperties::SizeOfSetProperty());
       }
     } else if (propertyName == "accessibilityRole") {
       if (propertyValue.isString()) {
@@ -444,9 +439,9 @@ bool FrameworkElementViewManager::UpdateProperty(
         auto value = react::uwp::asHstring(propertyValue);
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
-        element.SetValue(winrt::AutomationProperties::AutomationIdProperty(), boxedValue);
+        element.SetValue(xaml::Automation::AutomationProperties::AutomationIdProperty(), boxedValue);
       } else if (propertyValue.isNull()) {
-        element.ClearValue(winrt::AutomationProperties::AutomationIdProperty());
+        element.ClearValue(xaml::Automation::AutomationProperties::AutomationIdProperty());
       }
     } else if (propertyName == "tooltip") {
       if (propertyValue.isString()) {
@@ -489,7 +484,7 @@ bool FrameworkElementViewManager::UpdateProperty(
 //    pick up the new value.
 // 3) Create an ExpressionAnimation to multiply everything together.
 void FrameworkElementViewManager::ApplyTransformMatrix(
-    winrt::UIElement uielement,
+    xaml::UIElement uielement,
     ShadowNodeBase *shadowNode,
     winrt::Windows::Foundation::Numerics::float4x4 transformMatrix) {
   // Get our PropertySet from the ShadowNode and insert the TransformMatrix as
@@ -504,8 +499,8 @@ void FrameworkElementViewManager::ApplyTransformMatrix(
 // Starts ExpressionAnimation targeting UIElement.TransformMatrix with centered
 // transform
 void FrameworkElementViewManager::StartTransformAnimation(
-    winrt::UIElement uielement,
-    winrt::Windows::UI::Composition::CompositionPropertySet transformPS) {
+    xaml::UIElement uielement,
+    comp::CompositionPropertySet transformPS) {
   auto instance = GetReactInstance().lock();
   assert(instance != nullptr);
   auto expression = instance->GetExpressionAnimationStore().GetTransformCenteringExpression();
@@ -520,7 +515,7 @@ void FrameworkElementViewManager::RefreshTransformMatrix(ShadowNodeBase *shadowN
     // First we need to update the reference parameter on the centering
     // expression to point to the new backing UIElement.
     shadowNode->UpdateTransformPS();
-    auto uielement = shadowNode->GetView().try_as<winrt::UIElement>();
+    auto uielement = shadowNode->GetView().try_as<xaml::UIElement>();
     assert(uielement != nullptr);
 
     // Start a new ExpressionAnimation targeting the new

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.cpp
@@ -9,7 +9,6 @@
 #include "ImageViewManager.h"
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 
 #include <IReactInstance.h>
 #include <Utils/PropertyHandlerUtils.h>
@@ -19,7 +18,7 @@
 
 namespace winrt {
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Controls;
+using namespace xaml::Controls;
 } // namespace winrt
 
 // Such code is better to move to a seperate parser layer

--- a/vnext/ReactUWP/Views/Image/ImageViewManager.h
+++ b/vnext/ReactUWP/Views/Image/ImageViewManager.h
@@ -18,7 +18,7 @@ class ImageViewManager : public FrameworkElementViewManager {
   folly::dynamic GetExportedCustomDirectEventTypeConstants() const override;
   folly::dynamic GetNativeProps() const override;
   facebook::react::ShadowNode *createShadow() const override;
-  void EmitImageEvent(winrt::Windows::UI::Xaml::Controls::Grid grid, const char *eventName, ReactImageSource &source);
+  void EmitImageEvent(xaml::Controls::Grid grid, const char *eventName, ReactImageSource &source);
 
  protected:
   bool UpdateProperty(
@@ -29,7 +29,7 @@ class ImageViewManager : public FrameworkElementViewManager {
   XamlView CreateViewCore(int64_t tag) override;
 
  private:
-  void setSource(winrt::Windows::UI::Xaml::Controls::Grid grid, const folly::dynamic &sources);
+  void setSource(xaml::Controls::Grid grid, const folly::dynamic &sources);
 };
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -15,9 +15,9 @@ namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::Storage::Streams;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Media;
-using namespace Windows::UI::Xaml::Media::Imaging;
+using namespace xaml;
+using namespace xaml::Media;
+using namespace xaml::Media::Imaging;
 using namespace Windows::Web::Http;
 } // namespace winrt
 
@@ -35,7 +35,7 @@ namespace uwp {
   auto reactImage = winrt::make_self<ReactImage>();
   // Grid inheirts the layout direction from parent and mirrors the background image in RTL mode.
   // Forcing the container to LTR mode to avoid the unexpected mirroring behavior.
-  reactImage->FlowDirection(winrt::FlowDirection::LeftToRight);
+  reactImage->FlowDirection(xaml::FlowDirection::LeftToRight);
   return reactImage;
 }
 

--- a/vnext/ReactUWP/Views/Image/ReactImage.h
+++ b/vnext/ReactUWP/Views/Image/ReactImage.h
@@ -7,10 +7,6 @@
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 #include <folly/dynamic.h>
 
@@ -31,8 +27,8 @@ struct ReactImageSource {
   ImageSourceType sourceType = ImageSourceType::Uri;
 };
 
-struct ReactImage : winrt::Windows::UI::Xaml::Controls::GridT<ReactImage> {
-  using Super = winrt::Windows::UI::Xaml::Controls::GridT<ReactImage>;
+struct ReactImage : xaml::Controls::GridT<ReactImage> {
+  using Super = xaml::Controls::GridT<ReactImage>;
 
   ReactImage() = default;
 
@@ -58,7 +54,7 @@ struct ReactImage : winrt::Windows::UI::Xaml::Controls::GridT<ReactImage> {
   void ResizeMode(react::uwp::ResizeMode value);
 
  private:
-  winrt::Windows::UI::Xaml::Media::Stretch ResizeModeToStretch(react::uwp::ResizeMode value);
+  xaml::Media::Stretch ResizeModeToStretch(react::uwp::ResizeMode value);
   winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
   GetImageMemoryStreamAsync(ReactImageSource source);
   winrt::fire_and_forget SetBackground(bool fireLoadEndEvent);
@@ -68,13 +64,13 @@ struct ReactImage : winrt::Windows::UI::Xaml::Controls::GridT<ReactImage> {
   react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
 
   winrt::event<winrt::Windows::Foundation::EventHandler<bool>> m_onLoadEndEvent;
-  winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker m_sizeChangedRevoker;
-  winrt::Windows::UI::Xaml::Media::LoadedImageSurface::LoadCompleted_revoker m_surfaceLoadedRevoker;
-  winrt::Windows::UI::Xaml::Media::Imaging::BitmapImage::ImageOpened_revoker m_bitmapImageOpened;
-  winrt::Windows::UI::Xaml::Media::ImageBrush::ImageOpened_revoker m_imageBrushOpenedRevoker;
-  winrt::Windows::UI::Xaml::Media::ImageBrush::ImageFailed_revoker m_imageBrushFailedRevoker;
-  winrt::Windows::UI::Xaml::Media::Imaging::SvgImageSource::Opened_revoker m_svgImageSourceOpenedRevoker;
-  winrt::Windows::UI::Xaml::Media::Imaging::SvgImageSource::OpenFailed_revoker m_svgImageSourceOpenFailedRevoker;
+  xaml::FrameworkElement::SizeChanged_revoker m_sizeChangedRevoker;
+  xaml::Media::LoadedImageSurface::LoadCompleted_revoker m_surfaceLoadedRevoker;
+  xaml::Media::Imaging::BitmapImage::ImageOpened_revoker m_bitmapImageOpened;
+  xaml::Media::ImageBrush::ImageOpened_revoker m_imageBrushOpenedRevoker;
+  xaml::Media::ImageBrush::ImageFailed_revoker m_imageBrushFailedRevoker;
+  xaml::Media::Imaging::SvgImageSource::Opened_revoker m_svgImageSourceOpenedRevoker;
+  xaml::Media::Imaging::SvgImageSource::OpenFailed_revoker m_svgImageSourceOpenFailedRevoker;
 };
 
 // Helper functions

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -55,7 +55,7 @@ void ReactImageBrush::Source(winrt::LoadedImageSurface const &value) {
     m_loadedImageSurface = value;
 
     if (updateSurface) {
-      winrt::CompositionSurfaceBrush surfaceBrush{GetOrCreateSurfaceBrush()};
+      comp::CompositionSurfaceBrush surfaceBrush{GetOrCreateSurfaceBrush()};
       surfaceBrush.Surface(m_loadedImageSurface);
     }
 
@@ -65,10 +65,10 @@ void ReactImageBrush::Source(winrt::LoadedImageSurface const &value) {
 
 void ReactImageBrush::UpdateCompositionBrush() {
   if (m_loadedImageSurface) {
-    winrt::CompositionSurfaceBrush surfaceBrush{GetOrCreateSurfaceBrush()};
+    comp::CompositionSurfaceBrush surfaceBrush{GetOrCreateSurfaceBrush()};
     surfaceBrush.Stretch(ResizeModeToStretch());
 
-    auto compositionBrush{surfaceBrush.as<winrt::CompositionBrush>()};
+    auto compositionBrush{surfaceBrush.as<comp::CompositionBrush>()};
     if (ResizeMode() == ResizeMode::Repeat) {
       // If ResizeMode is set to Repeat, then we need to use a CompositionEffectBrush.
       // The CompositionSurfaceBrush holding the image is used as its source.
@@ -102,65 +102,65 @@ bool ReactImageBrush::IsImageSmallerThanView() {
   return false;
 }
 
-winrt::CompositionStretch ReactImageBrush::ResizeModeToStretch() {
-  auto stretch{winrt::CompositionStretch::None};
+comp::CompositionStretch ReactImageBrush::ResizeModeToStretch() {
+  auto stretch{comp::CompositionStretch::None};
 
   switch (ResizeMode()) {
     case ResizeMode::Contain:
-      stretch = winrt::CompositionStretch::Uniform;
+      stretch = comp::CompositionStretch::Uniform;
       break;
 
     case ResizeMode::Cover:
-      stretch = winrt::CompositionStretch::UniformToFill;
+      stretch = comp::CompositionStretch::UniformToFill;
       break;
 
     case ResizeMode::Stretch:
-      stretch = winrt::CompositionStretch::Fill;
+      stretch = comp::CompositionStretch::Fill;
       break;
 
     case ResizeMode::Center:
     case ResizeMode::Repeat:
-      stretch = IsImageSmallerThanView() ? winrt::CompositionStretch::None : winrt::CompositionStretch::Uniform;
+      stretch = IsImageSmallerThanView() ? comp::CompositionStretch::None : comp::CompositionStretch::Uniform;
       break;
   }
 
   return stretch;
 }
 
-winrt::CompositionSurfaceBrush ReactImageBrush::GetOrCreateSurfaceBrush() {
+comp::CompositionSurfaceBrush ReactImageBrush::GetOrCreateSurfaceBrush() {
   // If it doesn't exist, create it
   if (!CompositionBrush()) {
-    winrt::CompositionSurfaceBrush surfaceBrush{xaml::Window::Current().Compositor().CreateSurfaceBrush()};
+    comp::CompositionSurfaceBrush surfaceBrush{xaml::Window::Current().Compositor().CreateSurfaceBrush()};
     surfaceBrush.Surface(m_loadedImageSurface);
 
     return surfaceBrush;
   }
 
-  auto surfaceBrush{CompositionBrush().try_as<winrt::CompositionSurfaceBrush>()};
+  auto surfaceBrush{CompositionBrush().try_as<comp::CompositionSurfaceBrush>()};
 
   // If ResizeMode is set to Repeat, then we're using a CompositionEffectBrush.
   // Get the CompositionSurfaceBrush from its source.
   if (!surfaceBrush) {
-    auto effectBrush{CompositionBrush().as<winrt::CompositionEffectBrush>()};
+    auto effectBrush{CompositionBrush().as<comp::CompositionEffectBrush>()};
     assert(effectBrush);
 
-    surfaceBrush = effectBrush.GetSourceParameter(L"source").as<winrt::CompositionSurfaceBrush>();
+    surfaceBrush = effectBrush.GetSourceParameter(L"source").as<comp::CompositionSurfaceBrush>();
   }
 
   return surfaceBrush;
 }
 
-winrt::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
-    winrt::CompositionSurfaceBrush const &surfaceBrush) {
+comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
+    comp::CompositionSurfaceBrush const &surfaceBrush) {
   if (!m_effectBrush) {
     auto borderEffect{winrt::make<winrt::implementation::BorderEffect>()};
-    borderEffect.ExtendX(winrt::CanvasEdgeBehavior::Wrap);
-    borderEffect.ExtendY(winrt::CanvasEdgeBehavior::Wrap);
+    borderEffect.ExtendX(comp::CanvasEdgeBehavior::Wrap);
+    borderEffect.ExtendY(comp::CanvasEdgeBehavior::Wrap);
 
-    winrt::CompositionEffectSourceParameter borderEffectSourceParameter{L"source"};
+    comp::CompositionEffectSourceParameter borderEffectSourceParameter{L"source"};
     borderEffect.Source(borderEffectSourceParameter);
 
-    winrt::CompositionEffectFactory effectFactory{
+    comp::CompositionEffectFactory effectFactory{
         xaml::Window::Current().Compositor().CreateEffectFactory(borderEffect)};
     m_effectBrush = effectFactory.CreateBrush();
 

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -7,7 +7,6 @@
 
 #include <sstream>
 
-
 #include "BorderEffect.h"
 
 namespace winrt {

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -154,8 +154,8 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
     comp::CompositionSurfaceBrush const &surfaceBrush) {
   if (!m_effectBrush) {
     auto borderEffect{winrt::make<winrt::implementation::BorderEffect>()};
-    borderEffect.ExtendX(comp::CanvasEdgeBehavior::Wrap);
-    borderEffect.ExtendY(comp::CanvasEdgeBehavior::Wrap);
+    borderEffect.ExtendX(winrt::CanvasEdgeBehavior::Wrap);
+    borderEffect.ExtendY(winrt::CanvasEdgeBehavior::Wrap);
 
     comp::CompositionEffectSourceParameter borderEffectSourceParameter{L"source"};
     borderEffect.Source(borderEffectSourceParameter);

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -7,15 +7,14 @@
 
 #include <sstream>
 
-#include <winrt/Windows.UI.Composition.h>
 
 #include "BorderEffect.h"
 
 namespace winrt {
 using namespace winrt::Windows::Storage::Streams;
-using namespace winrt::Windows::UI::Composition;
-using namespace winrt::Windows::UI::Xaml;
-using namespace winrt::Windows::UI::Xaml::Media;
+using namespace comp;
+using namespace xaml;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -131,7 +130,7 @@ winrt::CompositionStretch ReactImageBrush::ResizeModeToStretch() {
 winrt::CompositionSurfaceBrush ReactImageBrush::GetOrCreateSurfaceBrush() {
   // If it doesn't exist, create it
   if (!CompositionBrush()) {
-    winrt::CompositionSurfaceBrush surfaceBrush{winrt::Window::Current().Compositor().CreateSurfaceBrush()};
+    winrt::CompositionSurfaceBrush surfaceBrush{xaml::Window::Current().Compositor().CreateSurfaceBrush()};
     surfaceBrush.Surface(m_loadedImageSurface);
 
     return surfaceBrush;
@@ -162,7 +161,7 @@ winrt::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
     borderEffect.Source(borderEffectSourceParameter);
 
     winrt::CompositionEffectFactory effectFactory{
-        winrt::Window::Current().Compositor().CreateEffectFactory(borderEffect)};
+        xaml::Window::Current().Compositor().CreateEffectFactory(borderEffect)};
     m_effectBrush = effectFactory.CreateBrush();
 
     m_effectBrush.SetSourceParameter(L"source", surfaceBrush);

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.h
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.h
@@ -40,8 +40,7 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
   bool IsImageSmallerThanView();
   comp::CompositionStretch ResizeModeToStretch();
   comp::CompositionSurfaceBrush GetOrCreateSurfaceBrush();
-  comp::CompositionEffectBrush GetOrCreateEffectBrush(
-      comp::CompositionSurfaceBrush const &surfaceBrush);
+  comp::CompositionEffectBrush GetOrCreateEffectBrush(comp::CompositionSurfaceBrush const &surfaceBrush);
 
   react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
   winrt::Windows::Foundation::Size m_availableSize{};

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.h
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.h
@@ -4,16 +4,14 @@
 #pragma once
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 namespace react {
 namespace uwp {
 
 enum class ResizeMode { Cover = 0, Contain = 1, Stretch = 2, Repeat = 3, Center = 4 };
 
-struct ReactImageBrush : winrt::Windows::UI::Xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush> {
-  using Super = winrt::Windows::UI::Xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>;
+struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush> {
+  using Super = xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>;
 
   ReactImageBrush() = default;
 
@@ -35,20 +33,20 @@ struct ReactImageBrush : winrt::Windows::UI::Xaml::Media::XamlCompositionBrushBa
   }
   void AvailableSize(winrt::Windows::Foundation::Size const &value);
 
-  void Source(winrt::Windows::UI::Xaml::Media::LoadedImageSurface const &value);
+  void Source(xaml::Media::LoadedImageSurface const &value);
 
  private:
   void UpdateCompositionBrush();
   bool IsImageSmallerThanView();
-  winrt::Windows::UI::Composition::CompositionStretch ResizeModeToStretch();
-  winrt::Windows::UI::Composition::CompositionSurfaceBrush GetOrCreateSurfaceBrush();
-  winrt::Windows::UI::Composition::CompositionEffectBrush GetOrCreateEffectBrush(
-      winrt::Windows::UI::Composition::CompositionSurfaceBrush const &surfaceBrush);
+  comp::CompositionStretch ResizeModeToStretch();
+  comp::CompositionSurfaceBrush GetOrCreateSurfaceBrush();
+  comp::CompositionEffectBrush GetOrCreateEffectBrush(
+      comp::CompositionSurfaceBrush const &surfaceBrush);
 
   react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
   winrt::Windows::Foundation::Size m_availableSize{};
-  winrt::Windows::UI::Xaml::Media::LoadedImageSurface m_loadedImageSurface{nullptr};
-  winrt::Windows::UI::Composition::CompositionEffectBrush m_effectBrush{nullptr};
+  xaml::Media::LoadedImageSurface m_loadedImageSurface{nullptr};
+  comp::CompositionEffectBrush m_effectBrush{nullptr};
 };
 } // namespace uwp
 } // namespace react

--- a/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.cpp
+++ b/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.cpp
@@ -53,7 +53,7 @@ void ScrollViewUWPImplementation::UpdateScrollableSize() const {
     const auto zoomFactor = scrollViewer.ZoomFactor();
     const auto scaledViewportWidth = static_cast<float>(scrollViewer.ViewportWidth() / zoomFactor);
     const auto scaledviewportHeight = static_cast<float>(scrollViewer.ViewportHeight() / zoomFactor);
-    const auto scrollViewContent = scrollViewer.Content().as<winrt::ContentControl>();
+    const auto scrollViewContent = scrollViewer.Content().as<xaml::Controls::ContentControl>();
     const auto contentWidth = scrollViewContent.ActualWidth();
     const auto contentHeight = scrollViewContent.ActualHeight();
 

--- a/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.h
+++ b/vnext/ReactUWP/Views/Impl/ScrollViewUWPImplementation.h
@@ -9,14 +9,13 @@
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Controls::Primitives;
 } // namespace winrt
 
 namespace react {

--- a/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
+++ b/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.cpp
@@ -79,7 +79,7 @@ void SnapPointManagingContentControl::VerticalSnapPointsChanged(winrt::event_tok
 }
 
 winrt::IVectorView<float> SnapPointManagingContentControl::GetIrregularSnapPoints(
-    winrt::Orientation /*orientation*/,
+    xaml::Controls::Orientation /*orientation*/,
     winrt::SnapPointsAlignment /*alignment*/) {
   const auto retVal = winrt::single_threaded_vector<float>();
 
@@ -99,7 +99,7 @@ winrt::IVectorView<float> SnapPointManagingContentControl::GetIrregularSnapPoint
 }
 
 float SnapPointManagingContentControl::GetRegularSnapPoints(
-    winrt::Orientation /*orientation*/,
+    xaml::Controls::Orientation /*orientation*/,
     winrt::SnapPointsAlignment /*alignment*/,
     float /*offset*/) {
   if (m_interval > 0.0f) {

--- a/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
+++ b/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
@@ -2,23 +2,20 @@
 
 #include "winrt/Windows.Foundation.Collections.h"
 #include "winrt/Windows.Foundation.h"
-#include "winrt/Windows.UI.Xaml.Controls.Primitives.h"
-#include "winrt/Windows.UI.Xaml.Controls.h"
-#include "winrt/Windows.UI.Xaml.h"
 
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Controls::Primitives;
 } // namespace winrt
 
 namespace react {
 namespace uwp {
 
 class SnapPointManagingContentControl
-    : public winrt::ContentControlT<SnapPointManagingContentControl, winrt::IScrollSnapPointsInfo> {
+    : public xaml::Controls::ContentControlT<SnapPointManagingContentControl, winrt::IScrollSnapPointsInfo> {
  public:
   SnapPointManagingContentControl();
 
@@ -43,10 +40,10 @@ class SnapPointManagingContentControl
   void VerticalSnapPointsChanged(winrt::event_token const &token);
 
   winrt::IVectorView<float> GetIrregularSnapPoints(
-      winrt::Orientation orientation,
+      xaml::Controls::Orientation orientation,
       winrt::SnapPointsAlignment alignment);
 
-  float GetRegularSnapPoints(winrt::Orientation orientation, winrt::SnapPointsAlignment alignment, float offset);
+  float GetRegularSnapPoints(xaml::Controls::Orientation orientation, winrt::SnapPointsAlignment alignment, float offset);
 
   // Helpers
   void SetHorizontal(bool horizontal);

--- a/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
+++ b/vnext/ReactUWP/Views/Impl/SnapPointManagingContentControl.h
@@ -43,7 +43,8 @@ class SnapPointManagingContentControl
       xaml::Controls::Orientation orientation,
       winrt::SnapPointsAlignment alignment);
 
-  float GetRegularSnapPoints(xaml::Controls::Orientation orientation, winrt::SnapPointsAlignment alignment, float offset);
+  float
+  GetRegularSnapPoints(xaml::Controls::Orientation orientation, winrt::SnapPointsAlignment alignment, float offset);
 
   // Helpers
   void SetHorizontal(bool horizontal);

--- a/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
+++ b/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
@@ -3,11 +3,11 @@
 
 #include "pch.h"
 
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Core.h>
 #include "Utils/Helpers.h"
 #include "Utils/PropertyHandlerUtils.h"
 #include "Views/KeyboardEventHandler.h"
-#include <winrt/Windows.System.h>
 
 using namespace std::placeholders;
 
@@ -576,7 +576,8 @@ static const std::string GetOrUnidentified(
   return "Unidentified";
 }
 
-std::string KeyboardHelper::FromVirtualKey(winrt::Windows::System::VirtualKey virtualKey, bool /*shiftDown*/, bool /*capLocked*/) {
+std::string
+KeyboardHelper::FromVirtualKey(winrt::Windows::System::VirtualKey virtualKey, bool /*shiftDown*/, bool /*capLocked*/) {
   int key = static_cast<int>(virtualKey);
 
   if (!isupper(key) && !isdigit(key)) {
@@ -590,8 +591,10 @@ std::string KeyboardHelper::FromVirtualKey(winrt::Windows::System::VirtualKey vi
   return std::string(1, static_cast<char>(key));
 }
 
-inline winrt::Windows::System::VirtualKey
-GetLeftOrRightModifiedKey(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey leftKey, winrt::Windows::System::VirtualKey rightKey) {
+inline winrt::Windows::System::VirtualKey GetLeftOrRightModifiedKey(
+    winrt::CoreWindow const &coreWindow,
+    winrt::Windows::System::VirtualKey leftKey,
+    winrt::Windows::System::VirtualKey rightKey) {
   return KeyboardHelper::IsModifiedKeyPressed(coreWindow, leftKey) ? leftKey : rightKey;
 }
 
@@ -606,23 +609,31 @@ std::string KeyboardHelper::CodeFromVirtualKey(winrt::Windows::System::VirtualKe
     // Override the virtual key if it's modified key of Control, Shift or Menu
     auto const &coreWindow = winrt::CoreWindow::GetForCurrentThread();
     if (virtualKey == winrt::Windows::System::VirtualKey::Control) {
-      virtualKey =
-          GetLeftOrRightModifiedKey(coreWindow, winrt::Windows::System::VirtualKey::LeftControl, winrt::Windows::System::VirtualKey::RightControl);
+      virtualKey = GetLeftOrRightModifiedKey(
+          coreWindow,
+          winrt::Windows::System::VirtualKey::LeftControl,
+          winrt::Windows::System::VirtualKey::RightControl);
     } else if (virtualKey == winrt::Windows::System::VirtualKey::Shift) {
-      virtualKey = GetLeftOrRightModifiedKey(coreWindow, winrt::Windows::System::VirtualKey::LeftShift, winrt::Windows::System::VirtualKey::RightShift);
+      virtualKey = GetLeftOrRightModifiedKey(
+          coreWindow, winrt::Windows::System::VirtualKey::LeftShift, winrt::Windows::System::VirtualKey::RightShift);
     } else if (virtualKey == winrt::Windows::System::VirtualKey::Menu) {
-      virtualKey = GetLeftOrRightModifiedKey(coreWindow, winrt::Windows::System::VirtualKey::LeftMenu, winrt::Windows::System::VirtualKey::RightMenu);
+      virtualKey = GetLeftOrRightModifiedKey(
+          coreWindow, winrt::Windows::System::VirtualKey::LeftMenu, winrt::Windows::System::VirtualKey::RightMenu);
     }
   }
 
   return GetOrUnidentified(virtualKey, g_virtualKeyToCode);
 }
 
-bool KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey) {
+bool KeyboardHelper::IsModifiedKeyPressed(
+    winrt::CoreWindow const &coreWindow,
+    winrt::Windows::System::VirtualKey virtualKey) {
   return (coreWindow.GetKeyState(virtualKey) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 }
 
-bool KeyboardHelper::IsModifiedKeyLocked(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey) {
+bool KeyboardHelper::IsModifiedKeyLocked(
+    winrt::CoreWindow const &coreWindow,
+    winrt::Windows::System::VirtualKey virtualKey) {
   return (coreWindow.GetKeyState(virtualKey) & winrt::CoreVirtualKeyStates::Locked) ==
       winrt::CoreVirtualKeyStates::Locked;
 }

--- a/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
+++ b/vnext/ReactUWP/Views/KeyboardEventHandler.cpp
@@ -7,6 +7,7 @@
 #include "Utils/Helpers.h"
 #include "Utils/PropertyHandlerUtils.h"
 #include "Views/KeyboardEventHandler.h"
+#include <winrt/Windows.System.h>
 
 using namespace std::placeholders;
 
@@ -67,8 +68,8 @@ PreviewKeyboardEventHandler::PreviewKeyboardEventHandler(KeyboardEventCallback &
     : KeyboardEventBaseHandler(std::move(keyDown), std::move(keyUp)) {}
 
 void PreviewKeyboardEventHandler::hook(XamlView xamlView) {
-  auto uiElement = xamlView.as<winrt::UIElement>();
-  if (uiElement.try_as<winrt::IUIElement7>()) {
+  auto uiElement = xamlView.as<xaml::UIElement>();
+  if (uiElement.try_as<xaml::IUIElement7>()) {
     if (m_keyDownCallback)
       m_previewKeyDownRevoker = uiElement.PreviewKeyDown(winrt::auto_revoke, m_keyDownCallback);
 
@@ -86,7 +87,7 @@ KeyboardEventHandler::KeyboardEventHandler(KeyboardEventCallback &&keyDown, Keyb
     : KeyboardEventBaseHandler(std::move(keyDown), std::move(keyUp)) {}
 
 void KeyboardEventHandler::hook(XamlView xamlView) {
-  auto uiElement = xamlView.as<winrt::UIElement>();
+  auto uiElement = xamlView.as<xaml::UIElement>();
   if (m_keyDownCallback)
     m_keyDownRevoker = uiElement.KeyDown(winrt::auto_revoke, m_keyDownCallback);
 
@@ -107,13 +108,13 @@ PreviewKeyboardEventHandlerOnRoot::PreviewKeyboardEventHandlerOnRoot(const std::
 
 void PreviewKeyboardEventHandlerOnRoot::OnPreKeyDown(
     winrt::IInspectable const & /*sender*/,
-    winrt::KeyRoutedEventArgs const &args) {
+    xaml::Input::KeyRoutedEventArgs const &args) {
   DispatchEventToJs("topKeyDown", args);
 }
 
 void PreviewKeyboardEventHandlerOnRoot::OnPreKeyUp(
     winrt::IInspectable const & /*sender*/,
-    winrt::KeyRoutedEventArgs const &args) {
+    xaml::Input::KeyRoutedEventArgs const &args) {
   DispatchEventToJs("topKeyUp", args);
 }
 
@@ -166,7 +167,7 @@ void HandledKeyboardEventHandler::EnsureKeyboardEventHandler() {
 void HandledKeyboardEventHandler::KeyboardEventHandledHandler(
     KeyboardEventPhase phase,
     winrt::IInspectable const & /*sender*/,
-    winrt::KeyRoutedEventArgs const &args) {
+    xaml::Input::KeyRoutedEventArgs const &args) {
   HandledEventPhase currentEventPhase =
       (phase == KeyboardEventPhase::PreviewKeyUp || phase == KeyboardEventPhase::PreviewKeyDown)
       ? HandledEventPhase::Capturing
@@ -199,19 +200,19 @@ bool HandledKeyboardEventHandler::ShouldMarkKeyboardHandled(
 template <typename T>
 void UpdateModifiedKeyStatusTo(T &event) {
   auto const &coreWindow = winrt::CoreWindow::GetForCurrentThread();
-  event.altKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::VirtualKey::Menu);
-  event.shiftKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::VirtualKey::Shift);
-  event.metaKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::VirtualKey::LeftWindows) ||
-      KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::VirtualKey::RightWindows);
-  event.ctrlKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::VirtualKey::Control);
-  event.capLocked = KeyboardHelper::IsModifiedKeyLocked(coreWindow, winrt::VirtualKey::CapitalLock);
+  event.altKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::Windows::System::VirtualKey::Menu);
+  event.shiftKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::Windows::System::VirtualKey::Shift);
+  event.metaKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::Windows::System::VirtualKey::LeftWindows) ||
+      KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::Windows::System::VirtualKey::RightWindows);
+  event.ctrlKey = KeyboardHelper::IsModifiedKeyPressed(coreWindow, winrt::Windows::System::VirtualKey::Control);
+  event.capLocked = KeyboardHelper::IsModifiedKeyLocked(coreWindow, winrt::Windows::System::VirtualKey::CapitalLock);
 };
 
 void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
     std::string const &eventName,
-    winrt::KeyRoutedEventArgs const &args) {
+    xaml::Input::KeyRoutedEventArgs const &args) {
   if (auto instance = m_wkReactInstance.lock()) {
-    if (auto source = args.OriginalSource().try_as<winrt::FrameworkElement>()) {
+    if (auto source = args.OriginalSource().try_as<xaml::FrameworkElement>()) {
       auto reactId = getViewId(instance.operator->(), source);
       if (reactId.isValid) {
         ReactKeyboardEvent event;
@@ -228,7 +229,7 @@ void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
 
 HandledKeyboardEvent KeyboardHelper::CreateKeyboardEvent(
     HandledEventPhase phase,
-    winrt::KeyRoutedEventArgs const &args) {
+    xaml::Input::KeyRoutedEventArgs const &args) {
   HandledKeyboardEvent event;
   event.handledEventPhase = phase;
   UpdateModifiedKeyStatusTo(event);
@@ -239,112 +240,112 @@ HandledKeyboardEvent KeyboardHelper::CreateKeyboardEvent(
 
 // Should align to
 // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
-static const std::vector<std::pair<winrt::VirtualKey, std::string>> g_virtualKeyToKey{
+static const std::vector<std::pair<winrt::Windows::System::VirtualKey, std::string>> g_virtualKeyToKey{
     // Modifier keys
-    {winrt::VirtualKey::LeftMenu, "Alt"},
-    {winrt::VirtualKey::RightMenu, "Alt"},
-    {winrt::VirtualKey::Menu, "Alt"},
-    {winrt::VirtualKey::CapitalLock, "CapsLock"},
-    {winrt::VirtualKey::LeftControl, "Control"},
-    {winrt::VirtualKey::RightControl, "Control"},
-    {winrt::VirtualKey::Control, "Control"},
-    {winrt::VirtualKey::LeftWindows, "Meta"},
-    {winrt::VirtualKey::RightWindows, "Meta"},
-    {winrt::VirtualKey::NumberKeyLock, "NumLock"},
-    {winrt::VirtualKey::Scroll, "ScrollLock"},
-    {winrt::VirtualKey::LeftShift, "Shift"},
-    {winrt::VirtualKey::RightShift, "Shift"},
-    {winrt::VirtualKey::Shift, "Shift"},
+    {winrt::Windows::System::VirtualKey::LeftMenu, "Alt"},
+    {winrt::Windows::System::VirtualKey::RightMenu, "Alt"},
+    {winrt::Windows::System::VirtualKey::Menu, "Alt"},
+    {winrt::Windows::System::VirtualKey::CapitalLock, "CapsLock"},
+    {winrt::Windows::System::VirtualKey::LeftControl, "Control"},
+    {winrt::Windows::System::VirtualKey::RightControl, "Control"},
+    {winrt::Windows::System::VirtualKey::Control, "Control"},
+    {winrt::Windows::System::VirtualKey::LeftWindows, "Meta"},
+    {winrt::Windows::System::VirtualKey::RightWindows, "Meta"},
+    {winrt::Windows::System::VirtualKey::NumberKeyLock, "NumLock"},
+    {winrt::Windows::System::VirtualKey::Scroll, "ScrollLock"},
+    {winrt::Windows::System::VirtualKey::LeftShift, "Shift"},
+    {winrt::Windows::System::VirtualKey::RightShift, "Shift"},
+    {winrt::Windows::System::VirtualKey::Shift, "Shift"},
 
     // Whitespace keys
-    {winrt::VirtualKey::Enter, "Enter"},
-    {winrt::VirtualKey::Tab, "Tab"},
-    {winrt::VirtualKey::Space, " "},
+    {winrt::Windows::System::VirtualKey::Enter, "Enter"},
+    {winrt::Windows::System::VirtualKey::Tab, "Tab"},
+    {winrt::Windows::System::VirtualKey::Space, " "},
 
     // Navigation keys
-    {winrt::VirtualKey::Down, "ArrowDown"},
-    {winrt::VirtualKey::Left, "ArrowLeft"},
-    {winrt::VirtualKey::Right, "ArrowRight"},
-    {winrt::VirtualKey::Up, "ArrowUp"},
-    {winrt::VirtualKey::End, "End"},
-    {winrt::VirtualKey::Home, "Home"},
-    {winrt::VirtualKey::PageDown, "PageDown"},
-    {winrt::VirtualKey::PageUp, "PageUp"},
+    {winrt::Windows::System::VirtualKey::Down, "ArrowDown"},
+    {winrt::Windows::System::VirtualKey::Left, "ArrowLeft"},
+    {winrt::Windows::System::VirtualKey::Right, "ArrowRight"},
+    {winrt::Windows::System::VirtualKey::Up, "ArrowUp"},
+    {winrt::Windows::System::VirtualKey::End, "End"},
+    {winrt::Windows::System::VirtualKey::Home, "Home"},
+    {winrt::Windows::System::VirtualKey::PageDown, "PageDown"},
+    {winrt::Windows::System::VirtualKey::PageUp, "PageUp"},
 
     // Editing keys
-    {winrt::VirtualKey::Back, "Backspace"},
-    {winrt::VirtualKey::Clear, "Clear"},
-    {winrt::VirtualKey::Delete, "Delete"},
-    {winrt::VirtualKey::Insert, "Insert"},
+    {winrt::Windows::System::VirtualKey::Back, "Backspace"},
+    {winrt::Windows::System::VirtualKey::Clear, "Clear"},
+    {winrt::Windows::System::VirtualKey::Delete, "Delete"},
+    {winrt::Windows::System::VirtualKey::Insert, "Insert"},
 
     // UI keys
-    {winrt::VirtualKey::Accept, "Accept"},
-    {winrt::VirtualKey::Application, "ContextMenu"},
-    {winrt::VirtualKey::Escape, "Escape"},
-    {winrt::VirtualKey::Execute, "Execute"},
-    {winrt::VirtualKey::Help, "Help"},
-    {winrt::VirtualKey::Pause, "Pause"},
-    {winrt::VirtualKey::Select, "Select"},
+    {winrt::Windows::System::VirtualKey::Accept, "Accept"},
+    {winrt::Windows::System::VirtualKey::Application, "ContextMenu"},
+    {winrt::Windows::System::VirtualKey::Escape, "Escape"},
+    {winrt::Windows::System::VirtualKey::Execute, "Execute"},
+    {winrt::Windows::System::VirtualKey::Help, "Help"},
+    {winrt::Windows::System::VirtualKey::Pause, "Pause"},
+    {winrt::Windows::System::VirtualKey::Select, "Select"},
 
     // Device keys
-    {winrt::VirtualKey::Snapshot, "PrintScreen"},
-    {winrt::VirtualKey::Sleep, "Standby"},
+    {winrt::Windows::System::VirtualKey::Snapshot, "PrintScreen"},
+    {winrt::Windows::System::VirtualKey::Sleep, "Standby"},
 
     // Common IME keys
-    {winrt::VirtualKey::Convert, "Convert"},
-    {winrt::VirtualKey::Final, "FinalMode"},
-    {winrt::VirtualKey::ModeChange, "ModeChange"},
-    {winrt::VirtualKey::NonConvert, "NonConvert"},
+    {winrt::Windows::System::VirtualKey::Convert, "Convert"},
+    {winrt::Windows::System::VirtualKey::Final, "FinalMode"},
+    {winrt::Windows::System::VirtualKey::ModeChange, "ModeChange"},
+    {winrt::Windows::System::VirtualKey::NonConvert, "NonConvert"},
 
     // Korean keyboards only
-    {winrt::VirtualKey::Hangul, "HangulMode"},
-    {winrt::VirtualKey::Hanja, "HanjaMode"},
-    {winrt::VirtualKey::Junja, "JunjaMode"},
+    {winrt::Windows::System::VirtualKey::Hangul, "HangulMode"},
+    {winrt::Windows::System::VirtualKey::Hanja, "HanjaMode"},
+    {winrt::Windows::System::VirtualKey::Junja, "JunjaMode"},
 
     // Japanese keyboards only
-    {winrt::VirtualKey::Kana, "KanaMode"},
-    {winrt::VirtualKey::Kanji, "KanjiMode"},
+    {winrt::Windows::System::VirtualKey::Kana, "KanaMode"},
+    {winrt::Windows::System::VirtualKey::Kanji, "KanjiMode"},
 
     // Function keys
-    {winrt::VirtualKey::F1, "F1"},
-    {winrt::VirtualKey::F2, "F2"},
-    {winrt::VirtualKey::F3, "F3"},
-    {winrt::VirtualKey::F4, "F4"},
-    {winrt::VirtualKey::F5, "F5"},
-    {winrt::VirtualKey::F6, "F6"},
-    {winrt::VirtualKey::F7, "F7"},
-    {winrt::VirtualKey::F8, "F8"},
-    {winrt::VirtualKey::F9, "F9"},
-    {winrt::VirtualKey::F10, "F10"},
-    {winrt::VirtualKey::F11, "F11"},
-    {winrt::VirtualKey::F12, "F12"},
-    {winrt::VirtualKey::F13, "F13"},
-    {winrt::VirtualKey::F14, "F14"},
-    {winrt::VirtualKey::F15, "F15"},
-    {winrt::VirtualKey::F16, "F16"},
-    {winrt::VirtualKey::F17, "F17"},
-    {winrt::VirtualKey::F18, "F18"},
-    {winrt::VirtualKey::F19, "F19"},
-    {winrt::VirtualKey::F20, "F20"},
+    {winrt::Windows::System::VirtualKey::F1, "F1"},
+    {winrt::Windows::System::VirtualKey::F2, "F2"},
+    {winrt::Windows::System::VirtualKey::F3, "F3"},
+    {winrt::Windows::System::VirtualKey::F4, "F4"},
+    {winrt::Windows::System::VirtualKey::F5, "F5"},
+    {winrt::Windows::System::VirtualKey::F6, "F6"},
+    {winrt::Windows::System::VirtualKey::F7, "F7"},
+    {winrt::Windows::System::VirtualKey::F8, "F8"},
+    {winrt::Windows::System::VirtualKey::F9, "F9"},
+    {winrt::Windows::System::VirtualKey::F10, "F10"},
+    {winrt::Windows::System::VirtualKey::F11, "F11"},
+    {winrt::Windows::System::VirtualKey::F12, "F12"},
+    {winrt::Windows::System::VirtualKey::F13, "F13"},
+    {winrt::Windows::System::VirtualKey::F14, "F14"},
+    {winrt::Windows::System::VirtualKey::F15, "F15"},
+    {winrt::Windows::System::VirtualKey::F16, "F16"},
+    {winrt::Windows::System::VirtualKey::F17, "F17"},
+    {winrt::Windows::System::VirtualKey::F18, "F18"},
+    {winrt::Windows::System::VirtualKey::F19, "F19"},
+    {winrt::Windows::System::VirtualKey::F20, "F20"},
 
     // Numeric keypad keys
-    {winrt::VirtualKey::Decimal, "Decimal"},
-    {winrt::VirtualKey::Multiply, "Multiply"},
-    {winrt::VirtualKey::Add, "Add"},
-    {winrt::VirtualKey::Divide, "Divide"},
-    {winrt::VirtualKey::Subtract, "Subtract"},
-    {winrt::VirtualKey::Separator, "Separator"},
+    {winrt::Windows::System::VirtualKey::Decimal, "Decimal"},
+    {winrt::Windows::System::VirtualKey::Multiply, "Multiply"},
+    {winrt::Windows::System::VirtualKey::Add, "Add"},
+    {winrt::Windows::System::VirtualKey::Divide, "Divide"},
+    {winrt::Windows::System::VirtualKey::Subtract, "Subtract"},
+    {winrt::Windows::System::VirtualKey::Separator, "Separator"},
 
-    {winrt::VirtualKey::NumberPad0, "0"},
-    {winrt::VirtualKey::NumberPad1, "1"},
-    {winrt::VirtualKey::NumberPad2, "2"},
-    {winrt::VirtualKey::NumberPad3, "3"},
-    {winrt::VirtualKey::NumberPad4, "4"},
-    {winrt::VirtualKey::NumberPad5, "5"},
-    {winrt::VirtualKey::NumberPad6, "6"},
-    {winrt::VirtualKey::NumberPad7, "7"},
-    {winrt::VirtualKey::NumberPad8, "8"},
-    {winrt::VirtualKey::NumberPad9, "9"},
+    {winrt::Windows::System::VirtualKey::NumberPad0, "0"},
+    {winrt::Windows::System::VirtualKey::NumberPad1, "1"},
+    {winrt::Windows::System::VirtualKey::NumberPad2, "2"},
+    {winrt::Windows::System::VirtualKey::NumberPad3, "3"},
+    {winrt::Windows::System::VirtualKey::NumberPad4, "4"},
+    {winrt::Windows::System::VirtualKey::NumberPad5, "5"},
+    {winrt::Windows::System::VirtualKey::NumberPad6, "6"},
+    {winrt::Windows::System::VirtualKey::NumberPad7, "7"},
+    {winrt::Windows::System::VirtualKey::NumberPad8, "8"},
+    {winrt::Windows::System::VirtualKey::NumberPad9, "9"},
     //
 };
 
@@ -360,22 +361,22 @@ constexpr auto to_underlying(E e) noexcept {
 // codes are from
 // https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes All
 // codes are listed except alpha and numbers. For the unsupported code, they are
-// all commented and they key is 'to_underlying(winrt::VirtualKey::None)' For
+// all commented and they key is 'to_underlying(winrt::Windows::System::None)' For
 // example, IntlBackslash is not sent to user:
-// //{to_underlying(winrt::VirtualKey::None), "IntlBackslash"},
+// //{to_underlying(winrt::Windows::System::None), "IntlBackslash"},
 static const std::vector<std::pair<int, std::string>> g_virtualKeyToCode{
     // writing system keys in the Alphanumeric section
     {192, "Backquote"},
     {220, "Backslash"},
-    {to_underlying(winrt::VirtualKey::Back), "Backspace"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Back), "Backspace"},
     {219, "BracketLeft"},
     {221, "BracketRight"},
     {192, "BracketLeft"},
     {188, "Comma"},
     {187, "Equal"},
-    //{to_underlying(winrt::VirtualKey::None), "IntlBackslash"},
-    //{to_underlying(winrt::VirtualKey::None), "IntlRo"},
-    //{to_underlying(winrt::VirtualKey::None), "IntlYen"},
+    //{to_underlying(winrt::Windows::System::None), "IntlBackslash"},
+    //{to_underlying(winrt::Windows::System::None), "IntlRo"},
+    //{to_underlying(winrt::Windows::System::None), "IntlYen"},
     {189, "Minus"},
     {190, "Period"},
     {222, "Quote"},
@@ -383,120 +384,120 @@ static const std::vector<std::pair<int, std::string>> g_virtualKeyToCode{
     {191, "Slash"},
 
     // Functional Keys
-    {to_underlying(winrt::VirtualKey::LeftMenu), "AltLeft"},
-    {to_underlying(winrt::VirtualKey::RightMenu), "AltRight"},
-    {to_underlying(winrt::VirtualKey::CapitalLock), "CapsLock"},
-    {to_underlying(winrt::VirtualKey::Menu), "ContextMenu"},
-    {to_underlying(winrt::VirtualKey::LeftControl), "ControlLeft"},
-    {to_underlying(winrt::VirtualKey::RightControl), "ControlRight"},
-    {to_underlying(winrt::VirtualKey::Enter), "Enter"},
-    {to_underlying(winrt::VirtualKey::LeftWindows), "MetaLeft"},
-    {to_underlying(winrt::VirtualKey::RightWindows), "MetaRight"},
-    {to_underlying(winrt::VirtualKey::LeftShift), "ShiftLeft"},
-    {to_underlying(winrt::VirtualKey::RightShift), "ShiftRight"},
-    {to_underlying(winrt::VirtualKey::Space), "Space"},
-    {to_underlying(winrt::VirtualKey::Tab), "Tab"},
+    {to_underlying(winrt::Windows::System::VirtualKey::LeftMenu), "AltLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::RightMenu), "AltRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::CapitalLock), "CapsLock"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Menu), "ContextMenu"},
+    {to_underlying(winrt::Windows::System::VirtualKey::LeftControl), "ControlLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::RightControl), "ControlRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Enter), "Enter"},
+    {to_underlying(winrt::Windows::System::VirtualKey::LeftWindows), "MetaLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::RightWindows), "MetaRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::LeftShift), "ShiftLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::RightShift), "ShiftRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Space), "Space"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Tab), "Tab"},
 
     // List of code values for functional keys found on Japanese and Korean
     // keyboards.
-    {to_underlying(winrt::VirtualKey::Convert), "Convert"},
-    {to_underlying(winrt::VirtualKey::Kana), "KanaMode"},
-    {to_underlying(winrt::VirtualKey::Hangul), "Lang1"},
-    {to_underlying(winrt::VirtualKey::Hanja), "Lang2"},
-    //{to_underlying(winrt::VirtualKey::None), "Lang3"},
-    //{to_underlying(winrt::VirtualKey::None), "Lang4"},
-    //{to_underlying(winrt::VirtualKey::None), "Lang5"},
-    {to_underlying(winrt::VirtualKey::NonConvert), "NonConvert"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Convert), "Convert"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Kana), "KanaMode"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Hangul), "Lang1"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Hanja), "Lang2"},
+    //{to_underlying(winrt::Windows::System::None), "Lang3"},
+    //{to_underlying(winrt::Windows::System::None), "Lang4"},
+    //{to_underlying(winrt::Windows::System::None), "Lang5"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NonConvert), "NonConvert"},
 
     // Control Pad Section
-    {to_underlying(winrt::VirtualKey::Delete), "Delete"},
-    {to_underlying(winrt::VirtualKey::End), "End"},
-    {to_underlying(winrt::VirtualKey::Help), "Help"},
-    {to_underlying(winrt::VirtualKey::Home), "Home"},
-    {to_underlying(winrt::VirtualKey::Insert), "Insert"},
-    {to_underlying(winrt::VirtualKey::PageDown), "PageDown"},
-    {to_underlying(winrt::VirtualKey::PageUp), "PageUp"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Delete), "Delete"},
+    {to_underlying(winrt::Windows::System::VirtualKey::End), "End"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Help), "Help"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Home), "Home"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Insert), "Insert"},
+    {to_underlying(winrt::Windows::System::VirtualKey::PageDown), "PageDown"},
+    {to_underlying(winrt::Windows::System::VirtualKey::PageUp), "PageUp"},
 
     // Arrow Pad Section
-    {to_underlying(winrt::VirtualKey::Down), "ArrowDown"},
-    {to_underlying(winrt::VirtualKey::Left), "ArrowLeft"},
-    {to_underlying(winrt::VirtualKey::Right), "ArrowRight"},
-    {to_underlying(winrt::VirtualKey::Up), "ArrowUp"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Down), "ArrowDown"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Left), "ArrowLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Right), "ArrowRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Up), "ArrowUp"},
 
     // Numpad Section
-    {to_underlying(winrt::VirtualKey::NumberKeyLock), "NumLock"},
-    {to_underlying(winrt::VirtualKey::NumberPad0), "Numpad0"},
-    {to_underlying(winrt::VirtualKey::NumberPad1), "Numpad1"},
-    {to_underlying(winrt::VirtualKey::NumberPad2), "Numpad2"},
-    {to_underlying(winrt::VirtualKey::NumberPad3), "Numpad3"},
-    {to_underlying(winrt::VirtualKey::NumberPad4), "Numpad4"},
-    {to_underlying(winrt::VirtualKey::NumberPad5), "Numpad5"},
-    {to_underlying(winrt::VirtualKey::NumberPad6), "Numpad6"},
-    {to_underlying(winrt::VirtualKey::NumberPad7), "Numpad7"},
-    {to_underlying(winrt::VirtualKey::NumberPad8), "Numpad8"},
-    {to_underlying(winrt::VirtualKey::NumberPad9), "Numpad9"},
-    {to_underlying(winrt::VirtualKey::Add), "NumpadAdd"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadBackspace"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadClear"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadClearEntry"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadComma"},
-    {to_underlying(winrt::VirtualKey::Decimal), "NumpadDecimal"},
-    {to_underlying(winrt::VirtualKey::Divide), "NumpadDivide"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadEnter"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadEqual"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadHash"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryAdd"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryClear"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryRecall"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadMemoryStore"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadMemorySubtract"},
-    {to_underlying(winrt::VirtualKey::Multiply), "NumpadMultiply"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadParenLeft"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadParenRight"},
-    //{to_underlying(winrt::VirtualKey::None), "NumpadStar"},
-    {to_underlying(winrt::VirtualKey::Subtract), "NumpadSubtract"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberKeyLock), "NumLock"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad0), "Numpad0"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad1), "Numpad1"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad2), "Numpad2"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad3), "Numpad3"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad4), "Numpad4"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad5), "Numpad5"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad6), "Numpad6"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad7), "Numpad7"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad8), "Numpad8"},
+    {to_underlying(winrt::Windows::System::VirtualKey::NumberPad9), "Numpad9"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Add), "NumpadAdd"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadBackspace"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadClear"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadClearEntry"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadComma"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Decimal), "NumpadDecimal"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Divide), "NumpadDivide"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadEnter"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadEqual"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadHash"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadMemoryAdd"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadMemoryClear"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadMemoryRecall"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadMemoryStore"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadMemorySubtract"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Multiply), "NumpadMultiply"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadParenLeft"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadParenRight"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "NumpadStar"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Subtract), "NumpadSubtract"},
 
     // Function Section
-    {to_underlying(winrt::VirtualKey::Escape), "Escape"},
-    {to_underlying(winrt::VirtualKey::F1), "F1"},
-    {to_underlying(winrt::VirtualKey::F2), "F2"},
-    {to_underlying(winrt::VirtualKey::F3), "F3"},
-    {to_underlying(winrt::VirtualKey::F4), "F4"},
-    {to_underlying(winrt::VirtualKey::F5), "F5"},
-    {to_underlying(winrt::VirtualKey::F6), "F6"},
-    {to_underlying(winrt::VirtualKey::F7), "F7"},
-    {to_underlying(winrt::VirtualKey::F8), "F8"},
-    {to_underlying(winrt::VirtualKey::F9), "F9"},
-    {to_underlying(winrt::VirtualKey::F10), "F10"},
-    {to_underlying(winrt::VirtualKey::F11), "F11"},
-    {to_underlying(winrt::VirtualKey::F12), "F12"},
-    {to_underlying(winrt::VirtualKey::F13), "F13"},
-    {to_underlying(winrt::VirtualKey::F14), "F14"},
-    {to_underlying(winrt::VirtualKey::F15), "F15"},
-    {to_underlying(winrt::VirtualKey::F16), "F16"},
-    {to_underlying(winrt::VirtualKey::F17), "F17"},
-    {to_underlying(winrt::VirtualKey::F18), "F18"},
-    {to_underlying(winrt::VirtualKey::F19), "F19"},
-    {to_underlying(winrt::VirtualKey::F20), "F20"},
-    {to_underlying(winrt::VirtualKey::F21), "F21"},
-    {to_underlying(winrt::VirtualKey::F22), "F22"},
-    {to_underlying(winrt::VirtualKey::F23), "F23"},
-    {to_underlying(winrt::VirtualKey::F24), "F24"},
-    //{to_underlying(winrt::VirtualKey::None), "Fn"},
-    //{to_underlying(winrt::VirtualKey::None), "FnLock"},
-    {to_underlying(winrt::VirtualKey::Print), "PrintScreen"},
-    {to_underlying(winrt::VirtualKey::Scroll), "ScrollLock"},
-    {to_underlying(winrt::VirtualKey::Pause), "Pause"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Escape), "Escape"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F1), "F1"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F2), "F2"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F3), "F3"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F4), "F4"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F5), "F5"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F6), "F6"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F7), "F7"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F8), "F8"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F9), "F9"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F10), "F10"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F11), "F11"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F12), "F12"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F13), "F13"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F14), "F14"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F15), "F15"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F16), "F16"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F17), "F17"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F18), "F18"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F19), "F19"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F20), "F20"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F21), "F21"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F22), "F22"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F23), "F23"},
+    {to_underlying(winrt::Windows::System::VirtualKey::F24), "F24"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Fn"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "FnLock"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Print), "PrintScreen"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Scroll), "ScrollLock"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Pause), "Pause"},
 
     //// Media Keys
-    {to_underlying(winrt::VirtualKey::GoBack), "BrowserBack"},
-    {to_underlying(winrt::VirtualKey::Favorites), "BrowserFavorites"},
-    {to_underlying(winrt::VirtualKey::GoForward), "BrowserForward"},
-    {to_underlying(winrt::VirtualKey::GoHome), "BrowserHome"},
-    {to_underlying(winrt::VirtualKey::Refresh), "BrowserRefresh"},
-    {to_underlying(winrt::VirtualKey::Search), "BrowserSearch"},
-    {to_underlying(winrt::VirtualKey::Stop), "BrowserStop"},
-    //{to_underlying(winrt::VirtualKey::None), "Eject"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GoBack), "BrowserBack"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Favorites), "BrowserFavorites"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GoForward), "BrowserForward"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GoHome), "BrowserHome"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Refresh), "BrowserRefresh"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Search), "BrowserSearch"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Stop), "BrowserStop"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Eject"},
     {182, "LaunchApp1"},
     {183, "LaunchApp2"},
     {180, "LaunchMail"},
@@ -505,64 +506,64 @@ static const std::vector<std::pair<int, std::string>> g_virtualKeyToCode{
     {178, "MediaStop"},
     {176, "MediaTrackNext"},
     {177, "MediaTrackPrevious"},
-    //{to_underlying(winrt::VirtualKey::None), "Power"},
-    {to_underlying(winrt::VirtualKey::Sleep), "Sleep"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Power"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Sleep), "Sleep"},
     {174, "AudioVolumeDown"},
     {173, "AudioVolumeMute"},
     {175, "AudioVolumeUp"},
-    //{to_underlying(winrt::VirtualKey::None), "WakeUp"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "WakeUp"},
 
     ////List of code values for legacy modifier keys.
-    //{to_underlying(winrt::VirtualKey::None), "Hyper"},
-    //{to_underlying(winrt::VirtualKey::None), "Super"},
-    //{to_underlying(winrt::VirtualKey::None), "Turbo"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Hyper"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Super"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Turbo"},
 
     ////List of code values for legacy process control keys.
-    //{to_underlying(winrt::VirtualKey::None), "Abort"},
-    //{to_underlying(winrt::VirtualKey::None), "Resume"},
-    //{to_underlying(winrt::VirtualKey::None), "Suspend"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Abort"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Resume"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Suspend"},
 
     ////List of code values for legacy editing keys.
-    //{to_underlying(winrt::VirtualKey::None), "Again"},
-    //{to_underlying(winrt::VirtualKey::None), "Copy"},
-    //{to_underlying(winrt::VirtualKey::None), "Cut"},
-    //{to_underlying(winrt::VirtualKey::None), "Find"},
-    //{to_underlying(winrt::VirtualKey::None), "Open"},
-    //{to_underlying(winrt::VirtualKey::None), "Paste"},
-    //{to_underlying(winrt::VirtualKey::None), "Props"},
-    {to_underlying(winrt::VirtualKey::Select), "Select"},
-    //{to_underlying(winrt::VirtualKey::None), "Undo"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Again"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Copy"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Cut"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Find"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Open"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Paste"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Props"},
+    {to_underlying(winrt::Windows::System::VirtualKey::Select), "Select"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Undo"},
 
     // The following keys may be found on non-standard international keyboards.
-    //{to_underlying(winrt::VirtualKey::None), "Hiragana"},
-    //{to_underlying(winrt::VirtualKey::None), "Katakana"},
-    //{to_underlying(winrt::VirtualKey::None), "Undo"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Hiragana"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Katakana"},
+    //{to_underlying(winrt::Windows::System::VirtualKey::None), "Undo"},
 
     // Xbox Gamepad
-    {to_underlying(winrt::VirtualKey::GamepadA), "GamepadA"},
-    {to_underlying(winrt::VirtualKey::GamepadB), "GamepadB"},
-    {to_underlying(winrt::VirtualKey::GamepadX), "GamepadX"},
-    {to_underlying(winrt::VirtualKey::GamepadY), "GamepadY"},
-    {to_underlying(winrt::VirtualKey::GamepadRightShoulder), "GamepadRightShoulder"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftShoulder), "GamepadLeftShoulder"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftTrigger), "GamepadLeftTrigger"},
-    {to_underlying(winrt::VirtualKey::GamepadRightTrigger), "GamepadRightTrigger"},
-    {to_underlying(winrt::VirtualKey::GamepadDPadUp), "GamepadDPadUp"},
-    {to_underlying(winrt::VirtualKey::GamepadDPadDown), "GamepadDPadDown"},
-    {to_underlying(winrt::VirtualKey::GamepadDPadLeft), "GamepadDPadLeft"},
-    {to_underlying(winrt::VirtualKey::GamepadDPadRight), "GamepadDPadRight"},
-    {to_underlying(winrt::VirtualKey::GamepadMenu), "GamepadMenu"},
-    {to_underlying(winrt::VirtualKey::GamepadView), "GamepadView"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickButton), "GamepadLeftThumbstickButton"},
-    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickButton), "GamepadRightThumbstickButton"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickUp), "GamepadLeftThumbstickUp"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickDown), "GamepadLeftThumbstickDown"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickRight), "GamepadLeftThumbstickRight"},
-    {to_underlying(winrt::VirtualKey::GamepadLeftThumbstickLeft), "GamepadLeftThumbstickLeft"},
-    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickUp), "GamepadRightThumbstickUp"},
-    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickDown), "GamepadRightThumbstickDown"},
-    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickRight), "GamepadRightThumbstickRight"},
-    {to_underlying(winrt::VirtualKey::GamepadRightThumbstickLeft), "GamepadRightThumbstickLeft"}};
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadA), "GamepadA"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadB), "GamepadB"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadX), "GamepadX"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadY), "GamepadY"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightShoulder), "GamepadRightShoulder"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftShoulder), "GamepadLeftShoulder"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftTrigger), "GamepadLeftTrigger"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightTrigger), "GamepadRightTrigger"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadDPadUp), "GamepadDPadUp"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadDPadDown), "GamepadDPadDown"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadDPadLeft), "GamepadDPadLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadDPadRight), "GamepadDPadRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadMenu), "GamepadMenu"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadView), "GamepadView"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftThumbstickButton), "GamepadLeftThumbstickButton"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightThumbstickButton), "GamepadRightThumbstickButton"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftThumbstickUp), "GamepadLeftThumbstickUp"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftThumbstickDown), "GamepadLeftThumbstickDown"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftThumbstickRight), "GamepadLeftThumbstickRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadLeftThumbstickLeft), "GamepadLeftThumbstickLeft"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightThumbstickUp), "GamepadRightThumbstickUp"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightThumbstickDown), "GamepadRightThumbstickDown"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightThumbstickRight), "GamepadRightThumbstickRight"},
+    {to_underlying(winrt::Windows::System::VirtualKey::GamepadRightThumbstickLeft), "GamepadRightThumbstickLeft"}};
 
 template <typename T>
 static const std::string GetOrUnidentified(
@@ -575,7 +576,7 @@ static const std::string GetOrUnidentified(
   return "Unidentified";
 }
 
-std::string KeyboardHelper::FromVirtualKey(winrt::VirtualKey virtualKey, bool /*shiftDown*/, bool /*capLocked*/) {
+std::string KeyboardHelper::FromVirtualKey(winrt::Windows::System::VirtualKey virtualKey, bool /*shiftDown*/, bool /*capLocked*/) {
   int key = static_cast<int>(virtualKey);
 
   if (!isupper(key) && !isdigit(key)) {
@@ -589,12 +590,12 @@ std::string KeyboardHelper::FromVirtualKey(winrt::VirtualKey virtualKey, bool /*
   return std::string(1, static_cast<char>(key));
 }
 
-inline winrt::VirtualKey
-GetLeftOrRightModifiedKey(winrt::CoreWindow const &coreWindow, winrt::VirtualKey leftKey, winrt::VirtualKey rightKey) {
+inline winrt::Windows::System::VirtualKey
+GetLeftOrRightModifiedKey(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey leftKey, winrt::Windows::System::VirtualKey rightKey) {
   return KeyboardHelper::IsModifiedKeyPressed(coreWindow, leftKey) ? leftKey : rightKey;
 }
 
-std::string KeyboardHelper::CodeFromVirtualKey(winrt::VirtualKey virtualKey) {
+std::string KeyboardHelper::CodeFromVirtualKey(winrt::Windows::System::VirtualKey virtualKey) {
   int key = static_cast<int>(virtualKey);
 
   if (isdigit(key)) {
@@ -604,24 +605,24 @@ std::string KeyboardHelper::CodeFromVirtualKey(winrt::VirtualKey virtualKey) {
   } else {
     // Override the virtual key if it's modified key of Control, Shift or Menu
     auto const &coreWindow = winrt::CoreWindow::GetForCurrentThread();
-    if (virtualKey == winrt::VirtualKey::Control) {
+    if (virtualKey == winrt::Windows::System::VirtualKey::Control) {
       virtualKey =
-          GetLeftOrRightModifiedKey(coreWindow, winrt::VirtualKey::LeftControl, winrt::VirtualKey::RightControl);
-    } else if (virtualKey == winrt::VirtualKey::Shift) {
-      virtualKey = GetLeftOrRightModifiedKey(coreWindow, winrt::VirtualKey::LeftShift, winrt::VirtualKey::RightShift);
-    } else if (virtualKey == winrt::VirtualKey::Menu) {
-      virtualKey = GetLeftOrRightModifiedKey(coreWindow, winrt::VirtualKey::LeftMenu, winrt::VirtualKey::RightMenu);
+          GetLeftOrRightModifiedKey(coreWindow, winrt::Windows::System::VirtualKey::LeftControl, winrt::Windows::System::VirtualKey::RightControl);
+    } else if (virtualKey == winrt::Windows::System::VirtualKey::Shift) {
+      virtualKey = GetLeftOrRightModifiedKey(coreWindow, winrt::Windows::System::VirtualKey::LeftShift, winrt::Windows::System::VirtualKey::RightShift);
+    } else if (virtualKey == winrt::Windows::System::VirtualKey::Menu) {
+      virtualKey = GetLeftOrRightModifiedKey(coreWindow, winrt::Windows::System::VirtualKey::LeftMenu, winrt::Windows::System::VirtualKey::RightMenu);
     }
   }
 
   return GetOrUnidentified(virtualKey, g_virtualKeyToCode);
 }
 
-bool KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::VirtualKey virtualKey) {
+bool KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey) {
   return (coreWindow.GetKeyState(virtualKey) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 }
 
-bool KeyboardHelper::IsModifiedKeyLocked(winrt::CoreWindow const &coreWindow, winrt::VirtualKey virtualKey) {
+bool KeyboardHelper::IsModifiedKeyLocked(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey) {
   return (coreWindow.GetKeyState(virtualKey) & winrt::CoreVirtualKeyStates::Locked) ==
       winrt::CoreVirtualKeyStates::Locked;
 }

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -12,7 +12,6 @@
 #include <IReactInstance.h>
 
 #include <winrt/Windows.Foundation.Metadata.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 
 namespace react {
 namespace uwp {
@@ -41,18 +40,18 @@ class PickerShadowNode : public ShadowNodeBase {
   // FUTURE: remove when we can require RS5+
   bool m_isEditableComboboxSupported;
 
-  winrt::ComboBox::SelectionChanged_revoker m_comboBoxSelectionChangedRevoker{};
-  winrt::ComboBox::DropDownClosed_revoker m_comboBoxDropDownClosedRevoker{};
+  xaml::Controls::ComboBox::SelectionChanged_revoker m_comboBoxSelectionChangedRevoker{};
+  xaml::Controls::ComboBox::DropDownClosed_revoker m_comboBoxDropDownClosedRevoker{};
 };
 
 PickerShadowNode::PickerShadowNode() : Super() {
   m_isEditableComboboxSupported = winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
-      L"Windows.UI.Xaml.Controls.ComboBox", L"IsEditableProperty");
+      XAML_NAMESPACE L".Controls.ComboBox", L"IsEditableProperty");
 }
 
 void PickerShadowNode::createView() {
   Super::createView();
-  auto combobox = GetView().as<winrt::ComboBox>();
+  auto combobox = GetView().as<xaml::Controls::ComboBox>();
   combobox.TabIndex(0);
   auto wkinstance = GetViewManager()->GetReactInstance();
 
@@ -76,7 +75,7 @@ void PickerShadowNode::createView() {
     // When the drop down closes, attempt to move focus to its anchor
     // textbox to prevent cases where focus can land on an outer flyout
     // content and therefore trigger a unexpected flyout dismissal
-    winrt::FocusManager::TryFocusAsync(combobox, winrt::FocusState::Programmatic);
+    xaml::Input::FocusManager::TryFocusAsync(combobox, xaml::FocusState::Programmatic);
   });
 }
 
@@ -84,7 +83,7 @@ void PickerShadowNode::updateProperties(const folly::dynamic &&props) {
   m_updating = true;
 
   bool updateSelectedIndex = false;
-  auto combobox = GetView().as<winrt::ComboBox>();
+  auto combobox = GetView().as<xaml::Controls::ComboBox>();
   for (auto &pair : props.items()) {
     const std::string &propertyName = pair.first.getString();
     const folly::dynamic &propertyValue = pair.second;
@@ -94,14 +93,14 @@ void PickerShadowNode::updateProperties(const folly::dynamic &&props) {
         if (propertyValue.isBool())
           combobox.IsEditable(propertyValue.asBool());
         else if (propertyValue.isNull())
-          combobox.ClearValue(winrt::ComboBox::IsEditableProperty());
+          combobox.ClearValue(xaml::Controls::ComboBox::IsEditableProperty());
       }
     } else if (propertyName == "text") {
       if (m_isEditableComboboxSupported) {
         if (propertyValue.isString())
           combobox.Text(asHstring(propertyValue));
         else if (propertyValue.isNull())
-          combobox.ClearValue(winrt::ComboBox::TextProperty());
+          combobox.ClearValue(xaml::Controls::ComboBox::TextProperty());
       }
     } else if (propertyName == "enabled") {
       if (propertyValue.isBool())
@@ -132,14 +131,14 @@ void PickerShadowNode::updateProperties(const folly::dynamic &&props) {
 }
 
 void PickerShadowNode::RepopulateItems() {
-  auto combobox = GetView().as<winrt::ComboBox>();
+  auto combobox = GetView().as<xaml::Controls::ComboBox>();
 
   auto comboBoxItems = combobox.Items();
   comboBoxItems.Clear();
   for (const auto &item : m_items) {
     if (item.count("label")) {
       std::string label = item["label"].asString();
-      auto comboboxItem = winrt::ComboBoxItem();
+      auto comboboxItem = xaml::Controls::ComboBoxItem();
 
       comboboxItem.Content(winrt::box_value(Microsoft::Common::Unicode::Utf8ToUtf16(label)));
 
@@ -188,7 +187,7 @@ facebook::react::ShadowNode *PickerViewManager::createShadow() const {
 }
 
 XamlView PickerViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto combobox = winrt::ComboBox();
+  auto combobox = xaml::Controls::ComboBox();
   return combobox;
 }
 

--- a/vnext/ReactUWP/Views/PickerViewManager.cpp
+++ b/vnext/ReactUWP/Views/PickerViewManager.cpp
@@ -46,7 +46,7 @@ class PickerShadowNode : public ShadowNodeBase {
 
 PickerShadowNode::PickerShadowNode() : Super() {
   m_isEditableComboboxSupported = winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
-      XAML_NAMESPACE L".Controls.ComboBox", L"IsEditableProperty");
+      XAML_NAMESPACE_STR L".Controls.ComboBox", L"IsEditableProperty");
 }
 
 void PickerShadowNode::createView() {

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -12,10 +12,8 @@
 #include <Utils/ValueUtils.h>
 #include <winrt/Windows.UI.Core.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-
 namespace winrt {
-using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace xaml::Controls::Primitives;
 } // namespace winrt
 
 namespace react {
@@ -36,7 +34,7 @@ class PopupShadowNode : public ShadowNodeBase {
 
   static void OnPopupClosed(IReactInstance &instance, int64_t tag);
   winrt::Windows::Foundation::Size GetAppWindowSize();
-  winrt::ContentControl GetControl();
+  xaml::Controls::ContentControl GetControl();
   void UpdateTabStops();
   void UpdateLayout();
 
@@ -54,8 +52,8 @@ class PopupShadowNode : public ShadowNodeBase {
   int64_t m_targetTag;
   winrt::Popup::Closed_revoker m_popupClosedRevoker{};
   winrt::Popup::Opened_revoker m_popupOpenedRevoker{};
-  winrt::FrameworkElement::SizeChanged_revoker m_popupSizeChangedRevoker{};
-  winrt::Window::SizeChanged_revoker m_windowSizeChangedRevoker{};
+  xaml::FrameworkElement::SizeChanged_revoker m_popupSizeChangedRevoker{};
+  xaml::Window::SizeChanged_revoker m_windowSizeChangedRevoker{};
 };
 
 PopupShadowNode::~PopupShadowNode() {
@@ -63,9 +61,9 @@ PopupShadowNode::~PopupShadowNode() {
   m_previewKeyboardEventHandlerOnRoot->unhook();
 }
 
-winrt::ContentControl PopupShadowNode::GetControl() {
+xaml::Controls::ContentControl PopupShadowNode::GetControl() {
   auto popup = GetView().as<winrt::Popup>();
-  auto control = popup.Child().as<winrt::ContentControl>();
+  auto control = popup.Child().as<xaml::Controls::ContentControl>();
 
   return control;
 }
@@ -93,7 +91,7 @@ void PopupShadowNode::createView() {
       // translation based on an elevation derived from the count of open
       // popups/flyouts. We apply this translation on open of the popup.
       // (Translation is only supported on RS5+, eg. IUIElement9)
-      if (auto uiElement9 = GetView().try_as<winrt::IUIElement9>()) {
+      if (auto uiElement9 = GetView().try_as<xaml::IUIElement9>()) {
         auto numOpenPopups = CountOpenPopups();
         if (numOpenPopups > 0) {
           winrt::Numerics::float3 translation{0, 0, (float)16 * numOpenPopups};
@@ -113,7 +111,7 @@ void PopupShadowNode::createView() {
     }
   });
 
-  m_windowSizeChangedRevoker = winrt::Window::Current().SizeChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
+  m_windowSizeChangedRevoker = xaml::Window::Current().SizeChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
     auto instance = wkinstance.lock();
     if (!m_updating && instance != nullptr) {
       UpdateLayout();
@@ -248,7 +246,7 @@ void PopupShadowNode::UpdateLayout() {
 
     if (pShadowNodeChild != nullptr) {
       auto targetView = pShadowNodeChild->GetView();
-      auto targetElement = targetView.as<winrt::FrameworkElement>();
+      auto targetElement = targetView.as<xaml::FrameworkElement>();
 
       auto popupTransform = targetElement.TransformToVisual(popup);
       winrt::Point bottomRightPoint(
@@ -259,7 +257,7 @@ void PopupShadowNode::UpdateLayout() {
     }
   } else // Center relative to app window
   {
-    auto appWindow = winrt::Window::Current().Content();
+    auto appWindow = xaml::Window::Current().Content();
     auto popupToWindow = appWindow.TransformToVisual(popup);
     auto appWindowSize = GetAppWindowSize();
     winrt::Point centerPoint;
@@ -275,18 +273,18 @@ void PopupShadowNode::UpdateTabStops() {
   auto control = GetControl();
   if (m_autoFocus) {
     control.IsTabStop(true);
-    control.TabFocusNavigation(winrt::Windows::UI::Xaml::Input::KeyboardNavigationMode::Cycle);
-    winrt::FocusManager::TryFocusAsync(control, winrt::Windows::UI::Xaml::FocusState::Programmatic);
+    control.TabFocusNavigation(xaml::Input::KeyboardNavigationMode::Cycle);
+    xaml::Input::FocusManager::TryFocusAsync(control, xaml::FocusState::Programmatic);
   } else {
     control.IsTabStop(false);
-    control.TabFocusNavigation(winrt::Windows::UI::Xaml::Input::KeyboardNavigationMode::Local);
+    control.TabFocusNavigation(xaml::Input::KeyboardNavigationMode::Local);
   }
 }
 
 winrt::Size PopupShadowNode::GetAppWindowSize() {
   winrt::Size windowSize = winrt::SizeHelper::Empty();
 
-  if (auto current = winrt::Window::Current()) {
+  if (auto current = xaml::Window::Current()) {
     if (auto coreWindow = current.CoreWindow()) {
       windowSize.Width = coreWindow.Bounds().Width;
       windowSize.Height = coreWindow.Bounds().Height;
@@ -317,7 +315,7 @@ facebook::react::ShadowNode *PopupViewManager::createShadow() const {
 
 XamlView PopupViewManager::CreateViewCore(int64_t /*tag*/) {
   auto popup = winrt::Popup();
-  auto control = winrt::ContentControl();
+  auto control = xaml::Controls::ContentControl();
 
   popup.Child(control);
 
@@ -332,7 +330,7 @@ void PopupViewManager::SetLayoutProps(
     float width,
     float height) {
   auto popup = viewToUpdate.as<winrt::Popup>();
-  auto control = popup.Child().as<winrt::ContentControl>();
+  auto control = popup.Child().as<xaml::Controls::ContentControl>();
 
   control.Width(width);
   control.Height(height);

--- a/vnext/ReactUWP/Views/RawTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/RawTextViewManager.cpp
@@ -12,16 +12,14 @@
 #include <Utils/ValueUtils.h>
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Documents.h>
 
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Documents;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Documents;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -19,12 +19,6 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Markup.h>
-#include <winrt/Windows.UI.Xaml.Media.Media3D.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 namespace react {
 namespace uwp {
@@ -72,7 +66,7 @@ void ReactControl::HandleInstanceErrorOnUIThread() {
     if (m_errorTextBlock == nullptr) {
       m_errorTextBlock = winrt::TextBlock();
       m_redBoxGrid = winrt::Grid();
-      m_redBoxGrid.Background(winrt::SolidColorBrush(winrt::ColorHelper::FromArgb(0xee, 0xcc, 0, 0)));
+      m_redBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xee, 0xcc, 0, 0)));
       m_redBoxGrid.Children().Append(m_errorTextBlock);
     }
 
@@ -86,9 +80,9 @@ void ReactControl::HandleInstanceErrorOnUIThread() {
 
     // Format TextBlock
     m_errorTextBlock.TextAlignment(winrt::TextAlignment::Center);
-    m_errorTextBlock.TextWrapping(winrt::TextWrapping::Wrap);
+    m_errorTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
     m_errorTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
-    m_errorTextBlock.Foreground(winrt::SolidColorBrush(winrt::Colors::White()));
+    m_errorTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
     winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
     m_errorTextBlock.Margin(margin);
   }
@@ -114,9 +108,9 @@ void ReactControl::HandleInstanceWaitingOnUIThread() {
     if (m_waitingTextBlock == nullptr) {
       m_waitingTextBlock = winrt::TextBlock();
       m_greenBoxGrid = winrt::Grid();
-      m_greenBoxGrid.Background(winrt::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
+      m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
       m_greenBoxGrid.Children().Append(m_waitingTextBlock);
-      m_greenBoxGrid.VerticalAlignment(winrt::Windows::UI::Xaml::VerticalAlignment::Top);
+      m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Top);
     }
 
     // Add box grid to root view
@@ -128,9 +122,9 @@ void ReactControl::HandleInstanceWaitingOnUIThread() {
 
     // Format TextBlock
     m_waitingTextBlock.TextAlignment(winrt::TextAlignment::Center);
-    m_waitingTextBlock.TextWrapping(winrt::TextWrapping::Wrap);
+    m_waitingTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
     m_waitingTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
-    m_waitingTextBlock.Foreground(winrt::SolidColorBrush(winrt::Colors::White()));
+    m_waitingTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
     winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
     m_waitingTextBlock.Margin(margin);
   }
@@ -251,9 +245,9 @@ void ReactControl::blur(XamlView const &xamlView) noexcept {
   EnsureFocusSafeHarbor();
   if (m_focusSafeHarbor) {
     m_focusSafeHarbor.IsTabStop(true);
-    winrt::FocusManager::TryFocusAsync(m_focusSafeHarbor, winrt::FocusState::Pointer);
+    xaml::Input::FocusManager::TryFocusAsync(m_focusSafeHarbor, winrt::FocusState::Pointer);
   } else
-    winrt::FocusManager::TryFocusAsync(xamlView, winrt::FocusState::Pointer);
+    xaml::Input::FocusManager::TryFocusAsync(xamlView, winrt::FocusState::Pointer);
 }
 
 void ReactControl::DetachInstance() {
@@ -321,14 +315,14 @@ std::string ReactControl::JSComponentName() const noexcept {
 }
 
 int64_t ReactControl::GetActualHeight() const {
-  auto element = m_xamlRootView.as<winrt::FrameworkElement>();
+  auto element = m_xamlRootView.as<xaml::FrameworkElement>();
   assert(element != nullptr);
 
   return static_cast<int64_t>(element.ActualHeight());
 }
 
 int64_t ReactControl::GetActualWidth() const {
-  auto element = m_xamlRootView.as<winrt::FrameworkElement>();
+  auto element = m_xamlRootView.as<xaml::FrameworkElement>();
   assert(element != nullptr);
 
   return static_cast<int64_t>(element.ActualWidth());
@@ -349,9 +343,9 @@ void ReactControl::PrepareXamlRootView(XamlView const &rootView) {
     // Xaml's default projection in 3D is orthographic (all lines are parallel)
     // However React Native's default projection is a one-point perspective.
     // Set a default perspective projection on the main control to mimic this.
-    auto perspectiveTransform3D = winrt::Windows::UI::Xaml::Media::Media3D::PerspectiveTransform3D();
+    auto perspectiveTransform3D = xaml::Media::Media3D::PerspectiveTransform3D();
     perspectiveTransform3D.Depth(850);
-    winrt::Windows::UI::Xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
+    xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
     newRootView.Transform3D(t3d);
     children.Append(newRootView);
     m_xamlRootView = newRootView;
@@ -365,7 +359,7 @@ void ReactControl::EnsureFocusSafeHarbor() {
     auto panel = m_rootView.try_as<winrt::Panel>();
     assert(panel.Children().Size() == 1);
 
-    m_focusSafeHarbor = winrt::ContentControl();
+    m_focusSafeHarbor = xaml::Controls::ContentControl();
     m_focusSafeHarbor.Width(0.0);
     m_focusSafeHarbor.IsTabStop(false);
     panel.Children().InsertAt(0, m_focusSafeHarbor);
@@ -382,9 +376,9 @@ void ReactControl::InitializeDeveloperMenu() {
   m_coreDispatcherAKARevoker = coreWindow.Dispatcher().AcceleratorKeyActivated(
       winrt::auto_revoke, [this](const auto &sender, const winrt::AcceleratorKeyEventArgs &args) {
         if ((args.VirtualKey() == winrt::Windows::System::VirtualKey::D) &&
-            KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow::GetForCurrentThread(), winrt::VirtualKey::Shift) &&
+            KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
             KeyboardHelper::IsModifiedKeyPressed(
-                winrt::CoreWindow::GetForCurrentThread(), winrt::VirtualKey::Control)) {
+                winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Control)) {
           if (!IsDeveloperMenuShowing()) {
             ShowDeveloperMenu();
           }

--- a/vnext/ReactUWP/Views/ReactControl.cpp
+++ b/vnext/ReactUWP/Views/ReactControl.cpp
@@ -376,7 +376,8 @@ void ReactControl::InitializeDeveloperMenu() {
   m_coreDispatcherAKARevoker = coreWindow.Dispatcher().AcceleratorKeyActivated(
       winrt::auto_revoke, [this](const auto &sender, const winrt::AcceleratorKeyEventArgs &args) {
         if ((args.VirtualKey() == winrt::Windows::System::VirtualKey::D) &&
-            KeyboardHelper::IsModifiedKeyPressed(winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
+            KeyboardHelper::IsModifiedKeyPressed(
+                winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
             KeyboardHelper::IsModifiedKeyPressed(
                 winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Control)) {
           if (!IsDeveloperMenuShowing()) {

--- a/vnext/ReactUWP/Views/ReactControl.h
+++ b/vnext/ReactUWP/Views/ReactControl.h
@@ -7,7 +7,6 @@
 #include <set>
 
 #include <IReactInstance.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
 #include "IXamlRootView.h"
 #include "SIPEventHandler.h"
 #include "TouchEventHandler.h"
@@ -15,11 +14,11 @@
 
 namespace winrt {
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Input;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Input;
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -100,8 +99,8 @@ class ReactControl final : public std::enable_shared_from_this<ReactControl>, pu
   ErrorCallbackCookie m_errorCallbackCookie{0};
   DebuggerAttachCallbackCookie m_debuggerAttachCallbackCookie{0};
 
-  winrt::ContentControl m_focusSafeHarbor{nullptr};
-  winrt::ContentControl::LosingFocus_revoker m_focusSafeHarborLosingFocusRevoker{};
+  xaml::Controls::ContentControl m_focusSafeHarbor{nullptr};
+  xaml::Controls::ContentControl::LosingFocus_revoker m_focusSafeHarborLosingFocusRevoker{};
   winrt::Grid m_redBoxGrid{nullptr};
   winrt::Grid m_greenBoxGrid{nullptr};
   winrt::TextBlock m_errorTextBlock{nullptr};

--- a/vnext/ReactUWP/Views/ReactRootView.cpp
+++ b/vnext/ReactUWP/Views/ReactRootView.cpp
@@ -16,17 +16,13 @@
 #include <winrt/Windows.ApplicationModel.Core.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Core.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Input;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Input;
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {

--- a/vnext/ReactUWP/Views/RefreshControlManager.cpp
+++ b/vnext/ReactUWP/Views/RefreshControlManager.cpp
@@ -5,14 +5,12 @@
 
 #include "RefreshControlManager.h"
 
-#include <winrt/Windows.UI.Xaml.Shapes.h>
-
 #include <ReactUWP\Utils\Helpers.h>
 #include <Views/ShadowNodeBase.h>
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
+using namespace xaml;
+using namespace xaml::Controls;
 using namespace Windows::Foundation;
 } // namespace winrt
 

--- a/vnext/ReactUWP/Views/RootViewManager.cpp
+++ b/vnext/ReactUWP/Views/RootViewManager.cpp
@@ -7,12 +7,10 @@
 
 #include <IXamlRootView.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.h>
-
 namespace winrt {
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
+using namespace xaml;
+using namespace xaml::Controls;
 } // namespace winrt
 
 namespace react {
@@ -33,7 +31,7 @@ XamlView RootViewManager::CreateViewCore(int64_t /*tag*/) {
 void RootViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
   auto panel(parent.as<winrt::Panel>());
   if (panel != nullptr)
-    panel.Children().InsertAt(static_cast<uint32_t>(index), child.as<winrt::UIElement>());
+    panel.Children().InsertAt(static_cast<uint32_t>(index), child.as<xaml::UIElement>());
 }
 
 void RootViewManager::RemoveAllChildren(const XamlView &parent) {

--- a/vnext/ReactUWP/Views/SIPEventHandler.cpp
+++ b/vnext/ReactUWP/Views/SIPEventHandler.cpp
@@ -8,16 +8,13 @@
 #include <Modules/NativeUIManager.h>
 
 #include <ReactUWP/Utils/Helpers.h>
-#include <winrt/Windows.ApplicationModel.Core.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
 
 namespace winrt {
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 using namespace Windows::UI::ViewManagement::Core;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Media;
 } // namespace winrt
 namespace react {
 namespace uwp {
@@ -39,7 +36,7 @@ void SIPEventHandler::AttachView(XamlView xamlView, bool fireKeyboardEvents) {
   if (winrt::VisualTreeHelper::GetParent(xamlView)) {
     InitializeCoreInputView();
   } else {
-    m_loadedRevoker = xamlView.as<winrt::FrameworkElement>().Loaded(
+    m_loadedRevoker = xamlView.as<xaml::FrameworkElement>().Loaded(
         winrt::auto_revoke, [this](const auto & /*sender*/, const auto &) { InitializeCoreInputView(); });
   }
 }
@@ -52,7 +49,7 @@ void SIPEventHandler::InitializeCoreInputView() {
 
     if (Is19H1OrHigher()) {
       // 19H1 and higher supports island scenarios
-      auto uiElement(xamlView.as<winrt::UIElement>());
+      auto uiElement(xamlView.as<xaml::UIElement>());
       m_coreInputView = winrt::CoreInputView::GetForUIContext(uiElement.UIContext());
     } else {
       m_coreInputView = winrt::CoreInputView::GetForCurrentView();

--- a/vnext/ReactUWP/Views/SIPEventHandler.h
+++ b/vnext/ReactUWP/Views/SIPEventHandler.h
@@ -36,7 +36,7 @@ class SIPEventHandler {
   winrt::Rect m_finalRect;
   winrt::CoreInputView m_coreInputView{nullptr};
   winrt::weak_ref<XamlView> m_view{};
-  winrt::Windows::UI::Xaml::FrameworkElement::Loaded_revoker m_loadedRevoker{};
+  xaml::FrameworkElement::Loaded_revoker m_loadedRevoker{};
   bool m_isShowing{false};
   bool m_fireKeyboradEvents;
 

--- a/vnext/ReactUWP/Views/ScrollViewManager.cpp
+++ b/vnext/ReactUWP/Views/ScrollViewManager.cpp
@@ -50,13 +50,13 @@ class ScrollViewShadowNode : public ShadowNodeBase {
 
   std::shared_ptr<SIPEventHandler> m_SIPEventHandler;
 
-  winrt::FrameworkElement::SizeChanged_revoker m_scrollViewerSizeChangedRevoker{};
-  winrt::FrameworkElement::SizeChanged_revoker m_contentSizeChangedRevoker{};
+  xaml::FrameworkElement::SizeChanged_revoker m_scrollViewerSizeChangedRevoker{};
+  xaml::FrameworkElement::SizeChanged_revoker m_contentSizeChangedRevoker{};
   winrt::ScrollViewer::ViewChanged_revoker m_scrollViewerViewChangedRevoker{};
   winrt::ScrollViewer::ViewChanging_revoker m_scrollViewerViewChangingRevoker{};
   winrt::ScrollViewer::DirectManipulationCompleted_revoker m_scrollViewerDirectManipulationCompletedRevoker{};
   winrt::ScrollViewer::DirectManipulationStarted_revoker m_scrollViewerDirectManipulationStartedRevoker{};
-  winrt::Control::Loaded_revoker m_controlLoadedRevoker{};
+  xaml::Controls::Control::Loaded_revoker m_controlLoadedRevoker{};
 };
 
 ScrollViewShadowNode::ScrollViewShadowNode() {}

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -33,9 +33,9 @@ void ShadowNodeBase::createView() {
   m_view = GetViewManager()->CreateView(this->m_tag);
 
   if (g_HasActualSizeProperty == TriBit::Undefined) {
-    if (auto uielement = m_view.try_as<winrt::UIElement>()) {
+    if (auto uielement = m_view.try_as<xaml::UIElement>()) {
       // ActualSize works on 19H1+ only
-      g_HasActualSizeProperty = (uielement.try_as<winrt::IUIElement10>()) ? TriBit::Set : TriBit::NotSet;
+      g_HasActualSizeProperty = (uielement.try_as<xaml::IUIElement10>()) ? TriBit::Set : TriBit::NotSet;
     }
   }
 }
@@ -100,9 +100,9 @@ void ShadowNodeBase::ReparentView(XamlView view) {
   }
 }
 
-winrt::Windows::UI::Composition::CompositionPropertySet ShadowNodeBase::EnsureTransformPS() {
+comp::CompositionPropertySet ShadowNodeBase::EnsureTransformPS() {
   if (m_transformPS == nullptr) {
-    m_transformPS = winrt::Window::Current().Compositor().CreatePropertySet();
+    m_transformPS = xaml::Window::Current().Compositor().CreatePropertySet();
     UpdateTransformPS();
   }
 
@@ -117,7 +117,7 @@ void ShadowNodeBase::UpdateTransformPS() {
     // First build up an ExpressionAnimation to compute the "center" property,
     // like so: The input to the expression is UIElement.ActualSize/2, output is
     // a vector3 with [cx, cy, 0].
-    auto uielement = m_view.try_as<winrt::UIElement>();
+    auto uielement = m_view.try_as<xaml::UIElement>();
     assert(uielement != nullptr);
     m_transformPS = EnsureTransformPS();
     m_transformPS.InsertVector3(L"center", {0, 0, 0});
@@ -136,7 +136,7 @@ void ShadowNodeBase::UpdateTransformPS() {
     // XAML element, here we will just transfer existing value to a new backing
     // XAML element.
     if (m_transformPS.TryGetMatrix4x4(L"transform", unused) ==
-        winrt::Windows::UI::Composition::CompositionGetValueStatus::NotFound) {
+        comp::CompositionGetValueStatus::NotFound) {
       m_transformPS.InsertMatrix4x4(L"transform", winrt::Windows::Foundation::Numerics::float4x4::identity());
     }
   }

--- a/vnext/ReactUWP/Views/ShadowNodeBase.cpp
+++ b/vnext/ReactUWP/Views/ShadowNodeBase.cpp
@@ -135,8 +135,7 @@ void ShadowNodeBase::UpdateTransformPS() {
     // we will use this value in the scenario where a View changed its backing
     // XAML element, here we will just transfer existing value to a new backing
     // XAML element.
-    if (m_transformPS.TryGetMatrix4x4(L"transform", unused) ==
-        comp::CompositionGetValueStatus::NotFound) {
+    if (m_transformPS.TryGetMatrix4x4(L"transform", unused) == comp::CompositionGetValueStatus::NotFound) {
       m_transformPS.InsertMatrix4x4(L"transform", winrt::Windows::Foundation::Numerics::float4x4::identity());
     }
   }

--- a/vnext/ReactUWP/Views/SliderViewManager.cpp
+++ b/vnext/ReactUWP/Views/SliderViewManager.cpp
@@ -10,10 +10,8 @@
 
 #include <IReactInstance.h>
 
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-
 namespace winrt {
-using ToggleButton = Windows::UI::Xaml::Controls::Primitives::ToggleButton;
+using ToggleButton = xaml::Controls::Primitives::ToggleButton;
 }
 
 namespace react {
@@ -57,7 +55,7 @@ facebook::react::ShadowNode *SliderViewManager::createShadow() const {
 }
 
 XamlView SliderViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto slider = winrt::Slider();
+  auto slider = xaml::Controls::Slider();
   return slider;
 }
 
@@ -65,7 +63,7 @@ bool SliderViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,
     const folly::dynamic &propertyValue) {
-  auto slider = nodeToUpdate->GetView().as<winrt::Slider>();
+  auto slider = nodeToUpdate->GetView().as<xaml::Controls::Slider>();
   if (slider == nullptr)
     return true;
 
@@ -73,7 +71,7 @@ bool SliderViewManager::UpdateProperty(
     if (propertyValue.isBool())
       slider.IsEnabled(!propertyValue.asBool());
     else if (propertyValue.isNull())
-      slider.ClearValue(winrt::Control::IsEnabledProperty());
+      slider.ClearValue(xaml::Controls::Control::IsEnabledProperty());
   } else if (propertyName == "value") {
     if (propertyValue.isNumber())
       slider.Value(propertyValue.asDouble());

--- a/vnext/ReactUWP/Views/SwitchViewManager.cpp
+++ b/vnext/ReactUWP/Views/SwitchViewManager.cpp
@@ -7,13 +7,12 @@
 #include <Utils/ResourceBrushUtils.h>
 #include <Utils/ValueUtils.h>
 #include <Views/ShadowNodeBase.h>
-#include <winrt/Windows.UI.Xaml.Shapes.h>
 #include "SwitchViewManager.h"
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Shapes;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Shapes;
 } // namespace winrt
 
 namespace react {
@@ -148,7 +147,7 @@ bool SwitchViewManager::UpdateProperty(
     if (propertyValue.isBool())
       toggleSwitch.IsEnabled(!propertyValue.asBool());
     else if (propertyValue.isNull())
-      toggleSwitch.ClearValue(winrt::Control::IsEnabledProperty());
+      toggleSwitch.ClearValue(xaml::Controls::Control::IsEnabledProperty());
   } else if (propertyName == "value") {
     if (propertyValue.isBool())
       toggleSwitch.IsOn(propertyValue.asBool());

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -673,8 +673,10 @@ void TextInputViewManager::TransferInputScope(
 }
 
 void TextInputViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
-  if ((oldView.try_as<xaml::Controls::TextBox>() != nullptr && newView.try_as<xaml::Controls::PasswordBox>() != nullptr) ||
-      (oldView.try_as<xaml::Controls::PasswordBox>() != nullptr && newView.try_as<xaml::Controls::TextBox>() != nullptr)) {
+  if ((oldView.try_as<xaml::Controls::TextBox>() != nullptr &&
+       newView.try_as<xaml::Controls::PasswordBox>() != nullptr) ||
+      (oldView.try_as<xaml::Controls::PasswordBox>() != nullptr &&
+       newView.try_as<xaml::Controls::TextBox>() != nullptr)) {
     bool copyToPasswordBox = oldView.try_as<xaml::Controls::TextBox>() != nullptr;
 
     // sync common properties between TextBox and PasswordBox

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -673,9 +673,9 @@ void TextInputViewManager::TransferInputScope(
 }
 
 void TextInputViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
-  if ((oldView.try_as<xaml::Controls::TextBox>() != nullptr && newView.try_as<winrt::PasswordBox>() != nullptr) ||
-      (oldView.try_as<xaml::Controls::PasswordBox>() != nullptr && newView.try_as<winrt::TextBox>() != nullptr)) {
-    bool copyToPasswordBox = oldView.try_as<winrt::TextBox>() != nullptr;
+  if ((oldView.try_as<xaml::Controls::TextBox>() != nullptr && newView.try_as<xaml::Controls::PasswordBox>() != nullptr) ||
+      (oldView.try_as<xaml::Controls::PasswordBox>() != nullptr && newView.try_as<xaml::Controls::TextBox>() != nullptr)) {
+    bool copyToPasswordBox = oldView.try_as<xaml::Controls::TextBox>() != nullptr;
 
     // sync common properties between TextBox and PasswordBox
     if (copyToPasswordBox) {

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -12,12 +12,12 @@
 #include <Utils/ValueUtils.h>
 
 #include <IReactInstance.h>
-#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include "CppWinRTIncludes.h"
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Shapes;
+using namespace xaml;
+using namespace xaml::Shapes;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -60,21 +60,21 @@ struct json_type_traits<react::uwp::Selection> {
   }
 };
 
-static const std::unordered_map<std::string, winrt::InputScopeNameValue> textBoxKeyboardTypeMap = {
-    {"default", winrt::InputScopeNameValue::Default},
-    {"number-pad", winrt::InputScopeNameValue::TelephoneNumber},
-    {"decimal-pad", winrt::InputScopeNameValue::Digits},
-    {"email-address", winrt::InputScopeNameValue::EmailNameOrAddress},
-    {"phone-pad", winrt::InputScopeNameValue::TelephoneNumber},
-    {"numeric", winrt::InputScopeNameValue::Number},
-    {"url", winrt::InputScopeNameValue::Url},
-    {"web-search", winrt::InputScopeNameValue::Search}};
+static const std::unordered_map<std::string, xaml::Input::InputScopeNameValue> textBoxKeyboardTypeMap = {
+    {"default", xaml::Input::InputScopeNameValue::Default},
+    {"number-pad", xaml::Input::InputScopeNameValue::TelephoneNumber},
+    {"decimal-pad", xaml::Input::InputScopeNameValue::Digits},
+    {"email-address", xaml::Input::InputScopeNameValue::EmailNameOrAddress},
+    {"phone-pad", xaml::Input::InputScopeNameValue::TelephoneNumber},
+    {"numeric", xaml::Input::InputScopeNameValue::Number},
+    {"url", xaml::Input::InputScopeNameValue::Url},
+    {"web-search", xaml::Input::InputScopeNameValue::Search}};
 
-static const std::unordered_map<std::string, winrt::InputScopeNameValue> passwordBoxKeyboardTypeMap = {
-    {"default", winrt::InputScopeNameValue::Password},
-    {"numeric", winrt::InputScopeNameValue::NumericPin}};
+static const std::unordered_map<std::string, xaml::Input::InputScopeNameValue> passwordBoxKeyboardTypeMap = {
+    {"default", xaml::Input::InputScopeNameValue::Password},
+    {"numeric", xaml::Input::InputScopeNameValue::NumericPin}};
 
-static winrt::InputScopeNameValue parseKeyboardType(const folly::dynamic &val, const bool isTextBox) {
+static xaml::Input::InputScopeNameValue parseKeyboardType(const folly::dynamic &val, const bool isTextBox) {
   auto keyboardTypeMap = isTextBox ? textBoxKeyboardTypeMap : passwordBoxKeyboardTypeMap;
 
   auto iter = keyboardTypeMap.find(val.asString());
@@ -83,7 +83,7 @@ static winrt::InputScopeNameValue parseKeyboardType(const folly::dynamic &val, c
     return iter->second;
   }
 
-  return isTextBox ? winrt::InputScopeNameValue::Default : winrt::InputScopeNameValue::Password;
+  return isTextBox ? xaml::Input::InputScopeNameValue::Default : xaml::Input::InputScopeNameValue::Password;
 }
 
 namespace react {
@@ -105,8 +105,8 @@ class TextInputShadowNode : public ShadowNodeBase {
   void dispatchTextInputChangeEvent(winrt::hstring newText);
   void registerEvents();
   void HideCaretIfNeeded();
-  void setPasswordBoxPlaceholderForeground(winrt::PasswordBox passwordBox, folly::dynamic color);
-  winrt::Shape FindCaret(winrt::DependencyObject element);
+  void setPasswordBoxPlaceholderForeground(xaml::Controls::PasswordBox passwordBox, folly::dynamic color);
+  winrt::Shape FindCaret(xaml::DependencyObject element);
 
   bool m_shouldClearTextOnFocus = false;
   bool m_shouldSelectTextOnFocus = false;
@@ -123,22 +123,22 @@ class TextInputShadowNode : public ShadowNodeBase {
   uint32_t m_mostRecentEventCount{0}; // EventCount from javascript
 
  private:
-  winrt::TextBox::TextChanging_revoker m_textBoxTextChangingRevoker{};
-  winrt::TextBox::TextChanged_revoker m_textBoxTextChangedRevoker{};
-  winrt::TextBox::SelectionChanged_revoker m_textBoxSelectionChangedRevoker{};
-  winrt::TextBox::ContextMenuOpening_revoker m_textBoxContextMenuOpeningRevoker{};
+  xaml::Controls::TextBox::TextChanging_revoker m_textBoxTextChangingRevoker{};
+  xaml::Controls::TextBox::TextChanged_revoker m_textBoxTextChangedRevoker{};
+  xaml::Controls::TextBox::SelectionChanged_revoker m_textBoxSelectionChangedRevoker{};
+  xaml::Controls::TextBox::ContextMenuOpening_revoker m_textBoxContextMenuOpeningRevoker{};
 
-  winrt::PasswordBox::PasswordChanging_revoker m_passwordBoxPasswordChangingRevoker{};
-  winrt::PasswordBox::PasswordChanged_revoker m_passwordBoxPasswordChangedRevoker{};
-  winrt::PasswordBox::ContextMenuOpening_revoker m_passwordBoxContextMenuOpeningRevoker{};
+  xaml::Controls::PasswordBox::PasswordChanging_revoker m_passwordBoxPasswordChangingRevoker{};
+  xaml::Controls::PasswordBox::PasswordChanged_revoker m_passwordBoxPasswordChangedRevoker{};
+  xaml::Controls::PasswordBox::ContextMenuOpening_revoker m_passwordBoxContextMenuOpeningRevoker{};
 
-  winrt::Control::GotFocus_revoker m_controlGotFocusRevoker{};
-  winrt::Control::LostFocus_revoker m_controlLostFocusRevoker{};
-  winrt::Control::KeyDown_revoker m_controlKeyDownRevoker{};
-  winrt::Control::SizeChanged_revoker m_controlSizeChangedRevoker{};
-  winrt::Control::CharacterReceived_revoker m_controlCharacterReceivedRevoker{};
-  winrt::ScrollViewer::ViewChanging_revoker m_scrollViewerViewChangingRevoker{};
-  winrt::Control::Loaded_revoker m_controlLoadedRevoker{};
+  xaml::Controls::Control::GotFocus_revoker m_controlGotFocusRevoker{};
+  xaml::Controls::Control::LostFocus_revoker m_controlLostFocusRevoker{};
+  xaml::Controls::Control::KeyDown_revoker m_controlKeyDownRevoker{};
+  xaml::Controls::Control::SizeChanged_revoker m_controlSizeChangedRevoker{};
+  xaml::Controls::Control::CharacterReceived_revoker m_controlCharacterReceivedRevoker{};
+  xaml::Controls::ScrollViewer::ViewChanging_revoker m_scrollViewerViewChangingRevoker{};
+  xaml::Controls::Control::Loaded_revoker m_controlLoadedRevoker{};
 };
 
 void TextInputShadowNode::createView() {
@@ -158,7 +158,7 @@ void TextInputShadowNode::dispatchTextInputChangeEvent(winrt::hstring newText) {
 }
 
 void TextInputShadowNode::registerEvents() {
-  auto control = GetView().as<winrt::Control>();
+  auto control = GetView().as<xaml::Controls::Control>();
   auto wkinstance = GetViewManager()->GetReactInstance();
   auto tag = m_tag;
 
@@ -177,41 +177,41 @@ void TextInputShadowNode::registerEvents() {
   if (m_isTextBox) {
     m_passwordBoxPasswordChangingRevoker = {};
     m_textBoxTextChangingRevoker =
-        control.as<winrt::TextBox>().TextChanging(winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
+        control.as<xaml::Controls::TextBox>().TextChanging(winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
   } else {
     m_textBoxTextChangingRevoker = {};
-    if (control.try_as<winrt::IPasswordBox4>()) {
-      m_passwordBoxPasswordChangingRevoker = control.as<winrt::IPasswordBox4>().PasswordChanging(
+    if (control.try_as<xaml::Controls::IPasswordBox4>()) {
+      m_passwordBoxPasswordChangingRevoker = control.as<xaml::Controls::IPasswordBox4>().PasswordChanging(
           winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
     }
   }
 
   if (m_isTextBox) {
     m_passwordBoxPasswordChangedRevoker = {};
-    auto textBox = control.as<winrt::TextBox>();
+    auto textBox = control.as<xaml::Controls::TextBox>();
     m_textBoxTextChangedRevoker = textBox.TextChanged(
         winrt::auto_revoke, [=](auto &&, auto &&) { dispatchTextInputChangeEvent(textBox.Text()); });
   } else {
     m_textBoxTextChangedRevoker = {};
-    auto passwordBox = control.as<winrt::PasswordBox>();
+    auto passwordBox = control.as<xaml::Controls::PasswordBox>();
     m_passwordBoxPasswordChangedRevoker = passwordBox.PasswordChanged(
         winrt::auto_revoke, [=](auto &&, auto &&) { dispatchTextInputChangeEvent(passwordBox.Password()); });
   }
 
   if (m_isTextBox) {
     m_passwordBoxContextMenuOpeningRevoker = {};
-    auto textBox = control.as<winrt::TextBox>();
+    auto textBox = control.as<xaml::Controls::TextBox>();
     m_textBoxContextMenuOpeningRevoker =
-        textBox.ContextMenuOpening(winrt::auto_revoke, [=](auto &&, winrt::ContextMenuEventArgs const &e) {
+        textBox.ContextMenuOpening(winrt::auto_revoke, [=](auto &&, xaml::Controls::ContextMenuEventArgs const &e) {
           if (m_contextMenuHidden) {
             e.Handled(true);
           }
         });
   } else {
     m_textBoxContextMenuOpeningRevoker = {};
-    auto passwordBox = control.as<winrt::PasswordBox>();
+    auto passwordBox = control.as<xaml::Controls::PasswordBox>();
     m_passwordBoxContextMenuOpeningRevoker =
-        passwordBox.ContextMenuOpening(winrt::auto_revoke, [=](auto &&, winrt::ContextMenuEventArgs const &e) {
+        passwordBox.ContextMenuOpening(winrt::auto_revoke, [=](auto &&, xaml::Controls::ContextMenuEventArgs const &e) {
           if (m_contextMenuHidden) {
             e.Handled(true);
           }
@@ -221,17 +221,17 @@ void TextInputShadowNode::registerEvents() {
   m_controlGotFocusRevoker = control.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&) {
     if (m_shouldClearTextOnFocus) {
       if (m_isTextBox) {
-        control.as<winrt::TextBox>().ClearValue(winrt::TextBox::TextProperty());
+        control.as<xaml::Controls::TextBox>().ClearValue(xaml::Controls::TextBox::TextProperty());
       } else {
-        control.as<winrt::PasswordBox>().ClearValue(winrt::PasswordBox::PasswordProperty());
+        control.as<xaml::Controls::PasswordBox>().ClearValue(xaml::Controls::PasswordBox::PasswordProperty());
       }
     }
 
     if (m_shouldSelectTextOnFocus) {
       if (m_isTextBox) {
-        control.as<winrt::TextBox>().SelectAll();
+        control.as<xaml::Controls::TextBox>().SelectAll();
       } else {
-        control.as<winrt::PasswordBox>().SelectAll();
+        control.as<xaml::Controls::PasswordBox>().SelectAll();
       }
     }
     HideCaretIfNeeded();
@@ -248,10 +248,10 @@ void TextInputShadowNode::registerEvents() {
     folly::dynamic eventDataEndEditing = {};
     if (m_isTextBox) {
       eventDataEndEditing =
-          folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<winrt::TextBox>().Text()));
+          folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
     } else {
       eventDataEndEditing =
-          folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<winrt::PasswordBox>().Password()));
+          folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
     }
     if (!m_updating && instance != nullptr) {
       instance->DispatchEvent(tag, "topTextInputBlur", std::move(eventDataBlur));
@@ -259,16 +259,16 @@ void TextInputShadowNode::registerEvents() {
     }
   });
 
-  m_controlKeyDownRevoker = control.KeyDown(winrt::auto_revoke, [=](auto &&, winrt::KeyRoutedEventArgs const &args) {
-    if (args.Key() == winrt::VirtualKey::Enter && !args.Handled()) {
+  m_controlKeyDownRevoker = control.KeyDown(winrt::auto_revoke, [=](auto &&, xaml::Input::KeyRoutedEventArgs const &args) {
+    if (args.Key() == winrt::Windows::System::VirtualKey::Enter && !args.Handled()) {
       if (auto instance = wkinstance.lock()) {
         folly::dynamic eventDataSubmitEditing = {};
         if (m_isTextBox) {
           eventDataSubmitEditing =
-              folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<winrt::TextBox>().Text()));
+              folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
         } else {
           eventDataSubmitEditing = folly::dynamic::object("target", tag)(
-              "text", HstringToDynamic(control.as<winrt::PasswordBox>().Password()));
+              "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
         }
         instance->DispatchEvent(tag, "topTextInputSubmitEditing", std::move(eventDataSubmitEditing));
       }
@@ -276,7 +276,7 @@ void TextInputShadowNode::registerEvents() {
   });
 
   if (m_isTextBox) {
-    auto textBox = control.as<winrt::TextBox>();
+    auto textBox = control.as<xaml::Controls::TextBox>();
     m_textBoxSelectionChangedRevoker = textBox.SelectionChanged(winrt::auto_revoke, [=](auto &&, auto &&) {
       auto instance = wkinstance.lock();
       folly::dynamic selectionData = folly::dynamic::object("start", textBox.SelectionStart())(
@@ -290,7 +290,7 @@ void TextInputShadowNode::registerEvents() {
   m_controlSizeChangedRevoker =
       control.SizeChanged(winrt::auto_revoke, [=](auto &&, winrt::SizeChangedEventArgs const &args) {
         if (m_isTextBox) {
-          if (control.as<winrt::TextBox>().TextWrapping() == winrt::TextWrapping::Wrap) {
+          if (control.as<xaml::Controls::TextBox>().TextWrapping() == xaml::TextWrapping::Wrap) {
             auto instance = wkinstance.lock();
             folly::dynamic contentSizeData =
                 folly::dynamic::object("width", args.NewSize().Width)("height", args.NewSize().Height);
@@ -302,10 +302,10 @@ void TextInputShadowNode::registerEvents() {
       });
 
   m_controlLoadedRevoker = control.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
-    auto textBoxView = control.GetTemplateChild(asHstring("ContentElement")).as<winrt::ScrollViewer>();
+    auto textBoxView = control.GetTemplateChild(asHstring("ContentElement")).as<xaml::Controls::ScrollViewer>();
     if (textBoxView) {
       m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(
-          winrt::auto_revoke, [=](auto &&, winrt::ScrollViewerViewChangingEventArgs const &args) {
+          winrt::auto_revoke, [=](auto &&, xaml::Controls::ScrollViewerViewChangingEventArgs const &args) {
             auto instance = wkinstance.lock();
             if (!m_updating && instance != nullptr) {
               folly::dynamic offsetData = folly::dynamic::object("x", args.FinalView().HorizontalOffset())(
@@ -318,9 +318,9 @@ void TextInputShadowNode::registerEvents() {
     HideCaretIfNeeded();
   });
 
-  if (control.try_as<winrt::IUIElement7>()) {
+  if (control.try_as<xaml::IUIElement7>()) {
     m_controlCharacterReceivedRevoker = control.CharacterReceived(
-        winrt::auto_revoke, [=](auto &&, winrt::CharacterReceivedRoutedEventArgs const &args) {
+        winrt::auto_revoke, [=](auto &&, xaml::Input::CharacterReceivedRoutedEventArgs const &args) {
           auto instance = wkinstance.lock();
           std::string key;
           wchar_t s[2] = L" ";
@@ -341,7 +341,7 @@ void TextInputShadowNode::registerEvents() {
   }
 }
 
-winrt::Shape TextInputShadowNode::FindCaret(winrt::DependencyObject element) {
+xaml::Shapes::Shape TextInputShadowNode::FindCaret(xaml::DependencyObject element) {
   if (element == nullptr)
     return nullptr;
 
@@ -361,23 +361,23 @@ winrt::Shape TextInputShadowNode::FindCaret(winrt::DependencyObject element) {
 // hacking solution to hide the caret
 void TextInputShadowNode::HideCaretIfNeeded() {
   if (m_hideCaret) {
-    auto control = GetView().as<winrt::Control>();
+    auto control = GetView().as<xaml::Controls::Control>();
     if (auto caret = FindCaret(control)) {
-      caret.CompositeMode(winrt::Windows::UI::Xaml::Media::ElementCompositeMode::Inherit);
-      winrt::SolidColorBrush transparentColor(winrt::Colors::Transparent());
+      caret.CompositeMode(xaml::Media::ElementCompositeMode::Inherit);
+      xaml::Media::SolidColorBrush transparentColor(winrt::Windows::UI::Colors::Transparent());
       caret.Fill(transparentColor);
     }
   }
 }
 
-void TextInputShadowNode::setPasswordBoxPlaceholderForeground(winrt::PasswordBox passwordBox, folly::dynamic color) {
+void TextInputShadowNode::setPasswordBoxPlaceholderForeground(xaml::Controls::PasswordBox passwordBox, folly::dynamic color) {
   m_placeholderTextColor = color;
-  auto defaultRD = winrt::Windows::UI::Xaml::ResourceDictionary();
+  auto defaultRD = xaml::ResourceDictionary();
   auto solidColorBrush = ColorFrom(color);
   defaultRD.Insert(winrt::box_value(L"TextControlPlaceholderForeground"), winrt::box_value(solidColorBrush));
   defaultRD.Insert(winrt::box_value(L"TextControlPlaceholderForegroundFocused"), winrt::box_value(solidColorBrush));
   defaultRD.Insert(winrt::box_value(L"TextControlPlaceholderForegroundPointerOver"), winrt::box_value(solidColorBrush));
-  auto passwordBoxResource = winrt::Windows::UI::Xaml::ResourceDictionary();
+  auto passwordBoxResource = xaml::ResourceDictionary();
   auto themeDictionaries = passwordBoxResource.ThemeDictionaries();
   themeDictionaries.Insert(winrt::box_value(L"Default"), defaultRD);
   passwordBoxResource.Insert(winrt::box_value(L"ThemeDictionaries"), themeDictionaries);
@@ -386,9 +386,9 @@ void TextInputShadowNode::setPasswordBoxPlaceholderForeground(winrt::PasswordBox
 
 void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
   m_updating = true;
-  auto control = GetView().as<winrt::Control>();
-  auto textBox = control.try_as<winrt::TextBox>();
-  auto passwordBox = control.try_as<winrt::PasswordBox>();
+  auto control = GetView().as<xaml::Controls::Control>();
+  auto textBox = control.try_as<xaml::Controls::TextBox>();
+  auto passwordBox = control.try_as<xaml::Controls::PasswordBox>();
 
   for (auto &pair : props.items()) {
     const std::string &propertyName = pair.first.getString();
@@ -403,7 +403,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
       if (propertyValue.isBool())
         control.IsTextScaleFactorEnabled(propertyValue.asBool());
       else if (propertyValue.isNull())
-        control.ClearValue(winrt::Control::IsTextScaleFactorEnabledProperty());
+        control.ClearValue(xaml::Controls::Control::IsTextScaleFactorEnabledProperty());
     } else if (propertyName == "clearTextOnFocus") {
       if (propertyValue.isBool())
         m_shouldClearTextOnFocus = propertyValue.asBool();
@@ -426,11 +426,11 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
       if (propertyValue.isBool()) {
         if (propertyValue.asBool()) {
           if (m_isTextBox) {
-            winrt::PasswordBox newPasswordBox;
+            xaml::Controls::PasswordBox newPasswordBox;
             ReparentView(newPasswordBox);
             m_isTextBox = false;
             registerEvents();
-            control = newPasswordBox.as<winrt::Control>();
+            control = newPasswordBox.as<xaml::Controls::Control>();
             passwordBox = newPasswordBox;
             if (!m_placeholderTextColor.isNull()) {
               setPasswordBoxPlaceholderForeground(newPasswordBox, m_placeholderTextColor);
@@ -438,11 +438,11 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
           }
         } else {
           if (!m_isTextBox) {
-            winrt::TextBox newTextBox;
+            xaml::Controls::TextBox newTextBox;
             ReparentView(newTextBox);
             m_isTextBox = true;
             registerEvents();
-            control = newTextBox.as<winrt::Control>();
+            control = newTextBox.as<xaml::Controls::Control>();
             textBox = newTextBox;
             if (!m_placeholderTextColor.isNull()) {
               textBox.PlaceholderForeground(SolidColorBrushFrom(m_placeholderTextColor));
@@ -453,50 +453,50 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
     } else if (propertyName == "maxLength") {
       if (propertyValue.isNumber()) {
         control.SetValue(
-            m_isTextBox ? winrt::TextBox::MaxLengthProperty() : winrt::PasswordBox::MaxLengthProperty(),
+            m_isTextBox ? xaml::Controls::TextBox::MaxLengthProperty() : xaml::Controls::PasswordBox::MaxLengthProperty(),
             winrt::PropertyValue::CreateInt32(static_cast<int32_t>(propertyValue.asDouble())));
       } else if (propertyValue.isNull()) {
-        control.ClearValue(m_isTextBox ? winrt::TextBox::MaxLengthProperty() : winrt::PasswordBox::MaxLengthProperty());
+        control.ClearValue(m_isTextBox ? xaml::Controls::TextBox::MaxLengthProperty() : xaml::Controls::PasswordBox::MaxLengthProperty());
       }
     } else if (propertyName == "placeholder") {
       if (propertyValue.isString()) {
         control.SetValue(
-            m_isTextBox ? winrt::TextBox::PlaceholderTextProperty() : winrt::PasswordBox::PlaceholderTextProperty(),
+            m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty() : xaml::Controls::PasswordBox::PlaceholderTextProperty(),
             winrt::PropertyValue::CreateString(asHstring(propertyValue)));
       } else if (propertyValue.isNull()) {
         control.ClearValue(
-            m_isTextBox ? winrt::TextBox::PlaceholderTextProperty() : winrt::PasswordBox::PlaceholderTextProperty());
+            m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty() : xaml::Controls::PasswordBox::PlaceholderTextProperty());
       }
     } else if (propertyName == "selectionColor") {
       if (IsValidColorValue(propertyValue)) {
         control.SetValue(
-            m_isTextBox ? winrt::TextBox::SelectionHighlightColorProperty()
-                        : winrt::PasswordBox::SelectionHighlightColorProperty(),
+            m_isTextBox ? xaml::Controls::TextBox::SelectionHighlightColorProperty()
+                        : xaml::Controls::PasswordBox::SelectionHighlightColorProperty(),
             SolidColorBrushFrom(propertyValue));
       } else if (propertyValue.isNull())
         control.ClearValue(
-            m_isTextBox ? winrt::TextBox::SelectionHighlightColorProperty()
-                        : winrt::PasswordBox::SelectionHighlightColorProperty());
+            m_isTextBox ? xaml::Controls::TextBox::SelectionHighlightColorProperty()
+                        : xaml::Controls::PasswordBox::SelectionHighlightColorProperty());
     } else if (propertyName == "keyboardType") {
       if (propertyValue.isString()) {
         auto inputScopeNameVaue = parseKeyboardType(propertyValue, m_isTextBox);
-        auto scope = winrt::InputScope();
-        auto scopeName = winrt::InputScopeName(inputScopeNameVaue);
+        auto scope = xaml::Input::InputScope();
+        auto scopeName = xaml::Input::InputScopeName(inputScopeNameVaue);
         auto names = scope.Names();
         names.Append(scopeName);
         control.SetValue(
-            m_isTextBox ? winrt::TextBox::InputScopeProperty() : winrt::PasswordBox::InputScopeProperty(), scope);
+            m_isTextBox ? xaml::Controls::TextBox::InputScopeProperty() : xaml::Controls::PasswordBox::InputScopeProperty(), scope);
       } else if (propertyValue.isNull())
         control.ClearValue(
-            m_isTextBox ? winrt::TextBox::InputScopeProperty() : winrt::PasswordBox::InputScopeProperty());
+            m_isTextBox ? xaml::Controls::TextBox::InputScopeProperty() : xaml::Controls::PasswordBox::InputScopeProperty());
     } else if (propertyName == "placeholderTextColor") {
       m_placeholderTextColor = nullptr;
-      if (textBox.try_as<winrt::ITextBox6>() && m_isTextBox) {
+      if (textBox.try_as<xaml::Controls::ITextBox6>() && m_isTextBox) {
         if (IsValidColorValue(propertyValue)) {
           m_placeholderTextColor = propertyValue;
           textBox.PlaceholderForeground(SolidColorBrushFrom(propertyValue));
         } else if (propertyValue.isNull())
-          textBox.ClearValue(winrt::TextBox::PlaceholderForegroundProperty());
+          textBox.ClearValue(xaml::Controls::TextBox::PlaceholderForegroundProperty());
       } else if (m_isTextBox != true && IsValidColorValue(propertyValue)) {
         setPasswordBoxPlaceholderForeground(passwordBox, propertyValue);
       }
@@ -507,20 +507,20 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
         } else if (propertyName == "multiline") {
           if (propertyValue.isBool()) {
             const bool isMultiline = propertyValue.asBool();
-            textBox.TextWrapping(isMultiline ? winrt::TextWrapping::Wrap : winrt::TextWrapping::NoWrap);
+            textBox.TextWrapping(isMultiline ? xaml::TextWrapping::Wrap : xaml::TextWrapping::NoWrap);
             textBox.AcceptsReturn(isMultiline);
           } else if (propertyValue.isNull())
-            textBox.ClearValue(winrt::TextBox::TextWrappingProperty());
+            textBox.ClearValue(xaml::Controls::TextBox::TextWrappingProperty());
         } else if (propertyName == "editable") {
           if (propertyValue.isBool())
             textBox.IsReadOnly(!propertyValue.asBool());
           else if (propertyValue.isNull())
-            textBox.ClearValue(winrt::TextBox::IsReadOnlyProperty());
+            textBox.ClearValue(xaml::Controls::TextBox::IsReadOnlyProperty());
         } else if (propertyName == "scrollEnabled") {
-          if (propertyValue.isBool() && textBox.TextWrapping() == winrt::TextWrapping::Wrap) {
-            auto scrollMode = propertyValue.asBool() ? winrt::ScrollMode::Auto : winrt::ScrollMode::Disabled;
-            winrt::ScrollViewer::SetVerticalScrollMode(textBox, scrollMode);
-            winrt::ScrollViewer::SetHorizontalScrollMode(textBox, scrollMode);
+          if (propertyValue.isBool() && textBox.TextWrapping() == xaml::TextWrapping::Wrap) {
+            auto scrollMode = propertyValue.asBool() ? xaml::Controls::ScrollMode::Auto : xaml::Controls::ScrollMode::Disabled;
+            xaml::Controls::ScrollViewer::SetVerticalScrollMode(textBox, scrollMode);
+            xaml::Controls::ScrollViewer::SetHorizontalScrollMode(textBox, scrollMode);
           }
         } else if (propertyName == "selection") {
           if (propertyValue.isObject()) {
@@ -533,7 +533,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
           if (propertyValue.isBool())
             textBox.IsSpellCheckEnabled(propertyValue.asBool());
           else if (propertyValue.isNull())
-            textBox.ClearValue(winrt::TextBox::IsSpellCheckEnabledProperty());
+            textBox.ClearValue(xaml::Controls::TextBox::IsSpellCheckEnabledProperty());
         } else if (propertyName == "text") {
           if (m_mostRecentEventCount == m_nativeEventCount) {
             if (propertyValue.isString()) {
@@ -543,19 +543,19 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
                 textBox.Text(newValue);
               }
             } else if (propertyValue.isNull())
-              textBox.ClearValue(winrt::TextBox::TextProperty());
+              textBox.ClearValue(xaml::Controls::TextBox::TextProperty());
           }
         } else if (propertyName == "autoCapitalize") {
-          if (textBox.try_as<winrt::ITextBox6>()) {
+          if (textBox.try_as<xaml::Controls::ITextBox6>()) {
             if (propertyValue.isString()) {
               if (propertyValue.asString() == "characters") {
-                textBox.CharacterCasing(winrt::CharacterCasing::Upper);
+                textBox.CharacterCasing(xaml::Controls::CharacterCasing::Upper);
               } else { // anything else turns off autoCap (should be "None" but
                        // we don't support "words"/"senetences" yet)
-                textBox.CharacterCasing(winrt::CharacterCasing::Normal);
+                textBox.CharacterCasing(xaml::Controls::CharacterCasing::Normal);
               }
             } else if (propertyValue.isNull())
-              textBox.ClearValue(winrt::TextBox::CharacterCasingProperty());
+              textBox.ClearValue(xaml::Controls::TextBox::CharacterCasingProperty());
           }
         }
       } else { // Applicable properties for PasswordBox
@@ -568,7 +568,7 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
                 passwordBox.Password(newValue);
               }
             } else if (propertyValue.isNull())
-              passwordBox.ClearValue(winrt::PasswordBox::PasswordProperty());
+              passwordBox.ClearValue(xaml::Controls::PasswordBox::PasswordProperty());
           }
         }
       }
@@ -619,7 +619,7 @@ facebook::react::ShadowNode *TextInputViewManager::createShadow() const {
 }
 
 XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/) {
-  winrt::TextBox textBox;
+  xaml::Controls::TextBox textBox;
   textBox.TabIndex(0);
   return textBox;
 }
@@ -635,63 +635,63 @@ void TextInputViewManager::TransferInputScope(
   // transfer input scope, only common keyboardType between secureTextEntry
   // on/off is numeric, so only need to transfer input scope "Number" <=>
   // "NumericPin", everything else leave it as default.
-  winrt::InputScope inputScope;
+  xaml::Input::InputScope inputScope;
   if (copyToPasswordBox) {
-    inputScope = oldView.try_as<winrt::TextBox>().InputScope();
+    inputScope = oldView.try_as<xaml::Controls::TextBox>().InputScope();
   } else {
-    inputScope = oldView.try_as<winrt::PasswordBox>().InputScope();
+    inputScope = oldView.try_as<xaml::Controls::PasswordBox>().InputScope();
   }
 
   if (inputScope != nullptr) {
     auto nameValue = inputScope.Names().GetAt(0).NameValue();
 
-    if ((nameValue == winrt::InputScopeNameValue::Number && copyToPasswordBox) ||
-        (nameValue == winrt::InputScopeNameValue::NumericPin && !copyToPasswordBox)) {
-      auto newScope = winrt::InputScope();
-      auto scopeName = winrt::InputScopeName(
-          copyToPasswordBox ? winrt::InputScopeNameValue::NumericPin : winrt::InputScopeNameValue::Number);
+    if ((nameValue == xaml::Input::InputScopeNameValue::Number && copyToPasswordBox) ||
+        (nameValue == xaml::Input::InputScopeNameValue::NumericPin && !copyToPasswordBox)) {
+      auto newScope = xaml::Input::InputScope();
+      auto scopeName = xaml::Input::InputScopeName(
+          copyToPasswordBox ? xaml::Input::InputScopeNameValue::NumericPin : xaml::Input::InputScopeNameValue::Number);
       auto names = newScope.Names();
       names.Append(scopeName);
       newView.SetValue(
-          copyToPasswordBox ? winrt::PasswordBox::InputScopeProperty() : winrt::TextBox::InputScopeProperty(),
+          copyToPasswordBox ? xaml::Controls::PasswordBox::InputScopeProperty() : xaml::Controls::TextBox::InputScopeProperty(),
           newScope);
     }
   }
 }
 
 void TextInputViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
-  if ((oldView.try_as<winrt::TextBox>() != nullptr && newView.try_as<winrt::PasswordBox>() != nullptr) ||
-      (oldView.try_as<winrt::PasswordBox>() != nullptr && newView.try_as<winrt::TextBox>() != nullptr)) {
+  if ((oldView.try_as<xaml::Controls::TextBox>() != nullptr && newView.try_as<winrt::PasswordBox>() != nullptr) ||
+      (oldView.try_as<xaml::Controls::PasswordBox>() != nullptr && newView.try_as<winrt::TextBox>() != nullptr)) {
     bool copyToPasswordBox = oldView.try_as<winrt::TextBox>() != nullptr;
 
     // sync common properties between TextBox and PasswordBox
     if (copyToPasswordBox) {
-      TransferProperty(oldView, newView, winrt::TextBox::MaxLengthProperty(), winrt::PasswordBox::MaxLengthProperty());
+      TransferProperty(oldView, newView, xaml::Controls::TextBox::MaxLengthProperty(), xaml::Controls::PasswordBox::MaxLengthProperty());
       TransferProperty(
-          oldView, newView, winrt::TextBox::PlaceholderTextProperty(), winrt::PasswordBox::PlaceholderTextProperty());
+          oldView, newView, xaml::Controls::TextBox::PlaceholderTextProperty(), xaml::Controls::PasswordBox::PlaceholderTextProperty());
       TransferProperty(
           oldView,
           newView,
-          winrt::TextBox::SelectionHighlightColorProperty(),
-          winrt::PasswordBox::SelectionHighlightColorProperty());
-      newView.as<winrt::PasswordBox>().Password(oldView.as<winrt::TextBox>().Text());
+          xaml::Controls::TextBox::SelectionHighlightColorProperty(),
+          xaml::Controls::PasswordBox::SelectionHighlightColorProperty());
+      newView.as<xaml::Controls::PasswordBox>().Password(oldView.as<xaml::Controls::TextBox>().Text());
     } else {
-      TransferProperty(oldView, newView, winrt::PasswordBox::MaxLengthProperty(), winrt::TextBox::MaxLengthProperty());
+      TransferProperty(oldView, newView, xaml::Controls::PasswordBox::MaxLengthProperty(), xaml::Controls::TextBox::MaxLengthProperty());
       TransferProperty(
-          oldView, newView, winrt::PasswordBox::PlaceholderTextProperty(), winrt::TextBox::PlaceholderTextProperty());
+          oldView, newView, xaml::Controls::PasswordBox::PlaceholderTextProperty(), xaml::Controls::TextBox::PlaceholderTextProperty());
       TransferProperty(
           oldView,
           newView,
-          winrt::PasswordBox::SelectionHighlightColorProperty(),
-          winrt::TextBox::SelectionHighlightColorProperty());
-      newView.as<winrt::TextBox>().Text(oldView.as<winrt::PasswordBox>().Password());
+          xaml::Controls::PasswordBox::SelectionHighlightColorProperty(),
+          xaml::Controls::TextBox::SelectionHighlightColorProperty());
+      newView.as<xaml::Controls::TextBox>().Text(oldView.as<xaml::Controls::PasswordBox>().Password());
     }
 
     TransferInputScope(oldView, newView, copyToPasswordBox);
     // Set focus if current control has focus
-    auto focusState = oldView.as<winrt::Control>().FocusState();
+    auto focusState = oldView.as<xaml::Controls::Control>().FocusState();
     if (focusState != winrt::FocusState::Unfocused) {
-      newView.as<winrt::Control>().Focus(focusState);
+      newView.as<xaml::Controls::Control>().Focus(focusState);
     }
   }
   Super::TransferProperties(oldView, newView);

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -176,8 +176,8 @@ void TextInputShadowNode::registerEvents() {
   // another TextChanged event with correct event count.
   if (m_isTextBox) {
     m_passwordBoxPasswordChangingRevoker = {};
-    m_textBoxTextChangingRevoker =
-        control.as<xaml::Controls::TextBox>().TextChanging(winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
+    m_textBoxTextChangingRevoker = control.as<xaml::Controls::TextBox>().TextChanging(
+        winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
   } else {
     m_textBoxTextChangingRevoker = {};
     if (control.try_as<xaml::Controls::IPasswordBox4>()) {
@@ -250,8 +250,8 @@ void TextInputShadowNode::registerEvents() {
       eventDataEndEditing =
           folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
     } else {
-      eventDataEndEditing =
-          folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
+      eventDataEndEditing = folly::dynamic::object("target", tag)(
+          "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
     }
     if (!m_updating && instance != nullptr) {
       instance->DispatchEvent(tag, "topTextInputBlur", std::move(eventDataBlur));
@@ -259,21 +259,22 @@ void TextInputShadowNode::registerEvents() {
     }
   });
 
-  m_controlKeyDownRevoker = control.KeyDown(winrt::auto_revoke, [=](auto &&, xaml::Input::KeyRoutedEventArgs const &args) {
-    if (args.Key() == winrt::Windows::System::VirtualKey::Enter && !args.Handled()) {
-      if (auto instance = wkinstance.lock()) {
-        folly::dynamic eventDataSubmitEditing = {};
-        if (m_isTextBox) {
-          eventDataSubmitEditing =
-              folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
-        } else {
-          eventDataSubmitEditing = folly::dynamic::object("target", tag)(
-              "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
+  m_controlKeyDownRevoker =
+      control.KeyDown(winrt::auto_revoke, [=](auto &&, xaml::Input::KeyRoutedEventArgs const &args) {
+        if (args.Key() == winrt::Windows::System::VirtualKey::Enter && !args.Handled()) {
+          if (auto instance = wkinstance.lock()) {
+            folly::dynamic eventDataSubmitEditing = {};
+            if (m_isTextBox) {
+              eventDataSubmitEditing = folly::dynamic::object("target", tag)(
+                  "text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
+            } else {
+              eventDataSubmitEditing = folly::dynamic::object("target", tag)(
+                  "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
+            }
+            instance->DispatchEvent(tag, "topTextInputSubmitEditing", std::move(eventDataSubmitEditing));
+          }
         }
-        instance->DispatchEvent(tag, "topTextInputSubmitEditing", std::move(eventDataSubmitEditing));
-      }
-    }
-  });
+      });
 
   if (m_isTextBox) {
     auto textBox = control.as<xaml::Controls::TextBox>();
@@ -370,7 +371,9 @@ void TextInputShadowNode::HideCaretIfNeeded() {
   }
 }
 
-void TextInputShadowNode::setPasswordBoxPlaceholderForeground(xaml::Controls::PasswordBox passwordBox, folly::dynamic color) {
+void TextInputShadowNode::setPasswordBoxPlaceholderForeground(
+    xaml::Controls::PasswordBox passwordBox,
+    folly::dynamic color) {
   m_placeholderTextColor = color;
   auto defaultRD = xaml::ResourceDictionary();
   auto solidColorBrush = ColorFrom(color);
@@ -453,19 +456,24 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
     } else if (propertyName == "maxLength") {
       if (propertyValue.isNumber()) {
         control.SetValue(
-            m_isTextBox ? xaml::Controls::TextBox::MaxLengthProperty() : xaml::Controls::PasswordBox::MaxLengthProperty(),
+            m_isTextBox ? xaml::Controls::TextBox::MaxLengthProperty()
+                        : xaml::Controls::PasswordBox::MaxLengthProperty(),
             winrt::PropertyValue::CreateInt32(static_cast<int32_t>(propertyValue.asDouble())));
       } else if (propertyValue.isNull()) {
-        control.ClearValue(m_isTextBox ? xaml::Controls::TextBox::MaxLengthProperty() : xaml::Controls::PasswordBox::MaxLengthProperty());
+        control.ClearValue(
+            m_isTextBox ? xaml::Controls::TextBox::MaxLengthProperty()
+                        : xaml::Controls::PasswordBox::MaxLengthProperty());
       }
     } else if (propertyName == "placeholder") {
       if (propertyValue.isString()) {
         control.SetValue(
-            m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty() : xaml::Controls::PasswordBox::PlaceholderTextProperty(),
+            m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty()
+                        : xaml::Controls::PasswordBox::PlaceholderTextProperty(),
             winrt::PropertyValue::CreateString(asHstring(propertyValue)));
       } else if (propertyValue.isNull()) {
         control.ClearValue(
-            m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty() : xaml::Controls::PasswordBox::PlaceholderTextProperty());
+            m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty()
+                        : xaml::Controls::PasswordBox::PlaceholderTextProperty());
       }
     } else if (propertyName == "selectionColor") {
       if (IsValidColorValue(propertyValue)) {
@@ -485,10 +493,13 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
         auto names = scope.Names();
         names.Append(scopeName);
         control.SetValue(
-            m_isTextBox ? xaml::Controls::TextBox::InputScopeProperty() : xaml::Controls::PasswordBox::InputScopeProperty(), scope);
+            m_isTextBox ? xaml::Controls::TextBox::InputScopeProperty()
+                        : xaml::Controls::PasswordBox::InputScopeProperty(),
+            scope);
       } else if (propertyValue.isNull())
         control.ClearValue(
-            m_isTextBox ? xaml::Controls::TextBox::InputScopeProperty() : xaml::Controls::PasswordBox::InputScopeProperty());
+            m_isTextBox ? xaml::Controls::TextBox::InputScopeProperty()
+                        : xaml::Controls::PasswordBox::InputScopeProperty());
     } else if (propertyName == "placeholderTextColor") {
       m_placeholderTextColor = nullptr;
       if (textBox.try_as<xaml::Controls::ITextBox6>() && m_isTextBox) {
@@ -518,7 +529,8 @@ void TextInputShadowNode::updateProperties(const folly::dynamic &&props) {
             textBox.ClearValue(xaml::Controls::TextBox::IsReadOnlyProperty());
         } else if (propertyName == "scrollEnabled") {
           if (propertyValue.isBool() && textBox.TextWrapping() == xaml::TextWrapping::Wrap) {
-            auto scrollMode = propertyValue.asBool() ? xaml::Controls::ScrollMode::Auto : xaml::Controls::ScrollMode::Disabled;
+            auto scrollMode =
+                propertyValue.asBool() ? xaml::Controls::ScrollMode::Auto : xaml::Controls::ScrollMode::Disabled;
             xaml::Controls::ScrollViewer::SetVerticalScrollMode(textBox, scrollMode);
             xaml::Controls::ScrollViewer::SetHorizontalScrollMode(textBox, scrollMode);
           }
@@ -653,7 +665,8 @@ void TextInputViewManager::TransferInputScope(
       auto names = newScope.Names();
       names.Append(scopeName);
       newView.SetValue(
-          copyToPasswordBox ? xaml::Controls::PasswordBox::InputScopeProperty() : xaml::Controls::TextBox::InputScopeProperty(),
+          copyToPasswordBox ? xaml::Controls::PasswordBox::InputScopeProperty()
+                            : xaml::Controls::TextBox::InputScopeProperty(),
           newScope);
     }
   }
@@ -666,9 +679,16 @@ void TextInputViewManager::TransferProperties(const XamlView &oldView, const Xam
 
     // sync common properties between TextBox and PasswordBox
     if (copyToPasswordBox) {
-      TransferProperty(oldView, newView, xaml::Controls::TextBox::MaxLengthProperty(), xaml::Controls::PasswordBox::MaxLengthProperty());
       TransferProperty(
-          oldView, newView, xaml::Controls::TextBox::PlaceholderTextProperty(), xaml::Controls::PasswordBox::PlaceholderTextProperty());
+          oldView,
+          newView,
+          xaml::Controls::TextBox::MaxLengthProperty(),
+          xaml::Controls::PasswordBox::MaxLengthProperty());
+      TransferProperty(
+          oldView,
+          newView,
+          xaml::Controls::TextBox::PlaceholderTextProperty(),
+          xaml::Controls::PasswordBox::PlaceholderTextProperty());
       TransferProperty(
           oldView,
           newView,
@@ -676,9 +696,16 @@ void TextInputViewManager::TransferProperties(const XamlView &oldView, const Xam
           xaml::Controls::PasswordBox::SelectionHighlightColorProperty());
       newView.as<xaml::Controls::PasswordBox>().Password(oldView.as<xaml::Controls::TextBox>().Text());
     } else {
-      TransferProperty(oldView, newView, xaml::Controls::PasswordBox::MaxLengthProperty(), xaml::Controls::TextBox::MaxLengthProperty());
       TransferProperty(
-          oldView, newView, xaml::Controls::PasswordBox::PlaceholderTextProperty(), xaml::Controls::TextBox::PlaceholderTextProperty());
+          oldView,
+          newView,
+          xaml::Controls::PasswordBox::MaxLengthProperty(),
+          xaml::Controls::TextBox::MaxLengthProperty());
+      TransferProperty(
+          oldView,
+          newView,
+          xaml::Controls::PasswordBox::PlaceholderTextProperty(),
+          xaml::Controls::TextBox::PlaceholderTextProperty());
       TransferProperty(
           oldView,
           newView,

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -5,20 +5,15 @@
 
 #include "TextViewManager.h"
 
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
-
 #include <Views/ShadowNodeBase.h>
 
 #include <Utils/PropertyUtils.h>
 #include <Utils/ValueUtils.h>
 
-#include <winrt/Windows.UI.Xaml.Documents.h>
-
 namespace winrt {
-using namespace Windows::UI::Xaml::Documents;
-using namespace Windows::UI::Xaml::Automation;
-using namespace Windows::UI::Xaml::Automation::Peers;
+using namespace xaml::Documents;
+using namespace xaml::Automation;
+using namespace xaml::Automation::Peers;
 } // namespace winrt
 
 namespace react {
@@ -43,13 +38,13 @@ class TextShadowNode : public ShadowNodeBase {
       auto run = static_cast<ShadowNodeBase &>(child).GetView().try_as<winrt::Run>();
       if (run != nullptr) {
         m_firstChildNode = &child;
-        auto textBlock = this->GetView().as<winrt::TextBlock>();
+        auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
         textBlock.Text(run.Text());
         return;
       }
     } else if (index == 1 && m_firstChildNode != nullptr) {
-      auto textBlock = this->GetView().as<winrt::TextBlock>();
-      textBlock.ClearValue(winrt::TextBlock::TextProperty());
+      auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
+      textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
       Super::AddView(*m_firstChildNode, 0);
       m_firstChildNode = nullptr;
     }
@@ -80,8 +75,8 @@ const char *TextViewManager::GetName() const {
 }
 
 XamlView TextViewManager::CreateViewCore(int64_t /*tag*/) {
-  auto textBlock = winrt::TextBlock();
-  textBlock.TextWrapping(winrt::TextWrapping::Wrap); // Default behavior in React Native
+  auto textBlock = xaml::Controls::TextBlock();
+  textBlock.TextWrapping(xaml::TextWrapping::Wrap); // Default behavior in React Native
   return textBlock;
 }
 
@@ -89,7 +84,7 @@ bool TextViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,
     const folly::dynamic &propertyValue) {
-  auto textBlock = nodeToUpdate->GetView().as<winrt::TextBlock>();
+  auto textBlock = nodeToUpdate->GetView().as<xaml::Controls::TextBlock>();
   if (textBlock == nullptr)
     return true;
 
@@ -104,38 +99,38 @@ bool TextViewManager::UpdateProperty(
     if (propertyValue.isNumber()) {
       auto numberLines = static_cast<int32_t>(propertyValue.asDouble());
       if (numberLines == 1) {
-        textBlock.TextWrapping(winrt::TextWrapping::NoWrap); // setting no wrap for single line
+        textBlock.TextWrapping(xaml::TextWrapping::NoWrap); // setting no wrap for single line
                                                              // text for better trimming
                                                              // experience
       } else {
-        textBlock.TextWrapping(winrt::TextWrapping::Wrap);
+        textBlock.TextWrapping(xaml::TextWrapping::Wrap);
       }
       textBlock.MaxLines(numberLines);
     } else if (propertyValue.isNull()) {
-      textBlock.TextWrapping(winrt::TextWrapping::Wrap); // set wrapping back to default
-      textBlock.ClearValue(winrt::TextBlock::MaxLinesProperty());
+      textBlock.TextWrapping(xaml::TextWrapping::Wrap); // set wrapping back to default
+      textBlock.ClearValue(xaml::Controls::TextBlock::MaxLinesProperty());
     }
   } else if (propertyName == "lineHeight") {
     if (propertyValue.isNumber())
       textBlock.LineHeight(static_cast<int32_t>(propertyValue.asDouble()));
     else if (propertyValue.isNull())
-      textBlock.ClearValue(winrt::TextBlock::LineHeightProperty());
+      textBlock.ClearValue(xaml::Controls::TextBlock::LineHeightProperty());
   } else if (propertyName == "selectable") {
     if (propertyValue.isBool())
       textBlock.IsTextSelectionEnabled(propertyValue.asBool());
     else if (propertyValue.isNull())
-      textBlock.ClearValue(winrt::TextBlock::IsTextSelectionEnabledProperty());
+      textBlock.ClearValue(xaml::Controls::TextBlock::IsTextSelectionEnabledProperty());
   } else if (propertyName == "allowFontScaling") {
     if (propertyValue.isBool()) {
       textBlock.IsTextScaleFactorEnabled(propertyValue.asBool());
     } else {
-      textBlock.ClearValue(winrt::TextBlock::IsTextScaleFactorEnabledProperty());
+      textBlock.ClearValue(xaml::Controls::TextBlock::IsTextScaleFactorEnabledProperty());
     }
   } else if (propertyName == "selectionColor") {
     if (IsValidColorValue(propertyValue)) {
       textBlock.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
     } else
-      textBlock.ClearValue(winrt::TextBlock::SelectionHighlightColorProperty());
+      textBlock.ClearValue(xaml::Controls::TextBlock::SelectionHighlightColorProperty());
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }
@@ -143,18 +138,18 @@ bool TextViewManager::UpdateProperty(
 }
 
 void TextViewManager::AddView(const XamlView &parent, const XamlView &child, int64_t index) {
-  auto textBlock(parent.as<winrt::TextBlock>());
+  auto textBlock(parent.as<xaml::Controls::TextBlock>());
   auto childInline(child.as<winrt::Inline>());
   textBlock.Inlines().InsertAt(static_cast<uint32_t>(index), childInline);
 }
 
 void TextViewManager::RemoveAllChildren(const XamlView &parent) {
-  auto textBlock(parent.as<winrt::TextBlock>());
+  auto textBlock(parent.as<xaml::Controls::TextBlock>());
   textBlock.Inlines().Clear();
 }
 
 void TextViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
-  auto textBlock(parent.as<winrt::TextBlock>());
+  auto textBlock(parent.as<xaml::Controls::TextBlock>());
   return textBlock.Inlines().RemoveAt(static_cast<uint32_t>(index));
 }
 
@@ -163,14 +158,14 @@ YGMeasureFunc TextViewManager::GetYogaCustomMeasureFunc() const {
 }
 
 void TextViewManager::OnDescendantTextPropertyChanged(ShadowNodeBase *node) {
-  if (auto element = node->GetView().try_as<winrt::TextBlock>()) {
+  if (auto element = node->GetView().try_as<xaml::Controls::TextBlock>()) {
     // If name is set, it's controlled by accessibilityLabel, and it's already
     // handled in FrameworkElementViewManager. Here it only handles when name is
     // not set.
-    if (winrt::AutomationProperties::GetLiveSetting(element) != winrt::AutomationLiveSetting::Off &&
-        winrt::AutomationProperties::GetName(element).empty() &&
-        winrt::AutomationProperties::GetAccessibilityView(element) != winrt::Peers::AccessibilityView::Raw) {
-      if (auto peer = winrt::FrameworkElementAutomationPeer::FromElement(element)) {
+    if (xaml::Automation::AutomationProperties::GetLiveSetting(element) != winrt::AutomationLiveSetting::Off &&
+        xaml::Automation::AutomationProperties::GetName(element).empty() &&
+        xaml::Automation::AutomationProperties::GetAccessibilityView(element) != winrt::Peers::AccessibilityView::Raw) {
+      if (auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element)) {
         peer.RaiseAutomationEvent(winrt::AutomationEvents::LiveRegionChanged);
       }
     }

--- a/vnext/ReactUWP/Views/TextViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextViewManager.cpp
@@ -100,8 +100,8 @@ bool TextViewManager::UpdateProperty(
       auto numberLines = static_cast<int32_t>(propertyValue.asDouble());
       if (numberLines == 1) {
         textBlock.TextWrapping(xaml::TextWrapping::NoWrap); // setting no wrap for single line
-                                                             // text for better trimming
-                                                             // experience
+                                                            // text for better trimming
+                                                            // experience
       } else {
         textBlock.TextWrapping(xaml::TextWrapping::Wrap);
       }

--- a/vnext/ReactUWP/Views/TouchEventHandler.cpp
+++ b/vnext/ReactUWP/Views/TouchEventHandler.cpp
@@ -14,10 +14,6 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 namespace react {
 namespace uwp {
@@ -30,7 +26,7 @@ TouchEventHandler::~TouchEventHandler() {
 }
 
 void TouchEventHandler::AddTouchHandlers(XamlView xamlView) {
-  auto uiElement(xamlView.as<winrt::UIElement>());
+  auto uiElement(xamlView.as<xaml::UIElement>());
   if (uiElement == nullptr) {
     assert(false);
     return;
@@ -74,7 +70,7 @@ void TouchEventHandler::OnPointerPressed(
 
   // Only if the view has a Tag can we process this
   int64_t tag;
-  winrt::FrameworkElement sourceElement(nullptr);
+  xaml::FrameworkElement sourceElement(nullptr);
   if (!TagFromOriginalSource(args, &tag, &sourceElement))
     return;
 
@@ -85,7 +81,7 @@ void TouchEventHandler::OnPointerPressed(
     return;
   }
 
-  if (m_xamlView.as<winrt::FrameworkElement>().CapturePointer(args.Pointer())) {
+  if (m_xamlView.as<xaml::FrameworkElement>().CapturePointer(args.Pointer())) {
     // Pointer pressing updates the enter/leave state
     UpdatePointersInViews(args, tag, sourceElement);
 
@@ -128,7 +124,7 @@ void TouchEventHandler::OnPointerMoved(
 
   // Only if the view has a Tag can we process this
   int64_t tag;
-  winrt::FrameworkElement sourceElement(nullptr);
+  xaml::FrameworkElement sourceElement(nullptr);
   if (!TagFromOriginalSource(args, &tag, &sourceElement))
     return;
 
@@ -158,7 +154,7 @@ void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt
   // if the view has a Tag, update the pointer info.
   // Regardless of that, ensure we Dispatch & cleanup the pointer
   int64_t tag;
-  winrt::FrameworkElement sourceElement(nullptr);
+  xaml::FrameworkElement sourceElement(nullptr);
   if (TagFromOriginalSource(args, &tag, &sourceElement))
     UpdateReactPointer(m_pointers[pointerIndex], args, sourceElement);
 
@@ -168,13 +164,13 @@ void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt
   if (m_pointers.size() == 0)
     m_touchId = 0;
 
-  m_xamlView.as<winrt::FrameworkElement>().ReleasePointerCapture(args.Pointer());
+  m_xamlView.as<xaml::FrameworkElement>().ReleasePointerCapture(args.Pointer());
 }
 
 size_t TouchEventHandler::AddReactPointer(
     const winrt::PointerRoutedEventArgs &args,
     int64_t tag,
-    winrt::FrameworkElement sourceElement) {
+    xaml::FrameworkElement sourceElement) {
   ReactPointer pointer = CreateReactPointer(args, tag, sourceElement);
   m_pointers.emplace_back(std::move(pointer));
   return m_pointers.size() - 1;
@@ -183,7 +179,7 @@ size_t TouchEventHandler::AddReactPointer(
 TouchEventHandler::ReactPointer TouchEventHandler::CreateReactPointer(
     const winrt::PointerRoutedEventArgs &args,
     int64_t tag,
-    winrt::FrameworkElement sourceElement) {
+    xaml::FrameworkElement sourceElement) {
   auto point = args.GetCurrentPoint(sourceElement);
 
   ReactPointer pointer;
@@ -204,8 +200,8 @@ TouchEventHandler::ReactPointer TouchEventHandler::CreateReactPointer(
 void TouchEventHandler::UpdateReactPointer(
     ReactPointer &pointer,
     const winrt::PointerRoutedEventArgs &args,
-    winrt::FrameworkElement sourceElement) {
-  auto rootPoint = args.GetCurrentPoint(m_xamlView.as<winrt::FrameworkElement>());
+    xaml::FrameworkElement sourceElement) {
+  auto rootPoint = args.GetCurrentPoint(m_xamlView.as<xaml::FrameworkElement>());
   auto point = args.GetCurrentPoint(sourceElement);
 
   pointer.positionRoot = rootPoint.Position();
@@ -236,7 +232,7 @@ std::optional<size_t> TouchEventHandler::IndexOfPointerWithId(uint32_t pointerId
 void TouchEventHandler::UpdatePointersInViews(
     const winrt::PointerRoutedEventArgs &args,
     int64_t tag,
-    winrt::FrameworkElement sourceElement) {
+    xaml::FrameworkElement sourceElement) {
   auto instance = m_wkReactInstance.lock();
   if (!instance || instance->IsInError())
     return;
@@ -289,7 +285,7 @@ void TouchEventHandler::UpdatePointersInViews(
 void TouchEventHandler::SendPointerMove(
     const winrt::PointerRoutedEventArgs &args,
     int64_t tag,
-    winrt::FrameworkElement sourceElement) {
+    xaml::FrameworkElement sourceElement) {
   auto instance = m_wkReactInstance.lock();
   auto nativeUiManager = static_cast<NativeUIManager *>(instance->NativeUIManager());
   facebook::react::INativeUIManagerHost *puiManagerHost = nativeUiManager->getHost();
@@ -302,7 +298,7 @@ void TouchEventHandler::SendPointerMove(
   }
   if (node == nullptr || !node->m_onMouseMove)
     return;
-  sourceElement = node->GetView().try_as<winrt::FrameworkElement>();
+  sourceElement = node->GetView().try_as<xaml::FrameworkElement>();
   if (sourceElement == nullptr)
     return;
 
@@ -402,20 +398,20 @@ const char *TouchEventHandler::GetTouchEventTypeName(TouchEventType eventType) n
 bool TouchEventHandler::TagFromOriginalSource(
     const winrt::PointerRoutedEventArgs &args,
     int64_t *pTag,
-    winrt::FrameworkElement *pSourceElement) {
+    xaml::FrameworkElement *pSourceElement) {
   assert(pTag != nullptr);
 
   if (args.OriginalSource() == nullptr)
     return false;
 
-  auto sourceElement = args.OriginalSource().try_as<winrt::FrameworkElement>();
+  auto sourceElement = args.OriginalSource().try_as<xaml::FrameworkElement>();
   if (sourceElement == nullptr) {
     // TODO: Do we need to handle this for non FrameworkElement views?
     return false;
   } else {
     auto tag = sourceElement.Tag();
     while (tag == nullptr && sourceElement && winrt::VisualTreeHelper::GetParent(sourceElement)) {
-      sourceElement = winrt::VisualTreeHelper::GetParent(sourceElement).try_as<winrt::FrameworkElement>();
+      sourceElement = winrt::VisualTreeHelper::GetParent(sourceElement).try_as<xaml::FrameworkElement>();
       tag = sourceElement.Tag();
     }
 
@@ -436,7 +432,7 @@ bool TouchEventHandler::TagFromOriginalSource(
 
 std::set<int64_t> TouchEventHandler::GetTagsAtPoint(const winrt::PointerRoutedEventArgs &e) {
   std::set<int64_t> tags;
-  winrt::UIElement root(m_xamlView.as<winrt::UIElement>());
+  xaml::UIElement root(m_xamlView.as<xaml::UIElement>());
 
   winrt::Point point = e.GetCurrentPoint(root).Position();
   auto transform = root.TransformToVisual(nullptr);
@@ -444,7 +440,7 @@ std::set<int64_t> TouchEventHandler::GetTagsAtPoint(const winrt::PointerRoutedEv
 
   auto elements = winrt::VisualTreeHelper::FindElementsInHostCoordinates(point, root);
   for (const auto &elem : elements) {
-    auto element = elem.try_as<winrt::FrameworkElement>();
+    auto element = elem.try_as<xaml::FrameworkElement>();
     if (element != nullptr) {
       auto tag = element.Tag();
       if (tag != nullptr)

--- a/vnext/ReactUWP/Views/TouchEventHandler.h
+++ b/vnext/ReactUWP/Views/TouchEventHandler.h
@@ -3,8 +3,6 @@
 
 #pragma once
 #include <folly/dynamic.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
 #include <optional>
 #include <set>
 
@@ -13,11 +11,11 @@
 
 namespace winrt {
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Input;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Input;
 using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml::Media;
 } // namespace winrt
 
 namespace react {
@@ -64,16 +62,16 @@ class TouchEventHandler {
     bool ctrlKey = false;
     bool altKey = false;
   };
-  size_t AddReactPointer(const winrt::PointerRoutedEventArgs &args, int64_t tag, winrt::FrameworkElement sourceElement);
+  size_t AddReactPointer(const winrt::PointerRoutedEventArgs &args, int64_t tag, xaml::FrameworkElement sourceElement);
   ReactPointer
-  CreateReactPointer(const winrt::PointerRoutedEventArgs &args, int64_t tag, winrt::FrameworkElement sourceElement);
+  CreateReactPointer(const winrt::PointerRoutedEventArgs &args, int64_t tag, xaml::FrameworkElement sourceElement);
   void UpdateReactPointer(
       ReactPointer &pointer,
       const winrt::PointerRoutedEventArgs &args,
-      winrt::FrameworkElement sourceElement);
+      xaml::FrameworkElement sourceElement);
   void
-  UpdatePointersInViews(const winrt::PointerRoutedEventArgs &args, int64_t tag, winrt::FrameworkElement sourceElement);
-  void SendPointerMove(const winrt::PointerRoutedEventArgs &args, int64_t tag, winrt::FrameworkElement sourceElement);
+  UpdatePointersInViews(const winrt::PointerRoutedEventArgs &args, int64_t tag, xaml::FrameworkElement sourceElement);
+  void SendPointerMove(const winrt::PointerRoutedEventArgs &args, int64_t tag, xaml::FrameworkElement sourceElement);
 
   enum class TouchEventType { Start = 0, End, Move, Cancel, PointerEntered, PointerExited, PointerMove };
   void OnPointerConcluded(TouchEventType eventType, const winrt::PointerRoutedEventArgs &args);
@@ -91,7 +89,7 @@ class TouchEventHandler {
   bool TagFromOriginalSource(
       const winrt::PointerRoutedEventArgs &args,
       int64_t *pTag,
-      winrt::FrameworkElement *pSourceElement);
+      xaml::FrameworkElement *pSourceElement);
   std::set<int64_t> GetTagsAtPoint(const winrt::PointerRoutedEventArgs &e);
 
   XamlView m_xamlView;

--- a/vnext/ReactUWP/Views/ViewControl.cpp
+++ b/vnext/ReactUWP/Views/ViewControl.cpp
@@ -12,15 +12,15 @@
 #endif
 
 namespace winrt {
-using namespace Windows::UI::Xaml::Automation::Peers;
-using namespace Windows::UI::Xaml;
+using namespace xaml::Automation::Peers;
+using namespace xaml;
 } // namespace winrt
 
 namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
 
 ViewControl::ViewControl() : Super() {
-  VerticalContentAlignment(winrt::VerticalAlignment::Stretch);
-  HorizontalContentAlignment(winrt::HorizontalAlignment::Stretch);
+  VerticalContentAlignment(xaml::VerticalAlignment::Stretch);
+  HorizontalContentAlignment(xaml::HorizontalAlignment::Stretch);
 }
 
 winrt::AutomationPeer ViewControl::OnCreateAutomationPeer() {
@@ -30,7 +30,7 @@ winrt::AutomationPeer ViewControl::OnCreateAutomationPeer() {
 winrt::PROJECT_ROOT_NAMESPACE::ViewPanel ViewControl::GetPanel() const {
   auto child = Content();
 
-  if (auto border = child.try_as<winrt::Windows::UI::Xaml::Controls::Border>()) {
+  if (auto border = child.try_as<xaml::Controls::Border>()) {
     child = border.Child();
   }
 

--- a/vnext/ReactUWP/Views/ViewControl.h
+++ b/vnext/ReactUWP/Views/ViewControl.h
@@ -5,9 +5,6 @@
 
 #include <Views/ViewPanel.h>
 
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
-
 #include "ViewControl.g.h"
 
 namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
@@ -23,7 +20,7 @@ struct ViewControl : ViewControlT<ViewControl> {
   // Constructors
   ViewControl();
 
-  winrt::Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
+  xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
 
   winrt::PROJECT_ROOT_NAMESPACE::ViewPanel GetPanel() const;
 };

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -14,13 +14,11 @@
 #include <IReactInstance.h>
 #include <IXamlRootView.h>
 #include <Views/ShadowNodeBase.h>
-#include <winrt/Windows.UI.Xaml.Interop.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 using namespace folly;
 
 namespace winrt {
-using namespace Windows::UI::Xaml;
+using namespace xaml;
 }
 
 namespace react {
@@ -48,7 +46,7 @@ YGSize DefaultYogaSelfMeasureFunc(
   // TODO: VEC context != nullptr, DefaultYogaSelfMeasureFunc expects a context.
 
   XamlView view = context->view;
-  auto element = view.as<winrt::UIElement>();
+  auto element = view.as<xaml::UIElement>();
 
   float constrainToWidth =
       widthMode == YGMeasureMode::YGMeasureModeUndefined ? std::numeric_limits<float>::max() : width;
@@ -59,8 +57,8 @@ YGSize DefaultYogaSelfMeasureFunc(
     winrt::Windows::Foundation::Size availableSpace(constrainToWidth, constrainToHeight);
 
     // Clear out current size so it doesn't constrain the measurement
-    auto widthProp = winrt::FrameworkElement::WidthProperty();
-    auto heightProp = winrt::FrameworkElement::HeightProperty();
+    auto widthProp = xaml::FrameworkElement::WidthProperty();
+    auto heightProp = xaml::FrameworkElement::HeightProperty();
     auto origWidth = element.GetValue(widthProp);
     auto origHeight = element.GetValue(heightProp);
     element.ClearValue(widthProp);
@@ -185,7 +183,7 @@ XamlView ViewManagerBase::CreateView(int64_t tag) {
   // In Debug, set the element name to the tag for convienent
   // searching within VisualStudio's Live Visual Tree pane
 #ifdef DEBUG
-  auto element = view.try_as<winrt::FrameworkElement>();
+  auto element = view.try_as<xaml::FrameworkElement>();
   if (element) {
     element.Name(L"<reacttag>: " + std::to_wstring(tag));
   }
@@ -321,12 +319,12 @@ void ViewManagerBase::SetLayoutProps(
     float top,
     float width,
     float height) {
-  auto element = viewToUpdate.as<winrt::UIElement>();
+  auto element = viewToUpdate.as<xaml::UIElement>();
   if (element == nullptr) {
     // TODO: Assert
     return;
   }
-  auto fe = element.as<winrt::FrameworkElement>();
+  auto fe = element.as<xaml::FrameworkElement>();
 
   // Set Position & Size Properties
   ViewPanel::SetLeft(element, left);

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -7,7 +7,6 @@
 #include "ViewPanel.h"
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Interop.h>
 
 // Needed for latest versions of C++/WinRT
 #if __has_include("ViewPanel.g.cpp")
@@ -16,11 +15,11 @@
 
 namespace winrt {
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Automation::Peers;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Interop;
-using namespace Windows::UI::Xaml::Media;
+using namespace xaml;
+using namespace xaml::Automation::Peers;
+using namespace xaml::Controls;
+using namespace xaml::Interop;
+using namespace xaml::Media;
 using namespace Windows::Foundation;
 } // namespace winrt
 
@@ -36,33 +35,33 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
 }
 
 /*static*/ void ViewPanel::VisualPropertyChanged(
-    winrt::DependencyObject sender,
-    winrt::DependencyPropertyChangedEventArgs e) {
+    xaml::DependencyObject sender,
+    xaml::DependencyPropertyChangedEventArgs e) {
   auto panel{sender.as<ViewPanel>()};
   if (panel.get() != nullptr)
     panel->m_propertiesChanged = true;
 }
 
 /*static*/ void ViewPanel::PositionPropertyChanged(
-    winrt::DependencyObject sender,
-    winrt::DependencyPropertyChangedEventArgs e) {
-  auto element{sender.as<winrt::UIElement>()};
+    xaml::DependencyObject sender,
+    xaml::DependencyPropertyChangedEventArgs e) {
+  auto element{sender.as<xaml::UIElement>()};
   if (element != nullptr)
     element.InvalidateArrange();
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::ViewBackgroundProperty() {
-  static winrt::DependencyProperty s_viewBackgroundProperty = winrt::DependencyProperty::Register(
+/*static*/ xaml::DependencyProperty ViewPanel::ViewBackgroundProperty() {
+  static xaml::DependencyProperty s_viewBackgroundProperty = xaml::DependencyProperty::Register(
       L"ViewBackground",
       winrt::xaml_typename<winrt::Brush>(),
       viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::SolidColorBrush(), ViewPanel::VisualPropertyChanged));
+      winrt::PropertyMetadata(xaml::Media::SolidColorBrush(), ViewPanel::VisualPropertyChanged));
 
   return s_viewBackgroundProperty;
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::BorderThicknessProperty() {
-  static winrt::DependencyProperty s_borderThicknessProperty = winrt::DependencyProperty::Register(
+/*static*/ xaml::DependencyProperty ViewPanel::BorderThicknessProperty() {
+  static xaml::DependencyProperty s_borderThicknessProperty = xaml::DependencyProperty::Register(
       L"BorderThickness",
       winrt::xaml_typename<winrt::Thickness>(),
       viewPanelTypeName,
@@ -71,28 +70,28 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   return s_borderThicknessProperty;
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::BorderBrushProperty() {
-  static winrt::DependencyProperty s_borderBrushProperty = winrt::DependencyProperty::Register(
+/*static*/ xaml::DependencyProperty ViewPanel::BorderBrushProperty() {
+  static xaml::DependencyProperty s_borderBrushProperty = xaml::DependencyProperty::Register(
       L"BorderBrush",
       winrt::xaml_typename<winrt::Brush>(),
       viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::SolidColorBrush(), ViewPanel::VisualPropertyChanged));
+      winrt::PropertyMetadata(xaml::Media::SolidColorBrush(), ViewPanel::VisualPropertyChanged));
 
   return s_borderBrushProperty;
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::CornerRadiusProperty() {
-  static winrt::DependencyProperty s_cornerRadiusProperty = winrt::DependencyProperty::Register(
+/*static*/ xaml::DependencyProperty ViewPanel::CornerRadiusProperty() {
+  static xaml::DependencyProperty s_cornerRadiusProperty = xaml::DependencyProperty::Register(
       L"CornerRadius",
-      winrt::xaml_typename<winrt::CornerRadius>(),
+      winrt::xaml_typename<xaml::CornerRadius>(),
       viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::box_value(winrt::CornerRadius()), ViewPanel::VisualPropertyChanged));
+      winrt::PropertyMetadata(winrt::box_value(xaml::CornerRadius()), ViewPanel::VisualPropertyChanged));
 
   return s_cornerRadiusProperty;
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::TopProperty() {
-  static winrt::DependencyProperty s_topProperty = winrt::DependencyProperty::RegisterAttached(
+/*static*/ xaml::DependencyProperty ViewPanel::TopProperty() {
+  static xaml::DependencyProperty s_topProperty = xaml::DependencyProperty::RegisterAttached(
       L"Top",
       winrt::xaml_typename<double>(),
       viewPanelTypeName,
@@ -101,8 +100,8 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   return s_topProperty;
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::LeftProperty() {
-  static winrt::DependencyProperty s_LeftProperty = winrt::DependencyProperty::RegisterAttached(
+/*static*/ xaml::DependencyProperty ViewPanel::LeftProperty() {
+  static xaml::DependencyProperty s_LeftProperty = xaml::DependencyProperty::RegisterAttached(
       L"Left",
       winrt::xaml_typename<double>(),
       viewPanelTypeName,
@@ -111,8 +110,8 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   return s_LeftProperty;
 }
 
-/*static*/ winrt::DependencyProperty ViewPanel::ClipChildrenProperty() {
-  static winrt::DependencyProperty s_clipChildrenProperty = winrt::DependencyProperty::Register(
+/*static*/ xaml::DependencyProperty ViewPanel::ClipChildrenProperty() {
+  static xaml::DependencyProperty s_clipChildrenProperty = xaml::DependencyProperty::Register(
       L"ClipChildren",
       winrt::xaml_typename<bool>(),
       viewPanelTypeName,
@@ -121,12 +120,12 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   return s_clipChildrenProperty;
 }
 
-/*static*/ void ViewPanel::SetTop(winrt::Windows::UI::Xaml::UIElement const &element, double value) {
+/*static*/ void ViewPanel::SetTop(xaml::UIElement const &element, double value) {
   element.SetValue(TopProperty(), winrt::box_value<double>(value));
   element.InvalidateArrange();
 }
 
-/*static*/ void ViewPanel::SetLeft(winrt::Windows::UI::Xaml::UIElement const &element, double value) {
+/*static*/ void ViewPanel::SetLeft(xaml::UIElement const &element, double value) {
   element.SetValue(LeftProperty(), winrt::box_value<double>(value));
   element.InvalidateArrange();
 }
@@ -135,7 +134,7 @@ winrt::Size ViewPanel::MeasureOverride(winrt::Size /*availableSize*/) {
   // All children are given as much size as they'd like
   winrt::Size childConstraint(INFINITY, INFINITY);
 
-  for (winrt::UIElement child : Children())
+  for (xaml::UIElement child : Children())
     child.Measure(childConstraint);
 
   // ViewPanels never choose their size, that is completely up to the parent -
@@ -154,7 +153,7 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
     outerBorderLeft = static_cast<float>(borderThickness.Left);
     outerBorderTop = static_cast<float>(borderThickness.Top);
   }
-  for (winrt::UIElement child : Children()) {
+  for (xaml::UIElement child : Children()) {
     double childHeight = 0.0;
     double childWidth = 0.0;
 
@@ -165,7 +164,7 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
     } else {
       // We expect elements to have been arranged by yoga which means their
       // Width & Height are set
-      winrt::FrameworkElement fe = child.try_as<winrt::FrameworkElement>();
+      xaml::FrameworkElement fe = child.try_as<xaml::FrameworkElement>();
       if (fe != nullptr) {
         childWidth = fe.Width();
         childHeight = fe.Height();
@@ -193,7 +192,7 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
   return finalSize;
 }
 
-void ViewPanel::InsertAt(uint32_t const index, winrt::UIElement const &value) const {
+void ViewPanel::InsertAt(uint32_t const index, xaml::UIElement const &value) const {
   Children().InsertAt(index, value);
 }
 
@@ -201,7 +200,7 @@ void ViewPanel::RemoveAt(uint32_t const index) const {
   Children().RemoveAt(index);
 }
 
-void ViewPanel::Remove(winrt::UIElement element) const {
+void ViewPanel::Remove(xaml::UIElement element) const {
   uint32_t index;
 
   if (Children().IndexOf(element, index))
@@ -224,7 +223,7 @@ void ViewPanel::BorderBrush(winrt::Brush const &value) {
   SetValue(BorderBrushProperty(), winrt::box_value(value));
 }
 
-void ViewPanel::CornerRadius(winrt::CornerRadius const &value) {
+void ViewPanel::CornerRadius(xaml::CornerRadius const &value) {
   SetValue(CornerRadiusProperty(), winrt::box_value(value));
 }
 
@@ -253,7 +252,7 @@ void ViewPanel::FinalizeProperties() {
   //      this ViewPanel
   //      >> Border* properties and Background applied to Border
 
-  const auto unsetValue = winrt::DependencyProperty::UnsetValue();
+  const auto unsetValue = xaml::DependencyProperty::UnsetValue();
   const Thickness emptyThickness = ThicknessHelper::FromUniformLength(0.0);
 
   bool hasBackground = ReadLocalValue(ViewBackgroundProperty()) != unsetValue;
@@ -287,7 +286,7 @@ void ViewPanel::FinalizeProperties() {
   if (scenario != Scenario::NoBorder) {
     // Ensure Border is created
     if (m_border == nullptr) {
-      m_border = winrt::Border();
+      m_border = xaml::Controls::Border();
 
       // Add border as the top child if using as inner border
       if (scenario == Scenario::InnerBorder)
@@ -298,17 +297,17 @@ void ViewPanel::FinalizeProperties() {
     if (hasBorderBrush)
       m_border.BorderBrush(BorderBrush());
     else
-      m_border.ClearValue(winrt::Border::BorderBrushProperty());
+      m_border.ClearValue(xaml::Controls::Border::BorderBrushProperty());
 
     if (hasBorderThickness)
       m_border.BorderThickness(BorderThickness());
     else
-      m_border.ClearValue(winrt::Border::BorderThicknessProperty());
+      m_border.ClearValue(xaml::Controls::Border::BorderThicknessProperty());
 
     if (hasCornerRadius)
       m_border.CornerRadius(CornerRadius());
     else
-      m_border.ClearValue(winrt::Border::CornerRadiusProperty());
+      m_border.ClearValue(xaml::Controls::Border::CornerRadiusProperty());
   } else if (m_border != nullptr) {
     // Clean up and remove the Border element
     m_border.Child(nullptr);
@@ -320,7 +319,7 @@ void ViewPanel::FinalizeProperties() {
     if (hasBackground)
       m_border.Background(ViewBackground());
     else
-      m_border.ClearValue(winrt::Border::BackgroundProperty());
+      m_border.ClearValue(xaml::Controls::Border::BackgroundProperty());
 
     ClearValue(winrt::Panel::BackgroundProperty());
 
@@ -337,11 +336,11 @@ void ViewPanel::FinalizeProperties() {
   m_propertiesChanged = false;
 }
 
-winrt::Border ViewPanel::GetOuterBorder() {
+xaml::Controls::Border ViewPanel::GetOuterBorder() {
   if (m_hasOuterBorder && (m_border != nullptr))
     return m_border;
   else
-    return winrt::Border(nullptr);
+    return xaml::Controls::Border(nullptr);
 }
 
 void ViewPanel::UpdateClip(winrt::Size &finalSize) {

--- a/vnext/ReactUWP/Views/ViewPanel.h
+++ b/vnext/ReactUWP/Views/ViewPanel.h
@@ -3,11 +3,6 @@
 
 #pragma once
 
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
-
 #include "ViewPanel.g.h"
 
 #ifndef PROJECT_ROOT_NAMESPACE
@@ -31,40 +26,40 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   // Constructors
   ViewPanel();
 
-  winrt::Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
+  xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
 
   // Overrides
   virtual winrt::Windows::Foundation::Size MeasureOverride(winrt::Windows::Foundation::Size availableSize);
   virtual winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size finalSize);
 
   // Public Methods
-  void InsertAt(uint32_t const index, winrt::Windows::UI::Xaml::UIElement const &value) const;
+  void InsertAt(uint32_t const index, xaml::UIElement const &value) const;
   void RemoveAt(uint32_t const index) const;
   void Clear() const;
 
   void FinalizeProperties();
-  winrt::Windows::UI::Xaml::Controls::Border GetOuterBorder();
+  xaml::Controls::Border GetOuterBorder();
 
   // Public Properties
-  winrt::Windows::UI::Xaml::Media::Brush ViewBackground() {
-    return GetValue(ViewBackgroundProperty()).as<winrt::Windows::UI::Xaml::Media::Brush>();
+  xaml::Media::Brush ViewBackground() {
+    return GetValue(ViewBackgroundProperty()).as<xaml::Media::Brush>();
   }
-  void ViewBackground(winrt::Windows::UI::Xaml::Media::Brush const &value);
+  void ViewBackground(xaml::Media::Brush const &value);
 
-  winrt::Windows::UI::Xaml::Thickness BorderThickness() {
-    return winrt::unbox_value<winrt::Windows::UI::Xaml::Thickness>(GetValue(BorderThicknessProperty()));
+  xaml::Thickness BorderThickness() {
+    return winrt::unbox_value<xaml::Thickness>(GetValue(BorderThicknessProperty()));
   }
-  void BorderThickness(winrt::Windows::UI::Xaml::Thickness const &value);
+  void BorderThickness(xaml::Thickness const &value);
 
-  winrt::Windows::UI::Xaml::Media::Brush BorderBrush() {
-    return GetValue(BorderBrushProperty()).as<winrt::Windows::UI::Xaml::Media::Brush>();
+  xaml::Media::Brush BorderBrush() {
+    return GetValue(BorderBrushProperty()).as<xaml::Media::Brush>();
   }
-  void BorderBrush(winrt::Windows::UI::Xaml::Media::Brush const &value);
+  void BorderBrush(xaml::Media::Brush const &value);
 
-  winrt::Windows::UI::Xaml::CornerRadius CornerRadius() {
-    return winrt::unbox_value<winrt::Windows::UI::Xaml::CornerRadius>(GetValue(CornerRadiusProperty()));
+  xaml::CornerRadius CornerRadius() {
+    return winrt::unbox_value<xaml::CornerRadius>(GetValue(CornerRadiusProperty()));
   }
-  void CornerRadius(winrt::Windows::UI::Xaml::CornerRadius const &value);
+  void CornerRadius(xaml::CornerRadius const &value);
 
   bool ClipChildren() {
     return winrt::unbox_value<bool>(GetValue(ClipChildrenProperty()));
@@ -72,27 +67,27 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   void ClipChildren(bool value);
 
   // ViewPanel Properties
-  static winrt::Windows::UI::Xaml::DependencyProperty ViewBackgroundProperty();
-  static winrt::Windows::UI::Xaml::DependencyProperty BorderThicknessProperty();
-  static winrt::Windows::UI::Xaml::DependencyProperty BorderBrushProperty();
-  static winrt::Windows::UI::Xaml::DependencyProperty CornerRadiusProperty();
-  static winrt::Windows::UI::Xaml::DependencyProperty ClipChildrenProperty();
+  static xaml::DependencyProperty ViewBackgroundProperty();
+  static xaml::DependencyProperty BorderThicknessProperty();
+  static xaml::DependencyProperty BorderBrushProperty();
+  static xaml::DependencyProperty CornerRadiusProperty();
+  static xaml::DependencyProperty ClipChildrenProperty();
 
   // Attached Properties
-  static winrt::Windows::UI::Xaml::DependencyProperty TopProperty();
-  static void SetTop(winrt::Windows::UI::Xaml::UIElement const &element, double value);
-  static double GetTop(winrt::Windows::UI::Xaml::UIElement const &element) {
+  static xaml::DependencyProperty TopProperty();
+  static void SetTop(xaml::UIElement const &element, double value);
+  static double GetTop(xaml::UIElement const &element) {
     return winrt::unbox_value<double>(element.GetValue(TopProperty()));
   }
 
-  static winrt::Windows::UI::Xaml::DependencyProperty LeftProperty();
-  static void SetLeft(winrt::Windows::UI::Xaml::UIElement const &element, double value);
-  static double GetLeft(winrt::Windows::UI::Xaml::UIElement const &element) {
+  static xaml::DependencyProperty LeftProperty();
+  static void SetLeft(xaml::UIElement const &element, double value);
+  static double GetLeft(xaml::UIElement const &element) {
     return winrt::unbox_value<double>(element.GetValue(LeftProperty()));
   }
 
  private:
-  void Remove(winrt::Windows::UI::Xaml::UIElement element) const;
+  void Remove(xaml::UIElement element) const;
 
   void UpdateClip(winrt::Windows::Foundation::Size &finalSize);
 
@@ -100,16 +95,16 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   bool m_propertiesChanged{false};
 
   // Child Elements
-  winrt::Windows::UI::Xaml::Controls::Border m_border{nullptr};
+  xaml::Controls::Border m_border{nullptr};
   bool m_hasOuterBorder;
 
  private:
   static void VisualPropertyChanged(
-      winrt::Windows::UI::Xaml::DependencyObject sender,
-      winrt::Windows::UI::Xaml::DependencyPropertyChangedEventArgs e);
+      xaml::DependencyObject sender,
+      xaml::DependencyPropertyChangedEventArgs e);
   static void PositionPropertyChanged(
-      winrt::Windows::UI::Xaml::DependencyObject sender,
-      winrt::Windows::UI::Xaml::DependencyPropertyChangedEventArgs e);
+      xaml::DependencyObject sender,
+      xaml::DependencyPropertyChangedEventArgs e);
 };
 
 } // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation

--- a/vnext/ReactUWP/Views/ViewPanel.h
+++ b/vnext/ReactUWP/Views/ViewPanel.h
@@ -99,12 +99,8 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   bool m_hasOuterBorder;
 
  private:
-  static void VisualPropertyChanged(
-      xaml::DependencyObject sender,
-      xaml::DependencyPropertyChangedEventArgs e);
-  static void PositionPropertyChanged(
-      xaml::DependencyObject sender,
-      xaml::DependencyPropertyChangedEventArgs e);
+  static void VisualPropertyChanged(xaml::DependencyObject sender, xaml::DependencyPropertyChangedEventArgs e);
+  static void PositionPropertyChanged(xaml::DependencyObject sender, xaml::DependencyPropertyChangedEventArgs e);
 };
 
 } // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -90,7 +90,7 @@ class ViewShadowNode : public ShadowNodeBase {
     if (IsControl()) {
       if (tabIndex < 0) {
         GetControl().IsTabStop(false);
-        GetControl().ClearValue(winrt::Control::TabIndexProperty());
+        GetControl().ClearValue(xaml::Controls::Control::TabIndexProperty());
       } else {
         GetControl().IsTabStop(true);
         GetControl().TabIndex(tabIndex);
@@ -107,7 +107,7 @@ class ViewShadowNode : public ShadowNodeBase {
 
   void AddView(ShadowNode &child, int64_t index) override {
     GetViewPanel().InsertAt(
-        static_cast<uint32_t>(index), static_cast<ShadowNodeBase &>(child).GetView().as<winrt::UIElement>());
+        static_cast<uint32_t>(index), static_cast<ShadowNodeBase &>(child).GetView().as<xaml::UIElement>());
   }
 
   void RemoveChildAt(int64_t indexToRemove) override {
@@ -123,13 +123,13 @@ class ViewShadowNode : public ShadowNodeBase {
     // TODO NOW: Why do we do this? Removal of children doesn't seem to imply we
     // tear down the infrastr
     if (IsControl()) {
-      auto control = m_view.as<winrt::ContentControl>();
+      auto control = m_view.as<xaml::Controls::ContentControl>();
       current = control.Content().as<XamlView>();
       control.Content(nullptr);
     }
 
     if (HasOuterBorder()) {
-      if (auto border = current.try_as<winrt::Border>()) {
+      if (auto border = current.try_as<xaml::Controls::Border>()) {
         border.Child(nullptr);
       }
     }
@@ -139,9 +139,9 @@ class ViewShadowNode : public ShadowNodeBase {
     auto pPanel = GetViewPanel();
     if (pPanel != nullptr) {
       uint32_t index;
-      if (pPanel.Children().IndexOf(oldChildView.as<winrt::UIElement>(), index)) {
+      if (pPanel.Children().IndexOf(oldChildView.as<xaml::UIElement>(), index)) {
         pPanel.RemoveAt(index);
-        pPanel.InsertAt(index, newChildView.as<winrt::UIElement>());
+        pPanel.InsertAt(index, newChildView.as<xaml::UIElement>());
       } else {
         assert(false);
       }
@@ -160,13 +160,13 @@ class ViewShadowNode : public ShadowNodeBase {
     XamlView current = m_view;
 
     if (IsControl()) {
-      if (auto control = m_view.try_as<winrt::ContentControl>()) {
+      if (auto control = m_view.try_as<xaml::Controls::ContentControl>()) {
         current = control.Content().as<XamlView>();
       }
     }
 
     if (HasOuterBorder()) {
-      if (auto border = current.try_as<winrt::Border>()) {
+      if (auto border = current.try_as<xaml::Controls::Border>()) {
         current = border.Child().try_as<XamlView>();
       }
     }
@@ -185,14 +185,14 @@ class ViewShadowNode : public ShadowNodeBase {
     auto contentControl = winrt::make<winrt::react::uwp::implementation::ViewControl>();
 
     m_contentControlGotFocusRevoker = contentControl.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&args) {
-      if (args.OriginalSource().try_as<winrt::UIElement>() == contentControl.as<winrt::UIElement>()) {
+      if (args.OriginalSource().try_as<xaml::UIElement>() == contentControl.as<xaml::UIElement>()) {
         auto tag = m_tag;
         DispatchEvent("topFocus", std::move(folly::dynamic::object("target", tag)));
       }
     });
 
     m_contentControlLostFocusRevoker = contentControl.LostFocus(winrt::auto_revoke, [=](auto &&, auto &&args) {
-      if (args.OriginalSource().try_as<winrt::UIElement>() == contentControl.as<winrt::UIElement>()) {
+      if (args.OriginalSource().try_as<xaml::UIElement>() == contentControl.as<xaml::UIElement>()) {
         auto tag = m_tag;
         DispatchEvent("topBlur", std::move(folly::dynamic::object("target", tag)));
       }
@@ -215,8 +215,8 @@ class ViewShadowNode : public ShadowNodeBase {
   bool m_onClick = false;
   int32_t m_tabIndex = -1;
 
-  winrt::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
-  winrt::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};
+  xaml::Controls::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
+  xaml::Controls::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};
 };
 
 // ViewPanel uses a ViewBackground property, not Background, so need to
@@ -315,8 +315,8 @@ facebook::react::ShadowNode *ViewViewManager::createShadow() const {
 
 XamlView ViewViewManager::CreateViewCore(int64_t /*tag*/) {
   auto panel = winrt::make<winrt::react::uwp::implementation::ViewPanel>();
-  panel.VerticalAlignment(winrt::VerticalAlignment::Stretch);
-  panel.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
+  panel.VerticalAlignment(xaml::VerticalAlignment::Stretch);
+  panel.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
 
   return panel.as<XamlView>();
 }
@@ -382,7 +382,7 @@ bool ViewViewManager::UpdateProperty(
     }
   }
 
-  if (auto view = pViewShadowNode->GetView().try_as<winrt::UIElement>()) {
+  if (auto view = pViewShadowNode->GetView().try_as<xaml::UIElement>()) {
     // If we have DynamicAutomationProperties, we need a ViewControl with a
     // DynamicAutomationPeer
     shouldBeControl = shouldBeControl || HasDynamicAutomationProperties(view);
@@ -497,12 +497,12 @@ void ViewViewManager::TryUpdateView(
   }
 
   // Ensure parenting is setup properly
-  auto visualRoot = pPanel.try_as<winrt::UIElement>();
+  auto visualRoot = pPanel.try_as<xaml::UIElement>();
 
   if (hasOuterBorder) {
-    winrt::Border outerBorder = pPanel.GetOuterBorder();
+    xaml::Controls::Border outerBorder = pPanel.GetOuterBorder();
     if (outerBorder.Child() == nullptr)
-      outerBorder.Child(pPanel.try_as<winrt::UIElement>());
+      outerBorder.Child(pPanel.try_as<xaml::UIElement>());
 
     visualRoot = outerBorder;
   }

--- a/vnext/ReactUWP/Views/ViewViewManager.h
+++ b/vnext/ReactUWP/Views/ViewViewManager.h
@@ -6,10 +6,6 @@
 #include <Views/FrameworkElementViewManager.h>
 #include <Views/ViewPanel.h>
 
-namespace winrt {
-using ContentControl = winrt::Windows::UI::Xaml::Controls::ContentControl;
-}
-
 namespace react {
 namespace uwp {
 

--- a/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
+++ b/vnext/ReactUWP/Views/VirtualTextViewManager.cpp
@@ -9,14 +9,12 @@
 #include <Utils/ValueUtils.h>
 
 #include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Documents.h>
 
 namespace winrt {
 using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Documents;
+using namespace xaml;
+using namespace xaml::Controls;
+using namespace xaml::Documents;
 } // namespace winrt
 
 namespace react {

--- a/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationPeer.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationPeer.idl
@@ -75,49 +75,49 @@ namespace PROJECT_ROOT_NAMESPACE
   runtimeclass DynamicAutomationProperties
   {
     // Attached Properties
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityRoleProperty { get; };
-    static void SetAccessibilityRole(WUXMUX_TYPE(UIElement) element, AccessibilityRoles value);
-    static AccessibilityRoles GetAccessibilityRole(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityRoleProperty { get; };
+    static void SetAccessibilityRole(XAML_NAMESPACE.UIElement element, AccessibilityRoles value);
+    static AccessibilityRoles GetAccessibilityRole(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateSelectedProperty { get; };
-    static void SetAccessibilityStateSelected(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateSelected(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateSelectedProperty { get; };
+    static void SetAccessibilityStateSelected(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateSelected(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateDisabledProperty { get; };
-    static void SetAccessibilityStateDisabled(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateDisabled(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateDisabledProperty { get; };
+    static void SetAccessibilityStateDisabled(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateDisabled(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateCheckedProperty { get; };
-    static void SetAccessibilityStateChecked(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateChecked(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateCheckedProperty { get; };
+    static void SetAccessibilityStateChecked(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateChecked(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateUncheckedProperty { get; };
-    static void SetAccessibilityStateUnchecked(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateUnchecked(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateUncheckedProperty { get; };
+    static void SetAccessibilityStateUnchecked(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateUnchecked(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateBusyProperty { get; };
-    static void SetAccessibilityStateBusy(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateBusy(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateBusyProperty { get; };
+    static void SetAccessibilityStateBusy(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateBusy(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateExpandedProperty { get; };
-    static void SetAccessibilityStateExpanded(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateExpanded(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateExpandedProperty { get; };
+    static void SetAccessibilityStateExpanded(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateExpanded(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateCollapsedProperty { get; };
-    static void SetAccessibilityStateCollapsed(WUXMUX_TYPE(UIElement) element, Boolean value);
-    static Boolean GetAccessibilityStateCollapsed(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityStateCollapsedProperty { get; };
+    static void SetAccessibilityStateCollapsed(XAML_NAMESPACE.UIElement element, Boolean value);
+    static Boolean GetAccessibilityStateCollapsed(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityInvokeEventHandlerProperty { get; };
-    static void SetAccessibilityInvokeEventHandler(WUXMUX_TYPE(UIElement) element, AccessibilityInvokeEventHandler value);
-    static AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityInvokeEventHandlerProperty { get; };
+    static void SetAccessibilityInvokeEventHandler(XAML_NAMESPACE.UIElement element, AccessibilityInvokeEventHandler value);
+    static AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityActionsProperty { get; };
-    static void SetAccessibilityActions(WUXMUX_TYPE(UIElement) element, Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> value);
-    static Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> GetAccessibilityActions(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityActionsProperty { get; };
+    static void SetAccessibilityActions(XAML_NAMESPACE.UIElement element, Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> value);
+    static Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> GetAccessibilityActions(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) AccessibilityActionEventHandlerProperty { get; };
-    static void SetAccessibilityActionEventHandler(WUXMUX_TYPE(UIElement) element, AccessibilityActionEventHandler value);
-    static AccessibilityActionEventHandler GetAccessibilityActionEventHandler(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty AccessibilityActionEventHandlerProperty { get; };
+    static void SetAccessibilityActionEventHandler(XAML_NAMESPACE.UIElement element, AccessibilityActionEventHandler value);
+    static AccessibilityActionEventHandler GetAccessibilityActionEventHandler(XAML_NAMESPACE.UIElement element);
   }
 
   [default_interface]
@@ -130,6 +130,6 @@ namespace PROJECT_ROOT_NAMESPACE
     XAML_NAMESPACE.Automation.Provider.IToggleProvider,
     XAML_NAMESPACE.Automation.Provider.IExpandCollapseProvider
   {
-    DynamicAutomationPeer(WUXMUX_TYPE(FrameworkElement) owner);
+    DynamicAutomationPeer(XAML_NAMESPACE.FrameworkElement owner);
   }
 }

--- a/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationPeer.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/DynamicAutomationPeer.idl
@@ -9,6 +9,7 @@
 #define VERSION 1.0
 
 import "AccessibilityAction.idl";
+#include "../../../include/NamespaceRedirect.h"
 
 // The DynamicAutomationProperties must be in the project namespace to be
 // usable by Xaml dependency properties.
@@ -19,116 +20,116 @@ import "AccessibilityAction.idl";
 
 namespace PROJECT_ROOT_NAMESPACE
 {
-	enum AccessibilityRoles
-	{
-		None = 0,
-		Button,
-		Link,
-		Search,
-		Image,
-		KeyboardKey,
-		Text,
-		Adjustable,
-		ImageButton,
-		Header,
-		Summary,
-		Alert,
-		CheckBox,
-		ComboBox,
-		Menu,
-		MenuBar,
-		MenuItem,
-		ProgressBar,
-		Radio,
-		RadioGroup,
-		ScrollBar,
-		SpinButton,
-		Switch,
-		Tab,
-		TabList,
-		Timer,
-		ToolBar,
-		List, // RNW extension
-		ListItem, // RNW extension
-		Unknown, // Catch-all
-		CountRoles
-	};
+  enum AccessibilityRoles
+  {
+    None = 0,
+    Button,
+    Link,
+    Search,
+    Image,
+    KeyboardKey,
+    Text,
+    Adjustable,
+    ImageButton,
+    Header,
+    Summary,
+    Alert,
+    CheckBox,
+    ComboBox,
+    Menu,
+    MenuBar,
+    MenuItem,
+    ProgressBar,
+    Radio,
+    RadioGroup,
+    ScrollBar,
+    SpinButton,
+    Switch,
+    Tab,
+    TabList,
+    Timer,
+    ToolBar,
+    List, // RNW extension
+    ListItem, // RNW extension
+    Unknown, // Catch-all
+    CountRoles
+  };
 
-	enum AccessibilityStates
-	{
-		Selected = 0,
-		Disabled,
-		Checked,
-		Unchecked,
-		Busy,
-		Expanded,
-		Collapsed,
-		CountStates
-	};
+  enum AccessibilityStates
+  {
+    Selected = 0,
+    Disabled,
+    Checked,
+    Unchecked,
+    Busy,
+    Expanded,
+    Collapsed,
+    CountStates
+  };
 
-	delegate void AccessibilityInvokeEventHandler();
-	delegate void AccessibilityActionEventHandler(AccessibilityAction action);
+  delegate void AccessibilityInvokeEventHandler();
+  delegate void AccessibilityActionEventHandler(AccessibilityAction action);
 
-	[default_interface]
-	[webhosthidden]
-	runtimeclass DynamicAutomationProperties
-	{
-		// Attached Properties
-		static Windows.UI.Xaml.DependencyProperty AccessibilityRoleProperty { get; };
-		static void SetAccessibilityRole(Windows.UI.Xaml.UIElement element, AccessibilityRoles value);
-		static AccessibilityRoles GetAccessibilityRole(Windows.UI.Xaml.UIElement element);
+  [default_interface]
+  [webhosthidden]
+  runtimeclass DynamicAutomationProperties
+  {
+    // Attached Properties
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityRoleProperty { get; };
+    static void SetAccessibilityRole(WUXMUX_TYPE(UIElement) element, AccessibilityRoles value);
+    static AccessibilityRoles GetAccessibilityRole(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateSelectedProperty { get; };
-		static void SetAccessibilityStateSelected(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateSelected(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateSelectedProperty { get; };
+    static void SetAccessibilityStateSelected(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateSelected(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateDisabledProperty { get; };
-		static void SetAccessibilityStateDisabled(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateDisabled(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateDisabledProperty { get; };
+    static void SetAccessibilityStateDisabled(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateDisabled(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateCheckedProperty { get; };
-		static void SetAccessibilityStateChecked(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateChecked(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateCheckedProperty { get; };
+    static void SetAccessibilityStateChecked(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateChecked(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateUncheckedProperty { get; };
-		static void SetAccessibilityStateUnchecked(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateUnchecked(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateUncheckedProperty { get; };
+    static void SetAccessibilityStateUnchecked(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateUnchecked(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateBusyProperty { get; };
-		static void SetAccessibilityStateBusy(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateBusy(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateBusyProperty { get; };
+    static void SetAccessibilityStateBusy(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateBusy(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateExpandedProperty { get; };
-		static void SetAccessibilityStateExpanded(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateExpanded(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateExpandedProperty { get; };
+    static void SetAccessibilityStateExpanded(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateExpanded(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityStateCollapsedProperty { get; };
-		static void SetAccessibilityStateCollapsed(Windows.UI.Xaml.UIElement element, Boolean value);
-		static Boolean GetAccessibilityStateCollapsed(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityStateCollapsedProperty { get; };
+    static void SetAccessibilityStateCollapsed(WUXMUX_TYPE(UIElement) element, Boolean value);
+    static Boolean GetAccessibilityStateCollapsed(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityInvokeEventHandlerProperty { get; };
-		static void SetAccessibilityInvokeEventHandler(Windows.UI.Xaml.UIElement element, AccessibilityInvokeEventHandler value);
-		static AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityInvokeEventHandlerProperty { get; };
+    static void SetAccessibilityInvokeEventHandler(WUXMUX_TYPE(UIElement) element, AccessibilityInvokeEventHandler value);
+    static AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityActionsProperty { get; };
-		static void SetAccessibilityActions(Windows.UI.Xaml.UIElement element, Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> value);
-		static Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> GetAccessibilityActions(Windows.UI.Xaml.UIElement element);
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityActionsProperty { get; };
+    static void SetAccessibilityActions(WUXMUX_TYPE(UIElement) element, Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> value);
+    static Windows.Foundation.Collections.IVector<PROJECT_ROOT_NAMESPACE.AccessibilityAction> GetAccessibilityActions(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty AccessibilityActionEventHandlerProperty { get; };
-		static void SetAccessibilityActionEventHandler(Windows.UI.Xaml.UIElement element, AccessibilityActionEventHandler value);
-		static AccessibilityActionEventHandler GetAccessibilityActionEventHandler(Windows.UI.Xaml.UIElement element);
-	}
+    static WUXMUX_TYPE(DependencyProperty) AccessibilityActionEventHandlerProperty { get; };
+    static void SetAccessibilityActionEventHandler(WUXMUX_TYPE(UIElement) element, AccessibilityActionEventHandler value);
+    static AccessibilityActionEventHandler GetAccessibilityActionEventHandler(WUXMUX_TYPE(UIElement) element);
+  }
 
-	[default_interface]
-	[webhosthidden]
-	runtimeclass DynamicAutomationPeer :
-		Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,
-		Windows.UI.Xaml.Automation.Provider.IInvokeProvider,
-		Windows.UI.Xaml.Automation.Provider.ISelectionProvider,
-		Windows.UI.Xaml.Automation.Provider.ISelectionItemProvider,
-		Windows.UI.Xaml.Automation.Provider.IToggleProvider,
-		Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
-	{
-		DynamicAutomationPeer(Windows.UI.Xaml.FrameworkElement owner);
-	}
+  [default_interface]
+  [webhosthidden]
+  runtimeclass DynamicAutomationPeer :
+    XAML_NAMESPACE.Automation.Peers.FrameworkElementAutomationPeer,
+    XAML_NAMESPACE.Automation.Provider.IInvokeProvider,
+    XAML_NAMESPACE.Automation.Provider.ISelectionProvider,
+    XAML_NAMESPACE.Automation.Provider.ISelectionItemProvider,
+    XAML_NAMESPACE.Automation.Provider.IToggleProvider,
+    XAML_NAMESPACE.Automation.Provider.IExpandCollapseProvider
+  {
+    DynamicAutomationPeer(WUXMUX_TYPE(FrameworkElement) owner);
+  }
 }

--- a/vnext/ReactUWP/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/ViewPanel.idl
@@ -8,6 +8,8 @@
 
 import "DynamicAutomationPeer.idl";
 
+#include "../../../include/NamespaceRedirect.h"
+
 // The ViewPanel must be in the project namespace to be
 // usable by Xaml dependency properties.
 // We use a macro to be able to change it from the project file.
@@ -17,51 +19,51 @@ import "DynamicAutomationPeer.idl";
 
 namespace PROJECT_ROOT_NAMESPACE
 {
-	[default_interface]
-	[webhosthidden]
-	runtimeclass ViewPanel : Windows.UI.Xaml.Controls.Panel
-	{
-		// Constructors
-		ViewPanel();
+  [default_interface]
+  [webhosthidden]
+  runtimeclass ViewPanel : XAML_NAMESPACE.Controls.Panel
+  {
+    // Constructors
+    ViewPanel();
 
-		// Public Methods
-		void InsertAt(UInt32 index, Windows.UI.Xaml.UIElement value);
-  		void RemoveAt(UInt32 index);
-  		void Clear();
+    // Public Methods
+    void InsertAt(UInt32 index, WUXMUX_TYPE(UIElement) value);
+      void RemoveAt(UInt32 index);
+      void Clear();
 
-		void FinalizeProperties();
-  		Windows.UI.Xaml.Controls.Border GetOuterBorder();
+    void FinalizeProperties();
+      WUXMUX_TYPE(Controls.Border) GetOuterBorder();
 
-		// Public Properties
-		Windows.UI.Xaml.Media.Brush ViewBackground { get; set; };
-		Windows.UI.Xaml.Thickness BorderThickness { get; set; };
-		Windows.UI.Xaml.Media.Brush BorderBrush { get; set; };
-		Windows.UI.Xaml.CornerRadius CornerRadius { get; set; };
-		Boolean ClipChildren { get; set; };
+    // Public Properties
+    WUXMUX_TYPE(Media.Brush) ViewBackground { get; set; };
+    WUXMUX_TYPE(Thickness) BorderThickness { get; set; };
+    WUXMUX_TYPE(Media.Brush) BorderBrush { get; set; };
+    WUXMUX_TYPE(CornerRadius) CornerRadius { get; set; };
+    Boolean ClipChildren { get; set; };
 
-		// ViewPanel Properties
-		static Windows.UI.Xaml.DependencyProperty ViewBackgroundProperty { get; };
-		static Windows.UI.Xaml.DependencyProperty BorderThicknessProperty { get; };
-		static Windows.UI.Xaml.DependencyProperty BorderBrushProperty { get; };
-		static Windows.UI.Xaml.DependencyProperty CornerRadiusProperty { get; };
-		static Windows.UI.Xaml.DependencyProperty ClipChildrenProperty { get; };
+    // ViewPanel Properties
+    static WUXMUX_TYPE(DependencyProperty) ViewBackgroundProperty { get; };
+    static WUXMUX_TYPE(DependencyProperty) BorderThicknessProperty { get; };
+    static WUXMUX_TYPE(DependencyProperty) BorderBrushProperty { get; };
+    static WUXMUX_TYPE(DependencyProperty) CornerRadiusProperty { get; };
+    static WUXMUX_TYPE(DependencyProperty) ClipChildrenProperty { get; };
 
-		// Attached Properties
-		static Windows.UI.Xaml.DependencyProperty TopProperty { get; };
-		static void SetTop(Windows.UI.Xaml.UIElement element, Double value);
-		static Double GetTop(Windows.UI.Xaml.UIElement element);
+    // Attached Properties
+    static WUXMUX_TYPE(DependencyProperty) TopProperty { get; };
+    static void SetTop(WUXMUX_TYPE(UIElement) element, Double value);
+    static Double GetTop(WUXMUX_TYPE(UIElement) element);
 
-		static Windows.UI.Xaml.DependencyProperty LeftProperty { get; };
-		static void SetLeft(Windows.UI.Xaml.UIElement element, Double value);
-		static Double GetLeft(Windows.UI.Xaml.UIElement element);
-	}
+    static WUXMUX_TYPE(DependencyProperty) LeftProperty { get; };
+    static void SetLeft(WUXMUX_TYPE(UIElement) element, Double value);
+    static Double GetLeft(WUXMUX_TYPE(UIElement) element);
+  }
 
-	[default_interface]
-	[webhosthidden]
-	runtimeclass ViewControl : Windows.UI.Xaml.Controls.ContentControl
-	{
-		ViewControl();
+  [default_interface]
+  [webhosthidden]
+  runtimeclass ViewControl : XAML_NAMESPACE.Controls.ContentControl
+  {
+    ViewControl();
 
-		ViewPanel GetPanel();
-	}
+    ViewPanel GetPanel();
+  }
 }

--- a/vnext/ReactUWP/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/ViewPanel.idl
@@ -27,35 +27,35 @@ namespace PROJECT_ROOT_NAMESPACE
     ViewPanel();
 
     // Public Methods
-    void InsertAt(UInt32 index, WUXMUX_TYPE(UIElement) value);
+    void InsertAt(UInt32 index, XAML_NAMESPACE.UIElement value);
       void RemoveAt(UInt32 index);
       void Clear();
 
     void FinalizeProperties();
-      WUXMUX_TYPE(Controls.Border) GetOuterBorder();
+      XAML_NAMESPACE.Controls.Border GetOuterBorder();
 
     // Public Properties
-    WUXMUX_TYPE(Media.Brush) ViewBackground { get; set; };
-    WUXMUX_TYPE(Thickness) BorderThickness { get; set; };
-    WUXMUX_TYPE(Media.Brush) BorderBrush { get; set; };
-    WUXMUX_TYPE(CornerRadius) CornerRadius { get; set; };
+    XAML_NAMESPACE.Media.Brush ViewBackground { get; set; };
+    XAML_NAMESPACE.Thickness BorderThickness { get; set; };
+    XAML_NAMESPACE.Media.Brush BorderBrush { get; set; };
+    XAML_NAMESPACE.CornerRadius CornerRadius { get; set; };
     Boolean ClipChildren { get; set; };
 
     // ViewPanel Properties
-    static WUXMUX_TYPE(DependencyProperty) ViewBackgroundProperty { get; };
-    static WUXMUX_TYPE(DependencyProperty) BorderThicknessProperty { get; };
-    static WUXMUX_TYPE(DependencyProperty) BorderBrushProperty { get; };
-    static WUXMUX_TYPE(DependencyProperty) CornerRadiusProperty { get; };
-    static WUXMUX_TYPE(DependencyProperty) ClipChildrenProperty { get; };
+    static XAML_NAMESPACE.DependencyProperty ViewBackgroundProperty { get; };
+    static XAML_NAMESPACE.DependencyProperty BorderThicknessProperty { get; };
+    static XAML_NAMESPACE.DependencyProperty BorderBrushProperty { get; };
+    static XAML_NAMESPACE.DependencyProperty CornerRadiusProperty { get; };
+    static XAML_NAMESPACE.DependencyProperty ClipChildrenProperty { get; };
 
     // Attached Properties
-    static WUXMUX_TYPE(DependencyProperty) TopProperty { get; };
-    static void SetTop(WUXMUX_TYPE(UIElement) element, Double value);
-    static Double GetTop(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty TopProperty { get; };
+    static void SetTop(XAML_NAMESPACE.UIElement element, Double value);
+    static Double GetTop(XAML_NAMESPACE.UIElement element);
 
-    static WUXMUX_TYPE(DependencyProperty) LeftProperty { get; };
-    static void SetLeft(WUXMUX_TYPE(UIElement) element, Double value);
-    static Double GetLeft(WUXMUX_TYPE(UIElement) element);
+    static XAML_NAMESPACE.DependencyProperty LeftProperty { get; };
+    static void SetLeft(XAML_NAMESPACE.UIElement element, Double value);
+    static Double GetLeft(XAML_NAMESPACE.UIElement element);
   }
 
   [default_interface]

--- a/vnext/Universal.IntegrationTests/UniversalTestInstance.cpp
+++ b/vnext/Universal.IntegrationTests/UniversalTestInstance.cpp
@@ -4,7 +4,7 @@
 
 #include "UniversalTestInstance.h"
 
-#include <Windows.UI.Xaml.h>
+#include <Windows.UI.Xaml.h> // C++/CX
 #include <wrl.h>
 
 namespace cx {
@@ -64,7 +64,7 @@ void UniversalTestInstance::AttachMeasuredRootView(std::string &&appName) noexce
             reinterpret_cast<::ABI::Windows::UI::Xaml::IFrameworkElement *>(rootFrameworkElement);
         // Create C++/WinRT pointer from ABI pointer.
         ::react::uwp::XamlView xamlView =
-            reinterpret_cast<const winrt::Windows::UI::Xaml::FrameworkElement &>(spFrameworkElementABI);
+            reinterpret_cast<const xaml::FrameworkElement &>(spFrameworkElementABI);
 
         m_rootView = ::react::uwp::CreateReactRootView(xamlView, L"DummyTest", m_instanceCreator);
 

--- a/vnext/Universal.IntegrationTests/UniversalTestInstance.cpp
+++ b/vnext/Universal.IntegrationTests/UniversalTestInstance.cpp
@@ -8,7 +8,7 @@
 #include <wrl.h>
 
 namespace cx {
-  namespace xaml = ::Windows::UI::Xaml;
+namespace xaml = ::Windows::UI::Xaml;
 }
 
 using namespace react::uwp;
@@ -63,8 +63,7 @@ void UniversalTestInstance::AttachMeasuredRootView(std::string &&appName) noexce
         Microsoft::WRL::ComPtr<::ABI::Windows::UI::Xaml::IFrameworkElement> spFrameworkElementABI =
             reinterpret_cast<::ABI::Windows::UI::Xaml::IFrameworkElement *>(rootFrameworkElement);
         // Create C++/WinRT pointer from ABI pointer.
-        ::react::uwp::XamlView xamlView =
-            reinterpret_cast<const xaml::FrameworkElement &>(spFrameworkElementABI);
+        ::react::uwp::XamlView xamlView = reinterpret_cast<const xaml::FrameworkElement &>(spFrameworkElementABI);
 
         m_rootView = ::react::uwp::CreateReactRootView(xamlView, L"DummyTest", m_instanceCreator);
 

--- a/vnext/Universal.IntegrationTests/UniversalTestInstance.cpp
+++ b/vnext/Universal.IntegrationTests/UniversalTestInstance.cpp
@@ -5,10 +5,11 @@
 #include "UniversalTestInstance.h"
 
 #include <Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Xaml.h>
 #include <wrl.h>
 
-namespace xaml = Windows::UI::Xaml;
+namespace cx {
+  namespace xaml = ::Windows::UI::Xaml;
+}
 
 using namespace react::uwp;
 
@@ -53,14 +54,14 @@ void UniversalTestInstance::AttachMeasuredRootView(std::string &&appName) noexce
   // Instantiate root view.
   auto action = Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(
       Windows::UI::Core::CoreDispatcherPriority::Normal, ref new Windows::UI::Core::DispatchedHandler([this]() {
-        auto frame = xaml::Window::Current->Content;
-        auto presenter = xaml::Media::VisualTreeHelper::GetChild(frame, 0);
-        auto page = xaml::Media::VisualTreeHelper::GetChild(presenter, 0);
-        auto mainGrid = static_cast<xaml::Controls::Grid ^>(xaml::Media::VisualTreeHelper::GetChild(page, 0));
+        auto frame = cx::xaml::Window::Current->Content;
+        auto presenter = cx::xaml::Media::VisualTreeHelper::GetChild(frame, 0);
+        auto page = cx::xaml::Media::VisualTreeHelper::GetChild(presenter, 0);
+        auto mainGrid = static_cast<cx::xaml::Controls::Grid ^>(cx::xaml::Media::VisualTreeHelper::GetChild(page, 0));
 
-        xaml::IFrameworkElement ^ rootFrameworkElement = mainGrid;
+        cx::xaml::IFrameworkElement ^ rootFrameworkElement = mainGrid;
         Microsoft::WRL::ComPtr<::ABI::Windows::UI::Xaml::IFrameworkElement> spFrameworkElementABI =
-            reinterpret_cast<ABI::Windows::UI::Xaml::IFrameworkElement *>(rootFrameworkElement);
+            reinterpret_cast<::ABI::Windows::UI::Xaml::IFrameworkElement *>(rootFrameworkElement);
         // Create C++/WinRT pointer from ABI pointer.
         ::react::uwp::XamlView xamlView =
             reinterpret_cast<const winrt::Windows::UI::Xaml::FrameworkElement &>(spFrameworkElementABI);

--- a/vnext/Universal.IntegrationTests/UniversalTestRunner.cpp
+++ b/vnext/Universal.IntegrationTests/UniversalTestRunner.cpp
@@ -9,7 +9,7 @@
 #include <cxxreact/ReactMarker.h>
 #include "UniversalTestInstance.h"
 
-#include <Windows.UI.Xaml.h>  // C++/CX
+#include <Windows.UI.Xaml.h> // C++/CX
 #include <wrl.h>
 
 #include <concrt.h> // Concurrency namespace.
@@ -17,7 +17,7 @@
 #include "MainPage.xaml.h"
 
 namespace cx {
-  namespace xaml = ::Windows::UI::Xaml;
+namespace xaml = ::Windows::UI::Xaml;
 }
 using namespace facebook::react;
 using namespace facebook::xplat::module;

--- a/vnext/Universal.IntegrationTests/UniversalTestRunner.cpp
+++ b/vnext/Universal.IntegrationTests/UniversalTestRunner.cpp
@@ -9,7 +9,7 @@
 #include <cxxreact/ReactMarker.h>
 #include "UniversalTestInstance.h"
 
-#include <Windows.UI.Xaml.h>
+#include <Windows.UI.Xaml.h>  // C++/CX
 #include <wrl.h>
 
 #include <concrt.h> // Concurrency namespace.

--- a/vnext/Universal.IntegrationTests/UniversalTestRunner.cpp
+++ b/vnext/Universal.IntegrationTests/UniversalTestRunner.cpp
@@ -10,15 +10,15 @@
 #include "UniversalTestInstance.h"
 
 #include <Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Xaml.h>
 #include <wrl.h>
 
 #include <concrt.h> // Concurrency namespace.
 
 #include "MainPage.xaml.h"
 
-namespace xaml = Windows::UI::Xaml;
-
+namespace cx {
+  namespace xaml = ::Windows::UI::Xaml;
+}
 using namespace facebook::react;
 using namespace facebook::xplat::module;
 

--- a/vnext/include/CppWinRTIncludes.h
+++ b/vnext/include/CppWinRTIncludes.h
@@ -3,6 +3,7 @@
 // information.
 
 #pragma once
+#include "NamespaceRedirect.h"
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.Metadata.h>
@@ -11,7 +12,6 @@
 #include <winrt/Windows.System.h>
 
 #ifndef WINUI3_SUPPORT
-#define XAML_NAMESPACE L"Windows.UI.Xaml"
 
 #include <winrt/Windows.ApplicationModel.Activation.h>
 #include <winrt/Windows.System.h>
@@ -45,8 +45,6 @@ namespace comp = winrt::Windows::UI::Composition;
 
 #else
 
-#define XAML_NAMESPACE L"Microsoft.UI.Xaml"
-
 #include <winrt/Microsoft.UI.Composition.h>
 #include <winrt/Microsoft.UI.Text.h>
 #include <winrt/Microsoft.UI.Xaml.Automation.Peers.h>
@@ -68,3 +66,7 @@ using namespace Windows::UI::Core;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 } // namespace winrt
+
+#define _QUOTE(x) L#x
+#define QUOTE(x) _QUOTE(x)
+#define XAML_NAMESPACE_STR QUOTE(XAML_NAMESPACE)

--- a/vnext/include/CppWinRTIncludes.h
+++ b/vnext/include/CppWinRTIncludes.h
@@ -8,23 +8,44 @@
 #include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.System.h>
 
 #ifndef WINUI3_SUPPORT
+#define XAML_NAMESPACE L"Windows.UI.Xaml"
+
 #include <winrt/Windows.ApplicationModel.Activation.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
+#include <winrt/Windows.UI.Xaml.Media.Media3D.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/Windows.UI.Xaml.Navigation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.Xaml.Documents.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+
+#include <winrt/Windows.UI.Xaml.Input.h>
+
+#include <winrt/Windows.UI.Xaml.Interop.h>
+#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
+#include <winrt/Windows.UI.Xaml.Automation.Provider.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.h>
+
 namespace xaml = winrt::Windows::UI::Xaml;
 namespace comp = winrt::Windows::UI::Composition;
 
 #else
+
+#define XAML_NAMESPACE L"Microsoft.UI.Xaml"
 
 #include <winrt/Windows.ApplicationModel.Activation.h>
 #include <winrt/Windows.System.h>

--- a/vnext/include/CppWinRTIncludes.h
+++ b/vnext/include/CppWinRTIncludes.h
@@ -16,28 +16,28 @@
 #include <winrt/Windows.ApplicationModel.Activation.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Composition.h>
+#include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Documents.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
 #include <winrt/Windows.UI.Xaml.Media.Media3D.h>
-#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Navigation.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
 #include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.UI.Xaml.Documents.h>
-#include <winrt/Windows.UI.Xaml.Markup.h>
 
 #include <winrt/Windows.UI.Xaml.Input.h>
 
-#include <winrt/Windows.UI.Xaml.Interop.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Automation.Provider.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Interop.h>
 #include <winrt/Windows.UI.Xaml.h>
 
 namespace xaml = winrt::Windows::UI::Xaml;
@@ -47,24 +47,24 @@ namespace comp = winrt::Windows::UI::Composition;
 
 #define XAML_NAMESPACE L"Microsoft.UI.Xaml"
 
-#include <winrt/Windows.ApplicationModel.Activation.h>
-#include <winrt/Windows.System.h>
 #include <winrt/Microsoft.UI.Composition.h>
+#include <winrt/Microsoft.UI.Text.h>
 #include <winrt/Microsoft.UI.Xaml.Automation.Peers.h>
 #include <winrt/Microsoft.UI.Xaml.Automation.h>
-#include <winrt/Microsoft.UI.Xaml.Media.h>
-#include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Hosting.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
 #include <winrt/Microsoft.UI.Xaml.h>
-#include <winrt/Microsoft.UI.Text.h>
+#include <winrt/Windows.ApplicationModel.Activation.h>
+#include <winrt/Windows.System.h>
 
 namespace xaml = winrt::Microsoft::UI::Xaml;
 namespace comp = winrt::Microsoft::UI::Composition;
 #endif
 
 namespace winrt {
-    using namespace Windows::UI::Core;
-    using namespace Windows::Foundation;
-    using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Core;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
 } // namespace winrt

--- a/vnext/include/CppWinRTIncludes.h
+++ b/vnext/include/CppWinRTIncludes.h
@@ -4,22 +4,46 @@
 
 #pragma once
 
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Storage.Streams.h>
+
+#ifndef WINUI3_SUPPORT
+#include <winrt/Windows.ApplicationModel.Activation.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Text.h>
+namespace xaml = winrt::Windows::UI::Xaml;
+namespace comp = winrt::Windows::UI::Composition;
+
+#else
+
+#include <winrt/Windows.ApplicationModel.Activation.h>
+#include <winrt/Windows.System.h>
+#include <winrt/Microsoft.UI.Composition.h>
+#include <winrt/Microsoft.UI.Xaml.Automation.Peers.h>
+#include <winrt/Microsoft.UI.Xaml.Automation.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Microsoft.UI.Xaml.Hosting.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Text.h>
+
+namespace xaml = winrt::Microsoft::UI::Xaml;
+namespace comp = winrt::Microsoft::UI::Composition;
+#endif
 
 namespace winrt {
-using namespace ::winrt::Windows::UI::Xaml;
-using namespace ::winrt::Windows::UI::Core;
-using namespace Windows::Foundation;
-using namespace Windows::Foundation::Collections;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Controls::Primitives;
-using namespace Windows::UI::Composition;
-using namespace Windows::UI::Xaml::Hosting;
+    using namespace Windows::UI::Core;
+    using namespace Windows::Foundation;
+    using namespace Windows::Foundation::Collections;
 } // namespace winrt

--- a/vnext/include/Include.vcxitems
+++ b/vnext/include/Include.vcxitems
@@ -45,4 +45,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactWindowsCore\SourceCodeModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactWindowsCore\ViewManager.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Midl Include="$(MSBuildThisFileDirectory)NamespaceRedirect.h" />
+  </ItemGroup>
 </Project>

--- a/vnext/include/Include.vcxitems.filters
+++ b/vnext/include/Include.vcxitems.filters
@@ -102,4 +102,7 @@
       <UniqueIdentifier>{77bf1091-5dda-46a7-ac20-6540d6e396d3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <Midl Include="$(MSBuildThisFileDirectory)NamespaceRedirect.h" />
+  </ItemGroup>
 </Project>

--- a/vnext/include/NamespaceRedirect.h
+++ b/vnext/include/NamespaceRedirect.h
@@ -5,4 +5,3 @@
 #else
 #define XAML_NAMESPACE Microsoft.UI.Xaml
 #endif
-

--- a/vnext/include/NamespaceRedirect.h
+++ b/vnext/include/NamespaceRedirect.h
@@ -6,11 +6,3 @@
 #define XAML_NAMESPACE Microsoft.UI.Xaml
 #endif
 
-#define CONCAT_(X, Y) X##Y
-#define CONCAT(X, Y) CONCAT_(X, Y)
-#define MAKE_CONCAT(X) CONCAT(XAML_NAMESPACE, X)
-#define DOT .
-
-/// WUXMUX_TYPE(x) generates a the equivalent of Windows.UI.Xaml.x or Microsoft.UI.Xaml.x,
-// depending on whether WINUI3_SUPPORT is defined or not.
-#define WUXMUX_TYPE(X) MAKE_CONCAT(CONCAT(DOT, X))

--- a/vnext/include/NamespaceRedirect.h
+++ b/vnext/include/NamespaceRedirect.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifndef WINUI3_SUPPORT
+#define XAML_NAMESPACE Windows.UI.Xaml
+#else
+#define XAML_NAMESPACE Microsoft.UI.Xaml
+#endif
+
+#define CONCAT_(X, Y) X##Y
+#define CONCAT(X, Y) CONCAT_(X, Y)
+#define MAKE_CONCAT(X) CONCAT(XAML_NAMESPACE, X)
+#define DOT .
+
+/// WUXMUX_TYPE(x) generates a the equivalent of Windows.UI.Xaml.x or Microsoft.UI.Xaml.x,
+// depending on whether WINUI3_SUPPORT is defined or not.
+#define WUXMUX_TYPE(X) MAKE_CONCAT(CONCAT(DOT, X))

--- a/vnext/include/ReactUWP/Utils/AccessibilityUtils.h
+++ b/vnext/include/ReactUWP/Utils/AccessibilityUtils.h
@@ -9,9 +9,9 @@ namespace react {
 namespace uwp {
 
 REACTWINDOWS_API_(void)
-AnnounceLiveRegionChangedIfNeeded(const winrt::Windows::UI::Xaml::FrameworkElement &element);
+AnnounceLiveRegionChangedIfNeeded(const xaml::FrameworkElement &element);
 
 REACTWINDOWS_API_(bool)
-HasDynamicAutomationProperties(const winrt::Windows::UI::Xaml::UIElement &element);
+HasDynamicAutomationProperties(const xaml::UIElement &element);
 } // namespace uwp
 } // namespace react

--- a/vnext/include/ReactUWP/Utils/AccessibilityUtils.h
+++ b/vnext/include/ReactUWP/Utils/AccessibilityUtils.h
@@ -3,12 +3,8 @@
 
 #pragma once
 
-#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
-#include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.h>
-
 #include <ReactWindowsCore/ReactWindowsAPI.h>
-
+#include "CppWinRTIncludes.h"
 namespace react {
 namespace uwp {
 

--- a/vnext/include/ReactUWP/Utils/Helpers.h
+++ b/vnext/include/ReactUWP/Utils/Helpers.h
@@ -6,11 +6,6 @@
 #include <IReactInstance.h>
 #include <folly/dynamic.h>
 #include <stdint.h>
-#include <winrt/Windows.UI.Xaml.h>
-
-namespace winrt {
-using namespace Windows::UI::Xaml;
-}
 
 namespace react {
 namespace uwp {
@@ -27,7 +22,7 @@ inline typename T asEnum(folly::dynamic const &obj) {
   return static_cast<T>(obj.asInt());
 }
 
-ReactId getViewId(_In_ IReactInstance *instance, winrt::FrameworkElement const &fe);
+ReactId getViewId(_In_ IReactInstance *instance, xaml::FrameworkElement const &fe);
 std::int32_t CountOpenPopups();
 
 bool IsRS3OrHigher();

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -10,16 +10,8 @@
 #include <stdint.h>
 #include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
 
 #include <Views/ShadowNodeBase.h>
-
-namespace winrt {
-using namespace Windows::UI::Xaml;
-}
 
 namespace react {
 namespace uwp {
@@ -40,14 +32,14 @@ static const std::unordered_map<std::string, ShadowEdges> edgeTypeMap = {
     {"borderWidth", ShadowEdges::AllEdges},
 };
 
-inline winrt::Windows::UI::Xaml::Thickness GetThickness(double thicknesses[ShadowEdges::CountEdges]) {
+inline xaml::Thickness GetThickness(double thicknesses[ShadowEdges::CountEdges]) {
   const double defaultWidth = std::max<double>(0, thicknesses[ShadowEdges::AllEdges]);
   double startWidth = DefaultOrOverride(thicknesses[ShadowEdges::Left], thicknesses[ShadowEdges::Start]);
   double endWidth = DefaultOrOverride(thicknesses[ShadowEdges::Right], thicknesses[ShadowEdges::End]);
 
   // Compute each edge.  Most specific setting wins, so fill from broad to
   // narrow: all, horiz/vert, start/end, left/right
-  winrt::Windows::UI::Xaml::Thickness thickness = {defaultWidth, defaultWidth, defaultWidth, defaultWidth};
+  xaml::Thickness thickness = {defaultWidth, defaultWidth, defaultWidth, defaultWidth};
 
   if (thicknesses[ShadowEdges::Horizontal] != c_UndefinedEdge)
     thickness.Left = thickness.Right = thicknesses[ShadowEdges::Horizontal];
@@ -66,8 +58,8 @@ inline winrt::Windows::UI::Xaml::Thickness GetThickness(double thicknesses[Shado
   return thickness;
 }
 
-inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(double cornerRadii[ShadowCorners::CountCorners]) {
-  winrt::Windows::UI::Xaml::CornerRadius cornerRadius;
+inline xaml::CornerRadius GetCornerRadius(double cornerRadii[ShadowCorners::CountCorners]) {
+  xaml::CornerRadius cornerRadius;
   const double defaultRadius = std::max<double>(0, cornerRadii[ShadowCorners::AllCorners]);
   double topStartRadius = DefaultOrOverride(cornerRadii[ShadowCorners::TopLeft], cornerRadii[ShadowCorners::TopStart]);
   double topEndRadius = DefaultOrOverride(cornerRadii[ShadowCorners::TopRight], cornerRadii[ShadowCorners::TopEnd]);
@@ -87,19 +79,19 @@ inline winrt::Windows::UI::Xaml::CornerRadius GetCornerRadius(double cornerRadii
 template <class T>
 void UpdatePadding(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
   node->m_padding[edge] = margin;
-  winrt::Thickness thickness = GetThickness(node->m_padding);
+  xaml::Thickness thickness = GetThickness(node->m_padding);
   element.Padding(thickness);
 }
 
 template <class T>
 void SetBorderThickness(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
   node->m_border[edge] = margin;
-  winrt::Thickness thickness = GetThickness(node->m_border);
+  xaml::Thickness thickness = GetThickness(node->m_border);
   element.BorderThickness(thickness);
 }
 
 template <class T>
-void SetBorderBrush(const T &element, const winrt::Windows::UI::Xaml::Media::Brush &brush) {
+void SetBorderBrush(const T &element, const xaml::Media::Brush &brush) {
   element.BorderBrush(brush);
 }
 
@@ -131,7 +123,7 @@ UpdateCornerRadiusValueOnNode(ShadowNodeBase *node, ShadowCorners corner, const 
 
 template <class T>
 void UpdateCornerRadiusOnElement(ShadowNodeBase *node, const T &element) {
-  winrt::CornerRadius cornerRadius = GetCornerRadius(node->m_cornerRadius);
+  xaml::CornerRadius cornerRadius = GetCornerRadius(node->m_cornerRadius);
   element.CornerRadius(cornerRadius);
 }
 
@@ -270,7 +262,7 @@ bool TryUpdateFontProperties(const T &element, const std::string &propertyName, 
       element.ClearValue(T::FontSizeProperty());
   } else if (propertyName == "fontFamily") {
     if (propertyValue.isString())
-      element.FontFamily(winrt::Windows::UI::Xaml::Media::FontFamily(asWStr(propertyValue)));
+      element.FontFamily(xaml::Media::FontFamily(asWStr(propertyValue)));
     else if (propertyValue.isNull())
       element.ClearValue(T::FontFamilyProperty());
   } else if (propertyName == "fontWeight") {
@@ -326,15 +318,15 @@ bool TryUpdateFontProperties(const T &element, const std::string &propertyName, 
 template <class T>
 void SetTextAlignment(const T &element, const std::string &value) {
   if (value == "left")
-    element.TextAlignment(winrt::TextAlignment::Left);
+    element.TextAlignment(xaml::TextAlignment::Left);
   else if (value == "right")
-    element.TextAlignment(winrt::TextAlignment::Right);
+    element.TextAlignment(xaml::TextAlignment::Right);
   else if (value == "center")
-    element.TextAlignment(winrt::TextAlignment::Center);
+    element.TextAlignment(xaml::TextAlignment::Center);
   else if (value == "justify")
-    element.TextAlignment(winrt::TextAlignment::Justify);
+    element.TextAlignment(xaml::TextAlignment::Justify);
   else
-    element.TextAlignment(winrt::TextAlignment::DetectFromContent);
+    element.TextAlignment(xaml::TextAlignment::DetectFromContent);
 }
 
 template <class T>
@@ -356,13 +348,13 @@ bool TryUpdateTextAlignment(const T &element, const std::string &propertyName, c
 template <class T>
 void SetTextTrimming(const T &element, const std::string &value) {
   if (value == "clip")
-    element.TextTrimming(winrt::TextTrimming::Clip);
+    element.TextTrimming(xaml::TextTrimming::Clip);
   else if (value == "head" || value == "middle" || value == "tail") {
     // "head" and "middle" not supported by UWP, but "tail"
     // behavior is the most similar
-    element.TextTrimming(winrt::TextTrimming::CharacterEllipsis);
+    element.TextTrimming(xaml::TextTrimming::CharacterEllipsis);
   } else
-    element.TextTrimming(winrt::TextTrimming::None);
+    element.TextTrimming(xaml::TextTrimming::None);
 }
 
 template <class T>
@@ -389,7 +381,7 @@ bool TryUpdateTextDecorationLine(
   if (propertyName == "textDecorationLine") {
     // FUTURE: remove when SDK target minVer >= 10.0.15063.0
     static bool isTextDecorationsSupported = winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
-        L"Windows.UI.Xaml.Controls.TextBlock", L"TextDecorations");
+        XAML_NAMESPACE ".Controls.TextBlock", L"TextDecorations");
     if (!isTextDecorationsSupported)
       return true;
 
@@ -421,11 +413,11 @@ bool TryUpdateTextDecorationLine(
 template <class T>
 void SetFlowDirection(const T &element, const std::string &value) {
   if (value == "rtl")
-    element.FlowDirection(winrt::FlowDirection::RightToLeft);
+    element.FlowDirection(xaml::FlowDirection::RightToLeft);
   else if (value == "ltr")
-    element.FlowDirection(winrt::FlowDirection::LeftToRight);
+    element.FlowDirection(xaml::FlowDirection::LeftToRight);
   else // 'auto', 'inherit'
-    element.ClearValue(winrt::FrameworkElement::FlowDirectionProperty());
+    element.ClearValue(xaml::FrameworkElement::FlowDirectionProperty());
 }
 
 template <class T>
@@ -466,9 +458,9 @@ bool TryUpdateOrientation(const T &element, const std::string &propertyName, con
     } else if (propertyValue.isString()) {
       const std::string &valueString = propertyValue.getString();
       if (valueString == "horizontal")
-        element.Orientation(winrt::Orientation::Horizontal);
+        element.Orientation(xaml::Controls::Orientation::Horizontal);
       else if (valueString == "vertical")
-        element.Orientation(winrt::Orientation::Vertical);
+        element.Orientation(xaml::Controls::Orientation::Vertical);
     }
 
     return true;

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -381,7 +381,7 @@ bool TryUpdateTextDecorationLine(
   if (propertyName == "textDecorationLine") {
     // FUTURE: remove when SDK target minVer >= 10.0.15063.0
     static bool isTextDecorationsSupported = winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
-        XAML_NAMESPACE ".Controls.TextBlock", L"TextDecorations");
+        XAML_NAMESPACE_STR L".Controls.TextBlock", L"TextDecorations");
     if (!isTextDecorationsSupported)
       return true;
 

--- a/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
+++ b/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
@@ -16,17 +16,11 @@ namespace uwp {
 // re-rendering with different props in response to state
 // change events (onFocus, onBlur, onMouseEnter, onMouseLeave)
 // or when changing enabled/disabled props.
-void UpdateControlBackgroundResourceBrushes(
-    const xaml::FrameworkElement &element,
-    const xaml::Media::Brush brush);
+void UpdateControlBackgroundResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush brush);
 
-void UpdateControlForegroundResourceBrushes(
-    const xaml::DependencyObject object,
-    const xaml::Media::Brush brush);
+void UpdateControlForegroundResourceBrushes(const xaml::DependencyObject object, const xaml::Media::Brush brush);
 
-void UpdateControlBorderResourceBrushes(
-    const xaml::FrameworkElement &element,
-    const xaml::Media::Brush brush);
+void UpdateControlBorderResourceBrushes(const xaml::FrameworkElement &element, const xaml::Media::Brush brush);
 
 void UpdateToggleSwitchThumbResourceBrushes(
     const xaml::Controls::ToggleSwitch &toggleSwitch,

--- a/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
+++ b/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
@@ -2,15 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.h>
-
-namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Media;
-} // namespace winrt
+#include "CppWinRTIncludes.h"
 
 namespace react {
 namespace uwp {
@@ -25,25 +17,25 @@ namespace uwp {
 // change events (onFocus, onBlur, onMouseEnter, onMouseLeave)
 // or when changing enabled/disabled props.
 void UpdateControlBackgroundResourceBrushes(
-    const winrt::Windows::UI::Xaml::FrameworkElement &element,
-    const winrt::Media::Brush brush);
+    const xaml::FrameworkElement &element,
+    const xaml::Media::Brush brush);
 
 void UpdateControlForegroundResourceBrushes(
-    const winrt::Windows::UI::Xaml::DependencyObject object,
-    const winrt::Media::Brush brush);
+    const xaml::DependencyObject object,
+    const xaml::Media::Brush brush);
 
 void UpdateControlBorderResourceBrushes(
-    const winrt::Windows::UI::Xaml::FrameworkElement &element,
-    const winrt::Media::Brush brush);
+    const xaml::FrameworkElement &element,
+    const xaml::Media::Brush brush);
 
 void UpdateToggleSwitchThumbResourceBrushes(
-    const winrt::Windows::UI::Xaml::Controls::ToggleSwitch &toggleSwitch,
-    const winrt::Windows::UI::Xaml::Media::Brush thumbBrush);
+    const xaml::Controls::ToggleSwitch &toggleSwitch,
+    const xaml::Media::Brush thumbBrush);
 
 void UpdateToggleSwitchTrackResourceBrushes(
-    const winrt::Windows::UI::Xaml::Controls::ToggleSwitch &toggleSwitch,
-    const winrt::Windows::UI::Xaml::Media::Brush onTrackBrush,
-    const winrt::Windows::UI::Xaml::Media::Brush offTrackBrush);
+    const xaml::Controls::ToggleSwitch &toggleSwitch,
+    const xaml::Media::Brush onTrackBrush,
+    const xaml::Media::Brush offTrackBrush);
 
 } // namespace uwp
 } // namespace react

--- a/vnext/include/ReactUWP/Utils/ValueUtils.h
+++ b/vnext/include/ReactUWP/Utils/ValueUtils.h
@@ -3,13 +3,10 @@
 
 #pragma once
 
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.h>
-#include <winrt/Windows.UI.h>
 #include <string>
 
 #include <ReactWindowsCore/ReactWindowsAPI.h>
+#include "CppWinRTIncludes.h"
 
 namespace folly {
 struct dynamic;
@@ -18,16 +15,16 @@ struct dynamic;
 namespace react {
 namespace uwp {
 
-winrt::Windows::UI::Xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
+xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
 
 REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const folly::dynamic &d);
-REACTWINDOWS_API_(winrt::Windows::UI::Xaml::Media::Brush)
+REACTWINDOWS_API_(xaml::Media::Brush)
 BrushFrom(const folly::dynamic &d);
-REACTWINDOWS_API_(winrt::Windows::UI::Xaml::Media::SolidColorBrush)
+REACTWINDOWS_API_(xaml::Media::SolidColorBrush)
 SolidColorBrushFrom(const folly::dynamic &d);
-REACTWINDOWS_API_(winrt::Windows::UI::Xaml::VerticalAlignment)
+REACTWINDOWS_API_(xaml::VerticalAlignment)
 VerticalAlignmentFrom(const folly::dynamic &d);
-REACTWINDOWS_API_(winrt::Windows::UI::Xaml::HorizontalAlignment)
+REACTWINDOWS_API_(xaml::HorizontalAlignment)
 HorizontalAlignmentFrom(const folly::dynamic &d);
 REACTWINDOWS_API_(winrt::Windows::Foundation::DateTime)
 DateTimeFrom(int64_t timeInMilliSeconds, int64_t timeZoneOffsetInSeconds);

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <winrt/Windows.UI.Composition.h>
 #include "ViewManagerBase.h"
 
 namespace react {

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -20,8 +20,8 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
   // Helper functions related to setting/updating TransformMatrix
   void RefreshTransformMatrix(ShadowNodeBase *shadowNode);
   void StartTransformAnimation(
-      winrt::UIElement uielement,
-      winrt::Windows::UI::Composition::CompositionPropertySet transformPS);
+      xaml::UIElement uielement,
+      comp::CompositionPropertySet transformPS);
 
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
@@ -42,7 +42,7 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
 
  private:
   void ApplyTransformMatrix(
-      winrt::UIElement uielement,
+      xaml::UIElement uielement,
       ShadowNodeBase *shadowNode,
       winrt::Windows::Foundation::Numerics::float4x4 transformMatrix);
 };

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -18,9 +18,7 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
 
   // Helper functions related to setting/updating TransformMatrix
   void RefreshTransformMatrix(ShadowNodeBase *shadowNode);
-  void StartTransformAnimation(
-      xaml::UIElement uielement,
-      comp::CompositionPropertySet transformPS);
+  void StartTransformAnimation(xaml::UIElement uielement, comp::CompositionPropertySet transformPS);
 
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
@@ -30,8 +28,7 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const folly::dynamic &propertyValue) override;
 
-  void
-  TransferProperty(const XamlView &oldView, const XamlView &newView, xaml::DependencyProperty dp);
+  void TransferProperty(const XamlView &oldView, const XamlView &newView, xaml::DependencyProperty dp);
 
   void TransferProperty(
       const XamlView &oldView,

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -33,8 +33,8 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
   void TransferProperty(
       const XamlView &oldView,
       const XamlView &newView,
-      winrt::DependencyProperty oldViewDP,
-      winrt::DependencyProperty newViewDP);
+      xaml::DependencyProperty oldViewDP,
+      xaml::DependencyProperty newViewDP);
 
  private:
   void ApplyTransformMatrix(

--- a/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
+++ b/vnext/include/ReactUWP/Views/FrameworkElementViewManager.h
@@ -32,7 +32,7 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       const folly::dynamic &propertyValue) override;
 
   void
-  TransferProperty(const XamlView &oldView, const XamlView &newView, winrt::Windows::UI::Xaml::DependencyProperty dp);
+  TransferProperty(const XamlView &oldView, const XamlView &newView, xaml::DependencyProperty dp);
 
   void TransferProperty(
       const XamlView &oldView,

--- a/vnext/include/ReactUWP/Views/KeyboardEventHandler.h
+++ b/vnext/include/ReactUWP/Views/KeyboardEventHandler.h
@@ -2,15 +2,15 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <IReactInstance.h>
 #include <folly/dynamic.h>
 #include <optional>
 #include <set>
 #include "CppWinRTIncludes.h"
-#include <IReactInstance.h>
 #include "XamlView.h"
 
 namespace winrt {
-  using namespace Windows::UI::Core;
+using namespace Windows::UI::Core;
 } // namespace winrt
 
 namespace react {

--- a/vnext/include/ReactUWP/Views/KeyboardEventHandler.h
+++ b/vnext/include/ReactUWP/Views/KeyboardEventHandler.h
@@ -3,23 +3,14 @@
 
 #pragma once
 #include <folly/dynamic.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Input.h>
 #include <optional>
 #include <set>
-
+#include "CppWinRTIncludes.h"
 #include <IReactInstance.h>
 #include "XamlView.h"
 
 namespace winrt {
-using namespace Windows::UI;
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Input;
-using namespace Windows::Foundation;
-using namespace Windows::UI::Xaml::Media;
-using namespace Windows::System;
-using namespace Windows::UI::Core;
+  using namespace Windows::UI::Core;
 } // namespace winrt
 
 namespace react {
@@ -49,7 +40,7 @@ struct HandledKeyboardEvent : ModifiedKeyState {
   std::string code{};
 };
 
-typedef std::function<void(winrt::IInspectable const &, winrt::KeyRoutedEventArgs const &)> KeyboardEventCallback;
+typedef std::function<void(winrt::IInspectable const &, xaml::Input::KeyRoutedEventArgs const &)> KeyboardEventCallback;
 
 class KeyboardEventBaseHandler {
  public:
@@ -72,8 +63,8 @@ class PreviewKeyboardEventHandler : public KeyboardEventBaseHandler {
   void unhook();
 
  private:
-  winrt::UIElement::PreviewKeyDown_revoker m_previewKeyDownRevoker{};
-  winrt::UIElement::PreviewKeyUp_revoker m_previewKeyUpRevoker{};
+  xaml::UIElement::PreviewKeyDown_revoker m_previewKeyDownRevoker{};
+  xaml::UIElement::PreviewKeyUp_revoker m_previewKeyUpRevoker{};
 };
 
 class KeyboardEventHandler : public KeyboardEventBaseHandler {
@@ -84,8 +75,8 @@ class KeyboardEventHandler : public KeyboardEventBaseHandler {
   void unhook();
 
  private:
-  winrt::UIElement::KeyDown_revoker m_keyDownRevoker{};
-  winrt::UIElement::KeyUp_revoker m_keyUpRevoker{};
+  xaml::UIElement::KeyDown_revoker m_keyDownRevoker{};
+  xaml::UIElement::KeyUp_revoker m_keyUpRevoker{};
 };
 
 class PreviewKeyboardEventHandlerOnRoot : public PreviewKeyboardEventHandler {
@@ -93,10 +84,10 @@ class PreviewKeyboardEventHandlerOnRoot : public PreviewKeyboardEventHandler {
   PreviewKeyboardEventHandlerOnRoot(const std::weak_ptr<IReactInstance> &reactInstance);
 
  private:
-  void OnPreKeyDown(winrt::IInspectable const &sender, winrt::KeyRoutedEventArgs const &args);
-  void OnPreKeyUp(winrt::IInspectable const &sender, winrt::KeyRoutedEventArgs const &args);
+  void OnPreKeyDown(winrt::IInspectable const &sender, xaml::Input::KeyRoutedEventArgs const &args);
+  void OnPreKeyUp(winrt::IInspectable const &sender, xaml::Input::KeyRoutedEventArgs const &args);
 
-  void DispatchEventToJs(std::string const &name, winrt::KeyRoutedEventArgs const &args);
+  void DispatchEventToJs(std::string const &name, xaml::Input::KeyRoutedEventArgs const &args);
   std::weak_ptr<IReactInstance> m_wkReactInstance;
 };
 
@@ -118,7 +109,7 @@ class HandledKeyboardEventHandler {
   void KeyboardEventHandledHandler(
       KeyboardEventPhase phase,
       winrt::IInspectable const &sender,
-      winrt::KeyRoutedEventArgs const &args);
+      xaml::Input::KeyRoutedEventArgs const &args);
   bool ShouldMarkKeyboardHandled(
       std::vector<HandledKeyboardEvent> const &handledEvents,
       HandledKeyboardEvent currentEvent);
@@ -132,11 +123,11 @@ class HandledKeyboardEventHandler {
 
 struct KeyboardHelper {
   static std::vector<HandledKeyboardEvent> FromJS(folly::dynamic const &obj);
-  static HandledKeyboardEvent CreateKeyboardEvent(HandledEventPhase phase, winrt::KeyRoutedEventArgs const &args);
-  static std::string FromVirtualKey(winrt::VirtualKey key, bool shiftDown, bool capLocked);
-  static std::string CodeFromVirtualKey(winrt::VirtualKey key);
-  static bool IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::VirtualKey virtualKey);
-  static bool IsModifiedKeyLocked(winrt::CoreWindow const &coreWindow, winrt::VirtualKey virtualKey);
+  static HandledKeyboardEvent CreateKeyboardEvent(HandledEventPhase phase, xaml::Input::KeyRoutedEventArgs const &args);
+  static std::string FromVirtualKey(winrt::Windows::System::VirtualKey key, bool shiftDown, bool capLocked);
+  static std::string CodeFromVirtualKey(winrt::Windows::System::VirtualKey key);
+  static bool IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey);
+  static bool IsModifiedKeyLocked(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey);
 };
 } // namespace uwp
 } // namespace react

--- a/vnext/include/ReactUWP/Views/ShadowNodeBase.h
+++ b/vnext/include/ReactUWP/Views/ShadowNodeBase.h
@@ -92,13 +92,13 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
   bool HasTransformPS() const {
     return m_transformPS != nullptr;
   }
-  winrt::Windows::UI::Composition::CompositionPropertySet EnsureTransformPS();
+  comp::CompositionPropertySet EnsureTransformPS();
   void UpdateTransformPS();
 
  protected:
   XamlView m_view;
   bool m_updating = false;
-  winrt::Windows::UI::Composition::CompositionPropertySet m_transformPS{nullptr};
+  comp::CompositionPropertySet m_transformPS{nullptr};
 
  public:
   double m_padding[ShadowEdges::CountEdges] = INIT_UNDEFINED_EDGES;

--- a/vnext/include/ReactUWP/XamlView.h
+++ b/vnext/include/ReactUWP/XamlView.h
@@ -3,26 +3,19 @@
 
 #pragma once
 
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.h>
-
-namespace winrt {
-using namespace Windows::UI::Xaml;
-using namespace Windows::UI::Xaml::Input;
-using namespace Windows::Foundation;
-} // namespace winrt
+#include "CppWinRTIncludes.h"
 
 namespace react {
 namespace uwp {
 
-using XamlView = winrt::DependencyObject;
+using XamlView = xaml::DependencyObject;
 
 inline int64_t GetTag(XamlView view) {
-  return view.GetValue(winrt::FrameworkElement::TagProperty()).as<winrt::IPropertyValue>().GetInt64();
+  return view.GetValue(xaml::FrameworkElement::TagProperty()).as<winrt::IPropertyValue>().GetInt64();
 }
 
 inline void SetTag(XamlView view, int64_t tag) {
-  view.SetValue(winrt::FrameworkElement::TagProperty(), winrt::PropertyValue::CreateInt64(tag));
+  view.SetValue(xaml::FrameworkElement::TagProperty(), winrt::PropertyValue::CreateInt64(tag));
 }
 
 inline void SetTag(XamlView view, winrt::IInspectable tag) {
@@ -39,9 +32,9 @@ inline int64_t GetTag(winrt::IPropertyValue value) {
   return value.GetInt64();
 }
 
-inline winrt::IPropertyValue GetTagAsPropertyValue(winrt::FrameworkElement fe) {
+inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
   assert(fe);
-  return fe.GetValue(winrt::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
 } // namespace uwp


### PR DESCRIPTION
This PR starts to get us closer to using MUX (WinUI3). It centralizes #includes and replaces all Windows.UI.Xaml and Windows.UI.Composition namespaces with aliases that can be switched to their WinUI3 analogs. More work is needed to get RNW working on WinUI3 (addressing APIs that are missing in WinUI3, addressing APIs that have changed shape, and actually switching to using WinUI3) but wanted to get this larger bulk in first.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4715)