### PR TITLE
Remove unneeded or undesirable eslint suppressions

### DIFF
--- a/packages/E2ETest/.eslintignore
+++ b/packages/E2ETest/.eslintignore
@@ -1,7 +1,1 @@
-**/node_modules
-wdio
-app
-wdio.conf.js
-hasteImpl.js
-metro.config.js
-postinstall.js
+/dist

--- a/packages/E2ETest/app/ControlStyleTestPage.tsx
+++ b/packages/E2ETest/app/ControlStyleTestPage.tsx
@@ -3,24 +3,31 @@
  * Licensed under the MIT License.
  */
 
- import { Switch, CheckBox, TextInput, View, StyleSheet, Button } from 'react-native';
+import {
+  Switch,
+  CheckBox,
+  TextInput,
+  View,
+  StyleSheet,
+  Button,
+} from 'react-native';
 import { DatePicker, Picker } from 'react-native-windows';
 import React, { useState } from 'react';
 import { SHOWBORDER_ON_CONTROLSTYLE, TREE_DUMP_RESULT } from './Consts';
-import { TreeDumpControl } from './TreeDumpControl'
+import { TreeDumpControl } from './TreeDumpControl';
 
 const styles = StyleSheet.create({
   container: {
-    padding: 20
+    padding: 20,
   },
   regularBorder: {
     height: 50,
     backgroundColor: 'rgba(225,225,225,0.2)',
-    borderWidth:1,
+    borderWidth: 1,
     borderColor: '#ff00ff55',
     marginBottom: 10,
     padding: 10,
-    color: '#fff'
+    color: '#fff',
   },
   roundBorder: {
     height: 50,
@@ -29,7 +36,7 @@ const styles = StyleSheet.create({
     padding: 10,
     color: '#000',
     borderRadius: 10.0,
-    borderWidth:10,
+    borderWidth: 10,
     borderColor: '#00ff0055',
   },
   buttonText: {
@@ -51,34 +58,58 @@ export function ControlStyleTestPage() {
   const onPressShowRoundBorder = () => {
     var previousState = showRoundBorder;
     setShowRoundBorder(!previousState);
- }
+  };
 
-   return (
+  return (
     <View>
       <View testID={'ControlStyleView'}>
         {
-        <Switch style={showRoundBorder? styles.roundBorder :styles.regularBorder} thumbColor='blue'/> 
+          <Switch
+            style={showRoundBorder ? styles.roundBorder : styles.regularBorder}
+            thumbColor="blue"
+          />
         }
-        <CheckBox style={showRoundBorder? styles.roundBorder :styles.regularBorder} />
-        <TextInput style={showRoundBorder? styles.roundBorder :styles.regularBorder}
-          placeholder='TextBox'
-          placeholderTextColor='rgba(225,225,225,0.7)'
-          editable={false} />
+        <CheckBox
+          style={showRoundBorder ? styles.roundBorder : styles.regularBorder}
+        />
+        <TextInput
+          style={showRoundBorder ? styles.roundBorder : styles.regularBorder}
+          placeholder="TextBox"
+          placeholderTextColor="rgba(225,225,225,0.7)"
+          editable={false}
+        />
 
-        <TextInput style={showRoundBorder? styles.roundBorder :styles.regularBorder}
-          placeholder='Password'
-          placeholderTextColor='rgba(225,225,225,0.7)'
-          secureTextEntry = {true}
-          editable={false}/>
-        <DatePicker style={showRoundBorder? styles.roundBorder :styles.regularBorder}/>
-        <Picker style={showRoundBorder? styles.roundBorder :styles.regularBorder}/>
+        <TextInput
+          style={showRoundBorder ? styles.roundBorder : styles.regularBorder}
+          placeholder="Password"
+          placeholderTextColor="rgba(225,225,225,0.7)"
+          secureTextEntry={true}
+          editable={false}
+        />
+        <DatePicker
+          style={showRoundBorder ? styles.roundBorder : styles.regularBorder}
+        />
+        <Picker
+          style={showRoundBorder ? styles.roundBorder : styles.regularBorder}
+        />
       </View>
-      
-      <Button title= {showRoundBorder?"Hide Round Border":"Show Round Border"} 
-        onPress={onPressShowRoundBorder} 
-        testID={SHOWBORDER_ON_CONTROLSTYLE}/>
 
-      <TreeDumpControl style={styles.treeDumpControl} dumpID={showRoundBorder?'ControlStyleRoundBorder':'ControlStyleRegularBorder'} uiaID={'ControlStyleView'} testID={TREE_DUMP_RESULT} />
-      
-    </View >);
+      <Button
+        title={showRoundBorder ? 'Hide Round Border' : 'Show Round Border'}
+        onPress={onPressShowRoundBorder}
+        testID={SHOWBORDER_ON_CONTROLSTYLE}
+      />
+
+      <TreeDumpControl
+        style={styles.treeDumpControl}
+        dumpID={
+          showRoundBorder
+            ? 'ControlStyleRoundBorder'
+            : 'ControlStyleRegularBorder'
+        }
+        uiaID={'ControlStyleView'}
+        testID={TREE_DUMP_RESULT}
+      />
+    </View>
+  );
 }

--- a/packages/E2ETest/app/DirectManipulationPage.tsx
+++ b/packages/E2ETest/app/DirectManipulationPage.tsx
@@ -5,65 +5,84 @@
 
 import React, { useState } from 'react';
 import { Text, View, StyleSheet, Button, findNodeHandle } from 'react-native';
-import { MEASURE_IN_WINDOW_BUTTON, MEASURE_LAYOUT_BUTTON, DIRECT_MANIPULATION_RESULT } from './Consts';
+import {
+  MEASURE_IN_WINDOW_BUTTON,
+  MEASURE_LAYOUT_BUTTON,
+  DIRECT_MANIPULATION_RESULT,
+} from './Consts';
 
 const styles = StyleSheet.create({
-    container: {
-        padding: 20
-    },
-    text: {
-        textAlign: 'center',
-        fontWeight: '700',
-        height: 30
-    },
-    childView: {
-        width: 50,
-        height: 50,
-        backgroundColor: 'lightgreen',
-        marginBottom: 20,
-    }
+  container: {
+    padding: 20,
+  },
+  text: {
+    textAlign: 'center',
+    fontWeight: '700',
+    height: 30,
+  },
+  childView: {
+    width: 50,
+    height: 50,
+    backgroundColor: 'lightgreen',
+    marginBottom: 20,
+  },
 });
 
 const rootViewRef = React.createRef<View>();
 const childViewRef = React.createRef<View>();
 
 export function DirectManipulationTestPage() {
-    const [resultTextState, setResultTextState] = useState('');
+  const [resultTextState, setResultTextState] = useState('');
 
-    const measureLayoutSucceeded = (x: number, y: number, width: number, height: number) => {
-        setResultTextState(`x=${x};y=${y};width=${Math.trunc(width)};height=${Math.trunc(height)}`);
-    }
+  const measureLayoutSucceeded = (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ) => {
+    setResultTextState(
+      `x=${x};y=${y};width=${Math.trunc(width)};height=${Math.trunc(height)}`
+    );
+  };
 
-    const measureLayoutFailed = () => {
-        setResultTextState('MeasureLayout failed');
-    }
+  const measureLayoutFailed = () => {
+    setResultTextState('MeasureLayout failed');
+  };
 
-    return (
-        <View ref={rootViewRef} style={styles.container}>
-            <Text style={styles.text}>DirectManipulationResult:
-            </Text>
-            <Text testID={DIRECT_MANIPULATION_RESULT}>
-                {resultTextState}
-            </Text>
-            <View style={styles.childView} ref={childViewRef}></View>
-            <Button title='Call MeasureInWindow'
-                onPress={() => {
-                    rootViewRef.current && rootViewRef.current.measureInWindow((x, y, width, height) => {
-                        setResultTextState(`x=${x};y=${y};width=${width};height=${height}`);
-                    })
-                }}
-                testID={MEASURE_IN_WINDOW_BUTTON} />
+  return (
+    <View ref={rootViewRef} style={styles.container}>
+      <Text style={styles.text}>DirectManipulationResult:</Text>
+      <Text testID={DIRECT_MANIPULATION_RESULT}>{resultTextState}</Text>
+      <View style={styles.childView} ref={childViewRef} />
+      <Button
+        title="Call MeasureInWindow"
+        onPress={() => {
+          rootViewRef.current &&
+            rootViewRef.current.measureInWindow((x, y, width, height) => {
+              setResultTextState(
+                `x=${x};y=${y};width=${width};height=${height}`
+              );
+            });
+        }}
+        testID={MEASURE_IN_WINDOW_BUTTON}
+      />
 
-            <Button title='Call MeasureLayout'
-                onPress={() => {
-                    if (childViewRef.current) {
-                        const rootViewHandle = findNodeHandle(rootViewRef.current);
-                        if (rootViewHandle) {
-                            childViewRef.current.measureLayout(rootViewHandle, measureLayoutSucceeded, measureLayoutFailed);
-                        }
-                    }
-                }}
-                testID={MEASURE_LAYOUT_BUTTON} />
-
-        </View >);
+      <Button
+        title="Call MeasureLayout"
+        onPress={() => {
+          if (childViewRef.current) {
+            const rootViewHandle = findNodeHandle(rootViewRef.current);
+            if (rootViewHandle) {
+              childViewRef.current.measureLayout(
+                rootViewHandle,
+                measureLayoutSucceeded,
+                measureLayoutFailed
+              );
+            }
+          }
+        }}
+        testID={MEASURE_LAYOUT_BUTTON}
+      />
+    </View>
+  );
 }

--- a/packages/E2ETest/app/ImageTestPage.tsx
+++ b/packages/E2ETest/app/ImageTestPage.tsx
@@ -3,32 +3,37 @@
  * Licensed under the MIT License.
  */
 
-import { StyleSheet, View, Image, Button } from 'react-native'
+import { StyleSheet, View, Image, Button } from 'react-native';
 import React, { useState } from 'react';
-import { SHOW_IMAGE_BORDER, SET_RTL_MODE, IMAGE_CONTAINER, TREE_DUMP_RESULT } from './Consts';
-import { TreeDumpControl } from './TreeDumpControl'
+import {
+  SHOW_IMAGE_BORDER,
+  SET_RTL_MODE,
+  IMAGE_CONTAINER,
+  TREE_DUMP_RESULT,
+} from './Consts';
+import { TreeDumpControl } from './TreeDumpControl';
 
 const styles = StyleSheet.create({
   container: {
-    height:300,
-    width:500,
+    height: 300,
+    width: 500,
     backgroundColor: 'yellow',
-    alignItems:'center',
+    alignItems: 'center',
   },
   containerWithBorder: {
-    height:300,
-    width:500,
+    height: 300,
+    width: 500,
     borderRadius: 10.0,
-    borderWidth:10,
+    borderWidth: 10,
     borderColor: '#00ff0055',
     backgroundColor: 'yellow',
-    alignItems:'center',
+    alignItems: 'center',
   },
   imageWithBorder: {
     height: '100%',
     width: '100%',
     borderRadius: 10.0,
-    borderWidth:10,
+    borderWidth: 10,
     borderColor: '#0000ff55',
     backgroundColor: 'red',
   },
@@ -41,7 +46,7 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
     backgroundColor: 'red',
-    direction: 'rtl'
+    direction: 'rtl',
   },
   treeDumpControl: {
     height: 150,
@@ -58,42 +63,64 @@ export function ImageTestPage() {
     var previousImageBorderState = imageWithBorder;
     setImageBorder(!previousImageBorderState);
     var previousClickCount = clickCount;
-    setClickCount(previousClickCount+1);
- }
+    setClickCount(previousClickCount + 1);
+  };
 
   const imageStyle = () => {
-    if(rltMode) return styles.rtlImage;
-    if(imageWithBorder) return styles.imageWithBorder;
+    if (rltMode) {
+      return styles.rtlImage;
+    }
+    if (imageWithBorder) {
+      return styles.imageWithBorder;
+    }
     return styles.image;
-  }
+  };
 
   const dumpId = () => {
-    if(rltMode) return 'ImageRTL';
-    if(imageWithBorder) return 'ImageWithBorder';
-    if(clickCount == 0) return 'ImageWithoutBorder';
+    if (rltMode) {
+      return 'ImageRTL';
+    }
+    if (imageWithBorder) {
+      return 'ImageWithBorder';
+    }
+    if (clickCount == 0) {
+      return 'ImageWithoutBorder';
+    }
     return 'ImageWithoutBorder-Subsequent';
-  }
+  };
 
-  return(
-  <View>
-    <View testID={IMAGE_CONTAINER} style={imageWithBorder?styles.containerWithBorder:styles.container}>
-      <Image
-        style={imageStyle()}
-        resizeMode={'center'}
-        source={{uri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg=='}}        
-      />      
-    </View >
-    <Button title= {imageWithBorder?"Hide Border":"Show Border"} 
-          onPress={onPressBorder} 
-          testID={SHOW_IMAGE_BORDER}/> 
-    <Button title= {rltMode?"Set image to LTR":"Set image to RTL"} 
-          onPress={()=>setRtlMode(!rltMode)} 
-          testID={SET_RTL_MODE}/> 
-    <TreeDumpControl
-      style={styles.treeDumpControl}
-      dumpID={dumpId()}
-      uiaID={IMAGE_CONTAINER}
-      additionalProperties={rltMode ? ['FlowDirection'] : []}
-      testID={TREE_DUMP_RESULT} />
-  </View>);
+  return (
+    <View>
+      <View
+        testID={IMAGE_CONTAINER}
+        style={imageWithBorder ? styles.containerWithBorder : styles.container}
+      >
+        <Image
+          style={imageStyle()}
+          resizeMode={'center'}
+          source={{
+            uri:
+              'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==',
+          }}
+        />
+      </View>
+      <Button
+        title={imageWithBorder ? 'Hide Border' : 'Show Border'}
+        onPress={onPressBorder}
+        testID={SHOW_IMAGE_BORDER}
+      />
+      <Button
+        title={rltMode ? 'Set image to LTR' : 'Set image to RTL'}
+        onPress={() => setRtlMode(!rltMode)}
+        testID={SET_RTL_MODE}
+      />
+      <TreeDumpControl
+        style={styles.treeDumpControl}
+        dumpID={dumpId()}
+        uiaID={IMAGE_CONTAINER}
+        additionalProperties={rltMode ? ['FlowDirection'] : []}
+        testID={TREE_DUMP_RESULT}
+      />
+    </View>
+  );
 }

--- a/packages/E2ETest/app/TestApp.tsx
+++ b/packages/E2ETest/app/TestApp.tsx
@@ -3,48 +3,75 @@
  * Licensed under the MIT License.
  */
 
-import React, { useState } from "react";
-import TestPages, { ITestPage } from './TestPages'
-import { TouchableOpacity, Text, View, TextInput, FlatList, Button, StyleSheet } from 'react-native'
-import { SEARCH_BUTTON, HOME_BUTTON } from './Consts'
-
+import React, { useState } from 'react';
+import TestPages, { ITestPage } from './TestPages';
+import {
+  TouchableOpacity,
+  Text,
+  View,
+  TextInput,
+  FlatList,
+  Button,
+  StyleSheet,
+} from 'react-native';
+import { SEARCH_BUTTON, HOME_BUTTON } from './Consts';
 
 interface TestPageListProps {
-  onNavigateTo: (pageTestId: string) => void,
-  testPages: ITestPage[]
+  onNavigateTo: (pageTestId: string) => void;
+  testPages: ITestPage[];
 }
 
 function TestPageList(props: TestPageListProps) {
-  const [filter, setFilter] = useState("");
+  const [filter, setFilter] = useState('');
 
-  const _renderItem = ({ item }: {item: ITestPage}) => (
-    <TouchableOpacity onPress={() => { props.onNavigateTo(item.testId) }} testID={item.testId}>
+  const _renderItem = ({ item }: { item: ITestPage }) => (
+    <TouchableOpacity
+      onPress={() => {
+        props.onNavigateTo(item.testId);
+      }}
+      testID={item.testId}
+    >
       <View>
         <Text>{item.description}</Text>
       </View>
-    </TouchableOpacity >
+    </TouchableOpacity>
   );
 
-  const data = props.testPages.filter((item: ITestPage) => !filter || (item.testId && item.testId.includes(filter)) || (item.description && item.description.includes(filter)))
+  const data = props.testPages.filter(
+    (item: ITestPage) =>
+      !filter ||
+      (item.testId && item.testId.includes(filter)) ||
+      (item.description && item.description.includes(filter))
+  );
 
   return (
     <View>
-      <TextInput placeholder='Search test page' onChangeText={(text) => setFilter(text)} value={filter} testID={SEARCH_BUTTON} />
-      <FlatList<ITestPage> data={data} renderItem={_renderItem} keyExtractor={(item) => item.testId}/>
-    </View>)
+      <TextInput
+        placeholder="Search test page"
+        onChangeText={text => setFilter(text)}
+        value={filter}
+        testID={SEARCH_BUTTON}
+      />
+      <FlatList<ITestPage>
+        data={data}
+        renderItem={_renderItem}
+        keyExtractor={item => item.testId}
+      />
+    </View>
+  );
 }
 
 interface TestPageDetailProps {
-  testPage: ITestPage
+  testPage: ITestPage;
 }
 
 function TestPageDetail(props: TestPageDetailProps) {
-  return <props.testPage.content />
+  return <props.testPage.content />;
 }
 
 interface HeaderProps {
-  onNavigateTo: (pageTestId: string) => void,
-  description: string
+  onNavigateTo: (pageTestId: string) => void;
+  description: string;
 }
 
 function Header(props: HeaderProps) {
@@ -54,9 +81,16 @@ function Header(props: HeaderProps) {
         <View style={styles.headerCenter}>
           <Text style={styles.title}>{props.description}</Text>
         </View>
-        <Button title='Home' onPress={() => { props.onNavigateTo('') }} testID={HOME_BUTTON} />
+        <Button
+          title="Home"
+          onPress={() => {
+            props.onNavigateTo('');
+          }}
+          testID={HOME_BUTTON}
+        />
       </View>
-    </View>);
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -66,7 +100,7 @@ const styles = StyleSheet.create({
   },
   header: {
     height: 40,
-    flexDirection: 'row'
+    flexDirection: 'row',
   },
   headerLeft: {},
   headerCenter: {
@@ -74,36 +108,51 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 7,
     left: 0,
-    right: 0
+    right: 0,
   },
   title: {
     fontSize: 19,
     fontWeight: '600',
-    textAlign: 'center'
+    textAlign: 'center',
   },
   testPageContainer: {
-    flex: 1
-  }
+    flex: 1,
+  },
 });
 
-
 export default function TestApp() {
-  const [toPageTestId, setToPageTestId] = useState("");
+  const [toPageTestId, setToPageTestId] = useState('');
 
-  const _onNavigateTo = (pageTestId: string) => { setToPageTestId(pageTestId) };
+  const _onNavigateTo = (pageTestId: string) => {
+    setToPageTestId(pageTestId);
+  };
 
   if (toPageTestId.length > 0) {
-    const page = TestPages.filter(testPage => testPage.testId === toPageTestId)[0];
+    const page = TestPages.filter(
+      testPage => testPage.testId === toPageTestId
+    )[0];
     return (
       <View style={styles.testPageContainer}>
-        <Header onNavigateTo={() => { _onNavigateTo('') }} description={page.description} />
+        <Header
+          onNavigateTo={() => {
+            _onNavigateTo('');
+          }}
+          description={page.description}
+        />
         <TestPageDetail testPage={page} />
-      </View>)
+      </View>
+    );
   } else {
     return (
       <View style={styles.testPageContainer}>
-        <Header onNavigateTo={() => { }} description='Home' />
-        <TestPageList testPages={TestPages} onNavigateTo={(testPageId) => { _onNavigateTo(testPageId) }} />
-      </View>)
+        <Header onNavigateTo={() => {}} description="Home" />
+        <TestPageList
+          testPages={TestPages}
+          onNavigateTo={testPageId => {
+            _onNavigateTo(testPageId);
+          }}
+        />
+      </View>
+    );
   }
 }

--- a/packages/E2ETest/app/TextInputTestPage.tsx
+++ b/packages/E2ETest/app/TextInputTestPage.tsx
@@ -5,9 +5,15 @@
  */
 
 import React from 'react';
-import {Text, TextInput, View} from 'react-native';
-import {TEXTINPUT_ON_TEXTINPUT, ML_TEXTINPUT_ON_TEXTINPUT, CURTEXT_ON_TEXTINPUT,
-  PREVTEXT_ON_TEXTINPUT, PREV2TEXT_ON_TEXTINPUT, CAP_TEXTINPUT_ON_TEXTINPUT} from './Consts';
+import { Text, TextInput, View } from 'react-native';
+import {
+  TEXTINPUT_ON_TEXTINPUT,
+  ML_TEXTINPUT_ON_TEXTINPUT,
+  CURTEXT_ON_TEXTINPUT,
+  PREVTEXT_ON_TEXTINPUT,
+  PREV2TEXT_ON_TEXTINPUT,
+  CAP_TEXTINPUT_ON_TEXTINPUT,
+} from './Consts';
 
 interface ITextInputTestPageState {
   curText: string;
@@ -42,7 +48,7 @@ export class TextInputTestPage extends React.Component<
     return (
       <View>
         <TextInput
-          style={{height: 32}}
+          style={{ height: 32 }}
           testID={TEXTINPUT_ON_TEXTINPUT}
           placeholder="Enter text to see events"
           onFocus={() => this.updateText('onFocus')}
@@ -61,7 +67,7 @@ export class TextInputTestPage extends React.Component<
               'onSelectionChange range: ' +
                 event.nativeEvent.selection.start +
                 ',' +
-                event.nativeEvent.selection.end,
+                event.nativeEvent.selection.end
             );
           }}
           onKeyPress={event => {
@@ -70,20 +76,26 @@ export class TextInputTestPage extends React.Component<
         />
         <TextInput
           testID={ML_TEXTINPUT_ON_TEXTINPUT}
-          style={{height: 80}}
+          style={{ height: 80 }}
           placeholder="MultiLine"
           multiline={true}
         />
         <TextInput
           testID={CAP_TEXTINPUT_ON_TEXTINPUT}
-          style={{height: 80}}
+          style={{ height: 80 }}
           placeholder="autoCapitalize"
           autoCapitalize="characters"
         />
-        <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-          <Text testID={CURTEXT_ON_TEXTINPUT}>curText: {this.state.curText}</Text>
-          <Text testID={PREVTEXT_ON_TEXTINPUT}>prev: {this.state.prevText}</Text>
-          <Text testID={PREV2TEXT_ON_TEXTINPUT}>prev2: {this.state.prev2Text})</Text>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Text testID={CURTEXT_ON_TEXTINPUT}>
+            curText: {this.state.curText}
+          </Text>
+          <Text testID={PREVTEXT_ON_TEXTINPUT}>
+            prev: {this.state.prevText}
+          </Text>
+          <Text testID={PREV2TEXT_ON_TEXTINPUT}>
+            prev2: {this.state.prev2Text})
+          </Text>
           <Text testID="Prev3Text">prev3: {this.state.prev3Text}</Text>
         </View>
       </View>

