### PR TITLE
Fix Playground app crash on instance load

### DIFF
--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -42,6 +42,9 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseFastRefresh(x_UseFastRefreshCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerPort(static_cast<uint16_t>(std::stoi(std::wstring(x_DebuggerPort().Text()))));
+  host.InstanceSettings().Properties().Set(
+      winrt::Microsoft::ReactNative::ReactDispatcherHelper::UIDispatcherProperty(),
+      winrt::Microsoft::ReactNative::ReactDispatcherHelper::UIThreadDispatcher());
 
   // Nudge the ReactNativeHost to create the instance and wrapping context
   host.ReloadInstance();


### PR DESCRIPTION
The playground app does not use ReactApplication, and so its required that it provides a UIDispatcher as part of the instance settings.  - This was missed as part of #4877 

This gets playground booting again.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4896)