### PR TITLE
Improve run_wdio to print out failed tests

### DIFF
--- a/packages/E2ETest/run_wdio.js
+++ b/packages/E2ETest/run_wdio.js
@@ -92,12 +92,13 @@ function parseLog(logfile) {
               failures[name].testcase = testcases[j].ATTR.name;
               failures[name].error = testcases[j].error[0].ATTR.message;
               const systemErr = testcases[j]['system-err'][0];
-              const stack = systemErr.substr(systemErr.indexOf('\n    at ') + 1);
+              const stack = systemErr.substr(
+                systemErr.indexOf('\n    at ') + 1
+              );
               failures[name].stack = stack;
             }
           }
         }
-
       }
     }
   });
@@ -117,7 +118,11 @@ function PrintFailedTests(ft) {
   for (let i = 0; i < Object.keys(ft).length; i++) {
     const key = Object.keys(ft)[i];
     console.log(chalk.redBright(key));
-    console.log('  ', chalk.underline('testcase'), chalk.bold(ft[key].testcase));
+    console.log(
+      '  ',
+      chalk.underline('testcase'),
+      chalk.bold(ft[key].testcase)
+    );
     console.log('  ', chalk.underline('error'), chalk.bold(ft[key].error));
     console.log('  ', chalk.underline('stack'));
     console.log(ft[key].stack);

--- a/packages/E2ETest/run_wdio.js
+++ b/packages/E2ETest/run_wdio.js
@@ -4,6 +4,7 @@ const xml2js = require('xml2js');
 const parser = new xml2js.Parser({ attrkey: 'ATTR' });
 const child_process = require('child_process');
 const prompt = require('prompt-sync')();
+const chalk = require('chalk');
 
 const specFolder = 'wdio/test';
 
@@ -53,7 +54,7 @@ function SelectSpecs(folder) {
 let opts = SelectSpecs(specFolder);
 console.log(`Selected tests: ${opts}`);
 
-function OverrideHyperV() {
+function EnsureRunningInHyperV() {
   const baseboardMfr = child_process
     .execSync('powershell.exe (gwmi Win32_BaseBoard).Manufacturer')
     .toString()
@@ -69,26 +70,38 @@ function OverrideHyperV() {
   }
 }
 
-OverrideHyperV();
-
 const Launcher = require('@wdio/cli').default;
 
 const wdio = new Launcher('wdio.conf.js', { specs: opts });
 
 function parseLog(logfile) {
   const xmlString = fs.readFileSync(logfile);
-  let name;
+  let failures = {};
   parser.parseString(xmlString, (err, res) => {
     if (!res.testsuites) {
-      name = 'something went wrong';
+      failures = 'something went wrong';
     } else {
-      const attr = res.testsuites.testsuite[0].ATTR;
-      if (attr.errors > 0 || attr.failures > 0) {
-        name = attr.name;
+      for (let i = 0; i < res.testsuites.testsuite.length; i++) {
+        const attr = res.testsuites.testsuite[i].ATTR;
+        if (attr.errors > 0 || attr.failures > 0) {
+          let name = attr.name;
+          failures[name] = {};
+          const testcases = res.testsuites.testsuite[i].testcase;
+          for (let j = 0; j < testcases.length; j++) {
+            if (testcases[j].error && testcases[j].error[0].ATTR) {
+              failures[name].testcase = testcases[j].ATTR.name;
+              failures[name].error = testcases[j].error[0].ATTR.message;
+              const systemErr = testcases[j]['system-err'][0];
+              const stack = systemErr.substr(systemErr.indexOf('\n    at ') + 1);
+              failures[name].stack = stack;
+            }
+          }
+        }
+
       }
     }
   });
-  return name;
+  return failures;
 }
 
 function parseLogs() {
@@ -100,20 +113,38 @@ function parseLogs() {
   return names;
 }
 
+function PrintFailedTests(ft) {
+  for (let i = 0; i < Object.keys(ft).length; i++) {
+    const key = Object.keys(ft)[i];
+    console.log(chalk.redBright(key));
+    console.log('  ', chalk.underline('testcase'), chalk.bold(ft[key].testcase));
+    console.log('  ', chalk.underline('error'), chalk.bold(ft[key].error));
+    console.log('  ', chalk.underline('stack'));
+    console.log(ft[key].stack);
+  }
+}
+
 function Process(code) {
   const failedTests = parseLogs();
   for (let i = 0; i < failedTests.length; i++) {
-    console.log(`Failed test: ${failedTests[i]}`);
+    console.log('Failed tests: ');
+    PrintFailedTests(failedTests[i]);
   }
   process.exit(code);
 }
 
-wdio.run().then(
-  code => {
-    Process(code);
-  },
-  error => {
-    console.error('Launcher failed to start the test', error.stacktrace);
-    process.exit(1);
-  }
-);
+function RunWdio() {
+  EnsureRunningInHyperV();
+
+  wdio.run().then(
+    code => {
+      Process(code);
+    },
+    error => {
+      console.error('Launcher failed to start the test', error.stacktrace);
+      process.exit(1);
+    }
+  );
+}
+
+RunWdio();


### PR DESCRIPTION
I'm going to break up my RNTester visual test PR (#4699) into independent pieces because it's too massive otherwise.

This part deals with improving run_wdio to report failed tests to the console, with stacks.
Fixes #4845. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4843)