### PR TITLE
Fix - onPress callback not working for nested <Text> elements

### DIFF
--- a/change/react-native-windows-2020-06-08-13-24-45-nested_onPress.json
+++ b/change/react-native-windows-2020-06-08-13-24-45-nested_onPress.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix onPress for nested Text",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-08T20:24:45.321Z"
+}

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -11,6 +11,7 @@
 #include <Modules/NativeUIManager.h>
 #include <UI.Xaml.Controls.Primitives.h>
 #include <UI.Xaml.Controls.h>
+#include <UI.Xaml.Documents.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.h>
 #include <Utils/Helpers.h>

--- a/vnext/ReactUWP/Views/PopupViewManager.cpp
+++ b/vnext/ReactUWP/Views/PopupViewManager.cpp
@@ -10,6 +10,7 @@
 #include <Modules/NativeUIManager.h>
 #include <UI.Xaml.Controls.Primitives.h>
 #include <UI.Xaml.Controls.h>
+#include <UI.Xaml.Documents.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.h>
 #include <Utils/Helpers.h>

--- a/vnext/ReactUWP/Views/TouchEventHandler.cpp
+++ b/vnext/ReactUWP/Views/TouchEventHandler.cpp
@@ -8,6 +8,8 @@
 
 #include <Modules/NativeUIManager.h>
 #include <UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Documents.h>
+#include <UI.Xaml.Documents.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.h>
 #include <Utils/ValueUtils.h>
@@ -407,11 +409,28 @@ bool TouchEventHandler::TagFromOriginalSource(
   // Find the React element that triggered the input event
   xaml::UIElement sourceElement = args.OriginalSource().try_as<xaml::UIElement>();
   winrt::IPropertyValue tag(nullptr);
+
   while (sourceElement) {
     tag = sourceElement.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
     if (tag) {
+      // If a TextBlock was the UIElement event source, perform a more accurate hit test,
+      // searching for the tag of the nested Run/Span XAML elements that the user actually clicked.
+      // This is to support nested <Text> elements in React.
+      // Nested React <Text> elements get translated into nested XAML <Span> elements,
+      // while the content of the <Text> becomes a list of XAML <Run> elements.
+      if (const auto textBlock = sourceElement.try_as<winrt::Controls::TextBlock>()) {
+        const auto pointerPos = args.GetCurrentPoint(textBlock).RawPosition();
+        const auto inlines = textBlock.Inlines().GetView();
+
+        auto finerTag = TestHit(inlines, pointerPos);
+        if (finerTag) {
+          tag = finerTag;
+        }
+      }
+
       break;
     }
+
     sourceElement = winrt::VisualTreeHelper::GetParent(sourceElement).try_as<xaml::UIElement>();
   }
 
@@ -425,6 +444,42 @@ bool TouchEventHandler::TagFromOriginalSource(
   *pTag = tag.GetInt64();
   *pSourceElement = sourceElement;
   return true;
+}
+
+winrt::IPropertyValue TouchEventHandler::TestHit(
+    const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
+    const winrt::Point &pointerPos) {
+  winrt::IPropertyValue tag(nullptr);
+  for (const auto &el : inlines) {
+    if (const auto span = el.try_as<winrt::Documents::Span>()) {
+      const auto resTag = TestHit(span.Inlines().GetView(), pointerPos);
+
+      if (resTag) {
+        return resTag;
+      }
+
+    } else if (const auto run = el.try_as<winrt::Documents::Run>()) {
+      const auto start = el.ContentStart();
+      const auto end = el.ContentEnd();
+
+      const auto startRect = start.GetCharacterRect(winrt::Documents::LogicalDirection::Forward);
+      const auto endRect = end.GetCharacterRect(winrt::Documents::LogicalDirection::Forward);
+
+      // Approximate the bounding rect (for now, don't account for text wrapping or right-to-left orientation)
+      if ((startRect.X <= pointerPos.X) && (endRect.X + endRect.Width >= pointerPos.X) &&
+          (startRect.Y <= pointerPos.Y) && (endRect.Y + endRect.Height >= pointerPos.Y)) {
+        tag = el.GetValue(winrt::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+        if (tag) {
+          return tag;
+        } else {
+          // TODO what if we land here? Can there be any more elements that satisfy the pointer position test?
+          // Why was the tag property not set?
+        }
+      }
+    }
+  }
+
+  return tag;
 }
 
 //

--- a/vnext/ReactUWP/Views/TouchEventHandler.h
+++ b/vnext/ReactUWP/Views/TouchEventHandler.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include <optional>
 #include <set>
-
+#include <UI.Xaml.Documents.h>
 #include <IReactInstance.h>
 #include "XamlView.h"
 
@@ -13,6 +13,7 @@ namespace winrt {
 using namespace Windows::UI;
 using namespace xaml;
 using namespace xaml::Controls;
+using namespace xaml::Documents;
 using namespace xaml::Input;
 using namespace Windows::Foundation;
 using namespace xaml::Media;
@@ -93,6 +94,9 @@ class TouchEventHandler {
   int64_t m_touchId = 0;
 
   bool TagFromOriginalSource(const winrt::PointerRoutedEventArgs &args, int64_t *pTag, xaml::UIElement *pSourceElement);
+  winrt::IPropertyValue TestHit(
+      const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
+      const winrt::Point &pointerPos);
 
   XamlView m_xamlView;
   std::weak_ptr<IReactInstance> m_wkReactInstance;

--- a/vnext/ReactUWP/Views/TouchEventHandler.h
+++ b/vnext/ReactUWP/Views/TouchEventHandler.h
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <IReactInstance.h>
+#include <UI.Xaml.Documents.h>
 #include <folly/dynamic.h>
 #include <optional>
 #include <set>
-#include <UI.Xaml.Documents.h>
-#include <IReactInstance.h>
 #include "XamlView.h"
 
 namespace winrt {


### PR DESCRIPTION
RNW nested  \<Text> tag translation uses a combination of XAML Run and Span elements, which get added to the collection of Inline elements of the resulting TextBlock and recursively its children Spans, while following these rules:
1. the outermost \<Text> becomes the parent XAML TextBlock
2. each piece of the string content of a \<Text> on a given level becomes a XAML child element of type Run 
3. each nested \<Text> becomes a XAML Span child element, appended to the InlineCollection of its parent, becoming a sister element on the same level as the Run elements.

For example, the JSX code on the left, produces the XAML tree on the right:
```
<Text>                 //<TextBlock>
   "outer" {X}            //<Run> <Run>
  <Text>                  //<Span>
    "inner_1" {Y}            //<Run> <Run>
    <Text>                   //<Span>
      "inner 2"                 //<Run>
    </Text>
  </Text>
</Text>

```
Since nested React \<Text> elements only produce one XAML UIElement (Span and Run are of type Inline), all clicks within the resulting XAML TextBlock cause the same JS onPress callback to be invoked - all clicks on the nested \<Text> elements are deemed to be from within the same outer React \<Text> element, because only UIElement instances raise XAML events.

**Solution**:
inside TouchEventHandler::TagFromOriginalSource(), perform a more refined hit test in case a TextBlock was identified as the source of the PointerPressed event. Iterate over the InlineCollection of the XAML TextBlock, for each Inline (Run/Span) element call (recursively for Span) ContentStart() and ContentEnd() to get the 2 TextPointers, and from them the bounding box. From that, we can check if the pointer coordinates fall within a child \<Text> or indeed the outer one, as we now ascribe all click events to.

Caveats: this does not handle text wrapping, which can happen over multiple lines, and makes obtaining the bounding boxes more involved; nor does it account for right-to-left scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5125)