--- a/packages/E2ETest/app/TransformTestPage.tsx
+++ b/packages/E2ETest/app/TransformTestPage.tsx
@@ -5,60 +5,80 @@
 
 import React, { useState } from 'react';
 import { Text, View, StyleSheet, Button, findNodeHandle } from 'react-native';
-import { APPLY_SCALE_TRANSFORM_BUTTON, MEASURE_LAYOUT_BUTTON, TRANSFORM_TEST_RESULT } from './Consts';
+import {
+  APPLY_SCALE_TRANSFORM_BUTTON,
+  MEASURE_LAYOUT_BUTTON,
+  TRANSFORM_TEST_RESULT,
+} from './Consts';
 
 const styles = StyleSheet.create({
-    text: {
-        textAlign: 'center',
-        fontWeight: '700',
-        height: 30
-    },
-    childView: {
-        width: 60,
-        height: 60,
-        marginTop: 50,
-        backgroundColor: 'lightgreen',
-        marginBottom: 20,
-    }
+  text: {
+    textAlign: 'center',
+    fontWeight: '700',
+    height: 30,
+  },
+  childView: {
+    width: 60,
+    height: 60,
+    marginTop: 50,
+    backgroundColor: 'lightgreen',
+    marginBottom: 20,
+  },
 });
 
 const rootViewRef = React.createRef<View>();
 const childViewRef = React.createRef<View>();
 
 export function TransformTestPage() {
-    const [resultTextState, setResultTextState] = useState('');
-    const [viewScale, setViewScale] = useState(1);
+  const [resultTextState, setResultTextState] = useState('');
+  const [viewScale, setViewScale] = useState(1);
 
-    const measureLayoutSucceeded = (x: number, y: number, width: number, height: number) => {
-        setResultTextState(`x=${x};y=${y};width=${Math.trunc(width)};height=${Math.trunc(height)}`);
-    }
+  const measureLayoutSucceeded = (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ) => {
+    setResultTextState(
+      `x=${x};y=${y};width=${Math.trunc(width)};height=${Math.trunc(height)}`
+    );
+  };
 
-    const measureLayoutFailed = () => {
-        setResultTextState('MeasureLayout failed');
-    }
+  const measureLayoutFailed = () => {
+    setResultTextState('MeasureLayout failed');
+  };
 
-    return (
-        <View ref={rootViewRef}>
-            <Text testID={TRANSFORM_TEST_RESULT}>
-                {resultTextState}
-            </Text>
-            <View style={[styles.childView, { transform: [{ scale: viewScale }] }]} ref={childViewRef}></View>
-            <Button title='Apply ScaleTransform'
-                onPress={() => {
-                    setViewScale(viewScale === 1 ? 0.5 : 1);
-                }}
-                testID={APPLY_SCALE_TRANSFORM_BUTTON} />
+  return (
+    <View ref={rootViewRef}>
+      <Text testID={TRANSFORM_TEST_RESULT}>{resultTextState}</Text>
+      <View
+        style={[styles.childView, { transform: [{ scale: viewScale }] }]}
+        ref={childViewRef}
+      />
+      <Button
+        title="Apply ScaleTransform"
+        onPress={() => {
+          setViewScale(viewScale === 1 ? 0.5 : 1);
+        }}
+        testID={APPLY_SCALE_TRANSFORM_BUTTON}
+      />
 
-            <Button title='MeasureLayout'
-                onPress={() => {
-                    if (childViewRef.current) {
-                        const rootViewHandle = findNodeHandle(rootViewRef.current);
-                        if (rootViewHandle) {
-                            childViewRef.current.measureLayout(rootViewHandle, measureLayoutSucceeded, measureLayoutFailed);
-                        }
-                    }
-                }}
-                testID={MEASURE_LAYOUT_BUTTON} />
-
-        </View >);
+      <Button
+        title="MeasureLayout"
+        onPress={() => {
+          if (childViewRef.current) {
+            const rootViewHandle = findNodeHandle(rootViewRef.current);
+            if (rootViewHandle) {
+              childViewRef.current.measureLayout(
+                rootViewHandle,
+                measureLayoutSucceeded,
+                measureLayoutFailed
+              );
+            }
+          }
+        }}
+        testID={MEASURE_LAYOUT_BUTTON}
+      />
+    </View>
+  );
 }

