### PR TITLE
Expose Debug macro for hresult_error. Start catching these...

### DIFF
--- a/change/react-native-windows-2020-04-29-03-28-07-debug_hresult.json
+++ b/change/react-native-windows-2020-04-29-03-28-07-debug_hresult.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Expose Debug macro for hresult_error. Start catching these...",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T10:28:07.247Z"
+}

--- a/vnext/ReactUWP/Views/Image/ReactImage.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImage.cpp
@@ -10,6 +10,7 @@
 #include <winrt/Windows.Web.Http.h>
 
 #include "Unicode.h"
+#include "cdebug.h"
 
 namespace winrt {
 using namespace Windows::Foundation;
@@ -84,6 +85,7 @@ winrt::Stretch ReactImage::ResizeModeToStretch(react::uwp::ResizeMode value) {
     default: // ResizeMode::Center
       // This function should never be called for the 'repeat' resizeMode case.
       // That is handled by the shouldUseCompositionBrush/switchBrushes code path.
+      // #4691
       assert(value != ResizeMode::Repeat);
 
       if (m_imageSource.height < ActualHeight() && m_imageSource.width < ActualWidth()) {
@@ -328,7 +330,8 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageStreamAsync(Re
 
       co_return memoryStream;
     }
-  } catch (winrt::hresult_error const &) {
+  } catch (winrt::hresult_error const &e) {
+    DEBUG_HRESULT_ERROR(e);
   }
 
   co_return nullptr;

--- a/vnext/include/ReactWindowsCore/cdebug.h
+++ b/vnext/include/ReactWindowsCore/cdebug.h
@@ -35,3 +35,8 @@ class basic_dostream : public std::basic_ostream<CharT> {
 
 extern basic_dostream<char> cdebug;
 extern basic_dostream<wchar_t> cwdebug;
+
+#define DEBUG_HRESULT_ERROR(e)                    \
+  cdebug << __FILE__ << " (" << __LINE__ << ") "; \
+  cdebug.flush();                                 \
+  cwdebug << e.message().c_str() << std::endl;


### PR DESCRIPTION
I caught one issue in the Image RNTester page where we are getting a HTTPS to HTTP degradation in a redirect (See #4743). We'll need to understand why this happens but getting this tiny change in so we can start using this facility everywhere appropriate.

e.g.:
`C:\rnw2\vnext\ReactUWP\Views\Image\ReactImage.cpp (334) A redirect request will change a secure to a non-secure connection`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4742)