### PR TITLE
 Fix support for `--namespace` on react-native-windows init for cpp

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -8,6 +8,7 @@ parameters:
   vsComponents: ''
   listVsComponents: false
   installVsComponents: false
+  additionalInitArguments: ''
 
 steps:
   - checkout: self # self represents the repo where the initial Pipelines YAML file was found
@@ -69,7 +70,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: npx react-native-windows-init --version master --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }}
+      script: npx react-native-windows-init --version master --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: PowerShell@2

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -540,7 +540,7 @@ jobs:
           configuration: $(configuration)
           platform: $(platform)
           version: $(reactNativeVersion)
-          additionalInitArguments: $(additionalInitArguments)
+          additionalInitArguments: $[ coalesce($(additionalInitArguments), '') ]
 
   - job: CliInitExperimental
     displayName: Verify react-native init experimental
@@ -559,6 +559,7 @@ jobs:
           configuration: Debug
           platform: x86
           version: $(reactNativeVersion)
+          additionalInitArguments: ${{ '' }}
           experimentalNugetDependency: true
 
   - job: RNWExtraChecks

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -466,10 +466,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
+          additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
         X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
+          additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
         #X86ReleaseCpp:
         #  language: cpp
         #  configuration: Release
@@ -538,6 +540,7 @@ jobs:
           configuration: $(configuration)
           platform: $(platform)
           version: $(reactNativeVersion)
+          additionalInitArguments: $(additionalInitArguments)
 
   - job: CliInitExperimental
     displayName: Verify react-native init experimental

--- a/change/react-native-windows-2020-06-06-20-24-10-master.json
+++ b/change/react-native-windows-2020-06-06-20-24-10-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix support for `--namespace` on react-native-windows init for cpp",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-07T03:24:10.384Z"
+}

--- a/change/react-native-windows-init-2020-06-06-20-24-10-master.json
+++ b/change/react-native-windows-init-2020-06-06-20-24-10-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix support for `--namespace` on react-native-windows init for cpp",
+  "packageName": "react-native-windows-init",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-07T03:24:06.820Z"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -29,7 +29,11 @@ const argv = yargs.version(false).options({
     type: 'string',
     describe: 'The version of react-native-windows to use.',
   },
