### PR TITLE
Fix ReactInstance error state to avoid crashes

### DIFF
--- a/change/react-native-windows-2020-05-21-22-04-55-PR-FixInstanceLoading.json
+++ b/change/react-native-windows-2020-05-21-22-04-55-PR-FixInstanceLoading.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactInstance error state to avoid crashes",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-22T05:04:55.630Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -407,7 +407,12 @@ void ReactInstanceWin::OnReactInstanceLoaded(const Mso::ErrorCode &errorCode) no
       if (auto strongThis = weakThis.GetStrongPtr()) {
         if (!strongThis->m_isLoaded) {
           strongThis->m_isLoaded = true;
-          strongThis->m_state = ReactInstanceState::Loaded;
+          if (!errorCode) {
+            strongThis->m_state = ReactInstanceState::Loaded;
+          } else {
+            strongThis->m_state = ReactInstanceState::HasError;
+          }
+
           if (auto onLoaded = strongThis->m_options.OnInstanceLoaded.Get()) {
             onLoaded->Invoke(*strongThis, errorCode);
           }

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -46,10 +46,12 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
   }
 
   void WindowSizeChanged(winrt::Windows::UI::Core::WindowSizeChangedEventArgs const &args) noexcept {
-    m_redboxContent.MaxHeight(args.Size().Height);
-    m_redboxContent.Height(args.Size().Height);
-    m_redboxContent.MaxWidth(args.Size().Width);
-    m_redboxContent.Width(args.Size().Width);
+    if (m_redboxContent) {
+      m_redboxContent.MaxHeight(args.Size().Height);
+      m_redboxContent.Height(args.Size().Height);
+      m_redboxContent.MaxWidth(args.Size().Width);
+      m_redboxContent.Width(args.Size().Width);
+    }
   }
 
   void ShowNewJSError() noexcept {
@@ -138,6 +140,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_reloadButton.Click(m_tokenReload);
     xaml::Window::Current().SizeChanged(m_tokenSizeChanged);
     m_popup.Closed(m_tokenClosed);
+    m_redboxContent = nullptr;
     m_onClosedCallback(GetId());
   }
 


### PR DESCRIPTION
This change is to address the issue #4923.
The crash was caused by React Instance not setting HasError state on error.
Since the state was as if the instance loaded correctly, it was causing crashes when code continues execution.

In this PR we are addressing the issue by setting the HasError state on error.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4986)