### PR TITLE
Remove unnecessary CLI elevation

### DIFF
--- a/change/react-native-windows-2020-04-29-10-09-33-tryUninstall2.json
+++ b/change/react-native-windows-2020-04-29-10-09-33-tryUninstall2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Try uninstalling without elevation in case since it is not needed for layout installs (debug)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T17:09:33.939Z"
+}

--- a/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -63,7 +63,12 @@ function Uninstall-App {
 
     if($package) {
         $pfn = $package.PackageFullName
-        Invoke-Expression-MayElevate "Remove-AppxPackage $pfn -ErrorAction Stop" -ErrorAction Stop
+        $command = "Remove-AppxPackage $pfn -ErrorAction Stop"
+        try {
+            Invoke-Expression $command
+        } catch {
+            Invoke-Expression-MayElevate $command -ErrorAction Stop
+        }
     }
 }
 


### PR DESCRIPTION
Try uninstalling without elevation in case since it is not needed for layout installs (debug).
Fixes #4744 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4745)