### PR TITLE
Fix ReloadInstance crash caused by unloaded instance

### DIFF
--- a/change/react-native-windows-2020-06-02-09-55-24-FixReload.json
+++ b/change/react-native-windows-2020-06-02-09-55-24-FixReload.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReloadInstance crash caused by unloaded instance",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-02T16:55:24.324Z"
+}

--- a/packages/playground/windows/playground.sln
+++ b/packages/playground/windows/playground.sln
@@ -31,7 +31,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "..\..\..\vnext\Co
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReactNative", "ReactNative", "{5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shared", "..\..\..\vnext\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Shared", "..\..\..\vnext\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\..\..\vnext\Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
 EndProject
@@ -40,7 +40,6 @@ Global
 		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
 		..\..\..\vnext\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		..\..\..\vnext\Microsoft.ReactNative.SharedManaged\Microsoft.ReactNative.SharedManaged.projitems*{67a1076f-7790-4203-86ea-4402ccb5e782}*SharedItemsImports = 13
-		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{6b6aa847-b32f-41ac-9d3b-48a8cdfa8ade}*SharedItemsImports = 4
 		..\..\..\vnext\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
 		..\..\..\vnext\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -752,6 +752,10 @@ std::shared_ptr<react::uwp::IReactInstance> ReactInstanceWin::UwpReactInstance()
   return m_legacyInstance;
 }
 
+bool ReactInstanceWin::IsLoaded() noexcept {
+  return m_state == ReactInstanceState::Loaded;
+}
+
 void ReactInstanceWin::AttachMeasuredRootView(
     facebook::react::IReactRootView *rootView,
     folly::dynamic &&initialProps) noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -752,7 +752,7 @@ std::shared_ptr<react::uwp::IReactInstance> ReactInstanceWin::UwpReactInstance()
   return m_legacyInstance;
 }
 
