### PR TITLE
[0.60] Ensure WebSocket write lifetime

### DIFF
--- a/change/react-native-windows-2020-05-06-21-22-41-OC-4133953-pwrav-60.json
+++ b/change/react-native-windows-2020-05-06-21-22-41-OC-4133953-pwrav-60.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Promote PerformWrite queue await callback to member",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "commit": "fcb72e0b5e232b261623fd1c3f5266dc2c38d2b3",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T04:22:41.521Z"
+}

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -15,6 +15,7 @@ using namespace folly;
 
 using Microsoft::Common::Unicode::Utf8ToUtf16;
 
+using std::shared_ptr;
 using std::string;
 using std::weak_ptr;
 
@@ -24,7 +25,15 @@ constexpr char moduleName[] = "WebSocketModule";
 
 namespace Microsoft::React {
 
-WebSocketModule::WebSocketModule() {}
+WebSocketModule::WebSocketModule()
+    : m_resourceFactory{[](const string &url, bool legacyImplementation, bool acceptSelfSigned) {
+        return IWebSocketResource::Make(url, legacyImplementation, acceptSelfSigned);
+      }} {}
+
+void WebSocketModule::SetResourceFactory(
+    std::function<shared_ptr<IWebSocketResource>(const string &, bool, bool)> &&resourceFactory) {
+  m_resourceFactory = std::move(resourceFactory);
+}
 
 string WebSocketModule::getName() {
   return moduleName;
@@ -146,8 +155,7 @@ std::shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_
   auto itr = m_webSockets.find(id);
   if (itr == m_webSockets.end())
   {
-    // #4559: Revert legacyImplementation or set externally.
-    auto ws = IWebSocketResource::Make(std::move(url), /*legacyImplementation*/ true);
+    auto ws = m_resourceFactory(std::move(url), /*legacyImplementation*/ false, /*acceptSelfSigned*/ false);
     auto weakInstance = this->getInstance();
     ws->SetOnError([this, id, weakInstance](const IWebSocketResource::Error& err)
     {

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -24,7 +24,7 @@ IWebSocketResource::Make(const string &urlString, bool legacyImplementation, boo
       certExceptions.emplace_back(
           winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
     }
-    return make_shared<WinRTWebSocketResource>(urlString, certExceptions);
+    return make_shared<WinRTWebSocketResource>(urlString, std::move(certExceptions));
   } else {
     Url url(urlString);
 

--- a/vnext/ReactWindowsCore/Modules/WebSocketModule.h
+++ b/vnext/ReactWindowsCore/Modules/WebSocketModule.h
@@ -18,21 +18,28 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
 
   WebSocketModule();
 
+#pragma region CxxModule overrides
+
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getName" />
   /// </summary>
-  std::string getName();
+  std::string getName() override;
 
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getConstants" />
   /// </summary>
-  virtual std::map<std::string, folly::dynamic> getConstants();
+  std::map<std::string, folly::dynamic> getConstants() override;
 
   /// <summary>
   /// <see cref="facebook::xplat::module::CxxModule::getMethods" />
   /// </summary>
   /// <remarks>See See react-native/Libraries/WebSocket/WebSocket.js</remarks>
-  virtual std::vector<Method> getMethods();
+  std::vector<Method> getMethods() override;
+
+#pragma endregion CxxModule overrides
+
+  void SetResourceFactory(
+      std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> &&resourceFactory = nullptr);
 
  private:
   /// <summary>
@@ -50,6 +57,11 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// As defined in WebSocket.js.
   /// </summary>
   std::map<int64_t, std::shared_ptr<IWebSocketResource>> m_webSockets;
+
+  /// <summary>
+  /// Generates IWebSocketResource instances, defaulting to IWebSocketResource::Make.
+  /// </summary>
+  std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> m_resourceFactory;
 };
 
 } // namespace Microsoft::React

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -391,7 +391,7 @@ void WinRTWebSocketResource::Send(const string& message)
 
 void WinRTWebSocketResource::SendBinary(const string& base64String)
 {
-  m_writeQueue.push({ base64String, false });
+  m_writeQueue.push({ base64String, true });
 
   PerformWrite();
 }

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.h
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.h
@@ -20,9 +20,10 @@ namespace Microsoft::React {
 
 class WinRTWebSocketResource : public IWebSocketResource, public std::enable_shared_from_this<WinRTWebSocketResource> {
   winrt::Windows::Foundation::Uri m_uri;
-  winrt::Windows::Networking::Sockets::MessageWebSocket m_socket;
-  winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_revoker;
-  winrt::Windows::Storage::Streams::DataWriter m_writer{m_socket.OutputStream()};
+  winrt::Windows::Networking::Sockets::IMessageWebSocket m_socket;
+  // TODO: Use or remove.
+  winrt::Windows::Networking::Sockets::IMessageWebSocket::MessageReceived_revoker m_revoker;
+  winrt::Windows::Storage::Streams::IDataWriter m_writer;
 
   Mso::DispatchQueue m_dispatchQueue;
   Mso::ManualResetEvent m_closePerformed;
@@ -44,6 +45,7 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   std::function<void(Error &&)> m_errorHandler;
 
   WinRTWebSocketResource(
+      winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Foundation::Uri &&uri,
       std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions);
 
@@ -54,13 +56,20 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
 
   void OnMessageReceived(
       winrt::Windows::Networking::Sockets::IWebSocket const &sender,
-      winrt::Windows::Networking::Sockets::MessageWebSocketMessageReceivedEventArgs const &args);
+      winrt::Windows::Networking::Sockets::IMessageWebSocketMessageReceivedEventArgs const &args);
   void Synchronize();
 
  public:
   WinRTWebSocketResource(
+      winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
+      winrt::Windows::Storage::Streams::IDataWriter &&writer,
+      winrt::Windows::Foundation::Uri &&uri,
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
+
+  WinRTWebSocketResource(
       const std::string &urlString,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
+
   ~WinRTWebSocketResource() override;
 
 #pragma region IWebSocketResource


### PR DESCRIPTION
Backport of #4790

Resume point in `WinRTWebSocketResource::PerformWrite` is represented as a functor when awaited by the member `Mso::DispatchQueue`.

Such functor is currently implicitly created within `resume_on_queue::await_suspend` in the stack.

This change makes the functor a member variable so no stack allocations happen within `await_suspend`.

See https://devblogs.microsoft.com/oldnewthing/20191209-00/?p=103195

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4818)