### PR TITLE
Allow paremeterization of buildLogDirectory for msbuild task when using run-windows

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -13,7 +13,7 @@ jobs:
       vmImage: $(VmImage)
 
     variables:
-      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
+      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
 
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -12,6 +12,9 @@ jobs:
     pool:
       vmImage: $(VmImage)
 
+    variables:
+      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
+
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
@@ -40,15 +43,16 @@ jobs:
       - task: CmdLine@2
         displayName: run-windows
         inputs:
-          script: yarn windows --no-packager --arch ${{ parameters.BuildPlatform }} --release --logging --msbuildprops BaseIntDir=$(BaseIntDir)
+          script: yarn windows --no-packager --arch ${{ parameters.BuildPlatform }} --release --logging --buildLogDirectory $(BuildLogDirectory) --msbuildprops BaseIntDir=$(BaseIntDir)
           workingDirectory: packages/E2ETest
 
       - task: PublishBuildArtifacts@1
+        displayName: Upload build logs
         condition:  succeededOrFailed()
         timeoutInMinutes: 10
         inputs:    
-          pathtoPublish: packages/E2ETest/msbuild.binlog 
-          artifactName: 'ReactUWPTestApp build log' 
+          targetPath: '$(BuildLogDirectory)'
+          artifactName: 'Build logs - $(Agent.JobName)' 
           publishLocation: 'Container'
 
       - task: CopyFiles@2

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -13,7 +13,7 @@ jobs:
       vmImage: $(VmImage)
 
     variables:
-      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
+      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\BuildLogs
 
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
@@ -49,11 +49,9 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: Upload build logs
         condition:  succeededOrFailed()
-        timeoutInMinutes: 10
         inputs:    
-          targetPath: '$(BuildLogDirectory)'
+          pathtoPublish: '$(BuildLogDirectory)'
           artifactName: 'Build logs - $(Agent.JobName)' 
-          publishLocation: 'Container'
 
       - task: CopyFiles@2
         displayName: Copy ReactUWPTestApp artifacts

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -9,6 +9,9 @@ parameters:
   listVsComponents: false
   installVsComponents: false
 
+variables:
+  BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
+
 steps:
   - checkout: self # self represents the repo where the initial Pipelines YAML file was found
     clean: true # whether to fetch clean each time
@@ -120,16 +123,25 @@ steps:
   - task: CmdLine@2
     displayName: Build project (Release)
     inputs:
-      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --release
+      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(BuildLogDirectory) --release
       workingDirectory: $(Agent.BuildDirectory)\testcli
     condition: and(succeeded(), eq('Release', variables['localConfig']))
 
   - task: CmdLine@2
     displayName: Build project (Debug)
     inputs:
-      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging
+      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(BuildLogDirectory)
       workingDirectory: $(Agent.BuildDirectory)\testcli
     condition: and(succeeded(), eq('Debug', variables['localConfig']))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Upload build logs
+    condition:  succeededOrFailed()
+    timeoutInMinutes: 10
+    inputs:    
+      targetPath: '$(BuildLogDirectory)'
+      artifactName: 'Build logs - $(Agent.JobName)' 
+      publishLocation: 'Container'
 
   - task: CmdLine@2
     displayName: Create bundle testcli
@@ -148,7 +160,6 @@ steps:
         stop-process -name node
     condition: failed()
 
-
   - task: PublishPipelineArtifact@1
     displayName: Upload Verdaccio.log (on failure)
     inputs:
@@ -157,10 +168,3 @@ steps:
       publishLocation: 'pipeline'
     condition: failed()
 
-  - task: PublishPipelineArtifact@1
-    displayName: Upload msbuild.binlog (on failure)
-    inputs:
-      targetPath: '$(Agent.BuildDirectory)\testcli\*.binlog'
-      artifact: '$(Agent.JobName).msbuild.binlog'
-      publishLocation: 'pipeline'
-    condition: failed()

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -8,7 +8,6 @@ parameters:
   vsComponents: ''
   listVsComponents: false
   installVsComponents: false
-  BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
 
 steps:
   - checkout: self # self represents the repo where the initial Pipelines YAML file was found
@@ -121,25 +120,23 @@ steps:
   - task: CmdLine@2
     displayName: Build project (Release)
     inputs:
-      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(BuildLogDirectory) --release
+      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(Build.BinariesDirectory)\$(platform)\$(configuration)\BuildLogs --release
       workingDirectory: $(Agent.BuildDirectory)\testcli
     condition: and(succeeded(), eq('Release', variables['localConfig']))
 
   - task: CmdLine@2
     displayName: Build project (Debug)
     inputs:
