### PR TITLE
Docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+# This is a basic workflow to help you get started with Actions
+
+name: docsCI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: run unbroken
+      run: |
+        npx unbroken -q -l

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,4 +23,4 @@ jobs:
     # Runs a single command using the runners shell
     - name: run unbroken
       run: |
-        npx unbroken -q -l
+        npx unbroken -q

--- a/.unbroken_exclusions
+++ b/.unbroken_exclusions
@@ -1,0 +1,14 @@
+!node_modules
+!vnext/packages
+!vnext/ReactCopies
+!packages/react-native-platform-override/node_modules
+!packages/override-tools/node_modules
+!packages/react-native-win32/node_modules
+!packages/E2ETest/node_modules
+!packages/microsoft-reactnative-sampleapps/node_modules
+!packages/playground/node_modules
+!packages/react-native-windows-codegen/node_modules
+!packages/react-native-windows-init/node_modules
+!packages/rnpm-plugin-windows/node_modules
+!packages/scripts/node_modules
+!.github/ISSUE_TEMPLATE

--- a/change/react-native-windows-2020-05-29-11-44-59-docsCI.json
+++ b/change/react-native-windows-2020-05-29-11-44-59-docsCI.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "docs CI",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-29T18:44:59.796Z"
+}

--- a/docs/building-rnw.md
+++ b/docs/building-rnw.md
@@ -1,7 +1,7 @@
 
 # Building React-Native-Windows
 
-- Make sure you have installed [dependencies](./GettingStarted.md#dependencies)
+- Make sure you have installed [dependencies](https://microsoft.github.io/react-native-windows/docs/next/rnw-dependencies). Just run `vnext\scripts\rnw-dependencies.ps1` in an elevated PowerShell session.
 - Install [Git](https://git-scm.com/download/win) if you don't have it installed in your development machine
 
 ## Build Steps
@@ -16,7 +16,7 @@
     yarn
     yarn build
     ```
-Note that react-native-windows is a monorepo and relies on monorepo tools like yarn and lerna.  See [this page](https://github.com/microsoft/react-native-windows/blob/master/vnext/docs/Monorepo.md) for more details.
+Note that react-native-windows is a monorepo and relies on monorepo tools like yarn and lerna.  See [this page](Monorepo.md) for more details.
 
 # Running the Playground app
   There are two ways to run the app.  In a fully managed easy way, or by manually running all the required steps:

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -245,7 +245,7 @@ Option 2 is for advance user only. Each time we release a new WinAppDriver, we a
 
 If `yarn install` is run as admin privilege, WinAppDriver would be installed automatically, otherwise you need to install WinAppDriver manually.
 
-For the Azure pipeline, WinAppDriver is already installed on  [HostedVS2019](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md) and [HostedVS2017](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2017-Server2016-Readme.md)
+For the Azure pipeline, WinAppDriver is already installed on  [HostedVS2019](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md) and [HostedVS2017](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2016-Readme.md)
 
 
 ## Bundle

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -4,7 +4,7 @@ Playground is a sample standalone application that allows testing of various JS 
 
 ## Launching the app
 
-1. Make sure your development machine has been set up with all the system requirements and dependencies mentioned [here](https://github.com/microsoft/react-native-windows/blob/master/vnext/docs/GettingStarted.md). Make sure a browser is launched and running.
+1. Make sure your development machine has been set up with all the system requirements and dependencies mentioned [here](https://microsoft.github.io/react-native-windows/docs/next/rnw-dependencies). Make sure a browser is launched and running.
 
 1. Install Packages with-in the repo
 

--- a/vnext/proposals/readme.md
+++ b/vnext/proposals/readme.md
@@ -13,7 +13,7 @@ The proposal process here takes its inspiration from the react-native-community 
 
 ## Proposal process
 
-1. Follow the steps outlined in [Contribution guidelines](https://github.com/microsoft/react-native-windows/blob/master/vnext/docs/CONTRIBUTING.md) to set up your fork and branch to begin contributing.
+1. Follow the steps outlined in [Contribution guidelines](../../docs/contributing.md) to set up your fork and branch to begin contributing.
 
 2. Create a new folder for your proposal under the [active](active/readme.md) folder
 


### PR DESCRIPTION
Fixes #4339 
We add a CI job to verify that there are no broken links in the in-repo markdown files, by using [unbroken](http://npmjs.org/package/unbroken). The exclusion file just lists which folders to avoid checking.
Also fixing some already-broken links

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5056)