### PR TITLE
Expose JSDispatcher on IReactContext

### DIFF
--- a/change/react-native-windows-2020-06-04-13-42-36-pull_request_jsd.json
+++ b/change/react-native-windows-2020-06-04-13-42-36-pull_request_jsd.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Expose JSDispatcher on IReactContext",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-04T20:42:36.629Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -20,6 +20,10 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  IReactDispatcher JSDispatcher() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   void DispatchEvent(
       xaml::FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -123,6 +123,10 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  IReactDispatcher JSDispatcher() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   void DispatchEvent(
       xaml::FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -41,6 +41,10 @@ struct ReactContext {
     return ReactDispatcher{m_handle.UIDispatcher()};
   }
 
+  ReactDispatcher JSDispatcher() const noexcept {
+    return ReactDispatcher{m_handle.JSDispatcher()};
+  }
+
   // Call methodName JS function of module with moduleName.
   // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -311,6 +311,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public IReactDispatcher UIDispatcher => Properties.Get(ReactDispatcherHelper.UIDispatcherProperty) as IReactDispatcher;
 
+    public IReactDispatcher JSDispatcher => Properties.Get(ReactDispatcherHelper.JSDispatcherProperty) as IReactDispatcher;
+
     public void DispatchEvent(FrameworkElement view, string eventName, JSValueArgWriter eventDataArgWriter)
     {
       throw new NotImplementedException();

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -22,6 +22,10 @@ IReactDispatcher ReactContext::UIDispatcher() noexcept {
   return Properties().Get(ReactDispatcherHelper::UIDispatcherProperty()).try_as<IReactDispatcher>();
 }
 
+IReactDispatcher ReactContext::JSDispatcher() noexcept {
+  return Properties().Get(ReactDispatcherHelper::JSDispatcherProperty()).try_as<IReactDispatcher>();
+}
+
 // Deprecated: Use XamlUIService directly.
 void ReactContext::DispatchEvent(
     xaml::FrameworkElement const &view,

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -15,6 +15,7 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   IReactPropertyBag Properties() noexcept;
   IReactNotificationService Notifications() noexcept;
   IReactDispatcher UIDispatcher() noexcept;
+  IReactDispatcher JSDispatcher() noexcept;
   void DispatchEvent(
       xaml::FrameworkElement const &view,
       hstring const &eventName,

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -29,6 +29,9 @@ namespace Microsoft.ReactNative {
     // Get ReactDispatcherHelper::UIDispatcherProperty from the Properties property bag.
     IReactDispatcher UIDispatcher { get; };
 
+    // Get ReactDispatcherHelper::JSDispatcherProperty from the Properties property bag.
+    IReactDispatcher JSDispatcher { get; };
+
     // Deprecated: Use DispatchEvent on XamlUIService instead
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -65,4 +65,10 @@ void ReactDispatcher::Post(ReactDispatcherCallback const &callback) noexcept {
   properties.Set(UIDispatcherProperty(), UIThreadDispatcher());
 }
 
+/*static*/ IReactPropertyName ReactDispatcher::JSDispatcherProperty() noexcept {
+  static IReactPropertyName jsThreadDispatcherProperty{ReactPropertyBagHelper::GetName(
+      ReactPropertyBagHelper::GetNamespace(L"ReactNative.Dispatcher"), L"JSDispatcher")};
+  return jsThreadDispatcherProperty;
+}
+
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -24,6 +24,8 @@ struct ReactDispatcher : implements<ReactDispatcher, winrt::default_interface<IR
   static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;
   static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
 
+  static IReactPropertyName JSDispatcherProperty() noexcept;
+
  private:
   Mso::DispatchQueue m_queue;
 };
@@ -41,6 +43,10 @@ struct ReactDispatcherHelper {
 
   static IReactPropertyName UIDispatcherProperty() noexcept {
     return ReactDispatcher::UIDispatcherProperty();
+  }
+
+  static IReactPropertyName JSDispatcherProperty() noexcept {
+    return ReactDispatcher::JSDispatcherProperty();
   }
 };
 

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -31,5 +31,8 @@ namespace Microsoft.ReactNative {
 
     // Get name of the UIDispatcher property for the IReactPropertyBag.
     static IReactPropertyName UIDispatcherProperty { get; };
+
+    // Get name of the JSDispatcher property for the IReactPropertyBag.
+    static IReactPropertyName JSDispatcherProperty { get; };
   }
 } // namespace ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -489,6 +489,11 @@ void ReactInstanceWin::InitJSMessageThread() noexcept {
 
   // Create MessageQueueThread for the DispatchQueue
   VerifyElseCrashSz(jsDispatchQueue, "m_jsDispatchQueue must not be null");
+
+  auto jsDispatcher =
+      winrt::make<winrt::Microsoft::ReactNative::implementation::ReactDispatcher>(Mso::Copy(jsDispatchQueue));
+  m_options.Properties.Set(ReactDispatcherHelper::JSDispatcherProperty(), jsDispatcher);
+
   m_jsMessageThread.Exchange(std::make_shared<MessageDispatchQueue>(
       jsDispatchQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError), Mso::Copy(m_whenDestroyed)));
   m_jsDispatchQueue.Exchange(std::move(jsDispatchQueue));


### PR DESCRIPTION
JSI requires API to be called on the same thread that running the JavaScript engine. Users need to call JSI when implementing a turbo module. Currently `IReactContext` has only `UIDispatcher`, it becomes a blocker.
Add this API to enable this scenario.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5117)