### PR TITLE
Allow storing non-WinRT types in ReactPropertyBag

### DIFF
--- a/change/react-native-windows-2020-05-12-18-57-59-UnsafePropertyId.json
+++ b/change/react-native-windows-2020-05-12-18-57-59-UnsafePropertyId.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow storing non-WinRT types in ReactPropertyBag",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T01:57:59.370Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/BoxedValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/BoxedValue.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef MICROSOFT_REACTNATIVE_BOXEDVALUE
+#define MICROSOFT_REACTNATIVE_BOXEDVALUE
+
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+template <class T>
+struct BoxedValue : implements<BoxedValue<T>, IBoxedValue> {
+  template <class... TArgs>
+  BoxedValue(TArgs &&... args) noexcept : m_value(std::forward<TArgs>(args)...) {}
+
+  int64_t GetPtr() noexcept {
+    return reinterpret_cast<int64_t>(&m_value);
+  }
+
+  static T &GetValueUnsafe(IBoxedValue const &boxedValue) noexcept {
+    return *reinterpret_cast<T *>(boxedValue.GetPtr());
+  }
+
+ private:
+  T m_value{};
+};
+
+} // namespace winrt::Microsoft::ReactNative
+
+#endif // MICROSOFT_REACTNATIVE_BOXEDVALUE

--- a/vnext/Microsoft.ReactNative.Cxx/BoxedValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/BoxedValue.h
@@ -14,7 +14,7 @@ struct BoxedValue : implements<BoxedValue<T>, IBoxedValue> {
   template <class... TArgs>
   BoxedValue(TArgs &&... args) noexcept : m_value(std::forward<TArgs>(args)...) {}
 
-  int64_t GetPtr() noexcept {
+  int64_t GetPtr() const noexcept {
     return reinterpret_cast<int64_t>(&m_value);
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -17,6 +17,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)BoxedValue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)CppWinRTIncludes.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Crash.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValue.h" />

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "winrt/Microsoft.ReactNative.h"
 
+#include "BoxedValue.h"
 #include "JSValueReader.h"
 #include "JSValueWriter.h"
 #include "ModuleRegistration.h"
@@ -1103,23 +1104,6 @@ struct TurboModuleSpec {
     return CheckMethodsHelper<TModule, TModuleSpec>(
         std::make_index_sequence<std::tuple_size_v<decltype(TModuleSpec::methods)>>{});
   }
-};
-
-template <class T>
-struct BoxedValue : implements<BoxedValue<T>, IBoxedValue> {
-  template <class... TArgs>
-  BoxedValue(TArgs &&... args) noexcept : m_value(std::forward<TArgs>(args)...) {}
-
-  int64_t GetPtr() noexcept {
-    return reinterpret_cast<int64_t>(&m_value);
-  }
-
-  static T &GetValueUnsafe(IBoxedValue const &boxedValue) noexcept {
-    return *reinterpret_cast<T *>(boxedValue.GetPtr());
-  }
-
- private:
-  T m_value{};
 };
 
 template <class TModule>

--- a/vnext/Microsoft.ReactNative.Cxx/ReactPropertyBag.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactPropertyBag.h
@@ -118,7 +118,7 @@ struct ReactPropertyId {
 // ReactPropertyBag is a wrapper for IReactPropertyBag to store strongly-typed properties in a thread-safe way.
 // Types inherited from IInspectable are stored directly.
 // Values of other types are boxed with help of winrt::box_value.
-// Non-WinRT types are wrapped with help of BoxedValue template.
+// Non-WinRT types are wrapped with the help of BoxedValue template.
 struct ReactPropertyBag {
   // Property result type is either T or std::optional<T>.
   // T is returned for types inherited from IInspectable.

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactPropertyBagTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactPropertyBagTests.cpp
@@ -6,6 +6,7 @@
 
 using namespace winrt;
 using namespace Microsoft::ReactNative;
+using namespace Windows::Foundation;
 
 namespace ReactNativeIntegrationTests {
 
@@ -515,6 +516,27 @@ TEST_CLASS (ReactPropertyBagTests) {
     TestCheckEqual(5, winrt::unbox_value<int>((*pb.Get(fooName))()));
 
     ReactCreatePropertyValue createValue2 = []() { return winrt::box_value(10); };
+    pb.Set(fooName, createValue2);
+    TestCheckEqual(createValue2, *pb.Get(fooName));
+    TestCheckEqual(10, winrt::unbox_value<int>((*pb.Get(fooName))()));
+    TestCheck(createValue1 != *pb.Get(fooName));
+    pb.Remove(fooName);
+    TestCheck(!pb.Get(fooName));
+  }
+
+  TEST_METHOD(PropertyBag_Property_Functor) {
+    ReactPropertyId<Mso::Functor<IInspectable()>> fooName{L"Foo"};
+    ReactPropertyBag pb{ReactPropertyBagHelper::CreatePropertyBag()};
+
+    TestCheck(!pb.Get(fooName));
+    Mso::Functor<IInspectable()> createValue1 = []() noexcept {
+      return winrt::box_value(5);
+    };
+    TestCheckEqual(createValue1, *pb.GetOrCreate(fooName, [&createValue1]() { return createValue1; }));
+    TestCheckEqual(createValue1, *pb.Get(fooName));
+    TestCheckEqual(5, winrt::unbox_value<int>((*pb.Get(fooName))()));
+
+    Mso::Functor<IInspectable()> createValue2 = []() { return winrt::box_value(10); };
     pb.Set(fooName, createValue2);
     TestCheckEqual(createValue2, *pb.Get(fooName));
     TestCheckEqual(10, winrt::unbox_value<int>((*pb.Get(fooName))()));


### PR DESCRIPTION
The ReactPropertyBag allows storing only WinRT types. It can be useful to pass values across ABI boundary. In some cases we want to store non-WinRT types that local only to the native module.
In this change we add ability to store non-WinRT types in the ReactPropertyBag with help of BoxedValue wrapper.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4884)