### PR TITLE
Add support for 0..n args in native module callbacks

### DIFF
--- a/change/react-native-windows-2020-05-17-09-26-39-MS_CallbackMultiArgs.json
+++ b/change/react-native-windows-2020-05-17-09-26-39-MS_CallbackMultiArgs.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Support 0..n args in native module callbacks",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-17T16:26:39.781Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
@@ -135,6 +135,18 @@ struct SimpleNativeModule2 {
     resolve("Static Hello_2");
   }
 
+  void CallbackZeroArgs(std::function<void()> const &resolve) noexcept {
+    resolve();
+  }
+
+  void CallbackTwoArgs(std::function<void(int, int)> const &resolve) noexcept {
+    resolve(1, 2);
+  }
+
+  void CallbackThreeArgs(std::function<void(int, int, std::string const &)> const &resolve) noexcept {
+    resolve(1, 2, "Hello");
+  }
+
   void DivideCallbacks(
       int x,
       int y,
@@ -279,6 +291,38 @@ struct SimpleNativeModule2 {
       std::function<void(std::string const &)> const & /*resolve*/,
       std::function<void(std::string const &)> const &reject) noexcept {
     reject("Goodbye");
+  }
+
+  void TwoCallbacksZeroArgs1(std::function<void()> const &resolve, std::function<void()> const & /*reject*/) noexcept {
+    resolve();
+  }
+
+  void TwoCallbacksZeroArgs2(std::function<void()> const & /*resolve*/, std::function<void()> const &reject) noexcept {
+    reject();
+  }
+
+  void TwoCallbacksTwoArgs1(
+      std::function<void(int, int)> const &resolve,
+      std::function<void(int, int)> const & /*reject*/) noexcept {
+    resolve(1, 2);
+  }
+
+  void TwoCallbacksTwoArgs2(
+      std::function<void(int, int)> const & /*resolve*/,
+      std::function<void(int, int)> const &reject) noexcept {
+    reject(1, 2);
+  }
+
+  void TwoCallbacksThreeArgs1(
+      std::function<void(int, int, std::string const &)> const &resolve,
+      std::function<void(int, int, std::string const &)> const & /*reject*/) noexcept {
+    resolve(1, 2, "Hello");
+  }
+
+  void TwoCallbacksThreeArgs2(
+      std::function<void(int, int, std::string const &)> const & /*resolve*/,
+      std::function<void(int, int, std::string const &)> const &reject) noexcept {
+    reject(1, 2, "Hello");
   }
 
   void DividePromise(int x, int y, React::ReactPromise<int> const &result) noexcept {
@@ -535,6 +579,9 @@ void GetReactModuleInfo(SimpleNativeModule2 *, React::ReactModuleBuilder<SimpleN
       &SimpleNativeModule2::StaticNegateDispatchQueueCallback, L"StaticNegateDispatchQueueCallback");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::StaticNegateFutureCallback, L"StaticNegateFutureCallback");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::StaticSayHelloCallback, L"StaticSayHelloCallback");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::CallbackZeroArgs, L"CallbackZeroArgs");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::CallbackTwoArgs, L"CallbackTwoArgs");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::CallbackThreeArgs, L"CallbackThreeArgs");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::DivideCallbacks, L"DivideCallbacks");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::NegateCallbacks, L"NegateCallbacks");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::NegateAsyncCallbacks, L"NegateAsyncCallbacks");
