### PR TITLE
Update react version

### DIFF
--- a/change/react-native-windows-2020-04-27-20-28-42-fix-peerdependency.json
+++ b/change/react-native-windows-2020-04-27-20-28-42-fix-peerdependency.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update react version",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-28T03:28:42.499Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "prompt-sync": "^4.2.0",
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-native": "0.62.2",
     "react-native-windows": "0.0.0-master.50"
   },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -52,14 +52,14 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.36.1",
     "prettier": "1.17.0",
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-native-windows-codegen": "0.0.3",
     "react-native-windows-override-tools": "^0.0.1",
     "react-native": "0.62.2",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-native": "0.62.2"
   },
   "beachball": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11640,6 +11640,15 @@ react-test-renderer@16.9.0:
     react-is "^16.9.0"
     scheduler "^0.15.0"
 
+react@16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
+  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
 react@16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"


### PR DESCRIPTION
We updated react-native to 0.62.2 (which has a peer dependency of react 16.11.0), but our react version is still on 16.9.0, updating to 16.11.0.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4734)