### PR TITLE
Support --version file:<path> for running init against local changes

### DIFF
--- a/change/react-native-windows-init-2020-05-05-12-50-32-cli.json
+++ b/change/react-native-windows-init-2020-05-05-12-50-32-cli.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Support --version file:<path> for running init against local changes",
+  "packageName": "react-native-windows-init",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-05T19:50:32.625Z"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -49,7 +49,6 @@ const argv = yargs.version(false).options({
   },
 }).argv;
 
-const EXITCODE_NO_MATCHING_RNW = 2;
 const EXITCODE_UNSUPPORTED_VERION_RN = 3;
 const EXITCODE_USER_CANCEL = 4;
 const EXITCODE_NO_REACTNATIVE_FOUND = 5;
@@ -254,10 +253,11 @@ function isProjectUsingYarn(cwd: string) {
 
     if (!rnwResolvedVersion) {
       if (argv.version) {
-        console.error(
-          `Error: No version of react-native-windows@${argv.version} found`,
+        console.warn(
+          `Warning: Querying npm to find react-native-windows@${
+            argv.version
+          } failed.  Attempting to continue anyway...`,
         );
-        process.exit(EXITCODE_NO_MATCHING_RNW);
       } else {
         const rnwLatestVersion = await getLatestRNWVersion();
         console.error(


### PR DESCRIPTION
For testing local changes to the template, its useful to be able to specify a filepath to a local react-native-windows package to use as a template.

With this you can now do something like:
```cmd
npx react-native init myProject --template react-native@^0.62
cd myProject
npx react-native-windows-init --version file:d:\repos\react-native-windows\vnext
```
 
Note that yarn does a copy of all the files under vnext to install react-native-windows.  Unlike when the package has been published, this will include all the native built files which would normally be excluded by npmignore.  Its probably better to clean your native built bits before running this command.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4794)