### PR TITLE
Manually set Lib and Include paths for Hermes

### DIFF
--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -43,7 +43,6 @@
     <CppWinRTNamespaceMergeDepth>2</CppWinRTNamespaceMergeDepth>
     <CppWinRTUsePrefixes>true</CppWinRTUsePrefixes>
     <USE_V8>true</USE_V8>
-    <USE_HERMES>false</USE_HERMES>
   </PropertyGroup>
   <PropertyGroup Label="Permissive">
     <ENABLEPermissive>true</ENABLEPermissive>
@@ -99,12 +98,19 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>-minpdbpathlen:256</AdditionalOptions>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)\Microsoft.ReactNative;$(ReactNativeWindowsDir)\Microsoft.ReactNative.Cxx;</AdditionalIncludeDirectories>
     </Midl>
+  </ItemDefinitionGroup>
+  <!-- TODO: Remove after https://github.com/microsoft/hermes-windows/issues/12 is fixed. -->
+  <ItemDefinitionGroup Condition="'$(USE_HERMES)'=='true'">
+    <Lib>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release'">$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.6\installed\$(Platform)-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.6\installed\$(Platform)-windows\debug\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>hermes.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <ItemGroup>

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -11,6 +11,7 @@
     <Message Text="=> PlatformName            [$(PlatformName)]" />
     <Message Text="=> DefaultPlatformToolset  [$(DefaultPlatformToolset)]" />
     <Message Text="=> PlatformToolset         [$(PlatformToolset)]" />
+    <Message Text="=> SolutionDir             [$(SolutionDir)]" />
     <Message Text="=> RootDir                 [$(RootDir)]" />
     <Message Text="=> RootIntDir              [$(RootIntDir)]" />
     <Message Text="=> RootOutDir              [$(RootOutDir)]" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -140,7 +140,8 @@
         $(ReactNativeWindowsDir)ReactWindowsCore\tracing;
         $(ReactNativeWindowsDir)include\ReactWindowsCore;
         $(YogaDir);
-        %(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;_HAS_AUTO_PTR_ETC;RN_EXPORT=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--
         REACTWINDOWS_BUILD - building with REACTWINDOWS_API as dll exports
@@ -175,6 +176,17 @@
     <Midl>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)ReactUWP\Views\cppwinrt;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </Midl>
+  </ItemDefinitionGroup>
+  <!-- TODO: Remove after https://github.com/microsoft/hermes-windows/issues/12 is fixed. -->
+  <ItemDefinitionGroup Condition="'$(USE_HERMES)'=='true'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.6\installed\$(Platform)-windows\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Release'">$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.6\installed\$(Platform)-windows\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)' == 'Debug'">$(SolutionDir)packages\ReactNative.Hermes.Windows.0.1.6\installed\$(Platform)-windows\debug\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>hermes.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -23,7 +23,9 @@
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\ReactPatches.targets" />
 
   <PropertyGroup>
-    <USE_HERMES Condition="'$(USE_HERMES)' == ''">false</USE_HERMES>
+    <!-- <USE_HERMES Condition="'$(USE_HERMES)' == ''">false</USE_HERMES> -->
+    <!-- TODO: Revert before merging! Only for build validation purposes. -->
+    <USE_HERMES>true</USE_HERMES>
     <HERMES_Version Condition="'$(HERMES_Version)' == ''">0.1.6</HERMES_Version>
     <HERMES_Package Condition="'$(HERMES_Package)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HERMES_Version)</HERMES_Package>
 


### PR DESCRIPTION
See https://github.com/microsoft/hermes-windows/issues/12.

Hermes NuGet package does not correctly set directories for consuming projects.

This change updates those projects in RNW to build correctly with the `USE_HERMES` flag enabled.