### PR TITLE
Fix appPackage path in deploy.js

### DIFF
--- a/change/react-native-windows-2020-04-30-12-57-06-fix-apppackage-path.json
+++ b/change/react-native-windows-2020-04-30-12-57-06-fix-apppackage-path.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix appPackage path",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T19:57:06.111Z"
+}

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -192,8 +192,6 @@ async function deployToDesktop(options, verbose, slnFile) {
     }
   }
 
-  const popd = pushd(options.root);
-
   await runPowerShellScriptFunction(
     'Removing old version of the app',
     windowsStoreAppUtils,
@@ -260,7 +258,6 @@ async function deployToDesktop(options, verbose, slnFile) {
     newInfo('Skip the step to start the app');
   }
 
-  popd();
 }
 
 function startServerInNewWindow(options, verbose) {

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -45,7 +45,12 @@ function getAppPackage(options) {
     options.arch === 'x86'
       ? `{*_x86_${configuration}_*,*_Win32_${configuration}_*}`
       : `*_${options.arch}_${configuration}_*`;
-  const appPackageGlob = path.join(options.root, `windows/{*/AppPackages,AppPackages/*}/${packageFolder}`);
+
+  const appPackageGlob = path.join(
+    options.root,
+    `windows/{*/AppPackages,AppPackages/*}/${packageFolder}`,
+  );
+
   let appPackage = glob.sync(appPackageGlob)[0];
 
   if (!appPackage && options.release) {
@@ -53,8 +58,12 @@ function getAppPackage(options) {
     newWarn(
       'No package found in *_Release_* folder, remove _Release_ and check again',
     );
+
     appPackage = glob.sync(
-      path.join(options.root, `windows/{*/AppPackages,AppPackages/*}/*_${options.arch}_*`),
+      path.join(
+        options.root,
+        `windows/{*/AppPackages,AppPackages/*}/*_${options.arch}_*`,
+      ),
     )[0];
   }
 
@@ -257,7 +266,6 @@ async function deployToDesktop(options, verbose, slnFile) {
   } else {
     newInfo('Skip the step to start the app');
   }
-
 }
 
 function startServerInNewWindow(options, verbose) {

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -45,7 +45,7 @@ function getAppPackage(options) {
     options.arch === 'x86'
       ? `{*_x86_${configuration}_*,*_Win32_${configuration}_*}`
       : `*_${options.arch}_${configuration}_*`;
-  const appPackageGlob = `windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
+  const appPackageGlob = path.join(options.root, `windows/{*/AppPackages,AppPackages/*}/${packageFolder}`);
   let appPackage = glob.sync(appPackageGlob)[0];
 
   if (!appPackage && options.release) {
@@ -54,7 +54,7 @@ function getAppPackage(options) {
       'No package found in *_Release_* folder, remove _Release_ and check again',
     );
     appPackage = glob.sync(
-      `windows/{*/AppPackages,AppPackages/*}/*_${options.arch}_*`,
+      path.join(options.root, `windows/{*/AppPackages,AppPackages/*}/*_${options.arch}_*`),
     )[0];
   }
 

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -46,11 +46,9 @@ function getAppPackage(options) {
       ? `{*_x86_${configuration}_*,*_Win32_${configuration}_*}`
       : `*_${options.arch}_${configuration}_*`;
 
-  const appPackageGlob = path.join(
-    options.root,
-    `windows/{*/AppPackages,AppPackages/*}/${packageFolder}`,
-  );
-
+  const appPackageGlob = `${
+    options.root
+  }/windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
   let appPackage = glob.sync(appPackageGlob)[0];
 
   if (!appPackage && options.release) {
@@ -60,10 +58,9 @@ function getAppPackage(options) {
     );
 
     appPackage = glob.sync(
-      path.join(
-        options.root,
-        `windows/{*/AppPackages,AppPackages/*}/*_${options.arch}_*`,
-      ),
+      `${options.root}/windows/{*/AppPackages,AppPackages/*}/*_${
+        options.arch
+      }_*`,
     )[0];
   }
 


### PR DESCRIPTION
The deploy script couldn't find the app package when `react-native run-windows` specifies a `--root` argument since it's searching for the hard coded windows folder.

Joining `options.root` with the existing search path to fix the issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4762)