### PR TITLE
Treat yes the same as y in template overwrite prompt

### DIFF
--- a/change/react-native-windows-2020-05-05-08-23-01-promptyes.json
+++ b/change/react-native-windows-2020-05-05-08-23-01-promptyes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Treat yes the same as y in template overwrite prompt",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-05T15:23:01.596Z"
+}

--- a/vnext/local-cli/generator-common/index.js
+++ b/vnext/local-cli/generator-common/index.js
@@ -76,14 +76,17 @@ function upgradeFileContentChangedCallback(
     console.log(
       `${chalk.bold(relativeDestPath)} ` +
       `has changed in the new version.\nDo you want to keep your ${relativeDestPath} or replace it with the ` +
-      'latest version?\nIf you ever made any changes ' +
-      'to this file, you\'ll probably want to keep it.\n' +
+      'latest version?\nMake sure you have any changes you made to this file saved somewhere.\n' +
       `You can see the new version here: ${absoluteSrcFilePath}\n` +
       `Do you want to replace ${relativeDestPath}? ` +
       'Answer y to replace, n to keep your version: '
     );
-    const answer = prompt();
-    if (answer === 'y') {
+    let answer;
+    while (!answer) {
+       answer = prompt();
+    }
+
+    if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
       console.log(`Replacing ${relativeDestPath}`);
       return 'overwrite';
     }


### PR DESCRIPTION
I just failed to correctly init a windows RN app because I typed 'yes' to overwrite the metro config, instead of 'y'.  

This makes 'yes' be treated the same way as 'y'.

Long term, I'd like to unify on the prompt we use in react-native-windows-init, but that call is async, and would require more refactoring of the template code.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4788)