### PR TITLE
Don't bundle during intellisense

### DIFF
--- a/change/react-native-windows-2020-05-05-19-47-51-dontBundleDuringIntellisense.json
+++ b/change/react-native-windows-2020-05-05-19-47-51-dontBundleDuringIntellisense.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Only bundle when not running Intellisense builds",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-06T02:47:51.102Z"
+}

--- a/vnext/PropertySheets/Bundle.Common.targets
+++ b/vnext/PropertySheets/Bundle.Common.targets
@@ -5,7 +5,7 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="MakeBundle" BeforeTargets="PrepareForBuild" 
-      Condition="'$(UseBundle)' == 'true'">
+      Condition="'$(UseBundle)' == 'true' And ('$(BuildingInsideVisualStudio)'!='true' Or '$(BuildingProject)'=='true')">
         <MakeDir Directories="$(BundleContentRoot)" Condition=" !Exists('$(BundleContentRoot)') and '$(BundleContentRoot)' != '' " />
         <MakeDir Directories="$([MSBuild]::MakeRelative($(ProjectDir), $(BundleSourceMapDir)))" Condition=" !Exists('$([MSBuild]::MakeRelative($(ProjectDir), $(BundleSourceMapDir)))') and '$(BundleSourceMapDir)' != '' " />
         <Message Importance="High" Text="Running [$(BundleCliCommand) --platform windows --entry-file $(BundleEntryFile) --bundle-output $([MSBuild]::NormalizePath('$(BundleOutputPath)\$(BundleAssetName)')) --assets-dest $(BundleContentRoot) --dev $(UseDevBundle) --reset-cache --sourcemap-output $([MSBuild]::MakeRelative($(BundleCommandWorkingDir), $([MSBuild]::NormalizePath('$(BundleSourceMapDir)\$(BundleAssetName).map')))) $(BundlerExtraArgs)] to build bundle file." />


### PR DESCRIPTION
Fixes #4777 
the VS UI will hang when switching configuration to Release, because the Release build runs the bundler, and we run a build for Intellisense. However we don't need the bundler to run during intellisense so adding a check to exclude this task if either: running in VS and not running in VS "Build Project" mode (the condition is a little weird because it's negated).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4800)