### PR TITLE
Fix difference in layout algorithm between windows and other platforms

### DIFF
--- a/change/react-native-windows-2020-06-06-07-10-00-uselegacystretch.json
+++ b/change/react-native-windows-2020-06-06-07-10-00-uselegacystretch.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use yoga config to align with ios/android",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-06T14:10:00.885Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -379,6 +379,10 @@
     <ClInclude Include="Threading\BatchingQueueThread.h" />
     <ClInclude Include="Threading\MessageDispatchQueue.h" />
     <ClInclude Include="Threading\MessageQueueThreadFactory.h" />
+    <ClInclude Include="QuirkSettings.h">
+      <DependentUpon>QuirkSettings.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="ViewManagersProvider.h" />
     <ClInclude Include="Views\DevMenu.h" />
     <ClInclude Include="Views\ReactRootControl.h" />
@@ -555,6 +559,10 @@
     <ClCompile Include="Threading\BatchingQueueThread.cpp" />
     <ClCompile Include="Threading\MessageDispatchQueue.cpp" />
     <ClCompile Include="Threading\MessageQueueThreadFactory.cpp" />
+    <ClCompile Include="QuirkSettings.cpp">
+      <DependentUpon>QuirkSettings.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="ViewManagersProvider.cpp" />
     <ClCompile Include="Views\DevMenu.cpp" />
     <ClCompile Include="Views\ReactRootControl.cpp" />
@@ -595,6 +603,9 @@
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="ReactRootView.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+    <Midl Include="QuirkSettings.idl">
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="XamlHelper.idl" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -712,6 +712,7 @@
     <Midl Include="ReactNativeHost.idl" />
     <Midl Include="ReactRootView.idl" />
     <Midl Include="RedBoxHandler.idl" />
+    <Midl Include="QuirkSettings.idl" />
     <Midl Include="XamlHelper.idl" />
     <Midl Include="XamlUIService.idl" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -5,20 +5,22 @@
 #include "QuirkSettings.h"
 #include "QuirkSettings.g.cpp"
 
-#include "ReactPropertyBag.h"
 #include "QuirkSettings.h"
+#include "ReactPropertyBag.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
 QuirkSettings::QuirkSettings() noexcept {}
 
