### PR TITLE
Cherry pick API changes for 0.62

### DIFF
--- a/change/react-native-windows-2020-05-21-13-01-25-WeakModule.json
+++ b/change/react-native-windows-2020-05-21-13-01-25-WeakModule.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implemented support for native module std::weak_ptr",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T20:01:24.822Z"
+}

--- a/change/react-native-windows-2020-05-21-22-04-55-PR-FixInstanceLoading.json
+++ b/change/react-native-windows-2020-05-21-22-04-55-PR-FixInstanceLoading.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactInstance error state to avoid crashes",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-22T05:04:55.630Z"
+}

--- a/change/react-native-windows-2020-05-25-15-56-21-PR-UIDispatcherProperty.json
+++ b/change/react-native-windows-2020-05-25-15-56-21-PR-UIDispatcherProperty.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add UIDispatcher property to ReactInstanceSettings and IReactContext",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-25T22:56:21.049Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -10,7 +10,7 @@
 #include "DebugHelpers.h"
 #include "NativeModules.h"
 
-#define DEBUG_OUTPUT(...) DebugWriteLine("SampleModuleCppImpl", ##__VA_ARGS__);
+#define DEBUG_OUTPUT(...) DebugWriteLine("SampleLibraryCpp", ##__VA_ARGS__);
 
 namespace SampleLibraryCpp {
 
@@ -39,6 +39,7 @@ struct SampleModuleCppImpl {
     DEBUG_OUTPUT("C++ Properties.Prop1:", *reactContext.Properties().Get(myProp1));
     DEBUG_OUTPUT("C++ Properties.Prop2:", winrt::to_string(*reactContext.Properties().Get(myProp2)));
 
+    // Note that all notification subscriptions are removed automatically when React instance is unloaded.
     m_timer = winrt::Windows::System::Threading::ThreadPoolTimer::CreatePeriodicTimer(
         [this](const winrt::Windows::System::Threading::ThreadPoolTimer) noexcept {
           TimedEvent(++m_timerCount);
@@ -244,6 +245,24 @@ struct SampleModuleCppImpl {
   winrt::Windows::System::Threading::ThreadPoolTimer m_timer{nullptr};
   int m_timerCount{0};
   static constexpr std::chrono::milliseconds TimedEventInterval{5000};
+};
+
+// SampleSharedCppModule shows how to inherited native modules from std::enable_shared_from_this
+// to use weak_from_this() in event handlers. In this example we use notifications instead
+// of events just to show case the std::weak_ptr use.
+REACT_MODULE(SampleSharedCppModule);
+struct SampleSharedCppModule : std::enable_shared_from_this<SampleSharedCppModule> {
+  using IInspectable = winrt::Windows::Foundation::IInspectable;
+
+  // The Initialize method is called when React instance loaded JavaScript and the module is ready to use.
+  REACT_INIT(Initialize)
+  void Initialize(React::ReactContext const & /*reactContext*/) noexcept {}
+
+  REACT_METHOD(SayHello)
+  std::string SayHello() noexcept {
+    // This method is currently unused
+    return "Hello";
+  }
 };
 
 } // namespace SampleLibraryCpp

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -141,12 +141,13 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IJSValueReader.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IJSValueWriter.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactContext.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactDispatcher.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactModuleBuilder.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactNonAbiValue.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilder.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPropertyBag.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IViewManager.idl" />
-    <Midl Include="..\Microsoft.ReactNative\IReactNonAbiValue.idl" />
-    <Midl Include="..\Microsoft.ReactNative\IReactPropertyBag.idl" />
-    <Midl Include="..\Microsoft.ReactNative\NoExceptionAttribute.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\NoExceptionAttribute.idl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -12,6 +12,10 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  IReactDispatcher UIDispatcher() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   void DispatchEvent(
       Windows::UI::Xaml::FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -116,6 +116,10 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  IReactDispatcher UIDispatcher() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   void DispatchEvent(
       FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/pch.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/pch.h
@@ -10,9 +10,9 @@
 
 #undef GetCurrentTime
 
+#include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#include "winrt/Microsoft.ReactNative.h"
 
 #include "gtest/gtest.h"
 #include "motifCpp/gTestAdapter.h"

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -15,6 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)Crash.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)ReactHandleHelper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValueReader.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValueTreeReader.h" />
@@ -23,6 +24,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValueXaml.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ModuleRegistration.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)NativeModules.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)ReactDispatcher.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactNonAbiValue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactPropertyBag.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactContext.h" />

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "winrt/Microsoft.ReactNative.h"
+#include <winrt/Microsoft.ReactNative.h>
+#include <winrt/Windows.Foundation.h>
 
 #include "JSValueReader.h"
 #include "JSValueWriter.h"
@@ -1108,29 +1109,77 @@ struct TurboModuleSpec {
   }
 };
 
