### PR TITLE
Update tscodegen to version based on 0.62

### DIFF
--- a/change/react-native-windows-codegen-2020-04-29-06-16-44-uptsgen.json
+++ b/change/react-native-windows-codegen-2020-04-29-06-16-44-uptsgen.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update tscodegen to version based on 0.62",
+  "packageName": "react-native-windows-codegen",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T13:16:44.451Z"
+}

--- a/packages/react-native-windows-codegen/package.json
+++ b/packages/react-native-windows-codegen/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "chalk": "^3",
     "globby": "^9.2.0",
-    "react-native-tscodegen": "0.0.10",
-    "react-native-codegen": "0.0.2",
+    "react-native-tscodegen": "0.62.1",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,11 +4198,6 @@ ast-types@0.11.7:
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.7.tgz#f318bf44e339db6a320be0009ded64ec1471f46c"
   integrity sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==
 
-ast-types@0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
-  integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
-
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -6966,11 +6961,6 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.113.0.tgz#5b5913c54833918d0c3136ba69f6cf0cdd85fc20"
   integrity sha512-+hRyEB1sVLNMTMniDdM1JIS8BJ3HUL7IFIJaxX+t/JUy0GNYdI0Tg1QLx8DJmOF8HeoCrUDcREpnDAc/pPta3w==
 
-flow-parser@^0.121.0:
-  version "0.121.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.121.0.tgz#9f9898eaec91a9f7c323e9e992d81ab5c58e618f"
-  integrity sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==
-
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -8735,30 +8725,6 @@ jscodeshift@0.6.4, jscodeshift@^0.6.2:
     neo-async "^2.5.0"
     node-dir "^0.1.17"
     recast "^0.16.1"
-    temp "^0.8.1"
-    write-file-atomic "^2.3.0"
-
-jscodeshift@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.7.0.tgz#4eee7506fd4fdacbd80340287d61575af991fdab"
-  integrity sha512-Kt6rpTa1HVhAWagD6J0y6qxxqRmDgkFvczerLgOsDNSGoUZSmq2CO1vFRcda9OV1BaZKSHCIh+VREPts5tB/Ig==
-  dependencies:
-    "@babel/core" "^7.1.6"
-    "@babel/parser" "^7.1.6"
-    "@babel/plugin-proposal-class-properties" "^7.1.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/preset-env" "^7.1.6"
-    "@babel/preset-flow" "^7.0.0"
-    "@babel/preset-typescript" "^7.1.0"
-    "@babel/register" "^7.0.0"
-    babel-core "^7.0.0-bridge.0"
-    colors "^1.1.2"
-    flow-parser "0.*"
-    graceful-fs "^4.1.11"
-    micromatch "^3.1.10"
-    neo-async "^2.5.0"
-    node-dir "^0.1.17"
-    recast "^0.18.1"
     temp "^0.8.1"
     write-file-atomic "^2.3.0"
 
@@ -11570,19 +11536,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-codegen@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.2.tgz#2a1c15a9deb80b62a5e9c0f215bb29900216f7ee"
-  integrity sha512-cZ28TUlYanjpca6dcxyGmZi4JKTmeaE4vJhjTABMRD+R7Rw6FtTAUqU2BoAKksEsrf8dJN5pQEUOSb4Cv0502Q==
-  dependencies:
-    flow-parser "^0.121.0"
-    jscodeshift "^0.7.0"
-    nullthrows "^1.1.1"
-
-react-native-tscodegen@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/react-native-tscodegen/-/react-native-tscodegen-0.0.10.tgz#2997f039625e55aac91a367ac3d6b496c50f1265"
-  integrity sha512-MwG76JC/YpelWgcOmPQIiYdIAL+4uwafFROVUMNHI1ko5LkSay1sY1D7FDdAq9fXE0kZoHna7YHD50DR6CLj8w==
+react-native-tscodegen@0.62.1:
+  version "0.62.1"
+  resolved "https://registry.yarnpkg.com/react-native-tscodegen/-/react-native-tscodegen-0.62.1.tgz#a52b01f1d515a12ebf22487d88cb58452d8e3210"
+  integrity sha512-fhEzT6pgHuo08mGZwtOZCTAhg+XcNdK0eUwes2x/vCbFzpKm8N3FOq3EMJ9dI9XnNe0DItxWGdRWjeo/DFisJA==
   dependencies:
     jscodeshift "0.6.4"
     nullthrows "1.1.1"
@@ -11799,16 +11756,6 @@ recast@^0.16.1:
     ast-types "0.11.7"
     esprima "~4.0.0"
     private "~0.1.5"
-    source-map "~0.6.1"
-
-recast@^0.18.1:
-  version "0.18.10"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.10.tgz#605ebbe621511eb89b6356a7e224bff66ed91478"
-  integrity sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==
-  dependencies:
-    ast-types "0.13.3"
-    esprima "~4.0.0"
-    private "^0.1.8"
     source-map "~0.6.1"
 
 rechoir@^0.6.2:


### PR DESCRIPTION
We were using some codegen code from RN 0.61 - this updates to to align with RN 0.62

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4747)