--- a/packages/E2ETest/app/UnknownPage.tsx
+++ b/packages/E2ETest/app/UnknownPage.tsx
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import {Text} from 'react-native'
+import { Text } from 'react-native';
 import React from 'react';
 
 export function UnknownPage() {
-  return (<Text>Unknown</Text>)
+  return <Text>Unknown</Text>;
 }

--- a/packages/E2ETest/wdio.conf.js
+++ b/packages/E2ETest/wdio.conf.js
@@ -1,291 +1,290 @@
 const baseUrl = 'https://webdriver.io';
 
 exports.config = {
-    //
-    // ====================
-    // Runner Configuration
-    // ====================
-    //
-    // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
-    // on a remote machine).
-    runner: 'local',
-    //
-    // =====================
-    // Server Configurations
-    // =====================
-    // Host address of the running Selenium server. This information is usually obsolete as
-    // WebdriverIO automatically connects to localhost. Also, if you are using one of the
-    // supported cloud services like Sauce Labs, Browserstack, or Testing Bot you don't
-    // need to define host and port information because WebdriverIO can figure that out
-    // according to your user and key information. However, if you are using a private Selenium
-    // backend you should define the host address, port, and path here.
-    //
-    // hostname: '172.18.5.185',
-    // port: 4444,
-    // path: '/wd/hub',
-    
-    //
-    // ==================
-    // Specify Test Files
-    // ==================
-    // Define which test specs should run. The pattern is relative to the directory
-    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
-    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
-    // directory is where your package.json resides, so `wdio` will be called from there.
-    //
-    specs: [
-        'wdio/test/**/*.ts'
-    ],
-    // Patterns to exclude.
-    exclude: [
-        // 'path/to/excluded/files'
-    ],
-    //
-    // ============
-    // Capabilities
-    // ============
-    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
-    // time. Depending on the number of capabilities, WebdriverIO launches several test
-    // sessions. Within your capabilities you can overwrite the spec and exclude options in
-    // order to group specific specs to a specific capability.
-    //
-    // First, you can define how many instances should be started at the same time. Let's
-    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
-    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
-    // files and you set maxInstances to 10, all spec files will get tested at the same time
-    // and 30 processes will get spawned. The property handles how many capabilities
-    // from the same test should run tests.
-    //
-    maxInstances: 1,
-    //
-    // If you have trouble getting all important capabilities together, check out the
-    // Sauce Labs platform configurator - a great tool to configure your capabilities:
-    // https://docs.saucelabs.com/reference/platforms-configurator
-    //
-    capabilities: [
-        {
-            // maxInstances can get overwritten per capability. So if you have an in-house Selenium
-            // grid with only 5 firefox instances available you can make sure that not more than
-            // 5 instances get started at a time.
-            maxInstances: 1,
-            //
-            platformName: 'windows',
-            // For W3C the appium capabilities need to have an extension prefix
-            // http://appium.io/docs/en/writing-running-appium/caps/
-            // This is `appium:` for all Appium Capabilities which can be found here
-            'appium:deviceName': 'WindowsPC',
-            'appium:app': 'ReactUWPTestApp_kc2bncckyf4ap!App',
-            'deviceName': 'WindowsPC',
-            'app': 'ReactUWPTestApp_kc2bncckyf4ap!App',
-            'winAppDriver:experimental-w3c': true,
-        },
-        // {
-        //     // maxInstances can get overwritten per capability. So if you have an in house Selenium
-        //     // grid with only 5 firefox instance available you can make sure that not more than
-        //     // 5 instance gets started at a time.
-        //     maxInstances: 5,
-        //     browserName: 'firefox',
-        //     // specs: [
-        //     //     'test/ffOnly/*'
-        //     // ],
-        //     "moz:firefoxOptions": {
-        //     // flag to activate Firefox headless mode (see https://github.com/mozilla/geckodriver/blob/master/README.md#firefox-capabilities for more details about moz:firefoxOptions)
-        //     // args: ['-headless']
-        //     }
-        // }
-    ],
-    //
-    // ===================
-    // Test Configurations
-    // ===================
-    // Define all options that are relevant for the WebdriverIO instance here
-    //
-    // Level of logging verbosity: trace | debug | info | warn | error
-    logLevel: 'trace',
-    //
-    // Warns when a deprecated command is used
-    deprecationWarnings: true,
-    //
-    // If you only want to run your tests until a specific amount of tests have failed use
-    // bail (default is 0 - don't bail, run all tests).
-    bail: 0,
-    //
-    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
-    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
-    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
-    // gets prepended directly.
-    baseUrl: baseUrl,
-    //
-    // Default timeout for all waitFor* commands.
-    waitforTimeout: 10000,
-    //
-    // Default timeout in milliseconds for request
-    // if Selenium Grid doesn't send response
-    connectionRetryTimeout: 90000,
-    //
-    // Default request retries count
-    connectionRetryCount: 1,
+  //
+  // ====================
+  // Runner Configuration
+  // ====================
+  //
+  // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+  // on a remote machine).
+  runner: 'local',
+  //
+  // =====================
+  // Server Configurations
+  // =====================
+  // Host address of the running Selenium server. This information is usually obsolete as
+  // WebdriverIO automatically connects to localhost. Also, if you are using one of the
+  // supported cloud services like Sauce Labs, Browserstack, or Testing Bot you don't
+  // need to define host and port information because WebdriverIO can figure that out
+  // according to your user and key information. However, if you are using a private Selenium
+  // backend you should define the host address, port, and path here.
+  //
+  // hostname: '172.18.5.185',
+  // port: 4444,
+  // path: '/wd/hub',
 
-    port: 4723,
-    //
-    // Test runner services
-    // Services take over a specific job you don't want to take care of. They enhance
-    // your test setup with almost no effort. Unlike plugins, they don't add new
-    // commands. Instead, they hook themselves up into the test process.
-    services: ['appium'],
-    appium: {
-        logPath: './reports/',
-        args: {
-            port: '4723',
-        }
+  //
+  // ==================
+  // Specify Test Files
+  // ==================
+  // Define which test specs should run. The pattern is relative to the directory
+  // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+  // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+  // directory is where your package.json resides, so `wdio` will be called from there.
+  //
+  specs: ['wdio/test/**/*.ts'],
+  // Patterns to exclude.
+  exclude: [
+    // 'path/to/excluded/files'
+  ],
+  //
+  // ============
+  // Capabilities
+  // ============
+  // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+  // time. Depending on the number of capabilities, WebdriverIO launches several test
+  // sessions. Within your capabilities you can overwrite the spec and exclude options in
+  // order to group specific specs to a specific capability.
+  //
+  // First, you can define how many instances should be started at the same time. Let's
+  // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+  // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+  // files and you set maxInstances to 10, all spec files will get tested at the same time
+  // and 30 processes will get spawned. The property handles how many capabilities
+  // from the same test should run tests.
+  //
+  maxInstances: 1,
+  //
+  // If you have trouble getting all important capabilities together, check out the
+  // Sauce Labs platform configurator - a great tool to configure your capabilities:
+  // https://docs.saucelabs.com/reference/platforms-configurator
+  //
+  capabilities: [
+    {
+      // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+      // grid with only 5 firefox instances available you can make sure that not more than
+      // 5 instances get started at a time.
+      maxInstances: 1,
+      //
+      platformName: 'windows',
+      // For W3C the appium capabilities need to have an extension prefix
+      // http://appium.io/docs/en/writing-running-appium/caps/
+      // This is `appium:` for all Appium Capabilities which can be found here
+      'appium:deviceName': 'WindowsPC',
+      'appium:app': 'ReactUWPTestApp_kc2bncckyf4ap!App',
+      deviceName: 'WindowsPC',
+      app: 'ReactUWPTestApp_kc2bncckyf4ap!App',
+      'winAppDriver:experimental-w3c': true,
     },
-
-    //
-    // Framework you want to run your specs with.
-    // The following are supported: Mocha, Jasmine, and Cucumber
-    // see also: https://webdriver.io/docs/frameworks.html
-    //
-    // Make sure you have the wdio adapter package for the specific framework installed
-    // before running any tests.
-    framework: 'jasmine',
-    //
-    // Test reporter for stdout.
-    // The only one supported by default is 'dot'
-    // see also: https://webdriver.io/docs/dot-reporter.html
-    reporters: ['dot', ['junit', { outputDir : '.\\reports' }]],
-    
-    //
-    // Options to be passed to Mocha.
-    // See the full list at http://mochajs.org/
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 60000,
-        compilers: [
-            // 'ts-node/register',
-            'tsconfig-paths/register'
-        ]
-    },
-
-    jasmineNodeOpts: {
-        defaultTimeoutInterval: 60000,
-    },
-
-    //
-    // =====
-    // Hooks
-    // =====
-    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
-    // it and to build services around it. You can either apply a single function or an array of
-    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
-    // resolved to continue.
-    /**
-     * Gets executed once before all workers get launched.
-     * @param {Object} config wdio configuration object
-     * @param {Array.<Object>} capabilities list of capabilities details
-     */
-    // onPrepare: function (config, capabilities) {
-    // },
-    /**
-     * Gets executed just before initialising the webdriver session and test framework. It allows you
-     * to manipulate configurations depending on the capability or spec.
-     * @param {Object} config wdio configuration object
-     * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {Array.<String>} specs List of spec file paths that are to be run
-     */
-    // beforeSession: function (config, capabilities, specs) {
-    // },
-    /**
-     * Gets executed before test execution begins. At this point you can access to all global
-     * variables like `browser`. It is the perfect place to define custom commands.
-     * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {Array.<String>} specs List of spec file paths that are to be run
-     */
-    before: function (capabilities, specs) {
-        // require('ts-node/register');        
-        require('ts-node').register({ files: true });
-    },
-    /**
-     * Runs before a WebdriverIO command gets executed.
-     * @param {String} commandName hook command name
-     * @param {Array} args arguments that command would receive
-     */
-    // beforeCommand: function (commandName, args) {
-    // },
-    
-    /**
-     * Hook that gets executed before the suite starts
-     * @param {Object} suite suite details
-     */
-    // beforeSuite: function (suite) {
-    // },
-    /**
-     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
-     * @param {Object} test test details
-     */
-    // beforeTest: function (test) {
-    // },
-    /**
-     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-     * beforeEach in Mocha)
-     */
-    // beforeHook: function () {
-    // },
-    /**
-     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
-     * afterEach in Mocha)
-     */
-    // afterHook: function () {
-    // },
-    /**
-     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
-     * @param {Object} test test details
-     */
-    afterTest: function (test) {        
-        if (test.error !== undefined) {
-            let name = 'ERROR-' + Date.now();
-            browser.saveScreenshot('./errorShots/' + name + '.png');
-        }        
-    },
-    /**
-     * Hook that gets executed after the suite has ended
-     * @param {Object} suite suite details
-     */
-    // afterSuite: function (suite) {
-    // },
-    
-    /**
-     * Runs after a WebdriverIO command gets executed
-     * @param {String} commandName hook command name
-     * @param {Array} args arguments that command would receive
-     * @param {Number} result 0 - command success, 1 - command error
-     * @param {Object} error error object if any
-     */
-    // afterCommand: function (commandName, args, result, error) {
-    // },
-    /**
-     * Gets executed after all tests are done. You still have access to all global variables from
-     * the test.
-     * @param {Number} result 0 - test pass, 1 - test fail
-     * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {Array.<String>} specs List of spec file paths that ran
-     */
-    // after: function (result, capabilities, specs) {
-    // },
-    /**
-     * Gets executed right after terminating the webdriver session.
-     * @param {Object} config wdio configuration object
-     * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {Array.<String>} specs List of spec file paths that ran
-     */
-    // afterSession: function (config, capabilities, specs) {
-    // },
-    /**
-     * Gets executed after all workers got shut down and the process is about to exit.
-     * @param {Object} exitCode 0 - success, 1 - fail
-     * @param {Object} config wdio configuration object
-     * @param {Array.<Object>} capabilities list of capabilities details
-     * @param {<Object>} results object containing test results
-     */
-    // onComplete: function(exitCode, config, capabilities, results) {
+    // {
+    //     // maxInstances can get overwritten per capability. So if you have an in house Selenium
+    //     // grid with only 5 firefox instance available you can make sure that not more than
+    //     // 5 instance gets started at a time.
+    //     maxInstances: 5,
+    //     browserName: 'firefox',
+    //     // specs: [
+    //     //     'test/ffOnly/*'
+    //     // ],
+    //     "moz:firefoxOptions": {
+    //     // flag to activate Firefox headless mode (see https://github.com/mozilla/geckodriver/blob/master/README.md#firefox-capabilities for more details about moz:firefoxOptions)
+    //     // args: ['-headless']
+    //     }
     // }
-}
+  ],
+  //
+  // ===================
+  // Test Configurations
+  // ===================
+  // Define all options that are relevant for the WebdriverIO instance here
+  //
+  // Level of logging verbosity: trace | debug | info | warn | error
+  logLevel: 'trace',
+  //
+  // Warns when a deprecated command is used
+  deprecationWarnings: true,
+  //
+  // If you only want to run your tests until a specific amount of tests have failed use
+  // bail (default is 0 - don't bail, run all tests).
+  bail: 0,
+  //
+  // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+  // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+  // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+  // gets prepended directly.
+  baseUrl: baseUrl,
+  //
+  // Default timeout for all waitFor* commands.
+  waitforTimeout: 10000,
+  //
+  // Default timeout in milliseconds for request
+  // if Selenium Grid doesn't send response
+  connectionRetryTimeout: 90000,
+  //
+  // Default request retries count
+  connectionRetryCount: 1,
+
+  port: 4723,
+  //
+  // Test runner services
+  // Services take over a specific job you don't want to take care of. They enhance
+  // your test setup with almost no effort. Unlike plugins, they don't add new
+  // commands. Instead, they hook themselves up into the test process.
+  services: ['appium'],
+  appium: {
+    logPath: './reports/',
+    args: {
+      port: '4723',
+    },
+  },
+
+  //
+  // Framework you want to run your specs with.
+  // The following are supported: Mocha, Jasmine, and Cucumber
+  // see also: https://webdriver.io/docs/frameworks.html
+  //
+  // Make sure you have the wdio adapter package for the specific framework installed
+  // before running any tests.
+  framework: 'jasmine',
+  //
+  // Test reporter for stdout.
+  // The only one supported by default is 'dot'
+  // see also: https://webdriver.io/docs/dot-reporter.html
+  reporters: ['dot', ['junit', { outputDir: '.\\reports' }]],
+
+  //
+  // Options to be passed to Mocha.
+  // See the full list at http://mochajs.org/
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+    compilers: [
+      // 'ts-node/register',
+      'tsconfig-paths/register',
+    ],
+  },
+
+  jasmineNodeOpts: {
+    defaultTimeoutInterval: 60000,
+  },
+
+  //
+  // =====
+  // Hooks
+  // =====
+  // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+  // it and to build services around it. You can either apply a single function or an array of
+  // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+  // resolved to continue.
+  /**
+   * Gets executed once before all workers get launched.
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   */
+  // onPrepare: function (config, capabilities) {
+  // },
+  /**
+   * Gets executed just before initialising the webdriver session and test framework. It allows you
+   * to manipulate configurations depending on the capability or spec.
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that are to be run
+   */
+  // beforeSession: function (config, capabilities, specs) {
+  // },
+  /**
+   * Gets executed before test execution begins. At this point you can access to all global
+   * variables like `browser`. It is the perfect place to define custom commands.
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that are to be run
+   */
+  before: function(capabilities, specs) {
+    // require('ts-node/register');
+    require('ts-node').register({ files: true });
+  },
+  /**
+   * Runs before a WebdriverIO command gets executed.
+   * @param {String} commandName hook command name
+   * @param {Array} args arguments that command would receive
+   */
+  // beforeCommand: function (commandName, args) {
+  // },
+
+  /**
+   * Hook that gets executed before the suite starts
+   * @param {Object} suite suite details
+   */
+  // beforeSuite: function (suite) {
+  // },
+  /**
+   * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+   * @param {Object} test test details
+   */
+  // beforeTest: function (test) {
+  // },
+  /**
+   * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+   * beforeEach in Mocha)
+   */
+  // beforeHook: function () {
+  // },
+  /**
+   * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+   * afterEach in Mocha)
+   */
+  // afterHook: function () {
+  // },
+  /**
+   * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+   * @param {Object} test test details
+   */
+  afterTest: function(test) {
+    if (test.error !== undefined) {
+      let name = 'ERROR-' + Date.now();
+      // eslint-disable-next-line no-undef
+      browser.saveScreenshot('./errorShots/' + name + '.png');
+    }
+  },
+  /**
+   * Hook that gets executed after the suite has ended
+   * @param {Object} suite suite details
+   */
+  // afterSuite: function (suite) {
+  // },
+
+  /**
+   * Runs after a WebdriverIO command gets executed
+   * @param {String} commandName hook command name
+   * @param {Array} args arguments that command would receive
+   * @param {Number} result 0 - command success, 1 - command error
+   * @param {Object} error error object if any
+   */
+  // afterCommand: function (commandName, args, result, error) {
+  // },
+  /**
+   * Gets executed after all tests are done. You still have access to all global variables from
+   * the test.
+   * @param {Number} result 0 - test pass, 1 - test fail
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that ran
+   */
+  // after: function (result, capabilities, specs) {
+  // },
+  /**
+   * Gets executed right after terminating the webdriver session.
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {Array.<String>} specs List of spec file paths that ran
+   */
+  // afterSession: function (config, capabilities, specs) {
+  // },
+  /**
+   * Gets executed after all workers got shut down and the process is about to exit.
+   * @param {Object} exitCode 0 - success, 1 - fail
+   * @param {Object} config wdio configuration object
+   * @param {Array.<Object>} capabilities list of capabilities details
+   * @param {<Object>} results object containing test results
+   */
+  // onComplete: function(exitCode, config, capabilities, results) {
+  // }
+};