+// The default factory for the TModule.
+// It wraps up the TModule into a ReactNonAbiValue to be passed through the ABI boundary.
+template <class TModule>
+inline std::tuple<winrt::Windows::Foundation::IInspectable, TModule *> MakeDefaultReactModuleWrapper() noexcept {
+  ReactNonAbiValue<TModule> moduleWrapper{std::in_place};
+  TModule *module = moduleWrapper.GetPtr();
+  return std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>{std::move(moduleWrapper), module};
+}
+
+// The default factory for TModule inherited from enable_shared_from_this<T>.
+// It wraps up the TModule into an  std::shared_ptr before giving it to ReactNonAbiValue.
+template <class TModule>
+inline std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>
+MakeDefaultSharedPtrReactModuleWrapper() noexcept {
+  ReactNonAbiValue<std::shared_ptr<TModule>> moduleWrapper{std::in_place, std::make_shared<TModule>()};
+  TModule *module = moduleWrapper.GetPtr()->get();
+  return std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>{std::move(moduleWrapper), module};
+}
+
+namespace Internal {
+// Internal functions to test if type is inherited from std::enable_shared_from_this<T>.
+template <class T>
+std::true_type IsBaseOfTemplateTest(std::enable_shared_from_this<T> *);
+std::false_type IsBaseOfTemplateTest(...);
+} // namespace Internal
+
+// Check if type T is inherited from std::enable_shared_form_this<U>.
+// We support the scenario when the T and U are different types.
+template <class T>
+using IsEnabledSharedFromThisT = decltype(Internal::IsBaseOfTemplateTest((T *)nullptr));
+template <class T>
+inline constexpr bool IsEnabledSharedFromThisV = IsEnabledSharedFromThisT<T>::value;
+
+// Default implementation of factory getter for a TModule type **not** inherited from std::enable_shared_form_this.
+// For the custom implementation define GetReactModuleFactory with the last parameter to be 'int' (not 'int *').
+template <class TModule, std::enable_if_t<!IsEnabledSharedFromThisV<TModule>, int> = 0>
+inline constexpr auto GetReactModuleFactory(TModule * /*moduleNullPtr*/, int * /*useDefault*/) noexcept {
+  return &MakeDefaultReactModuleWrapper<TModule>;
+}
+
+// Default implementation of factory getter for a TModule type inherited from std::enable_shared_form_this.
+// For the custom implementation define GetReactModuleFactory with the last parameter to be 'int' (not 'int *').
+template <class TModule, std::enable_if_t<IsEnabledSharedFromThisV<TModule>, int> = 0>
+inline constexpr auto GetReactModuleFactory(TModule * /*moduleNullPtr*/, int * /*useDefault*/) noexcept {
+  return &MakeDefaultSharedPtrReactModuleWrapper<TModule>;
+}
+
+// Type traits for TModule. It defines a factory to create the module and its ABI-safe wrapper.
+template <class TModule>
+struct ReactModuleTraits {
+  using FactoryType = std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>() noexcept;
+  static constexpr FactoryType *Factory = GetReactModuleFactory((TModule *)nullptr, 0);
+};
+
+// Create a module provider for TModule type.
 template <class TModule>
 inline ReactModuleProvider MakeModuleProvider() noexcept {
   return [](IReactModuleBuilder const &moduleBuilder) noexcept {
-    ReactNonAbiValue<TModule> moduleObject{std::in_place};
-    TModule *module = moduleObject.GetPtr();
+    auto [moduleWrapper, module] = ReactModuleTraits<TModule>::Factory();
     ReactModuleBuilder builder{module, moduleBuilder};
     GetReactModuleInfo(module, builder);
     builder.CompleteRegistration();
-    return moduleObject;
+    return moduleWrapper;
   };
 }
 
