### PR TITLE
[0.61] Ensure WebSocket write lifetime

### DIFF
--- a/change/react-native-windows-2020-05-07-18-34-56-OC-4133953-pwrav-61.json
+++ b/change/react-native-windows-2020-05-07-18-34-56-OC-4133953-pwrav-61.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure WebSocket write lifetime",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-08T01:34:56.237Z"
+}

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -314,7 +314,7 @@ void WinRTWebSocketResource::Send(const string &message) {
 }
 
 void WinRTWebSocketResource::SendBinary(const string &base64String) {
-  m_writeQueue.push({base64String, false});
+  m_writeQueue.push({base64String, true});
 
   PerformWrite();
 }

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -55,13 +55,15 @@ auto resume_in_queue(const Mso::DispatchQueue &queue) {
     void await_resume() const noexcept {}
 
     void await_suspend(std::experimental::coroutine_handle<> resume) {
-      m_queue.Post([context = resume.address()]() noexcept {
+      m_callback = [context = resume.address()]() noexcept {
         std::experimental::coroutine_handle<>::from_address(context)();
-      });
+      };
+      m_queue.Post(std::move(m_callback));
     }
 
    private:
     Mso::DispatchQueue m_queue;
+    Mso::VoidFunctor m_callback;
   };
 
   return awaitable{queue};


### PR DESCRIPTION
Backport of #4790 and #4829

Resume point in `WinRTWebSocketResource::PerformWrite` is represented as a functor when awaited by the member `Mso::DispatchQueue`.

Such functor is currently implicitly created within `resume_on_queue::await_suspend` in the stack.

This change makes the functor a member variable so no stack allocations happen within `await_suspend`.

See https://devblogs.microsoft.com/oldnewthing/20191209-00/?p=103195

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4830)