### PR TITLE
Work around regression in app packaging in VS 16.5-16.6

### DIFF
--- a/change/react-native-windows-2020-05-20-12-14-56-certVS.json
+++ b/change/react-native-windows-2020-05-20-12-14-56-certVS.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Work around regression in app packaging in VS 16.5-16.6",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-20T19:14:55.769Z"
+}

--- a/vnext/local-cli/runWindows/utils/Add-AppDevPackage.ps1
+++ b/vnext/local-cli/runWindows/utils/Add-AppDevPackage.ps1
@@ -1,0 +1,640 @@
+#
+# Add-AppxDevPackage.ps1 is a PowerShell script designed to install app
+# packages created by Visual Studio for developers.  To run this script from
+# Explorer, right-click on its icon and choose "Run with PowerShell".
+#
+# Visual Studio supplies this script in the folder generated with its
+# "Prepare Package" command.  The same folder will also contain the app
+# package (a .appx file), the signing certificate (a .cer file), and a
+# "Dependencies" subfolder containing all the framework packages used by the
+# app.
+#
+# This script simplifies installing these packages by automating the
+# following functions:
+#   1. Find the app package and signing certificate in the script directory
+#   2. Prompt the user to acquire a developer license and to install the
+#      certificate if necessary
+#   3. Find dependency packages that are applicable to the operating system's
+#      CPU architecture
+#   4. Install the package along with all applicable dependencies
+#
+# All command line parameters are reserved for use internally by the script.
+# Users should launch this script from Explorer.
+#
+
+# .Link
+# http://go.microsoft.com/fwlink/?LinkId=243053
+
+param(
+    [switch]$Force = $false,
+    [switch]$GetDeveloperLicense = $false,
+    [switch]$SkipLoggingTelemetry = $false,
+    [string]$CertificatePath = $null
+)
+
+$ErrorActionPreference = "Stop"
+
+# The language resources for this script are placed in the
+# "Add-AppDevPackage.resources" subfolder alongside the script.  Since the
+# current working directory might not be the directory that contains the
+# script, we need to create the full path of the resources directory to
+# pass into Import-LocalizedData
+$ScriptPath = $null
+try
+{
+    $ScriptPath = (Get-Variable MyInvocation).Value.MyCommand.Path
+    $ScriptDir = Split-Path -Parent $ScriptPath
+}
+catch {}
+
+if (!$ScriptPath)
+{
+    PrintMessageAndExit $UiStrings.ErrorNoScriptPath $ErrorCodes.NoScriptPath
+}
+
+$LocalizedResourcePath = Join-Path $ScriptDir "Add-AppDevPackage.resources"
+Import-LocalizedData -BindingVariable UiStrings -BaseDirectory $LocalizedResourcePath
+
+$ErrorCodes = Data {
+    ConvertFrom-StringData @'
+    Success = 0
+    NoScriptPath = 1
+    NoPackageFound = 2
+    ManyPackagesFound = 3
+    NoCertificateFound = 4
+    ManyCertificatesFound = 5
+    BadCertificate = 6
+    PackageUnsigned = 7
+    CertificateMismatch = 8
+    ForceElevate = 9
+    LaunchAdminFailed = 10
+    GetDeveloperLicenseFailed = 11
+    InstallCertificateFailed = 12
+    AddPackageFailed = 13
+    ForceDeveloperLicense = 14
+    CertUtilInstallFailed = 17
+    CertIsCA = 18
+    BannedEKU = 19
+    NoBasicConstraints = 20
+    NoCodeSigningEku = 21
+    InstallCertificateCancelled = 22
+    BannedKeyUsage = 23
+    ExpiredCertificate = 24
+'@
+}
+
+$ProcessorArchitecture = $Env:Processor_Architecture
+
+# Getting $Env:Processor_Architecture on arm64 machines will return x86.  So check if the environment
+# variable "ProgramFiles(Arm)" is also set, if it is we know the actual processor architecture is arm64.
+# The value will also be x86 on amd64 machines when running the x86 version of PowerShell.
+if ($ProcessorArchitecture -eq "x86")
+{
+    if ($null -ne ${Env:ProgramFiles(Arm)})
+    {
+        $ProcessorArchitecture = "arm64"
+    }
+    elseif ($null -ne ${Env:ProgramFiles(x86)})
+    {
+        $ProcessorArchitecture = "amd64"
+    }
+}
+
+function PrintMessageAndExit($ErrorMessage, $ReturnCode)
+{
+    Write-Host $ErrorMessage
+    try
+    {
+        # Log telemetry data regarding the use of the script if possible.
+        # There are three ways that this can be disabled:
+        #   1. If the "TelemetryDependencies" folder isn't present.  This can be excluded at build time by setting the MSBuild property AppxLogTelemetryFromSideloadingScript to false
+        #   2. If the SkipLoggingTelemetry switch is passed to this script.
+        #   3. If Visual Studio telemetry is disabled via the registry.
+        $TelemetryAssembliesFolder = (Join-Path $PSScriptRoot "TelemetryDependencies")
+        if (!$SkipLoggingTelemetry -And (Test-Path $TelemetryAssembliesFolder))
+        {
+            $job = Start-Job -FilePath (Join-Path $TelemetryAssembliesFolder "LogSideloadingTelemetry.ps1") -ArgumentList $TelemetryAssembliesFolder, "VS/DesignTools/SideLoadingScript/AddAppDevPackage", $ReturnCode, $ProcessorArchitecture
+            Wait-Job -Job $job -Timeout 60 | Out-Null
+        }
+    }
+    catch
+    {
+        # Ignore telemetry errors
+    }
+
+    if (!$Force)
+    {
+        Pause
+    }
+    
+    exit $ReturnCode
+}
+
+#
+# Warns the user about installing certificates, and presents a Yes/No prompt
+# to confirm the action.  The default is set to No.
+#
+function ConfirmCertificateInstall
+{
+    $Answer = $host.UI.PromptForChoice(
+                    "", 
+                    $UiStrings.WarningInstallCert, 
+                    [System.Management.Automation.Host.ChoiceDescription[]]@($UiStrings.PromptYesString, $UiStrings.PromptNoString), 
+                    1)
+    
+    return $Answer -eq 0
+}
+
+#
+# Validates whether a file is a valid certificate using CertUtil.
+# This needs to be done before calling Get-PfxCertificate on the file, otherwise
+# the user will get a cryptic "Password: " prompt for invalid certs.
+#
+function ValidateCertificateFormat($FilePath)
+{
+    # certutil -verify prints a lot of text that we don't need, so it's redirected to $null here
+    certutil.exe -verify $FilePath > $null
+    if ($LastExitCode -lt 0)
+    {
+        PrintMessageAndExit ($UiStrings.ErrorBadCertificate -f $FilePath, $LastExitCode) $ErrorCodes.BadCertificate
+    }
+    
+    # Check if certificate is expired
+    $cert = Get-PfxCertificate $FilePath
+    if (($cert.NotBefore -gt (Get-Date)) -or ($cert.NotAfter -lt (Get-Date)))
+    {
+        PrintMessageAndExit ($UiStrings.ErrorExpiredCertificate -f $FilePath) $ErrorCodes.ExpiredCertificate
+    }
+}
+
+#
+# Verify that the developer certificate meets the following restrictions:
+#   - The certificate must contain a Basic Constraints extension, and its
+#     Certificate Authority (CA) property must be false.
+#   - The certificate's Key Usage extension must be either absent, or set to
+#     only DigitalSignature.
+#   - The certificate must contain an Extended Key Usage (EKU) extension with
+#     Code Signing usage.
+#   - The certificate must NOT contain any other EKU except Code Signing and
+#     Lifetime Signing.
+#
+# These restrictions are enforced to decrease security risks that arise from
+# trusting digital certificates.
+#
+function CheckCertificateRestrictions
+{
+    Set-Variable -Name BasicConstraintsExtensionOid -Value "2.5.29.19" -Option Constant
+    Set-Variable -Name KeyUsageExtensionOid -Value "2.5.29.15" -Option Constant
+    Set-Variable -Name EkuExtensionOid -Value "2.5.29.37" -Option Constant
+    Set-Variable -Name CodeSigningEkuOid -Value "1.3.6.1.5.5.7.3.3" -Option Constant
+    Set-Variable -Name LifetimeSigningEkuOid -Value "1.3.6.1.4.1.311.10.3.13" -Option Constant
+    Set-Variable -Name UwpSigningEkuOid -Value "1.3.6.1.4.1.311.84.3.1" -Option Constant
+    Set-Variable -Name DisposableSigningEkuOid -Value "1.3.6.1.4.1.311.84.3.2" -Option Constant
+
+    $CertificateExtensions = (Get-PfxCertificate $CertificatePath).Extensions
+    $HasBasicConstraints = $false
+    $HasCodeSigningEku = $false
+
+    foreach ($Extension in $CertificateExtensions)
+    {
+        # Certificate must contain the Basic Constraints extension
+        if ($Extension.oid.value -eq $BasicConstraintsExtensionOid)
+        {
+            # CA property must be false
+            if ($Extension.CertificateAuthority)
+            {
+                PrintMessageAndExit $UiStrings.ErrorCertIsCA $ErrorCodes.CertIsCA
+            }
+            $HasBasicConstraints = $true
+        }
+
+        # If key usage is present, it must be set to digital signature
+        elseif ($Extension.oid.value -eq $KeyUsageExtensionOid)
+        {
+            if ($Extension.KeyUsages -ne "DigitalSignature")
+            {
+                PrintMessageAndExit ($UiStrings.ErrorBannedKeyUsage -f $Extension.KeyUsages) $ErrorCodes.BannedKeyUsage
+            }
+        }
+
+        elseif ($Extension.oid.value -eq $EkuExtensionOid)
+        {
+            # Certificate must contain the Code Signing EKU
+            $EKUs = $Extension.EnhancedKeyUsages.Value
+            if ($EKUs -contains $CodeSigningEkuOid)
+            {
+                $HasCodeSigningEKU = $True
+            }
+
+            # EKUs other than code signing and lifetime signing are not allowed
+            foreach ($EKU in $EKUs)
+            {
+                if ($EKU -ne $CodeSigningEkuOid -and $EKU -ne $LifetimeSigningEkuOid -and $EKU -ne $UwpSigningEkuOid -and $EKU -ne $DisposableSigningEkuOid)
+                {
+                    PrintMessageAndExit ($UiStrings.ErrorBannedEKU -f $EKU) $ErrorCodes.BannedEKU
+                }
+            }
+        }
+    }
+
+    if (!$HasBasicConstraints)
+    {
+        PrintMessageAndExit $UiStrings.ErrorNoBasicConstraints $ErrorCodes.NoBasicConstraints
+    }
+    if (!$HasCodeSigningEKU)
+    {
+        PrintMessageAndExit $UiStrings.ErrorNoCodeSigningEku $ErrorCodes.NoCodeSigningEku
+    }
+}
+
+#
+# Performs operations that require administrative privileges:
+#   - Prompt the user to obtain a developer license
+#   - Install the developer certificate (if -Force is not specified, also prompts the user to confirm)
+#
+function DoElevatedOperations
+{
+    if ($GetDeveloperLicense)
+    {
+        Write-Host $UiStrings.GettingDeveloperLicense
+
+        if ($Force)
+        {
+            PrintMessageAndExit $UiStrings.ErrorForceDeveloperLicense $ErrorCodes.ForceDeveloperLicense
+        }
+        try
+        {
+            Show-WindowsDeveloperLicenseRegistration
+        }
+        catch
+        {
+            $Error[0] # Dump details about the last error
+            PrintMessageAndExit $UiStrings.ErrorGetDeveloperLicenseFailed $ErrorCodes.GetDeveloperLicenseFailed
+        }
+    }
+
+    if ($CertificatePath)
+    {
+        Write-Host $UiStrings.InstallingCertificate
+
+        # Make sure certificate format is valid and usage constraints are followed
+        ValidateCertificateFormat $CertificatePath
+        CheckCertificateRestrictions
+
+        # If -Force is not specified, warn the user and get consent
+        if ($Force -or (ConfirmCertificateInstall))
+        {
+            # Add cert to store
+            certutil.exe -addstore TrustedPeople $CertificatePath
+            if ($LastExitCode -lt 0)
+            {
+                PrintMessageAndExit ($UiStrings.ErrorCertUtilInstallFailed -f $LastExitCode) $ErrorCodes.CertUtilInstallFailed
+            }
+        }
+        else
+        {
+            PrintMessageAndExit $UiStrings.ErrorInstallCertificateCancelled $ErrorCodes.InstallCertificateCancelled
+        }
+    }
+}
+
+#
+# Checks whether the machine is missing a valid developer license.
+#
+function CheckIfNeedDeveloperLicense
+{
+    $Result = $true
+    try
+    {
+        $Result = (Get-WindowsDeveloperLicense | Where-Object { $_.IsValid } | Measure-Object).Count -eq 0
+    }
+    catch {}
+
+    return $Result
+}
+
+#
+# Launches an elevated process running the current script to perform tasks
+# that require administrative privileges.  This function waits until the
+# elevated process terminates, and checks whether those tasks were successful.
+#
+function LaunchElevated
+{
+    # Set up command line arguments to the elevated process
+    $RelaunchArgs = '-ExecutionPolicy Unrestricted -file "' + $ScriptPath + '"'
+
+    if ($Force)
+    {
+        $RelaunchArgs += ' -Force'
+    }
+    if ($NeedDeveloperLicense)
+    {
+        $RelaunchArgs += ' -GetDeveloperLicense'
+    }
+    if ($SkipLoggingTelemetry)
+    {
+        $RelaunchArgs += ' -SkipLoggingTelemetry'
+    }
+    if ($NeedInstallCertificate)
+    {
+        $RelaunchArgs += ' -CertificatePath "' + $DeveloperCertificatePath.FullName + '"'
+    }
+
+    # Launch the process and wait for it to finish
+    try
+    {
+        $AdminProcess = Start-Process "$PsHome\PowerShell.exe" -Verb RunAs -ArgumentList $RelaunchArgs -PassThru
+    }
+    catch
+    {
+        $Error[0] # Dump details about the last error
+        PrintMessageAndExit $UiStrings.ErrorLaunchAdminFailed $ErrorCodes.LaunchAdminFailed
+    }
+
+    while (!($AdminProcess.HasExited))
+    {
+        Start-Sleep -Seconds 2
+    }
+
+    # Check if all elevated operations were successful
+    if ($NeedDeveloperLicense)
+    {
+        if (CheckIfNeedDeveloperLicense)
+        {
+            PrintMessageAndExit $UiStrings.ErrorGetDeveloperLicenseFailed $ErrorCodes.GetDeveloperLicenseFailed
+        }
+        else
+        {
+            Write-Host $UiStrings.AcquireLicenseSuccessful
+        }
+    }
+    if ($NeedInstallCertificate)
+    {
+        $Signature = Get-AuthenticodeSignature $DeveloperPackagePath -Verbose
+        if ($Signature.Status -ne "Valid")
+        {
+            PrintMessageAndExit ($UiStrings.ErrorInstallCertificateFailed -f $Signature.Status) $ErrorCodes.InstallCertificateFailed
+        }
+        else
+        {
+            Write-Host $UiStrings.InstallCertificateSuccessful
+        }
+    }
+}
+
+#
+# Finds all applicable dependency packages according to OS architecture, and
+# installs the developer package with its dependencies.  The expected layout
+# of dependencies is:
+#
+# <current dir>
+#     \Dependencies
+#         <Architecture neutral dependencies>.appx\.msix
+#         \x86
+#             <x86 dependencies>.appx\.msix
+#         \x64
+#             <x64 dependencies>.appx\.msix
+#         \arm
+#             <arm dependencies>.appx\.msix
+#         \arm64
+#             <arm64 dependencies>.appx\.msix
+#
+function InstallPackageWithDependencies
+{
+    $DependencyPackagesDir = (Join-Path $ScriptDir "Dependencies")
+    $DependencyPackages = @()
+    if (Test-Path $DependencyPackagesDir)
+    {
+        # Get architecture-neutral dependencies
+        $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+        $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+
+        # Get architecture-specific dependencies
+        if (($ProcessorArchitecture -eq "x86" -or $ProcessorArchitecture -eq "amd64" -or $ProcessorArchitecture -eq "arm64") -and (Test-Path (Join-Path $DependencyPackagesDir "x86")))
+        {
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "x86\*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "x86\*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+        }
+        if (($ProcessorArchitecture -eq "amd64") -and (Test-Path (Join-Path $DependencyPackagesDir "x64")))
+        {
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "x64\*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "x64\*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+        }
+        if (($ProcessorArchitecture -eq "arm" -or $ProcessorArchitecture -eq "arm64") -and (Test-Path (Join-Path $DependencyPackagesDir "arm")))
+        {
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "arm\*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "arm\*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+        }
+        if (($ProcessorArchitecture -eq "arm64") -and (Test-Path (Join-Path $DependencyPackagesDir "arm64")))
+        {
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "arm64\*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+            $DependencyPackages += Get-ChildItem (Join-Path $DependencyPackagesDir "arm64\*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+        }
+    }
+    Write-Host $UiStrings.InstallingPackage
+
+    $AddPackageSucceeded = $False
+    try
+    {
+        if ($DependencyPackages.FullName.Count -gt 0)
+        {
+            Write-Host $UiStrings.DependenciesFound
+            $DependencyPackages.FullName
+            Add-AppxPackage -Path $DeveloperPackagePath.FullName -DependencyPath $DependencyPackages.FullName -ForceApplicationShutdown
+        }
+        else
+        {
+            Add-AppxPackage -Path $DeveloperPackagePath.FullName -ForceApplicationShutdown
+        }
+        $AddPackageSucceeded = $?
+    }
+    catch
+    {
+        $Error[0] # Dump details about the last error
+    }
+
+    if (!$AddPackageSucceeded)
+    {
+        if ($NeedInstallCertificate)
+        {
+            PrintMessageAndExit $UiStrings.ErrorAddPackageFailedWithCert $ErrorCodes.AddPackageFailed
+        }
+        else
+        {
+            PrintMessageAndExit $UiStrings.ErrorAddPackageFailed $ErrorCodes.AddPackageFailed
+        }
+    }
+}
+
+#
+# Main script logic when the user launches the script without parameters.
+#
+function DoStandardOperations
+{
+    # Check for an .appx or .msix file in the script directory
+    $PackagePath = Get-ChildItem (Join-Path $ScriptDir "*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+    if ($PackagePath -eq $null)
+    {
+        $PackagePath = Get-ChildItem (Join-Path $ScriptDir "*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+    }
+    $PackageCount = ($PackagePath | Measure-Object).Count
+
+    # Check for an .appxbundle or .msixbundle file in the script directory
+    $BundlePath = Get-ChildItem (Join-Path $ScriptDir "*.appxbundle") | Where-Object { $_.Mode -NotMatch "d" }
+    if ($BundlePath -eq $null)
+    {
+        $BundlePath = Get-ChildItem (Join-Path $ScriptDir "*.msixbundle") | Where-Object { $_.Mode -NotMatch "d" }
+    }
+    $BundleCount = ($BundlePath | Measure-Object).Count
+
+    # Check for an .eappx or .emsix file in the script directory
+    $EncryptedPackagePath = Get-ChildItem (Join-Path $ScriptDir "*.eappx") | Where-Object { $_.Mode -NotMatch "d" }
+    if ($EncryptedPackagePath -eq $null)
+    {
+        $EncryptedPackagePath = Get-ChildItem (Join-Path $ScriptDir "*.emsix") | Where-Object { $_.Mode -NotMatch "d" }
+    }
+    $EncryptedPackageCount = ($EncryptedPackagePath | Measure-Object).Count
+
+    # Check for an .eappxbundle or .emsixbundle file in the script directory
+    $EncryptedBundlePath = Get-ChildItem (Join-Path $ScriptDir "*.eappxbundle") | Where-Object { $_.Mode -NotMatch "d" }
+    if ($EncryptedBundlePath -eq $null)
+    {
+        $EncryptedBundlePath = Get-ChildItem (Join-Path $ScriptDir "*.emsixbundle") | Where-Object { $_.Mode -NotMatch "d" }
+    }
+    $EncryptedBundleCount = ($EncryptedBundlePath | Measure-Object).Count
+
+    $NumberOfPackages = $PackageCount + $EncryptedPackageCount
+    $NumberOfBundles = $BundleCount + $EncryptedBundleCount
+
+    # There must be at least one package or bundle
+    if ($NumberOfPackages + $NumberOfBundles -lt 1)
+    {
+        PrintMessageAndExit $UiStrings.ErrorNoPackageFound $ErrorCodes.NoPackageFound
+    }
+    # We must have exactly one bundle OR no bundle and exactly one package
+    elseif ($NumberOfBundles -gt 1 -or
+            ($NumberOfBundles -eq 0 -and $NumberOfpackages -gt 1))
+    {
+        PrintMessageAndExit $UiStrings.ErrorManyPackagesFound $ErrorCodes.ManyPackagesFound
+    }
+
+    # First attempt to install a bundle or encrypted bundle. If neither exists, fall back to packages and then encrypted packages
+    if ($BundleCount -eq 1)
+    {
+        $DeveloperPackagePath = $BundlePath
+        Write-Host ($UiStrings.BundleFound -f $DeveloperPackagePath.FullName)
+    }
+    elseif ($EncryptedBundleCount -eq 1)
+    {
+        $DeveloperPackagePath = $EncryptedBundlePath
+        Write-Host ($UiStrings.EncryptedBundleFound -f $DeveloperPackagePath.FullName)
+    }
+    elseif ($PackageCount -eq 1)
+    {
+        $DeveloperPackagePath = $PackagePath
+        Write-Host ($UiStrings.PackageFound -f $DeveloperPackagePath.FullName)
+    }
+    elseif ($EncryptedPackageCount -eq 1)
+    {
+        $DeveloperPackagePath = $EncryptedPackagePath
+        Write-Host ($UiStrings.EncryptedPackageFound -f $DeveloperPackagePath.FullName)
+    }
+    
+    # The package must be signed
+    $PackageSignature = Get-AuthenticodeSignature $DeveloperPackagePath
+    $PackageCertificate = $PackageSignature.SignerCertificate
+    if (!$PackageCertificate)
+    {
+        PrintMessageAndExit $UiStrings.ErrorPackageUnsigned $ErrorCodes.PackageUnsigned
+    }
+
+    # Test if the package signature is trusted.  If not, the corresponding certificate
+    # needs to be present in the current directory and needs to be installed.
+    $NeedInstallCertificate = ($PackageSignature.Status -ne "Valid")
+
+    if ($NeedInstallCertificate)
+    {
+        # List all .cer files in the script directory
+        $DeveloperCertificatePath = Get-ChildItem (Join-Path $ScriptDir "*.cer") | Where-Object { $_.Mode -NotMatch "d" }
+        $DeveloperCertificateCount = ($DeveloperCertificatePath | Measure-Object).Count
+
+        # There must be exactly 1 certificate
+        if ($DeveloperCertificateCount -lt 1)
+        {
+            PrintMessageAndExit $UiStrings.ErrorNoCertificateFound $ErrorCodes.NoCertificateFound
+        }
+        elseif ($DeveloperCertificateCount -gt 1)
+        {
+            PrintMessageAndExit $UiStrings.ErrorManyCertificatesFound $ErrorCodes.ManyCertificatesFound
+        }
+
+        Write-Host ($UiStrings.CertificateFound -f $DeveloperCertificatePath.FullName)
+
+        # The .cer file must have the format of a valid certificate
+        ValidateCertificateFormat $DeveloperCertificatePath
+
+        # The package signature must match the certificate file
+        if ($PackageCertificate -ne (Get-PfxCertificate $DeveloperCertificatePath))
+        {
+            PrintMessageAndExit $UiStrings.ErrorCertificateMismatch $ErrorCodes.CertificateMismatch
+        }
+    }
+
+    $NeedDeveloperLicense = CheckIfNeedDeveloperLicense
+
+    # Relaunch the script elevated with the necessary parameters if needed
+    if ($NeedDeveloperLicense -or $NeedInstallCertificate)
+    {
+        Write-Host $UiStrings.ElevateActions
+        if ($NeedDeveloperLicense)
+        {
+            Write-Host $UiStrings.ElevateActionDevLicense
+        }
+        if ($NeedInstallCertificate)
+        {
+            Write-Host $UiStrings.ElevateActionCertificate
+        }
+
+        $IsAlreadyElevated = ([Security.Principal.WindowsIdentity]::GetCurrent().Groups.Value -contains "S-1-5-32-544")
+        if ($IsAlreadyElevated)
+        {
+            if ($Force -and $NeedDeveloperLicense)
+            {
+                PrintMessageAndExit $UiStrings.ErrorForceDeveloperLicense $ErrorCodes.ForceDeveloperLicense
+            }
+            if ($Force -and $NeedInstallCertificate)
+            {
+                Write-Warning $UiStrings.WarningInstallCert
+            }
+        }
+        else
+        {
+            if ($Force)
+            {
+                PrintMessageAndExit $UiStrings.ErrorForceElevate $ErrorCodes.ForceElevate
+            }
+            else
+            {
+                Write-Host $UiStrings.ElevateActionsContinue
+                Pause
+            }
+        }
+
+        LaunchElevated
+    }
+
+    InstallPackageWithDependencies
+}
+
+#
+# Main script entry point
+#
+if ($GetDeveloperLicense -or $CertificatePath)
+{
+    DoElevatedOperations
+}
+else
+{
+    DoStandardOperations
+    PrintMessageAndExit $UiStrings.Success $ErrorCodes.Success
+}

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -208,7 +208,9 @@ async function deployToDesktop(options, verbose, slnFile) {
     // This will be fixed in 16.7. In the meantime we need to copy the Add-AppDevPackage that has the fix for this EKU issue:
     // https://developercommunity.visualstudio.com/content/problem/1012921/uwp-packaging-generates-incompatible-certificate.html
     if (verbose) {
-      newWarn('Applying Add-AppDevPackage.ps1 workaround for VS 16.5-16.6 bug - see https://developercommunity.visualstudio.com/content/problem/1012921/uwp-packaging-generates-incompatible-certificate.html');
+      newWarn(
+        'Applying Add-AppDevPackage.ps1 workaround for VS 16.5-16.6 bug - see https://developercommunity.visualstudio.com/content/problem/1012921/uwp-packaging-generates-incompatible-certificate.html',
+      );
     }
     fs.copyFileSync(
       path.join(path.resolve(__dirname), 'Add-AppDevPackage.ps1'),
@@ -240,7 +242,7 @@ async function deployToDesktop(options, verbose, slnFile) {
   await runPowerShellScriptFunction(
     'Enabling Developer Mode',
     windowsStoreAppUtils,
-    `EnableDevMode`,
+    'EnableDevMode',
     verbose,
   );
 


### PR DESCRIPTION
Fixes #4836 
Works around a regression in app packaging introduced in VS 16.5 which will be fixed in 16.7. For the time being, shipping a private copy of Add-AppDevPackage that has the fix for the issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4958)