### PR TITLE
Create JSI implementation for IJSValueReader and IJSValueWriter

### DIFF
--- a/change/react-native-windows-2020-05-26-13-47-12-pull_request.json
+++ b/change/react-native-windows-2020-05-26-13-47-12-pull_request.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Create JSI implementation for IJSValueReader and IJSValueWriter",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-26T20:47:12.811Z"
+}

--- a/vnext/Microsoft.ReactNative/JsiReader.cpp
+++ b/vnext/Microsoft.ReactNative/JsiReader.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "JsiReader.h"
+#include <crash/verifyElseCrash.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+//===========================================================================
+// JsiReader implementation
+//===========================================================================
+
+JsiReader::JsiReader(facebook::jsi::Runtime &runtime, const facebook::jsi::Value &root) noexcept
+    : m_runtime(runtime), m_root(root) {
+  SetValue(root);
+}
+
+JSValueType JsiReader::ValueType() noexcept {
+  if (m_currentPrimitiveValue) {
+    if (m_currentPrimitiveValue.value().isString()) {
+      return JSValueType::String;
+    } else if (m_currentPrimitiveValue.value().isBool()) {
+      return JSValueType::Boolean;
+    } else if (m_currentPrimitiveValue.value().isNumber()) {
+      double number = m_currentPrimitiveValue.value().getNumber();
+
+      // unfortunately JSI doesn't differentiate int and double
+      // here we test if the double value can be converted to int without data loss
+      // treat it like an int if we succeeded
+
+      if (floor(number) == number && MinSafeInteger <= number && number <= MaxSafeInteger) {
+        return JSValueType::Int64;
+      } else {
+        return JSValueType::Double;
+      }
+    }
+  } else if (m_nonPrimitiveValues.size() > 0) {
+    return m_nonPrimitiveValues[m_nonPrimitiveValues.size() - 1].Action == ContinuationAction::MoveToNextObjectProperty
+        ? JSValueType::Object
+        : JSValueType::Array;
+  }
+  return JSValueType::Null;
+}
+
+bool JsiReader::GetNextObjectProperty(hstring &propertyName) noexcept {
+  if (m_nonPrimitiveValues.size() == 0) {
+    return false;
+  }
+
+  auto &top = m_nonPrimitiveValues[m_nonPrimitiveValues.size() - 1];
+  if (top.Action != ContinuationAction::MoveToNextObjectProperty) {
+    return false;
+  }
+
+  top.Index++;
+  if (top.Index < static_cast<int>(top.PropertyNames.value().size(m_runtime))) {
+    auto propertyId =
+        top.PropertyNames.value().getValueAtIndex(m_runtime, static_cast<size_t>(top.Index)).getString(m_runtime);
+    propertyName = winrt::to_hstring(propertyId.utf8(m_runtime));
+    SetValue(top.CurrentObject.value().getProperty(m_runtime, propertyId));
+    return true;
+  } else {
+    m_nonPrimitiveValues.pop_back();
+    return false;
+  }
+}
+
+bool JsiReader::GetNextArrayItem() noexcept {
+  if (m_nonPrimitiveValues.size() == 0) {
+    return false;
+  }
+
+  auto &top = m_nonPrimitiveValues[m_nonPrimitiveValues.size() - 1];
+  if (top.Action != ContinuationAction::MoveToNextArrayElement) {
+    return false;
+  }
+
+  top.Index++;
+  if (top.Index < static_cast<int>(top.CurrentArray.value().size(m_runtime))) {
+    SetValue(top.CurrentArray.value().getValueAtIndex(m_runtime, static_cast<size_t>(top.Index)));
+    return true;
+  } else {
+    m_nonPrimitiveValues.pop_back();
+    return false;
+  }
+}
+
+hstring JsiReader::GetString() noexcept {
+  if (ValueType() != JSValueType::String) {
+    return {};
+  }
+  return winrt::to_hstring(m_currentPrimitiveValue.value().getString(m_runtime).utf8(m_runtime));
+}
+
+bool JsiReader::GetBoolean() noexcept {
+  if (ValueType() != JSValueType::Boolean) {
+    return false;
+  }
+  return m_currentPrimitiveValue.value().getBool();
+}
+
+int64_t JsiReader::GetInt64() noexcept {
+  if (ValueType() != JSValueType::Int64) {
+    return 0;
+  }
+  return static_cast<int64_t>(m_currentPrimitiveValue.value().getNumber());
+}
+
+double JsiReader::GetDouble() noexcept {
+  auto valueType = ValueType();
+  if (valueType != JSValueType::Int64 && valueType != JSValueType::Double) {
+    return 0;
+  }
+  return m_currentPrimitiveValue.value().getNumber();
+}
+
+void JsiReader::SetValue(const facebook::jsi::Value &value) noexcept {
+  if (value.isObject()) {
+    auto obj = value.getObject(m_runtime);
+    if (obj.isArray(m_runtime)) {
+      m_nonPrimitiveValues.push_back(obj.getArray(m_runtime));
+    } else {
+      m_nonPrimitiveValues.push_back({m_runtime, std::move(obj)});
+    }
+    m_currentPrimitiveValue = std::nullopt;
+  } else if (value.isString() || value.isBool() || value.isNumber()) {
+    m_currentPrimitiveValue = {m_runtime, value};
+  } else {
+    m_currentPrimitiveValue = facebook::jsi::Value::null();
+  }
+}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JsiReader.h
+++ b/vnext/Microsoft.ReactNative/JsiReader.h
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "jsi/jsi.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+struct JsiReader : implements<JsiReader, IJSValueReader> {
+  JsiReader(facebook::jsi::Runtime &runtime, const facebook::jsi::Value &root) noexcept;
+
+ public: // IJSValueReader
+  JSValueType ValueType() noexcept;
+  bool GetNextObjectProperty(hstring &propertyName) noexcept;
+  bool GetNextArrayItem() noexcept;
+  hstring GetString() noexcept;
+  bool GetBoolean() noexcept;
+  int64_t GetInt64() noexcept;
+  double GetDouble() noexcept;
+
+ private:
+  enum class ContinuationAction {
+    MoveToNextObjectProperty,
+    MoveToNextArrayElement,
+  };
+
+  struct Continuation {
+    ContinuationAction Action;
+    std::optional<facebook::jsi::Object> CurrentObject; // valid for object
+    std::optional<facebook::jsi::Array> PropertyNames; // valid for object
+    std::optional<facebook::jsi::Array> CurrentArray; // valid for array
+    int Index = -1;
+
+    Continuation(facebook::jsi::Runtime &runtime, facebook::jsi::Object &&value) noexcept
+        : Action(ContinuationAction::MoveToNextObjectProperty),
+          CurrentObject(std::make_optional<facebook::jsi::Object>(std::move(value))) {
+      PropertyNames = CurrentObject.value().getPropertyNames(runtime);
+    }
+
+    Continuation(facebook::jsi::Array &&value) noexcept
+        : Action(ContinuationAction::MoveToNextArrayElement),
+          CurrentArray(std::make_optional<facebook::jsi::Array>(std::move(value))) {}
+
+    Continuation(const Continuation &) = delete;
+    Continuation(Continuation &&) = default;
+  };
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
+  static const int64_t MinSafeInteger = -9007199254740991L;
+  static const int64_t MaxSafeInteger = 9007199254740991L;
+
+ private:
+  void SetValue(const facebook::jsi::Value &value) noexcept;
+
+ private:
+  facebook::jsi::Runtime &m_runtime;
+  const facebook::jsi::Value &m_root;
+
+  // when m_currentPrimitiveValue is not null, the current value is a primitive value
+  // when m_currentPrimitiveValue is null, the current value is the top value of m_nonPrimitiveValues
+  std::optional<facebook::jsi::Value> m_currentPrimitiveValue;
+  std::vector<Continuation> m_nonPrimitiveValues;
+};
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JsiWriter.cpp
+++ b/vnext/Microsoft.ReactNative/JsiWriter.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "JsiWriter.h"
+#include <crash/verifyElseCrash.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+//===========================================================================
+// JsiWriter implementation
+//===========================================================================
+
+JsiWriter::JsiWriter(facebook::jsi::Runtime &runtime) noexcept : m_runtime(runtime) {
+  Push({ContinuationAction::AcceptValueAndFinish});
+}
+
+facebook::jsi::Value JsiWriter::MoveResult() noexcept {
+  VerifyElseCrash(m_continuations.size() == 0);
+  return std::move(m_result);
+}
+
+facebook::jsi::Value JsiWriter::CopyResult() noexcept {
+  VerifyElseCrash(m_continuations.size() == 0);
+  return {m_runtime, m_result};
+}
+
+void JsiWriter::WriteNull() noexcept {
+  WriteValue(facebook::jsi::Value::null());
+}
+
+void JsiWriter::WriteBoolean(bool value) noexcept {
+  WriteValue({value});
+}
+
+void JsiWriter::WriteInt64(int64_t value) noexcept {
+  // JavaScript's integer is not int64_t, need to ensure that the value is in range
+  VerifyElseCrash(MinSafeInteger <= value && value <= MaxSafeInteger);
+
+  // unfortunately JSI only supports int and double for number, choose double here
+  // make sure that doing type conversion in C++ makes no data loss
+  double d = static_cast<double>(value);
+  VerifyElseCrash(floor(d) == d);
+  WriteValue(d);
+}
+
+void JsiWriter::WriteDouble(double value) noexcept {
+  WriteValue({value});
+}
+
+void JsiWriter::WriteString(const winrt::hstring &value) noexcept {
+  WriteValue({m_runtime, facebook::jsi::String::createFromUtf8(m_runtime, winrt::to_string(value))});
+}
+
+void JsiWriter::WriteObjectBegin() noexcept {
+  // legal to create an object when it is accepting a value
+  VerifyElseCrash(Top().Action != ContinuationAction::AcceptPropertyName);
+  Push({ContinuationAction::AcceptPropertyName, {m_runtime, facebook::jsi::Object(m_runtime)}});
+}
+
+void JsiWriter::WritePropertyName(const winrt::hstring &name) noexcept {
+  // legal to set a property name only when AcceptPropertyName
+  auto &top = Top();
+  VerifyElseCrash(top.Action == ContinuationAction::AcceptPropertyName);
+  top.Action = ContinuationAction::AcceptPropertyValue;
+  top.PropertyName = winrt::to_string(name);
+}
+
+void JsiWriter::WriteObjectEnd() noexcept {
+  // legal to finish an object only when AcceptPropertyName
+  VerifyElseCrash(Top().Action == ContinuationAction::AcceptPropertyName);
+  auto createdObject = std::move(Pop().Values.at(0));
+  WriteValue(std::move(createdObject));
+}
+
+void JsiWriter::WriteArrayBegin() noexcept {
+  // legal to create an array only when it is accepting a value
+  VerifyElseCrash(Top().Action != ContinuationAction::AcceptPropertyName);
+  Push({ContinuationAction::AcceptArrayElement});
+}
+
+void JsiWriter::WriteArrayEnd() noexcept {
+  // legal to finish an array only when AcceptArrayElement
+  auto &top = Top();
+  VerifyElseCrash(top.Action == ContinuationAction::AcceptArrayElement);
+  facebook::jsi::Array createdArray(m_runtime, top.Values.size());
+  for (size_t i = 0; i < top.Values.size(); i++) {
+    createdArray.setValueAtIndex(m_runtime, i, std::move(top.Values.at(i)));
+  }
+  Pop();
+  WriteValue({m_runtime, createdArray});
+}
+
+void JsiWriter::WriteValue(facebook::jsi::Value &&value) noexcept {
+  auto &top = Top();
+  switch (top.Action) {
+    case ContinuationAction::AcceptValueAndFinish: {
+      m_result = std::move(value);
+      Pop();
+      VerifyElseCrash(m_continuations.size() == 0);
+      break;
+    }
+    case ContinuationAction::AcceptArrayElement: {
+      top.Values.push_back(std::move(value));
+      break;
+    }
+    case ContinuationAction::AcceptPropertyValue: {
+      auto createdObject = top.Values.at(0).getObject(m_runtime);
+      createdObject.setProperty(m_runtime, top.PropertyName.c_str(), std::move(value));
+      top.Action = ContinuationAction::AcceptPropertyName;
+      top.PropertyName = {};
+      break;
+    }
+    default:
+      VerifyElseCrash(false);
+  }
+}
+
+JsiWriter::Continuation &JsiWriter::Top() noexcept {
+  VerifyElseCrash(m_continuations.size() > 0);
+  return m_continuations[m_continuations.size() - 1];
+}
+
+JsiWriter::Continuation JsiWriter::Pop() noexcept {
+  auto top = std::move(Top());
+  m_continuations.pop_back();
+  return top;
+}
+
+void JsiWriter::Push(Continuation &&continuation) noexcept {
+  m_continuations.push_back(std::move(continuation));
+}
+
+/*static*/ facebook::jsi::Value JsiWriter::ToJsiValue(
+    facebook::jsi::Runtime &runtime,
+    JSValueArgWriter const &argWriter) noexcept {
+  if (argWriter) {
+    IJSValueWriter jsiWriter = winrt::make<JsiWriter>(runtime);
+    argWriter(jsiWriter);
+    return jsiWriter.as<JsiWriter>()->MoveResult();
+  }
+
+  return {};
+}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JsiWriter.h
+++ b/vnext/Microsoft.ReactNative/JsiWriter.h
@@ -1,0 +1,68 @@
+#pragma once
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "jsi/jsi.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+struct JsiWriter : winrt::implements<JsiWriter, IJSValueWriter> {
+  JsiWriter(facebook::jsi::Runtime &runtime) noexcept;
+  facebook::jsi::Value MoveResult() noexcept;
+  facebook::jsi::Value CopyResult() noexcept;
+
+ public: // IJSValueWriter
+  void WriteNull() noexcept;
+  void WriteBoolean(bool value) noexcept;
+  void WriteInt64(int64_t value) noexcept;
+  void WriteDouble(double value) noexcept;
+  void WriteString(const winrt::hstring &value) noexcept;
+  void WriteObjectBegin() noexcept;
+  void WritePropertyName(const winrt::hstring &name) noexcept;
+  void WriteObjectEnd() noexcept;
+  void WriteArrayBegin() noexcept;
+  void WriteArrayEnd() noexcept;
+
+ public:
+  static facebook::jsi::Value ToJsiValue(facebook::jsi::Runtime &runtime, JSValueArgWriter const &argWriter) noexcept;
+
+ private:
+  enum class ContinuationAction {
+    AcceptValueAndFinish,
+    AcceptArrayElement,
+    AcceptPropertyName,
+    AcceptPropertyValue,
+  };
+
+  struct Continuation {
+    ContinuationAction Action;
+    std::vector<facebook::jsi::Value> Values;
+    std::string PropertyName;
+
+    Continuation(ContinuationAction action) noexcept : Action(action) {}
+    Continuation(ContinuationAction action, facebook::jsi::Value &&value) noexcept : Action(action) {
+      Values.push_back(std::move(value));
+    }
+
+    Continuation(const Continuation &) = delete;
+    Continuation(Continuation &&) = default;
+  };
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
+  static const int64_t MinSafeInteger = -9007199254740991L;
+  static const int64_t MaxSafeInteger = 9007199254740991L;
+
+ private:
+  void WriteValue(facebook::jsi::Value &&value) noexcept;
+  Continuation &Top() noexcept;
+  Continuation Pop() noexcept;
+  void Push(Continuation &&continuation) noexcept;
+
+ private:
+  facebook::jsi::Runtime &m_runtime;
+  facebook::jsi::Value m_result;
+  std::vector<Continuation> m_continuations;
+};
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -312,6 +312,12 @@
       <DependentUpon>IReactNotificationService.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="JsiReader.h">
