### PR TITLE
Correct WebSocket binary message tagging

### DIFF
--- a/change/react-native-windows-2020-05-07-18-29-02-enable-binaryws.json
+++ b/change/react-native-windows-2020-05-07-18-29-02-enable-binaryws.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Correct binary message tagging",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-08T01:29:02.376Z"
+}

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -391,7 +391,7 @@ void WinRTWebSocketResource::Send(const string& message)
 
 void WinRTWebSocketResource::SendBinary(const string& base64String)
 {
-  m_writeQueue.push({ base64String, false });
+  m_writeQueue.push({ base64String, true });
 
   PerformWrite();
 }


### PR DESCRIPTION
`SendBinary` was incorrectly enqueuing messages as non-binary.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4829)