### PR TITLE
Align local metro config with future CLI changes

### DIFF
--- a/change/@office-iss-react-native-win32-2020-05-07-14-18-13-clifeedback.json
+++ b/change/@office-iss-react-native-win32-2020-05-07-14-18-13-clifeedback.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Align local metro config with future CLI changes",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T21:18:12.974Z"
+}

--- a/change/react-native-windows-2020-05-07-14-18-13-clifeedback.json
+++ b/change/react-native-windows-2020-05-07-14-18-13-clifeedback.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Align local metro config with future CLI changes",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T21:18:13.813Z"
+}

--- a/packages/react-native-win32/metro-react-native-platform.js
+++ b/packages/react-native-win32/metro-react-native-platform.js
@@ -29,11 +29,11 @@ function reactNativePlatformResolver(platformImplementations) {
         }
       }
       let result = resolve(context, modifiedModuleName, platform);
-      context.resolveRequest = backupResolveRequest;
       return result;
     } catch (e) {
-      context.resolveRequest = backupResolveRequest;
       throw e;
+    } finally {
+      context.resolveRequest = backupResolveRequest;
     }
   };
 }

--- a/vnext/metro-react-native-platform.js
+++ b/vnext/metro-react-native-platform.js
@@ -29,11 +29,11 @@ function reactNativePlatformResolver(platformImplementations) {
         }
       }
       let result = resolve(context, modifiedModuleName, platform);
-      context.resolveRequest = backupResolveRequest;
       return result;
     } catch (e) {
-      context.resolveRequest = backupResolveRequest;
       throw e;
+    } finally {
+      context.resolveRequest = backupResolveRequest;
     }
   };
 }


### PR DESCRIPTION
In https://github.com/react-native-community/cli/pull/1115 some minor code review feedback slightly modified the metro config.  I want our local copy that we are using until the CLI has this logic to match the CLI version as much as possible to catch issues, so I'm applying those changes here too.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4827)