### PR TITLE
[NOT READY FOR MERGE] Do not Create Scratch Git Repo For Non-Upgrade Override Commands

### DIFF
--- a/packages/react-native-platform-override/src/Cli.ts
+++ b/packages/react-native-platform-override/src/Cli.ts
@@ -28,7 +28,7 @@ import {getInstalledRNVersion, getNpmPackage} from './PackageUtils';
 import CrossProcessLock from './CrossProcessLock';
 import GitReactFileRepository from './GitReactFileRepository';
 import OverrideFileRepositoryImpl from './OverrideFileRepositoryImpl';
-import {PackageReactFileRepository} from './PackageReactFileRepository';
+import PackageReactFileRepository from './PackageReactFileRepository';
 
 const UPGRADE_LOCK = 'upgrade-overrides';
 

--- a/packages/react-native-platform-override/src/PackageReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/PackageReactFileRepository.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {ReactFileRepository} from './FileRepository';
+import {getInstalledRNVersion} from './PackageUtils';
+
+const rnPath = path.dirname(require.resolve('react-native/package.json'));
+
+/**
+ * ReactFileRepository pointing to the locally installed package for
+ * react-native.
+ */
+export class PackageReactFileRepository implements ReactFileRepository {
+  async getFileContents(filename: string): Promise<string | null> {
+    const fullPath = path.join(rnPath, filename);
+    try {
+      return (await fs.promises.readFile(fullPath)).toString();
+    } catch {
+      return null;
+    }
+  }
+
+  getVersion(): string {
+    return getInstalledRNVersion();
+  }
+}

--- a/packages/react-native-platform-override/src/PackageReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/PackageReactFileRepository.ts
@@ -17,7 +17,7 @@ const rnPath = path.dirname(require.resolve('react-native/package.json'));
  * ReactFileRepository pointing to the locally installed package for
  * react-native.
  */
-export class PackageReactFileRepository implements ReactFileRepository {
+export default class PackageReactFileRepository implements ReactFileRepository {
   async getFileContents(filename: string): Promise<string | null> {
     const fullPath = path.join(rnPath, filename);
     try {

--- a/packages/react-native-platform-override/src/PackageUtils.ts
+++ b/packages/react-native-platform-override/src/PackageUtils.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
  * Try to find the currently installed React Native version by searching for and
  * reading it's package.json.
  */
-export async function getInstalledRNVersion(): Promise<string> {
+export function getInstalledRNVersion(): string {
   const rnPackage = require('react-native/package.json');
   const version = rnPackage.version;
 
@@ -26,10 +26,10 @@ export async function getInstalledRNVersion(): Promise<string> {
  * Return an object representing the package.json of this package
  */
 export function getNpmPackage(): any {
-  const npmPackageDir = path.join(
+  const npmPackageFile = path.join(
     path.dirname(require.main.filename),
     'package.json',
   );
 
-  return require(npmPackageDir);
+  return require(npmPackageFile);
 }

--- a/packages/react-native-platform-override/src/scripts/generateManifest.ts
+++ b/packages/react-native-platform-override/src/scripts/generateManifest.ts
@@ -30,7 +30,7 @@ const WHITESPACE_PATTERN = /\s/g;
   const spinner = ora();
   spinner.start('Creating manifest');
 
-  const version = await getInstalledRNVersion();
+  const version = getInstalledRNVersion();
   const [overrides, reactSources] = await getFileRepos(ovrPath, version);
   const manifest: ManifestData.Manifest = {overrides: []};
   const overrideFiles = await overrides.listFiles();


### PR DESCRIPTION
Would fix #4860, but we cannot use this yet due to relying on unpublished RNTester and IntegrationTest bits. Putting this into a draft PR to not lose it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5017)