### PR TITLE
Add test cases for (Dynamic|Jsi)(Reader|Writer)

### DIFF
--- a/change/react-native-windows-2020-05-28-14-57-30-pull_request.json
+++ b/change/react-native-windows-2020-05-28-14-57-30-pull_request.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add test cases for (Dynamic|Jsi)(Reader|Writer)",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-28T21:57:30.486Z"
+}

--- a/vnext/Microsoft.ReactNative.ComponentTests/CommonReaderTest.h
+++ b/vnext/Microsoft.ReactNative.ComponentTests/CommonReaderTest.h
@@ -7,13 +7,13 @@ namespace winrt::Microsoft::ReactNative::ReaderTestCases {
 
 // a construction to assert JSValueType::Object without hard-coded property order
 
-inline void TestCheckObject(std::map<hstring, std::function<void()>> props, IJSValueReader &reader) {
+inline void TestCheckObject(const std::map<hstring, std::function<void()>> &props, IJSValueReader &reader) {
   std::set<hstring> propNames;
   hstring propertyName;
 
-  for (int i = 0; i < props.size(); i++) {
+  for (size_t i = 0; i < props.size(); i++) {
     // ensure that we succeeded in reading a property name
-    TestCheckEqual(true, reader.GetNextObjectProperty(propertyName));
+    TestCheck(reader.GetNextObjectProperty(propertyName));
 
     // ensure that we don't get duplicated property names from the reader
     TestCheckEqual(propNames.end(), propNames.find(propertyName));
@@ -21,12 +21,12 @@ inline void TestCheckObject(std::map<hstring, std::function<void()>> props, IJSV
 
     // ensure that the property value is expected
     auto it = props.find(propertyName);
-    TestCheckEqual(true, it != props.end());
+    TestCheck(it != props.end());
     it->second();
   }
 
   // ensure that we read all properties as expected
-  TestCheckEqual(false, reader.GetNextObjectProperty(propertyName));
+  TestCheck(!reader.GetNextObjectProperty(propertyName));
   TestCheckEqual(props.size(), propNames.size());
 }
 
@@ -49,7 +49,7 @@ struct PrimitiveBoolean {
 
   static void Read(IJSValueReader &reader) {
     TestCheckEqual(JSValueType::Boolean, reader.ValueType());
-    TestCheckEqual(false, reader.GetBoolean());
+    TestCheck(!reader.GetBoolean());
   }
 };
 
@@ -98,7 +98,7 @@ struct EmptyArray {
 
   static void Read(IJSValueReader &reader) {
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
   }
 };
 
@@ -112,10 +112,10 @@ struct ArrayWitnOneElement {
 
   static void Read(IJSValueReader &reader) {
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Boolean, reader.ValueType());
-    TestCheckEqual(true, reader.GetBoolean());
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(reader.GetBoolean());
+    TestCheck(!reader.GetNextArrayItem());
   }
 };
 
@@ -132,11 +132,11 @@ struct ArrayWitnMultipleElement {
   static void Read(IJSValueReader &reader) {
     TestCheckEqual(JSValueType::Array, reader.ValueType());
     for (int i = 0; i < 5; i++) {
-      TestCheckEqual(true, reader.GetNextArrayItem());
+      TestCheck(reader.GetNextArrayItem());
       TestCheckEqual(JSValueType::Int64, reader.ValueType());
       TestCheckEqual(i, reader.GetInt64());
     }
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
   }
 };
 
@@ -153,13 +153,13 @@ struct EmptyNestedArray {
 
   static void Read(IJSValueReader &reader) {
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(false, reader.GetNextArrayItem());
-    TestCheckEqual(false, reader.GetNextArrayItem());
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
   }
 };
 
@@ -186,27 +186,27 @@ struct NestedArrayWithPrimitiveValues {
   static void Read(IJSValueReader &reader) {
     TestCheckEqual(JSValueType::Array, reader.ValueType());
 
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Null, reader.ValueType());
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
 
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Boolean, reader.ValueType());
-    TestCheckEqual(true, reader.GetBoolean());
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(reader.GetBoolean());
+    TestCheck(!reader.GetNextArrayItem());
 
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::Int64, reader.ValueType());
     TestCheckEqual(12345, reader.GetInt64());
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
 
-    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheck(!reader.GetNextArrayItem());
   }
 };
 
