### PR TITLE
Install exact version of WinAppDriver

### DIFF
--- a/change/react-native-windows-2020-05-14-00-25-43-rnw-dep-winappdriver.json
+++ b/change/react-native-windows-2020-05-14-00-25-43-rnw-dep-winappdriver.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "exact match of WinAppDriver required",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-14T07:25:43.437Z"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -109,7 +109,13 @@ $requirements = @(
     @{
         Name = 'WinAppDriver';
         Valid = (Test-Path "${env:ProgramFiles(x86)}\Windows Application Driver\WinAppDriver.exe");
-        Install = { choco install -y WinAppDriver };
+        Install = { 
+            # don't install from choco as we need an exact version match. appium-windows-driver checks the checksum of WAD.
+            # See \node_modules\appium-windows-driver\build\lib\installer.js
+            $ProgressPreference = 'Ignore';
+            Invoke-WebRequest https://github.com/microsoft/WinAppDriver/releases/download/v1.1/WindowsApplicationDriver.msi  -OutFile $env:TEMP\WindowsApplicationDriver.msi 
+            & $env:TEMP\WindowsApplicationDriver.msi /q
+        };
     }
 
     );


### PR DESCRIPTION
Don't install this one from choco as we need an exact version match. appium-windows-driver checks the checksum of WAD.
See \node_modules\appium-windows-driver\build\lib\installer.js

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4905)