@@ -550,6 +597,12 @@ void GetReactModuleInfo(SimpleNativeModule2 *, React::ReactModuleBuilder<SimpleN
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::StaticNegateFutureCallbacks, L"StaticNegateFutureCallbacks");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::StaticResolveSayHelloCallbacks, L"StaticResolveSayHelloCallbacks");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::StaticRejectSayHelloCallbacks, L"StaticRejectSayHelloCallbacks");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::TwoCallbacksZeroArgs1, L"TwoCallbacksZeroArgs1");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::TwoCallbacksZeroArgs2, L"TwoCallbacksZeroArgs2");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::TwoCallbacksTwoArgs1, L"TwoCallbacksTwoArgs1");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::TwoCallbacksTwoArgs2, L"TwoCallbacksTwoArgs2");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::TwoCallbacksThreeArgs1, L"TwoCallbacksThreeArgs1");
+  moduleBuilder.RegisterMethod(&SimpleNativeModule2::TwoCallbacksThreeArgs2, L"TwoCallbacksThreeArgs2");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::DividePromise, L"DividePromise");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::NegatePromise, L"NegatePromise");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::NegateAsyncPromise, L"NegateAsyncPromise");
@@ -750,6 +803,30 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
     m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
                         ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_CallbackZeroArgs) {
+    m_builderMock.Call1(L"CallbackZeroArgs", std::function<void()>([]() noexcept {}));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_CallbackTwoArgs) {
+    m_builderMock.Call1(L"CallbackTwoArgs", std::function<void(int, int)>([](int p1, int p2) noexcept {
+                          TestCheckEqual(1, p1);
+                          TestCheckEqual(2, p2);
+                        }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_CallbackThreeArgs) {
+    m_builderMock.Call1(
+        L"CallbackThreeArgs",
+        std::function<void(int, int, std::string const &)>([](int p1, int p2, std::string const &p3) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+          TestCheckEqual("Hello", p3);
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -994,6 +1071,68 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
             [](const std::string &result) noexcept { TestCheck(result == "Hello_3"); }),
         std::function<void(std::string const &)>(
             [](std::string const &error) noexcept { TestCheck(error == "Goodbye"); }));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
+    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
+                        ]() noexcept { TestCheckFail(); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs2) {
+    m_builderMock.Call2(
+        L"TwoCallbacksZeroArgs2",
+        std::function<void()>([]() noexcept { TestCheckFail(); }),
+        std::function<void()>([]() noexcept {}));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksTwoArgs1) {
+    m_builderMock.Call2(
+        L"TwoCallbacksTwoArgs1",
+        std::function<void(int, int)>([](int p1, int p2) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+        }),
+        std::function<void(int, int)>([](int /*p1*/, int /*p2*/) noexcept { TestCheckFail(); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksTwoArgs2) {
+    m_builderMock.Call2(
+        L"TwoCallbacksTwoArgs2",
+        std::function<void(int, int)>([](int /*p1*/, int /*p2*/) noexcept { TestCheckFail(); }),
+        std::function<void(int, int)>([](int p1, int p2) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+        }));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksThreeArgs1) {
+    m_builderMock.Call2(
+        L"TwoCallbacksThreeArgs1",
+        std::function<void(int, int, const std::string &)>([](int p1, int p2, std::string const &p3) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+          TestCheckEqual("Hello", p3);
+        }),
+        std::function<void(int, int, const std::string &)>(
+            [](int /*p1*/, int /*p2*/, std::string const & /*p3*/) noexcept { TestCheckFail(); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksThreeArgs2) {
+    m_builderMock.Call2(
+        L"TwoCallbacksThreeArgs2",
+        std::function<void(int, int, const std::string &)>(
+            [](int /*p1*/, int /*p2*/, std::string const & /*p3*/) noexcept { TestCheckFail(); }),
+        std::function<void(int, int, const std::string &)>([](int p1, int p2, std::string const &p3) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+          TestCheckEqual("Hello", p3);
+        }));
     TestCheck(m_builderMock.IsRejectCallbackCalled());
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include "CppWinRTIncludes.h"
 #include "JSValue.h"
+#include "NativeModules.h"
 
 #undef GetCurrentTime
 
@@ -22,26 +23,15 @@ struct ReactModuleBuilderMock {
   template <class... TArgs>
   void Call0(std::wstring const &methodName, TArgs &&... args) noexcept;
 
-  template <class TResult, class... TArgs>
+  template <class... TArgs, class... TReasolveArgs>
   Mso::Future<bool>
-  Call1(std::wstring const &methodName, std::function<void(TResult)> &&resolve, TArgs &&... args) noexcept;
+  Call1(std::wstring const &methodName, std::function<void(TReasolveArgs...)> &&resolve, TArgs &&... args) noexcept;
 
-  template <class... TArgs>
-  Mso::Future<bool>
-  Call1(std::wstring const &methodName, std::function<void()> const &resolve, TArgs &&... args) noexcept;
-
-  template <class TResult, class TError, class... TArgs>
+  template <class... TArgs, class... TResolveArgs, class... TRejectArgs>
   Mso::Future<bool> Call2(
       std::wstring const &methodName,
-      std::function<void(TResult)> const &resolve,
-      std::function<void(TError)> const &reject,
-      TArgs &&... args) noexcept;
-
-  template <class TError, class... TArgs>
-  Mso::Future<bool> Call2(
-      std::wstring const &methodName,
-      std::function<void()> const &resolve,
-      std::function<void(TError)> const &reject,
+      std::function<void(TResolveArgs...)> const &resolve,
+      std::function<void(TRejectArgs...)> const &reject,
       TArgs &&... args) noexcept;
 
   template <class TResult, class... TArgs>
@@ -95,15 +85,16 @@ struct ReactModuleBuilderMock {
   static IJSValueReader ArgReader(TArgs &&... args) noexcept;
   static IJSValueReader CreateArgReader(std::function<void(IJSValueWriter const &)> const &argWriter) noexcept;
 
-  template <class T>
+  template <class... TArgs, size_t... I>
   MethodResultCallback ResolveCallback(
-      std::function<void(T)> const &resolve,
+      std::function<void(TArgs...)> const &resolve,
+      std::index_sequence<I...>,
       Mso::Promise<bool> const &promise) noexcept;
-  MethodResultCallback ResolveCallback(
-      std::function<void()> const &resolve,
+  template <class... TArgs, size_t... I>
+  MethodResultCallback RejectCallback(
+      std::function<void(TArgs...)> const &reject,
+      std::index_sequence<I...>,
       Mso::Promise<bool> const &promise) noexcept;
-  template <class T>
-  MethodResultCallback RejectCallback(std::function<void(T)> const &reject, Mso::Promise<bool> const &promise) noexcept;
 
  private:
   IReactContext m_reactContext{nullptr};
@@ -167,60 +158,35 @@ inline void ReactModuleBuilderMock::Call0(std::wstring const &methodName, TArgs 
   }
 }
 
-template <class TResult, class... TArgs>
+template <class... TArgs, class... TResolveArgs>
 inline Mso::Future<bool> ReactModuleBuilderMock::Call1(
     std::wstring const &methodName,
-    std::function<void(TResult)> &&resolve,
+    std::function<void(TResolveArgs...)> &&resolve,
     TArgs &&... args) noexcept {
   Mso::Promise<bool> promise;
   if (auto method = GetMethod1(methodName)) {
-    method(ArgReader(std::forward<TArgs>(args)...), ArgWriter(), ResolveCallback(resolve, promise), nullptr);
+    method(
+        ArgReader(std::forward<TArgs>(args)...),
+        ArgWriter(),
+        ResolveCallback(resolve, std::make_index_sequence<sizeof...(TResolveArgs)>{}, promise),
+        nullptr);
   }
   return promise.AsFuture();
 }
 
-template <class... TArgs>
-inline Mso::Future<bool> ReactModuleBuilderMock::Call1(
-    std::wstring const &methodName,
-    std::function<void()> const &resolve,
-    TArgs &&... args) noexcept {
-  Mso::Promise<bool> promise;
-  if (auto method = GetMethod1(methodName)) {
-    method(ArgReader(std::forward<TArgs>(args)...), ArgWriter(), ResolveCallback(resolve, promise), nullptr);
-  }
-  return promise.AsFuture();
-}
-
-template <class TResult, class TError, class... TArgs>
+template <class... TArgs, class... TResolveArgs, class... TRejectArgs>
 inline Mso::Future<bool> ReactModuleBuilderMock::Call2(
     std::wstring const &methodName,
-    std::function<void(TResult)> const &resolve,
-    std::function<void(TError)> const &reject,
+    std::function<void(TResolveArgs...)> const &resolve,
+    std::function<void(TRejectArgs...)> const &reject,
     TArgs &&... args) noexcept {
   Mso::Promise<bool> promise;
   if (auto method = GetMethod2(methodName)) {
     method(
         ArgReader(std::forward<TArgs>(args)...),
         ArgWriter(),
-        ResolveCallback(resolve, promise),
-        RejectCallback(reject, promise));
-  }
-  return promise.AsFuture();
-}
-
-template <class TError, class... TArgs>
-inline Mso::Future<bool> ReactModuleBuilderMock::Call2(
-    std::wstring const &methodName,
-    std::function<void()> const &resolve,
-    std::function<void(TError)> const &reject,
-    TArgs &&... args) noexcept {
-  Mso::Promise<bool> promise;
-  if (auto method = GetMethod2(methodName)) {
-    method(
-        ArgReader(std::forward<TArgs>(args)...),
-        ArgWriter(),
-        ResolveCallback(resolve, promise),
-        RejectCallback(reject, promise));
+        ResolveCallback(resolve, std::make_index_sequence<sizeof...(TResolveArgs)>{}, promise),
+        RejectCallback(reject, std::make_index_sequence<sizeof...(TRejectArgs)>{}, promise));
   }
   return promise.AsFuture();
 }
@@ -242,37 +208,29 @@ inline /*static*/ IJSValueReader ReactModuleBuilderMock::ArgReader(TArgs &&... a
   });
 }
 
-template <class T>
+template <class... TArgs, size_t... I>
 inline MethodResultCallback ReactModuleBuilderMock::ResolveCallback(
-    std::function<void(T)> const &resolve,
+    std::function<void(TArgs...)> const &resolve,
+    std::index_sequence<I...>,
     Mso::Promise<bool> const &promise) noexcept {
   return [ this, resolve, promise ](IJSValueWriter const &writer) noexcept {
-    std::remove_const_t<std::remove_reference_t<T>> arg;
-    ReadArgs(MakeJSValueTreeReader(TakeJSValue(writer)), arg);
-    resolve(arg);
+    std::tuple<RemoveConstRef<TArgs>...> args;
+    ReadArgs(MakeJSValueTreeReader(TakeJSValue(writer)), std::get<I>(args)...);
+    resolve(std::get<I>(args)...);
     m_isResolveCallbackCalled = true;
     promise.TrySetValue(true);
   };
 }
 
-inline MethodResultCallback ReactModuleBuilderMock::ResolveCallback(
-    std::function<void()> const &resolve,
-    Mso::Promise<bool> const &promise) noexcept {
-  return [ this, resolve, promise ](IJSValueWriter const & /*writer*/) noexcept {
-    resolve();
-    m_isResolveCallbackCalled = true;
-    promise.TrySetValue(true);
-  };
-}
-
-template <class T>
+template <class... TArgs, size_t... I>
 inline MethodResultCallback ReactModuleBuilderMock::RejectCallback(
-    std::function<void(T)> const &reject,
+    std::function<void(TArgs...)> const &reject,
+    std::index_sequence<I...>,
     Mso::Promise<bool> const &promise) noexcept {
   return [ this, reject, promise ](IJSValueWriter const &writer) noexcept {
-    std::remove_const_t<std::remove_reference_t<T>> arg;
-    ReadArgs(MakeJSValueTreeReader(TakeJSValue(writer)), arg);
-    reject(arg);
+    std::tuple<RemoveConstRef<TArgs>...> args;
+    ReadArgs(MakeJSValueTreeReader(TakeJSValue(writer)), std::get<I>(args)...);
+    reject(std::get<I>(args)...);
     m_isRejectCallbackCalled = true;
     promise.TrySetValue(false);
   };

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -151,6 +151,21 @@ struct MyTurboModule {
     resolve("Static Hello_2");
   }
 
+  REACT_METHOD(CallbackZeroArgs)
+  void CallbackZeroArgs(std::function<void()> const &resolve) noexcept {
+    resolve();
+  }
+
+  REACT_METHOD(CallbackTwoArgs)
+  void CallbackTwoArgs(std::function<void(int, int)> const &resolve) noexcept {
+    resolve(1, 2);
+  }
+
+  REACT_METHOD(CallbackThreeArgs)
+  void CallbackThreeArgs(std::function<void(int, int, std::string const &)> const &resolve) noexcept {
+    resolve(1, 2, "Hello");
+  }
+
   REACT_METHOD(DivideCallbacks)
   void DivideCallbacks(
       int x,
@@ -309,6 +324,44 @@ struct MyTurboModule {
       std::function<void(std::string const &)> const & /*resolve*/,
       std::function<void(std::string const &)> const &reject) noexcept {
     reject("Goodbye");
+  }
+
+  REACT_METHOD(TwoCallbacksZeroArgs1)
+  void TwoCallbacksZeroArgs1(std::function<void()> const &resolve, std::function<void()> const & /*reject*/) noexcept {
+    resolve();
+  }
+
+  REACT_METHOD(TwoCallbacksZeroArgs2)
+  void TwoCallbacksZeroArgs2(std::function<void()> const & /*resolve*/, std::function<void()> const &reject) noexcept {
+    reject();
+  }
+
+  REACT_METHOD(TwoCallbacksTwoArgs1)
+  void TwoCallbacksTwoArgs1(
+      std::function<void(int, int)> const &resolve,
+      std::function<void(int, int)> const & /*reject*/) noexcept {
+    resolve(1, 2);
+  }
+
+  REACT_METHOD(TwoCallbacksTwoArgs2)
+  void TwoCallbacksTwoArgs2(
+      std::function<void(int, int)> const & /*resolve*/,
+      std::function<void(int, int)> const &reject) noexcept {
+    reject(1, 2);
+  }
+
+  REACT_METHOD(TwoCallbacksThreeArgs1)
+  void TwoCallbacksThreeArgs1(
+      std::function<void(int, int, std::string const &)> const &resolve,
+      std::function<void(int, int, std::string const &)> const & /*reject*/) noexcept {
+    resolve(1, 2, "Hello");
+  }
+
+  REACT_METHOD(TwoCallbacksThreeArgs2)
+  void TwoCallbacksThreeArgs2(
+      std::function<void(int, int, std::string const &)> const & /*resolve*/,
+      std::function<void(int, int, std::string const &)> const &reject) noexcept {
+    reject(1, 2, "Hello");
   }
 
   REACT_METHOD(DividePromise)
@@ -618,42 +671,55 @@ struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(int, Callback<int>) noexcept>{21, L"StaticNegateDispatchQueueCallback"},
       Method<void(int, Callback<int>) noexcept>{22, L"StaticNegateFutureCallback"},
       Method<void(Callback<std::string>) noexcept>{23, L"StaticSayHelloCallback"},
-      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{24, L"DivideCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{25, L"NegateCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{26, L"NegateAsyncCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{27, L"NegateDispatchQueueCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{28, L"NegateFutureCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{29, L"ResolveSayHelloCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{30, L"RejectSayHelloCallbacks"},
-      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{31, L"StaticDivideCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{32, L"StaticNegateCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{33, L"StaticNegateAsyncCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{34, L"StaticNegateDispatchQueueCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{35, L"StaticNegateFutureCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{36, L"StaticResolveSayHelloCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{37, L"StaticRejectSayHelloCallbacks"},
-      Method<void(int, int, Promise<int>) noexcept>{38, L"DividePromise"},
-      Method<void(int, Promise<int>) noexcept>{39, L"NegatePromise"},
-      Method<void(int, Promise<int>) noexcept>{40, L"NegateAsyncPromise"},
-      Method<void(int, Promise<int>) noexcept>{41, L"NegateDispatchQueuePromise"},
-      Method<void(int, Promise<int>) noexcept>{42, L"NegateFuturePromise"},
-      Method<void(int, Promise<void>) noexcept>{43, L"voidPromise"},
-      Method<void(Promise<std::string>) noexcept>{44, L"ResolveSayHelloPromise"},
-      Method<void(Promise<std::string>) noexcept>{45, L"RejectSayHelloPromise"},
-      Method<void(int, int, Promise<int>) noexcept>{46, L"StaticDividePromise"},
-      Method<void(int, Promise<int>) noexcept>{47, L"StaticNegatePromise"},
-      Method<void(int, Promise<int>) noexcept>{48, L"StaticNegateAsyncPromise"},
-      Method<void(int, Promise<int>) noexcept>{49, L"StaticNegateDispatchQueuePromise"},
-      Method<void(int, Promise<int>) noexcept>{50, L"StaticNegateFuturePromise"},
-      Method<void(int, Promise<void>) noexcept>{51, L"staticVoidPromise"},
-      Method<void(Promise<std::string>) noexcept>{52, L"StaticResolveSayHelloPromise"},
-      Method<void(Promise<std::string>) noexcept>{53, L"StaticRejectSayHelloPromise"},
-      SyncMethod<int(int, int) noexcept>{54, L"AddSync"},
-      SyncMethod<int(int) noexcept>{55, L"NegateSync"},
-      SyncMethod<std::string() noexcept>{56, L"SayHelloSync"},
-      SyncMethod<int(int, int) noexcept>{57, L"StaticAddSync"},
-      SyncMethod<int(int) noexcept>{58, L"StaticNegateSync"},
-      SyncMethod<std::string() noexcept>{59, L"StaticSayHelloSync"},
+      Method<void(Callback<>) noexcept>{24, L"CallbackZeroArgs"},
+      Method<void(Callback<int, int>) noexcept>{25, L"CallbackTwoArgs"},
+      Method<void(Callback<int, int, std::string>) noexcept>{26, L"CallbackThreeArgs"},
+      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{27, L"DivideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{28, L"NegateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{29, L"NegateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{30, L"NegateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{31, L"NegateFutureCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{32, L"ResolveSayHelloCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{33, L"RejectSayHelloCallbacks"},
+      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{34, L"StaticDivideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{35, L"StaticNegateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{36, L"StaticNegateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{37, L"StaticNegateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{38, L"StaticNegateFutureCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{39, L"StaticResolveSayHelloCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{40, L"StaticRejectSayHelloCallbacks"},
+      Method<void(Callback<>, Callback<>) noexcept>{41, L"TwoCallbacksZeroArgs1"},
+      Method<void(Callback<>, Callback<>) noexcept>{42, L"TwoCallbacksZeroArgs2"},
+      Method<void(Callback<int, int>, Callback<int, int>) noexcept>{43, L"TwoCallbacksTwoArgs1"},
+      Method<void(Callback<int, int>, Callback<int, int>) noexcept>{44, L"TwoCallbacksTwoArgs2"},
+      Method<void(Callback<int, int, std::string>, Callback<int, int, std::string>) noexcept>{
+          45,
+          L"TwoCallbacksThreeArgs1"},
+      Method<void(Callback<int, int, std::string>, Callback<int, int, std::string>) noexcept>{
+          46,
+          L"TwoCallbacksThreeArgs2"},
+      Method<void(int, int, Promise<int>) noexcept>{47, L"DividePromise"},
+      Method<void(int, Promise<int>) noexcept>{48, L"NegatePromise"},
+      Method<void(int, Promise<int>) noexcept>{49, L"NegateAsyncPromise"},
+      Method<void(int, Promise<int>) noexcept>{50, L"NegateDispatchQueuePromise"},
+      Method<void(int, Promise<int>) noexcept>{51, L"NegateFuturePromise"},
+      Method<void(int, Promise<void>) noexcept>{52, L"voidPromise"},
+      Method<void(Promise<std::string>) noexcept>{53, L"ResolveSayHelloPromise"},
+      Method<void(Promise<std::string>) noexcept>{54, L"RejectSayHelloPromise"},
+      Method<void(int, int, Promise<int>) noexcept>{55, L"StaticDividePromise"},
+      Method<void(int, Promise<int>) noexcept>{56, L"StaticNegatePromise"},
+      Method<void(int, Promise<int>) noexcept>{57, L"StaticNegateAsyncPromise"},
+      Method<void(int, Promise<int>) noexcept>{58, L"StaticNegateDispatchQueuePromise"},
+      Method<void(int, Promise<int>) noexcept>{59, L"StaticNegateFuturePromise"},
+      Method<void(int, Promise<void>) noexcept>{60, L"staticVoidPromise"},
+      Method<void(Promise<std::string>) noexcept>{61, L"StaticResolveSayHelloPromise"},
+      Method<void(Promise<std::string>) noexcept>{62, L"StaticRejectSayHelloPromise"},
+      SyncMethod<int(int, int) noexcept>{63, L"AddSync"},
+      SyncMethod<int(int) noexcept>{64, L"NegateSync"},
+      SyncMethod<std::string() noexcept>{65, L"SayHelloSync"},
+      SyncMethod<int(int, int) noexcept>{66, L"StaticAddSync"},
+      SyncMethod<int(int) noexcept>{67, L"StaticNegateSync"},
+      SyncMethod<std::string() noexcept>{68, L"StaticSayHelloSync"},
   };
 
   template <class TModule>
@@ -866,241 +932,304 @@ struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
         "    REACT_METHOD(StaticSayHelloCallback) static winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
         24,
+        "CallbackZeroArgs",
+        "    REACT_METHOD(CallbackZeroArgs) void CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackZeroArgs) winrt::fire_and_forget CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackZeroArgs) static void CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackZeroArgs) static winrt::fire_and_forget CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        25,
+        "CallbackTwoArgs",
+        "    REACT_METHOD(CallbackTwoArgs) void CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackTwoArgs) winrt::fire_and_forget CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackTwoArgs) static void CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackTwoArgs) static winrt::fire_and_forget CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        26,
+        "CallbackThreeArgs",
+        "    REACT_METHOD(CallbackThreeArgs) void CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackThreeArgs) winrt::fire_and_forget CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackThreeArgs) static void CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackThreeArgs) static winrt::fire_and_forget CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        27,
         "DivideCallbacks",
         "    REACT_METHOD(DivideCallbacks) void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(DivideCallbacks) winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(DivideCallbacks) static void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(DivideCallbacks) static winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        25,
+        28,
         "NegateCallbacks",
         "    REACT_METHOD(NegateCallbacks) void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateCallbacks) winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateCallbacks) static void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateCallbacks) static winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        26,
+        29,
         "NegateAsyncCallbacks",
         "    REACT_METHOD(NegateAsyncCallbacks) void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateAsyncCallbacks) winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateAsyncCallbacks) static void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateAsyncCallbacks) static winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        27,
+        30,
         "NegateDispatchQueueCallbacks",
         "    REACT_METHOD(NegateDispatchQueueCallbacks) void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateDispatchQueueCallbacks) winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateDispatchQueueCallbacks) static void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateDispatchQueueCallbacks) static winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        28,
+        31,
         "NegateFutureCallbacks",
         "    REACT_METHOD(NegateFutureCallbacks) void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateFutureCallbacks) winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateFutureCallbacks) static void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateFutureCallbacks) static winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        29,
+        32,
         "ResolveSayHelloCallbacks",
         "    REACT_METHOD(ResolveSayHelloCallbacks) void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(ResolveSayHelloCallbacks) winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(ResolveSayHelloCallbacks) static void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(ResolveSayHelloCallbacks) static winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        30,
+        33,
         "RejectSayHelloCallbacks",
         "    REACT_METHOD(RejectSayHelloCallbacks) void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(RejectSayHelloCallbacks) winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(RejectSayHelloCallbacks) static void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(RejectSayHelloCallbacks) static winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        31,
+        34,
         "StaticDivideCallbacks",
         "    REACT_METHOD(StaticDivideCallbacks) void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticDivideCallbacks) winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticDivideCallbacks) static void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticDivideCallbacks) static winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        32,
+        35,
         "StaticNegateCallbacks",
         "    REACT_METHOD(StaticNegateCallbacks) void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateCallbacks) winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateCallbacks) static void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateCallbacks) static winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        33,
+        36,
         "StaticNegateAsyncCallbacks",
         "    REACT_METHOD(StaticNegateAsyncCallbacks) void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateAsyncCallbacks) winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateAsyncCallbacks) static void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateAsyncCallbacks) static winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        34,
+        37,
         "StaticNegateDispatchQueueCallbacks",
         "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        35,
+        38,
         "StaticNegateFutureCallbacks",
         "    REACT_METHOD(StaticNegateFutureCallbacks) void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateFutureCallbacks) winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateFutureCallbacks) static void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateFutureCallbacks) static winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        36,
+        39,
         "StaticResolveSayHelloCallbacks",
         "    REACT_METHOD(StaticResolveSayHelloCallbacks) void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticResolveSayHelloCallbacks) winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticResolveSayHelloCallbacks) static void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticResolveSayHelloCallbacks) static winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        37,
+        40,
         "StaticRejectSayHelloCallbacks",
         "    REACT_METHOD(StaticRejectSayHelloCallbacks) void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticRejectSayHelloCallbacks) winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticRejectSayHelloCallbacks) static void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticRejectSayHelloCallbacks) static winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        38,
+        41,
+        "TwoCallbacksZeroArgs1",
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) void TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) winrt::fire_and_forget TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) static void TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) static winrt::fire_and_forget TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        42,
+        "TwoCallbacksZeroArgs2",
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) void TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) winrt::fire_and_forget TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) static void TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) static winrt::fire_and_forget TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        43,
+        "TwoCallbacksTwoArgs1",
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) void TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) winrt::fire_and_forget TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) static void TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) static winrt::fire_and_forget TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        44,
+        "TwoCallbacksTwoArgs2",
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) void TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) winrt::fire_and_forget TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) static void TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) static winrt::fire_and_forget TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        45,
+        "TwoCallbacksThreeArgs1",
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) void TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) winrt::fire_and_forget TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) static void TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) static winrt::fire_and_forget TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        46,
+        "TwoCallbacksThreeArgs2",
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) void TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) winrt::fire_and_forget TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) static void TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) static winrt::fire_and_forget TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        47,
         "DividePromise",
         "    REACT_METHOD(DividePromise) void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(DividePromise) winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(DividePromise) static void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(DividePromise) static winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        39,