--- a/packages/E2ETest/wdio/pages/BasePage.ts
+++ b/packages/E2ETest/wdio/pages/BasePage.ts
@@ -9,6 +9,7 @@ import {
 } from '../../app/Consts';
 
 export function By(testId: string): WebdriverIO.Element {
+  // eslint-disable-next-line no-undef
   return $('~' + testId);
 }
 
@@ -24,6 +25,7 @@ export class BasePage {
   }
 
   waitForPageLoaded(timeout?: number) {
+    // eslint-disable-next-line no-undef
     browser.waitUntil(
       () => {
         return this.isPagedLoadedOrLoadBundleError();
@@ -56,7 +58,9 @@ export class BasePage {
   }
 
   protected timeoutForPageLoaded(currentTimeout?: number) {
-    if (currentTimeout) return currentTimeout;
+    if (currentTimeout) {
+      return currentTimeout;
+    }
     return this.waitforPageTimeout;
   }
 

--- a/packages/microsoft-reactnative-sampleapps/.eslintignore
+++ b/packages/microsoft-reactnative-sampleapps/.eslintignore
@@ -1,1 +1,0 @@
-/node_modules


### PR DESCRIPTION
Fixes #4935

eslint will be default ignore node_modules. Custom ignore files adding node_modules is uneeded, but in E2ETest the file seemingly by design disables linting. We see some linting errors as well that nedeed fixing beyond formatting.

Fix that and get things formatted correctly.

// eslint-disable-next-line no-undef added for a couple of globals

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/4994)