-bool ReactInstanceWin::IsLoaded() noexcept {
+bool ReactInstanceWin::IsLoaded() const noexcept {
   return m_state == ReactInstanceState::Loaded;
 }
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -77,7 +77,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept override;
   std::string GetBundleRootPath() noexcept override;
   std::shared_ptr<react::uwp::IReactInstance> UwpReactInstance() noexcept override;
-  bool IsLoaded() noexcept override;
+  bool IsLoaded() const noexcept override;
   void AttachMeasuredRootView(
       facebook::react::IReactRootView *rootView,
       folly::dynamic &&initialProps) noexcept override;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -77,6 +77,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept override;
   std::string GetBundleRootPath() noexcept override;
   std::shared_ptr<react::uwp::IReactInstance> UwpReactInstance() noexcept override;
+  bool IsLoaded() noexcept override;
   void AttachMeasuredRootView(
       facebook::react::IReactRootView *rootView,
       folly::dynamic &&initialProps) noexcept override;

--- a/vnext/Microsoft.ReactNative/ReactHost/React_Win.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React_Win.h
@@ -24,6 +24,8 @@ struct ILegacyReactInstance : IUnknown {
   virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept = 0;
   virtual std::string GetBundleRootPath() noexcept = 0;
 
+  virtual bool IsLoaded() noexcept = 0;
+
   virtual std::shared_ptr<react::uwp::IReactInstance> UwpReactInstance() noexcept = 0;
 
   virtual void AttachMeasuredRootView(

--- a/vnext/Microsoft.ReactNative/ReactHost/React_Win.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React_Win.h
@@ -24,7 +24,7 @@ struct ILegacyReactInstance : IUnknown {
   virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept = 0;
   virtual std::string GetBundleRootPath() noexcept = 0;
 
-  virtual bool IsLoaded() noexcept = 0;
+  virtual bool IsLoaded() const noexcept = 0;
 
   virtual std::shared_ptr<react::uwp::IReactInstance> UwpReactInstance() noexcept = 0;
 

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
@@ -144,6 +144,14 @@ std::string UwpReactInstanceProxy::GetBundleRootPath() const noexcept {
   return "";
 }
 
+bool UwpReactInstanceProxy::IsLoaded() noexcept {
+  if (auto reactInstance = m_weakReactInstance.GetStrongPtr()) {
+    return query_cast<Mso::React::ILegacyReactInstance &>(*reactInstance).IsLoaded();
+  }
+
+  return false;
+}
+
 void UwpReactInstanceProxy::SetXamlViewCreatedTestHook(std::function<void(react::uwp::XamlView)> testHook) {
   m_xamlViewCreatedTestHook = std::move(testHook);
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
@@ -144,7 +144,7 @@ std::string UwpReactInstanceProxy::GetBundleRootPath() const noexcept {
   return "";
 }
 
-bool UwpReactInstanceProxy::IsLoaded() noexcept {
+bool UwpReactInstanceProxy::IsLoaded() const noexcept {
   if (auto reactInstance = m_weakReactInstance.GetStrongPtr()) {
     return query_cast<Mso::React::ILegacyReactInstance &>(*reactInstance).IsLoaded();
   }

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
@@ -51,7 +51,7 @@ struct UwpReactInstanceProxy : IReactInstance, std::enable_shared_from_this<UwpR
   ExpressionAnimationStore &GetExpressionAnimationStore() override;
   const ReactInstanceSettings &GetReactInstanceSettings() const override;
   std::string GetBundleRootPath() const noexcept override;
-  bool IsLoaded() noexcept override;
+  bool IsLoaded() const noexcept override;
 
   // Test hooks
   void SetXamlViewCreatedTestHook(std::function<void(react::uwp::XamlView)> testHook) override;

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
@@ -51,6 +51,7 @@ struct UwpReactInstanceProxy : IReactInstance, std::enable_shared_from_this<UwpR
   ExpressionAnimationStore &GetExpressionAnimationStore() override;
   const ReactInstanceSettings &GetReactInstanceSettings() const override;
   std::string GetBundleRootPath() const noexcept override;
+  bool IsLoaded() noexcept override;
 
   // Test hooks
   void SetXamlViewCreatedTestHook(std::function<void(react::uwp::XamlView)> testHook) override;

--- a/vnext/ReactUWP/Views/ViewManagerBase.cpp
+++ b/vnext/ReactUWP/Views/ViewManagerBase.cpp
@@ -222,7 +222,7 @@ void ViewManagerBase::UpdateProperties(ShadowNodeBase *nodeToUpdate, const dynam
   //  will include the containing Text element. And that's what matters.
   int64_t tag = GetTag(nodeToUpdate->GetView());
   auto instance = m_wkReactInstance.lock();
-  if (instance != nullptr)
+  if (instance != nullptr && instance->IsLoaded())
     static_cast<NativeUIManager *>(instance->NativeUIManager())->DirtyYogaNode(tag);
 
   for (const auto &pair : reactDiffMap.items()) {

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -113,6 +113,8 @@ struct IReactInstance {
   virtual ExpressionAnimationStore &GetExpressionAnimationStore() = 0;
 
   virtual const ReactInstanceSettings &GetReactInstanceSettings() const = 0;
+
+  virtual bool IsLoaded() noexcept = 0;
 };
 
 } // namespace uwp

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -114,7 +114,7 @@ struct IReactInstance {
 
   virtual const ReactInstanceSettings &GetReactInstanceSettings() const = 0;
 
-  virtual bool IsLoaded() noexcept = 0;
+  virtual bool IsLoaded() const noexcept = 0;
 };
 
 } // namespace uwp


### PR DESCRIPTION
Current ViewManagers hold to a weak pointer to the ReactInstance. They decide if it is safe continue or not based on the instance still being present. The issue is that during reload the instance can be already unloaded and to have an invalid state. In this change we expose IsLoaded method to communicate that instance is valid to be used.

It is all temporary and relatively fragile. We need to find a more permanent solution where the ReactInstance is immutable until it is destroyed.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5092)