### PR TITLE
Ensure InitializeCore is run before app code

### DIFF
--- a/change/@office-iss-react-native-win32-2020-05-06-14-34-01-fixfast.json
+++ b/change/@office-iss-react-native-win32-2020-05-06-14-34-01-fixfast.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure InitializeCore is run before app code",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-06T21:33:58.938Z"
+}

--- a/change/react-native-windows-2020-05-06-14-34-01-fixfast.json
+++ b/change/react-native-windows-2020-05-06-14-34-01-fixfast.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure InitializeCore is run before app code",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-06T21:34:00.993Z"
+}

--- a/packages/E2ETest/metro.config.js
+++ b/packages/E2ETest/metro.config.js
@@ -6,6 +6,10 @@
  */
 const path = require('path');
 const blacklist = require('metro-config/src/defaults/blacklist');
+const {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+} = require('react-native-windows/metro-react-native-platform');
 
 const rnwPath = path.resolve(__dirname, '../../vnext');
 
@@ -19,9 +23,9 @@ module.exports = {
   ],
 
   resolver: {
-    resolveRequest: require('react-native-windows/metro-react-native-platform').reactNativePlatformResolver(
-      { windows: 'react-native-windows' }
-    ),
+    resolveRequest: reactNativePlatformResolver({
+      windows: 'react-native-windows',
+    }),
     extraNodeModules: {
       // Redirect metro to rnwPath instead of node_modules/react-native-windows, since metro doesn't like symlinks
       'react-native-windows': rnwPath,
@@ -33,6 +37,9 @@ module.exports = {
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`
       ),
     ]),
+  },
+  serializer: {
+    getModulesRunBeforeMainModule,
   },
   transformer: {
     // The cli defaults this to a full path to react-native, which bypasses the reactNativePlatformResolver above

--- a/packages/microsoft-reactnative-sampleapps/metro.config.js
+++ b/packages/microsoft-reactnative-sampleapps/metro.config.js
@@ -6,6 +6,10 @@
  */
 const path = require('path');
 const blacklist = require('metro-config/src/defaults/blacklist');
+const {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+} = require('react-native-windows/metro-react-native-platform');
 
 const rnwPath = path.resolve(__dirname, '../../vnext');
 
@@ -19,9 +23,9 @@ module.exports = {
   ],
 
   resolver: {
-    resolveRequest: require('react-native-windows/metro-react-native-platform').reactNativePlatformResolver(
-      {windows: 'react-native-windows'},
-    ),
+    resolveRequest: reactNativePlatformResolver({
+      windows: 'react-native-windows',
+    }),
     extraNodeModules: {
       // Redirect metro to rnwPath instead of node_modules/react-native-windows, since metro doesn't like symlinks
       'react-native-windows': rnwPath,
@@ -35,6 +39,9 @@ module.exports = {
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
       ),
     ]),
+  },
+  serializer: {
+    getModulesRunBeforeMainModule,
   },
   transformer: {
     // The cli defaults this to a full path to react-native, which bypasses the reactNativePlatformResolver above

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -7,6 +7,10 @@
 const fs = require('fs');
 const path = require('path');
 const blacklist = require('metro-config/src/defaults/blacklist');
+const {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+} = require('react-native-windows/metro-react-native-platform');
 
 const rnwPath = fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),
@@ -22,9 +26,9 @@ module.exports = {
   ],
 
   resolver: {
-    resolveRequest: require('react-native-windows/metro-react-native-platform').reactNativePlatformResolver(
-      {windows: 'react-native-windows'},
-    ),
+    resolveRequest: reactNativePlatformResolver({
+      windows: 'react-native-windows',
+    }),
     extraNodeModules: {
       // Redirect react-native-windows to avoid symlink (metro doesn't like symlinks)
       'react-native-windows': rnwPath,
@@ -35,6 +39,9 @@ module.exports = {
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
       ),
     ]),
+  },
+  serializer: {
+    getModulesRunBeforeMainModule,
   },
   transformer: {
     // The cli defaults this to a full path to react-native, which bypasses the reactNativePlatformResolver above

--- a/packages/react-native-win32/metro-react-native-platform.js
+++ b/packages/react-native-win32/metro-react-native-platform.js
@@ -38,4 +38,49 @@ function reactNativePlatformResolver(platformImplementations) {
   };
 }
 
-module.exports = {reactNativePlatformResolver};
+/**
+ * The CLI will get a more complete implementation of this in https://github.com/react-native-community/cli/pull/1115
+ * but until then, use a solution that supports having react-native-win32 and/or react-native-windows and/or react-native-macos
+ */
+const getModulesRunBeforeMainModule = () => {
+  const options = {
+    paths: [process.cwd()],
+  };
+  const modules = [
+    require.resolve('react-native/Libraries/Core/InitializeCore', options),
+  ];
+
+  try {
+    modules.push(
+      require.resolve(
+        '@office-iss/react-native-win32/Libraries/Core/InitializeCore',
+        options,
+      ),
+    );
+  } catch {}
+
+  try {
+    modules.push(
+      require.resolve(
+        'react-native-windows/Libraries/Core/InitializeCore',
+        options,
+      ),
+    );
+  } catch {}
+
+  try {
+    modules.push(
+      require.resolve(
+        'react-native-macos/Libraries/Core/InitializeCore',
+        options,
+      ),
+    );
+  } catch {}
+
+  return modules;
+};
+
+module.exports = {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+};

--- a/packages/react-native-win32/metro.config.js
+++ b/packages/react-native-win32/metro.config.js
@@ -3,6 +3,10 @@
  */
 const fs = require('fs');
 const path = require('path');
+const {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+} = require('./metro-react-native-platform');
 
 module.exports = {
   // WatchFolders is only needed due to the yarn workspace layout of node_modules, we need to watch the symlinked locations separately
@@ -12,9 +16,12 @@ module.exports = {
   ],
 
   resolver: {
-    resolveRequest: require('./metro-react-native-platform').reactNativePlatformResolver(
-      {win32: '@office-iss/react-native-win32'},
-    ),
+    resolveRequest: reactNativePlatformResolver({
+      win32: '@office-iss/react-native-win32',
+    }),
+  },
+  serializer: {
+    getModulesRunBeforeMainModule,
   },
   transformer: {
     // The cli defaults this to a full path to react-native, which bypasses the reactNativePlatformResolver above

--- a/vnext/local-cli/generator-windows/templates/metro.config.js
+++ b/vnext/local-cli/generator-windows/templates/metro.config.js
@@ -7,11 +7,16 @@
 const path = require('path');
 const blacklist = require('metro-config/src/defaults/blacklist');
 
+const {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+} = require('react-native-windows/metro-react-native-platform');
+
 module.exports = {
   resolver: {
-    resolveRequest: require('react-native-windows/metro-react-native-platform').reactNativePlatformResolver(
-      {windows: 'react-native-windows'},
-    ),
+    resolveRequest: reactNativePlatformResolver({
+      windows: 'react-native-windows',
+    }),
     blacklistRE: blacklist([
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
@@ -24,6 +29,9 @@ module.exports = {
           .replace(/[/\\]/g, '/')}.*`,
       ),
     ]),
