### PR TITLE
JustMyXaml.ps1

### DIFF
--- a/change/react-native-windows-2020-05-15-03-01-54-justMyXaml.json
+++ b/change/react-native-windows-2020-05-15-03-01-54-justMyXaml.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": ".\\JustMyXaml.ps1",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T10:01:54.898Z"
+}

--- a/vnext/Scripts/JustMyXaml.ps1
+++ b/vnext/Scripts/JustMyXaml.ps1
@@ -1,15 +1,20 @@
 # This script enables or disables VS 2019's JustMyXaml feature
 [CmdletBinding()]
 param([bool]$Enable)
-$instanceId = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -property instanceId
+
+if (!([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544"))) {
+    throw "Please run this script elevated";
+}
+
+$instanceId = & "$(${env:ProgramFiles(x86)})\Microsoft Visual Studio\Installer\vswhere.exe" -property instanceId
 $hiveFile = "$($env:LocalAppData)\Microsoft\VisualStudio\16.0_$instanceId\privateregistry.bin"
 & reg.exe load HKLM\VS2019_HIVE $hiveFile | Out-Null
 New-PSDrive -Name VS2019 -PSProvider Registry -Root HKLM\VS2019_HIVE  -ErrorAction Stop | Out-Null
-$currentValue = (Get-ItemProperty VS2019:\Software\Microsoft\VisualStudio\16.0_9f8d4bd3\Debugger -Name EnableXamlVisualDiagnosticsJustMyXaml).EnableXamlVisualDiagnosticsJustMyXaml
+$currentValue = (Get-ItemProperty VS2019:\Software\Microsoft\VisualStudio\16.0_$instanceId\Debugger -Name EnableXamlVisualDiagnosticsJustMyXaml).EnableXamlVisualDiagnosticsJustMyXaml
 if ($currentValue -eq 0) { $currentValue = $false; } else { $currentValue = $true; }
 Write-Host "Current value: $currentValue"
 if ($Enable) { $newValue = 1; } else { $newValue = 0; }
-Set-ItemProperty VS2019:\Software\Microsoft\VisualStudio\16.0_9f8d4bd3\Debugger -Name EnableXamlVisualDiagnosticsJustMyXaml -Value $newValue -Type DWord
+Set-ItemProperty VS2019:\Software\Microsoft\VisualStudio\16.0_$instanceId\Debugger -Name EnableXamlVisualDiagnosticsJustMyXaml -Value $newValue -Type DWord
 Write-Host "New value: $Enable"
 Remove-PSDrive -Name VS2019
 & reg.exe unload HKLM\VS2019_HIVE | Out-Null

--- a/vnext/Scripts/JustMyXaml.ps1
+++ b/vnext/Scripts/JustMyXaml.ps1
@@ -1,0 +1,15 @@
+# This script enables or disables VS 2019's JustMyXaml feature
+[CmdletBinding()]
+param([bool]$Enable)
+$instanceId = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -property instanceId
+$hiveFile = "$($env:LocalAppData)\Microsoft\VisualStudio\16.0_$instanceId\privateregistry.bin"
+& reg.exe load HKLM\VS2019_HIVE $hiveFile | Out-Null
+New-PSDrive -Name VS2019 -PSProvider Registry -Root HKLM\VS2019_HIVE  -ErrorAction Stop | Out-Null
+$currentValue = (Get-ItemProperty VS2019:\Software\Microsoft\VisualStudio\16.0_9f8d4bd3\Debugger -Name EnableXamlVisualDiagnosticsJustMyXaml).EnableXamlVisualDiagnosticsJustMyXaml
+if ($currentValue -eq 0) { $currentValue = $false; } else { $currentValue = $true; }
+Write-Host "Current value: $currentValue"
+if ($Enable) { $newValue = 1; } else { $newValue = 0; }
+Set-ItemProperty VS2019:\Software\Microsoft\VisualStudio\16.0_9f8d4bd3\Debugger -Name EnableXamlVisualDiagnosticsJustMyXaml -Value $newValue -Type DWord
+Write-Host "New value: $Enable"
+Remove-PSDrive -Name VS2019
+& reg.exe unload HKLM\VS2019_HIVE | Out-Null


### PR DESCRIPTION
Provide a script to easily turn off/on VS 2019's new feature "Just my XAML" since it hides programmatically created XAML elements from the Live Visual Tree.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4914)