### PR TITLE
We shouldn't ever need to install RN globally

### DIFF
--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -30,11 +30,6 @@ steps:
   - template: yarn-install.yml
 
   - task: CmdLine@2
-    displayName: Install react-native-cli
-    inputs:
-      script: npm install -g react-native-cli
-
-  - task: CmdLine@2
     displayName: yarn ${{ parameters.yarnBuildCmd }}
     inputs:
       script: yarn ${{ parameters.yarnBuildCmd }}


### PR DESCRIPTION
CI currently installs RN globally.  This should not be needed, wastes CI time, and actually creates a potential of testing incorrect bits.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5164)