### PR TITLE
Update shared props to have csc emit absolute paths on errors and warnings

### DIFF
--- a/change/react-native-windows-2020-05-28-09-47-11-master.json
+++ b/change/react-native-windows-2020-05-28-09-47-11-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update shared props to have csc emit absolute paths on errors and warnings",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-28T16:47:11.498Z"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <Import
-    Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')))"
-    Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')))" Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
 
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+
+    <!-- This property sets the CscTask to print the full path of the csharp file on errors and warnings rather than just the filename. -->
+    <GenerateFullPaths>true</GenerateFullPaths>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">


### PR DESCRIPTION
This change makes it a lot easier when building from a shell inside common text editors like VsCode. They will allow one to click on the files in the terminal and jump to the file and line,column of the error. 

For example here is a screenshot of the Terminal inside VsCode on an artificially introduced C# error:
![image](https://user-images.githubusercontent.com/11037542/83169844-78deeb80-a0c8-11ea-9e0e-bdfbc3c9bdd3.png)

Of course this also helps when building from command line. This has no effect on the visual studio error list.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5037)