### PR TITLE
Add preprocess target to M.RN and missing deploy target in playground, don't overwrite msbuild.binlog on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ bld/
 
 tsdoc-metadata.json
 *.dmp
+*.pp

--- a/change/react-native-windows-2020-05-21-08-23-39-preProcessTarget.json
+++ b/change/react-native-windows-2020-05-21-08-23-39-preProcessTarget.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "dont overwrite msbuild log when deploying",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T15:23:39.938Z"
+}

--- a/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -184,11 +184,5 @@
     <BundleEntryFile>dist/app/index.js</BundleEntryFile>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CSharpApp.targets"/>
 </Project>

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -206,6 +206,7 @@
     <BundleEntryFile>Samples/rntester.tsx</BundleEntryFile>
   </PropertyGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.Cpp.targets" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppApp.targets"/>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets" Condition="'$(UseWinUI3)'!='true' And Exists('..\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" />
@@ -220,5 +221,4 @@
     <Error Condition="'$(UseWinUI3)'!='true' And !Exists('..\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />
     <Error Condition="'$(UseWinUI3)'=='true' And !Exists('..\packages\Microsoft.WinUI.3.0.0-alpha.200210.0\build\native\Microsoft.WinUI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WinUI.3.0.0-alpha.200210.0\build\native\Microsoft.WinUI.targets'))" />
   </Target>
-  <Target Name="Deploy"/>
 </Project>

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -220,4 +220,5 @@
     <Error Condition="'$(UseWinUI3)'!='true' And !Exists('..\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />
     <Error Condition="'$(UseWinUI3)'=='true' And !Exists('..\packages\Microsoft.WinUI.3.0.0-alpha.200210.0\build\native\Microsoft.WinUI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WinUI.3.0.0-alpha.200210.0\build\native\Microsoft.WinUI.targets'))" />
   </Target>
+  <Target Name="Deploy"/>
 </Project>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -671,4 +671,9 @@
     </ItemGroup>
   </Target>
   <Target Name="Deploy" />
+  <Target Name="Preprocess">
+    <Message Condition="'$(Source)'!=''" Text="Preprocessing: $(Source)" />
+    <Error Condition="'$(Source)'==''" Text="To generate a pre-processed file, please specify a source file with msbuild /p:Source=nameOfTheSource.cpp" />
+    <CL PreprocessToFile="true" Sources="$(Source)" AdditionalIncludeDirectories="%(ClCompile.AdditionalIncludeDirectories)" PreprocessorDefinitions="%(ClCompile.PreprocessorDefinitions)" AdditionalOptions="%(ClCompile.AdditionalOptions) /d1PP" PreprocessKeepComments="true" PreprocessOutputPath="$(Source.Replace('.cpp', '.pp'))" />
+  </Target>
 </Project>

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -57,9 +57,14 @@ class MSBuildTools {
     newSuccess(`Found Solution: ${slnFile}`);
     newInfo(`Build configuration: ${buildType}`);
     newInfo(`Build platform: ${buildArch}`);
-
+    if (target) {
+      newInfo(`Build target: ${target}`);
+    }
     const verbosityOption = verbose ? 'normal' : 'minimal';
-    const errorLog = path.join(process.env.temp, `msbuild_${process.pid}.err`);
+    const errorLog = path.join(
+      process.env.temp,
+      `msbuild_${process.pid}${target ? '_' + target : ''}.err`,
+    );
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,
       '/nologo',
@@ -67,7 +72,7 @@ class MSBuildTools {
       `/p:Configuration=${buildType}`,
       `/p:Platform=${buildArch}`,
       '/p:AppxBundle=Never',
-      '/bl',
+      `/bl${target ? `:${target}.binlog` : ''}`,
       `/flp1:errorsonly;logfile=${errorLog}`,
     ];
 


### PR DESCRIPTION
Deploy is needed for Debug builds of playground and e2etest
Add Preprocess target to M.RN since that's just generally useful
dont overwrite build logs when deploying


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4965)