### PR TITLE
Implemented support for native module std::weak_ptr

### DIFF
--- a/change/react-native-windows-2020-05-21-13-01-25-WeakModule.json
+++ b/change/react-native-windows-2020-05-21-13-01-25-WeakModule.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implemented support for native module std::weak_ptr",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T20:01:24.822Z"
+}


### PR DESCRIPTION
This change is to address a customer need to be able to get a `std::weak_ptr` to a native module in case if the module must subscribe to some events. Since, a native module lifetime is bound to the React instance lifetime, we cannot use `this` pointer and we better use the `std::weak_ptr<T>`.
In this PR we enable the native modules to be inherited from the `std::enable_shared_from_this<T>` that allows use of the `weak_from_this()` function to get `std::weak_ptr<T>` to the module.

To support the new functionality we are doing the following changes:
- Introduce a mechanism for a module to associate a custom factory function with a module type.
- In case if custom factory is not provided then we offer two default native module factories:
  - `MakeDefaultReactModuleWrapper` - the default factory that wraps up native module into `ReactNonAbiValue<TModule>` to pass the module across the ABI boundary.
  - `MakeDefaultSharedPtrReactModuleWrapper` - the default factory that wraps up native module into `ReactNonAbiValue<shared_ptr<TModule>>` in case if module is inherited from `std::enable_shared_from_this<T>`.

The custom factory can be associated with a module type by providing `GetReactModuleFactory` function overload that has two arguments `Module *` pointer type and `int`. The `int` parameter is used to give the overload higher priority than the default `GetReactModuleFactory` function where we use `int *` when we pass 0 as a second argument.

To show the use of the `std::weak_ptr` we have added a new `SampleSharedCppModule` module to the sample project. It shows how the `std::weak_ptr` can be used with help of the `std::enable_shared_from_this` base and `weak_from_this()` method call.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4980)