+        48,
         "NegatePromise",
         "    REACT_METHOD(NegatePromise) void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegatePromise) winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegatePromise) static void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegatePromise) static winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        40,
+        49,
         "NegateAsyncPromise",
         "    REACT_METHOD(NegateAsyncPromise) void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateAsyncPromise) winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateAsyncPromise) static void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateAsyncPromise) static winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        41,
+        50,
         "NegateDispatchQueuePromise",
         "    REACT_METHOD(NegateDispatchQueuePromise) void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateDispatchQueuePromise) winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateDispatchQueuePromise) static void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateDispatchQueuePromise) static winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        42,
+        51,
         "NegateFuturePromise",
         "    REACT_METHOD(NegateFuturePromise) void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateFuturePromise) winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateFuturePromise) static void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateFuturePromise) static winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        43,
+        52,
         "voidPromise",
         "    REACT_METHOD(voidPromise) void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(voidPromise) winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(voidPromise) static void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(voidPromise) static winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        44,
+        53,
         "ResolveSayHelloPromise",
         "    REACT_METHOD(ResolveSayHelloPromise) void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(ResolveSayHelloPromise) winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(ResolveSayHelloPromise) static void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(ResolveSayHelloPromise) static winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        45,
+        54,
         "RejectSayHelloPromise",
         "    REACT_METHOD(RejectSayHelloPromise) void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(RejectSayHelloPromise) winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(RejectSayHelloPromise) static void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(RejectSayHelloPromise) static winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        46,
