### PR TITLE
Package Version Fixes

### DIFF
--- a/change/@office-iss-react-native-win32-2020-04-29-23-49-30-version-fixes.json
+++ b/change/@office-iss-react-native-win32-2020-04-29-23-49-30-version-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Package Fixes",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T06:49:27.467Z"
+}

--- a/change/react-native-windows-2020-04-29-23-49-30-version-fixes.json
+++ b/change/react-native-windows-2020-04-29-23-49-30-version-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Package Fixes",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T06:49:30.516Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -14,7 +14,7 @@
     "windows": "react-native run-windows"
   },
   "dependencies": {
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-native": "0.62.2",
     "react-native-windows": "0.0.0-master.53"
   },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "windows": "react-native run-windows"
   },
   "dependencies": {
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-native": "0.62.2",
     "react-native-windows": "0.0.0-master.53"
   },

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -53,16 +53,16 @@
     "flow-bin": "^0.113.0",
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.36.1",
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-native-windows-override-tools": "^0.0.1",
     "react-native": "0.62.2",
     "rimraf": "^3.0.0",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "16.9.0",
+    "react": "16.11.0",
     "react-dom": "16.8.6",
-    "react-native": "0.62.2"
+    "react-native": "^0.62.0-0"
   },
   "beachball": {
     "defaultNpmTag": "master",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": "16.11.0",
-    "react-native": "0.62.2"
+    "react-native": "^0.62.0-0"
   },
   "beachball": {
     "defaultNpmTag": "master",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11606,15 +11606,6 @@ react@16.11.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-react@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
 read-cmd-shim@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz#b4a53d43376211b45243f0072b6e603a8e37640d"


### PR DESCRIPTION
1. Use looser peer dependencies on React Native. 0.61 specified 0.61.5 explicitly, but based on recent discussion we want to allow patch releases of RN to work on any RNW version. Allow prerelease versions as well for any special forks, etc.

2. Fixup React Version everywhere. I missed upgraded React dependencies during the 0.62 upgrade. This was fixed in vnext and e2etest with #4734 but other packages were not updated. Update everything here.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4752)