### PR TITLE
Bring Trivially Appliable VS 16.6 Fixes into 0.61

### DIFF
--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,6 +2,6 @@ variables:
   VmImage: windows-2019
   VsComponents: Microsoft.Component.MSBuild,Microsoft.VisualStudio.ComponentGroup.UWP.VC,Microsoft.VisualStudio.Component.VC.Tools.x86.x64,Microsoft.VisualStudio.Component.VC.Tools.ARM,Microsoft.VisualStudio.Component.VC.Tools.ARM64,Microsoft.VisualStudio.Component.VC.v141.x86.x64,Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141,Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
   MSBuildVersion: 16.0
-  GoogleTestAdapterPath: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\ked32bft.vu0'
+  GoogleTestAdapterPathExpression: '(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\" -Recurse -Include GoogleTestAdapter.Core.dll).Directory.FullName'
   BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:
   runCodesignValidationInjection: false

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -72,6 +72,12 @@ jobs:
           project: vnext/ReactWindows-Universal.sln
           vsComponents: $(VsComponents),Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
 
+      - powershell: |
+          Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
+          Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$(Invoke-Expression $env:GOOGLETESTADAPTERPATHEXPRESSION)"
+          Write-Host "Set environment variable to ($env:GoogleTestAdapterPath)"
+        displayName: Set GoogleTestAdapterPath
+
       - task: VSTest@2
         displayName: Run Universal Unit Tests
         timeoutInMinutes: 5 # Set smaller timeout , due to hangs
@@ -120,7 +126,7 @@ jobs:
       - checkout: self
         clean: false
         submodules: false
-        
+
       - template: templates/prepare-env.yml
         parameters:
           vsComponents: $(VsComponents),Microsoft.VisualStudio.Component.VC.v141.ARM,Microsoft.VisualStudio.Component.VC.v141.ARM64
@@ -225,7 +231,7 @@ jobs:
       - checkout: self
         clean: false
         submodules: false
-        
+
       - template: templates/prepare-env.yml
         parameters:
           vsComponents: $(VsComponents)
@@ -294,7 +300,7 @@ jobs:
 
       - task: VisualStudioTestPlatformInstaller@1
         inputs:
-          testPlatformVersion: 16.3.0
+          testPlatformVersion: 16.5.0
 
       - template: templates/build-rnw.yml
         parameters:
@@ -310,6 +316,12 @@ jobs:
           script: yarn bundle
           workingDirectory: packages/react-native-win32
         condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x64'))
+
+      - powershell: |
+          Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
+          Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$(Invoke-Expression $env:GOOGLETESTADAPTERPATHEXPRESSION)"
+          Write-Host "Set environment variable to ($env:GoogleTestAdapterPath)"
+        displayName: Set GoogleTestAdapterPath
 
       - task: VSTest@2
         displayName: Run Desktop Unit Tests

--- a/change/react-native-windows-2020-05-20-21-06-50-MS_FixVS16_6_build.json
+++ b/change/react-native-windows-2020-05-20-21-06-50-MS_FixVS16_6_build.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed Microsoft.ReactNative build in VS 16.6.0",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T04:06:49.892Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -136,6 +136,7 @@
       </PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winsqlite3.lib;ChakraRT.lib;dxguid.lib;dloadhelper.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/vnext/ReactUWP/ReactUWP.vcxproj
+++ b/vnext/ReactUWP/ReactUWP.vcxproj
@@ -102,6 +102,7 @@
       <AdditionalIncludeDirectories Condition="'$(CHAKRACOREUWP)'=='true'">$(ChakraCoreInclude);$(ChakraCoreDebugInclude);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <ShowIncludes>false</ShowIncludes>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>


### PR DESCRIPTION
Monday discussion implied we wanted to bring VS 16.6 fixes into RNW 0.61. This PR brings changes into the branch that apply cleanly. It notably omits:
- Fix loading SampleAppCpp in VS 16.6.0 (#4982) 
- Work around regression in UWP app packaging in VS 16.5-16.6 (#4958) 

Following up separately on whether we want to reimplement those on top of 0.61.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5093)