### PR TITLE
Native Animations shouldn't crash on RS3-RS4

### DIFF
--- a/change/react-native-windows-2020-06-05-17-57-31-animationLowerThanRS5.json
+++ b/change/react-native-windows-2020-06-05-17-57-31-animationLowerThanRS5.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't crash when using animations in RS3-RS4, just no-op",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-06T00:57:31.416Z"
+}

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -9,6 +9,7 @@
 #include "NativeAnimatedNodeManager.h"
 #include "PropsAnimatedNode.h"
 #include "StyleAnimatedNode.h"
+#include <ReactUWP/Utils/Helpers.h>
 
 namespace react {
 namespace uwp {
@@ -158,7 +159,7 @@ void PropsAnimatedNode::StartAnimations() {
 void PropsAnimatedNode::DisposeCompletedAnimation(int64_t valueTag) {
   if (m_expressionAnimations.count(valueTag)) {
     if (const auto target = GetUIElement()) {
-      // We should start and stop the expression animtaions if there are
+      // We should start and stop the expression animations if there are
       // no active animations. Suspending the active expression animations
       // while they are not in use causes subsequent key frame animations
       // which target the providing property set to never fire their completed
@@ -267,9 +268,11 @@ ShadowNodeBase *PropsAnimatedNode::GetShadowNodeBase() {
 }
 
 xaml::UIElement PropsAnimatedNode::GetUIElement() {
-  if (const auto shadowNodeBase = GetShadowNodeBase()) {
-    if (const auto shadowNodeView = shadowNodeBase->GetView()) {
-      return shadowNodeView.as<xaml::UIElement>();
+  if (IsRS5OrHigher()) {
+    if (const auto shadowNodeBase = GetShadowNodeBase()) {
+      if (const auto shadowNodeView = shadowNodeBase->GetView()) {
+        return shadowNodeView.as<xaml::UIElement>();
+      }
     }
   }
   return nullptr;

--- a/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/ReactUWP/Modules/Animated/PropsAnimatedNode.cpp
@@ -4,12 +4,12 @@
 #include "pch.h"
 
 #include <ReactUWP/Modules/NativeUIManager.h>
+#include <ReactUWP/Utils/Helpers.h>
 #include <ReactUWP/Views/XamlFeatures.h>
 #include <Views/ShadowNodeBase.h>
 #include "NativeAnimatedNodeManager.h"
 #include "PropsAnimatedNode.h"
 #include "StyleAnimatedNode.h"
-#include <ReactUWP/Utils/Helpers.h>
 
 namespace react {
 namespace uwp {


### PR DESCRIPTION
Fixes #5132 (turns a crash into a no-op).
We use XAML APIs that aren't available below RS5, and we say so in our docs, but we still crash. Let's not crash and instead no-op.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5137)