-/*static*/ void QuirkSettings::SetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept {
+/*static*/ void QuirkSettings::SetMatchAndroidAndIOSStretchBehavior(
+    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+    bool value) noexcept {
   SetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag(settings.Properties()), value);
 }
 
 winrt::Microsoft::ReactNative::ReactPropertyId<bool> MatchAndroidAndIOSStretchBehaviorProperty() noexcept {
-  static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
-      L"ReactNative.QuirkSettings", L"MatchAndroidAndIOSyStretchBehavior"};
+  static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{L"ReactNative.QuirkSettings",
+                                                                     L"MatchAndroidAndIOSyStretchBehavior"};
   return propId;
 }
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "QuirkSettings.h"
+#include "QuirkSettings.g.cpp"
+
+#include "ReactPropertyBag.h"
+#include "QuirkSettings.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+QuirkSettings::QuirkSettings() noexcept {}
+
+/*static*/ void QuirkSettings::SetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept {
+  SetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag(settings.Properties()), value);
+}
+
+winrt::Microsoft::ReactNative::ReactPropertyId<bool> MatchAndroidAndIOSStretchBehaviorProperty() noexcept {
+  static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
+      L"ReactNative.QuirkSettings", L"MatchAndroidAndIOSyStretchBehavior"};
+  return propId;
+}
+
+/*static*/ void QuirkSettings::SetMatchAndroidAndIOSStretchBehavior(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    bool value) noexcept {
+  properties.Set(MatchAndroidAndIOSStretchBehaviorProperty(), value);
+}
+
+/*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept {
+  return properties.Get(MatchAndroidAndIOSStretchBehaviorProperty()).value_or(true);
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "QuirkSettings.g.h"
+#include "ReactPropertyBag.h"
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
+public:
+  QuirkSettings() noexcept;
+
+  // public API - part of idl interface
+  static void SetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept;
+
+  // Internal use
+  static void SetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties, bool value) noexcept;
+  static bool GetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+
+struct QuirkSettings : QuirkSettingsT<QuirkSettings, implementation::QuirkSettings> {};
+
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -4,23 +4,26 @@
 #pragma once
 
 #include "QuirkSettings.g.h"
-#include "ReactPropertyBag.h"
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
+#include "ReactPropertyBag.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
 struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
-public:
+ public:
   QuirkSettings() noexcept;
 
   // public API - part of idl interface
-  static void SetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept;
+  static void SetMatchAndroidAndIOSStretchBehavior(
+      winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+      bool value) noexcept;
 
   // Internal use
-  static void SetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties, bool value) noexcept;
+  static void SetMatchAndroidAndIOSStretchBehavior(
+      winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+      bool value) noexcept;
   static bool GetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
-
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "ReactInstanceSettings.idl";
+
+namespace Microsoft.ReactNative {
+
+  // This can be used to add settings that allow react-native-windows behavior to be maintained across version updates
+  // to facilitate upgrades.  Settings in here are likely to be removed in future releases, so apps should try to update
+  // their code to not rely on settings from here.
+  [webhosthidden]
+  [default_interface]
+  runtimeclass QuirkSettings {
+    QuirkSettings();
+
+    // Older versions of react-native-windows did not use yoga's legacy stretch behavior.  This meant that 
+    // react-native-windows would layout views slightly differently that in iOS and Android.
+    // Set this setting to false to maintain the behavior from react-native-windows <= 0.62
+    // The default value is true.
+    static void SetMatchAndroidAndIOSStretchBehavior(ReactInstanceSettings settings, Boolean value);
+  }
+
+} // namespace Microsoft.ReactNative

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -130,17 +130,6 @@ XamlView NativeUIManager::reactPeerOrContainerFrom(xaml::FrameworkElement fe) {
   return nullptr;
 }
 
-// Previous versions of react-native-windows did not configure Yoga to use "LegacyStretchBehaviour"
-// We now set it, but to allow apps a period to transition, we are adding a property that can be set to
-// maintain the previous behavior.
-winrt::Microsoft::ReactNative::IReactPropertyName LegacyStretchBehaviourProperty() noexcept {
-  static winrt::Microsoft::ReactNative::IReactPropertyName propName =
-      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetName(
-          winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetNamespace(L"ReactNative.NativeUIManager"),
-          L"LegacyStretchBehaviour");
-  return propName;
-}
-
 NativeUIManager::NativeUIManager(Mso::React::IReactContext *reactContext) {
   m_context = reactContext;
 

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -26,14 +26,13 @@ using namespace xaml::Media;
 namespace react {
 namespace uwp {
 
-
 YGConfigRef getYogaConfig(bool useLegacyStretchBehaviour) {
   static YGConfigRef yogaConfig;
   static std::once_flag onceFlag;
   std::call_once(onceFlag, [useLegacyStretchBehaviour]() {
     yogaConfig = YGConfigNew();
     YGConfigSetUseLegacyStretchBehaviour(yogaConfig, useLegacyStretchBehaviour);
-    });
+  });
   return yogaConfig;
 }
 

--- a/vnext/ReactUWP/Modules/NativeUIManager.h
+++ b/vnext/ReactUWP/Modules/NativeUIManager.h
@@ -101,6 +101,7 @@ class NativeUIManager : public facebook::react::INativeUIManager {
   facebook::react::INativeUIManagerHost *m_host = nullptr;
   Mso::CntPtr<Mso::React::IReactContext> m_context;
   bool m_inBatch = false;
+  bool m_useLegacyStretchBehaviour = true;
 
   std::map<int64_t, YogaNodePtr> m_tagsToYogaNodes;
   std::map<int64_t, std::unique_ptr<YogaContext>> m_tagsToYogaContext;

--- a/vnext/ReactUWP/Modules/NativeUIManager.h
+++ b/vnext/ReactUWP/Modules/NativeUIManager.h
@@ -100,8 +100,8 @@ class NativeUIManager : public facebook::react::INativeUIManager {
  private:
   facebook::react::INativeUIManagerHost *m_host = nullptr;
   Mso::CntPtr<Mso::React::IReactContext> m_context;
+  YGConfigRef m_yogaConfig;
   bool m_inBatch = false;
-  bool m_useLegacyStretchBehaviour = true;
 
   std::map<int64_t, YogaNodePtr> m_tagsToYogaNodes;
   std::map<int64_t, std::unique_ptr<YogaContext>> m_tagsToYogaContext;


### PR DESCRIPTION
The following UI lays out differently in react-native-windows than on android/iOS.  This difference is due to android/iOS configuring yoga to "useLegacyStretchBehaviour".

This change aligns the yoga config of react-native-windows to match the other platforms.  -- However, I also added a property to the PropertyBag that can be added to restore the previous behavior.  This should allow apps to keep the current behavior until they can fix any issues with moving to the same layout config as the other platforms.

```jsx
      <View
        style={{
          flex: 1,
        }}>
        <View
          style={{
            flexDirection: 'row',
            alignItems: 'center',
          }}>
          <View
            style={{
              flexDirection: 'row',
              alignItems: 'center',
              // flex: 1, // RNW requires this or the two boxes will be flush together, not flush to left/right edges of screen
            }}>
            <View
              style={{
                height: itemSize,
                width: itemSize,
                backgroundColor: 'red',
              }}
            />
            <View
              style={{
                flex: 1,
                backgroundColor: 'red',
              }}
            />
            <View
              style={{
                height: itemSize,
                width: itemSize,
                backgroundColor: 'red',
              }}
            />
          </View>
        </View>
      </View>
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5140)