### PR TITLE
Publish 0.61 as "v0.61-stable" instead of "latest"

### DIFF
--- a/change/@office-iss-react-native-win32-2020-05-18-08-22-44-61-no-latest.json
+++ b/change/@office-iss-react-native-win32-2020-05-18-08-22-44-61-no-latest.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Publish 0.61 as \"v0.61-stable\" instead of \"latest\"",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-18T15:22:42.701Z"
+}

--- a/change/react-native-windows-2020-05-18-08-22-44-61-no-latest.json
+++ b/change/react-native-windows-2020-05-18-08-22-44-61-no-latest.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Publish 0.61 as \"v0.61-stable\" instead of \"latest\"",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-18T15:22:44.140Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -63,7 +63,7 @@
     "react-native": "0.61.5"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.61-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -61,7 +61,7 @@
     "react-native": "0.61.5"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.61-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
Change the branch dist tag in preparation to move 0.62 to latest. This naming convention is somewhat ugly but matches what we've used for past branches. It is not currently possible to publish the package without a dist-tag, which would be preferable (beachball defaults to latest).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4938)