### PR TITLE
Only emit click events for left mouse button

### DIFF
--- a/change/react-native-windows-2020-05-20-15-15-21-master.json
+++ b/change/react-native-windows-2020-05-20-15-15-21-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Do not emit click events for buttons other than left.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-20T22:15:21.592Z"
+}

--- a/vnext/ReactUWP/Views/TouchEventHandler.cpp
+++ b/vnext/ReactUWP/Views/TouchEventHandler.cpp
@@ -91,7 +91,11 @@ void TouchEventHandler::OnPointerPressed(
     UpdatePointersInViews(instance, args, tag, sourceElement);
 
     size_t pointerIndex = AddReactPointer(args, tag, sourceElement);
-    DispatchTouchEvent(TouchEventType::Start, pointerIndex);
+
+    // For now, we only want to send click events for the left mouse button.
+    if (m_pointers[pointerIndex].isLeftButton) {
+        DispatchTouchEvent(TouchEventType::Start, pointerIndex);
+    }
   }
 }
 

--- a/vnext/ReactUWP/Views/TouchEventHandler.cpp
+++ b/vnext/ReactUWP/Views/TouchEventHandler.cpp
@@ -92,7 +92,8 @@ void TouchEventHandler::OnPointerPressed(
 
     size_t pointerIndex = AddReactPointer(args, tag, sourceElement);
 
-    // For now, we only want to send click events for the left mouse button.
+    // For now, when using the mouse we only want to send click events for the left button.
+    // Finger and pen taps will also set isLeftButton.
     if (m_pointers[pointerIndex].isLeftButton) {
         DispatchTouchEvent(TouchEventType::Start, pointerIndex);
     }

--- a/vnext/ReactUWP/Views/TouchEventHandler.cpp
+++ b/vnext/ReactUWP/Views/TouchEventHandler.cpp
@@ -95,7 +95,7 @@ void TouchEventHandler::OnPointerPressed(
     // For now, when using the mouse we only want to send click events for the left button.
     // Finger and pen taps will also set isLeftButton.
     if (m_pointers[pointerIndex].isLeftButton) {
-        DispatchTouchEvent(TouchEventType::Start, pointerIndex);
+      DispatchTouchEvent(TouchEventType::Start, pointerIndex);
     }
   }
 }


### PR DESCRIPTION
Closes #4566 
#2752 Discusses full mouse support. This PR is to mitigate the unexpected firing of identical onPress events for all mouse buttons.

Caveat - this approach results in the "Ended a touch event which was not counted in `trackedTouchCount`." warning being logged for all clicks other than the left mouse ones - open to suggestions of other ways to do this. 

I've tested that this doesn't break touch events (using my Surface laptop). Pen follows the same logic.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4878)