@@ -220,7 +220,7 @@ struct EmptyObject {
   static void Read(IJSValueReader &reader) {
     hstring propertyName;
     TestCheckEqual(JSValueType::Object, reader.ValueType());
-    TestCheckEqual(false, reader.GetNextObjectProperty(propertyName));
+    TestCheck(!reader.GetNextObjectProperty(propertyName));
   }
 };
 
@@ -244,7 +244,7 @@ struct SimpleObject {
          {L"b",
           [&]() {
             TestCheckEqual(JSValueType::Boolean, reader.ValueType());
-            TestCheckEqual(true, reader.GetBoolean());
+            TestCheck(reader.GetBoolean());
           }},
          {L"c",
           [&]() {
@@ -282,11 +282,11 @@ struct NestedObjectWithPrimitiveValues {
       ++index;
       assertions.insert({prop, [&, index]() {
                            TestCheckEqual(JSValueType::Object, reader.ValueType());
-                           TestCheckEqual(true, reader.GetNextObjectProperty(propertyName));
+                           TestCheck(reader.GetNextObjectProperty(propertyName));
                            TestCheckEqual(L"x", propertyName);
                            TestCheckEqual(JSValueType::Int64, reader.ValueType());
                            TestCheckEqual(index, reader.GetInt64());
-                           TestCheckEqual(false, reader.GetNextObjectProperty(propertyName));
+                           TestCheck(!reader.GetNextObjectProperty(propertyName));
                          }});
     }
 
@@ -303,9 +303,9 @@ struct NestedObjectWithPrimitiveValues {
 // on DynamicReader+DynamicWriter and JsiReader+JsiWriter
 // in this way we ensure that two implementation behaves exactly the same
 
-#define IMPORT_READER_TEST_CASE(NAME)       \
-  TEST_METHOD(NAME) {                       \
-    RunReaderTest<ReaderTestCases::NAME>(); \
+#define IMPORT_READER_TEST_CASE(name)       \
+  TEST_METHOD(name) {                       \
+    RunReaderTest<ReaderTestCases::name>(); \
   }
 
 #define IMPORT_READER_TEST_CASES                          \

--- a/vnext/Microsoft.ReactNative.ComponentTests/CommonReaderTest.h
+++ b/vnext/Microsoft.ReactNative.ComponentTests/CommonReaderTest.h
@@ -1,0 +1,324 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative::ReaderTestCases {
+
+// a construction to assert JSValueType::Object without hard-coded property order
+
+inline void TestCheckObject(std::map<hstring, std::function<void()>> props, IJSValueReader &reader) {
+  std::set<hstring> propNames;
+  hstring propertyName;
+
+  for (int i = 0; i < props.size(); i++) {
+    // ensure that we succeeded in reading a property name
+    TestCheckEqual(true, reader.GetNextObjectProperty(propertyName));
+
+    // ensure that we don't get duplicated property names from the reader
+    TestCheckEqual(propNames.end(), propNames.find(propertyName));
+    propNames.insert(propertyName);
+
+    // ensure that the property value is expected
+    auto it = props.find(propertyName);
+    TestCheckEqual(true, it != props.end());
+    it->second();
+  }
+
+  // ensure that we read all properties as expected
+  TestCheckEqual(false, reader.GetNextObjectProperty(propertyName));
+  TestCheckEqual(props.size(), propNames.size());
+}
+
+// null
+struct PrimitiveNull {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteNull();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Null, reader.ValueType());
+  }
+};
+
+// false
+struct PrimitiveBoolean {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteBoolean(false);
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Boolean, reader.ValueType());
+    TestCheckEqual(false, reader.GetBoolean());
+  }
+};
+
+// 12345
+struct PrimitiveInt {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteInt64(12345);
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Int64, reader.ValueType());
+    TestCheckEqual(12345, reader.GetInt64());
+  }
+};
+
+// 0.5
+struct PrimitiveDouble {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteDouble(0.5);
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Double, reader.ValueType());
+    TestCheckEqual(0.5, reader.GetDouble());
+  }
+};
+
+// "This is a string"
+struct PrimitiveString {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteString(L"This is a string");
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"This is a string", reader.GetString());
+  }
+};
+
+// []
+struct EmptyArray {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteArrayBegin();
+    writer.WriteArrayEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+  }
+};
+
+// [true]
+struct ArrayWitnOneElement {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteArrayBegin();
+    writer.WriteBoolean(true);
+    writer.WriteArrayEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Boolean, reader.ValueType());
+    TestCheckEqual(true, reader.GetBoolean());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+  }
+};
+
+// [0, 1, 2, 3, 4]
+struct ArrayWitnMultipleElement {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteArrayBegin();
+    for (int i = 0; i < 5; i++) {
+      writer.WriteInt64(i);
+    }
+    writer.WriteArrayEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    for (int i = 0; i < 5; i++) {
+      TestCheckEqual(true, reader.GetNextArrayItem());
+      TestCheckEqual(JSValueType::Int64, reader.ValueType());
+      TestCheckEqual(i, reader.GetInt64());
+    }
+    TestCheckEqual(false, reader.GetNextArrayItem());
+  }
+};
+
+// [[[]]]
+struct EmptyNestedArray {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteArrayBegin();
+    writer.WriteArrayBegin();
+    writer.WriteArrayBegin();
+    writer.WriteArrayEnd();
+    writer.WriteArrayEnd();
+    writer.WriteArrayEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+  }
+};
+
+// [[null], [true], [12345]]
+struct NestedArrayWithPrimitiveValues {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteArrayBegin();
+
+    writer.WriteArrayBegin();
+    writer.WriteNull();
+    writer.WriteArrayEnd();
+
+    writer.WriteArrayBegin();
+    writer.WriteBoolean(true);
+    writer.WriteArrayEnd();
+
+    writer.WriteArrayBegin();
+    writer.WriteInt64(12345);
+    writer.WriteArrayEnd();
+
+    writer.WriteArrayEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Null, reader.ValueType());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Boolean, reader.ValueType());
+    TestCheckEqual(true, reader.GetBoolean());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+    TestCheckEqual(true, reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Int64, reader.ValueType());
+    TestCheckEqual(12345, reader.GetInt64());
+    TestCheckEqual(false, reader.GetNextArrayItem());
+
+    TestCheckEqual(false, reader.GetNextArrayItem());
+  }
+};
+
+// {}
+struct EmptyObject {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteObjectBegin();
+    writer.WriteObjectEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    hstring propertyName;
+    TestCheckEqual(JSValueType::Object, reader.ValueType());
+    TestCheckEqual(false, reader.GetNextObjectProperty(propertyName));
+  }
+};
+
+// {a:null, b:true, c:12345}
+struct SimpleObject {
+  static void Write(IJSValueWriter &writer) {
+    writer.WriteObjectBegin();
+    writer.WritePropertyName(L"a");
+    writer.WriteNull();
+    writer.WritePropertyName(L"b");
+    writer.WriteBoolean(true);
+    writer.WritePropertyName(L"c");
+    writer.WriteInt64(12345);
+    writer.WriteObjectEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    TestCheckEqual(JSValueType::Object, reader.ValueType());
+    TestCheckObject(
+        {{L"a", [&]() { TestCheckEqual(JSValueType::Null, reader.ValueType()); }},
+         {L"b",
+          [&]() {
+            TestCheckEqual(JSValueType::Boolean, reader.ValueType());
+            TestCheckEqual(true, reader.GetBoolean());
+          }},
+         {L"c",
+          [&]() {
+            TestCheckEqual(JSValueType::Int64, reader.ValueType());
+            TestCheckEqual(12345, reader.GetInt64());
+          }}},
+        reader);
+  }
+};
+
+// {a:{x:1}, b:{x:2}, c:{x:3} ,d:{x:4}, e:{x:5}}
+struct NestedObjectWithPrimitiveValues {
+  static void Write(IJSValueWriter &writer) {
+    hstring props[] = {L"a", L"b", L"c", L"d", L"e"};
+    int index = 0;
+
+    writer.WriteObjectBegin();
+    for (auto prop : props) {
+      writer.WritePropertyName(prop);
+      writer.WriteObjectBegin();
+      writer.WritePropertyName(L"x");
+      writer.WriteInt64(++index);
+      writer.WriteObjectEnd();
+    }
+    writer.WriteObjectEnd();
+  }
+
+  static void Read(IJSValueReader &reader) {
+    hstring props[] = {L"a", L"b", L"c", L"d", L"e"};
+    int index = 0;
+
+    hstring propertyName;
+    std::map<hstring, std::function<void()>> assertions;
+    for (auto prop : props) {
+      ++index;
+      assertions.insert({prop, [&, index]() {
+                           TestCheckEqual(JSValueType::Object, reader.ValueType());
+                           TestCheckEqual(true, reader.GetNextObjectProperty(propertyName));
+                           TestCheckEqual(L"x", propertyName);
+                           TestCheckEqual(JSValueType::Int64, reader.ValueType());
+                           TestCheckEqual(index, reader.GetInt64());
+                           TestCheckEqual(false, reader.GetNextObjectProperty(propertyName));
+                         }});
+    }
+
+    TestCheckEqual(JSValueType::Object, reader.ValueType());
+    TestCheckObject(assertions, reader);
+  }
+};
+
+//
+
+} // namespace winrt::Microsoft::ReactNative::ReaderTestCases
+
+// IMPORT_READER_TEST_CASES macro runs the same set of test cases
+// on DynamicReader+DynamicWriter and JsiReader+JsiWriter
+// in this way we ensure that two implementation behaves exactly the same
+
+#define IMPORT_READER_TEST_CASE(NAME)       \
+  TEST_METHOD(NAME) {                       \
+    RunReaderTest<ReaderTestCases::NAME>(); \
+  }
+
+#define IMPORT_READER_TEST_CASES                          \
+  IMPORT_READER_TEST_CASE(PrimitiveNull)                  \
+  IMPORT_READER_TEST_CASE(PrimitiveBoolean)               \
+  IMPORT_READER_TEST_CASE(PrimitiveInt)                   \
+  IMPORT_READER_TEST_CASE(PrimitiveDouble)                \
+  IMPORT_READER_TEST_CASE(PrimitiveString)                \
+  IMPORT_READER_TEST_CASE(EmptyArray)                     \
+  IMPORT_READER_TEST_CASE(ArrayWitnOneElement)            \
+  IMPORT_READER_TEST_CASE(ArrayWitnMultipleElement)       \
+  IMPORT_READER_TEST_CASE(EmptyNestedArray)               \
+  IMPORT_READER_TEST_CASE(NestedArrayWithPrimitiveValues) \
+  IMPORT_READER_TEST_CASE(EmptyObject)                    \
+  IMPORT_READER_TEST_CASE(SimpleObject)                   \
+  IMPORT_READER_TEST_CASE(NestedObjectWithPrimitiveValues)

