### PR TITLE
Fail on PowerShell exceptinos

### DIFF
--- a/change/react-native-windows-2020-06-08-21-53-49-5153.json
+++ b/change/react-native-windows-2020-06-08-21-53-49-5153.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "translate PS exception into error code",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-09T04:53:49.046Z"
+}

--- a/vnext/local-cli/runWindows/utils/commandWithProgress.js
+++ b/vnext/local-cli/runWindows/utils/commandWithProgress.js
@@ -48,6 +48,7 @@ async function runPowerShellScriptFunction(
   verbose,
 ) {
   try {
+    const printException = verbose ? '$_;' : '';
     await commandWithProgress(
       newSpinner(taskDescription),
       taskDescription,
@@ -56,7 +57,7 @@ async function runPowerShellScriptFunction(
         '-NoProfile',
         '-ExecutionPolicy',
         'RemoteSigned',
-        `Import-Module "${script}"; ${funcName} -ErrorAction Stop; exit $LASTEXITCODE`,
+        `Import-Module "${script}"; try { ${funcName} -ErrorAction Stop; $lec = $LASTEXITCODE; } catch { $lec = 1; ${printException} }; exit $lec`,
       ],
       verbose,
     );


### PR DESCRIPTION
Fixes #5153 

Igor ran into an issue while making a change, where we were failing to run the `Start-Locally` cmdlet but the failure was not being treated as an error by the CLI. This fix addresses this for the scope of `runPowerShellScriptFunction`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5155)