### PR TITLE
Delay load ChakraCore.dll

### DIFF
--- a/change/react-native-windows-2020-05-01-15-34-56-master.json
+++ b/change/react-native-windows-2020-05-01-15-34-56-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Delay load ChakraCore.dll",
+  "packageName": "react-native-windows",
+  "email": "tudorm@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-01T22:34:56.237Z"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -94,7 +94,7 @@
       we have a better solution for handling the absence of WinRT string and error DLLs on Win7.
       -->
       <AdditionalDependencies>WindowsApp_downlevel.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-string-l1-1-0.dll;ChakraCore.Debugger.DLL;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-string-l1-1-0.dll;ChakraCore.Debugger.DLL;ChakraCore.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">


### PR DESCRIPTION
For the win32 binary, delay load ChakraCore.dll to avoid paying the memory mapping cost if you're using a different engine.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4773)