+        55,
         "StaticDividePromise",
         "    REACT_METHOD(StaticDividePromise) void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticDividePromise) winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticDividePromise) static void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticDividePromise) static winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        47,
+        56,
         "StaticNegatePromise",
         "    REACT_METHOD(StaticNegatePromise) void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegatePromise) winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegatePromise) static void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegatePromise) static winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        48,
+        57,
         "StaticNegateAsyncPromise",
         "    REACT_METHOD(StaticNegateAsyncPromise) void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateAsyncPromise) winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateAsyncPromise) static void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateAsyncPromise) static winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        49,
+        58,
         "StaticNegateDispatchQueuePromise",
         "    REACT_METHOD(StaticNegateDispatchQueuePromise) void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateDispatchQueuePromise) winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateDispatchQueuePromise) static void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateDispatchQueuePromise) static winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        50,
+        59,
         "StaticNegateFuturePromise",
         "    REACT_METHOD(StaticNegateFuturePromise) void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateFuturePromise) winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateFuturePromise) static void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateFuturePromise) static winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        51,
+        60,
         "staticVoidPromise",
         "    REACT_METHOD(staticVoidPromise) void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(staticVoidPromise) winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(staticVoidPromise) static void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(staticVoidPromise) static winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        52,
+        61,
         "StaticResolveSayHelloPromise",
         "    REACT_METHOD(StaticResolveSayHelloPromise) void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticResolveSayHelloPromise) winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticResolveSayHelloPromise) static void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticResolveSayHelloPromise) static winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
-        53,
+        62,
         "StaticRejectSayHelloPromise",
         "    REACT_METHOD(StaticRejectSayHelloPromise) void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticRejectSayHelloPromise) winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticRejectSayHelloPromise) static void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticRejectSayHelloPromise) static winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
     REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        54,
+        63,
         "AddSync",
         "    REACT_METHOD(AddSync) int AddSync(int, int) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(AddSync) static int AddSync(int, int) noexcept {/*implementation*/}\n");
     REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        55,
+        64,
         "NegateSync",
         "    REACT_METHOD(NegateSync) int NegateSync(int) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(NegateSync) static int NegateSync(int) noexcept {/*implementation*/}\n");
     REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        56,
+        65,
         "SayHelloSync",
         "    REACT_METHOD(SayHelloSync) std::string SayHelloSync() noexcept {/*implementation*/}\n"
         "    REACT_METHOD(SayHelloSync) static std::string SayHelloSync() noexcept {/*implementation*/}\n");
     REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        57,
+        66,
         "StaticAddSync",
         "    REACT_METHOD(StaticAddSync) int StaticAddSync(int, int) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticAddSync) static int StaticAddSync(int, int) noexcept {/*implementation*/}\n");
     REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        58,
+        67,
         "StaticNegateSync",
         "    REACT_METHOD(StaticNegateSync) int StaticNegateSync(int) noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticNegateSync) static int StaticNegateSync(int) noexcept {/*implementation*/}\n");
     REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        59,
+        68,
         "StaticSayHelloSync",
         "    REACT_METHOD(StaticSayHelloSync) std::string StaticSayHelloSync() noexcept {/*implementation*/}\n"
         "    REACT_METHOD(StaticSayHelloSync) static std::string StaticSayHelloSync() noexcept {/*implementation*/}\n");
