### PR TITLE
Fixed ReactContext CallJSFunction and EmitJSEvent

### DIFF
--- a/change/react-native-windows-2020-05-15-21-43-34-MS_FixReactContext2.json
+++ b/change/react-native-windows-2020-05-15-21-43-34-MS_FixReactContext2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed ReactContext CallJSFunction and EmitJSEvent",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-16T04:43:34.199Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -133,24 +133,27 @@ TEST_CLASS (ReactContextTest) {
     TestCheckEqual(1u, reactContextMock->Args.AsArray().size());
     TestCheckEqual(5, reactContextMock->Args[0]);
 
-    context.CallJSFunction(L"module1", L"method1", 14, 17);
+    context.CallJSFunction(L"module1", L"method1", 14, 17u);
     TestCheckEqual(2u, reactContextMock->Args.AsArray().size());
     TestCheckEqual(14, reactContextMock->Args[0]);
-    TestCheckEqual(17, reactContextMock->Args[1]);
+    TestCheckEqual(17u, reactContextMock->Args[1]);
 
-    context.CallJSFunction(L"module1", L"method1", JSValueArray{12, 18});
+    context.CallJSFunction(L"module1", L"method1", JSValueArray{12, 18u});
     TestCheckEqual(12, reactContextMock->Args[0][0]);
-    TestCheckEqual(18, reactContextMock->Args[0][1]);
+    TestCheckEqual(18u, reactContextMock->Args[0][1]);
 
-    context.CallJSFunction(L"module1", L"method1", JSValueObject{{"prop", 42}});
-    TestCheckEqual(42, reactContextMock->Args[0]["prop"]);
+    context.CallJSFunction(L"module1", L"method1", JSValueObject{{"prop1", 42}, {"prop2", 77u}});
+    TestCheckEqual(42, reactContextMock->Args[0]["prop1"]);
+    TestCheckEqual(77u, reactContextMock->Args[0]["prop2"]);
 
     context.CallJSFunction(L"module1", L"method1", [](IJSValueWriter const &writer) {
       writer.WriteArrayBegin();
-      WriteValue(writer, 10);
+      WriteValue(writer, 10u);
+      WriteValue(writer, 19);
       writer.WriteArrayEnd();
     });
-    TestCheckEqual(10, reactContextMock->Args[0]);
+    TestCheckEqual(10u, reactContextMock->Args[0]);
+    TestCheckEqual(19, reactContextMock->Args[1]);
   }
 
   TEST_METHOD(Test_EmitJSEvent) {
@@ -165,24 +168,27 @@ TEST_CLASS (ReactContextTest) {
     TestCheckEqual(1u, reactContextMock->Args.AsArray().size());
     TestCheckEqual(5, reactContextMock->Args[0]);
 
-    context.EmitJSEvent(L"module1", L"event1", 14, 17);
+    context.EmitJSEvent(L"module1", L"event1", 14, 17u);
     TestCheckEqual(2u, reactContextMock->Args.AsArray().size());
     TestCheckEqual(14, reactContextMock->Args[0]);
-    TestCheckEqual(17, reactContextMock->Args[1]);
+    TestCheckEqual(17u, reactContextMock->Args[1]);
 
-    context.EmitJSEvent(L"module1", L"event1", JSValueArray{12, 18});
+    context.EmitJSEvent(L"module1", L"event1", JSValueArray{12, 18u});
     TestCheckEqual(12, reactContextMock->Args[0][0]);
-    TestCheckEqual(18, reactContextMock->Args[0][1]);
+    TestCheckEqual(18u, reactContextMock->Args[0][1]);
 
-    context.EmitJSEvent(L"module1", L"event1", JSValueObject{{"prop", 42}});
-    TestCheckEqual(42, reactContextMock->Args[0]["prop"]);
+    context.EmitJSEvent(L"module1", L"event1", JSValueObject{{"prop1", 42}, {"prop2", 77u}});
+    TestCheckEqual(42, reactContextMock->Args[0]["prop1"]);
+    TestCheckEqual(77u, reactContextMock->Args[0]["prop2"]);
 
     context.EmitJSEvent(L"module1", L"event1", [](IJSValueWriter const &writer) {
       writer.WriteArrayBegin();
-      WriteValue(writer, 10);
+      WriteValue(writer, 10u);
+      WriteValue(writer, 19);
       writer.WriteArrayEnd();
     });
-    TestCheckEqual(10, reactContextMock->Args[0]);
+    TestCheckEqual(10u, reactContextMock->Args[0]);
+    TestCheckEqual(19, reactContextMock->Args[1]);
   }
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -20,18 +20,30 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
   }
 
   void CallJSFunction(
-      hstring const & /*moduleName*/,
-      hstring const & /*functionName*/,
-      JSValueArgWriter const & /*paramsArgWriter*/) noexcept {
-    VerifyElseCrashSz(false, "Not implemented");
+      hstring const &moduleName,
+      hstring const &functionName,
+      JSValueArgWriter const &paramsArgWriter) noexcept {
+    Module = moduleName;
+    Method = functionName;
+    auto writer = MakeJSValueTreeWriter();
+    paramsArgWriter(writer);
+    Args = TakeJSValue(writer);
   }
 
   void EmitJSEvent(
-      hstring const & /*eventEmitterName*/,
-      hstring const & /*eventName*/,
-      JSValueArgWriter const & /*paramsArgWriter*/) noexcept {
-    VerifyElseCrashSz(false, "Not implemented");
+      hstring const &eventEmitterName,
+      hstring const &eventName,
+      JSValueArgWriter const &paramsArgWriter) noexcept {
+    Module = eventEmitterName;
+    Method = eventName;
+    auto writer = MakeJSValueTreeWriter();
+    paramsArgWriter(writer);
+    Args = TakeJSValue(writer);
   }
