### PR TITLE
Prevent hard crash on invalid jsx (button inside text e.g.)

### DIFF
--- a/change/react-native-windows-2020-05-15-14-54-00-jsxCrash.json
+++ b/change/react-native-windows-2020-05-15-14-54-00-jsxCrash.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent hard crash on invalid jsx (button inside text e.g.)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T21:54:00.551Z"
+}


### PR DESCRIPTION
Fixes #4918 

If the jsx is not valid we may end up trying to add something that isn't a UIElement (but a DependencyObject, like a Span) to an items Children collection, which will cause a E_NOINTERFACE exception. This is eventually caught by facebook's code and they `std::terminate()` / `abort()`.

Instead, skip adding the node and show a yellowbox and appropriate debug output.

![image](https://user-images.githubusercontent.com/22989529/82099430-34148700-96bc-11ea-943b-b8a9c34131c4.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4921)