### PR TITLE
Add a step in CI to upload verdaccio logs to diagnose package restore failures

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -143,3 +143,12 @@ steps:
     inputs:
       script: npx --no-install react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
       workingDirectory: $(Agent.BuildDirectory)\testcli
+  
+  # We are experiencing random package restore failures. Uploading the  vedaccio logs to aid in diagnosing if it is verdaccio or npmjs.org
+  - task: PublishPipelineArtifact@1
+    displayName: Upload Verdaccio.log (on failure)
+    inputs:
+      targetPath: 'verdaccio.log'
+      artifact: 'Verdaccio.log'
+      publishLocation: 'pipeline'
+    condition: failed()


### PR DESCRIPTION
We have seen random package restore failures in the CI for testing 'init' the packages are restored via a test server ([verdaccio](https://verdaccio.org/)). This adds a step in the [PR validation pipeline](https://dev.azure.com/ms/react-native-windows/_build?definitionId=210&_a=summary) to upload the verdaccio.log file (as configured in the [verdaccio yaml config file](https://github.com/microsoft/react-native-windows/blob/master/.ado/verdaccio/config.yaml)) 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4761)