### PR TITLE
Fixed Microsoft.ReactNative build in VS 16.6.0

### DIFF
--- a/change/react-native-windows-2020-05-20-21-06-50-MS_FixVS16_6_build.json
+++ b/change/react-native-windows-2020-05-20-21-06-50-MS_FixVS16_6_build.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed Microsoft.ReactNative build in VS 16.6.0",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T04:06:49.892Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -163,6 +163,7 @@
       </PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winsqlite3.lib;ChakraRT.lib;dxguid.lib;dloadhelper.lib;OneCoreUap.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
The build in VS 16.6.0 is failing with linker errors that debug database is corrupted.
This PR has a temporary workaround where we replace the /ZI flag with /Zi that fixes the build.
We can rollback this change later when VS is fixed.
But for now this PR could unblock us to use the new VS version.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4962)