@@ -1262,6 +1391,30 @@ TEST_CLASS (TurboModuleTest) {
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
     m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
                         ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_CallbackZeroArgs) {
+    m_builderMock.Call1(L"CallbackZeroArgs", std::function<void()>([]() noexcept {}));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_CallbackTwoArgs) {
+    m_builderMock.Call1(L"CallbackTwoArgs", std::function<void(int, int)>([](int p1, int p2) noexcept {
+                          TestCheckEqual(1, p1);
+                          TestCheckEqual(2, p2);
+                        }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_CallbackThreeArgs) {
+    m_builderMock.Call1(
+        L"CallbackThreeArgs",
+        std::function<void(int, int, std::string const &)>([](int p1, int p2, std::string const &p3) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+          TestCheckEqual("Hello", p3);
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1506,6 +1659,68 @@ TEST_CLASS (TurboModuleTest) {
             [](const std::string &result) noexcept { TestCheck(result == "Hello_3"); }),
         std::function<void(std::string const &)>(
             [](std::string const &error) noexcept { TestCheck(error == "Goodbye"); }));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
+    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
+                        ]() noexcept { TestCheckFail(); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs2) {
+    m_builderMock.Call2(
+        L"TwoCallbacksZeroArgs2",
+        std::function<void()>([]() noexcept { TestCheckFail(); }),
+        std::function<void()>([]() noexcept {}));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksTwoArgs1) {
+    m_builderMock.Call2(
+        L"TwoCallbacksTwoArgs1",
+        std::function<void(int, int)>([](int p1, int p2) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+        }),
+        std::function<void(int, int)>([](int /*p1*/, int /*p2*/) noexcept { TestCheckFail(); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksTwoArgs2) {
+    m_builderMock.Call2(
+        L"TwoCallbacksTwoArgs2",
+        std::function<void(int, int)>([](int /*p1*/, int /*p2*/) noexcept { TestCheckFail(); }),
+        std::function<void(int, int)>([](int p1, int p2) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+        }));
+    TestCheck(m_builderMock.IsRejectCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksThreeArgs1) {
+    m_builderMock.Call2(
+        L"TwoCallbacksThreeArgs1",
+        std::function<void(int, int, const std::string &)>([](int p1, int p2, std::string const &p3) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+          TestCheckEqual("Hello", p3);
+        }),
+        std::function<void(int, int, const std::string &)>(
+            [](int /*p1*/, int /*p2*/, std::string const & /*p3*/) noexcept { TestCheckFail(); }));
+    TestCheck(m_builderMock.IsResolveCallbackCalled());
+  }
+
+  TEST_METHOD(TestMethodCall_TwoCallbacksThreeArgs2) {
+    m_builderMock.Call2(
+        L"TwoCallbacksThreeArgs2",
+        std::function<void(int, int, const std::string &)>(
+            [](int /*p1*/, int /*p2*/, std::string const & /*p3*/) noexcept { TestCheckFail(); }),
+        std::function<void(int, int, const std::string &)>([](int p1, int p2, std::string const &p3) noexcept {
+          TestCheckEqual(1, p1);
+          TestCheckEqual(2, p2);
+          TestCheckEqual("Hello", p3);
+        }));
     TestCheck(m_builderMock.IsRejectCallbackCalled());
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -205,6 +205,7 @@ struct GetCallbackSignatureImpl<TCallback<void(TArgs...) noexcept>> {
 template <class T>
 struct CallbackCreator;
 
+// Callback signature without noexcept
 template <template <class> class TCallback, class... TArgs>
 struct CallbackCreator<TCallback<void(TArgs...)>> {
   static TCallback<void(TArgs...)> Create(
@@ -217,6 +218,7 @@ struct CallbackCreator<TCallback<void(TArgs...)>> {
   }
 };
 
+// Callback signature with noexcept
 template <template <class> class TCallback, class... TArgs>
 struct CallbackCreator<TCallback<void(TArgs...) noexcept>> {
   static TCallback<void(TArgs...)> Create(

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
-    <CppWinRTVerbosity>high</CppWinRTVerbosity>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{14FA0516-E6D7-4E4D-B097-1470198C5072}</ProjectGuid>

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/NativeModuleTest.cs
@@ -157,6 +157,24 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     }
 
     [ReactMethod]
+    public void CallbackZeroArgs(Action resolve)
+    {
+      resolve();
+    }
+
+    [ReactMethod]
+    public void CallbackTwoArgs(Action<int, int> resolve)
+    {
+      resolve(1, 2);
+    }
+
+    [ReactMethod]
+    public void CallbackThreeArgs(Action<int, int, string> resolve)
+    {
+      resolve(1, 2, "Hello");
+    }
+
+    [ReactMethod]
     public void DivideCallbacks(int x, int y, Action<int> resolve, Action<string> reject)
     {
       if (y != 0)
@@ -260,6 +278,42 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public static void StaticRejectSayHelloCallbacks(Action<string> _, Action<string> reject)
     {
       reject("Goodbye");
+    }
+
+    [ReactMethod]
+    public void TwoCallbacksZeroArgs1(Action resolve, Action _)
+    {
+      resolve();
+    }
+
+    [ReactMethod]
+    public void TwoCallbacksZeroArgs2(Action _, Action reject)
+    {
+      reject();
+    }
+
+    [ReactMethod]
+    public void TwoCallbacksTwoArgs1(Action<int, int> resolve, Action<int, int> _)
+    {
+      resolve(1, 2);
+    }
+
+    [ReactMethod]
+    public void TwoCallbacksTwoArgs2(Action<int, int> _, Action<int, int> reject)
+    {
+      reject(1, 2);
+    }
+
+    [ReactMethod]
+    public void TwoCallbacksThreeArgs1(Action<int, int, string> resolve, Action<int, int, string> _)
+    {
+      resolve(1, 2, "Hello");
+    }
+
+    [ReactMethod]
+    public void TwoCallbacksThreeArgs2(Action<int, int, string> _, Action<int, int, string> reject)
+    {
+      reject(1, 2, "Hello");
     }
 
     [ReactMethod]
@@ -583,42 +637,42 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_Add()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.Add), 3, 5, (int result) => Assert.AreEqual(8, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule.Add), 3, 5, (int result) => Assert.AreEqual(8, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_Negate()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.Negate), 3, (int result) => Assert.AreEqual(-3, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule.Negate), 3, (int result) => Assert.AreEqual(-3, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_SayHello()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.SayHello), (string result) => Assert.AreEqual("Hello", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule.SayHello), (string result) => Assert.AreEqual("Hello", result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticAdd()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticAdd), 3, 5, (int result) => Assert.AreEqual(8, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule.StaticAdd), 3, 5, (int result) => Assert.AreEqual(8, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticNegate()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticNegate), 3, (int result) => Assert.AreEqual(-3, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule.StaticNegate), 3, (int result) => Assert.AreEqual(-3, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticSayHello()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticSayHello), (string result) => Assert.AreEqual("Hello", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule.StaticSayHello), (string result) => Assert.AreEqual("Hello", result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -668,63 +722,93 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_AddCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.AddCallback), 7, -8, (int result) => Assert.AreEqual(-1, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule.AddCallback), 7, -8, (int result) => Assert.AreEqual(-1, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_NegateCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.NegateCallback), 3, (int result) => Assert.AreEqual(-3, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule.NegateCallback), 3, (int result) => Assert.AreEqual(-3, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_NegateAyncCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.NegateAsyncCallback), 3, (int result) => Assert.AreEqual(-3, result)).Wait();
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule.NegateAsyncCallback), 3, (int result) => Assert.AreEqual(-3, result)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_SayHelloCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.SayHelloCallback), (string result) => Assert.AreEqual("Hello_2", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule.SayHelloCallback), (string result) => Assert.AreEqual("Hello_2", result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticAddCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticAddCallback), 4, 56, (int result) => Assert.AreEqual(60, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule.StaticAddCallback), 4, 56, (int result) => Assert.AreEqual(60, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticNegateCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticNegateCallback), 33, (int result) => Assert.AreEqual(-33, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule.StaticNegateCallback), 33, (int result) => Assert.AreEqual(-33, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticNegateAsyncCallback), 33, (int result) => Assert.AreEqual(-33, result)).Wait();
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule.StaticNegateAsyncCallback), 33, (int result) => Assert.AreEqual(-33, result)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticSayHelloCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule.StaticSayHelloCallback), (string result) => Assert.AreEqual("Static Hello_2", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule.StaticSayHelloCallback), (string result) => Assert.AreEqual("Static Hello_2", result));
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_CallbackZeroArgs()
+    {
+      m_moduleBuilderMock.Call1<Action>(nameof(SimpleNativeModule.CallbackZeroArgs), () => { });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_CallbackTwoArgs()
+    {
+      m_moduleBuilderMock.Call1<Action<int, int>>(nameof(SimpleNativeModule.CallbackTwoArgs), (int p1, int p2) =>
+      {
+        Assert.AreEqual(1, p1);
+        Assert.AreEqual(2, p2);
+      });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_CallbackThreeArgs()
+    {
+      m_moduleBuilderMock.Call1<Action<int, int, string>>(nameof(SimpleNativeModule.CallbackThreeArgs), (int p1, int p2, string p3) =>
+      {
+        Assert.AreEqual(1, p1);
+        Assert.AreEqual(2, p2);
+        Assert.AreEqual("Hello", p3);
+      });
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_DivideCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.DivideCallbacks), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule.DivideCallbacks), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -733,7 +817,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_DivideCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.DivideCallbacks), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule.DivideCallbacks), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -742,7 +826,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.NegateCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -751,7 +835,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.NegateCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -760,7 +844,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateAsyncCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.NegateAsyncCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -769,7 +853,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateAsyncCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.NegateAsyncCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -778,7 +862,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_ResolveSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.ResolveSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule.ResolveSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -787,7 +871,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_RejectSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.RejectSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule.RejectSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -796,7 +880,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDivideCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticDivideCallbacks), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule.StaticDivideCallbacks), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -805,7 +889,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDivideCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticDivideCallbacks), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule.StaticDivideCallbacks), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -814,7 +898,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.StaticNegateCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -823,7 +907,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.StaticNegateCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -832,7 +916,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateAsyncCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.StaticNegateAsyncCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -841,7 +925,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateAsyncCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule.StaticNegateAsyncCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -850,7 +934,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticResolveSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticResolveSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule.StaticResolveSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -859,16 +943,91 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticRejectSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticRejectSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule.StaticRejectSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
+      Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
+    }
+
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksZeroArgs1()
+    {
+      m_moduleBuilderMock.Call2<Action, Action>(nameof(SimpleNativeModule.TwoCallbacksZeroArgs1),
+        () => { }, () => { Assert.Fail(); });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksZeroArgs2()
+    {
+      m_moduleBuilderMock.Call2<Action, Action>(nameof(SimpleNativeModule.TwoCallbacksZeroArgs2),
+        () => { Assert.Fail(); }, () => { });
+      Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksTwoArgs1()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int>, Action<int, int>>(
+        nameof(SimpleNativeModule.TwoCallbacksTwoArgs1),
+        (int p1, int p2) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+        },
+        (int p1, int p2) => { Assert.Fail(); });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksTwoArgs2()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int>, Action<int, int>>(
+        nameof(SimpleNativeModule.TwoCallbacksTwoArgs2),
+        (int p1, int p2) => { Assert.Fail(); },
+        (int p1, int p2) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+        });
+      Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksThreeArgs1()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int, string>, Action<int, int, string>>(
+        nameof(SimpleNativeModule.TwoCallbacksThreeArgs1),
+        (int p1, int p2, string p3) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+          Assert.AreEqual("Hello", p3);
+        },
+        (int p1, int p2, string p3) => { Assert.Fail(); });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksThreeArgs2()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int, string>, Action<int, int, string>>(
+        nameof(SimpleNativeModule.TwoCallbacksThreeArgs2),
+        (int p1, int p2, string p3) => { Assert.Fail(); },
+        (int p1, int p2, string p3) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+          Assert.AreEqual("Hello", p3);
+        });
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_DividePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.DividePromise), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.DividePromise), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -877,7 +1036,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_DividePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.DividePromise), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.DividePromise), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -886,7 +1045,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegatePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegatePromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.NegatePromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -895,7 +1054,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegatePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegatePromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.NegatePromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -904,7 +1063,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateAsyncPromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.NegateAsyncPromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -913,7 +1072,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncPromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.NegateAsyncPromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.NegateAsyncPromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -922,7 +1081,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_VoidPromise()
     {
-      m_moduleBuilderMock.Call2("voidPromise", 2,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("voidPromise", 2,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -931,7 +1090,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_VoidPromiseError()
     {
-      m_moduleBuilderMock.Call2("voidPromise", 3,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("voidPromise", 3,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -940,7 +1099,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_ResolveSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.ResolveSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule.ResolveSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -949,7 +1108,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_RejectSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.RejectSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule.RejectSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -958,7 +1117,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDividePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticDividePromise), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.StaticDividePromise), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -967,7 +1126,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDividePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticDividePromise), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.StaticDividePromise), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -976,7 +1135,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegatePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegatePromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.StaticNegatePromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -985,7 +1144,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegatePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegatePromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.StaticNegatePromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -994,7 +1153,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateAsyncPromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.StaticNegateAsyncPromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1003,7 +1162,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncPromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticNegateAsyncPromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule.StaticNegateAsyncPromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1012,7 +1171,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticVoidPromise()
     {
-      m_moduleBuilderMock.Call2("staticVoidPromise", 2,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("staticVoidPromise", 2,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1021,7 +1180,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticVoidPromiseError()
     {
-      m_moduleBuilderMock.Call2("staticVoidPromise", 3,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("staticVoidPromise", 3,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1031,7 +1190,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticResolveSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticResolveSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule.StaticResolveSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1040,7 +1199,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticRejectSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule.StaticRejectSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule.StaticRejectSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/NoAttributeNativeModuleTest.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/NoAttributeNativeModuleTest.cs
@@ -122,6 +122,21 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       resolve("Static Hello_2");
     }
 
+    public void CallbackZeroArgs(Action resolve)
+    {
+      resolve();
+    }
+
+    public void CallbackTwoArgs(Action<int, int> resolve)
+    {
+      resolve(1, 2);
+    }
+
+    public void CallbackThreeArgs(Action<int, int, string> resolve)
+    {
+      resolve(1, 2, "Hello");
+    }
+
     public void DivideCallbacks(int x, int y, Action<int> resolve, Action<string> reject)
     {
       if (y != 0)
@@ -215,6 +230,36 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public static void StaticRejectSayHelloCallbacks(Action<string> _, Action<string> reject)
     {
       reject("Goodbye");
+    }
+
+    public void TwoCallbacksZeroArgs1(Action resolve, Action _)
+    {
+      resolve();
+    }
+
+    public void TwoCallbacksZeroArgs2(Action _, Action reject)
+    {
+      reject();
+    }
+
+    public void TwoCallbacksTwoArgs1(Action<int, int> resolve, Action<int, int> _)
+    {
+      resolve(1, 2);
+    }
+
+    public void TwoCallbacksTwoArgs2(Action<int, int> _, Action<int, int> reject)
+    {
+      reject(1, 2);
+    }
+
+    public void TwoCallbacksThreeArgs1(Action<int, int, string> resolve, Action<int, int, string> _)
+    {
+      resolve(1, 2, "Hello");
+    }
+
+    public void TwoCallbacksThreeArgs2(Action<int, int, string> _, Action<int, int, string> reject)
+    {
+      reject(1, 2, "Hello");
     }
 
     public void DividePromise(int x, int y, IReactPromise<int> promise)
@@ -546,13 +591,43 @@ namespace Microsoft.ReactNative.Managed.UnitTests
         });
     }
 
-    public void AddMethod<TResult>(string name, Func<TModule, Action<Action<TResult>>> getMethod)
+    public void AddMethod(string name, Func<TModule, Action<Action>> getMethod)
     {
       m_moduleBuilder.AddMethod(name, MethodReturnType.Callback,
         (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
         {
           var method = getMethod(m_module);
-          method(result => resolve(outputWriter.WriteArgs(result)));
+          method(() => resolve(outputWriter.WriteArgs()));
+        });
+    }
+
+    public void AddMethod<TResult1>(string name, Func<TModule, Action<Action<TResult1>>> getMethod)
+    {
+      m_moduleBuilder.AddMethod(name, MethodReturnType.Callback,
+        (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
+        {
+          var method = getMethod(m_module);
+          method(result1 => resolve(outputWriter.WriteArgs(result1)));
+        });
+    }
+
+    public void AddMethod<TResult1, TResult2>(string name, Func<TModule, Action<Action<TResult1, TResult2>>> getMethod)
+    {
+      m_moduleBuilder.AddMethod(name, MethodReturnType.Callback,
+        (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
+        {
+          var method = getMethod(m_module);
+          method((result1, result2) => resolve(outputWriter.WriteArgs(result1, result2)));
+        });
+    }
+
+    public void AddMethod<TResult1, TResult2, TResult3>(string name, Func<TModule, Action<Action<TResult1, TResult2, TResult3>>> getMethod)
+    {
+      m_moduleBuilder.AddMethod(name, MethodReturnType.Callback,
+        (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
+        {
+          var method = getMethod(m_module);
+          method((result1, result2, result3) => resolve(outputWriter.WriteArgs(result1, result2, result3)));
         });
     }
 
@@ -578,6 +653,16 @@ namespace Microsoft.ReactNative.Managed.UnitTests
         });
     }
 
+    public void AddMethod(string name, Func<TModule, Action<Action, Action>> getMethod)
+    {
+      m_moduleBuilder.AddMethod(name, MethodReturnType.TwoCallbacks,
+        (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
+        {
+          var method = getMethod(m_module);
+          method(() => resolve(outputWriter.WriteArgs()), () => reject(outputWriter.WriteArgs()));
+        });
+    }
+
     public void AddMethod<T1, T2>(string name, Func<TModule, Action<Action<T1>, Action<T2>>> getMethod)
     {
       m_moduleBuilder.AddMethod(name, MethodReturnType.TwoCallbacks,
@@ -585,6 +670,30 @@ namespace Microsoft.ReactNative.Managed.UnitTests
         {
           var method = getMethod(m_module);
           method(result => resolve(outputWriter.WriteArgs(result)), result => reject(outputWriter.WriteArgs(result)));
+        });
+    }
+
+    public void AddMethod<T1, T2, T3, T4>(string name, Func<TModule, Action<Action<T1, T2>, Action<T3, T4>>> getMethod)
+    {
+      m_moduleBuilder.AddMethod(name, MethodReturnType.TwoCallbacks,
+        (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
+        {
+          var method = getMethod(m_module);
+          method(
+            (result1, result2) => resolve(outputWriter.WriteArgs(result1, result2)),
+            (result1, result2) => reject(outputWriter.WriteArgs(result1, result2)));
+        });
+    }
+
+    public void AddMethod<T1, T2, T3, T4, T5, T6>(string name, Func<TModule, Action<Action<T1, T2, T3>, Action<T4, T5, T6>>> getMethod)
+    {
+      m_moduleBuilder.AddMethod(name, MethodReturnType.TwoCallbacks,
+        (IJSValueReader inputReader, IJSValueWriter outputWriter, MethodResultCallback resolve, MethodResultCallback reject) =>
+        {
+          var method = getMethod(m_module);
+          method(
+            (result1, result2, result3) => resolve(outputWriter.WriteArgs(result1, result2, result3)),
+            (result1, result2, result3) => reject(outputWriter.WriteArgs(result1, result2, result3)));
         });
     }
 
@@ -686,7 +795,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public void AddJSEvent(string eventEmitterName, string name, Action<TModule, Action> setEventHandler)
     {
-      m_moduleBuilder.AddInitializer(reactContext => {
+      m_moduleBuilder.AddInitializer(reactContext =>
+      {
         setEventHandler(m_module, () => new ReactContext(reactContext).EmitJSEvent(
           eventEmitterName ?? EventEmitterName ?? "RCTDeviceEventEmitter", name));
       });
@@ -694,7 +804,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public void AddJSEvent<T1>(string eventEmitterName, string name, Action<TModule, Action<T1>> setEventHandler)
     {
-      m_moduleBuilder.AddInitializer(reactContext => {
+      m_moduleBuilder.AddInitializer(reactContext =>
+      {
         setEventHandler(m_module, (T1 arg1) => new ReactContext(reactContext).EmitJSEvent(
           eventEmitterName ?? EventEmitterName ?? "RCTDeviceEventEmitter", name, arg1));
       });
@@ -702,7 +813,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public void AddJSEvent<T1, T2>(string eventEmitterName, string name, Action<TModule, Action<T1, T2>> setEventHandler)
     {
-      m_moduleBuilder.AddInitializer(reactContext => {
+      m_moduleBuilder.AddInitializer(reactContext =>
+      {
         setEventHandler(m_module, (T1 arg1, T2 arg2) => new ReactContext(reactContext).EmitJSEvent(
           eventEmitterName ?? EventEmitterName ?? "RCTDeviceEventEmitter", name, arg1, arg2));
       });
@@ -710,7 +822,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public void AddJSFunction(string moduleName, string name, Action<TModule, Action> setFunctionHandler)
     {
-      m_moduleBuilder.AddInitializer(reactContext => {
+      m_moduleBuilder.AddInitializer(reactContext =>
+      {
         setFunctionHandler(m_module, () => new ReactContext(reactContext).CallJSFunction(
           moduleName ?? ModuleName, name));
       });
@@ -718,7 +831,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public void AddJSFunction<T1>(string moduleName, string name, Action<TModule, Action<T1>> setFunctionHandler)
     {
-      m_moduleBuilder.AddInitializer(reactContext => {
+      m_moduleBuilder.AddInitializer(reactContext =>
+      {
         setFunctionHandler(m_module, (T1 arg1) => new ReactContext(reactContext).CallJSFunction(
           moduleName ?? ModuleName, name, arg1));
       });
@@ -726,7 +840,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public void AddJSFunction<T1, T2>(string moduleName, string name, Action<TModule, Action<T1, T2>> setFunctionHandler)
     {
-      m_moduleBuilder.AddInitializer(reactContext => {
+      m_moduleBuilder.AddInitializer(reactContext =>
+      {
         setFunctionHandler(m_module, (T1 arg1, T2 arg2) => new ReactContext(reactContext).CallJSFunction(
           moduleName ?? ModuleName, name, arg1, arg2));
       });
@@ -758,7 +873,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       mb.ModuleName = "SimpleNativeModule2";
 
       mb.AddInitializer(m => m.Initialize);
-    
+
       mb.AddMethod("Add", m => new Func<int, int, int>(m.Add));
       mb.AddMethod("Negate", m => new Func<int, int>(m.Negate));
       mb.AddMethod("SayHello", m => new Func<string>(m.SayHello));
@@ -782,6 +897,10 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       mb.AddMethod("StaticNegateAsyncCallback", m => new Action<int, Action<int>>(SimpleNativeModule2.StaticNegateAsyncCallback));
       mb.AddMethod("StaticSayHelloCallback", m => new Action<Action<string>>(SimpleNativeModule2.StaticSayHelloCallback));
 
+      mb.AddMethod("CallbackZeroArgs", m => new Action<Action>(m.CallbackZeroArgs));
+      mb.AddMethod("CallbackTwoArgs", m => new Action<Action<int, int>>(m.CallbackTwoArgs));
+      mb.AddMethod("CallbackThreeArgs", m => new Action<Action<int, int, string>>(m.CallbackThreeArgs));
+
       mb.AddMethod("DivideCallbacks", m => new Action<int, int, Action<int>, Action<string>>(m.DivideCallbacks));
       mb.AddMethod("NegateCallbacks", m => new Action<int, Action<int>, Action<string>>(m.NegateCallbacks));
       mb.AddMethod("NegateAsyncCallbacks", m => new Action<int, Action<int>, Action<string>>(m.NegateAsyncCallbacks));
@@ -792,6 +911,13 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       mb.AddMethod("StaticNegateAsyncCallbacks", m => new Action<int, Action<int>, Action<string>>(SimpleNativeModule2.StaticNegateAsyncCallbacks));
       mb.AddMethod("StaticResolveSayHelloCallbacks", m => new Action<Action<string>, Action<string>>(SimpleNativeModule2.StaticResolveSayHelloCallbacks));
       mb.AddMethod("StaticRejectSayHelloCallbacks", m => new Action<Action<string>, Action<string>>(SimpleNativeModule2.StaticRejectSayHelloCallbacks));
+
+      mb.AddMethod("TwoCallbacksZeroArgs1", m => new Action<Action, Action>(m.TwoCallbacksZeroArgs1));
+      mb.AddMethod("TwoCallbacksZeroArgs2", m => new Action<Action, Action>(m.TwoCallbacksZeroArgs2));
+      mb.AddMethod("TwoCallbacksTwoArgs1", m => new Action<Action<int, int>, Action<int, int>>(m.TwoCallbacksTwoArgs1));
+      mb.AddMethod("TwoCallbacksTwoArgs2", m => new Action<Action<int, int>, Action<int, int>>(m.TwoCallbacksTwoArgs2));
+      mb.AddMethod("TwoCallbacksThreeArgs1", m => new Action<Action<int, int, string>, Action<int, int, string>>(m.TwoCallbacksThreeArgs1));
+      mb.AddMethod("TwoCallbacksThreeArgs2", m => new Action<Action<int, int, string>, Action<int, int, string>>(m.TwoCallbacksThreeArgs2));
 
       mb.AddMethod("DividePromise", m => new Action<int, int, IReactPromise<int>>(m.DividePromise));
       mb.AddMethod("NegatePromise", m => new Action<int, IReactPromise<int>>(m.NegatePromise));
@@ -857,42 +983,42 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_Add()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.Add), 3, 5, (int result) => Assert.AreEqual(8, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule2.Add), 3, 5, (int result) => Assert.AreEqual(8, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_Negate()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.Negate), 3, (int result) => Assert.AreEqual(-3, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule2.Negate), 3, (int result) => Assert.AreEqual(-3, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_SayHello()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.SayHello), (string result) => Assert.AreEqual("Hello", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule2.SayHello), (string result) => Assert.AreEqual("Hello", result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticAdd()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticAdd), 3, 5, (int result) => Assert.AreEqual(8, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule2.StaticAdd), 3, 5, (int result) => Assert.AreEqual(8, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticNegate()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticNegate), 3, (int result) => Assert.AreEqual(-3, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule2.StaticNegate), 3, (int result) => Assert.AreEqual(-3, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticSayHello()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticSayHello), (string result) => Assert.AreEqual("Hello", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule2.StaticSayHello), (string result) => Assert.AreEqual("Hello", result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
@@ -942,63 +1068,93 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_AddCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.AddCallback), 7, -8, (int result) => Assert.AreEqual(-1, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule2.AddCallback), 7, -8, (int result) => Assert.AreEqual(-1, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_NegateCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.NegateCallback), 3, (int result) => Assert.AreEqual(-3, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule2.NegateCallback), 3, (int result) => Assert.AreEqual(-3, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
-    public void TestMethodCall_NegateAyncCallback()
+    public void TestMethodCall_NegateAsyncCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.NegateAsyncCallback), 3, (int result) => Assert.AreEqual(-3, result)).Wait();
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule2.NegateAsyncCallback), 3, (int result) => Assert.AreEqual(-3, result)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_SayHelloCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.SayHelloCallback), (string result) => Assert.AreEqual("Hello_2", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule2.SayHelloCallback), (string result) => Assert.AreEqual("Hello_2", result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticAddCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticAddCallback), 4, 56, (int result) => Assert.AreEqual(60, result));
+      m_moduleBuilderMock.Call1<int, int, Action<int>>(nameof(SimpleNativeModule2.StaticAddCallback), 4, 56, (int result) => Assert.AreEqual(60, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticNegateCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticNegateCallback), 33, (int result) => Assert.AreEqual(-33, result));
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule2.StaticNegateCallback), 33, (int result) => Assert.AreEqual(-33, result));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticNegateAsyncCallback), 33, (int result) => Assert.AreEqual(-33, result)).Wait();
+      m_moduleBuilderMock.Call1<int, Action<int>>(nameof(SimpleNativeModule2.StaticNegateAsyncCallback), 33, (int result) => Assert.AreEqual(-33, result)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_StaticSayHelloCallback()
     {
-      m_moduleBuilderMock.Call1(nameof(SimpleNativeModule2.StaticSayHelloCallback), (string result) => Assert.AreEqual("Static Hello_2", result));
+      m_moduleBuilderMock.Call1<Action<string>>(nameof(SimpleNativeModule2.StaticSayHelloCallback), (string result) => Assert.AreEqual("Static Hello_2", result));
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_CallbackZeroArgs()
+    {
+      m_moduleBuilderMock.Call1<Action>(nameof(SimpleNativeModule.CallbackZeroArgs), () => { });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_CallbackTwoArgs()
+    {
+      m_moduleBuilderMock.Call1<Action<int, int>>(nameof(SimpleNativeModule.CallbackTwoArgs), (int p1, int p2) =>
+      {
+        Assert.AreEqual(1, p1);
+        Assert.AreEqual(2, p2);
+      });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_CallbackThreeArgs()
+    {
+      m_moduleBuilderMock.Call1<Action<int, int, string>>(nameof(SimpleNativeModule.CallbackThreeArgs), (int p1, int p2, string p3) =>
+      {
+        Assert.AreEqual(1, p1);
+        Assert.AreEqual(2, p2);
+        Assert.AreEqual("Hello", p3);
+      });
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
     }
 
     [TestMethod]
     public void TestMethodCall_DivideCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.DivideCallbacks), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.DivideCallbacks), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1007,7 +1163,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_DivideCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.DivideCallbacks), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.DivideCallbacks), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1016,7 +1172,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegateCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.NegateCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1025,7 +1181,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegateCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.NegateCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1034,7 +1190,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegateAsyncCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.NegateAsyncCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1043,7 +1199,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegateAsyncCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.NegateAsyncCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1052,7 +1208,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_ResolveSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.ResolveSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule2.ResolveSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1061,7 +1217,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_RejectSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.RejectSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule2.RejectSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1070,7 +1226,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDivideCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticDivideCallbacks), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.StaticDivideCallbacks), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1079,7 +1235,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDivideCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticDivideCallbacks), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.StaticDivideCallbacks), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (string error) => Assert.AreEqual("Division by 0", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1088,7 +1244,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegateCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.StaticNegateCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1097,7 +1253,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegateCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.StaticNegateCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1106,7 +1262,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegateAsyncCallbacks), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.StaticNegateAsyncCallbacks), 5,
           (int result) => Assert.AreEqual(-5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1115,7 +1271,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncCallbacksError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegateAsyncCallbacks), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<string>>(nameof(SimpleNativeModule2.StaticNegateAsyncCallbacks), -5,
           (int result) => Assert.AreEqual(5, result),
           (string error) => Assert.AreEqual("Already negative", error)).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1124,7 +1280,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticResolveSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticResolveSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule2.StaticResolveSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1133,16 +1289,90 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticRejectSayHelloCallbacks()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticRejectSayHelloCallbacks),
+      m_moduleBuilderMock.Call2<Action<string>, Action<string>>(nameof(SimpleNativeModule2.StaticRejectSayHelloCallbacks),
           (string result) => Assert.AreEqual("Hello_3", result),
           (string error) => Assert.AreEqual("Goodbye", error));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
     }
 
     [TestMethod]
+    public void TestMethodCall_TwoCallbacksZeroArgs1()
+    {
+      m_moduleBuilderMock.Call2<Action, Action>(nameof(SimpleNativeModule.TwoCallbacksZeroArgs1),
+        () => { }, () => { Assert.Fail(); });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksZeroArgs2()
+    {
+      m_moduleBuilderMock.Call2<Action, Action>(nameof(SimpleNativeModule.TwoCallbacksZeroArgs2),
+        () => { Assert.Fail(); }, () => { });
+      Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksTwoArgs1()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int>, Action<int, int>>(
+        nameof(SimpleNativeModule.TwoCallbacksTwoArgs1),
+        (int p1, int p2) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+        },
+        (int p1, int p2) => { Assert.Fail(); });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksTwoArgs2()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int>, Action<int, int>>(
+        nameof(SimpleNativeModule.TwoCallbacksTwoArgs2),
+        (int p1, int p2) => { Assert.Fail(); },
+        (int p1, int p2) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+        });
+      Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksThreeArgs1()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int, string>, Action<int, int, string>>(
+        nameof(SimpleNativeModule.TwoCallbacksThreeArgs1),
+        (int p1, int p2, string p3) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+          Assert.AreEqual("Hello", p3);
+        },
+        (int p1, int p2, string p3) => { Assert.Fail(); });
+      Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
+    }
+
+    [TestMethod]
+    public void TestMethodCall_TwoCallbacksThreeArgs2()
+    {
+      m_moduleBuilderMock.Call2<Action<int, int, string>, Action<int, int, string>>(
+        nameof(SimpleNativeModule.TwoCallbacksThreeArgs2),
+        (int p1, int p2, string p3) => { Assert.Fail(); },
+        (int p1, int p2, string p3) =>
+        {
+          Assert.AreEqual(1, p1);
+          Assert.AreEqual(2, p2);
+          Assert.AreEqual("Hello", p3);
+        });
+      Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
+    }
+
+    [TestMethod]
     public void TestMethodCall_DividePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.DividePromise), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.DividePromise), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1151,7 +1381,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_DividePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.DividePromise), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.DividePromise), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1160,7 +1390,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegatePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegatePromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.NegatePromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1169,7 +1399,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegatePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegatePromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.NegatePromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1178,7 +1408,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegateAsyncPromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.NegateAsyncPromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1187,7 +1417,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_NegateAsyncPromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.NegateAsyncPromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.NegateAsyncPromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1196,7 +1426,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_VoidPromise()
     {
-      m_moduleBuilderMock.Call2("voidPromise", 2,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("voidPromise", 2,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1205,7 +1435,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_VoidPromiseError()
     {
-      m_moduleBuilderMock.Call2("voidPromise", 3,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("voidPromise", 3,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1214,7 +1444,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_ResolveSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.ResolveSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule2.ResolveSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1223,7 +1453,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_RejectSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.RejectSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule2.RejectSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1232,7 +1462,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDividePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticDividePromise), 6, 2,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticDividePromise), 6, 2,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1241,7 +1471,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticDividePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticDividePromise), 6, 0,
+      m_moduleBuilderMock.Call2<int, int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticDividePromise), 6, 0,
           (int result) => Assert.AreEqual(3, result),
           (JSValue error) => Assert.AreEqual("Division by 0", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1250,7 +1480,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegatePromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegatePromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticNegatePromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1259,7 +1489,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegatePromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegatePromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticNegatePromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1268,7 +1498,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegateAsyncPromise), 5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticNegateAsyncPromise), 5,
           (int result) => Assert.AreEqual(-5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1277,7 +1507,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticNegateAsyncPromiseError()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticNegateAsyncPromise), -5,
+      m_moduleBuilderMock.Call2<int, Action<int>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticNegateAsyncPromise), -5,
           (int result) => Assert.AreEqual(5, result),
           (JSValue error) => Assert.AreEqual("Already negative", error["message"])).Wait();
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1286,7 +1516,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticVoidPromise()
     {
-      m_moduleBuilderMock.Call2("staticVoidPromise", 2,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("staticVoidPromise", 2,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1295,7 +1525,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticVoidPromiseError()
     {
-      m_moduleBuilderMock.Call2("staticVoidPromise", 3,
+      m_moduleBuilderMock.Call2<int, Action<JSValue.Void>, Action<JSValue>>("staticVoidPromise", 3,
           (JSValue.Void result) => { },
           (JSValue error) => Assert.AreEqual("Odd unexpected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);
@@ -1305,7 +1535,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticResolveSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticResolveSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticResolveSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsResolveCallbackCalled);
@@ -1314,7 +1544,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     [TestMethod]
     public void TestMethodCall_StaticRejectSayHelloPromise()
     {
-      m_moduleBuilderMock.Call2(nameof(SimpleNativeModule2.StaticRejectSayHelloPromise),
+      m_moduleBuilderMock.Call2<Action<string>, Action<JSValue>>(nameof(SimpleNativeModule2.StaticRejectSayHelloPromise),
           (string result) => Assert.AreEqual("Hello_3", result),
           (JSValue error) => Assert.AreEqual("Promise rejected", error["message"]));
       Assert.IsTrue(m_moduleBuilderMock.IsRejectCallbackCalled);

--- a/vnext/Microsoft.ReactNative.SharedManaged/JSValueGenerator.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/JSValueGenerator.cs
@@ -447,12 +447,12 @@ namespace Microsoft.ReactNative.Managed
       out Type[] argTypes,
       out VariableWrapper[] args,
       out Type resolveCallbackType,
-      out Type resolveArgType)
+      out Type[] resolveArgTypes)
     {
       argTypes = parameters.Take(parameters.Length - 1).Select(p => p.ParameterType).ToArray();
       args = argTypes.Select(t => Variable(t, out _)).ToArray();
       resolveCallbackType = parameters[parameters.Length - 1].ParameterType;
-      resolveArgType = resolveCallbackType.GetMethod("Invoke").GetParameters()[0].ParameterType;
+      resolveArgTypes = resolveCallbackType.GetMethod("Invoke").GetParameters().Select(p => p.ParameterType).ToArray();
       return args;
     }
 
@@ -461,16 +461,16 @@ namespace Microsoft.ReactNative.Managed
       out Type[] argTypes,
       out VariableWrapper[] args,
       out Type resolveCallbackType,
-      out Type resolveArgType,
+      out Type[] resolveArgTypes,
       out Type rejectCallbackType,
-      out Type rejectArgType)
+      out Type[] rejectArgTypes)
     {
       argTypes = parameters.Take(parameters.Length - 2).Select(p => p.ParameterType).ToArray();
       args = argTypes.Select(t => Variable(t, out _)).ToArray();
       resolveCallbackType = parameters[parameters.Length - 2].ParameterType;
-      resolveArgType = resolveCallbackType.GetMethod("Invoke").GetParameters()[0].ParameterType;
+      resolveArgTypes = resolveCallbackType.GetMethod("Invoke").GetParameters().Select(p => p.ParameterType).ToArray();
       rejectCallbackType = parameters[parameters.Length - 1].ParameterType;
-      rejectArgType = rejectCallbackType.GetMethod("Invoke").GetParameters()[0].ParameterType;
+      rejectArgTypes = rejectCallbackType.GetMethod("Invoke").GetParameters().Select(p => p.ParameterType).ToArray();
       return args;
     }
 

--- a/vnext/Microsoft.ReactNative.SharedManaged/ReactMethodInfo.cs
+++ b/vnext/Microsoft.ReactNative.SharedManaged/ReactMethodInfo.cs
@@ -118,18 +118,18 @@ namespace Microsoft.ReactNative.Managed
       // {
       //   inputReader.ReadArgs(out ArgType0 arg0, out ArgType1 arg1);
       //   (module as ModuleType).Method(arg0, arg1,
-      //     result => resolve(outputWriter.WriteArgs(result)));
+      //     (result1, result2) => resolve(outputWriter.WriteArgs(result1, result2)));
       // }
 
       // The last parameter in parameters is a 'resolve' delegate
       return CompileLambda<ReactMethodImpl>(
         MethodParameters(out var module, out var inputReader, out var outputWriter, out var resolve, out _),
         MethodArgs(parameters, out var argTypes, out var args,
-          out var resolveCallbackType, out var resolveArgType),
+          out var resolveCallbackType, out var resolveArgTypes),
         inputReader.CallExt(ReadArgsOf(argTypes), args),
         module.CastTo(methodInfo.DeclaringType).Call(methodInfo, args,
-          AutoLambda(resolveCallbackType, Parameter(resolveArgType, out var result),
-            resolve.Invoke(outputWriter.CallExt(WriteArgsOf(resolveArgType), result)))));
+          AutoLambda(resolveCallbackType, Parameters(resolveArgTypes, out var results),
+            resolve.Invoke(outputWriter.CallExt(WriteArgsOf(resolveArgTypes), results)))));
     }
 
     private ReactMethodImpl MakeTwoCallbacksMethod(MethodInfo methodInfo, ParameterInfo[] parameters)
@@ -144,24 +144,23 @@ namespace Microsoft.ReactNative.Managed
       // {
       //   inputReader.ReadArgs(out ArgType0 arg0, out ArgType1 arg1);
       //   (module as ModuleType).Method(arg0, arg1,
-      //     value1 => resolve(outputWriter.WriteArgs(value1)),
-      //     value2 => reject(outputWriter.WriteArgs(value2)));
+      //     (result1, result2) => resolve(outputWriter.WriteArgs(result1, result2)),
+      //     (error1, error2) => reject(outputWriter.WriteArgs(error1, error2)));
       // }
 
       // The last two parameters in parameters are resolve and reject delegates
       return CompileLambda<ReactMethodImpl>(
         MethodParameters(out var module, out var inputReader, out var outputWriter, out var resolve, out var reject),
         MethodArgs(parameters, out var argTypes, out var args,
-          out var resolveCallbackType, out var resolveArgType,
-          out var rejectCallbackType, out var rejectArgType),
+          out var resolveCallbackType, out var resolveArgTypes,
+          out var rejectCallbackType, out var rejectArgTypes),
         inputReader.CallExt(ReadArgsOf(argTypes), args),
         module.CastTo(methodInfo.DeclaringType).Call(methodInfo, args,
-          AutoLambda(resolveCallbackType, Parameter(resolveArgType, out var value1),
-            resolve.Invoke(outputWriter.CallExt(WriteArgsOf(resolveArgType), value1))),
-          AutoLambda(rejectCallbackType, Parameter(rejectArgType, out var value2),
-            reject.Invoke(outputWriter.CallExt(WriteArgsOf(rejectArgType), value2)))));
+          AutoLambda(resolveCallbackType, Parameters(resolveArgTypes, out var results),
+            resolve.Invoke(outputWriter.CallExt(WriteArgsOf(resolveArgTypes), results))),
+          AutoLambda(rejectCallbackType, Parameters(rejectArgTypes, out var errors),
+            reject.Invoke(outputWriter.CallExt(WriteArgsOf(rejectArgTypes), errors)))));
     }
-
 
     private ReactMethodImpl MakePromiseMethod(MethodInfo methodInfo, ParameterInfo[] parameters)
     {


### PR DESCRIPTION
The fix is related to the issue #4789. 
In our C# native module implementation we previously supported callbacks with only one argument in native modules. The C++ native modules already support callbacks with 0..n arguments.

In this PR we:
- Implemented support for callbacks with 0..n arguments in C#.
- Added unit tests for callbacks with 0..n arguments to C++ and C# code.
 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4929)