### PR TITLE
Allow developers to independently set hostname and port.

### DIFF
--- a/change/react-native-windows-2020-05-21-13-07-11-independent_hostname_and_port.json
+++ b/change/react-native-windows-2020-05-21-13-07-11-independent_hostname_and_port.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow developers to independently set hostname and port.",
+  "packageName": "react-native-windows",
+  "email": "12337821+nasadigital@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T20:07:11.042Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/codegen/NativeMyModuleSpec.g.h
+++ b/packages/microsoft-reactnative-sampleapps/codegen/NativeMyModuleSpec.g.h
@@ -19,10 +19,10 @@ struct MyModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       SyncMethod<bool(bool) noexcept>{1, L"getBool"},
       SyncMethod<double(double) noexcept>{2, L"getNumber"},
       SyncMethod<std::string(std::string) noexcept>{3, L"getString"},
-      SyncMethod<JSValueArray(JSValueArray) noexcept>{4, L"getArray"},
-      SyncMethod<JSValueObject(JSValueObject) noexcept>{5, L"getObject"},
-      SyncMethod<JSValueObject(double, std::string, JSValueObject) noexcept>{6, L"getValue"},
-      Method<void(Callback<JSValue>) noexcept>{7, L"getValueWithCallback"},
+      SyncMethod<React::JSValueArray(React::JSValueArray) noexcept>{4, L"getArray"},
+      SyncMethod<React::JSValueObject(React::JSValueObject) noexcept>{5, L"getObject"},
+      SyncMethod<React::JSValueObject(double, std::string, React::JSValueObject) noexcept>{6, L"getValue"},
+      Method<void(Callback<React::JSValue>) noexcept>{7, L"getValueWithCallback"},
       Method<void(bool, Promise<React::JSValue>) noexcept>{8, L"getValueWithPromise"},
   };
 

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -85,6 +85,12 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   IRedBoxHandler RedBoxHandler() noexcept;
   void RedBoxHandler(IRedBoxHandler const &value) noexcept;
 
+  hstring SourceBundleHost() noexcept;
+  void SourceBundleHost(hstring const &value) noexcept;
+
+  uint16_t SourceBundlePort() noexcept;
+  void SourceBundlePort(uint16_t value) noexcept;
+
  private:
   IReactPropertyBag m_properties{ReactPropertyBagHelper::CreatePropertyBag()};
   IReactNotificationService m_notifications{ReactNotificationServiceHelper::CreateNotificationService()};
@@ -107,6 +113,8 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   hstring m_bundleRootPath{};
   uint16_t m_debuggerPort{9229};
   IRedBoxHandler m_redBoxHandler{nullptr};
+  hstring m_sourceBundleHost{};
+  uint16_t m_sourceBundlePort{0};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation
@@ -281,6 +289,22 @@ inline IRedBoxHandler ReactInstanceSettings::RedBoxHandler() noexcept {
 
 inline void ReactInstanceSettings::RedBoxHandler(IRedBoxHandler const &value) noexcept {
   m_redBoxHandler = value;
+}
+
+inline hstring ReactInstanceSettings::SourceBundleHost() noexcept {
+  return m_sourceBundleHost;
+}
+
+inline void ReactInstanceSettings::SourceBundleHost(hstring const &value) noexcept {
+  m_sourceBundleHost = value;
+}
+
+inline uint16_t ReactInstanceSettings::SourceBundlePort() noexcept {
+  return m_sourceBundlePort;
+}
+
+inline void ReactInstanceSettings::SourceBundlePort(uint16_t value) noexcept {
+  m_sourceBundlePort = value;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -33,5 +33,7 @@ namespace Microsoft.ReactNative {
     String BundleRootPath { get; set; };
     UInt16 DebuggerPort { get; set; };
     IRedBoxHandler RedBoxHandler { get; set; };
+    String SourceBundleHost { get; set; };
+    UInt16 SourceBundlePort { get; set; };
   }
 }

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -85,6 +85,8 @@ void ReactNativeHost::ReloadInstance() noexcept {
   legacySettings.UseLiveReload = m_instanceSettings.UseLiveReload();
   legacySettings.UseWebDebugger = m_instanceSettings.UseWebDebugger();
   legacySettings.DebuggerPort = m_instanceSettings.DebuggerPort();
+  legacySettings.SourceBundleHost = to_string(m_instanceSettings.SourceBundleHost());
+  legacySettings.SourceBundlePort = m_instanceSettings.SourceBundlePort();
 
   if (m_instanceSettings.RedBoxHandler()) {
     legacySettings.RedBoxHandler = std::move(Mso::React::CreateRedBoxHandler(m_instanceSettings.RedBoxHandler()));
@@ -105,6 +107,9 @@ void ReactNativeHost::ReloadInstance() noexcept {
   reactOptions.BundleRootPath = legacySettings.BundleRootPath;
   reactOptions.DeveloperSettings.DebuggerPort = legacySettings.DebuggerPort;
   reactOptions.RedBoxHandler = legacySettings.RedBoxHandler;
+  reactOptions.DeveloperSettings.SourceBundleHost = legacySettings.SourceBundleHost;
+  reactOptions.DeveloperSettings.SourceBundlePort =
+      legacySettings.SourceBundlePort != 0 ? std::to_string(legacySettings.SourceBundlePort) : "";
 
   reactOptions.LegacySettings = std::move(legacySettings);
 

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -45,11 +45,13 @@ struct ReactInstanceSettings {
   bool EnableByteCodeCaching{false};
   bool EnableDeveloperMenu{false};
   uint16_t DebuggerPort{9229};
+  uint16_t SourceBundlePort{0};
 
   std::string ByteCodeFileUri;
   std::string DebugHost;
   std::string DebugBundlePath;
   std::string BundleRootPath;
+  std::string SourceBundleHost;
   facebook::react::NativeLoggingHook LoggingCallback;
   std::shared_ptr<Mso::React::IRedBoxHandler> RedBoxHandler;
   JSIEngine jsiEngine{JSIEngine::Chakra};


### PR DESCRIPTION
Addresses #2586.
Adds new settings `SourceBundleHost` (defaults to `localhost`) and `SourceBundlePort` (defaults to `8081`) to specify hostname and port. If `DebugHost` is set, these settings are ignored.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4979)