--- a/vnext/Microsoft.ReactNative.ComponentTests/DynamicReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.ComponentTests/DynamicReaderTest.cpp
@@ -2,16 +2,23 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-
-#undef max
-#undef min
+#include <DynamicReader.h>
+#include <DynamicWriter.h>
+#include "CommonReaderTest.h"
 
 namespace winrt::Microsoft::ReactNative {
 
 TEST_CLASS (DynamicReaderTest) {
-  TEST_METHOD(EmptyTest) {
-    TestCheckEqual(1, 1);
+  template <typename TCase>
+  void RunReaderTest() {
+    IJSValueWriter writer = winrt::make<DynamicWriter>();
+    TCase::Write(writer);
+    auto dynamicValue = writer.as<DynamicWriter>()->TakeValue();
+    IJSValueReader reader = winrt::make<DynamicReader>(dynamicValue);
+    TCase::Read(reader);
   }
+
+  IMPORT_READER_TEST_CASES
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.ComponentTests/JsiReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.ComponentTests/JsiReaderTest.cpp
@@ -5,37 +5,24 @@
 #include <ChakraRuntime.h>
 #include <JsiReader.h>
 #include <JsiWriter.h>
-
-#undef max
-#undef min
+#include "CommonReaderTest.h"
 
 namespace winrt::Microsoft::ReactNative {
 
 TEST_CLASS (JsiReaderTest) {
-  TEST_METHOD(DummyTest) {
-    // just to make sure the code can execute
-    // this will be deleted and replaces by real test cases in the next pull request
+  ::Microsoft::JSI::ChakraRuntime m_runtime;
 
-    ::Microsoft::JSI::ChakraRuntime runtime(::Microsoft::JSI::ChakraRuntimeArgs{});
+  JsiReaderTest() : m_runtime({}) {}
 
-    IJSValueWriter writer = winrt::make<JsiWriter>(runtime);
-    writer.WriteArrayBegin();
-    writer.WriteBoolean(true);
-    writer.WriteInt64(0);
-    writer.WriteArrayEnd();
-
-    IJSValueReader reader = winrt::make<JsiReader>(runtime, writer.as<JsiWriter>()->MoveResult());
-
-    TestCheckEqual(JSValueType::Array, reader.ValueType());
-    TestCheckEqual(true, reader.GetNextArrayItem());
-    TestCheckEqual(JSValueType::Boolean, reader.ValueType());
-    TestCheckEqual(true, reader.GetBoolean());
-    TestCheckEqual(true, reader.GetNextArrayItem());
-    TestCheckEqual(JSValueType::Int64, reader.ValueType());
-    TestCheckEqual(0, reader.GetInt64());
-    TestCheckEqual(false, reader.GetNextArrayItem());
-    TestCheckEqual(JSValueType::Null, reader.ValueType());
+  template <typename TCase>
+  void RunReaderTest() {
+    IJSValueWriter writer = winrt::make<JsiWriter>(m_runtime);
+    TCase::Write(writer);
+    IJSValueReader reader = winrt::make<JsiReader>(m_runtime, writer.as<JsiWriter>()->MoveResult());
+    TCase::Read(reader);
   }
+
+  IMPORT_READER_TEST_CASES
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="pch/pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClInclude Include="CommonReaderTest.h" />
     <ClInclude Include="pch/pch.h" />
   </ItemGroup>
   <ItemGroup>
@@ -196,8 +197,8 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IJSValueWriter.idl" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="$(ReactNativeWindowsDir)ReactWindowsCore\tracing\fbsystrace.h"/>
-    <ClCompile Include="$(ReactNativeWindowsDir)ReactWindowsCore\tracing\tracing.cpp"/>
+    <ClInclude Include="$(ReactNativeWindowsDir)ReactWindowsCore\tracing\fbsystrace.h" />
+    <ClCompile Include="$(ReactNativeWindowsDir)ReactWindowsCore\tracing\tracing.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Base\FollyIncludes.h" />

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj.filters
@@ -62,5 +62,8 @@
     <ClInclude Include="$(ReactNativeWindowsDir)ReactWindowsCore\tracing\fbsystrace.h">
       <Filter>ExternalFiles\ReactWindowsCore</Filter>
     </ClInclude>
+    <ClInclude Include="CommonReaderTest.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Test cases added to Microsoft.ReactNative.ComponentTests
- Test cases executed by writing thing to the writer, and then read them out of the reader
- `Dynamic*` and `Jsi*` execute exactly the same set of test cases, to ensure that they behaves the same to each other.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5046)