-      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(BuildLogDirectory)
+      script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(Build.BinariesDirectory)\$(platform)\$(configuration)\BuildLogs
       workingDirectory: $(Agent.BuildDirectory)\testcli
     condition: and(succeeded(), eq('Debug', variables['localConfig']))
 
   - task: PublishBuildArtifacts@1
     displayName: Upload build logs
     condition:  succeededOrFailed()
-    timeoutInMinutes: 10
     inputs:    
-      targetPath: '$(BuildLogDirectory)'
+      pathtoPublish: '$(Build.BinariesDirectory)\$(platform)\$(configuration)\BuildLogs'
       artifactName: 'Build logs - $(Agent.JobName)' 
-      publishLocation: 'Container'
 
   - task: CmdLine@2
     displayName: Create bundle testcli

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -8,7 +8,7 @@ parameters:
   vsComponents: ''
   listVsComponents: false
   installVsComponents: false
-  BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
+  BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
 
 steps:
   - checkout: self # self represents the repo where the initial Pipelines YAML file was found

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -8,8 +8,6 @@ parameters:
   vsComponents: ''
   listVsComponents: false
   installVsComponents: false
-
-variables:
   BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
 
 steps:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -299,6 +299,8 @@ jobs:
     cancelTimeoutInMinutes: 5
     pool:
       vmImage: $(VmImage)
+    variables:
+      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
 
     steps:
       - checkout: self
@@ -318,14 +320,14 @@ jobs:
       - task: CmdLine@2
         displayName: run-windows (Debug)
         inputs:
-          script: yarn windows --no-packager --no-launch --no-deploy --arch $(BuildPlatform) --logging --msbuildprops BaseIntDir=$(BaseIntDir)
+          script: yarn windows --no-packager --no-launch --no-deploy --arch $(BuildPlatform) --logging --buildLogDirectory $(BuildLogDirectory) --msbuildprops BaseIntDir=$(BaseIntDir)
           workingDirectory: packages/microsoft-reactnative-sampleapps
         condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'))
 
       - task: CmdLine@2
         displayName: run-windows (Release)
         inputs:
-          script: yarn windows --no-packager --no-launch --no-deploy --arch $(BuildPlatform) --logging --release --msbuildprops BaseIntDir=$(BaseIntDir)
+          script: yarn windows --no-packager --no-launch --no-deploy --arch $(BuildPlatform) --logging --buildLogDirectory $(BuildLogDirectory) --release --msbuildprops BaseIntDir=$(BaseIntDir)
           workingDirectory: packages/microsoft-reactnative-sampleapps
         condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'))
 
@@ -335,6 +337,15 @@ jobs:
           script: yarn bundle-cpp
           workingDirectory: packages\microsoft-reactnative-sampleapps
         condition: succeeded()
+
+      - task: PublishBuildArtifacts@1
+        displayName: Upload build logs
+        condition:  succeededOrFailed()
+        timeoutInMinutes: 10
+        inputs:    
+          targetPath: '$(BuildLogDirectory)'
+          artifactName: 'Build logs - $(Agent.JobName)' 
+          publishLocation: 'Container'
 
   - job: RNWDesktopPR
     displayName: Desktop PR

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -300,7 +300,7 @@ jobs:
     pool:
       vmImage: $(VmImage)
     variables:
-      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\BuildLogs
+      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
 
     steps:
       - checkout: self

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -341,11 +341,9 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: Upload build logs
         condition:  succeededOrFailed()
-        timeoutInMinutes: 10
         inputs:    
-          targetPath: '$(BuildLogDirectory)'
+          pathtoPublish: '$(BuildLogDirectory)'
           artifactName: 'Build logs - $(Agent.JobName)' 
-          publishLocation: 'Container'
 
   - job: RNWDesktopPR
     displayName: Desktop PR

--- a/change/react-native-windows-2020-06-01-16-47-14-master.json
+++ b/change/react-native-windows-2020-06-01-16-47-14-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Allow paremeterization of buildLogDirectory for msbuild task when using run-windows",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-01T23:47:14.917Z"
+}

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -8,7 +8,7 @@
 
 const build = require('./utils/build');
 const deploy = require('./utils/deploy');
-const {newError, newInfo} = require('./utils/commandWithProgress');
+const { newError, newInfo } = require('./utils/commandWithProgress');
 const info = require('./utils/info');
 const msbuildtools = require('./utils/msbuildtools');
 const autolink = require('./utils/autolink');
