### PR TITLE
The react-native repo was renamed, this fixes the 0.60 branch to handle that

### DIFF
--- a/change/@office-iss-react-native-win32-2020-05-07-09-53-55-renamerepo.json
+++ b/change/@office-iss-react-native-win32-2020-05-07-09-53-55-renamerepo.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Handle rename of react-native-macos repo",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates@microsoft.com",
+  "commit": "bba1032d0bf1a6cbb3806488efdf757f5056ff42",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T16:53:51.150Z"
+}

--- a/change/react-native-windows-2020-05-07-09-53-55-renamerepo.json
+++ b/change/react-native-windows-2020-05-07-09-53-55-renamerepo.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Handle rename of react-native-macos repo",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "commit": "bba1032d0bf1a6cbb3806488efdf757f5056ff42",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T16:53:55.810Z"
+}

--- a/change/react-native-windows-extended-2020-05-07-09-53-55-renamerepo.json
+++ b/change/react-native-windows-extended-2020-05-07-09-53-55-renamerepo.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "comment": "Handle rename of react-native-macos repo",
+  "packageName": "react-native-windows-extended",
+  "email": "acoates@microsoft.com",
+  "commit": "bba1032d0bf1a6cbb3806488efdf757f5056ff42",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T16:53:54.491Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "react-native-windows": "0.60.0-vnext.164",
     "react-native-windows-extended": "0.60.69-46",
     "rnpm-plugin-windows": "^0.4.1"

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "react-native-windows": "0.60.0-vnext.164",
     "react-native-windows-extended": "0.60.69-46",
     "rnpm-plugin-windows": "^0.4.1"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "react-native-windows": "0.60.0-vnext.164",
     "react-native-windows-extended": "0.60.69-46",
     "rnpm-plugin-windows": "^0.4.1"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -41,7 +41,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "@office-iss/rex-win32": "0.0.33",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -56,7 +56,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "react": "16.8.6"
   },
   "beachball": {

--- a/packages/react-native-windows-extended/package.json
+++ b/packages/react-native-windows-extended/package.json
@@ -34,12 +34,12 @@
     "just-scripts": "^0.24.2",
     "prettier": "1.13.6",
     "react": "16.8.6",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
+    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -51,13 +51,13 @@
     "jscodeshift": "^0.6.2",
     "just-scripts": "^0.24.2",
     "prettier": "1.17.0",
-    "react-native": "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz",
+    "react-native": "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz",
     "react": "16.8.6",
     "typescript": "3.5.3"
   },
   "peerDependencies": {
     "react": "16.8.6",
-    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz"
+    "react-native": "^0.60.0-0 || https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz"
   },
   "beachball": {
     "defaultNpmTag": "v0.60-stable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10962,9 +10962,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-"react-native@https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz":
+"react-native@https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz":
   version "0.60.0-microsoft.40"
-  resolved "https://github.com/microsoft/react-native/archive/v0.60.0-microsoft.40.tar.gz#ce39a3d9368de1cee08e261e4fe92d86299ded08"
+  uid "18390dc87a000023e40412e5244c8577b459ffe5"
+  resolved "https://github.com/microsoft/react-native-macos/archive/v0.60.0-microsoft.40.tar.gz#18390dc87a000023e40412e5244c8577b459ffe5"
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^2.6.0"


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4822)