### PR TITLE
Exclude test projects and proposals from being published in the npm package

### DIFF
--- a/change/react-native-windows-2020-04-28-10-19-13-master.json
+++ b/change/react-native-windows-2020-04-28-10-19-13-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Exclude unittests and proposals from being published in the npm package",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-28T17:19:13.805Z"
+}

--- a/vnext/.npmignore
+++ b/vnext/.npmignore
@@ -9,12 +9,18 @@ build
 CMakeLists.txt
 /Desktop
 Desktop.Dll
+Desktop.ABITests
 Desktop.IntegrationTests
+Desktop.Test.DLL
 Desktop.UnitTests
 FollyWin32
 IntegrationTests
 IntegrationTestScripts
+JSI.Desktop.UnitTests
 /NuGet.Config
+Microsoft.ReactNative.Cxx.UnitTests
+Microsoft.ReactNative.IntegrationTests
+Microsoft.ReactNative.Managed.UnitTests
 package-deps.json
 packages
 react-native-windows.build.log
@@ -23,6 +29,8 @@ ReactWindows-Universal.sln
 ReactWindows-Desktop.sln
 RNTester.*
 RNTester/
+Mso.UnitTests
+proposals
 src/
 target
 temp


### PR DESCRIPTION
This saves approximate 1.5 Mb in the final published package.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4737)