### PR TITLE
Remove legacy react::uwp::ReactInstanceSettings struct

### DIFF
--- a/change/react-native-windows-2020-06-05-21-41-46-RemoveLegacySettings.json
+++ b/change/react-native-windows-2020-06-05-21-41-46-RemoveLegacySettings.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove legacy ReactInstanceSettings struct",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-06T04:41:46.309Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleApps.sln
@@ -34,7 +34,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "..\..\..\vnext\Co
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReactNative", "ReactNative", "{5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shared", "..\..\..\vnext\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Shared", "..\..\..\vnext\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\..\..\vnext\Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
 EndProject
@@ -46,9 +46,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ReactNative.Manag
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\..\..\vnext\ReactWindowsCore\ReactWindowsCore.vcxitems*{11c084a3-a57c-4296-a679-cac17b603144}*SharedItemsImports = 4
+		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
+		..\..\..\vnext\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
+		..\..\..\vnext\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
 		..\..\..\vnext\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
+		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
+		..\..\..\vnext\include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
 		..\..\..\vnext\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -133,10 +133,6 @@ struct ViewManagerProvider2 {
 //! A simple struct that describes the basic properties/needs of an SDX. Whenever a new SDX is
 //! getting hosted in React, properties here will be used to construct the SDX.
 struct ReactOptions {
-#ifndef CORE_ABI
-  react::uwp::ReactInstanceSettings LegacySettings;
-#endif
-
   winrt::Microsoft::ReactNative::IReactPropertyBag Properties;
 
   winrt::Microsoft::ReactNative::IReactNotificationService Notifications;
@@ -201,6 +197,13 @@ struct ReactOptions {
   //! Flag controlling whether the JavaScript engine uses JIT compilation.
   bool EnableJITCompilation{true};
 
+  std::string ByteCodeFileUri;
+  bool EnableByteCodeCaching{true};
+  bool UseJsi{true};
+#ifndef CORE_ABI
+  react::uwp::JSIEngine JsiEngine{react::uwp::JSIEngine::Chakra};
+#endif
+
   //! Enable function nativePerformanceNow.
   //! Method nativePerformanceNow() returns high resolution time info.
   //! It is not safe to expose to Custom Function. Add this flag so we can turn it off for Custom Function.
@@ -208,7 +211,7 @@ struct ReactOptions {
 
   ReactDevOptions DeveloperSettings = {};
 
-  //! This controls the availiablility of various developer support functionality including
+  //! This controls the availability of various developer support functionality including
   //! RedBox, and the Developer Menu
   void SetUseDeveloperSupport(bool enable) noexcept;
   bool UseDeveloperSupport() const noexcept;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -158,9 +158,8 @@ ReactInstanceWin::ReactInstanceWin(
           this,
           options.Properties,
           winrt::make<implementation::ReactNotificationService>(options.Notifications))},
-      m_legacyInstance{std::make_shared<react::uwp::UwpReactInstanceProxy>(
-          Mso::WeakPtr<Mso::React::IReactInstance>{this},
-          Mso::Copy(options.LegacySettings))} {
+      m_legacyInstance{
+          std::make_shared<react::uwp::UwpReactInstanceProxy>(Mso::WeakPtr<Mso::React::IReactInstance>{this})} {
   m_whenCreated.SetValue();
 }
 
@@ -172,8 +171,7 @@ void ReactInstanceWin::Initialize() noexcept {
   InitNativeMessageThread();
   InitUIMessageThread();
 
-  m_legacyReactInstance =
-      std::make_shared<react::uwp::UwpReactInstanceProxy>(this, Mso::Copy(m_options.LegacySettings));
+  m_legacyReactInstance = std::make_shared<react::uwp::UwpReactInstanceProxy>(this);
 
   // InitUIManager uses m_legacyReactInstance
   InitUIManager();
@@ -294,11 +292,11 @@ void ReactInstanceWin::Initialize() noexcept {
             cxxModules.insert(std::end(cxxModules), std::begin(customCxxModules), std::end(customCxxModules));
           }
 
-          if (m_options.LegacySettings.UseJsi) {
+          if (m_options.UseJsi) {
             std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
             std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
-            switch (m_options.LegacySettings.jsiEngine) {
+            switch (m_options.JsiEngine) {
               case react::uwp::JSIEngine::Hermes:
 #if defined(USE_HERMES)
                 devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
@@ -314,11 +312,10 @@ void ReactInstanceWin::Initialize() noexcept {
                 break;
 #endif
               case react::uwp::JSIEngine::Chakra:
-                if (m_options.LegacySettings.EnableByteCodeCaching ||
-                    !m_options.LegacySettings.ByteCodeFileUri.empty()) {
+                if (m_options.EnableByteCodeCaching || !m_options.ByteCodeFileUri.empty()) {
                   scriptStore = std::make_unique<react::uwp::UwpScriptStore>();
                   preparedScriptStore = std::make_unique<react::uwp::UwpPreparedScriptStore>(
-                      winrt::to_hstring(m_options.LegacySettings.ByteCodeFileUri));
+                      winrt::to_hstring(m_options.ByteCodeFileUri));
                 }
                 devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
                     devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
@@ -769,7 +766,7 @@ std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() 
 }
 
 std::string ReactInstanceWin::GetBundleRootPath() noexcept {
-  return m_bundleRootPath.empty() ? m_options.LegacySettings.BundleRootPath : m_bundleRootPath;
+  return m_bundleRootPath.empty() ? m_options.BundleRootPath : m_bundleRootPath;
 }
 
 std::shared_ptr<react::uwp::IReactInstance> ReactInstanceWin::UwpReactInstance() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
@@ -10,16 +10,8 @@
 
 namespace react::uwp {
 
-UwpReactInstanceProxy::UwpReactInstanceProxy(
-    Mso::WeakPtr<Mso::React::IReactInstance> &&weakReactInstance,
-    ReactInstanceSettings &&instanceSettings) noexcept
-    : m_weakReactInstance{weakReactInstance}, m_instanceSettings{std::move(instanceSettings)} {}
-
-void UwpReactInstanceProxy::Start(
-    const std::shared_ptr<IReactInstance> & /*spThis*/,
-    const ReactInstanceSettings & /*settings*/) {
-  VerifyElseCrashSz(false, "Deprecated. Use ReactHost.");
-}
+UwpReactInstanceProxy::UwpReactInstanceProxy(Mso::WeakPtr<Mso::React::IReactInstance> &&weakReactInstance) noexcept
+    : m_weakReactInstance{weakReactInstance} {}
 
 void UwpReactInstanceProxy::AttachMeasuredRootView(IXamlRootView * /*pRootView*/, folly::dynamic && /*initProps*/) {
   VerifyElseCrashSz(false, "Deprecated. Use ReactHost.");
@@ -130,10 +122,6 @@ void UwpReactInstanceProxy::loadBundle(std::string && /*jsBundleRelativePath*/) 
 
 ExpressionAnimationStore &UwpReactInstanceProxy::GetExpressionAnimationStore() {
   return m_expressionAnimationStore;
-}
-
-const ReactInstanceSettings &UwpReactInstanceProxy::GetReactInstanceSettings() const {
-  return m_instanceSettings;
 }
 
 std::string UwpReactInstanceProxy::GetBundleRootPath() const noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
@@ -21,13 +21,9 @@ namespace react::uwp {
 struct ViewManagerProvider;
 
 struct UwpReactInstanceProxy : IReactInstance, std::enable_shared_from_this<UwpReactInstanceProxy> {
-  UwpReactInstanceProxy(
-      Mso::WeakPtr<Mso::React::IReactInstance> &&weakReactInstance,
-      ReactInstanceSettings &&instanceSettings) noexcept;
+  UwpReactInstanceProxy(Mso::WeakPtr<Mso::React::IReactInstance> &&weakReactInstance) noexcept;
 
  public: // IReactInstance
-  void Start(const std::shared_ptr<IReactInstance> &spThis, const ReactInstanceSettings &settings) override;
-
   void AttachMeasuredRootView(IXamlRootView *pRootView, folly::dynamic &&initProps) override;
   void DetachRootView(IXamlRootView *pRootView) override;
   LiveReloadCallbackCookie RegisterLiveReloadCallback(std::function<void()> callback) override;
@@ -49,7 +45,6 @@ struct UwpReactInstanceProxy : IReactInstance, std::enable_shared_from_this<UwpR
   const std::string &LastErrorMessage() const noexcept override;
   void loadBundle(std::string &&jsBundleRelativePath) override;
   ExpressionAnimationStore &GetExpressionAnimationStore() override;
-  const ReactInstanceSettings &GetReactInstanceSettings() const override;
   std::string GetBundleRootPath() const noexcept override;
   bool IsLoaded() const noexcept override;
 
@@ -59,7 +54,6 @@ struct UwpReactInstanceProxy : IReactInstance, std::enable_shared_from_this<UwpR
 
  private:
   Mso::WeakPtr<Mso::React::IReactInstance> m_weakReactInstance;
-  ReactInstanceSettings m_instanceSettings;
   ExpressionAnimationStore m_expressionAnimationStore;
   std::function<void(XamlView)> m_xamlViewCreatedTestHook;
 };

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -68,48 +68,30 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
     }
   }
 
-  react::uwp::ReactInstanceSettings legacySettings{};
-  legacySettings.BundleRootPath = to_string(m_instanceSettings.BundleRootPath());
-  legacySettings.ByteCodeFileUri = to_string(m_instanceSettings.ByteCodeFileUri());
-  legacySettings.DebugBundlePath = to_string(m_instanceSettings.DebugBundlePath());
-  legacySettings.DebugHost = to_string(m_instanceSettings.DebugHost());
-  legacySettings.EnableByteCodeCaching = m_instanceSettings.EnableByteCodeCaching();
-  legacySettings.UseDeveloperSupport = m_instanceSettings.UseDeveloperSupport();
-  legacySettings.EnableJITCompilation = m_instanceSettings.EnableJITCompilation();
-  legacySettings.UseDirectDebugger = m_instanceSettings.UseDirectDebugger();
-  legacySettings.DebuggerBreakOnNextLine = m_instanceSettings.DebuggerBreakOnNextLine();
-  legacySettings.UseJsi = m_instanceSettings.UseJsi();
-  legacySettings.UseFastRefresh = m_instanceSettings.UseFastRefresh();
-  legacySettings.UseLiveReload = m_instanceSettings.UseLiveReload();
-  legacySettings.UseWebDebugger = m_instanceSettings.UseWebDebugger();
-  legacySettings.DebuggerPort = m_instanceSettings.DebuggerPort();
-  legacySettings.SourceBundleHost = to_string(m_instanceSettings.SourceBundleHost());
-  legacySettings.SourceBundlePort = m_instanceSettings.SourceBundlePort();
-
-  if (m_instanceSettings.RedBoxHandler()) {
-    legacySettings.RedBoxHandler = std::move(Mso::React::CreateRedBoxHandler(m_instanceSettings.RedBoxHandler()));
-  }
-
   Mso::React::ReactOptions reactOptions{};
   reactOptions.Properties = m_instanceSettings.Properties();
   reactOptions.Notifications = m_instanceSettings.Notifications();
-  reactOptions.SetUseDeveloperSupport(legacySettings.UseDeveloperSupport);
-  reactOptions.DeveloperSettings.SourceBundleName = legacySettings.DebugBundlePath;
-  reactOptions.SetUseWebDebugger(legacySettings.UseWebDebugger);
-  reactOptions.SetUseDirectDebugger(legacySettings.UseDirectDebugger);
-  reactOptions.SetDebuggerBreakOnNextLine(legacySettings.DebuggerBreakOnNextLine);
-  reactOptions.SetUseFastRefresh(legacySettings.UseFastRefresh);
-  reactOptions.SetUseLiveReload(legacySettings.UseLiveReload);
-  reactOptions.EnableJITCompilation = legacySettings.EnableJITCompilation;
-  reactOptions.DeveloperSettings.DebugHost = legacySettings.DebugHost;
-  reactOptions.BundleRootPath = legacySettings.BundleRootPath;
-  reactOptions.DeveloperSettings.DebuggerPort = legacySettings.DebuggerPort;
-  reactOptions.RedBoxHandler = legacySettings.RedBoxHandler;
-  reactOptions.DeveloperSettings.SourceBundleHost = legacySettings.SourceBundleHost;
+  reactOptions.SetUseDeveloperSupport(m_instanceSettings.UseDeveloperSupport());
+  reactOptions.DeveloperSettings.SourceBundleName = to_string(m_instanceSettings.DebugBundlePath());
+  reactOptions.SetUseWebDebugger(m_instanceSettings.UseWebDebugger());
+  reactOptions.SetUseDirectDebugger(m_instanceSettings.UseDirectDebugger());
+  reactOptions.SetDebuggerBreakOnNextLine(m_instanceSettings.DebuggerBreakOnNextLine());
+  reactOptions.SetUseFastRefresh(m_instanceSettings.UseFastRefresh());
+  reactOptions.SetUseLiveReload(m_instanceSettings.UseLiveReload());
+  reactOptions.EnableJITCompilation = m_instanceSettings.EnableJITCompilation();
+  reactOptions.DeveloperSettings.DebugHost = to_string(m_instanceSettings.DebugHost());
+  reactOptions.BundleRootPath = to_string(m_instanceSettings.BundleRootPath());
+  reactOptions.DeveloperSettings.DebuggerPort = m_instanceSettings.DebuggerPort();
+  if (m_instanceSettings.RedBoxHandler()) {
+    reactOptions.RedBoxHandler = Mso::React::CreateRedBoxHandler(m_instanceSettings.RedBoxHandler());
+  }
+  reactOptions.DeveloperSettings.SourceBundleHost = to_string(m_instanceSettings.SourceBundleHost());
   reactOptions.DeveloperSettings.SourceBundlePort =
-      legacySettings.SourceBundlePort != 0 ? std::to_string(legacySettings.SourceBundlePort) : "";
+      m_instanceSettings.SourceBundlePort() != 0 ? std::to_string(m_instanceSettings.SourceBundlePort()) : "";
 
-  reactOptions.LegacySettings = std::move(legacySettings);
+  reactOptions.ByteCodeFileUri = to_string(m_instanceSettings.ByteCodeFileUri());
+  reactOptions.EnableByteCodeCaching = m_instanceSettings.EnableByteCodeCaching();
+  reactOptions.UseJsi = m_instanceSettings.UseJsi();
 
   reactOptions.ModuleProvider = modulesProvider;
   reactOptions.ViewManagerProvider = viewManagersProvider;

--- a/vnext/include/ReactUWP/IReactInstance.h
+++ b/vnext/include/ReactUWP/IReactInstance.h
@@ -34,35 +34,8 @@ enum class JSIEngine : int32_t {
   V8 = 2, // Use the JSIExecutorFactory with V8
 };
 
-struct ReactInstanceSettings {
-  bool UseWebDebugger{false};
-  bool UseFastRefresh{false};
-  bool UseLiveReload{false};
-  bool DebuggerBreakOnNextLine{false};
-  bool UseDirectDebugger{false};
-  bool UseJsi{true};
-  bool EnableJITCompilation{true};
-  bool EnableByteCodeCaching{false};
-  bool UseDeveloperSupport{false};
-  uint16_t DebuggerPort{9229};
-  uint16_t SourceBundlePort{0};
-
-  std::string ByteCodeFileUri;
-  std::string DebugHost;
-  std::string DebugBundlePath;
-  std::string BundleRootPath;
-  std::string SourceBundleHost;
-  facebook::react::NativeLoggingHook LoggingCallback;
-  std::shared_ptr<Mso::React::IRedBoxHandler> RedBoxHandler;
-  JSIEngine jsiEngine{JSIEngine::Chakra};
-};
-
 struct IReactInstance {
   virtual ~IReactInstance() = default;
-
-  // Start the instance, triggering NativeModules descriptions and things to be
-  // resolved spThis make caller have full ability to create the shared_ptr
-  virtual void Start(const std::shared_ptr<IReactInstance> &spThis, const ReactInstanceSettings &settings) = 0;
 
   virtual void AttachMeasuredRootView(IXamlRootView *pRootView, folly::dynamic &&initProps) = 0;
   virtual void DetachRootView(IXamlRootView *pRootView) = 0;
@@ -111,8 +84,6 @@ struct IReactInstance {
   virtual void CallXamlViewCreatedTestHook(react::uwp::XamlView view) = 0;
 
   virtual ExpressionAnimationStore &GetExpressionAnimationStore() = 0;
-
-  virtual const ReactInstanceSettings &GetReactInstanceSettings() const = 0;
 
   virtual bool IsLoaded() const noexcept = 0;
 };


### PR DESCRIPTION
This PR is to simplify settings for ReactNative instance. Here we remove the `react::uwp::ReactInstanceSettings` struct which was used for the ReactUWP implementation before. After this change we initialize `ReactOptions` directly from the `ReactInstanceSettings`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5139)