### PR TITLE
.net projects need more work to build a package layout

### DIFF
--- a/change/react-native-windows-2020-04-29-18-21-26-4749.json
+++ b/change/react-native-windows-2020-04-29-18-21-26-4749.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": ".net projects need more work to build a package layout",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T01:21:26.428Z"
+}

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -25,6 +25,7 @@ function ExitProcessWithError(loggingWasEnabled) {
 
 async function runWindows(config, args, options) {
   const verbose = options.logging;
+
   if (verbose) {
     newInfo('Verbose: ON');
   }
@@ -47,12 +48,12 @@ async function runWindows(config, args, options) {
 
   // Fix up options
   options.root = options.root || process.cwd();
+  const slnFile = options.sln || build.getSolutionFile(options);
 
   if (options.autolink) {
     autolink.updateAutoLink(verbose);
   }
   if (options.build) {
-    const slnFile = options.sln || build.getSolutionFile(options);
     if (!slnFile) {
       newError(
         'Visual Studio Solution file not found. Maybe run "react-native windows" first?',
@@ -101,7 +102,7 @@ async function runWindows(config, args, options) {
       if (options.device || options.emulator || options.target) {
         await deploy.deployToDevice(options, verbose);
       } else {
-        await deploy.deployToDesktop(options, verbose);
+        await deploy.deployToDesktop(options, verbose, slnFile);
       }
     } catch (e) {
       newError(`Failed to deploy${e ? `: ${e.message}` : ''}`);

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -159,8 +159,8 @@ async function deployToDevice(options, verbose) {
   }
 }
 
-function hasDotNetProjects(slnFile) {
-  const contents = fs.readFileSync(slnFile).toString();
+async function hasDotNetProjects(slnFile) {
+  const contents = (await fs.promises.readFile(slnFile)).toString();
   let r = /\"([^"]+\.(csproj|vbproj))\"/;
   return r.test(contents);
 }
@@ -209,7 +209,7 @@ async function deployToDesktop(options, verbose, slnFile) {
   );
 
   // #4749 - need to deploy from appx for .net projects.
-  if (options.release || hasDotNetProjects(slnFile)) {
+  if (options.release || (await hasDotNetProjects(slnFile))) {
     await runPowerShellScriptFunction(
       'Installing new version of the app',
       windowsStoreAppUtils,

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -159,7 +159,13 @@ async function deployToDevice(options, verbose) {
   }
 }
 
-async function deployToDesktop(options, verbose) {
+function hasDotNetProjects(slnFile) {
+  const contents = fs.readFileSync(slnFile).toString();
+  let r = /\"([^"]+\.(csproj|vbproj))\"/;
+  return r.test(contents);
+}
+
+async function deployToDesktop(options, verbose, slnFile) {
   const appPackageFolder = getAppPackage(options);
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(options);
@@ -202,7 +208,8 @@ async function deployToDesktop(options, verbose) {
     verbose,
   );
 
-  if (options.release) {
+  // #4749 - need to deploy from appx for .net projects.
+  if (options.release || hasDotNetProjects(slnFile)) {
     await runPowerShellScriptFunction(
       'Installing new version of the app',
       windowsStoreAppUtils,


### PR DESCRIPTION
Opts .net projects out of the install from layout logic since that's broken as per #4749 (this isn't specific to RNW, as I can repro this with a plain C# UWP app) 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4751)