### PR TITLE
Fix animation bug

### DIFF
--- a/change/react-native-windows-2020-05-21-00-35-00-animation-bug.json
+++ b/change/react-native-windows-2020-05-21-00-35-00-animation-bug.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix for animation bug",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T07:35:00.513Z"
+}

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -97,9 +97,24 @@ void PropsAnimatedNode::UpdateView() {
   StartAnimations();
 }
 
+static void EnsureUIElementDirtyForRender(xaml::UIElement uiElement) {
+  auto compositeMode = uiElement.CompositeMode();
+  switch (compositeMode) {
+    case xaml::Media::ElementCompositeMode::SourceOver:
+    case xaml::Media::ElementCompositeMode::MinBlend:
+      uiElement.CompositeMode(xaml::Media::ElementCompositeMode::Inherit);
+      break;
+    default:
+      uiElement.CompositeMode(xaml::Media::ElementCompositeMode::SourceOver);
+      break;
+  }
+  uiElement.CompositeMode(compositeMode);
+}
+
 void PropsAnimatedNode::StartAnimations() {
   if (m_expressionAnimations.size()) {
     if (const auto uiElement = GetUIElement()) {
+      EnsureUIElementDirtyForRender(uiElement);
       uiElement.RotationAxis(m_rotationAxis);
       for (const auto anim : m_expressionAnimations) {
         if (anim.second.Target() == L"Translation.X") {

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -114,6 +114,7 @@ static void EnsureUIElementDirtyForRender(xaml::UIElement uiElement) {
 void PropsAnimatedNode::StartAnimations() {
   if (m_expressionAnimations.size()) {
     if (const auto uiElement = GetUIElement()) {
+      // Work around for https://github.com/microsoft/microsoft-ui-xaml/issues/2511
       EnsureUIElementDirtyForRender(uiElement);
       uiElement.RotationAxis(m_rotationAxis);
       for (const auto anim : m_expressionAnimations) {


### PR DESCRIPTION
Fixes #4312 

xbox folks ran into this animation bug where the component stays stuck invisible.  I root-caused this back to a dirty flag issue in XAML.  I filed this bug for us to fix the XAML bug in WinUI 3.0:
https://github.com/microsoft/microsoft-ui-xaml/issues/2511

Meanwhile this change works around the XAML bug in a very non-invasive way.  We can force the XAML element to render by "poking" one of the properties that dirties it for render (then set it back to whatever it was).  Once dirtied, the XAML render walk will put the visuals back into the tree and the element will become visible again.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4964)