+
+  std::wstring Module;
+  std::wstring Method;
+  JSValue Args;
 };
 
 namespace ReactNativeTests {
@@ -107,6 +119,70 @@ TEST_CLASS (ReactContextTest) {
     TestCheck(nullptr == context3);
     TestCheck(context11 != nullptr);
     TestCheck(nullptr != context11);
+  }
+
+  TEST_METHOD(Test_CallJSFunction) {
+    auto reactContextMock = winrt::make_self<ReactContextStub>();
+    ReactContext context{reactContextMock.as<IReactContext>()};
+    context.CallJSFunction(L"module1", L"method1");
+    TestCheckEqual(L"module1", reactContextMock->Module);
+    TestCheckEqual(L"method1", reactContextMock->Method);
+    TestCheckEqual(0u, reactContextMock->Args.AsArray().size());
+
+    context.CallJSFunction(L"module1", L"method1", 5);
+    TestCheckEqual(1u, reactContextMock->Args.AsArray().size());
+    TestCheckEqual(5, reactContextMock->Args[0]);
+
+    context.CallJSFunction(L"module1", L"method1", 14, 17);
+    TestCheckEqual(2u, reactContextMock->Args.AsArray().size());
+    TestCheckEqual(14, reactContextMock->Args[0]);
+    TestCheckEqual(17, reactContextMock->Args[1]);
+
+    context.CallJSFunction(L"module1", L"method1", JSValueArray{12, 18});
+    TestCheckEqual(12, reactContextMock->Args[0][0]);
+    TestCheckEqual(18, reactContextMock->Args[0][1]);
+
+    context.CallJSFunction(L"module1", L"method1", JSValueObject{{"prop", 42}});
+    TestCheckEqual(42, reactContextMock->Args[0]["prop"]);
+
+    context.CallJSFunction(L"module1", L"method1", [](IJSValueWriter const &writer) {
+      writer.WriteArrayBegin();
+      WriteValue(writer, 10);
+      writer.WriteArrayEnd();
+    });
+    TestCheckEqual(10, reactContextMock->Args[0]);
+  }
+
+  TEST_METHOD(Test_EmitJSEvent) {
+    auto reactContextMock = winrt::make_self<ReactContextStub>();
+    ReactContext context{reactContextMock.as<IReactContext>()};
+    context.EmitJSEvent(L"module1", L"event1");
+    TestCheckEqual(L"module1", reactContextMock->Module);
+    TestCheckEqual(L"event1", reactContextMock->Method);
+    TestCheckEqual(0u, reactContextMock->Args.AsArray().size());
+
+    context.EmitJSEvent(L"module1", L"event1", 5);
+    TestCheckEqual(1u, reactContextMock->Args.AsArray().size());
+    TestCheckEqual(5, reactContextMock->Args[0]);
+
+    context.EmitJSEvent(L"module1", L"event1", 14, 17);
+    TestCheckEqual(2u, reactContextMock->Args.AsArray().size());
+    TestCheckEqual(14, reactContextMock->Args[0]);
+    TestCheckEqual(17, reactContextMock->Args[1]);
+
+    context.EmitJSEvent(L"module1", L"event1", JSValueArray{12, 18});
+    TestCheckEqual(12, reactContextMock->Args[0][0]);
+    TestCheckEqual(18, reactContextMock->Args[0][1]);
+
+    context.EmitJSEvent(L"module1", L"event1", JSValueObject{{"prop", 42}});
+    TestCheckEqual(42, reactContextMock->Args[0]["prop"]);
+
+    context.EmitJSEvent(L"module1", L"event1", [](IJSValueWriter const &writer) {
+      writer.WriteArrayBegin();
+      WriteValue(writer, 10);
+      writer.WriteArrayEnd();
+    });
+    TestCheckEqual(10, reactContextMock->Args[0]);
   }
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -257,9 +257,14 @@ inline void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexc
   writer.WriteArrayEnd();
 }
 
