### PR TITLE
Removed the ref count work around from classes derived from ReactApplication

### DIFF
--- a/change/react-native-windows-2020-04-30-08-22-39-MS_RemoveReactAppRefCountHack.json
+++ b/change/react-native-windows-2020-04-30-08-22-39-MS_RemoveReactAppRefCountHack.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Removed the ref count work around from classes derived from ReactApplications",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T15:22:39.524Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.cpp
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.cpp
@@ -39,11 +39,6 @@ App::App() noexcept {
   PackageProviders().Append(winrt::SampleLibraryCS::ReactPackageProvider());
 
   InitializeComponent();
-
-  // This works around a cpp/winrt bug with composable/aggregable types tracked
-  // by 22116519
-  AddRef();
-  m_inner.as<::IUnknown>()->Release();
 }
 
 } // namespace winrt::SampleAppCpp::implementation

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "ReactApplication.h"
 #include "ReactApplication.g.cpp"
+
 #include "Modules/LinkingManagerModule.h"
 #include "ReactNativeHost.h"
 
@@ -22,7 +23,16 @@ using namespace xaml::Navigation;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-ReactApplication::ReactApplication() noexcept {
+ReactApplication::ReactApplication() = default;
+
+ReactApplication::ReactApplication(IInspectable const &outer) noexcept : ReactApplication{} {
+  // The factory is usually called in the base generated class. We call it here to pass correct
+  // 'outer' interface to enable inheritance from the ReactApplication class in user code.
+  impl::call_factory<xaml::Application, xaml::IApplicationFactory>([&](xaml::IApplicationFactory const &f) {
+    [[maybe_unused]] auto winrt_impl_discarded =
+        f.CreateInstance(outer ? outer : static_cast<IInspectable const &>(*this), this->m_inner);
+  });
+
   Suspending({this, &ReactApplication::OnSuspending});
 
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
@@ -111,7 +121,7 @@ void ReactApplication::OnActivated(IActivatedEventArgs const &e) {
 }
 
 void ReactApplication::OnLaunched(LaunchActivatedEventArgs const &e) {
-  Super::OnLaunched(e);
+  base_type::OnLaunched(e);
   // auto args = std::wstring(e.Arguments().c_str());
   this->OnCreate(e);
 }

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
@@ -36,11 +36,6 @@ App::App() noexcept
     REACT_REGISTER_NATIVE_MODULE_PACKAGES(); //code-gen macro from autolink
 
     InitializeComponent();
-
-    // This works around a cpp/winrt bug with composable/aggregable types tracked
-    // by 22116519
-    AddRef();
-    m_inner.as<::IUnknown>()->Release();
 }
 
 


### PR DESCRIPTION
If user code directly inherits from the XAML `Application` class then it works just fine.
The issue is that if we inherit our `ReactApplication` from the XAML `Applicaiton`, and then user code inherits from the `ReacApplication`, then the C++/WinRT current COM aggregation fails to work correctly and we have a crash.

To work around the crash we have added the following lines to the user `App` constructor:
 ```C++
App::App() noexcept {
  ....
  // This works around a cpp/winrt bug with composable/aggregable types tracked
  // by 22116519
  AddRef();
  m_inner.as<::IUnknown>()->Release();
}
```

It was good for a quick workaround while we worked on the `ReactApplication` prototype, but in the long run this code has no place in user applications, especially the Windows bug number that has no meaning for non-Microsoft users.

In this PR we are implementing a work around inside of our `ReactApplication` suggested by @jevansaks. The change makes sure that we pass a correct pointer to the outer class for the COM aggregation to work. It allowed us to remove the work around bits from the sample and template code.

**IMPORTANT**: All previously created applications **MUST remove the work around code** mentioned above to work with the new Microsoft.ReactNative.dll. **Otherwise, they will crash.** The new solution frees the user code from the work-around, but this is also a requirement to have applications working.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4755)