### PR TITLE
Expose turbo module registry API

### DIFF
--- a/change/react-native-windows-2020-06-01-15-09-20-pull_request.json
+++ b/change/react-native-windows-2020-06-01-15-09-20-pull_request.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "Expose turbo module registry API",
   "packageName": "react-native-windows",
   "email": "zihanc@microsoft.com",

--- a/change/react-native-windows-2020-06-01-15-09-20-pull_request.json
+++ b/change/react-native-windows-2020-06-01-15-09-20-pull_request.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Expose turbo module registry API",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-01T22:09:20.171Z"
+}

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -20,7 +20,7 @@ Playground is a sample standalone application that allows testing of various JS 
 
 1. Run the app
 
-`yarn windows`
+`yarn windows --sln windows\Playground.sln`
 
 This command will build and deploy the application along with launching Metro bundler and the dev tools.
 

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -14,6 +14,11 @@ namespace Microsoft.ReactNative {
   interface IReactPackageBuilder {
     void AddModule(String moduleName, ReactModuleProvider moduleProvider);
     void AddViewManager(String viewManagerName, ReactViewManagerProvider viewManagerProvider);
+  }
+
+  [webhosthidden]
+  interface IReactPackageBuilderExperimental
+    requires IReactPackageBuilder {
     void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -14,5 +14,6 @@ namespace Microsoft.ReactNative {
   interface IReactPackageBuilder {
     void AddModule(String moduleName, ReactModuleProvider moduleProvider);
     void AddViewManager(String viewManagerName, ReactViewManagerProvider viewManagerProvider);
+    void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -324,6 +324,7 @@
     <ClInclude Include="Modules\DevSettingsModule.h" />
     <ClInclude Include="Modules\I18nManagerModule.h" />
     <ClInclude Include="NativeModulesProvider.h" />
+    <ClInclude Include="TurboModulesProvider.h" />
     <ClInclude Include="Pch\pch.h" />
     <ClInclude Include="ReactApplication.h">
       <DependentUpon>ReactApplication.idl</DependentUpon>
@@ -501,6 +502,7 @@
     <ClCompile Include="Modules\DevSettingsModule.cpp" />
     <ClCompile Include="Modules\I18nManagerModule.cpp" />
     <ClCompile Include="NativeModulesProvider.cpp" />
+    <ClCompile Include="TurboModulesProvider.cpp" />
     <ClCompile Include="Pch\pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -277,6 +277,7 @@
       <Filter>Modules</Filter>
     </ClCompile>
     <ClCompile Include="NativeModulesProvider.cpp" />
+    <ClCompile Include="TurboModulesProvider.cpp" />
     <ClCompile Include="Pch\pch.cpp">
       <Filter>Pch</Filter>
     </ClCompile>
@@ -619,6 +620,7 @@
       <Filter>Modules</Filter>
     </ClInclude>
     <ClInclude Include="NativeModulesProvider.h" />
+    <ClInclude Include="TurboModulesProvider.h" />
     <ClInclude Include="Pch\pch.h">
       <Filter>Pch</Filter>
     </ClInclude>

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
@@ -16,18 +16,19 @@ void Clipboard::getString(React::ReactPromise<React::JSValue> result) noexcept {
   auto jsDispatcher = m_reactContext.JSDispatcher();
   auto promise = result;
   m_reactContext.UIDispatcher().Post(
-      [=]() -> winrt::fire_and_forget {
+      [jsDispatcher, promise]() -> winrt::fire_and_forget {
         auto jsDispatcher2 = jsDispatcher;
         auto promise2 = promise;
         winrt::Windows::ApplicationModel::DataTransfer::DataPackageView data =
             winrt::Windows::ApplicationModel::DataTransfer::Clipboard::GetContent();
         try {
           std::wstring text = std::wstring(co_await data.GetTextAsync());
-          jsDispatcher2.Post([=] { promise2.Resolve(React::JSValue{Microsoft::Common::Unicode::Utf16ToUtf8(text)}); });
+          jsDispatcher2.Post(
+              [promise2, text] { promise2.Resolve(React::JSValue{Microsoft::Common::Unicode::Utf16ToUtf8(text)}); });
         } catch (winrt::hresult_error const &e) {
-          jsDispatcher2.Post([=] { promise2.Reject(std::wstring(e.message()).c_str()); });
+          jsDispatcher2.Post([promise2, e] { promise2.Reject(std::wstring(e.message()).c_str()); });
         } catch (...) {
-          jsDispatcher2.Post([=] { promise2.Reject(React::ReactError()); });
+          jsDispatcher2.Post([promise2] { promise2.Reject(React::ReactError()); });
         }
       } // namespace Microsoft::ReactNative
   );

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
@@ -8,23 +8,37 @@
 
 namespace Microsoft::ReactNative {
 
-/* static */ winrt::fire_and_forget Clipboard::getString(React::ReactPromise<React::JSValue> result) noexcept {
-  winrt::Windows::ApplicationModel::DataTransfer::DataPackageView data =
-      winrt::Windows::ApplicationModel::DataTransfer::Clipboard::GetContent();
-  try {
-    std::wstring text = std::wstring(co_await data.GetTextAsync());
-    result.Resolve(React::JSValue{Microsoft::Common::Unicode::Utf16ToUtf8(text)});
-  } catch (winrt::hresult_error const &e) {
-    result.Reject(std::wstring(e.message()).c_str());
-  } catch (...) {
-    result.Reject(React::ReactError());
-  }
+void Clipboard::Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
+  m_reactContext = reactContext;
 }
 
-/* static */ void Clipboard::setString(std::string content) noexcept {
-  winrt::Windows::ApplicationModel::DataTransfer::DataPackage data;
-  data.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(content));
-  winrt::Windows::ApplicationModel::DataTransfer::Clipboard::SetContent(data);
+void Clipboard::getString(React::ReactPromise<React::JSValue> result) noexcept {
+  auto jsDispatcher = m_reactContext.JSDispatcher();
+  auto promise = result;
+  m_reactContext.UIDispatcher().Post(
+      [=]() -> winrt::fire_and_forget {
+        auto jsDispatcher2 = jsDispatcher;
+        auto promise2 = promise;
+        winrt::Windows::ApplicationModel::DataTransfer::DataPackageView data =
+            winrt::Windows::ApplicationModel::DataTransfer::Clipboard::GetContent();
+        try {
+          std::wstring text = std::wstring(co_await data.GetTextAsync());
+          jsDispatcher2.Post([=] { promise2.Resolve(React::JSValue{Microsoft::Common::Unicode::Utf16ToUtf8(text)}); });
+        } catch (winrt::hresult_error const &e) {
+          jsDispatcher2.Post([=] { promise2.Reject(std::wstring(e.message()).c_str()); });
+        } catch (...) {
+          jsDispatcher2.Post([=] { promise2.Reject(React::ReactError()); });
+        }
+      } // namespace Microsoft::ReactNative
+  );
+}
+
+void Clipboard::setString(std::string content) noexcept {
+  m_reactContext.UIDispatcher().Post([=] {
+    winrt::Windows::ApplicationModel::DataTransfer::DataPackage data;
+    data.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(content));
+    winrt::Windows::ApplicationModel::DataTransfer::Clipboard::SetContent(data);
+  });
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
@@ -8,11 +8,16 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(Clipboard)
 struct Clipboard {
+  REACT_INIT(Initialize)
+  void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
+
   REACT_METHOD(getString)
-  static winrt::fire_and_forget getString(React::ReactPromise<React::JSValue> result) noexcept;
+  void getString(React::ReactPromise<React::JSValue> result) noexcept;
 
   REACT_METHOD(setString)
-  static void setString(std::string content) noexcept;
+  void setString(std::string content) noexcept;
+
+  winrt::Microsoft::ReactNative::ReactContext m_reactContext;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -15,6 +15,7 @@
 #include "future/future.h"
 
 #include <NativeModuleProvider.h>
+#include <TurboModulesProvider.h>
 
 #ifdef CORE_ABI
 #include <folly/dynamic.h>
@@ -142,6 +143,7 @@ struct ReactOptions {
 
   std::shared_ptr<NativeModuleProvider2> ModuleProvider;
   std::shared_ptr<ViewManagerProvider2> ViewManagerProvider;
+  std::shared_ptr<winrt::Microsoft::ReactNative::TurboModulesProvider> TurboModuleProvider;
 
   //! Identity of the SDX. Must uniquely describe the SDX across the installed product.
   std::string Identity;

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -55,11 +55,11 @@ IAsyncAction ReactNativeHost::LoadInstance() noexcept {
 IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
 #ifndef CORE_ABI
   auto modulesProvider = std::make_shared<NativeModulesProvider>();
-
   auto viewManagersProvider = std::make_shared<ViewManagersProvider>();
+  auto turboModulesProvider = std::make_shared<TurboModulesProvider>();
 
   if (!m_packageBuilder) {
-    m_packageBuilder = make<ReactPackageBuilder>(modulesProvider, viewManagersProvider);
+    m_packageBuilder = make<ReactPackageBuilder>(modulesProvider, viewManagersProvider, turboModulesProvider);
 
     if (auto packageProviders = InstanceSettings().PackageProviders()) {
       for (auto const &packageProvider : packageProviders) {
@@ -113,6 +113,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
 
   reactOptions.ModuleProvider = modulesProvider;
   reactOptions.ViewManagerProvider = viewManagersProvider;
+  reactOptions.TurboModuleProvider = turboModulesProvider;
 
   std::string jsBundleFile = to_string(m_instanceSettings.JavaScriptBundleFile());
   std::string jsMainModuleName = to_string(m_instanceSettings.JavaScriptMainModuleName());

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -12,8 +12,11 @@ namespace winrt::Microsoft::ReactNative {
 
 ReactPackageBuilder::ReactPackageBuilder(
     std::shared_ptr<NativeModulesProvider> const &modulesProvider,
-    std::shared_ptr<ViewManagersProvider> const &viewManagersProvider) noexcept
-    : m_modulesProvider{modulesProvider}, m_viewManagersProvider{viewManagersProvider} {}
+    std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
+    std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept
+    : m_modulesProvider{modulesProvider},
+      m_viewManagersProvider{viewManagersProvider},
+      m_turboModulesProvider{turboModulesProvider} {}
 
 void ReactPackageBuilder::AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept {
   m_modulesProvider->AddModuleProvider(moduleName, moduleProvider);
@@ -23,6 +26,12 @@ void ReactPackageBuilder::AddViewManager(
     hstring const &viewManagerName,
     ReactViewManagerProvider const &viewManagerProvider) noexcept {
   m_viewManagersProvider->AddViewManagerProvider(viewManagerName, viewManagerProvider);
+}
+
+void ReactPackageBuilder::AddTurboModule(
+    hstring const &moduleName,
+    ReactModuleProvider const &moduleProvider) noexcept {
+  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -9,7 +9,8 @@
 
 namespace winrt::Microsoft::ReactNative {
 
-struct ReactPackageBuilder : winrt::implements<ReactPackageBuilder, IReactPackageBuilder> {
+struct ReactPackageBuilder
+    : winrt::implements<ReactPackageBuilder, IReactPackageBuilder, IReactPackageBuilderExperimental> {
   ReactPackageBuilder(
       std::shared_ptr<NativeModulesProvider> const &modulesProvider,
       std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 #include "NativeModulesProvider.h"
+#include "TurboModulesProvider.h"
 #include "ViewManagersProvider.h"
 #include "winrt/Microsoft.ReactNative.h"
 
@@ -11,15 +12,18 @@ namespace winrt::Microsoft::ReactNative {
 struct ReactPackageBuilder : winrt::implements<ReactPackageBuilder, IReactPackageBuilder> {
   ReactPackageBuilder(
       std::shared_ptr<NativeModulesProvider> const &modulesProvider,
-      std::shared_ptr<ViewManagersProvider> const &viewManagersProvider) noexcept;
+      std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
+      std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept;
 
  public: // IReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
   void AddViewManager(hstring const &viewManagerName, ReactViewManagerProvider const &viewManagerProvider) noexcept;
+  void AddTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
 
  private:
   std::shared_ptr<NativeModulesProvider> m_modulesProvider;
   std::shared_ptr<ViewManagersProvider> m_viewManagersProvider;
+  std::shared_ptr<TurboModulesProvider> m_turboModulesProvider;
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "TurboModulesProvider.h"
+#include <ReactCommon/TurboModuleUtils.h>
+#include "JsiReader.h"
+#include "JsiWriter.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace winrt::Microsoft::ReactNative {
+/*-------------------------------------------------------------------------------
+  TurboModuleBuilder
+-------------------------------------------------------------------------------*/
+
+struct TurboModuleMethodInfo {
+  MethodReturnType ReturnType;
+  MethodDelegate Method;
+};
+
+struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBuilder> {
+  TurboModuleBuilder(const IReactContext &reactContext) noexcept : m_reactContext(reactContext) {}
+
+ public: // IReactModuleBuilder
+  void AddInitializer(InitializerDelegate const &initializer) noexcept {
+    initializer(m_reactContext);
+  }
+
+  void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept {
+    VerifyElseCrash(false);
+  }
+
+  void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept {
+    auto key = to_string(name);
+    VerifyElseCrash(m_methods.find(key) == m_methods.end());
+    m_methods.insert({key, {returnType, method}});
+  }
+
+  void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept {
+    VerifyElseCrash(false);
+  }
+
+ public:
+  std::unordered_map<std::string, TurboModuleMethodInfo> m_methods;
+
+ private:
+  IReactContext m_reactContext;
+};
+
+/*-------------------------------------------------------------------------------
+  TurboModuleImpl
+-------------------------------------------------------------------------------*/
+
+class TurboModuleImpl : public facebook::react::TurboModule {
+ public:
+  TurboModuleImpl(
+      const IReactContext &reactContext,
+      const std::string &name,
+      std::shared_ptr<facebook::react::CallInvoker> jsInvoker,
+      ReactModuleProvider reactModuleProvider)
+      : facebook::react::TurboModule(name, jsInvoker), m_moduleBuilder(winrt::make<TurboModuleBuilder>(reactContext)) {
+    providedModule = reactModuleProvider(m_moduleBuilder);
+  }
+
+  facebook::jsi::Value get(facebook::jsi::Runtime &runtime, const facebook::jsi::PropNameID &propName) override {
+    // it is not safe to assume that "runtime" never changes, so members are not cached here
+    auto tmb = m_moduleBuilder.as<TurboModuleBuilder>();
+    auto key = propName.utf8(runtime);
+    {
+      // try to find a Method
+      auto it = tmb->m_methods.find(key);
+      if (it != tmb->m_methods.end()) {
+        return facebook::jsi::Function::createFromHostFunction(
+            runtime,
+            propName,
+            0,
+            [&runtime, method = it->second](
+                facebook::jsi::Runtime &rt,
+                const facebook::jsi::Value &thisVal,
+                const facebook::jsi::Value *args,
+                size_t count) {
+              // prepare input arguments
+              facebook::jsi::Array argsArray(runtime, count);
+              for (size_t i = 0; i < count; i++) {
+                argsArray.setValueAtIndex(runtime, i, args[i]);
+              }
+              auto argReader = winrt::make<JsiReader>(runtime, facebook::jsi::Value(runtime, argsArray));
+
+              // prepare output value
+              auto argWriter = winrt::make<JsiWriter>(runtime);
+
+              // call the function
+              switch (method.ReturnType) {
+                case MethodReturnType::Void: {
+                  method.Method(argReader, argWriter, nullptr, nullptr);
+                  return facebook::jsi::Value::undefined();
+                }
+                case MethodReturnType::Promise: {
+                  return facebook::react::createPromiseAsJSIValue(
+                      runtime, [=](facebook::jsi::Runtime &runtime, std::shared_ptr<facebook::react::Promise> promise) {
+                        method.Method(
+                            argReader,
+                            argWriter,
+                            [promise, &runtime](const IJSValueWriter &writer) {
+                              auto result = writer.as<JsiWriter>()->MoveResult();
+                              promise->resolve(result);
+                            },
+                            [promise, &runtime](const IJSValueWriter &writer) {
+                              auto result = writer.as<JsiWriter>()->MoveResult();
+                              VerifyElseCrash(result.isString());
+                              promise->reject(result.getString(runtime).utf8(runtime));
+                            });
+                      });
+                }
+                case MethodReturnType::Callback:
+                case MethodReturnType::TwoCallbacks:
+                  VerifyElseCrash(false);
+                default:
+                  VerifyElseCrash(false);
+              }
+            });
+      }
+    }
+
+    // missing member, return undefined
+    return facebook::jsi::Value::undefined();
+  }
+
+ private:
+  IReactModuleBuilder m_moduleBuilder;
+  IInspectable providedModule;
+};
+
+/*-------------------------------------------------------------------------------
+  TurboModulesProvider
+-------------------------------------------------------------------------------*/
+TurboModulesProvider::TurboModulePtr TurboModulesProvider::getModule(
+    const std::string &moduleName,
+    const CallInvokerPtr &callInvoker) noexcept {
+  // see if the expected turbo module has been cached
+  auto pair = std::make_pair(moduleName, callInvoker);
+  auto itCached = m_cachedModules.find(pair);
+  if (itCached != m_cachedModules.end()) {
+    return itCached->second;
+  }
+
+  // fail if the expected turbo module has not been registered
+  auto it = m_moduleProviders.find(moduleName);
+  if (it == m_moduleProviders.end()) {
+    return nullptr;
+  }
+
+  // cache and return the turbo module
+  auto tm = std::make_shared<TurboModuleImpl>(m_reactContext, moduleName, callInvoker, it->second);
+  m_cachedModules.insert({pair, tm});
+  return tm;
+}
+
+std::vector<std::string> TurboModulesProvider::getEagerInitModuleNames() noexcept {
+  return {};
+}
+
+void TurboModulesProvider::SetReactContext(const IReactContext &reactContext) noexcept {
+  m_reactContext = reactContext;
+}
+
+void TurboModulesProvider::AddModuleProvider(
+    winrt::hstring const &moduleName,
+    ReactModuleProvider const &moduleProvider) noexcept {
+  auto key = to_string(moduleName);
+  VerifyElseCrash(m_moduleProviders.find(key) == m_moduleProviders.end());
+  m_moduleProviders.insert({key, moduleProvider});
+}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <TurboModuleRegistry.h>
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
+ private:
+  using TurboModule = facebook::react::TurboModule;
+  using CallInvoker = facebook::react::CallInvoker;
+
+  using TurboModulePtr = std::shared_ptr<TurboModule>;
+  using CallInvokerPtr = std::shared_ptr<CallInvoker>;
+
+ public:
+  virtual TurboModulePtr getModule(const std::string &moduleName, const CallInvokerPtr &callInvoker) noexcept override;
+  virtual std::vector<std::string> getEagerInitModuleNames() noexcept override;
+
+ public:
+  void SetReactContext(const IReactContext &reactContext) noexcept;
+  void AddModuleProvider(winrt::hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+
+ private:
+  std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;
+  std::unordered_map<std::pair<std::string, CallInvokerPtr>, TurboModulePtr> m_cachedModules;
+  IReactContext m_reactContext;
+};
+
+} // namespace winrt::Microsoft::ReactNative


### PR DESCRIPTION
- Add `AddTurboModule` to `IReactPackageBuilder.idl`.
- Pass it all the way to `facebook::react::CreateReactInstance` in `ReactInstanceWin`.
- `Clipboard` registers itself as a turbo module instead of a native module, only when web debugger is disabled.
- `TurboModulesProvider` has limited functionalities, which only satisfy `Clipboard` module's need.
- `Clipboard` module is updated to run Clipboard functions in UI thread.
- `Clipboard` is updated to run `ReactPromise` in Javascript Engine's thread.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5085)