### PR TITLE
Call turbo module in IntegrationTests

### DIFF
--- a/change/react-native-windows-2020-06-09-15-04-44-pull_request.json
+++ b/change/react-native-windows-2020-06-09-15-04-44-pull_request.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Call turbo module in IntegrationTests",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-09T22:04:44.200Z"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -112,6 +112,7 @@
     <ClCompile Include="ReactNotificationServiceTests.cpp" />
     <ClCompile Include="ReactPropertyBagTests.cpp" />
     <ClCompile Include="ReactNativeHostTests.cpp" />
+    <ClCompile Include="TurboModuleTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
@@ -123,8 +124,10 @@
   <ItemGroup>
     <Manifest Include="Application.manifest" />
     <None Include="AddValues.js" />
+    <None Include="TurboModuleTests.js" />
     <None Include="packages.config" />
     <JsBundleEntry Include="AddValues.js" />
+    <JsBundleEntry Include="TurboModuleTests.js" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <NativeModules.h>
+#include <string>
+
+using namespace React;
+
+namespace ReactNativeIntegrationTests {
+
+REACT_MODULE(SampleTurboModule)
+struct SampleTurboModule {
+  REACT_INIT(Initialize)
+  void Initialize(ReactContext const & /*reactContext*/) noexcept {}
+
+  REACT_METHOD(voidFunction)
+  void voidFunction() noexcept {
+    voidFunctionSignal.set_value(65536);
+  }
+
+  static std::promise<int> voidFunctionSignal;
+};
+
+std::promise<int> SampleTurboModule::voidFunctionSignal;
+
+struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto methods = std::tuple{
+      Method<void() noexcept>{0, L"voidFunction"},
+  };
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    constexpr auto methodCheckResults = CheckMethods<TModule, SampleTurboModuleSpec>();
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(0, "voidFunction", "I don't care error message");
+  }
+};
+
+struct SampleTurboModulePackageProvider : winrt::implements<SampleTurboModulePackageProvider, IReactPackageProvider> {
+  void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
+    auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
+    experimental.AddTurboModule(
+        L"SampleTurboModule",
+        winrt::Microsoft::ReactNative::MakeTurboModuleProvider<SampleTurboModule, SampleTurboModuleSpec>());
+  }
+};
+
+TEST_CLASS (TurboModuleTests) {
+  TEST_METHOD(ExecuteSampleTurboModule) {
+    winrt::Microsoft::ReactNative::ReactNativeHost host{};
+
+    auto queueController = winrt::Windows::System::DispatcherQueueController::CreateOnDedicatedThread();
+    queueController.DispatcherQueue().TryEnqueue([&]() noexcept {
+      host.PackageProviders().Append(winrt::make<SampleTurboModulePackageProvider>());
+
+      // bundle is assumed to be co-located with the test binary
+      wchar_t testBinaryPath[MAX_PATH];
+      TestCheck(GetModuleFileNameW(NULL, testBinaryPath, MAX_PATH) < MAX_PATH);
+      testBinaryPath[std::wstring_view{testBinaryPath}.rfind(L"\\")] = 0;
+
+      host.InstanceSettings().BundleRootPath(testBinaryPath);
+      host.InstanceSettings().JavaScriptBundleFile(L"TurboModuleTests");
+      host.InstanceSettings().UseDeveloperSupport(false);
+      host.InstanceSettings().UseWebDebugger(false);
+      host.InstanceSettings().UseFastRefresh(false);
+      host.InstanceSettings().UseLiveReload(false);
+      host.InstanceSettings().EnableDeveloperMenu(false);
+
+      host.LoadInstance();
+    });
+
+    TestCheckEqual(1, SampleTurboModule::voidFunctionSignal.get_future().get());
+
+    host.UnloadInstance().get();
+    queueController.ShutdownQueueAsync().get();
+  }
+};
+
+} // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -70,7 +70,7 @@ TEST_CLASS (TurboModuleTests) {
       host.LoadInstance();
     });
 
-    TestCheckEqual(1, SampleTurboModule::voidFunctionSignal.get_future().get());
+    TestCheckEqual(65536, SampleTurboModule::voidFunctionSignal.get_future().get());
 
     host.UnloadInstance().get();
     queueController.ShutdownQueueAsync().get();

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -1,0 +1,6 @@
+import * as TurboModuleRegistry from '../Libraries/TurboModule/TurboModuleRegistry';
+
+const sampleTurboModule = TurboModuleRegistry.getEnforcing('SampleTurboModule');
+
+// function calls will be added to cover complete signatures
+sampleTurboModule.voidFunction();


### PR DESCRIPTION
- Add a new js bundle to require a turbo module from the native side and call a function
- Implement the turbo module and a test in IntegrationTests
- More tests will be added in the future to cover complete signatures

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5162)