### PR TITLE
Fix compile errors with Clang 10.0.0

### DIFF
--- a/change/react-native-windows-2020-05-18-02-05-00-chpurrer-rnw-clang-fixes.json
+++ b/change/react-native-windows-2020-05-18-02-05-00-chpurrer-rnw-clang-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix compile errors with Clang 10.0.0",
+  "packageName": "react-native-windows",
+  "email": "christophpurrer@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-18T09:05:00.527Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.h
@@ -818,7 +818,7 @@ inline T JSValue::To(T &&defaultValue) const noexcept {
 }
 
 template <class T>
-static JSValue JSValue::From(T const &value) noexcept {
+JSValue JSValue::From(T const &value) noexcept {
   auto writer = MakeJSValueTreeWriter();
   WriteValue(writer, value);
   return TakeJSValue(writer);

--- a/vnext/ReactUWP/Utils/ValueUtils.cpp
+++ b/vnext/ReactUWP/Utils/ValueUtils.cpp
@@ -199,7 +199,7 @@ REACTWINDOWS_API_(bool) IsValidColorValue(const folly::dynamic &d) {
 
 REACTWINDOWS_API_(winrt::TimeSpan) TimeSpanFromMs(double ms) {
   std::chrono::milliseconds dur((int64_t)ms);
-  return winrt::TimeSpan(dur);
+  return winrt::TimeSpan::duration(dur);
 }
 
 } // namespace uwp


### PR DESCRIPTION
Right now the code does not compile with Clang 10.0.0
These changes should make it work on MSVC and Clang
Built on a local repository using BUCK with Clang


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4937)