### PR TITLE
Fix a crash when setting border/foreground color on TextInput (#4708)

### DIFF
--- a/change/react-native-windows-2020-04-24-14-23-47-fix-textinput-brush-update.json
+++ b/change/react-native-windows-2020-04-24-14-23-47-fix-textinput-brush-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use separate brush for text control border",
+  "packageName": "react-native-windows",
+  "email": "kaigu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T21:23:47.396Z"
+}

--- a/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
+++ b/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
@@ -65,7 +65,14 @@ void UpdateTextControlForegroundResourceBrushes(const winrt::FrameworkElement el
   UpdateResourceBrush(element, c_textControlButtonBackgroundPressed, brush);
 }
 
-void UpdateTextControlBorderResourceBrushes(const winrt::FrameworkElement &element, const winrt::Brush brush) {
+void UpdateTextControlBorderResourceBrushes(const winrt::FrameworkElement &element, const winrt::Brush b) {
+  // Workaround for bug https://microsoft.visualstudio.com/OS/_workitems/edit/26118890.
+  // Remove when the bug gets fixed.
+  winrt::Brush brush = b;
+  if (auto solidBrush = b.as<winrt::SolidColorBrush>()) {
+    brush = winrt::SolidColorBrush{solidBrush.Color()};
+  }
+
   UpdateResourceBrush(element, c_textControlBorderBrush, brush);
   UpdateResourceBrush(element, c_textControlBorderBrushPointerOver, brush);
   UpdateResourceBrush(element, c_textControlBorderBrushFocused, brush);


### PR DESCRIPTION
Brings the change made in #4708 into the 0.60-stable branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4957)