@@ -80,11 +80,12 @@ async function runWindows(config, args, options) {
         msBuildProps,
         verbose,
         undefined, // build the default target
+        options.buildLogDirectory,
       );
     } catch (e) {
       newError(
         `Build failed with message ${
-          e.message
+        e.message
         }. Check your build configuration.`,
       );
       if (e.logfile) {
@@ -219,6 +220,11 @@ module.exports = {
       command: '--msbuildprops [string]',
       description:
         'Comma separated props to pass to msbuild, eg: prop1=value1,prop2=value2',
+    },
+    {
+      command: '--buildLogDirectory [string]',
+      description:
+        'Optional directory where msbuild log files should be stored',
     },
     {
       command: '--info',

--- a/vnext/local-cli/runWindows/runWindows.js
+++ b/vnext/local-cli/runWindows/runWindows.js
@@ -8,7 +8,7 @@
 
 const build = require('./utils/build');
 const deploy = require('./utils/deploy');
-const { newError, newInfo } = require('./utils/commandWithProgress');
+const {newError, newInfo} = require('./utils/commandWithProgress');
 const info = require('./utils/info');
 const msbuildtools = require('./utils/msbuildtools');
 const autolink = require('./utils/autolink');
@@ -85,7 +85,7 @@ async function runWindows(config, args, options) {
     } catch (e) {
       newError(
         `Build failed with message ${
-        e.message
+          e.message
         }. Check your build configuration.`,
       );
       if (e.logfile) {

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -9,11 +9,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const {execSync} = require('child_process');
+const { execSync } = require('child_process');
 const glob = require('glob');
 const MSBuildTools = require('./msbuildtools');
 const Version = require('./version');
-const {commandWithProgress, newSpinner} = require('./commandWithProgress');
+const { commandWithProgress, newSpinner } = require('./commandWithProgress');
 const util = require('util');
 const chalk = require('chalk');
 const existsAsync = util.promisify(fs.exists);
@@ -25,6 +25,7 @@ async function buildSolution(
   msBuildProps,
   verbose,
   target,
+  buildLogDirectory,
 ) {
   const minVersion = new Version(10, 0, 18362, 0);
   const allVersions = MSBuildTools.getAllAvailableUAPVersions();
@@ -42,6 +43,7 @@ async function buildSolution(
     msBuildProps,
     verbose,
     target,
+    buildLogDirectory,
   );
 }
 
@@ -77,7 +79,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
       nugetPath = execSync('where nuget')
         .toString()
         .trim();
-    } catch {}
+    } catch { }
   }
 
   if (!(await existsAsync(nugetPath))) {
@@ -108,7 +110,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
     );
   } catch (e) {
     if (!options.isRetryingNuget) {
-      const retryOptions = Object.assign({isRetryingNuget: true}, options);
+      const retryOptions = Object.assign({ isRetryingNuget: true }, options);
       if (downloadedNuget) {
         fs.unlinkSync(nugetPath);
       }

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -9,11 +9,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync } = require('child_process');
+const {execSync} = require('child_process');
 const glob = require('glob');
 const MSBuildTools = require('./msbuildtools');
 const Version = require('./version');
-const { commandWithProgress, newSpinner } = require('./commandWithProgress');
+const {commandWithProgress, newSpinner} = require('./commandWithProgress');
 const util = require('util');
 const chalk = require('chalk');
 const existsAsync = util.promisify(fs.exists);
@@ -79,7 +79,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
       nugetPath = execSync('where nuget')
         .toString()
         .trim();
-    } catch { }
+    } catch {}
   }
 
   if (!(await existsAsync(nugetPath))) {
@@ -110,7 +110,7 @@ async function restoreNuGetPackages(options, slnFile, verbose) {
     );
   } catch (e) {
     if (!options.isRetryingNuget) {
-      const retryOptions = Object.assign({ isRetryingNuget: true }, options);
+      const retryOptions = Object.assign({isRetryingNuget: true}, options);
       if (downloadedNuget) {
         fs.unlinkSync(nugetPath);
       }

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -6,7 +6,7 @@
 // @ts-check
 'use strict';
 
-const { spawn, execSync } = require('child_process');
+const {spawn, execSync} = require('child_process');
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -51,7 +51,7 @@ function getAppPackage(options) {
 
   const appPackageGlob = `${
     options.root
-    }/windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
+  }/windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
   let appPackage = glob.sync(appPackageGlob)[0];
 
   if (!appPackage && options.release) {
@@ -63,7 +63,7 @@ function getAppPackage(options) {
     const rootGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*}`;
     const newGlob = `${rootGlob}/*_${
       options.arch === 'x86' ? 'Win32' : options.arch
-      }_${options.release ? '' : 'Debug_'}Test`;
+    }_${options.release ? '' : 'Debug_'}Test`;
 
     const result = glob.sync(newGlob);
     if (result.length > 1) {
@@ -97,15 +97,15 @@ function getAppxManifestPath(options) {
   const configuration = getBuildConfiguration(options);
   const appxManifestGlob = `windows/{*/bin/${
     options.arch
-    }/${configuration},${configuration}/*,target/${
+  }/${configuration},${configuration}/*,target/${
     options.arch
-    }/${configuration}}/AppxManifest.xml`;
+  }/${configuration}}/AppxManifest.xml`;
   const appxPath = glob.sync(path.join(options.root, appxManifestGlob))[0];
 
   if (!appxPath) {
     throw new Error(
       `Unable to find AppxManifest from "${
-      options.root
+        options.root
       }", using search path: "${appxManifestGlob}" `,
     );
   }
@@ -135,12 +135,12 @@ async function deployToDevice(options, verbose) {
   const deployTarget = options.target
     ? options.target
     : options.emulator
-      ? 'emulator'
-      : 'device';
+    ? 'emulator'
+    : 'device';
   const deployTool = new WinAppDeployTool();
   const appxManifest = getAppxManifest(options);
   const shouldLaunch = shouldLaunchApp(options);
-  const identity = appxManifest.root.children.filter(function (x) {
+  const identity = appxManifest.root.children.filter(function(x) {
     return x.name === 'mp:PhoneIdentity';
   })[0];
   const appName = identity.attributes.PhoneProductId;
@@ -182,7 +182,7 @@ async function deployToDesktop(options, verbose, slnFile) {
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(options);
   const appxManifest = parseAppxManifest(appxManifestPath);
-  const identity = appxManifest.root.children.filter(function (x) {
+  const identity = appxManifest.root.children.filter(function(x) {
     return x.name === 'Identity';
   })[0];
   const appName = identity.attributes.Name;
@@ -258,7 +258,7 @@ async function deployToDesktop(options, verbose, slnFile) {
       slnFile,
       options.release ? 'Release' : 'Debug',
       options.arch,
-      { DeployLayout: true },
+      {DeployLayout: true},
       options.verbose,
       'Deploy',
       options.buildLogDirectory,

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -6,7 +6,7 @@
 // @ts-check
 'use strict';
 
-const {spawn, execSync} = require('child_process');
+const { spawn, execSync } = require('child_process');
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -51,7 +51,7 @@ function getAppPackage(options) {
 
   const appPackageGlob = `${
     options.root
-  }/windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
+    }/windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
   let appPackage = glob.sync(appPackageGlob)[0];
 
   if (!appPackage && options.release) {
@@ -63,7 +63,7 @@ function getAppPackage(options) {
     const rootGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*}`;
     const newGlob = `${rootGlob}/*_${
       options.arch === 'x86' ? 'Win32' : options.arch
-    }_${options.release ? '' : 'Debug_'}Test`;
+      }_${options.release ? '' : 'Debug_'}Test`;
 
     const result = glob.sync(newGlob);
     if (result.length > 1) {
@@ -97,15 +97,15 @@ function getAppxManifestPath(options) {
   const configuration = getBuildConfiguration(options);
   const appxManifestGlob = `windows/{*/bin/${
     options.arch
-  }/${configuration},${configuration}/*,target/${
+    }/${configuration},${configuration}/*,target/${
     options.arch
-  }/${configuration}}/AppxManifest.xml`;
+    }/${configuration}}/AppxManifest.xml`;
   const appxPath = glob.sync(path.join(options.root, appxManifestGlob))[0];
 
   if (!appxPath) {
     throw new Error(
       `Unable to find AppxManifest from "${
-        options.root
+      options.root
       }", using search path: "${appxManifestGlob}" `,
     );
   }
@@ -135,12 +135,12 @@ async function deployToDevice(options, verbose) {
   const deployTarget = options.target
     ? options.target
     : options.emulator
-    ? 'emulator'
-    : 'device';
+      ? 'emulator'
+      : 'device';
   const deployTool = new WinAppDeployTool();
   const appxManifest = getAppxManifest(options);
   const shouldLaunch = shouldLaunchApp(options);
-  const identity = appxManifest.root.children.filter(function(x) {
+  const identity = appxManifest.root.children.filter(function (x) {
     return x.name === 'mp:PhoneIdentity';
   })[0];
   const appName = identity.attributes.PhoneProductId;
@@ -182,7 +182,7 @@ async function deployToDesktop(options, verbose, slnFile) {
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(options);
   const appxManifest = parseAppxManifest(appxManifestPath);
-  const identity = appxManifest.root.children.filter(function(x) {
+  const identity = appxManifest.root.children.filter(function (x) {
     return x.name === 'Identity';
   })[0];
   const appName = identity.attributes.Name;
@@ -258,9 +258,10 @@ async function deployToDesktop(options, verbose, slnFile) {
       slnFile,
       options.release ? 'Release' : 'Debug',
       options.arch,
-      {DeployLayout: true},
+      { DeployLayout: true },
       options.verbose,
       'Deploy',
+      options.buildLogDirectory,
     );
   }
 

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -71,9 +71,7 @@ class MSBuildTools {
     const warnLog = logPrefix + '.wrn';
 
     const localBinLog = target ? `:${target}.binlog` : '';
-    const binlog = buildLogDirectory
-      ? `:${logPrefix}.binlog`
-      : localBinLog;
+    const binlog = buildLogDirectory ? `:${logPrefix}.binlog` : localBinLog;
 
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,
@@ -92,7 +90,7 @@ class MSBuildTools {
     }
 
     if (msBuildProps) {
-      Object.keys(msBuildProps).forEach(function (key) {
+      Object.keys(msBuildProps).forEach(function(key) {
         args.push(`/p:${key}=${msBuildProps[key]}`);
       });
     }
@@ -155,7 +153,7 @@ function VSWhere(requires, version, property, verbose) {
     const propertyValue = child_process
       .execSync(
         `"${vsWherePath}" -version [${version},${Number(version) +
-        1}) -products * -requires ${requires} -property ${property}`,
+          1}) -products * -requires ${requires} -property ${property}`,
       )
       .toString()
       .split(EOL)[0];
@@ -259,26 +257,26 @@ function checkMSBuildVersion(version, buildArch, verbose) {
   }
 }
 
-module.exports.findAvailableVersion = function (buildArch, verbose) {
+module.exports.findAvailableVersion = function(buildArch, verbose) {
   const versions =
     process.env.VisualStudioVersion != null
       ? [
-        checkMSBuildVersion(
-          process.env.VisualStudioVersion,
-          buildArch,
-          verbose,
-        ),
-      ]
-      : MSBUILD_VERSIONS.map(function (value) {
-        return checkMSBuildVersion(value, buildArch, verbose);
-      });
+          checkMSBuildVersion(
+            process.env.VisualStudioVersion,
+            buildArch,
+            verbose,
+          ),
+        ]
+      : MSBUILD_VERSIONS.map(function(value) {
+          return checkMSBuildVersion(value, buildArch, verbose);
+        });
   const msbuildTools = versions.find(Boolean);
 
   if (!msbuildTools) {
     if (process.env.VisualStudioVersion != null) {
       throw new Error(
         `MSBuild tools not found for version ${
-        process.env.VisualStudioVersion
+          process.env.VisualStudioVersion
         } (from environment). Make sure all required components have been installed`,
       );
     } else {
@@ -311,7 +309,7 @@ function getSDK10InstallationFolder() {
   return folder;
 }
 
-module.exports.getAllAvailableUAPVersions = function () {
+module.exports.getAllAvailableUAPVersions = function() {
   const results = [];
 
   const programFilesFolder =

--- a/vnext/local-cli/runWindows/utils/msbuildtools.js
+++ b/vnext/local-cli/runWindows/utils/msbuildtools.js
@@ -69,11 +69,11 @@ class MSBuildTools {
 
     const errorLog = logPrefix + '.err';
     const warnLog = logPrefix + '.wrn';
+
+    const localBinLog = target ? `:${target}.binlog` : '';
     const binlog = buildLogDirectory
-      ? ':' + logPrefix + '.binlog'
-      : target
-        ? `:${target}.binlog`
-        : '';
+      ? `:${logPrefix}.binlog`
+      : localBinLog;
 
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,


### PR DESCRIPTION
This change adds a new optional commandline option to `run-windows` to specify where the build logs should be saved. This change updates our CI to take advantage of this to store the logs in a specific directory that gets uploaded to an artifact after the build so it can be used for investigations.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5088)