### PR TITLE
Add --useDevMode flag to CLI template script to ease development of the local-cli templates.

### DIFF
--- a/change/react-native-windows-init-2020-05-18-18-01-10-master.json
+++ b/change/react-native-windows-init-2020-05-18-18-01-10-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "> This change is only intended for developers working on react-native-windows, it is not intended   for end-developers 'using' react-native-windows.",
+  "packageName": "react-native-windows-init",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-19T01:01:10.485Z"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -49,11 +49,16 @@ const argv = yargs.version(false).options({
   },
   useWinUI3: {
     type: 'boolean',
-    describe:
-    '[Experimental] Use WinUI3',
+    describe: '[Experimental] Use WinUI3',
     hidden: true,
     default: false,
-  }
+  },
+  useDevMode: {
+    type: 'boolean',
+    describe:
+      'Link rather than Add/Install the react-native-windows package. This option is for the developement workflow of the developers working on react-native-windows.',
+    hidden: true,
+  },
 }).argv;
 
 const EXITCODE_UNSUPPORTED_VERION_RN = 3;
@@ -248,6 +253,7 @@ function isProjectUsingYarn(cwd: string) {
     const name = getReactNativeAppName();
     const ns = argv.namespace || name;
     let version = argv.version;
+    let useDevMode = argv.useDevMode;
 
     if (!version) {
       const rnVersion = getReactNativeVersion();
@@ -336,7 +342,11 @@ You can either downgrade your version of ${chalk.green(
     }
 
     const pkgmgr = isProjectUsingYarn(process.cwd())
-      ? 'yarn add'
+      ? useDevMode
+        ? 'yarn link'
+        : 'yarn add'
+      : useDevMode
+      ? 'npm link'
       : 'npm install --save';
     const execOptions = argv.verbose ? {stdio: 'inherit' as 'inherit'} : {};
     console.log(
@@ -344,7 +354,10 @@ You can either downgrade your version of ${chalk.green(
         version,
       )}...`,
     );
-    execSync(`${pkgmgr} "react-native-windows@${version}"`, execOptions);
+    const pkgIdentity = useDevMode
+      ? 'react-native-windows'
+      : `react-native-windows@${version}`;
+    execSync(`${pkgmgr} ${pkgIdentity}`, execOptions);
     console.log(
       chalk.green(
         `react-native-windows@${chalk.cyan(


### PR DESCRIPTION
> This change is only intended for developers working on react-native-windows, it is not intended
  for end-developers 'using' react-native-windows.

The script for generating the templates is picked from the local\cli folder as defined in the react-native-windows package that the common-cli script install.
So to test any changes there one has to link the version you are using. The common
feature for this is [`npm link`](https://docs.npmjs.com/cli/link) or [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link/).
This allows one to 'register' their local dev enlistment as a package and use it from a test project.

Steps to test:
1. From [react-native-windows] enlistment
   1. `yarn build`
      This updates any built files (like ts to js etc.)
   1. `pushd vnext && yarn link`
      The react-native-windows package is defined in vnext folder
      This advertizes the project to the local yarn registry.
      This only has to happen once, for future changes `yarn build` is enough.
      If the link fails that the version is already registered, you can edit pacakge.json to have a unique version.
1. From the client app
   1. `node <rnw-enlistment-root>\packages\react-native-windows-init\lib-commonjs\Cli.js p4 --version 0.0.0 --useDevMode <OtherOptions>`
      linking ignores any version, so just pick 0.0.0 to avoid the default version being looked up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4946)