### PR TITLE
DevMenu should only show up when DeveloperSupport is on

### DIFF
--- a/change/react-native-windows-2020-06-05-17-10-24-devmenudevsup.json
+++ b/change/react-native-windows-2020-06-05-17-10-24-devmenudevsup.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "DevMenu should only show up when DeveloperSupport is on",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-06T00:10:24.492Z"
+}

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -41,6 +41,7 @@ void MainPage::OnLoadClick(
   ReactRootView().ComponentName(mainComponentName);
   ReactRootView().ReactNativeHost(host);
 
+  host.InstanceSettings().UseDeveloperSupport(true);
   host.InstanceSettings().UseWebDebugger(x_UseWebDebuggerCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseDirectDebugger(x_UseDirectDebuggerCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -80,6 +80,9 @@ void DevMenuManager::Init() noexcept {
 DevMenuManager::DevMenuManager(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
 
 void DevMenuManager::CreateAndShowUI() noexcept {
+  if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context->Properties()))
+    return;
+
   const winrt::hstring xamlString =
       LR"(
   <StackPanel


### PR DESCRIPTION
Fallout from #5115.  The devmenu is currently showing up even when DeveloperSupport is set to false.

(Also changing the playground app to always have DeveloperSupport turned on)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5136)