### PR TITLE
Fix spacing and extra dot in copyright of the property sheets

### DIFF
--- a/change/react-native-windows-2020-05-21-09-08-39-master.json
+++ b/change/react-native-windows-2020-05-21-09-08-39-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix spacing and extra dot in copyright of the property sheets",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T16:08:39.866Z"
+}

--- a/vnext/PropertySheets/Bundle.Common.targets
+++ b/vnext/PropertySheets/Bundle.Common.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="MakeBundle" BeforeTargets="PrepareForBuild" 

--- a/vnext/PropertySheets/Bundle.Cpp.targets
+++ b/vnext/PropertySheets/Bundle.Cpp.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\Bundle.Common.targets"/>

--- a/vnext/PropertySheets/Bundle.props
+++ b/vnext/PropertySheets/Bundle.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 

--- a/vnext/PropertySheets/Bundle.targets
+++ b/vnext/PropertySheets/Bundle.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\Bundle.Common.targets"/>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Shared">

--- a/vnext/PropertySheets/ReactPatches.targets
+++ b/vnext/PropertySheets/ReactPatches.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
- Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4970)