-  namespace: {type: 'string', describe: 'The native project namespace.'},
+  namespace: {
+    type: 'string',
+    describe:
+      "The native project namespace. This should be expressed using dots as separators. i.e. 'Level1.Level2.Level3'. The generator will apply the correct syntax for the target language",
+  },
   verbose: {type: 'boolean', describe: 'Enables logging.'},
   language: {
     type: 'string',
@@ -49,11 +53,10 @@ const argv = yargs.version(false).options({
   },
   useWinUI3: {
     type: 'boolean',
-    describe:
-    '[Experimental] Use WinUI3',
+    describe: '[Experimental] Use WinUI3',
     hidden: true,
     default: false,
-  }
+  },
 }).argv;
 
 const EXITCODE_UNSUPPORTED_VERION_RN = 3;

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -69,7 +69,8 @@ function copyProjectTemplateAndReplace(
   createDir(path.join(destPath, windowsDir, newProjectName, 'BundleBuilder'));
 
   const language = options.language;
-  const ns = options.ns || newProjectName;
+  const namespace = options.ns || newProjectName;
+  const namespaceCpp = toCppNamespace(namespace);
   if (options.experimentalNugetDependency) {
     console.log('Using experimental NuGet dependency.');
   }
@@ -85,7 +86,7 @@ function copyProjectTemplateAndReplace(
   const certificateThumbprint = generateCertificate(srcPath, destPath, newProjectName, currentUser);
 
   const xamlNamespace = options.useWinUI3 ? 'Microsoft.UI.Xaml' : 'Windows.UI.Xaml';
-  const xamlNamespaceCpp = xamlNamespace.replace(/\./g, '::',);
+  const xamlNamespaceCpp = toCppNamespace(xamlNamespace);
 
   const cppNugetPackages = [
     {
@@ -120,7 +121,8 @@ function copyProjectTemplateAndReplace(
     ],
 
     name: newProjectName,
-    namespace: ns,
+    namespace: namespace,
+    namespaceCpp: namespaceCpp,
 
     // Visual Studio is very picky about the casing of the guids for projects, project references and the solution
     // https://www.bing.com/search?q=visual+studio+project+guid+casing&cvid=311a5ad7f9fc41089507b24600d23ee7&FORM=ANAB01&PC=U531
@@ -184,6 +186,10 @@ function copyProjectTemplateAndReplace(
 
   console.log(chalk.white.bold('To run your app on UWP:'));
   console.log(chalk.white('   npx react-native run-windows'));
+}
+
+function toCppNamespace(namespace) {
+  return namespace.replace(/\./g, '::',);
 }
 
 function installDependencies(options) {

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
@@ -6,8 +6,8 @@
 #include "ReactPackageProvider.h"
 
 // clang-format off
-using namespace winrt::{{ namespace }};
-using namespace winrt::{{ namespace }}::implementation;
+using namespace winrt::{{ namespaceCpp }};
+using namespace winrt::{{ namespaceCpp }}::implementation;
 using namespace winrt;
 using namespace {{ xamlNamespaceCpp }};
 using namespace {{ xamlNamespaceCpp }}::Controls;
@@ -55,7 +55,7 @@ void App::OnLaunched(LaunchActivatedEventArgs const& e)
     super::OnLaunched(e);
 
     Frame rootFrame = Window::Current().Content().as<Frame>();
-    rootFrame.Navigate(xaml_typename<{{ name }}::MainPage>(), box_value(e.Arguments()));
+    rootFrame.Navigate(xaml_typename<{{ namespaceCpp }}::MainPage>(), box_value(e.Arguments()));
 }
 
 /// <summary>

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.h
@@ -3,7 +3,7 @@
 #include "App.xaml.g.h"
 
 // clang-format off
-namespace winrt::{{ namespace }}::implementation
+namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct App : AppT<App>
     {
@@ -14,6 +14,6 @@ namespace winrt::{{ namespace }}::implementation
       private:
         using super = AppT<App>;
     };
-} // namespace winrt::{{ namespace }}::implementation
+} // namespace winrt::{{ namespaceCpp }}::implementation
 
 // clang-format on

--- a/vnext/local-cli/generator-windows/templates/cpp/src/MainPage.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/MainPage.cpp
@@ -11,7 +11,7 @@
 using namespace winrt;
 using namespace {{ xamlNamespaceCpp }};
 
-namespace winrt::{{ namespace }}::implementation
+namespace winrt::{{ namespaceCpp }}::implementation
 {
     MainPage::MainPage()
     {

--- a/vnext/local-cli/generator-windows/templates/cpp/src/MainPage.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/MainPage.h
@@ -3,7 +3,7 @@
 #include <winrt/Microsoft.ReactNative.h>
 
 // clang-format off
-namespace winrt::{{ namespace }}::implementation
+namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct MainPage : MainPageT<MainPage>
     {
@@ -11,7 +11,7 @@ namespace winrt::{{ namespace }}::implementation
     };
 }
 
-namespace winrt::{{ namespace }}::factory_implementation
+namespace winrt::{{ namespaceCpp }}::factory_implementation
 {
     struct MainPage : MainPageT<MainPage, implementation::MainPage>
     {

--- a/vnext/local-cli/generator-windows/templates/cpp/src/MainPage.xaml
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/MainPage.xaml
@@ -1,13 +1,3 @@
-﻿<Page 
-    x:Class="{{ name }}.MainPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:{{ namespace }}"
-    xmlns:react="using:Microsoft.ReactNative"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-    <react:ReactRootView x:Name="ReactRootView" ComponentName="{{ name }}"
-        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" MinHeight="400"/>
+﻿<Page x:Class="{{ namespace }}.MainPage" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="using:{{ namespace }}" xmlns:react="using:Microsoft.ReactNative" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <react:ReactRootView x:Name="ReactRootView" ComponentName="{{ name }}" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" MinHeight="400"/>
 </Page>

--- a/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.cpp
@@ -5,7 +5,7 @@
 // clang-format off
 using namespace winrt::Microsoft::ReactNative;
 
-namespace winrt::{{ namespace }}::implementation
+namespace winrt::{{ namespaceCpp }}::implementation
 {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept
@@ -13,6 +13,6 @@ void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuil
     AddAttributedModules(packageBuilder);
 }
 
-} // namespace winrt::{{ namespace }}::implementation
+} // namespace winrt::{{ namespaceCpp }}::implementation
 
 // clang-format on

--- a/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/ReactPackageProvider.h
@@ -3,13 +3,13 @@
 #include "winrt/Microsoft.ReactNative.h"
 
 // clang-format off
-namespace winrt::{{ namespace }}::implementation
+namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct ReactPackageProvider : winrt::implements<ReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider>
     {
     public: // IReactPackageProvider
         void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept;
     };
-} // namespace winrt::{{ namespace }}::implementation
+} // namespace winrt::{{ namespaceCpp }}::implementation
 
 // clang-format on


### PR DESCRIPTION
The `react-native-windows init` template generation had a bug where namespaces weren't properly accounted for in the cpp project.
This PR takes the x86 slice of the init tests and forces the cpp and the cs language versions to have a namespace.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5145)