### PR TITLE
Handle HTTP errors in DevSupportManager.

### DIFF
--- a/change/react-native-windows-2020-05-12-14-18-36-OC-4094136-connectxcpt.json
+++ b/change/react-native-windows-2020-05-12-14-18-36-OC-4094136-connectxcpt.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Handle HTTP connect exceptions in DevSupportManager",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-12T21:18:36.538Z"
+}

--- a/vnext/Desktop/DevSupportManager.cpp
+++ b/vnext/Desktop/DevSupportManager.cpp
@@ -59,7 +59,12 @@ string DevSupportManager::GetJavaScriptFromServer(
   Url url(bundleUrl);
   auto const resolveResult = m_resolver.resolve(url.host, url.port);
   tcp::socket socket{m_context};
-  connect(socket, resolveResult);
+  boost::system::error_code ec;
+  connect(socket, resolveResult, ec);
+  if (ec) {
+    m_exceptionCaught = true;
+    return R"({"error:")"s + ec.message() + R"("})"s;
+  }
 
   request<string_body> request{verb::get, url.Target(), 11};
   request.set(field::host, url.host);
@@ -119,7 +124,12 @@ task<void> DevSupportManager::LaunchDevToolsAsync(const string &debugHost, const
     Url url(DevServerHelper::get_LaunchDevToolsCommandUrl(debugHost));
     auto const resolveResult = m_resolver.resolve(url.host, url.port);
     tcp::socket socket{m_context};
-    connect(socket, resolveResult);
+    boost::system::error_code ec;
+    connect(socket, resolveResult, ec);
+    if (ec) {
+      m_exceptionCaught = true;
+      return;
+    }
 
     request<string_body> request{verb::get, url.Target(), 11};
     request.set(field::host, url.host);


### PR DESCRIPTION
`DevSupportManager` uses `boost::beast::http` for HTTP calls, including downloading JS bundles.
Errors such as resource/host unavailable are not being handled, thus crashing the host app.