### PR TITLE
Ensure WebSocket write lifetime

### DIFF
--- a/change/react-native-windows-2020-05-04-19-05-45-OC-4133953-pwrav.json
+++ b/change/react-native-windows-2020-05-04-19-05-45-OC-4133953-pwrav.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Promote awaitable DispatchQueue callback to member field",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-05T02:05:45.427Z"
+}

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -66,16 +66,16 @@ namespace
 
       void await_suspend(std::experimental::coroutine_handle<> resume)
       {
-        m_callBack = [context = resume.address()]() noexcept
+        m_callback = [context = resume.address()]() noexcept
         {
           std::experimental::coroutine_handle<>::from_address(context)();
         };
-        m_queue.Post(std::move(m_callBack));
+        m_queue.Post(std::move(m_callback));
       }
 
     private:
       Mso::DispatchQueue m_queue;
-      Mso::VoidFunctor m_callBack;
+      Mso::VoidFunctor m_callback;
     };
 
     return awaitable{ queue };

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -66,14 +66,16 @@ namespace
 
       void await_suspend(std::experimental::coroutine_handle<> resume)
       {
-        m_queue.Post([context = resume.address()]() noexcept
+        m_callBack = [context = resume.address()]() noexcept
         {
           std::experimental::coroutine_handle<>::from_address(context)();
-        });
+        };
+        m_queue.Post(std::move(m_callBack));
       }
 
     private:
       Mso::DispatchQueue m_queue;
+      Mso::VoidFunctor m_callBack;
     };
 
     return awaitable{ queue };


### PR DESCRIPTION
Resume point in `WinRTWebSocketResource::PerformWrite` is represented as a functor when awaited by the member `Mso::DispatchQueue`.

Such functor is currently implicitly created within `resume_on_queue::await_suspend` in the stack.

This change makes the functor a member variable so no stack allocations happen within `await_suspend`.

See https://devblogs.microsoft.com/oldnewthing/20191209-00/?p=103195
Note: work in progress.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4790)