### PR TITLE
Re-enable most Desktop integration tests

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -370,7 +370,7 @@ jobs:
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
     variables:
-      Desktop.IntegrationTests.Filter: (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!~WebSocket)
+      Desktop.IntegrationTests.Filter: '(FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!~WebSocket)&(FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&(FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)'
 
     steps:
       - checkout: self
@@ -436,38 +436,6 @@ jobs:
           vsTestVersion: latest
           otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
         condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))
-
-      - task: VSTest@2
-        displayName: List Desktop Integration Tests
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: React.Windows.Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.dll
-          searchFolder: $(Build.SourcesDirectory)\vnext\target\$(BuildPlatform)\$(BuildConfiguration)
-          testFiltercriteria: $(Desktop.IntegrationTests.Filter)
-          runTestsInIsolation: false
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          publishRunAttachments: false
-          collectDumpOn: onAbortOnly
-          vsTestVersion: latest
-          otherConsoleOptions: '/ListTests'
-        condition: failed()
-
-      - task: VSTest@2
-        displayName: Re-Run Desktop Integration Tests
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: React.Windows.Desktop.IntegrationTests\React.Windows.Desktop.IntegrationTests.dll
-          searchFolder: $(Build.SourcesDirectory)\vnext\target\$(BuildPlatform)\$(BuildConfiguration)
-          testFiltercriteria: $(Desktop.IntegrationTests.Filter)
-          runTestsInIsolation: true
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          publishRunAttachments: true
-          collectDumpOn: onAbortOnly
-          vsTestVersion: latest
-          otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
-        condition: failed()
 
       - task: PowerShell@2
         displayName: Check the metro bundle server

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -370,6 +370,7 @@ jobs:
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
     variables:
+      #5059 Disable failing or intermittent tests.
       Desktop.IntegrationTests.Filter: '(FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&(FullyQualifiedName!~WebSocket)&(FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&(FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)'
 
     steps:

--- a/change/react-native-windows-2020-06-02-20-32-51-reenabledeskits.json
+++ b/change/react-native-windows-2020-06-02-20-32-51-reenabledeskits.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Re-enable RNTester integration tests.",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-03T03:32:51.480Z"
+}

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -17,7 +17,6 @@ std::wstring ToString<TestStatus>(const TestStatus &status) {
 } // namespace Microsoft::VisualStudio::CppUnitTestFramework
 
 // None of these tests are runnable
-#if 0
 TEST_CLASS (RNTesterIntegrationTests) {
   TestRunner m_runner;
 
@@ -186,4 +185,3 @@ TEST_CLASS (RNTesterIntegrationTests) {
     TestComponent("AccessibilityManagerTest");
   }
 };
-#endif

--- a/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketJSExecutorIntegrationTest.cpp
@@ -20,7 +20,6 @@ using std::string;
 using std::unique_ptr;
 
 // None of these tests are runnable
-#if 0
 TEST_CLASS (WebSocketJSExecutorIntegrationTest) {
   BEGIN_TEST_METHOD_ATTRIBUTE(ConnectAsyncSucceeds) END_TEST_METHOD_ATTRIBUTE() TEST_METHOD(ConnectAsyncSucceeds) {
     auto jsThread = make_shared<TestMessageQueueThread>();
@@ -119,4 +118,3 @@ TEST_CLASS (WebSocketJSExecutorIntegrationTest) {
     Assert::AreNotEqual({}, errorMessage);
   }
 };
-#endif

--- a/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketModuleIntegrationTest.cpp
@@ -14,7 +14,6 @@ using std::unique_ptr;
 using std::vector;
 
 // None of these tests are runnable
-#if 0
 TEST_CLASS (WebSocketModuleIntegrationTest) {
   TEST_METHOD(WebSocketModule_Ping) {
     auto module = make_unique<WebSocketModule>();
@@ -56,4 +55,3 @@ TEST_CLASS (WebSocketModuleIntegrationTest) {
     close.func(dynamic::array(0, "closing", /*id*/ 1), [](vector<dynamic>) {}, [](vector<dynamic>) {});
   }
 };
-#endif

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -24,7 +24,6 @@ using std::string;
 using std::vector;
 
 // None of these tests are runnable
-#if 0
 TEST_CLASS (WebSocketResourcePerformanceTest) {
   // See http://msdn.microsoft.com/en-us/library/ms686701(v=VS.85).aspx
   int32_t GetCurrentThreadCount() {
@@ -130,4 +129,3 @@ TEST_CLASS (WebSocketResourcePerformanceTest) {
     Assert::IsTrue(threadsPerResource <= expectedThreadsPerResource);
   }
 };
-#endif


### PR DESCRIPTION
A couple integration tests started failing with very high frequency after the latest [CI VM](https://github.com/actions/virtual-environments/blob/win19/20200531.1/images/win/Windows2019-Readme.md) upgrade:
- `RNTesterIntegrationTests::AsyncStorage`
- `RNTesterIntegrationTests::IntegrationTestHarness`

This change selectively excludes those tests from running, allowing the rest of the tests to be validated in the CI loops.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5109)