+      <DependentUpon>IJSValueReader.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="JsiWriter.h">
+      <DependentUpon>IJSValueWriter.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="LifecycleState.h" />
     <ClInclude Include="Modules\AppStateModule.h" />
     <ClInclude Include="Modules\ClipboardModule.h" />
@@ -486,6 +492,12 @@
     <ClCompile Include="IReactNotificationService.cpp">
       <DependentUpon>IReactNotificationService.idl</DependentUpon>
       <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="JsiReader.cpp">
+      <DependentUpon>IJSValueReader.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="JsiWriter.cpp">
+      <DependentUpon>IJSValueWriter.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="Modules\AppStateModule.cpp" />
     <ClCompile Include="Modules\ClipboardModule.cpp" />


### PR DESCRIPTION
- Create `JsiReader` and `JsiWriter` for interface `IJSValueReader` and `IJSValueWriter`.
- Try to keep exactly the same behavior as `DynamicReader` and `DynamicWriter`, with a little change, because JSI doesn't support `int64_t`, and doesn't differentiate integer and double.
- The code is not tested, I will finish the unit test in another pull request after I figure out how to run dynamic and jsi in ComponentTests.
- Before `ReactHost`, `ABICxxModule` and `ABIViewManager` have a turbo module version, `JsiReader` and `JsiWriter` will not be called in the project.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5009)