### PR TITLE
Block all ProjectImports.zip files

### DIFF
--- a/change/react-native-windows-2020-05-28-23-34-14-projectImports.json
+++ b/change/react-native-windows-2020-05-28-23-34-14-projectImports.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "blacklist all ProjectImports.zip",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-29T06:34:13.953Z"
+}

--- a/packages/E2ETest/metro.config.js
+++ b/packages/E2ETest/metro.config.js
@@ -24,7 +24,8 @@ module.exports = {
       'react-native-windows': rnwPath,
     },
     blacklistRE: blacklist([
-      new RegExp('.*E2ETest/msbuild.*'.replace(/[/\\]/g, '\\/')), // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\E2ETest\msbuild.ProjectImports.zip' in pipeline
+      // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\E2ETest\msbuild.ProjectImports.zip' in pipeline
+      /.*\.ProjectImports\.zip/,
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`

--- a/packages/microsoft-reactnative-sampleapps/metro.config.js
+++ b/packages/microsoft-reactnative-sampleapps/metro.config.js
@@ -23,9 +23,8 @@ module.exports = {
       'react-native-windows': rnwPath,
     },
     blacklistRE: blacklist([
-      new RegExp(
-        '.*microsoft-reactnative-sampleapps/msbuild.*'.replace(/[/\\]/g, '\\/'),
-      ), // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\E2ETest\msbuild.ProjectImports.zip' in pipeline
+      // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\E2ETest\msbuild.ProjectImports.zip' in pipeline
+      /.*\.ProjectImports\.zip/,
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -27,6 +27,9 @@ module.exports = {
       'react-native-windows': rnwPath,
     },
     blacklistRE: blacklist([
+      // Avoid error EBUSY: resource busy or locked, open 'D:\a\1\s\packages\playground\msbuild.ProjectImports.zip' in pipeline
+      /.*\.ProjectImports\.zip/,
+
       // This stops "react-native run-windows" from causing the metro server to crash if its already running
       new RegExp(
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,

--- a/vnext/local-cli/generator-windows/templates/metro.config.js
+++ b/vnext/local-cli/generator-windows/templates/metro.config.js
@@ -15,11 +15,7 @@ module.exports = {
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
       ),
       // This prevents "react-native run-windows" from hitting: EBUSY: resource busy or locked, open msbuild.ProjectImports.zip
-      new RegExp(
-        `${path
-          .resolve(__dirname, 'msbuild.ProjectImports.zip')
-          .replace(/[/\\]/g, '/')}.*`,
-      ),
+      /.*\.ProjectImports\.zip/,
     ]),
   },
   transformer: {


### PR DESCRIPTION
Fixes #5033 - at least the ProjectImports.zip part :)
Grab yourselves a chair because this is a doozy.
We've seen intermittent reports of Metro bundler hitting file-in-use errors on `msbuild.ProjectImports.zip` and similar. However there are no such files... WTH is going on and who is creating these files?!

We invoke MSBuild with the `/bl` flag to produce binary logs that we can inspect should something go wrong while building. These binary logs include all the commands that the build ran as well as all of the project files, props, targets, etc. that were imported. You can control whether the imported files are included in the `.binlog` file by choosing whether you want to `Embed` the imports (this is the default), create a separate zip file (`ZipFile`) or not include the imports at all (`None`) by specifying something like `/bl:ProjectImports=None`, etc.

We don't specify any `ProjectImports` flag so we are getting the default (`Embed`). So why is Metro complaining? Well, after looking through the MSBuild code, it turns out that the way this is implemented in MSBuild is that the zip file is created, msbuild writes to it as the build progresses, and then when it's about to finish it closes the file, reads all its contents and writes the contents into the binlog, then deletes the file. This approach will create file contention obviously.
[Relevant MSBuild code](https://github.com/microsoft/msbuild/blob/5cb677292e0fe6f9db973d416ea866332833c306/src/Build/Logging/BinaryLogger/BinaryLogger.cs#L187)

So then the question is but why does Metro care about this file? Why is it even monitoring it?
It turns out Metro has a set of asset and source extensions that are configurable (see [configuration](https://facebook.github.io/metro/docs/configuration)). The default Metro set of asset extensions however, includes zip files: [Default metro configuration](https://github.com/facebook/metro/blob/3e2d9116d8a7f2580dcda51990cca5b3d98a81ff/packages/metro-config/src/defaults/defaults.js#L49)

This change updates our `metro.config.js` files to ignore all `*.ProjectImports.zip` files, not just `msbuild.ProjectImports.zip`. Note that the prefix is given by the name of the binary log file, which is why we started seeing errors about `Deploy.ProjectImports.zip` too.

I've also filed a [doc bug](https://github.com/MicrosoftDocs/visualstudio-docs/issues/5388) and a [product bug](https://github.com/microsoft/msbuild/issues/5383) against MSBuild

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5050)