+template <class T, std::enable_if_t<std::is_invocable_v<T, IJSValueWriter const &>, int> = 0>
+inline JSValueArgWriter MakeJSValueArgWriter(T &&argWriter) noexcept {
+  return std::forward<T>(argWriter);
+}
+
 template <class... TArgs>
 inline JSValueArgWriter MakeJSValueArgWriter(TArgs &&... args) noexcept {
-  return [args...](IJSValueWriter const &writer) noexcept {
+  return [&args...](IJSValueWriter const &writer) noexcept {
     WriteArgs(writer, args...);
   };
 }

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -32,40 +32,26 @@ struct ReactContext {
     return ReactPropertyBag{m_handle.Properties()};
   }
 
+  // Call methodName JS function of module with moduleName.
+  // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>
   void CallJSFunction(std::wstring_view moduleName, std::wstring_view methodName, TArgs &&... args) const noexcept {
     m_handle.CallJSFunction(moduleName, methodName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
   }
 
-  void CallJSFunction(
-      std::wstring_view moduleName,
-      std::wstring_view methodName,
-      JSValueArgWriter const &paramsArgWriter) const noexcept {
-    m_handle.CallJSFunction(moduleName, methodName, paramsArgWriter);
-  }
-
+  // Simplifies calls to CallJSFunction to emit events (method named 'emit').
+  // Call eventName JS event of module with eventEmitterName.
+  // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>
   void EmitJSEvent(std::wstring_view eventEmitterName, std::wstring_view eventName, TArgs &&... args) const noexcept {
     m_handle.EmitJSEvent(eventEmitterName, eventName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
   }
 
-  void EmitJSEvent(
-      std::wstring_view eventEmitterName,
-      std::wstring_view eventName,
-      JSValueArgWriter const &paramsArgWriter) const noexcept {
-    m_handle.EmitJSEvent(eventEmitterName, eventName, paramsArgWriter);
-  }
-
+  // Dispatch eventName event to the view.
+  // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>
   void DispatchEvent(xaml::FrameworkElement const &view, std::wstring_view eventName, TArgs &&... args) const noexcept {
     m_handle.DispatchEvent(view, eventName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
-  }
-
-  void DispatchEvent(
-      xaml::FrameworkElement const &view,
-      std::wstring_view eventName,
-      JSValueArgWriter const &paramsArgWriter) const noexcept {
-    m_handle.DispatchEvent(view, eventName, paramsArgWriter);
   }
 
   friend bool operator==(ReactContext const &left, ReactContext const &right) noexcept {


### PR DESCRIPTION
In this PR we fix the ReactContext CallJSFunction and EmitJSEvent functions.
There were the following issues:
- Cannot pass move-only values. It is fixed by capturing arguments by reference in MakeJSValueArgWriter.
- Cannot pass lambda for JSValueArgWriter argument. It is fixed by adding special MakeJSValueArgWriter overload and removed the ReactContext overloads for JSValueArgWriter parameter.

Added new unit tests to make sure that the ReactContext CallJSFunction and EmitJSEvent functions work correctly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4922)