### PR TITLE
Use DispatcherQueue instead of CoreDispatcher for Mso::DispatchQueue

### DIFF
--- a/change/react-native-windows-2020-05-12-11-18-16-MS_UIQueue.json
+++ b/change/react-native-windows-2020-05-12-11-18-16-MS_UIQueue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use DispatcherQueue instead of CoreDispatcher for Mso::DispatchQueue",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-12T18:18:15.956Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -36,8 +36,8 @@ struct SampleModuleCppImpl {
   void Initialize(ReactContext const &reactContext) noexcept {
     const ReactPropertyId<int> myProp1{L"Prop1"};
     const ReactPropertyId<winrt::hstring> myProp2{L"Prop2"};
-    DEBUG_OUTPUT("globalProps.Prop1:", *reactContext.Properties().Get(myProp1));
-    DEBUG_OUTPUT("instanceProps.Prop2:", winrt::to_string(*reactContext.Properties().Get(myProp2)));
+    DEBUG_OUTPUT("C++ Properties.Prop1:", *reactContext.Properties().Get(myProp1));
+    DEBUG_OUTPUT("C++ Properties.Prop2:", winrt::to_string(*reactContext.Properties().Get(myProp2)));
 
     m_timer = winrt::Windows::System::Threading::ThreadPoolTimer::CreatePeriodicTimer(
         [this](const winrt::Windows::System::Threading::ThreadPoolTimer) noexcept {

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
@@ -26,8 +26,8 @@ namespace SampleLibraryCS
         [ReactInitializer]
         public void Initialize(ReactContext reactContext)
         {
-            Debug.WriteLine($"C# globalProps.Prop1: {reactContext.Handle.Properties.Get(ReactPropertyBagHelper.GetName(null, "Prop1"))}");
-            Debug.WriteLine($"C# instanceProps.Prop2: {reactContext.Handle.Properties.Get(ReactPropertyBagHelper.GetName(null, "Prop2"))}");
+            Debug.WriteLine($"C# Properties.Prop1: {reactContext.Handle.Properties.Get(ReactPropertyBagHelper.GetName(null, "Prop1"))}");
+            Debug.WriteLine($"C# Properties.Prop2: {reactContext.Handle.Properties.Get(ReactPropertyBagHelper.GetName(null, "Prop2"))}");
 
             _timer = ThreadPoolTimer.CreatePeriodicTimer(new TimerElapsedHandler((timer) =>
             {

--- a/packages/playground/windows/playground-win32.sln
+++ b/packages/playground/windows/playground-win32.sln
@@ -40,6 +40,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "..\..\..\vnext\Co
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Cxx", "..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems", "{DA8B35B3-DA00-4B02-BDE6-6A397B3FD46B}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\..\..\vnext\Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\..\vnext\ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603144}*SharedItemsImports = 4
@@ -47,6 +49,7 @@ Global
 		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
 		..\..\..\vnext\Mso\Mso.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
 		..\..\..\vnext\Shared\Shared.vcxitems*{2d5d43d9-cffc-4c40-b4cd-02efb4e2742b}*SharedItemsImports = 4
+		..\..\..\vnext\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{8b88ffae-4dbc-49a2-afa5-d2477d4ad189}*SharedItemsImports = 4
 		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
 		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -21,24 +21,24 @@ void ReactDispatcher::Post(ReactDispatcherCallback const &callback) noexcept {
 }
 
 /*static*/ Mso::DispatchQueue ReactDispatcher::GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept {
-  return GetUIThreadDispatcher(properties).as<ReactDispatcher>()->m_queue;
+  return GetUIDispatcher(properties).as<ReactDispatcher>()->m_queue;
 }
 
 /*static*/ IReactDispatcher ReactDispatcher::UIThreadDispatcher() noexcept {
   return make<ReactDispatcher>(Mso::DispatchQueue::MakeCurrentThreadUIQueue());
 }
 
-/*static*/ ReactPropertyId<IReactDispatcher> ReactDispatcher::UIThreadDispatcherProperty() noexcept {
-  static ReactPropertyId<IReactDispatcher> uiThreadDispatcherProperty{L"ReactNative", L"UIThreadDispatcher"};
+/*static*/ ReactPropertyId<IReactDispatcher> ReactDispatcher::UIDispatcherProperty() noexcept {
+  static ReactPropertyId<IReactDispatcher> uiThreadDispatcherProperty{L"ReactNative.Dispatcher", L"UIDispatcher"};
   return uiThreadDispatcherProperty;
 }
 
-/*static*/ IReactDispatcher ReactDispatcher::GetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept {
-  return ReactPropertyBag{properties}.Get(UIThreadDispatcherProperty());
+/*static*/ IReactDispatcher ReactDispatcher::GetUIDispatcher(IReactPropertyBag const &properties) noexcept {
+  return ReactPropertyBag{properties}.Get(UIDispatcherProperty());
 }
 
 /*static*/ void ReactDispatcher::SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept {
-  ReactPropertyBag{properties}.Set(UIThreadDispatcherProperty(), UIThreadDispatcher());
+  ReactPropertyBag{properties}.Set(UIDispatcherProperty(), UIThreadDispatcher());
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "IReactDispatcher.h"
+#include "ReactDispatcherHelper.g.cpp"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace winrt::Microsoft::ReactNative {
+
+ReactDispatcher::ReactDispatcher(Mso::DispatchQueue &&queue) noexcept : m_queue{std::move(queue)} {}
+
+bool ReactDispatcher::HasThreadAccess() noexcept {
+  return m_queue.HasThreadAccess();
+}
+
+void ReactDispatcher::Post(ReactDispatcherCallback const &callback) noexcept {
+  return m_queue.Post([callback]() noexcept { callback(); });
+}
+
+/*static*/ Mso::DispatchQueue ReactDispatcher::GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept {
+  return GetUIThreadDispatcher(properties).as<ReactDispatcher>()->m_queue;
+}
+
+/*static*/ IReactDispatcher ReactDispatcher::UIThreadDispatcher() noexcept {
+  return make<ReactDispatcher>(Mso::DispatchQueue::MakeCurrentThreadUIQueue());
+}
+
+/*static*/ ReactPropertyId<IReactDispatcher> ReactDispatcher::UIThreadDispatcherProperty() noexcept {
+  static ReactPropertyId<IReactDispatcher> uiThreadDispatcherProperty{L"ReactNative", L"UIThreadDispatcher"};
+  return uiThreadDispatcherProperty;
+}
+
+/*static*/ IReactDispatcher ReactDispatcher::GetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept {
+  return ReactPropertyBag{properties}.Get(UIThreadDispatcherProperty());
+}
+
+/*static*/ void ReactDispatcher::SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept {
+  ReactPropertyBag{properties}.Set(UIThreadDispatcherProperty(), UIThreadDispatcher());
+}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -19,8 +19,8 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
   static Mso::DispatchQueue GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept;
 
   static IReactDispatcher UIThreadDispatcher() noexcept;
-  static ReactPropertyId<IReactDispatcher> UIThreadDispatcherProperty() noexcept;
-  static IReactDispatcher GetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
+  static ReactPropertyId<IReactDispatcher> UIDispatcherProperty() noexcept;
+  static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;
   static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
 
  private:
@@ -38,8 +38,8 @@ struct ReactDispatcherHelper {
     return ReactDispatcher::UIThreadDispatcher();
   }
 
-  static IReactPropertyName UIThreadDispatcherProperty() noexcept {
-    return ReactDispatcher::UIThreadDispatcherProperty().Handle();
+  static IReactPropertyName UIDispatcherProperty() noexcept {
+    return ReactDispatcher::UIDispatcherProperty().Handle();
   }
 };
 

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "ReactDispatcherHelper.g.h"
+#include <ReactPropertyBag.h>
+#include <dispatchQueue/dispatchQueue.h>
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
+  ReactDispatcher() = default;
+  ReactDispatcher(Mso::DispatchQueue &&queue) noexcept;
+
+  bool HasThreadAccess() noexcept;
+  void Post(ReactDispatcherCallback const &callback) noexcept;
+
+  static Mso::DispatchQueue GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept;
+
+  static IReactDispatcher UIThreadDispatcher() noexcept;
+  static ReactPropertyId<IReactDispatcher> UIThreadDispatcherProperty() noexcept;
+  static IReactDispatcher GetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
+  static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
+
+ private:
+  Mso::DispatchQueue m_queue;
+};
+
+} // namespace winrt::Microsoft::ReactNative
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct ReactDispatcherHelper {
+  ReactDispatcherHelper() = default;
+
+  static IReactDispatcher UIThreadDispatcher() noexcept {
+    return ReactDispatcher::UIThreadDispatcher();
+  }
+
+  static IReactPropertyName UIThreadDispatcherProperty() noexcept {
+    return ReactDispatcher::UIThreadDispatcherProperty().Handle();
+  }
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+
+struct ReactDispatcherHelper : ReactDispatcherHelperT<ReactDispatcherHelper, implementation::ReactDispatcherHelper> {};
+
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -26,7 +26,7 @@ namespace Microsoft.ReactNative {
     // Get or create IReactDispatcher for the current UI thread.
     static IReactDispatcher UIThreadDispatcher{ get; };
 
-    // Get name of the UIThreadDispatcher property.
-    static IReactPropertyName UIThreadDispatcherProperty();
+    // Get name of the UIDispatcher property for the IReactPropertyBag.
+    static IReactPropertyName UIDispatcherProperty();
   }
 } // namespace ReactNative

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import "IReactPropertyBag.idl";
+
+namespace Microsoft.ReactNative {
+
+  // The delegate is used to create property value on-demand.
+  [webhosthidden]
+  delegate void ReactDispatcherCallback();
+
+  [webhosthidden]
+  interface IReactDispatcher
+  {
+    // True if dispatcher uses current thread.
+    Boolean HasThreadAccess { get; };
+
+    // Post task for the asynchronous execution.
+    void Post(ReactDispatcherCallback callback);
+  }
+
+  // Helper methods for the property bag implementation.
+  [webhosthidden]
+  static runtimeclass ReactDispatcherHelper
+  {
+    // Get or create IReactDispatcher for the current UI thread.
+    static IReactDispatcher UIThreadDispatcher{ get; };
+
+    // Get name of the UIThreadDispatcher property.
+    static IReactPropertyName UIThreadDispatcherProperty();
+  }
+} // namespace ReactNative

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" />
@@ -299,6 +299,9 @@
       <DependentUpon>IJSValueWriter.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="HResult.h" />
+    <ClInclude Include="IReactDispatcher.h">
+      <DependentUpon>IReactDispatcher.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="IReactModuleBuilder.h">
       <DependentUpon>IReactModuleBuilder.idl</DependentUpon>
     </ClInclude>
@@ -467,6 +470,9 @@
     <ClCompile Include="DynamicWriter.cpp">
       <DependentUpon>IJSValueWriter.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="IReactDispatcher.cpp">
+      <DependentUpon>IReactDispatcher.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="IReactModuleBuilder.cpp">
       <DependentUpon>IReactModuleBuilder.idl</DependentUpon>
     </ClCompile>
@@ -547,6 +553,7 @@
     <Midl Include="IJSValueReader.idl" />
     <Midl Include="IJSValueWriter.idl" />
     <Midl Include="ILifecycleEventListener.idl" />
+    <Midl Include="IReactDispatcher.idl" />
     <Midl Include="IReactPropertyBag.idl" />
     <Midl Include="IReactModuleBuilder.idl" />
     <Midl Include="IReactPackageBuilder.idl" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -265,6 +265,7 @@
     </ClCompile>
     <ClCompile Include="ABICxxModule.cpp" />
     <ClCompile Include="ABIViewManager.cpp" />
+    <ClCompile Include="IReactDispatcher.cpp" />
     <ClCompile Include="Modules\AppStateData.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
@@ -298,7 +299,6 @@
     <ClCompile Include="ReactHost\UwpReactInstanceProxy.cpp">
       <Filter>ReactHost</Filter>
     </ClCompile>
-    <ClCompile Include="ReactPropertyBag.cpp" />
     <ClCompile Include="ReactSupport.cpp" />
     <ClCompile Include="RedBox.cpp" />
     <ClCompile Include="TestHook.cpp" />
@@ -599,6 +599,7 @@
       <Filter>Base</Filter>
     </ClInclude>
     <ClInclude Include="HResult.h" />
+    <ClInclude Include="IReactDispatcher.h" />
     <ClInclude Include="LifecycleState.h" />
     <ClInclude Include="Modules\AppStateData.h">
       <Filter>Modules</Filter>
@@ -648,7 +649,6 @@
     <ClInclude Include="ReactHost\UwpReactInstanceProxy.h">
       <Filter>ReactHost</Filter>
     </ClInclude>
-    <ClInclude Include="ReactPropertyBag.h" />
     <ClInclude Include="ReactSupport.h" />
     <ClInclude Include="RedBox.h" />
     <ClInclude Include="TestHook.h" />
@@ -685,6 +685,7 @@
     <Midl Include="IJSValueWriter.idl" />
     <Midl Include="ILifecycleEventListener.idl" />
     <Midl Include="IReactContext.idl" />
+    <Midl Include="IReactDispatcher.idl" />
     <Midl Include="IReactModuleBuilder.idl" />
     <Midl Include="IReactPackageBuilder.idl" />
     <Midl Include="IReactPackageProvider.idl" />

--- a/vnext/Microsoft.ReactNative/Modules/AppStateData.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateData.cpp
@@ -11,8 +11,8 @@ using namespace xaml;
 
 namespace react::uwp {
 
-AppStateData::AppStateData(Mso::React::IReactContext &reactContext) noexcept
-    : Super(Mso::DispatchQueue::MainUIQueue()), m_lastState{"active"}, m_reactContext{&reactContext} {}
+AppStateData::AppStateData(Mso::React::IReactContext &reactContext, Mso::DispatchQueue const &uiQueue) noexcept
+    : Super(uiQueue), m_lastState{"active"}, m_reactContext{&reactContext} {}
 
 AppStateData::~AppStateData() = default;
 
@@ -59,8 +59,8 @@ void AppStateData::RaiseEvent(char const *newState) noexcept {
       "RCTDeviceEventEmitter", "emit", folly::dynamic::array("appStateDidChange", std::move(parameters)));
 }
 
-AppState2::AppState2(Mso::React::IReactContext &reactContext) noexcept
-    : m_data{Mso::Make<AppStateData>(reactContext)} {}
+AppState2::AppState2(Mso::React::IReactContext &reactContext, Mso::DispatchQueue const &uiQueue) noexcept
+    : m_data{Mso::Make<AppStateData>(reactContext, uiQueue)} {}
 
 AppState2::~AppState2() = default;
 

--- a/vnext/Microsoft.ReactNative/Modules/AppStateData.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateData.h
@@ -15,7 +15,7 @@ namespace react::uwp {
 struct AppStateData : Mso::ActiveObject<> {
   using Super = ActiveObjectType;
 
-  AppStateData(Mso::React::IReactContext &reactContext) noexcept;
+  AppStateData(Mso::React::IReactContext &reactContext, Mso::DispatchQueue const &uiQueue) noexcept;
   ~AppStateData() override;
   void Initialize() noexcept override;
   void Finalize() noexcept override;
@@ -36,7 +36,7 @@ struct AppStateData : Mso::ActiveObject<> {
 // It is a temporary class that we need to keep until we remove ReactUWP
 class AppState2 : public facebook::react::AppState {
  public:
-  AppState2(Mso::React::IReactContext &reactContext) noexcept;
+  AppState2(Mso::React::IReactContext &reactContext, Mso::DispatchQueue const &uiQueue) noexcept;
 
  public: // facebook::react::AppState
   ~AppState2() override;

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -5,6 +5,7 @@
 #include "ReactApplication.h"
 #include "ReactApplication.g.cpp"
 
+#include "IReactDispatcher.h"
 #include "Modules/LinkingManagerModule.h"
 #include "ReactNativeHost.h"
 
@@ -48,6 +49,7 @@ ReactApplication::ReactApplication(IInspectable const &outer) noexcept : ReactAp
 ReactNative::ReactInstanceSettings ReactApplication::InstanceSettings() noexcept {
   if (!m_instanceSettings) {
     m_instanceSettings = make<ReactInstanceSettings>();
+    ReactDispatcher::SetUIThreadDispatcher(m_instanceSettings.Properties());
   }
 
   return m_instanceSettings;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -20,6 +20,7 @@
 
 #include <ReactWindowsCore/ViewManager.h>
 #include <dispatchQueue/dispatchQueue.h>
+#include "IReactDispatcher.h"
 #include "Modules/AppStateData.h"
 #include "Modules/ClipboardModule.h"
 #include "Modules/DevSettingsModule.h"
@@ -153,7 +154,7 @@ void ReactInstanceWin::Initialize() noexcept {
   InitUIManager();
 
   Mso::PostFuture(
-      Mso::DispatchQueue::MainUIQueue(),
+      m_uiQueue,
       [weakThis = Mso::WeakPtr{this}]() noexcept {
         // Objects that must be created on the UI thread
         if (auto strongThis = weakThis.GetStrongPtr()) {
@@ -162,7 +163,8 @@ void ReactInstanceWin::Initialize() noexcept {
           strongThis->m_appTheme =
               std::make_shared<react::uwp::AppTheme>(legacyInstance, strongThis->m_uiMessageThread.LoadWithLock());
           react::uwp::I18nHelper().Instance().setInfo(react::uwp::I18nModule::GetI18nInfo());
-          strongThis->m_appearanceListener = Mso::Make<react::uwp::AppearanceChangeListener>(legacyInstance);
+          strongThis->m_appearanceListener =
+              Mso::Make<react::uwp::AppearanceChangeListener>(legacyInstance, strongThis->m_uiQueue);
         }
       })
       .Then(Queue(), [ this, weakThis = Mso::WeakPtr{this} ]() noexcept {
@@ -198,7 +200,7 @@ void ReactInstanceWin::Initialize() noexcept {
           devSettings->debuggerConsoleRedirection =
               false; // JSHost::ChangeGate::ChakraCoreDebuggerConsoleRedirection();
 
-          m_appState = std::make_shared<react::uwp::AppState2>(*m_reactContext);
+          m_appState = std::make_shared<react::uwp::AppState2>(*m_reactContext, m_uiQueue);
 
           // Acquire default modules and then populate with custom modules
           std::vector<facebook::react::NativeModuleDescription> cxxModules = react::uwp::GetCoreModules(
@@ -454,8 +456,9 @@ void ReactInstanceWin::InitNativeMessageThread() noexcept {
 
 void ReactInstanceWin::InitUIMessageThread() noexcept {
   // Native queue was already given us in constructor.
-  m_uiMessageThread.Exchange(std::make_shared<MessageDispatchQueue>(
-      Mso::DispatchQueue::MainUIQueue(), Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
+  m_uiQueue = winrt::Microsoft::ReactNative::ReactDispatcher::GetUIDispatchQueue(m_options.Properties);
+  m_uiMessageThread.Exchange(
+      std::make_shared<MessageDispatchQueue>(m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 
   m_batchingUIThread = react::uwp::MakeBatchingQueueThread(m_uiMessageThread.Load());
 }
@@ -517,7 +520,7 @@ std::shared_ptr<IRedBoxHandler> ReactInstanceWin::GetRedBoxHandler() noexcept {
     return m_options.RedBoxHandler;
   } else if (m_options.DeveloperSettings.IsDevModeEnabled) {
     auto localWkReactHost = m_weakReactHost;
-    return CreateDefaultRedBoxHandler(std::move(localWkReactHost));
+    return CreateDefaultRedBoxHandler(std::move(localWkReactHost), Mso::Copy(m_uiQueue));
   } else {
     return {};
   }

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -161,6 +161,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
   std::shared_ptr<react::uwp::AppTheme> m_appTheme;
   Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
   std::string m_bundleRootPath;
+  Mso::DispatchQueue m_uiQueue;
 };
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -30,6 +30,6 @@ namespace Microsoft.ReactNative {
     String DebugBundlePath { get; set; };
     String BundleRootPath { get; set; };
     UInt16 DebuggerPort { get; set; };
-    Microsoft.ReactNative.IRedBoxHandler RedBoxHandler { get; set; };
+    IRedBoxHandler RedBoxHandler { get; set; };
   }
 }

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -358,19 +358,19 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
  * This class is implemented such that the methods on IRedBoxHandler are thread safe.
  */
 struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxHandler>, IRedBoxHandler {
-  DefaultRedBoxHandler(Mso::WeakPtr<Mso::React::IReactHost> &&weakReactHost) noexcept
-      : m_weakReactHost(std::move(weakReactHost)) {}
+  DefaultRedBoxHandler(Mso::WeakPtr<Mso::React::IReactHost> &&weakReactHost, Mso::DispatchQueue &&uiQueue) noexcept
+      : m_weakReactHost{std::move(weakReactHost)}, m_uiQueue{std::move(uiQueue)} {}
 
   ~DefaultRedBoxHandler() {
-    // Hide any currently showing redboxes
-    std::vector<std::shared_ptr<RedBox>> redboxes;
+    // Hide any currently showing redBoxes
+    std::vector<std::shared_ptr<RedBox>> redBoxes;
     {
       std::scoped_lock lock{m_lockRedBox};
-      std::swap(m_redboxes, redboxes);
+      std::swap(m_redBoxes, redBoxes);
     }
-    Mso::DispatchQueue::MainUIQueue().Post([redboxes = std::move(redboxes)]() {
-      for (const auto redbox : redboxes) {
-        redbox->Dismiss();
+    m_uiQueue.Post([redBoxes = std::move(redBoxes)]() {
+      for (const auto redBox : redBoxes) {
+        redBox->Dismiss();
       }
     });
   }
@@ -386,7 +386,7 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
         std::move(info)));
     {
       std::scoped_lock lock{m_lockRedBox};
-      m_redboxes.push_back(std::move(redbox));
+      m_redBoxes.push_back(std::move(redbox));
     }
     showTopJSError();
   }
@@ -403,32 +403,33 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
     std::shared_ptr<RedBox> redbox;
     {
       std::scoped_lock lock{m_lockRedBox};
-      for (auto it = m_redboxes.begin(); it != m_redboxes.end(); ++it) {
+      for (auto it = m_redBoxes.begin(); it != m_redBoxes.end(); ++it) {
         if ((*it)->GetId() == info.Id) {
           redbox = *it;
           break;
         }
       }
     }
+
     if (redbox) {
-      Mso::DispatchQueue::MainUIQueue().Post([redboxCaptured = std::move(redbox), errorInfo = std::move(info)]() {
+      m_uiQueue.Post([redboxCaptured = std::move(redbox), errorInfo = std::move(info)]() {
         redboxCaptured->UpdateError(std::move(errorInfo));
       });
     }
   }
 
   virtual void dismissRedbox() override {
-    Mso::DispatchQueue::MainUIQueue().Post([wkthis = std::weak_ptr(shared_from_this())]() {
+    m_uiQueue.Post([wkthis = std::weak_ptr(shared_from_this())]() {
       if (auto pthis = wkthis.lock()) {
         std::scoped_lock lock{pthis->m_lockRedBox};
-        if (!pthis->m_redboxes.empty())
-          pthis->m_redboxes[0]->Dismiss();
+        if (!pthis->m_redBoxes.empty())
+          pthis->m_redBoxes[0]->Dismiss();
       }
     });
   }
 
  private:
-  // When notified by a redbox that its been dismisssed
+  // When notified by a redbox that its been dismissed
   void onDismissedCallback(uint32_t id) noexcept {
     // Save a local ref, so if we are removing the last redbox which could hold the last ref to the DefaultRedBoxHandler
     // We ensure that we exit the mutex before the handler is destroyed.
@@ -436,10 +437,10 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
     {
       {
         std::scoped_lock lock{m_lockRedBox};
-        for (auto it = m_redboxes.begin(); it != m_redboxes.end(); ++it) {
+        for (auto it = m_redBoxes.begin(); it != m_redBoxes.end(); ++it) {
           if ((*it)->GetId() == id) {
             redbox = *it;
-            it = m_redboxes.erase(it);
+            it = m_redBoxes.erase(it);
             break;
           }
         }
@@ -453,8 +454,8 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
     std::shared_ptr<RedBox> redbox;
     {
       std::scoped_lock lock{m_lockRedBox};
-      if (!m_redboxes.empty()) {
-        redbox = m_redboxes[0];
+      if (!m_redBoxes.empty()) {
+        redbox = m_redBoxes[0];
       }
     }
 
@@ -462,13 +463,14 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
       return;
     m_showingRedBox = true;
 
-    Mso::DispatchQueue::MainUIQueue().Post(
-        [redboxCaptured = std::move(redbox)]() { redboxCaptured->ShowNewJSError(); });
+    m_uiQueue.Post([redboxCaptured = std::move(redbox)]() { redboxCaptured->ShowNewJSError(); });
   }
 
-  bool m_showingRedBox = false; // Access from UI Thread only
+ private:
+  const Mso::DispatchQueue m_uiQueue;
+  bool m_showingRedBox{false}; // Access from UI Thread only
   std::mutex m_lockRedBox;
-  std::vector<std::shared_ptr<RedBox>> m_redboxes; // Protected by m_lockRedBox
+  std::vector<std::shared_ptr<RedBox>> m_redBoxes; // Protected by m_lockRedBox
   const Mso::WeakPtr<IReactHost> m_weakReactHost;
 };
 
@@ -564,8 +566,10 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
   return std::make_shared<RedBoxHandler>(redBoxHandler);
 }
 
-std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(Mso::WeakPtr<IReactHost> &&weakReactHost) noexcept {
-  return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost));
+std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
+    Mso::WeakPtr<IReactHost> &&weakReactHost,
+    Mso::DispatchQueue &&uiQueue) noexcept {
+  return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost), std::move(uiQueue));
 }
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBox.h
+++ b/vnext/Microsoft.ReactNative/RedBox.h
@@ -10,6 +10,8 @@ namespace Mso::React {
 std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
     winrt::Microsoft::ReactNative::IRedBoxHandler const &redBoxHandler) noexcept;
 
-std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(Mso::WeakPtr<IReactHost> &&weakReactHost) noexcept;
+std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
+    Mso::WeakPtr<IReactHost> &&weakReactHost,
+    Mso::DispatchQueue &&uiQueue) noexcept;
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
@@ -7,6 +7,7 @@
 #include "RedBoxHelper.g.cpp"
 #endif
 
+#include <IReactDispatcher.h>
 #include <ReactNativeHost.h>
 #include <RedBox.h>
 #include <unicode.h>
@@ -32,7 +33,8 @@ struct DefaultRedBoxHandler : winrt::implements<DefaultRedBoxHandler, IRedBoxHan
   DefaultRedBoxHandler(winrt::Microsoft::ReactNative::ReactNativeHost const &host) noexcept {
     auto hostImpl = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeHost>(host);
     Mso::WeakPtr<Mso::React::IReactHost> wkHost(hostImpl->ReactHost());
-    m_redBoxHandler = Mso::React::CreateDefaultRedBoxHandler(std::move(wkHost));
+    m_redBoxHandler = Mso::React::CreateDefaultRedBoxHandler(
+        std::move(wkHost), ReactDispatcher::GetUIDispatchQueue(host.InstanceSettings().Properties()));
   }
 
   void ShowNewError(IRedBoxErrorInfo const &info, RedBoxErrorType type) noexcept {

--- a/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.cpp
+++ b/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.cpp
@@ -12,7 +12,8 @@ std::shared_ptr<facebook::react::MessageQueueThread> MakeJSQueueThread() noexcep
 }
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeUIQueueThread() noexcept {
-  return std::make_shared<Mso::React::MessageDispatchQueue>(Mso::DispatchQueue::MainUIQueue(), nullptr, nullptr);
+  return std::make_shared<Mso::React::MessageDispatchQueue>(
+      Mso::DispatchQueue::MakeCurrentThreadUIQueue(), nullptr, nullptr);
 }
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeSerialQueueThread() noexcept {

--- a/vnext/Mso/dispatchQueue/dispatchQueue.h
+++ b/vnext/Mso/dispatchQueue/dispatchQueue.h
@@ -113,9 +113,6 @@ struct DispatchQueue {
   //! demand.
   static DispatchQueue const &ConcurrentQueue() noexcept;
 
-  //! Get DispatchQueue associated with the main UI thread. It is created on demand.
-  static DispatchQueue const &MainUIQueue() noexcept;
-
   //! Create new serial DispatchQueue on top of platform specific thread pool.
   static DispatchQueue MakeSerialQueue() noexcept;
 
@@ -158,8 +155,7 @@ struct DispatchQueue {
   //! True if tasks are invoked in a serial order by the queue.
   bool IsSerial() const noexcept;
 
-  //! True if queue is running on current thread or associated with it. E.g. MainUIQueue always returns true for the
-  //! main UI thread.
+  //! True if queue is running on current thread or associated with it.
   bool HasThreadAccess() const noexcept;
 
   //! Check if a long running task should yield.
@@ -416,9 +412,6 @@ struct IDispatchQueueStatic : IUnknown {
   //! demand.
   virtual DispatchQueue const &ConcurrentQueue() noexcept = 0;
 
-  //! Get DispatchQueue associated with the main UI thread. It is created on demand.
-  virtual DispatchQueue const &MainUIQueue() noexcept = 0;
-
   //! Create new serial DispatchQueue on top of platform specific thread pool.
   virtual DispatchQueue MakeSerialQueue() noexcept = 0;
 
@@ -543,10 +536,6 @@ inline /*static*/ DispatchQueue DispatchQueue::CurrentQueue() noexcept {
 
 inline /*static*/ DispatchQueue const &DispatchQueue::ConcurrentQueue() noexcept {
   return IDispatchQueueStatic::Instance()->ConcurrentQueue();
-}
-
-inline /*static*/ DispatchQueue const &DispatchQueue::MainUIQueue() noexcept {
-  return IDispatchQueueStatic::Instance()->MainUIQueue();
 }
 
 inline /*static*/ DispatchQueue DispatchQueue::MakeSerialQueue() noexcept {

--- a/vnext/Mso/src/dispatchQueue/queueService.cpp
+++ b/vnext/Mso/src/dispatchQueue/queueService.cpp
@@ -269,11 +269,6 @@ DispatchQueue const &DispatchQueueStatic::ConcurrentQueue() noexcept {
   return *static_cast<DispatchQueue *>(static_cast<void *>(&concurrentQueue));
 }
 
-DispatchQueue const &DispatchQueueStatic::MainUIQueue() noexcept {
-  static auto mainUIQueue{Mso::Make<QueueService, IDispatchQueueService>(MakeMainUIScheduler())};
-  return *static_cast<DispatchQueue *>(static_cast<void *>(&mainUIQueue));
-}
-
 DispatchQueue DispatchQueueStatic::MakeSerialQueue() noexcept {
   return Mso::Make<QueueService, IDispatchQueueService>(MakeThreadPoolScheduler(/*maxThreads:*/ 1));
 }

--- a/vnext/Mso/src/dispatchQueue/queueService.h
+++ b/vnext/Mso/src/dispatchQueue/queueService.h
@@ -82,14 +82,12 @@ struct QueueLocalValueEntry {
 struct DispatchQueueStatic : Mso::UnknownObject<Mso::RefCountStrategy::NoRefCount, IDispatchQueueStatic> {
   static DispatchQueueStatic *Instance() noexcept;
   static Mso::CntPtr<IDispatchQueueScheduler> MakeLooperScheduler() noexcept;
-  static Mso::CntPtr<IDispatchQueueScheduler> MakeMainUIScheduler() noexcept;
   static Mso::CntPtr<IDispatchQueueScheduler> MakeCurrentThreadUIScheduler() noexcept;
   static Mso::CntPtr<IDispatchQueueScheduler> MakeThreadPoolScheduler(uint32_t maxThreads) noexcept;
 
  public: // IDispatchQueueStatic
   DispatchQueue CurrentQueue() noexcept override;
   DispatchQueue const &ConcurrentQueue() noexcept override;
-  DispatchQueue const &MainUIQueue() noexcept override;
   DispatchQueue MakeSerialQueue() noexcept override;
   DispatchQueue MakeLooperQueue() noexcept override;
   DispatchQueue MakeCurrentThreadUIQueue() noexcept override;

--- a/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
+++ b/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
@@ -5,38 +5,36 @@
 #include "object/refCountedObject.h"
 #include "queueService.h"
 #include "taskQueue.h"
-#include "winrt/Windows.ApplicationModel.Core.h"
-#include "winrt/Windows.UI.Core.h"
+#include "winrt/Windows.System.h"
 
 using namespace winrt;
-using namespace Windows::ApplicationModel::Core;
-using namespace Windows::UI::Core;
+using namespace Windows::System;
 
 namespace Mso {
 
-struct UISchdulerWinRT;
+struct UISchedulerWinRT;
 
-//! TaskDispatchedHandler is a DispatchedHandler delegate that we pass to CoreDispatcher.
+//! TaskDispatcherHandler is a DispatcherQueueHandler delegate that we pass to DispatcherQueue.
 //! We use custom ref counting to avoid extra memory allocations and to handle reference to DispatchTask.
-struct TaskDispatchedHandler final : impl::abi_t<DispatchedHandler> {
-  TaskDispatchedHandler(UISchdulerWinRT *scheduler) noexcept;
+struct TaskDispatcherHandler final : impl::abi_t<DispatcherQueueHandler> {
+  TaskDispatcherHandler(UISchedulerWinRT *scheduler) noexcept;
   int32_t __stdcall QueryInterface(guid const &id, void **result) noexcept final;
   uint32_t __stdcall AddRef() noexcept final;
   uint32_t __stdcall Release() noexcept final;
   int32_t __stdcall Invoke() noexcept final;
 
  private:
-  UISchdulerWinRT *m_scheduler;
+  UISchedulerWinRT *m_scheduler;
 };
 
-struct UISchdulerWinRT : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDispatchQueueScheduler> {
-  UISchdulerWinRT(CoreDispatcher &&coreDispatcher) noexcept;
-  ~UISchdulerWinRT() noexcept override;
+struct UISchedulerWinRT : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDispatchQueueScheduler> {
+  UISchedulerWinRT(DispatcherQueue &&dispatcher) noexcept;
+  ~UISchedulerWinRT() noexcept override;
 
   uint32_t AddHandlerRef() noexcept;
   uint32_t ReleaseHandlerRef() noexcept;
 
-  DispatchedHandler MakeDispatchedHandler() noexcept;
+  DispatcherQueueHandler MakeDispatcherQueueHandler() noexcept;
   bool TryTakeTask(Mso::CntPtr<IDispatchQueueService> &queue, DispatchTask &task) noexcept;
 
  public: // IDispatchQueueScheduler
@@ -49,39 +47,39 @@ struct UISchdulerWinRT : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDis
 
  private:
   struct CleanupContext {
-    CleanupContext(UISchdulerWinRT *scheduler) noexcept;
+    CleanupContext(UISchedulerWinRT *scheduler) noexcept;
     ~CleanupContext() noexcept;
     void CheckShutdown() noexcept;
     void CheckTermination() noexcept;
 
    private:
-    UISchdulerWinRT *m_scheduler;
+    UISchedulerWinRT *m_scheduler;
     bool m_isShutdown{false};
     bool m_isTerminated{false};
   };
 
  private:
-  CoreDispatcher m_coreDispatcher{nullptr};
-  TaskDispatchedHandler m_dispatchedHandler{this};
+  DispatcherQueue m_dispatcher{nullptr};
+  TaskDispatcherHandler m_dispatcherHandler{this};
   ManualResetEvent m_terminationEvent;
   ThreadMutex m_mutex;
   Mso::WeakPtr<IDispatchQueueService> m_queue;
-  Mso::CntPtr<UISchdulerWinRT> m_self;
+  Mso::CntPtr<UISchedulerWinRT> m_self;
   uint32_t m_handlerRefCount{0};
   uint32_t m_taskCount{0};
   bool m_isShutdown{false};
 };
 
 //=============================================================================
-// TaskDispatchedHandler implementation
+// TaskDispatcherHandler implementation
 //=============================================================================
 
-TaskDispatchedHandler::TaskDispatchedHandler(UISchdulerWinRT *scheduler) noexcept : m_scheduler{scheduler} {}
+TaskDispatcherHandler::TaskDispatcherHandler(UISchedulerWinRT *scheduler) noexcept : m_scheduler{scheduler} {}
 
-int32_t __stdcall TaskDispatchedHandler::QueryInterface(guid const &id, void **result) noexcept {
-  if (is_guid_of<DispatchedHandler>(id) || is_guid_of<Windows::Foundation::IUnknown>(id) ||
+int32_t __stdcall TaskDispatcherHandler::QueryInterface(guid const &id, void **result) noexcept {
+  if (is_guid_of<DispatcherQueueHandler>(id) || is_guid_of<Windows::Foundation::IUnknown>(id) ||
       is_guid_of<IAgileObject>(id)) {
-    *result = static_cast<impl::abi_t<DispatchedHandler> *>(this);
+    *result = static_cast<impl::abi_t<DispatcherQueueHandler> *>(this);
     AddRef();
     return impl::error_ok;
   }
@@ -94,15 +92,15 @@ int32_t __stdcall TaskDispatchedHandler::QueryInterface(guid const &id, void **r
   return impl::error_no_interface;
 }
 
-uint32_t __stdcall TaskDispatchedHandler::AddRef() noexcept {
+uint32_t __stdcall TaskDispatcherHandler::AddRef() noexcept {
   return m_scheduler->AddHandlerRef();
 }
 
-uint32_t __stdcall TaskDispatchedHandler::Release() noexcept {
+uint32_t __stdcall TaskDispatcherHandler::Release() noexcept {
   return m_scheduler->ReleaseHandlerRef();
 }
 
-int32_t __stdcall TaskDispatchedHandler::Invoke() noexcept {
+int32_t __stdcall TaskDispatcherHandler::Invoke() noexcept {
   Mso::CntPtr<IDispatchQueueService> queue;
   DispatchTask task;
   if (m_scheduler->TryTakeTask(queue, task)) {
@@ -113,23 +111,22 @@ int32_t __stdcall TaskDispatchedHandler::Invoke() noexcept {
 }
 
 //=============================================================================
-// UISchdulerWinRT implementation
+// UISchedulerWinRT implementation
 //=============================================================================
 
-UISchdulerWinRT::UISchdulerWinRT(CoreDispatcher &&coreDispatcher) noexcept
-    : m_coreDispatcher{std::move(coreDispatcher)} {}
+UISchedulerWinRT::UISchedulerWinRT(DispatcherQueue &&dispatcher) noexcept : m_dispatcher{std::move(dispatcher)} {}
 
-UISchdulerWinRT::~UISchdulerWinRT() noexcept {
+UISchedulerWinRT::~UISchedulerWinRT() noexcept {
   AwaitTermination();
 }
 
-uint32_t UISchdulerWinRT::AddHandlerRef() noexcept {
+uint32_t UISchedulerWinRT::AddHandlerRef() noexcept {
   std::lock_guard lock{m_mutex};
   return ++m_handlerRefCount;
 }
 
-uint32_t UISchdulerWinRT::ReleaseHandlerRef() noexcept {
-  Mso::CntPtr<UISchdulerWinRT> self;
+uint32_t UISchedulerWinRT::ReleaseHandlerRef() noexcept {
+  Mso::CntPtr<UISchedulerWinRT> self;
   CleanupContext context{this};
 
   {
@@ -147,7 +144,7 @@ uint32_t UISchdulerWinRT::ReleaseHandlerRef() noexcept {
   }
 }
 
-bool UISchdulerWinRT::TryTakeTask(Mso::CntPtr<IDispatchQueueService> &queue, DispatchTask &task) noexcept {
+bool UISchedulerWinRT::TryTakeTask(Mso::CntPtr<IDispatchQueueService> &queue, DispatchTask &task) noexcept {
   {
     std::lock_guard lock{m_mutex};
     VerifyElseCrashSz(m_taskCount, "Task count cannot be negative");
@@ -161,45 +158,45 @@ bool UISchdulerWinRT::TryTakeTask(Mso::CntPtr<IDispatchQueueService> &queue, Dis
   return false;
 }
 
-DispatchedHandler UISchdulerWinRT::MakeDispatchedHandler() noexcept {
+DispatcherQueueHandler UISchedulerWinRT::MakeDispatcherQueueHandler() noexcept {
   VerifyElseCrash(m_mutex.IsLockedByMe());
 
   if (m_handlerRefCount == 0) {
-    m_self = this; // Keep reference to self while CoreDispatcher owns DispatchedHandler.
+    m_self = this; // Keep reference to self while DispatcherQueue owns DispatcherQueueHandler.
   }
 
   ++m_handlerRefCount;
-  return {static_cast<void *>(&m_dispatchedHandler), take_ownership_from_abi};
+  return {static_cast<void *>(&m_dispatcherHandler), take_ownership_from_abi};
 }
 
-void UISchdulerWinRT::IntializeScheduler(Mso::WeakPtr<IDispatchQueueService> &&queue) noexcept {
+void UISchedulerWinRT::IntializeScheduler(Mso::WeakPtr<IDispatchQueueService> &&queue) noexcept {
   m_queue = std::move(queue);
 }
 
-bool UISchdulerWinRT::HasThreadAccess() noexcept {
-  return m_coreDispatcher.HasThreadAccess();
+bool UISchedulerWinRT::HasThreadAccess() noexcept {
+  return m_dispatcher.HasThreadAccess();
 }
 
-bool UISchdulerWinRT::IsSerial() noexcept {
+bool UISchedulerWinRT::IsSerial() noexcept {
   return true;
 }
 
-void UISchdulerWinRT::Post() noexcept {
-  DispatchedHandler handler;
+void UISchedulerWinRT::Post() noexcept {
+  DispatcherQueueHandler handler;
   {
     std::lock_guard lock{m_mutex};
     if (!m_isShutdown) {
       ++m_taskCount;
-      handler = MakeDispatchedHandler();
+      handler = MakeDispatcherQueueHandler();
     }
   }
 
   if (handler) {
-    m_coreDispatcher.RunAsync(CoreDispatcherPriority::Normal, std::move(handler));
+    m_dispatcher.TryEnqueue(handler);
   }
 }
 
-void UISchdulerWinRT::Shutdown() noexcept {
+void UISchedulerWinRT::Shutdown() noexcept {
   CleanupContext context{this};
   {
     std::lock_guard lock{m_mutex};
@@ -208,18 +205,18 @@ void UISchdulerWinRT::Shutdown() noexcept {
   }
 }
 
-void UISchdulerWinRT::AwaitTermination() noexcept {
+void UISchedulerWinRT::AwaitTermination() noexcept {
   Shutdown();
   m_terminationEvent.Wait();
 }
 
 //=============================================================================
-// UISchdulerWinRT::CleanupContext implementation
+// UISchedulerWinRT::CleanupContext implementation
 //=============================================================================
 
-UISchdulerWinRT::CleanupContext::CleanupContext(UISchdulerWinRT *scheduler) noexcept : m_scheduler{scheduler} {}
+UISchedulerWinRT::CleanupContext::CleanupContext(UISchedulerWinRT *scheduler) noexcept : m_scheduler{scheduler} {}
 
-UISchdulerWinRT::CleanupContext::~CleanupContext() noexcept {
+UISchedulerWinRT::CleanupContext::~CleanupContext() noexcept {
   if (m_isTerminated) {
     m_scheduler->m_terminationEvent.Set();
   }
@@ -231,8 +228,8 @@ UISchdulerWinRT::CleanupContext::~CleanupContext() noexcept {
   }
 }
 
-void UISchdulerWinRT::CleanupContext::CheckShutdown() noexcept {
-  // See if core dispatcher released all handlers without invoking them.
+void UISchedulerWinRT::CleanupContext::CheckShutdown() noexcept {
+  // See if dispatcher queue released all handlers without invoking them.
   if (m_scheduler->m_taskCount != 0 && m_scheduler->m_handlerRefCount == 0) {
     m_isShutdown = true;
     m_scheduler->m_taskCount = 0;
@@ -240,20 +237,16 @@ void UISchdulerWinRT::CleanupContext::CheckShutdown() noexcept {
   }
 }
 
-void UISchdulerWinRT::CleanupContext::CheckTermination() noexcept {
+void UISchedulerWinRT::CleanupContext::CheckTermination() noexcept {
   m_isTerminated = m_scheduler->m_isShutdown && (m_scheduler->m_handlerRefCount == 0);
 }
 
 //=============================================================================
-// DispatchQueueStatic::MakeThreadPoolScheduler implementation
+// DispatchQueueStatic::MakeCurrentThreadUIScheduler implementation
 //=============================================================================
 
-/*static*/ Mso::CntPtr<IDispatchQueueScheduler> DispatchQueueStatic::MakeMainUIScheduler() noexcept {
-  return Mso::Make<UISchdulerWinRT, IDispatchQueueScheduler>(CoreApplication::MainView().CoreWindow().Dispatcher());
-}
-
 /*static*/ Mso::CntPtr<IDispatchQueueScheduler> DispatchQueueStatic::MakeCurrentThreadUIScheduler() noexcept {
-  return Mso::Make<UISchdulerWinRT, IDispatchQueueScheduler>(CoreWindow::GetForCurrentThread().Dispatcher());
+  return Mso::Make<UISchedulerWinRT, IDispatchQueueScheduler>(DispatcherQueue::GetForCurrentThread());
 }
 
 } // namespace Mso

--- a/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
+++ b/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
@@ -68,6 +68,7 @@ struct UISchedulerWinRT : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDi
   uint32_t m_handlerRefCount{0};
   uint32_t m_taskCount{0};
   bool m_isShutdown{false};
+  std::thread::id m_threadId{std::this_thread::get_id()};
 };
 
 //=============================================================================
@@ -174,7 +175,9 @@ void UISchedulerWinRT::IntializeScheduler(Mso::WeakPtr<IDispatchQueueService> &&
 }
 
 bool UISchedulerWinRT::HasThreadAccess() noexcept {
-  return m_dispatcher.HasThreadAccess();
+  // m_dispatcher.HasThreadAccess() is implemented only in Windows 19H1.
+  // We must use an alternative implementation.
+  return m_threadId == std::this_thread::get_id();
 }
 
 bool UISchedulerWinRT::IsSerial() noexcept {

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -115,7 +115,7 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance> &spThis, cons
   std::shared_ptr<react::uwp::AppTheme> appTheme =
       std::make_shared<react::uwp::AppTheme>(spThis, m_defaultNativeThread);
   I18nHelper::Instance().setInfo(I18nModule::GetI18nInfo());
-  auto appearanceListener = Mso::Make<AppearanceChangeListener>(spThis);
+  auto appearanceListener = Mso::Make<AppearanceChangeListener>(spThis, Mso::DispatchQueue::MakeCurrentThreadUIQueue());
 
   // TODO: Figure out threading. What thread should this really be on?
   m_initThread = std::make_unique<react::uwp::WorkerMessageQueueThread>();

--- a/vnext/ReactUWP/Modules/AppearanceModule.cpp
+++ b/vnext/ReactUWP/Modules/AppearanceModule.cpp
@@ -14,10 +14,12 @@ using Method = facebook::xplat::module::CxxModule::Method;
 
 namespace react::uwp {
 
-AppearanceChangeListener::AppearanceChangeListener(std::weak_ptr<IReactInstance> &&reactInstance) noexcept
-    : Mso::ActiveObject<>(Mso::DispatchQueue::MainUIQueue()), m_weakReactInstance(std::move(reactInstance)) {
+AppearanceChangeListener::AppearanceChangeListener(
+    std::weak_ptr<IReactInstance> &&reactInstance,
+    Mso::DispatchQueue const &uiQueue) noexcept
+    : Mso::ActiveObject<>(uiQueue), m_weakReactInstance(std::move(reactInstance)) {
   // Ensure we're constructed on the UI thread
-  VerifyIsInQueueElseCrash();
+  VerifyElseCrash(uiQueue.HasThreadAccess());
 
   m_currentTheme = Application::Current().RequestedTheme();
 

--- a/vnext/ReactUWP/Modules/AppearanceModule.h
+++ b/vnext/ReactUWP/Modules/AppearanceModule.h
@@ -17,13 +17,14 @@ class AppearanceChangeListener final : public Mso::ActiveObject<> {
   using UISettings = winrt::Windows::UI::ViewManagement::UISettings;
 
  public:
-  AppearanceChangeListener(std::weak_ptr<IReactInstance> &&reactInstance) noexcept;
+  AppearanceChangeListener(std::weak_ptr<IReactInstance> &&reactInstance, Mso::DispatchQueue const &uiQueue) noexcept;
   const char *GetColorScheme() const noexcept;
 
  private:
   static const char *ToString(ApplicationTheme theme) noexcept;
   void OnColorValuesChanged() noexcept;
 
+ private:
   UISettings m_uiSettings;
   UISettings::ColorValuesChanged_revoker m_revoker;
   std::atomic<ApplicationTheme> m_currentTheme;

--- a/vnext/ReactUWP/Modules/AppearanceModule.h
+++ b/vnext/ReactUWP/Modules/AppearanceModule.h
@@ -24,7 +24,6 @@ class AppearanceChangeListener final : public Mso::ActiveObject<> {
   static const char *ToString(ApplicationTheme theme) noexcept;
   void OnColorValuesChanged() noexcept;
 
- private:
   UISettings m_uiSettings;
   UISettings::ColorValuesChanged_revoker m_revoker;
   std::atomic<ApplicationTheme> m_currentTheme;

--- a/vnext/ReactUWP/ReactUWP.vcxproj.filters
+++ b/vnext/ReactUWP/ReactUWP.vcxproj.filters
@@ -106,6 +106,9 @@
     <ClCompile Include="Modules\Animated\ValueAnimatedNode.cpp">
       <Filter>Modules\Animated</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\AppearanceModule.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
     <ClCompile Include="Modules\AppStateModuleUwp.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
@@ -166,6 +169,7 @@
     <ClCompile Include="Polyester\IconViewManager.cpp">
       <Filter>Polyester</Filter>
     </ClCompile>
+    <ClCompile Include="TestHookMock.cpp" />
     <ClCompile Include="Threading\AsyncWorkQueue.cpp">
       <Filter>Threading</Filter>
     </ClCompile>
@@ -322,8 +326,6 @@
     <ClCompile Include="Views\XamlFeatures.cpp">
       <Filter>Views</Filter>
     </ClCompile>
-    <ClCompile Include="Modules\AppearanceModule.cpp" />
-    <ClCompile Include="TestHookMock.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\ReactUWP\InstanceFactory.h">
@@ -481,6 +483,9 @@
     </ClInclude>
     <ClInclude Include="Modules\Animated\ValueAnimatedNode.h">
       <Filter>Modules\Animated</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\AppearanceModule.h">
+      <Filter>Modules</Filter>
     </ClInclude>
     <ClInclude Include="Modules\AppStateModuleUwp.h">
       <Filter>Modules</Filter>
@@ -657,7 +662,6 @@
     <ClInclude Include="Views\VirtualTextViewManager.h">
       <Filter>Views</Filter>
     </ClInclude>
-    <ClInclude Include="Modules\AppearanceModule.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="EndPoints\dll\react-native-uwp.arm.def">


### PR DESCRIPTION
The CoreDispatcher is a UWP-only implementation of a queue running on top of a window message handler. The newer Windows versions have new DispatcherQueue that works for UWP and Win32 applications.

In this PR we change the Mso::DispatchQueue to use the new DispatcherQueue instead of CoreDispatcher.  It enables use of the UI Mso::DispatchQueue implementation on Win32 platforms.

We had to change use of the UI Mso::DispatchQueue in our code to accommodate the DispatcherQueue restriction that it cannot be globally discovered in the application. Instead, we must create it in the ReactApplication and pass through the ReactNativeHost.InstanceSettings().Properties() to other components and native modules.

After this change we do not see the Playground Win32 crash at the startup.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4877)