### PR TITLE
Update version number of the Azure DevOps PR validation step

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -1,5 +1,5 @@
 # This file defines the Windows Visual Studio PR build steps used during the CI loop
-name: $(Date:yyyyMMdd).$(Rev:.r)
+name: $(Date:yyyyMMdd).$(Rev:r)
 
 trigger: none # will disable CI builds entirely
 


### PR DESCRIPTION
The build numbers in the [PR validation on Azure Devops](https://dev.azure.com/ms/react-native-windows/_build?definitionId=210&_a=summary) were numbered like `20200428..4` with two dots. This PR removes one of the dots, so new builds will be numbered like `20200428.5`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4738)