### PR TITLE
 Fix SampleApp run-windows with deploy

### DIFF
--- a/change/react-native-windows-2020-06-04-13-09-07-master.json
+++ b/change/react-native-windows-2020-06-04-13-09-07-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix SampleApp run-windows with deploy",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T20:09:07.092Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    
+
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <Platforms>x64;x86;ARM;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
@@ -68,9 +68,10 @@
   </Target>
 
 
-   <!-- Override -->
+  <!-- Override -->
   <Target Name="_CheckForMismatchingPlatform">
 
   </Target>
 
+  <Target Name="Deploy" />
 </Project>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Debug.pubxml
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Debug.pubxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121. 
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. 
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
@@ -10,6 +9,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <PublishDir>$(OutDir)publish</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>false</SelfContained>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 </Project>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Release.pubxml
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Release.pubxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121. 
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. 
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
@@ -10,6 +9,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <PublishDir>$(OutDir)publish</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>false</SelfContained>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -28,17 +28,17 @@
   <Import Project="$(ProjectDir)AutolinkedNativeModules.g.targets"
           Condition="Exists('$(ProjectDir)AutolinkedNativeModules.g.targets')" />
 
-  <Import Project="$(MSBuildProjectDirectory)$(OutputPath)\$(AssemblyName).Build.appxrecipe"  
-          Condition="Exists('$(MSBuildProjectDirectory)$(OutputPath)\$(AssemblyName).Build.appxrecipe') And '$(DeployLayout)'=='true'" />
+  <Import Project="$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe"  
+          Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe') And '$(DeployLayout)'=='true'" />
   <Target Name="Deploy" Condition="'$(DeployLayout)'=='true'">
-    <Error Condition="!Exists('$(MSBuildProjectDirectory)$(OutputPath)\$(AssemblyName).Build.appxrecipe')" 
-           Text="You must first build the project before deploying it" />
+    <Error Condition="!Exists('$(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe')" 
+           Text="You must first build the project before deploying it. Did not find: $(MSBuildProjectDirectory)\$(OutputPath)\$(AssemblyName).Build.appxrecipe" />
     <Copy SourceFiles="%(AppxPackagedFile.Identity)" 
-          DestinationFiles="$(MSBuildProjectDirectory)$(OutputPath)Appx\%(AppxPackagedFile.PackagePath)" />
+          DestinationFiles="$(MSBuildProjectDirectory)\$(OutputPath)Appx\%(AppxPackagedFile.PackagePath)" />
     <Copy SourceFiles="%(AppXManifest.Identity)" 
-          DestinationFiles="$(MSBuildProjectDirectory)$(OutputPath)Appx\%(AppxManifest.PackagePath)" 
+          DestinationFiles="$(MSBuildProjectDirectory)\$(OutputPath)Appx\%(AppxManifest.PackagePath)" 
           Condition="'%(AppxManifest.SubType)'!='Designer'"/>
-    <Exec Command="powershell -NonInteractive -NoProfile -Command Add-AppxPackage -Register $(MSBuildProjectDirectory)$(OutputPath)Appx\AppxManifest.xml" 
+    <Exec Command="powershell -NonInteractive -NoProfile -Command Add-AppxPackage -Register $(MSBuildProjectDirectory)\$(OutputPath)Appx\AppxManifest.xml" 
           ContinueOnError="false" />
   </Target>
 </Project>


### PR DESCRIPTION
* Deploy codegen tool as standalone app, so the netcore runtime doesn't thave to be installed.
*  Fix SampleApp's run-windows. There was an error due to path issues.
* Add Deploy target to codegen project as an extra defense in case it gets looped into deployment by the solution build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5123)