### PR TITLE
BugFix:  fix default tabindex stomping over acceptsKeyboardFocus

### DIFF
--- a/change/react-native-windows-2020-05-13-12-47-43-tabfocus-fix.json
+++ b/change/react-native-windows-2020-05-13-12-47-43-tabfocus-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "revert dfc57fcf2504f57baab20f550b36a618eaa99e56",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T19:47:43.325Z"
+}

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -58,9 +58,9 @@ bool ControlViewManager::UpdateProperty(
     } else if (propertyName == "tabIndex") {
       if (propertyValue.isNumber()) {
         auto tabIndex = propertyValue.asDouble();
-          if (tabIndex == static_cast<int32_t>(tabIndex))
-              control.ClearValue(xaml::Controls::Control::TabIndexProperty());
-            control.TabIndex(static_cast<int32_t>(tabIndex));
+        if (tabIndex == static_cast<int32_t>(tabIndex))
+          control.ClearValue(xaml::Controls::Control::TabIndexProperty());
+        control.TabIndex(static_cast<int32_t>(tabIndex));
       } else if (propertyValue.isNull()) {
         control.ClearValue(xaml::Controls::Control::TabIndexProperty());
       }

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -58,15 +58,9 @@ bool ControlViewManager::UpdateProperty(
     } else if (propertyName == "tabIndex") {
       if (propertyValue.isNumber()) {
         auto tabIndex = propertyValue.asDouble();
-        if (tabIndex == static_cast<int32_t>(tabIndex)) {
-          if (tabIndex < 0) {
-            control.IsTabStop(false);
-            control.ClearValue(xaml::Controls::Control::TabIndexProperty());
-          } else {
-            control.IsTabStop(true);
+          if (tabIndex == static_cast<int32_t>(tabIndex))
+              control.ClearValue(xaml::Controls::Control::TabIndexProperty());
             control.TabIndex(static_cast<int32_t>(tabIndex));
-          }
-        }
       } else if (propertyValue.isNull()) {
         control.ClearValue(xaml::Controls::Control::TabIndexProperty());
       }

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -87,15 +87,8 @@ class ViewShadowNode : public ShadowNodeBase {
   void TabIndex(int32_t tabIndex) {
     m_tabIndex = tabIndex;
 
-    if (IsControl()) {
-      if (tabIndex < 0) {
-        GetControl().IsTabStop(false);
-        GetControl().ClearValue(xaml::Controls::Control::TabIndexProperty());
-      } else {
-        GetControl().IsTabStop(true);
-        GetControl().TabIndex(tabIndex);
-      }
-    }
+    if (IsControl())
+      GetControl().TabIndex(m_tabIndex);
   }
 
   bool OnClick() {
@@ -213,7 +206,7 @@ class ViewShadowNode : public ShadowNodeBase {
 
   bool m_enableFocusRing = true;
   bool m_onClick = false;
-  int32_t m_tabIndex = -1;
+  int32_t m_tabIndex = std::numeric_limits<std::int32_t>::max();
 
   xaml::Controls::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
   xaml::Controls::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -206,7 +206,7 @@ class ViewShadowNode : public ShadowNodeBase {
 
   bool m_enableFocusRing = true;
   bool m_onClick = false;
-  int32_t m_tabIndex = -1;
+  int32_t m_tabIndex = std::numeric_limits<std::int32_t>::max();
 
   xaml::Controls::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
   xaml::Controls::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};
@@ -368,7 +368,7 @@ bool ViewViewManager::UpdateProperty(
           pViewShadowNode->TabIndex(static_cast<int32_t>(tabIndex));
         }
       } else if (propertyValue.isNull()) {
-        pViewShadowNode->TabIndex(-1);
+        pViewShadowNode->TabIndex(std::numeric_limits<std::int32_t>::max());
       }
     } else {
       ret = Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/ReactUWP/Views/ViewViewManager.cpp
+++ b/vnext/ReactUWP/Views/ViewViewManager.cpp
@@ -206,7 +206,7 @@ class ViewShadowNode : public ShadowNodeBase {
 
   bool m_enableFocusRing = true;
   bool m_onClick = false;
-  int32_t m_tabIndex = std::numeric_limits<std::int32_t>::max();
+  int32_t m_tabIndex = -1;
 
   xaml::Controls::ContentControl::GotFocus_revoker m_contentControlGotFocusRevoker{};
   xaml::Controls::ContentControl::LostFocus_revoker m_contentControlLostFocusRevoker{};


### PR DESCRIPTION
Fixes #4703 

This fixes a regression that came in with this change:
https://github.com/microsoft/react-native-windows/pull/4180

this change introduced a convention that setting tabIndex = -1 makes the control no longer tab focusable.  This stomps over the behavior of the acceptsKeyboardFocus prop, making it not work correctly anymore.

This fix reverts that behavior.  To achieve this behavior, customers should set acceptsKeyboarFocus = false.  Note that this property will become deprecated and replaced by focusable.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4893)