### PR TITLE
Disable CxxFrameHandler4 

### DIFF
--- a/change/react-native-windows-2020-05-06-05-03-56-no-fh4.json
+++ b/change/react-native-windows-2020-05-06-05-03-56-no-fh4.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Disable CxxFrameHandler4",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-06T12:03:56.512Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -103,6 +103,19 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <!--
+    #4804: CxxFrameHandler4 leads to generated code that incompatible with VS
+    2015 and 2017. Disable it until consumers are updated or on an ABI-safe API
+  -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>/d2FH4- %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalOptions>/d2:-FH4- %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(ConfigurationType)' == 'Application' OR '$(ConfigurationType)' == 'DynamicLibrary'">
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
V142 Build tools turn on FH4 (CxxFrameHandler4) by default. This reduces the size of EH maps, but leads to incompatibility with code compiled using older toolsets. This is an issue for cosnumers that are not yet on Microsoft.ReactNative,

Disable FH4 until consumers (i.e. Office) are on an ABI-safe API or are updated.

Microsoft.ReactNative.dll x64 Release Size:
Before: 2,139 KB
After: 2,294 KB

Removal tracked by #4804

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4805)