### PR TITLE
ViewWin32 Accessibility: labeledBy, describedBy

### DIFF
--- a/change/@office-iss-react-native-win32-2020-05-12-21-44-51-accessibilityLabeledBy.json
+++ b/change/@office-iss-react-native-win32-2020-05-12-21-44-51-accessibilityLabeledBy.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add win32-specific accessibility props Description, DescribedBy, and LabeledBy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T04:44:51.679Z"
+}

--- a/packages/react-native-win32/etc/react-native-win32.api.md
+++ b/packages/react-native-win32/etc/react-native-win32.api.md
@@ -10,6 +10,7 @@ import { NativeSyntheticEvent } from 'react-native';
 import * as React_2 from 'react';
 import RN = require('react-native');
 import { StyleProp } from 'react-native';
+import { View } from 'react-native';
 import { ViewProps } from 'react-native';
 import { ViewStyle } from 'react-native';
 
@@ -49,6 +50,8 @@ export type BasePropsWin32 = {
     accessibilityRole?: RN.AccessibilityRole | ARIARole;
     accessibilityStates?: AccessibilityStates[];
     accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
+    accessibilityDescribedBy?: React_2.RefObject<any>;
+    accessibilityLabeledBy?: React_2.RefObject<any>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "IButtonWin32State" needs to be exported by the entry point typings-index.d.ts
@@ -440,12 +443,12 @@ export class TouchableWin32 extends React_2.Component<ITouchableWin32Props, IInt
 export type UseFrom<TOrigin, TUse, Key extends keyof TUse> = Pick<TOrigin, Exclude<keyof TOrigin, Key>> & Pick<TUse, Key>;
 
 // @public (undocumented)
-export class ViewWin32 extends React_2.Component<IViewWin32Props, {}> implements IViewWin32 {
-    constructor(props: IViewWin32Props);
-    focus(): void;
-    // (undocumented)
-    render(): JSX.Element;
-}
+export const ViewWin32: React_2.ForwardRefExoticComponent<IViewWin32Props & React_2.RefAttributes<any>>;
+
+// Warning: (ae-forgotten-export) The symbol "ViewWin32Type" needs to be exported by the entry point typings-index.d.ts
+//
+// @public (undocumented)
+export type ViewWin32 = ViewWin32Type;
 
 // @public (undocumented)
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid & RN.ViewPropsIOS & RN.AccessibilityPropsAndroid & Omit_2<RN.AccessibilityPropsIOS, SharedAccessibilityPropsIOSandWin32> & OmittedAccessibilityPropsWin32;

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "just-scripts lint:fix",
     "lint": "just-scripts lint",
     "api": "just-scripts api",
-    "run-win32-dev-web": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist/win32/dev --useWebDebugger",
+    "run-win32-dev-web": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist/win32/dev --useDevMain --useWebDebugger",
     "run-win32-devmain": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist/win32/dev --useDevMain",
     "run-win32": "rex-win32 --bundle RNTester --component RNTesterApp --basePath ./dist/win32/dev",
     "start": "react-native start",

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -134,10 +134,13 @@ const ReactNativeViewConfig = {
   validAttributes: {
     ...ReactNativeViewViewConfigAndroid.validAttributes,
     accessibilityActions: true,
+    accessibilityDescription: true,
+    accessibilityDescribedBy: true,
     accessibilityElementsHidden: true,
     accessibilityHint: true,
     accessibilityIgnoresInvertColors: true,
     accessibilityLabel: true,
+    accessibilityLabeledBy: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
     accessibilityStates: true, // TODO: Can be removed after next release

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -375,7 +375,6 @@ const ReactNativeViewConfig = {
     onMouseLeave: true,
     tooltip: true,
     cursor: true,
-    accessibilityDescription: true,
     accessibilityDescribedBy: true,
     accessibilityLabeledBy: true,
     // Windows]

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -134,13 +134,10 @@ const ReactNativeViewConfig = {
   validAttributes: {
     ...ReactNativeViewViewConfigAndroid.validAttributes,
     accessibilityActions: true,
-    accessibilityDescription: true,
-    accessibilityDescribedBy: true,
     accessibilityElementsHidden: true,
     accessibilityHint: true,
     accessibilityIgnoresInvertColors: true,
     accessibilityLabel: true,
-    accessibilityLabeledBy: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
     accessibilityStates: true, // TODO: Can be removed after next release
@@ -378,6 +375,9 @@ const ReactNativeViewConfig = {
     onMouseLeave: true,
     tooltip: true,
     cursor: true,
+    accessibilityDescription: true,
+    accessibilityDescribedBy: true,
+    accessibilityLabeledBy: true,
     // Windows]
   },
 };

--- a/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import * as React from 'react';
-import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
+import { StyleSheet, Text, TouchableHighlight } from 'react-native';
 import { ViewWin32 } from '../ViewWin32';
 import { IKeyboardEvent, IHandledKeyboardEvent } from '../ViewWin32.Props';
 
@@ -31,18 +31,20 @@ interface IFocusableComponentState {
 
 class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentState> {
   private _focusTarget: ViewWin32 = null;
-  private _labeledBy: React.RefObject<View>;
+  private _labeledBy: React.RefObject<ViewWin32>;
 
   public constructor(props) {
     super(props);
     this.state = {
       hasFocus: false,
     };
-    this._labeledBy = React.createRef<View>();
+    this._labeledBy = React.createRef<ViewWin32>();
   }
   public render() {
     return (
-      <View ref={this._labeledBy} accessibilityLabel="separate label for test" style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
+      <ViewWin32>
+        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" />
+      <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
         <TouchableHighlight onPress={this._onPress}>
           <ViewWin32 accessibilityLabeledBy={this._labeledBy} style={styles.blackbox} />
         </TouchableHighlight>
@@ -55,7 +57,8 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
         >
           <Text>{this.state.hasFocus ? 'Focus: Yes' : 'Focus: No'}</Text>
         </ViewWin32>
-      </View>
+      </ViewWin32>
+      </ViewWin32>
     );
   }
 

--- a/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import * as React from 'react';
-import { StyleSheet, Text, TouchableHighlight } from 'react-native';
+import { StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 import { ViewWin32 } from '../ViewWin32';
 import { IKeyboardEvent, IHandledKeyboardEvent } from '../ViewWin32.Props';
 
@@ -31,17 +31,20 @@ interface IFocusableComponentState {
 
 class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentState> {
   private _focusTarget: ViewWin32 = null;
+  private _labeledBy: React.RefObject<View>;
+
   public constructor(props) {
     super(props);
     this.state = {
       hasFocus: false,
     };
+    this._labeledBy = React.createRef<View>();
   }
   public render() {
     return (
-      <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
+      <View ref={this._labeledBy} accessibilityLabel="separate label for test" style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
         <TouchableHighlight onPress={this._onPress}>
-          <ViewWin32 style={styles.blackbox} />
+          <ViewWin32 accessibilityLabeledBy={this._labeledBy} style={styles.blackbox} />
         </TouchableHighlight>
         <ViewWin32
           ref={this._setRef}
@@ -52,7 +55,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
         >
           <Text>{this.state.hasFocus ? 'Focus: Yes' : 'Focus: No'}</Text>
         </ViewWin32>
-      </ViewWin32>
+      </View>
     );
   }
 

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -156,7 +156,6 @@ export type BasePropsWin32 = {
   * The reference will be converted to a native reference (tag) before passing to the native platform.
   */
  accessibilityDescribedBy?: React.RefObject<any>;
- accessibilityDescription?: string;
  accessibilityLabeledBy?: React.RefObject<any>;
 };
 

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -110,7 +110,7 @@ export type AccessibilityActionName =
   export type Cursor =
   | 'auto'
   | 'pointer'
-  
+
 export type AccessibilityActionInfo = Readonly<{
   name: AccessibilityActionName;
   label?: string;
@@ -148,6 +148,16 @@ export type BasePropsWin32 = {
   accessibilityRole?: RN.AccessibilityRole | ARIARole;
   accessibilityStates?: AccessibilityStates[];
   accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
+
+  /**
+  * Windows Accessibility extensions for allowing other DOM elements to label or describe a given element.
+  *
+  * Defined as a reference to another DOM element inheriting from the primary base classes of React-Native elements.
+  * The reference will be converted to a native reference (tag) before passing to the native platform.
+  */
+ accessibilityDescribedBy?: React.RefObject<any>;
+ accessibilityDescription?: string;
+ accessibilityLabeledBy?: React.RefObject<any>;
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -6,126 +6,57 @@
 
 import * as React from 'react';
 import RN = require('react-native');
-import { NativeModules, findNodeHandle } from 'react-native';
-import { IViewWin32Props, IViewWin32, UseFrom } from './ViewWin32.Props';
+import { View } from 'react-native';
+import { IViewWin32Props, UseFrom } from './ViewWin32.Props';
 
 /**
  * Basic View component with additional Win32 specific functionality
  */
 
-type InnerViewProps = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'> &
+type InnerViewWin32Props = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityStates'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
 
-type ViewWin32State = {
-  describedByTarget?: number | null;
-  describedByTargetRef?: React.RefObject<any>;
-  labeledByTarget?: number | null;
-  labeledByTargetRef?: React.RefObject<any>;
-};
+type ViewWin32Type = React.ForwardRefExoticComponent<
+IViewWin32Props & React.RefAttributes<View>
+> &
+  View;
 
-export class ViewWin32 extends React.Component<IViewWin32Props, ViewWin32State> implements IViewWin32 {
-  constructor(props: IViewWin32Props) {
-    super(props);
-    this.state = {
-      describedByTarget: null,
-      describedByTargetRef: null,
-      labeledByTarget: null,
-      labeledByTargetRef: null,
-    };
-  }
 
-  public ensureRefStateIsResolved() {
-    let newLabeledByTarget = null;
-    let newDescribedByTarget = null;
-    const currentLabeledByRef = this.state.labeledByTargetRef?.current;
-    if (currentLabeledByRef !== null && currentLabeledByRef !== undefined)
-    {
-      newLabeledByTarget = findNodeHandle(this.state.labeledByTargetRef.current as
-             | null
-             | number
-             | React.Component<any, any, any>
-             | React.ComponentClass<any, any>);
-    }
+export const ViewWin32 = React.forwardRef(
+  (props: IViewWin32Props, ref: React.Ref<any>) => {
 
-    const currentDescribedByRef = this.state.describedByTargetRef?.current;
-    if (currentDescribedByRef !== null && currentDescribedByRef !== undefined)
-    {
-      newDescribedByTarget = findNodeHandle(this.state.describedByTargetRef.current as
-        | null
-        | number
-        | React.Component<any, any, any>
-        | React.ComponentClass<any, any>);
-    }
-
-    if (newDescribedByTarget !== this.state.describedByTarget || newLabeledByTarget !== this.state.labeledByTarget)
-    {
-      this.setState({
-        describedByTarget: newDescribedByTarget,
-        labeledByTarget: newLabeledByTarget,
-        describedByTargetRef: this.state.describedByTargetRef,
-        labeledByTargetRef: this.state.labeledByTargetRef});
-    }
-  }
-
-  public componentDidMount() {
-    this.ensureRefStateIsResolved();
-  }
-
-  public componentDidUpdate() {
-    this.ensureRefStateIsResolved();
-  }
-
-  public static getDerivedStateFromProps(
-    nextProps: IViewWin32Props,
-    prevState: ViewWin32State,
-  ): ViewWin32State {
-    let nextState = prevState;
-
-    nextState.labeledByTargetRef = nextProps?.accessibilityLabeledBy;
-    nextState.describedByTargetRef = nextProps?.accessibilityDescribedBy;
-
-    return nextState;
-  }
-
-  public render() {
+    /**
+     * Check for raw text in the DOM.
+     */
     if (__DEV__) {
-      React.Children.toArray(this.props.children).forEach(item => {
+      React.Children.toArray(props.children).forEach(item => {
         if (typeof item === 'string') {
           console.error(`Unexpected text node: ${item}. A text node cannot be a child of a <View>.`);
         }
       });
     }
 
-    if (this.props.accessibilityDescribedBy?.current !== null && this.props.accessibilityDescribedBy?.current !== undefined)
-    {
-      console.error('somehow we got current without processing it ever... do I just move it into render?');
-    }
+    /**
+     *
+     */
 
-    if (this.props.accessibilityLabeledBy?.current !== null && this.props.accessibilityLabeledBy?.current !== undefined)
-    {
-      console.error('somehow we got current without processing it ever... do I just move it into render?');
-    }
+    /**
+     * Add focus() as a callable function.  PROBLEM: findNodeHandle doesn't work, focusRef.current is undefined ...
+     */
+    // const focusRef = React.useRef<ViewWin32>();
+    // React.useImperativeHandle(ref, () => ({
+    //   focus: () => {
+    //     NativeModules.UIManager.dispatchViewManagerCommand(
+    //       findNodeHandle(focusRef.current),
+    //       NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
+    //       null
+    //       );
+    //   },
+    // }));
 
-    // Remove props that have been derived and stored in state
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = this.props;
+    return <View ref={ref} {...(props as InnerViewWin32Props)} />;
+  });
 
-    return <RN.View
-      {...(rest as InnerViewProps)}
-      {...((this.state.labeledByTarget !== null) ? {accessibilityLabeledBy:this.state.labeledByTarget} : {})}
-      {...((this.state.describedByTarget !== null) ? {accessibilityDescribedBy:this.state.describedByTarget} : {})} />;
-  }
-
-  /**
-   * Moves focus to this view
-   */
-  public focus() {
-    NativeModules.UIManager.dispatchViewManagerCommand(
-      findNodeHandle(this),
-      NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
-      null
-    );
-  }
-}
+export type ViewWin32 = ViewWin32Type;

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import RN = require('react-native');
-import { View } from 'react-native';
+import { View, findNodeHandle, NativeModules } from 'react-native';
 import { IViewWin32Props, UseFrom } from './ViewWin32.Props';
 
 /**
@@ -37,26 +37,53 @@ export const ViewWin32 = React.forwardRef(
         }
       });
     }
+    const [labeledByTarget, setLabeledByTarget] = React.useState(null);
+    const [describedByTarget, setDescribedByTarget] = React.useState(null);
+    /**
+     * Process accessibility refs into node handles after initial DOM render, before sent across the bridge.
+     * useLayoutEffect will invalidate the render to assess the ref-based accessibility properties.
+     */
+    const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = props;
+    React.useLayoutEffect(() => {
+      if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy?.current !== null)
+      {
+        setLabeledByTarget(findNodeHandle(accessibilityLabeledBy.current as
+          | null
+          | number
+          | React.Component<any, any, any>
+          | React.ComponentClass<any, any>));
+      }
+
+      if (accessibilityDescribedBy !== undefined && accessibilityDescribedBy?.current !== null)
+      {
+        setDescribedByTarget(findNodeHandle(accessibilityDescribedBy.current as
+          | null
+          | number
+          | React.Component<any, any, any>
+          | React.ComponentClass<any, any>));
+      }
+    }, [accessibilityLabeledBy, accessibilityDescribedBy]);
 
     /**
-     *
+     * Add focus() as a callable function to the forwarded reference.
      */
+    const focusRef = React.useRef<ViewWin32>();
+    React.useImperativeHandle(ref, () => ({
+      focus: () => {
+        NativeModules.UIManager.dispatchViewManagerCommand(
+          findNodeHandle(focusRef.current),
+          NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
+          null
+          );
+      },
+      ...focusRef.current,
+    }));
 
-    /**
-     * Add focus() as a callable function.  PROBLEM: findNodeHandle doesn't work, focusRef.current is undefined ...
-     */
-    // const focusRef = React.useRef<ViewWin32>();
-    // React.useImperativeHandle(ref, () => ({
-    //   focus: () => {
-    //     NativeModules.UIManager.dispatchViewManagerCommand(
-    //       findNodeHandle(focusRef.current),
-    //       NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
-    //       null
-    //       );
-    //   },
-    // }));
-
-    return <View ref={ref} {...(props as InnerViewWin32Props)} />;
+    return <View ref={focusRef}
+    {...(rest as InnerViewWin32Props)}
+    {...((labeledByTarget !== null) ? {accessibilityLabeledBy:labeledByTarget} : {})}
+    {...((describedByTarget !== null) ? {accessibilityDescribedBy:describedByTarget} : {})}
+    />;
   });
 
 export type ViewWin32 = ViewWin32Type;

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -83,7 +83,7 @@ export const ViewWin32 = React.forwardRef(
         {
           localRef.focus = () => {
             NativeModules.UIManager.dispatchViewManagerCommand(
-              findNodeHandle(focusRef.current),
+              findNodeHandle(localRef),
               NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
               null
               );

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -18,9 +18,75 @@ type InnerViewProps = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
 
-export class ViewWin32 extends React.Component<IViewWin32Props, {}> implements IViewWin32 {
+type ViewWin32State = {
+  describedByTarget?: number | null;
+  describedByTargetRef?: React.RefObject<any>;
+  labeledByTarget?: number | null;
+  labeledByTargetRef?: React.RefObject<any>;
+};
+
+export class ViewWin32 extends React.Component<IViewWin32Props, ViewWin32State> implements IViewWin32 {
   constructor(props: IViewWin32Props) {
     super(props);
+    this.state = {
+      describedByTarget: null,
+      describedByTargetRef: null,
+      labeledByTarget: null,
+      labeledByTargetRef: null,
+    };
+  }
+
+  public ensureRefStateIsResolved() {
+    let newLabeledByTarget = null;
+    let newDescribedByTarget = null;
+    const currentLabeledByRef = this.state.labeledByTargetRef?.current;
+    if (currentLabeledByRef !== null && currentLabeledByRef !== undefined)
+    {
+      newLabeledByTarget = findNodeHandle(this.state.labeledByTargetRef.current as
+             | null
+             | number
+             | React.Component<any, any, any>
+             | React.ComponentClass<any, any>);
+    }
+
+    const currentDescribedByRef = this.state.describedByTargetRef?.current;
+    if (currentDescribedByRef !== null && currentDescribedByRef !== undefined)
+    {
+      newDescribedByTarget = findNodeHandle(this.state.describedByTargetRef.current as
+        | null
+        | number
+        | React.Component<any, any, any>
+        | React.ComponentClass<any, any>);
+    }
+
+    if (newDescribedByTarget !== this.state.describedByTarget || newLabeledByTarget !== this.state.labeledByTarget)
+    {
+      this.setState({
+        describedByTarget: newDescribedByTarget,
+        labeledByTarget: newLabeledByTarget,
+        describedByTargetRef: this.state.describedByTargetRef,
+        labeledByTargetRef: this.state.labeledByTargetRef});
+    }
+  }
+
+  public componentDidMount() {
+    this.ensureRefStateIsResolved();
+  }
+
+  public componentDidUpdate() {
+    this.ensureRefStateIsResolved();
+  }
+
+  public static getDerivedStateFromProps(
+    nextProps: IViewWin32Props,
+    prevState: ViewWin32State,
+  ): ViewWin32State {
+    let nextState = prevState;
+
+    nextState.labeledByTargetRef = nextProps?.accessibilityLabeledBy;
+    nextState.describedByTargetRef = nextProps?.accessibilityDescribedBy;
+
+    return nextState;
   }
 
   public render() {
@@ -31,7 +97,25 @@ export class ViewWin32 extends React.Component<IViewWin32Props, {}> implements I
         }
       });
     }
-    return <RN.View {...(this.props as InnerViewProps)} />;
+
+    if (this.props.accessibilityDescribedBy?.current !== null && this.props.accessibilityDescribedBy?.current !== undefined)
+    {
+      console.error('somehow we got current without processing it ever... do I just move it into render?');
+    }
+
+    if (this.props.accessibilityLabeledBy?.current !== null && this.props.accessibilityLabeledBy?.current !== undefined)
+    {
+      console.error('somehow we got current without processing it ever... do I just move it into render?');
+    }
+
+    // Remove props that have been derived and stored in state
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = this.props;
+
+    return <RN.View
+      {...(rest as InnerViewProps)}
+      {...((this.state.labeledByTarget !== null) ? {accessibilityLabeledBy:this.state.labeledByTarget} : {})}
+      {...((this.state.describedByTarget !== null) ? {accessibilityDescribedBy:this.state.describedByTarget} : {})} />;
   }
 
   /**

--- a/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
+++ b/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
@@ -134,13 +134,10 @@ const ReactNativeViewConfig = {
   validAttributes: {
     ...ReactNativeViewViewConfigAndroid.validAttributes,
     accessibilityActions: true,
-    accessibilityDescribedBy: true,
-    accessibilityDescription: true,
     accessibilityElementsHidden: true,
     accessibilityHint: true,
     accessibilityIgnoresInvertColors: true,
     accessibilityLabel: true,
-    accessibilityLabeledBy: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
     accessibilityStates: true, // TODO: Can be removed after next release

--- a/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
+++ b/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
@@ -134,10 +134,13 @@ const ReactNativeViewConfig = {
   validAttributes: {
     ...ReactNativeViewViewConfigAndroid.validAttributes,
     accessibilityActions: true,
+    accessibilityDescribedBy: true,
+    accessibilityDescription: true,
     accessibilityElementsHidden: true,
     accessibilityHint: true,
     accessibilityIgnoresInvertColors: true,
     accessibilityLabel: true,
+    accessibilityLabeledBy: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
     accessibilityStates: true, // TODO: Can be removed after next release


### PR DESCRIPTION
Enable referential accessibility props accessibilityLabeledBy and accessibilityDescribedBy for Win32.

Also rewrites ViewWin32 from a class component to a function component, as generally virtuous and simplifying the life cycle (useLayoutEffect) insertion handling the referential props.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4883)