### PR TITLE
Ensure Override Prompts Create Integral Issue Numbers

### DIFF
--- a/packages/override-tools/src/OverridePrompt.ts
+++ b/packages/override-tools/src/OverridePrompt.ts
@@ -82,7 +82,7 @@ async function promptDerivedDetails(): Promise<Details> {
         message: 'Github Issue Number:',
       },
     ]);
-    issue = issueResponse.issue;
+    issue = Number.parseInt(issueResponse.issue, 10);
   }
 
   const baseFileResponse = await inquirer.prompt([
@@ -110,11 +110,12 @@ async function promptPatchDetails(overrideFile: string): Promise<Details> {
   ]);
 
   const baseFile = overrideFile.replace(WIN_PLATFORM_EXT, '.js');
-  return {type: 'patch', baseFile, issue: response.issue};
+  return {type: 'patch', baseFile, issue: Number.parseInt(response.issue, 10)};
 }
 
 function validateIssueNumber(answer: string): boolean | string {
   return (
-    Number.isInteger(Number.parseInt(answer)) || 'Github issue must be a number'
+    Number.isInteger(Number.parseInt(answer, 10)) ||
+    'Github issue must be a number'
   );
 }


### PR DESCRIPTION
After reported issues I recently moved `override-tools` to use `inquirer` instead of `prompts` for asking for override details. During validation I missed that we now assign an issue number to be text instead of a parsed integer. This propagates to the manifest when adding a new issue number, leading to an assumed invalid manifest.

Make sure we treat the issue number as integral when returning it. Additionally make sure to specify radix while parsing in all places.

Validated integral issues are added to the manifest instead of strings.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4931)