+// Create a module provider for TModule type that satisfies the TModuleSpec.
 template <class TModule, class TModuleSpec>
 inline ReactModuleProvider MakeTurboModuleProvider() noexcept {
   TModuleSpec::template ValidateModule<TModule>();
-  return [](IReactModuleBuilder const &moduleBuilder) noexcept {
-    ReactNonAbiValue<TModule> moduleObject{std::in_place};
-    TModule *module = moduleObject.GetPtr();
-    ReactModuleBuilder builder{module, moduleBuilder};
-    GetReactModuleInfo(module, builder);
-    builder.CompleteRegistration();
-    return moduleObject;
-  };
+  return MakeModuleProvider<TModule>();
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -24,7 +24,7 @@ struct ReactContext {
   }
 
   explicit operator bool() const noexcept {
-    return static_cast<bool>(m_handle);
+    return m_handle ? true : false;
   }
 
   ReactPropertyBag Properties() const noexcept {

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -7,6 +7,7 @@
 
 #include <string_view>
 #include "JSValueWriter.h"
+#include "ReactDispatcher.h"
 #include "ReactPropertyBag.h"
 
 namespace winrt::Microsoft::ReactNative {
@@ -29,6 +30,10 @@ struct ReactContext {
 
   ReactPropertyBag Properties() const noexcept {
     return ReactPropertyBag{m_handle.Properties()};
+  }
+
+  ReactDispatcher UIDispatcher() const noexcept {
+    return ReactDispatcher{m_handle.UIDispatcher()};
   }
 
   // Call methodName JS function of module with moduleName.

--- a/vnext/Microsoft.ReactNative.Cxx/ReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactDispatcher.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef MICROSOFT_REACTNATIVE_REACTDISPATCHER
+#define MICROSOFT_REACTNATIVE_REACTDISPATCHER
+
+#include <winrt/Microsoft.ReactNative.h>
+#include "ReactHandleHelper.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+// Represents a dispatcher queue to invoke work item asynchronously.
+// It wraps up the IReactDispatcher and adds convenience methods for
+// working with C++ types.
+struct ReactDispatcher {
+  ReactDispatcher(std::nullptr_t = nullptr) noexcept {}
+
+  explicit ReactDispatcher(IReactDispatcher const &handle) noexcept : m_handle{handle} {}
+
+  IReactDispatcher const &Handle() const noexcept {
+    return m_handle;
+  }
+
+  explicit operator bool() const noexcept {
+    return m_handle ? true : false;
+  }
+
+  void Post(ReactDispatcherCallback const &callback) const noexcept {
+    if (m_handle) {
+      m_handle.Post(callback);
+    }
+  }
+
+  bool HasThreadAccess() const noexcept {
+    return m_handle ? m_handle.HasThreadAccess() : false;
+  }
+
+  static ReactDispatcher CreateSerialDispatcher() noexcept {
+    return ReactDispatcher{ReactDispatcherHelper::CreateSerialDispatcher()};
+  }
+
+ private:
+  IReactDispatcher m_handle;
+};
+
+} // namespace winrt::Microsoft::ReactNative
+
+#endif // MICROSOFT_REACTNATIVE_REACTDISPATCHER

--- a/vnext/Microsoft.ReactNative.Cxx/ReactHandleHelper.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactHandleHelper.h
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef MICROSOFT_REACTNATIVE_REACTHANDLEHELPER
+#define MICROSOFT_REACTNATIVE_REACTHANDLEHELPER
+
+//
+// Helper methods for types that have Handle() method that return
+// an IInspectable-inherited value.
+//
+
+#include <winrt/Microsoft.ReactNative.h>
+#include <type_traits>
+
+namespace winrt::Microsoft::ReactNative {
+
+namespace Internal {
+template <class T>
+auto TestHandle(int) -> decltype(std::declval<T>().Handle());
+template <class>
+auto TestHandle(int *) -> void;
+} // namespace Internal
+
+template <class T>
+inline constexpr bool HasHandleV =
+    std::is_base_of_v<Windows::Foundation::IInspectable, std::decay_t<decltype(Internal::TestHandle<T>(0))>>;
+
+// True if two types with Handle() have the same handle.
+template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>
+inline bool operator==(T const &left, T const &right) noexcept {
+  return left.Handle() == right.Handle();
+}
+
+// True if two types with Handle() have different handles.
+template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>
+inline bool operator!=(T const &left, T const &right) noexcept {
+  return !(left.Handle() == right.Handle());
+}
+
+// True if handle of left is null.
+template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>
+inline bool operator==(T const &left, std::nullptr_t) noexcept {
+  return !static_cast<bool>(left.Handle());
+}
+
+// True if handle of left is not null.
+template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>
+inline bool operator!=(T const &left, std::nullptr_t) noexcept {
+  return static_cast<bool>(left.Handle());
+}
+
+// True if handle of right is null.
+template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>
+inline bool operator==(std::nullptr_t, T const &right) noexcept {
+  return !static_cast<bool>(right.Handle());
+}
+
+// True if handle of left is not null.
+template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>
+inline bool operator!=(std::nullptr_t, T const &right) noexcept {
+  return static_cast<bool>(right.Handle());
+}
+
+} // namespace winrt::Microsoft::ReactNative
+
+#endif // MICROSOFT_REACTNATIVE_REACTHANDLEHELPER

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -107,6 +107,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="ReactInstanceSettingsTests.cpp" />
     <ClCompile Include="ReactNonAbiValueTests.cpp" />
     <ClCompile Include="ReactPropertyBagTests.cpp" />
     <ClCompile Include="ReactNativeHostTests.cpp" />

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactInstanceSettingsTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactInstanceSettingsTests.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <winrt/Microsoft.ReactNative.h>
+#include <winrt/Windows.System.h>
+
+using namespace winrt;
+using namespace Microsoft::ReactNative;
+using namespace Windows::System;
+
+namespace ReactNativeIntegrationTests {
+
+TEST_CLASS (ReactInstanceSettingsTests) {
+  TEST_METHOD(DefaultUIDispatcher_NonUIThread) {
+    // In case if current thread has no ThreadDispatcher, then the
+    // ReactInstanceSettings::UIDispatcher is not initialized.
+    ReactInstanceSettings settings;
+    TestCheck(settings);
+    TestCheck(!settings.UIDispatcher());
+    // UIDispatcher() is a shortcut for getting property value.
+    TestCheck(!settings.Properties().Get(ReactDispatcherHelper::UIDispatcherProperty()));
+  }
+
+  TEST_METHOD(DefaultUIDispatcher_UIThread) {
+    // ReactInstanceSettings::UIDispatcher is set to a non-null value if it is
+    // creates from a UI thread. We simulate the UI thread with DispatcherQueueController.
+    auto queueController = DispatcherQueueController::CreateOnDedicatedThread();
+    auto uiDispatcher = queueController.DispatcherQueue();
+    TestCheck(uiDispatcher);
+    uiDispatcher.TryEnqueue([]() noexcept {
+      ReactInstanceSettings settings;
+      TestCheck(settings);
+      TestCheck(settings.UIDispatcher());
+      // UIDispatcher() is a shortcut for getting property value.
+      TestCheck(settings.Properties().Get(ReactDispatcherHelper::UIDispatcherProperty()));
+      TestCheckEqual(ReactDispatcherHelper::UIThreadDispatcher(), settings.UIDispatcher());
+      TestCheckEqual(
+          ReactDispatcherHelper::UIThreadDispatcher(),
+          settings.Properties().Get(ReactDispatcherHelper::UIDispatcherProperty()));
+    });
+    queueController.ShutdownQueueAsync().get();
+  }
+};
+
+} // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactPropertyBagTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactPropertyBagTests.cpp
@@ -265,6 +265,21 @@ TEST_CLASS (ReactPropertyBagTests) {
     TestCheckEqual(ReactPropertyBagHelper::GlobalNamespace(), ReactPropertyNamespace::Global().Handle());
   }
 
+  TEST_METHOD(PropertyNamespace_Equality) {
+    ReactPropertyNamespace ns11{L"Foo"};
+    ReactPropertyNamespace ns12{ns11};
+    ReactPropertyNamespace ns2{L"Bar"};
+    ReactPropertyNamespace ns3;
+    TestCheckEqual(ns11, ns12);
+    TestCheckEqual(ns12, ns11);
+    TestCheck(ns11 != ns2);
+    TestCheck(ns2 != ns11);
+    TestCheck(ns2 != nullptr);
+    TestCheck(nullptr != ns2);
+    TestCheck(ns3 == nullptr);
+    TestCheck(nullptr == ns3);
+  }
+
   TEST_METHOD(PropertyId_ctor_default) {
     ReactPropertyId<int> name1;
     TestCheck(!name1);

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -307,6 +307,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public IReactPropertyBag Properties { get; } = ReactPropertyBagHelper.CreatePropertyBag();
 
+    public IReactDispatcher UIDispatcher => Properties.Get(ReactDispatcherHelper.UIDispatcherProperty) as IReactDispatcher;
+
     public void DispatchEvent(FrameworkElement view, string eventName, JSValueArgWriter eventDataArgWriter)
     {
       throw new NotImplementedException();

--- a/vnext/Microsoft.ReactNative.sln
+++ b/vnext/Microsoft.ReactNative.sln
@@ -29,7 +29,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "Mso\Mso.vcxitems", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso.UnitTests", "Mso.UnitTests\Mso.UnitTests.vcxproj", "{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "ReactWindowsCore\ReactWindowsCore.vcxitems", "{11c084a3-a57c-4296-a679-cac17b603145}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "ReactWindowsCore\ReactWindowsCore.vcxitems", "{11C084A3-A57C-4296-A679-CAC17B603145}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "ReactWindowsCore\ReactWindowsCore.vcxproj", "{11C084A3-A57C-4296-A679-CAC17B603144}"
 EndProject
@@ -118,6 +118,8 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
+		ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603144}*SharedItemsImports = 4
+		ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603145}*SharedItemsImports = 9
 		Mso\Mso.vcxitems*{1958ceaa-fbe0-44e3-8a99-90ad85531ffe}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		Microsoft.ReactNative.SharedManaged\Microsoft.ReactNative.SharedManaged.projitems*{46d76f7a-8fd9-4a7d-8102-2857e5da6b84}*SharedItemsImports = 4

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -27,7 +27,7 @@ ABIViewManager::ABIViewManager(
       m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()},
       m_name{to_string(viewManager.Name())} {
   if (m_viewManagerWithReactContext) {
-    m_viewManagerWithReactContext.ReactContext(winrt::make<ReactContext>(Mso::Copy(reactContext)));
+    m_viewManagerWithReactContext.ReactContext(winrt::make<implementation::ReactContext>(Mso::Copy(reactContext)));
   }
   if (m_viewManagerWithNativeProperties) {
     m_nativeProps = m_viewManagerWithNativeProperties.NativeProps();

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -5,12 +5,16 @@
 #include "IReactContext.h"
 #include "DynamicWriter.h"
 
-namespace winrt::Microsoft::ReactNative {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactContext::ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context{std::move(context)} {}
 
 IReactPropertyBag ReactContext::Properties() noexcept {
   return m_context->Properties();
+}
+
+IReactDispatcher ReactContext::UIDispatcher() noexcept {
+  return Properties().Get(ReactDispatcherHelper::UIDispatcherProperty()).try_as<IReactDispatcher>();
 }
 
 void ReactContext::DispatchEvent(
@@ -51,4 +55,4 @@ void ReactContext::EmitJSEvent(
   m_context->CallJSFunction(to_string(eventEmitterName), "emit", std::move(params));
 }
 
-} // namespace winrt::Microsoft::ReactNative
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -6,13 +6,14 @@
 #include "ReactHost/React.h"
 #include "winrt/Microsoft.ReactNative.h"
 
-namespace winrt::Microsoft::ReactNative {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
 
  public: // IReactContext
   IReactPropertyBag Properties() noexcept;
+  IReactDispatcher UIDispatcher() noexcept;
   void DispatchEvent(
       winrt::Windows::UI::Xaml::FrameworkElement const &view,
       hstring const &eventName,
@@ -30,4 +31,4 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   Mso::CntPtr<Mso::React::IReactContext> m_context;
 };
 
-} // namespace winrt::Microsoft::ReactNative
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "IJSValueWriter.idl";
+import "IReactDispatcher.idl";
 import "IReactPropertyBag.idl";
 
 namespace Microsoft.ReactNative {
@@ -10,6 +11,9 @@ namespace Microsoft.ReactNative {
   interface IReactContext {
     IReactPropertyBag Properties { get; };
     void DispatchEvent(Windows.UI.Xaml.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
+    // Get ReactDispatcherHelper::UIDispatcherProperty from the Properties property bag.
+    IReactDispatcher UIDispatcher { get; };
+
     void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
   }

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -8,7 +8,7 @@
 using namespace winrt;
 using namespace Windows::Foundation;
 
-namespace winrt::Microsoft::ReactNative {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactDispatcher::ReactDispatcher(Mso::DispatchQueue &&queue) noexcept : m_queue{std::move(queue)} {}
 
@@ -18,6 +18,10 @@ bool ReactDispatcher::HasThreadAccess() noexcept {
 
 void ReactDispatcher::Post(ReactDispatcherCallback const &callback) noexcept {
   return m_queue.Post([callback]() noexcept { callback(); });
+}
+
+/*static*/ IReactDispatcher ReactDispatcher::CreateSerialDispatcher() noexcept {
+  return make<ReactDispatcher>(Mso::DispatchQueue{});
 }
 
 /*static*/ Mso::DispatchQueue ReactDispatcher::GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept {
@@ -41,4 +45,4 @@ void ReactDispatcher::Post(ReactDispatcherCallback const &callback) noexcept {
   ReactPropertyBag{properties}.Set(UIDispatcherProperty(), UIThreadDispatcher());
 }
 
-} // namespace winrt::Microsoft::ReactNative
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -7,7 +7,7 @@
 #include <dispatchQueue/dispatchQueue.h>
 #include <winrt/Microsoft.ReactNative.h>
 
-namespace winrt::Microsoft::ReactNative {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
   ReactDispatcher() = default;
@@ -15,6 +15,8 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
 
   bool HasThreadAccess() noexcept;
   void Post(ReactDispatcherCallback const &callback) noexcept;
+
+  static IReactDispatcher CreateSerialDispatcher() noexcept;
 
   static Mso::DispatchQueue GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept;
 
@@ -27,12 +29,12 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
   Mso::DispatchQueue m_queue;
 };
 
-} // namespace winrt::Microsoft::ReactNative
-
-namespace winrt::Microsoft::ReactNative::implementation {
-
 struct ReactDispatcherHelper {
   ReactDispatcherHelper() = default;
+
+  static IReactDispatcher CreateSerialDispatcher() noexcept {
+    return ReactDispatcher::CreateSerialDispatcher();
+  }
 
   static IReactDispatcher UIThreadDispatcher() noexcept {
     return ReactDispatcher::UIThreadDispatcher();

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -3,13 +3,12 @@
 
 #pragma once
 #include "ReactDispatcherHelper.g.h"
-#include <ReactPropertyBag.h>
 #include <dispatchQueue/dispatchQueue.h>
 #include <winrt/Microsoft.ReactNative.h>
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
+struct ReactDispatcher : implements<ReactDispatcher, winrt::default_interface<IReactDispatcher>> {
   ReactDispatcher() = default;
   ReactDispatcher(Mso::DispatchQueue &&queue) noexcept;
 
@@ -21,7 +20,7 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher> {
   static Mso::DispatchQueue GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept;
 
   static IReactDispatcher UIThreadDispatcher() noexcept;
-  static ReactPropertyId<IReactDispatcher> UIDispatcherProperty() noexcept;
+  static IReactPropertyName UIDispatcherProperty() noexcept;
   static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;
   static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
 
@@ -41,7 +40,7 @@ struct ReactDispatcherHelper {
   }
 
   static IReactPropertyName UIDispatcherProperty() noexcept {
-    return ReactDispatcher::UIDispatcherProperty().Handle();
+    return ReactDispatcher::UIDispatcherProperty();
   }
 };
 

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -30,6 +30,6 @@ namespace Microsoft.ReactNative {
     static IReactDispatcher UIThreadDispatcher{ get; };
 
     // Get name of the UIDispatcher property for the IReactPropertyBag.
-    static IReactPropertyName UIDispatcherProperty();
+    static IReactPropertyName UIDispatcherProperty { get; };
   }
 } // namespace ReactNative

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -23,6 +23,9 @@ namespace Microsoft.ReactNative {
   [webhosthidden]
   static runtimeclass ReactDispatcherHelper
   {
+    // Creates a new serial dispatcher that uses thread pool to run tasks.
+    static IReactDispatcher CreateSerialDispatcher();
+
     // Get or create IReactDispatcher for the current UI thread.
     static IReactDispatcher UIThreadDispatcher{ get; };
 

--- a/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
@@ -34,7 +34,7 @@ std::vector<facebook::react::NativeModuleDescription> NativeModulesProvider::Get
     m_modulesWorkerQueue = react::uwp::MakeSerialQueueThread();
   }
 
-  auto winrtReactContext = winrt::make<ReactContext>(Mso::Copy(reactContext));
+  auto winrtReactContext = winrt::make<implementation::ReactContext>(Mso::Copy(reactContext));
 
   for (auto &entry : m_moduleProviders) {
     modules.emplace_back(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -461,7 +461,7 @@ void ReactInstanceWin::InitNativeMessageThread() noexcept {
 
 void ReactInstanceWin::InitUIMessageThread() noexcept {
   // Native queue was already given us in constructor.
-  m_uiQueue = winrt::Microsoft::ReactNative::ReactDispatcher::GetUIDispatchQueue(m_options.Properties);
+  m_uiQueue = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatchQueue(m_options.Properties);
   m_uiMessageThread.Exchange(
       std::make_shared<MessageDispatchQueue>(m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -462,6 +462,7 @@ void ReactInstanceWin::InitNativeMessageThread() noexcept {
 void ReactInstanceWin::InitUIMessageThread() noexcept {
   // Native queue was already given us in constructor.
   m_uiQueue = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatchQueue(m_options.Properties);
+  VerifyElseCrashSz(m_uiQueue, "No UI Dispatcher provided");
   m_uiMessageThread.Exchange(
       std::make_shared<MessageDispatchQueue>(m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -387,7 +387,12 @@ void ReactInstanceWin::OnReactInstanceLoaded(const Mso::ErrorCode &errorCode) no
       if (auto strongThis = weakThis.GetStrongPtr()) {
         if (!strongThis->m_isLoaded) {
           strongThis->m_isLoaded = true;
-          strongThis->m_state = ReactInstanceState::Loaded;
+          if (!errorCode) {
+            strongThis->m_state = ReactInstanceState::Loaded;
+          } else {
+            strongThis->m_state = ReactInstanceState::HasError;
+          }
+
           if (auto onLoaded = strongThis->m_options.OnInstanceLoaded.Get()) {
             onLoaded->Invoke(*strongThis, errorCode);
           }

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
@@ -7,4 +7,19 @@
 #include "ReactInstanceSettings.g.cpp"
 #endif
 
-namespace winrt::Microsoft::ReactNative::implementation {} // namespace winrt::Microsoft::ReactNative::implementation
+namespace winrt::Microsoft::ReactNative::implementation {
+
+ReactInstanceSettings::ReactInstanceSettings() noexcept {
+  // Use current thread dispatcher as a default UI dispatcher.
+  m_properties.Set(ReactDispatcherHelper::UIDispatcherProperty(), ReactDispatcherHelper::UIThreadDispatcher());
+}
+
+IReactDispatcher ReactInstanceSettings::UIDispatcher() noexcept {
+  return m_properties.Get(ReactDispatcherHelper::UIDispatcherProperty()).try_as<IReactDispatcher>();
+}
+
+void ReactInstanceSettings::UIDispatcher(IReactDispatcher const &value) noexcept {
+  m_properties.Set(ReactDispatcherHelper::UIDispatcherProperty(), value);
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -22,7 +22,7 @@
 namespace winrt::Microsoft::ReactNative::implementation {
 
 struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
-  ReactInstanceSettings() = default;
+  ReactInstanceSettings() noexcept;
 
   IReactPropertyBag Properties() noexcept;
 
@@ -82,6 +82,9 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
 
   IRedBoxHandler RedBoxHandler() noexcept;
   void RedBoxHandler(IRedBoxHandler const &value) noexcept;
+
+  IReactDispatcher UIDispatcher() noexcept;
+  void UIDispatcher(IReactDispatcher const &value) noexcept;
 
  private:
   IReactPropertyBag m_properties{ReactPropertyBagHelper::CreatePropertyBag()};

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import "RedBoxHandler.idl";
+import "IReactDispatcher.idl";
 import "IReactPropertyBag.idl";
+import "RedBoxHandler.idl";
 
 namespace Microsoft.ReactNative {
 
@@ -31,5 +32,6 @@ namespace Microsoft.ReactNative {
     String BundleRootPath { get; set; };
     UInt16 DebuggerPort { get; set; };
     IRedBoxHandler RedBoxHandler { get; set; };
+    IReactDispatcher UIDispatcher { get; set; };
   }
 }

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -55,10 +55,12 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
   }
 
   void WindowSizeChanged(winrt::Windows::UI::Core::WindowSizeChangedEventArgs const &args) noexcept {
-    m_redboxContent.MaxHeight(args.Size().Height);
-    m_redboxContent.Height(args.Size().Height);
-    m_redboxContent.MaxWidth(args.Size().Width);
-    m_redboxContent.Width(args.Size().Width);
+    if (m_redboxContent) {
+      m_redboxContent.MaxHeight(args.Size().Height);
+      m_redboxContent.Height(args.Size().Height);
+      m_redboxContent.MaxWidth(args.Size().Width);
+      m_redboxContent.Width(args.Size().Width);
+    }
   }
 
   void ShowNewJSError() noexcept {
@@ -147,6 +149,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_reloadButton.Click(m_tokenReload);
     xaml::Window::Current().SizeChanged(m_tokenSizeChanged);
     m_popup.Closed(m_tokenClosed);
+    m_redboxContent = nullptr;
     m_onClosedCallback(GetId());
   }
 

--- a/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.cpp
+++ b/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.cpp
@@ -12,8 +12,10 @@ std::shared_ptr<facebook::react::MessageQueueThread> MakeJSQueueThread() noexcep
 }
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeUIQueueThread() noexcept {
-  return std::make_shared<Mso::React::MessageDispatchQueue>(
-      Mso::DispatchQueue::MakeCurrentThreadUIQueue(), nullptr, nullptr);
+  Mso::DispatchQueue queue = Mso::DispatchQueue::GetCurrentUIThreadQueue();
+  std::shared_ptr<facebook::react::MessageQueueThread> messageThread =
+      queue ? std::make_shared<Mso::React::MessageDispatchQueue>(queue, nullptr, nullptr) : nullptr;
+  return messageThread;
 }
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeSerialQueueThread() noexcept {

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -49,7 +49,8 @@ namespace react::uwp {
 //===========================================================================
 
 ReactRootControl::ReactRootControl(XamlView const &rootView) noexcept
-    : m_weakRootView{rootView}, m_uiQueue(Mso::DispatchQueue::MakeCurrentThreadUIQueue()) {
+    : m_weakRootView{rootView}, m_uiQueue(Mso::DispatchQueue::GetCurrentUIThreadQueue()) {
+  VerifyElseCrashSz(m_uiQueue, "Cannot get UI dispatch queue for the current thread");
   PrepareXamlRootView(rootView);
 }
 

--- a/vnext/Mso/src/dispatchQueue/queueService.h
+++ b/vnext/Mso/src/dispatchQueue/queueService.h
@@ -40,8 +40,8 @@ struct QueueService : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDispat
   void BeginTaskBatching() noexcept override;
   DispatchTask EndTaskBatching() noexcept override;
   bool HasTaskBatching() noexcept override;
-  bool TryLockQueueLocalValue(SwapDispatchLocalValueCallback swapLocalValue, void *tlsValue) noexcept override;
-  void UnlockLocalValue(void *tlsValue) noexcept override;
+  bool TryLockQueueLocalValue(SwapDispatchLocalValueCallback swapLocalValue, void **tlsValue) noexcept override;
+  void UnlockLocalValue(void **tlsValue) noexcept override;
   void Suspend() noexcept override;
   void Resume() noexcept override;
   void Shutdown(PendingTaskAction pendingTaskAction) noexcept override;
@@ -54,7 +54,7 @@ struct QueueService : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDispat
  private:
   bool TrySwapLocalValue(
       SwapDispatchLocalValueCallback swapLocalValue,
-      void *tlsValue,
+      void **tlsValue,
       LocalValueSwapAction action) noexcept;
 
  private:
@@ -71,7 +71,7 @@ struct QueueService : Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, IDispat
 struct QueueLocalValueEntry {
   QueueLocalValueEntry(SwapDispatchLocalValueCallback swapLocalValue) noexcept;
   ~QueueLocalValueEntry() noexcept;
-  bool TrySwapLocalValue(void *tlsValue, LocalValueSwapAction action) noexcept;
+  bool TrySwapLocalValue(void **tlsValue, LocalValueSwapAction action) noexcept;
 
  private:
   const SwapDispatchLocalValueCallback m_swapLocalValue;
@@ -82,7 +82,6 @@ struct QueueLocalValueEntry {
 struct DispatchQueueStatic : Mso::UnknownObject<Mso::RefCountStrategy::NoRefCount, IDispatchQueueStatic> {
   static DispatchQueueStatic *Instance() noexcept;
   static Mso::CntPtr<IDispatchQueueScheduler> MakeLooperScheduler() noexcept;
-  static Mso::CntPtr<IDispatchQueueScheduler> MakeCurrentThreadUIScheduler() noexcept;
   static Mso::CntPtr<IDispatchQueueScheduler> MakeThreadPoolScheduler(uint32_t maxThreads) noexcept;
 
  public: // IDispatchQueueStatic
@@ -90,7 +89,7 @@ struct DispatchQueueStatic : Mso::UnknownObject<Mso::RefCountStrategy::NoRefCoun
   DispatchQueue const &ConcurrentQueue() noexcept override;
   DispatchQueue MakeSerialQueue() noexcept override;
   DispatchQueue MakeLooperQueue() noexcept override;
-  DispatchQueue MakeCurrentThreadUIQueue() noexcept override;
+  DispatchQueue GetCurrentUIThreadQueue() noexcept override;
   DispatchQueue MakeConcurrentQueue(uint32_t maxThreads) noexcept override;
   DispatchQueue MakeCustomQueue(Mso::CntPtr<IDispatchQueueScheduler> &&scheduler) noexcept override;
 };

--- a/vnext/ReactUWP/Base/UwpReactInstance.cpp
+++ b/vnext/ReactUWP/Base/UwpReactInstance.cpp
@@ -116,7 +116,7 @@ void UwpReactInstance::Start(const std::shared_ptr<IReactInstance> &spThis, cons
   std::shared_ptr<react::uwp::AppTheme> appTheme =
       std::make_shared<react::uwp::AppTheme>(spThis, m_defaultNativeThread);
   I18nHelper::Instance().setInfo(I18nModule::GetI18nInfo());
-  auto appearanceListener = Mso::Make<AppearanceChangeListener>(spThis, Mso::DispatchQueue::MakeCurrentThreadUIQueue());
+  auto appearanceListener = Mso::Make<AppearanceChangeListener>(spThis, Mso::DispatchQueue::GetCurrentUIThreadQueue());
 
   // TODO: Figure out threading. What thread should this really be on?
   m_initThread = std::make_unique<react::uwp::WorkerMessageQueueThread>();

--- a/vnext/ReactWindows-Desktop.sln
+++ b/vnext/ReactWindows-Desktop.sln
@@ -9,7 +9,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactCommon", "ReactCommon\
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "ReactWindowsCore\ReactWindowsCore.vcxitems", "{11c084a3-a57c-4296-a679-cac17b603145}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore", "ReactWindowsCore\ReactWindowsCore.vcxitems", "{11C084A3-A57C-4296-A679-CAC17B603145}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactWindowsCore-Desktop", "ReactWindowsCore\ReactWindowsCore-Desktop.vcxproj", "{11C084A3-A57C-4296-A679-CAC17B603144}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -123,6 +123,7 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
 		ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603144}*SharedItemsImports = 4
+		ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603145}*SharedItemsImports = 9
 		JSI\Shared\JSI.Shared.vcxitems*{17dd1b17-3094-40dd-9373-ac2497932eca}*SharedItemsImports = 4
 		Mso\Mso.vcxitems*{1958ceaa-fbe0-44e3-8a99-90ad85531ffe}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9


### PR DESCRIPTION
In this change we cherry pick three approved PR and one partial non-approved PR that is required for others.
- PR #4980 Implemented support for native module std::weak_ptr.
- PR #4986 Fix ReactInstance error state to avoid crashes.
- PR #4953 (not aprroved) ReactNotificationService to allow communication between native modules - we only bring **changes for ReactDispatcher** required by other PRs in this batch, not the IReactNotificationService itself.
- PR #5007 Add UIDispatcher property to ReactInstanceSettings and IReactContext

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5133)