### PR TITLE
[0.62] Correct WebSocket binary message tagging

### DIFF
--- a/change/react-native-windows-2020-05-07-18-50-32-enable-binaryws-62.json
+++ b/change/react-native-windows-2020-05-07-18-50-32-enable-binaryws-62.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Correct binary message tagging",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-08T01:50:32.635Z"
+}

--- a/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
+++ b/vnext/ReactWindowsCore/WinRTWebSocketResource.cpp
@@ -381,7 +381,7 @@ void WinRTWebSocketResource::Send(const string& message)
 
 void WinRTWebSocketResource::SendBinary(const string& base64String)
 {
-  m_writeQueue.push({ base64String, false });
+  m_writeQueue.push({ base64String, true });
 
   PerformWrite();
 }


### PR DESCRIPTION
`SendBinary` was incorrectly enqueuing messages as non-binary.

Backport of #4829

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4831)