### PR TITLE
App projects only builds from clean (i.e. the first time only)

### DIFF
--- a/change/react-native-windows-2020-05-21-16-35-04-doubleBuild.json
+++ b/change/react-native-windows-2020-05-21-16-35-04-doubleBuild.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix deploy issue causing 2nd+ builds to break due to bug in appxrecipe which gets imported",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T23:35:04.220Z"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -21,8 +21,8 @@
   <Import Project="$(ProjectDir)\AutolinkedNativeModules.g.targets" Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.targets')" />
 
   <Import Project="$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe"  
-          Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe')" />
-  <Target Name="Deploy">
+          Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe') And '$(DeployLayout)'=='true'" />
+  <Target Name="Deploy" Condition="'$(DeployLayout)'=='true'">
     <Error Condition="!Exists('$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe')" 
            Text="You must first build the project before deploying it" />
     <Copy SourceFiles="%(AppxPackagedFile.Identity)" 

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -16,9 +16,8 @@
   <Import Project="$(ProjectDir)\AutolinkedNativeModules.g.targets" Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.targets')" />
 
   <Import Project="$(OutputPath)\$(AssemblyName).Build.appxrecipe"  
-          Condition="Exists('$(OutputPath)\$(AssemblyName).Build.appxrecipe')" />
-  <Target Name="Deploy">
-    <Message Text="OutputPath=$(OutputPath)" /> 
+          Condition="Exists('$(OutputPath)\$(AssemblyName).Build.appxrecipe') And '$(DeployLayout)'=='true'" />
+  <Target Name="Deploy" Condition="'$(DeployLayout)'=='true'">
     <Error Condition="!Exists('$(OutputPath)\$(AssemblyName).Build.appxrecipe')" 
            Text="You must first build the project before deploying it" />
     <Copy SourceFiles="%(AppxPackagedFile.Identity)" 

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -258,7 +258,7 @@ async function deployToDesktop(options, verbose, slnFile) {
       slnFile,
       options.release ? 'Release' : 'Debug',
       options.arch,
-      null,
+      {DeployLayout: true},
       options.verbose,
       'Deploy',
     );


### PR DESCRIPTION
The fix for #4945 introduced an issue that manifests as projects not being able to be built more than once (or without a Clean pass).

The issue is that we Import the AppxRecipe file which has a bug in that the `ResolvedSDKReference` items are expected to have an `OriginalItemSpec` attribute in them, but they aren't being produced as such. When the build runs after we've built once already, we import these items from the appxrecipe, which lack this attribute, and the build breaks.

The fix is to only do the import conditional on a new variable which gets set by the CLI on deploy. The Deploy target is made conditional on this variable too.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4983)