+  },
+  serializer: {
+    getModulesRunBeforeMainModule,
   },
   transformer: {
     // The cli defaults this to a full path to react-native, which bypasses the reactNativePlatformResolver above

--- a/vnext/metro-react-native-platform.js
+++ b/vnext/metro-react-native-platform.js
@@ -38,4 +38,40 @@ function reactNativePlatformResolver(platformImplementations) {
   };
 }
 
-module.exports = {reactNativePlatformResolver};
+/**
+ * The CLI will get a more complete implementation of this in https://github.com/react-native-community/cli/pull/1115
+ * but until then, use a solution that supports having react-native-windows and/or react-native-macos
+ */
+const getModulesRunBeforeMainModule = () => {
+  const options = {
+    paths: [process.cwd()],
+  };
+  const modules = [
+    require.resolve('react-native/Libraries/Core/InitializeCore', options),
+  ];
+
+  try {
+    modules.push(
+      require.resolve(
+        'react-native-windows/Libraries/Core/InitializeCore',
+        options,
+      ),
+    );
+  } catch {}
+
+  try {
+    modules.push(
+      require.resolve(
+        'react-native-macos/Libraries/Core/InitializeCore',
+        options,
+      ),
+    );
+  } catch {}
+
+  return modules;
+};
+
+module.exports = {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+};

--- a/vnext/metro.config.js
+++ b/vnext/metro.config.js
@@ -3,7 +3,11 @@
  */
 const fs = require('fs');
 const path = require('path');
-const blacklist = require('metro-config/src/defaults/blacklist');
+
+const {
+  getModulesRunBeforeMainModule,
+  reactNativePlatformResolver,
+} = require('react-native-windows/metro-react-native-platform');
 
 const rnwPath = __dirname;
 
@@ -15,17 +19,20 @@ module.exports = {
   ],
 
   resolver: {
-    resolveRequest: require('./metro-react-native-platform').reactNativePlatformResolver(
-      {
-        windesktop: 'react-native-windows',
-        windows: 'react-native-windows',
-      },
-    ),
+    resolveRequest: reactNativePlatformResolver({
+      windesktop: 'react-native-windows',
+      windows: 'react-native-windows',
+    }),
     extraNodeModules: {
       // Redirect react-native-windows to this folder
       'react-native-windows': rnwPath,
     },
   },
+
+  serializer: {
+    getModulesRunBeforeMainModule,
+  },
+
   transformer: {
     // The cli defaults this to a full path to react-native, which bypasses the reactNativePlatformResolver above
     // Hopefully we can fix the default in the future


### PR DESCRIPTION
Fixes #4779 

The reason fast refresh wasn't working is that fast refresh requires a custom implementation of require to be used within the bundle.  That implementation of require expects a custom property 'Refresh' to be set on it.  That variable is set by 'setupReactRefresh', which is one of the things that InitializeCore does.

The solution to allow metro to work on all platforms at once caused the default config of metro to not run InitializeCore before other modules.

This happened because the default react-native config of metro uses a full path to react-native's InitializeCore to tell metro to require that module before the main entry file of the apps.  Metro silently ignores paths in getModulesRunBeforeMainModule that are not part of the bundle. Since we use InitializeCore from react-native-windows, the module specified in getModulesRunBeforeMainModule was just ignored.

The change here adds the path to InitializeCore from react-native, react-native-windows and react-native-macos to the config.  That way which ever of those modules ends up in the bundle will be required before the apps main entry file.

All of this custom metro config will be replaced by https://github.com/react-native-community/cli/pull/1115 which will fix the defaults in the CLI.  (But hopefully we can work through all these kinds of issues before we get that merged)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4814)