### PR TITLE
Add parallel MsBuild support (/m) when building the generated solution.

### DIFF
--- a/change/react-native-windows-2020-04-29-09-45-05-master.json
+++ b/change/react-native-windows-2020-04-29-09-45-05-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make generated msbuild project compile in parralel (/m)",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T16:45:05.116Z"
+}

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -56,6 +56,7 @@ class MSBuildTools {
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,
       '/nologo',
+      '/maxCpuCount',
       `/p:Configuration=${buildType}`,
       `/p:Platform=${buildArch}`,
       '/p:AppxBundle=Never',


### PR DESCRIPTION
This fixes #4654 by adding [`/maxCpuCount`](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019) through [msbuildtools.js](https://github.com/microsoft/react-native-windows/blob/master/vnext/local-cli/runWindows/utils/msbuildtools.js)
The bug is worried about missing dependencies but from testing it seems fine. And unfortunately there is almost no perf-gain either.

# How Tested:
I tested on a 48-thread machine (2 x E5-2687W) with 64Gb ram and NVME SSD using:
1. `npx react-native init projectName --version ^0.62.2`
1. `cd projectName`
1. `npx react-native-windows-init --overwrite`
1. `npx react-native run-windows`
1. Close all opened windows
1. Open VS 2019 Developer prompt
1. `cd windows`
1. Run the commands below and record time elapsed

### `msbuild /m /t:rebuild /p:Configuration=Debug /p:Platform=x86`
1. 00:02:51.80
1. 00:02:47.07
1. 00:02:53.30

### `msbuild /m /p:Configuration=Debug /p:Platform=x86`
1. 00:00:20.53
1. 00:00:07.21
1. 00:00:06.87

### `msbuild /m /t:rebuild /p:Configuration=Release /p:Platform=x64`
1. 00:03:29.60
1. 00:03:34.83
1. 00:03:25.49

### `msbuild /m /p:Configuration=Release /p:Platform=x64`
1. 00:00:51.54
1. 00:00:40.18
1. 00:00:40.31

## Before (without /m)
### `msbuild /t:rebuild /p:Configuration=Debug /p:Platform=x86`
1. 00:02:53.85
1. 00:03:05.64
1. 00:03:01.31

### `msbuild /p:Configuration=Debug /p:Platform=x86`
1. 00:00:22.00
1. 00:00:07.94
1. 00:00:07.71


# Results
I've run various builds (not keeping track) and I did not run into any ordering issues so far.
My machine only reached 100% CPU for a few seconds during the build when many cpp files were compiled, so dependencies seem fine as even with `/m` the concurrency level is holding back compile times.

This also shows as there is no significant time improvement over not passing `/m` in msbuild :(




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4739)