### PR TITLE
Implement SyncMethod and Constant for TurboModule

### DIFF
--- a/change/react-native-windows-2020-06-10-15-33-28-pull_request.json
+++ b/change/react-native-windows-2020-06-10-15-33-28-pull_request.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Implement SyncMethod and Constant for TurboModule",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-10T22:33:28.947Z"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -3,9 +3,11 @@
 
 #include "pch.h"
 #include <NativeModules.h>
+#include <sstream>
 #include <string>
 
 using namespace React;
+using namespace winrt::Microsoft::ReactNative;
 
 namespace ReactNativeIntegrationTests {
 
@@ -14,26 +16,89 @@ struct SampleTurboModule {
   REACT_INIT(Initialize)
   void Initialize(ReactContext const & /*reactContext*/) noexcept {}
 
-  REACT_METHOD(voidFunction)
-  void voidFunction() noexcept {
-    voidFunctionSignal.set_value(65536);
+  REACT_CONSTANT(constantString)
+  const std::string constantString{"constantString"};
+
+  REACT_CONSTANT(constantInt)
+  const int constantInt{3};
+
+  REACT_METHOD(succeeded)
+  void succeeded() noexcept {
+    succeededSignal.set_value(true);
   }
 
-  static std::promise<int> voidFunctionSignal;
+  REACT_METHOD(onError)
+  void onError(std::string errorMessage) noexcept {
+    // intended to keep the parameter name for debug purpose
+    succeededSignal.set_value(false);
+  }
+
+  REACT_METHOD(promiseFunction)
+  void promiseFunction(std::string a, int b, bool c, ReactPromise<React::JSValue> result) noexcept {
+    auto resultString = (std::stringstream() << a << ", " << b << ", " << (c ? "true" : "false")).str();
+    result.Resolve({resultString});
+    // TODO:
+    // calling ".then" in the bundle fails, figure out why
+    // it could be an issue about environment setup
+    // since the issue doesn't happen in Playground.sln
+    promiseFunctionResult(resultString);
+  }
+
+  REACT_METHOD(promiseFunctionResult)
+  void promiseFunctionResult(std::string a) noexcept {
+    promiseFunctionSignal.set_value(a);
+  }
+
+  REACT_SYNC_METHOD(syncFunction)
+  std::string syncFunction(std::string a, int b, bool c) noexcept {
+    auto resultString = (std::stringstream() << a << ", " << b << ", " << (c ? "true" : "false")).str();
+    return resultString;
+  }
+
+  REACT_METHOD(syncFunctionResult)
+  void syncFunctionResult(std::string a) noexcept {
+    syncFunctionSignal.set_value(a);
+  }
+
+  REACT_METHOD(constants)
+  void constants(std::string a, int b) noexcept {
+    auto resultString = (std::stringstream() << a << ", " << b).str();
+    constantsSignal.set_value(resultString);
+  }
+
+  static std::promise<bool> succeededSignal;
+  static std::promise<std::string> promiseFunctionSignal;
+  static std::promise<std::string> syncFunctionSignal;
+  static std::promise<std::string> constantsSignal;
 };
 
-std::promise<int> SampleTurboModule::voidFunctionSignal;
+std::promise<bool> SampleTurboModule::succeededSignal;
+std::promise<std::string> SampleTurboModule::promiseFunctionSignal;
+std::promise<std::string> SampleTurboModule::syncFunctionSignal;
+std::promise<std::string> SampleTurboModule::constantsSignal;
 
-struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+struct SampleTurboModuleSpec : TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void() noexcept>{0, L"voidFunction"},
+      Method<void() noexcept>{0, L"succeeded"},
+      Method<void(std::string) noexcept>{0, L"onError"},
+      Method<void(std::string, int, bool, ReactPromise<React::JSValue>) noexcept>{2, L"promiseFunction"},
+      Method<void(std::string) noexcept>{3, L"promiseFunctionResult"},
+      SyncMethod<std::string(std::string, int, bool) noexcept>{4, L"syncFunction"},
+      Method<void(std::string) noexcept>{5, L"syncFunctionResult"},
+      Method<void(std::string, int) noexcept>{6, L"constants"},
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
     constexpr auto methodCheckResults = CheckMethods<TModule, SampleTurboModuleSpec>();
 
-    REACT_SHOW_METHOD_SPEC_ERRORS(0, "voidFunction", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(0, "succeeded", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(1, "onError", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(2, "promiseFunction", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(3, "promiseFunctionResult", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(4, "syncFunction", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(5, "syncFunctionResult", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(6, "constants", "I don't care error message");
   }
 };
 
@@ -41,14 +106,13 @@ struct SampleTurboModulePackageProvider : winrt::implements<SampleTurboModulePac
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
     auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
     experimental.AddTurboModule(
-        L"SampleTurboModule",
-        winrt::Microsoft::ReactNative::MakeTurboModuleProvider<SampleTurboModule, SampleTurboModuleSpec>());
+        L"SampleTurboModule", MakeTurboModuleProvider<SampleTurboModule, SampleTurboModuleSpec>());
   }
 };
 
 TEST_CLASS (TurboModuleTests) {
   TEST_METHOD(ExecuteSampleTurboModule) {
-    winrt::Microsoft::ReactNative::ReactNativeHost host{};
+    ReactNativeHost host{};
 
     auto queueController = winrt::Windows::System::DispatcherQueueController::CreateOnDedicatedThread();
     queueController.DispatcherQueue().TryEnqueue([&]() noexcept {
@@ -70,7 +134,10 @@ TEST_CLASS (TurboModuleTests) {
       host.LoadInstance();
     });
 
-    TestCheckEqual(65536, SampleTurboModule::voidFunctionSignal.get_future().get());
+    TestCheckEqual(true, SampleTurboModule::succeededSignal.get_future().get());
+    TestCheckEqual("something, 1, true", SampleTurboModule::promiseFunctionSignal.get_future().get());
+    TestCheckEqual("something, 2, false", SampleTurboModule::syncFunctionSignal.get_future().get());
+    TestCheckEqual("constantString, 3", SampleTurboModule::constantsSignal.get_future().get());
 
     host.UnloadInstance().get();
     queueController.ShutdownQueueAsync().get();

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -3,4 +3,25 @@ import * as TurboModuleRegistry from '../Libraries/TurboModule/TurboModuleRegist
 const sampleTurboModule = TurboModuleRegistry.getEnforcing('SampleTurboModule');
 
 // function calls will be added to cover complete signatures
-sampleTurboModule.voidFunction();
+
+try {
+  sampleTurboModule
+    .promiseFunction('something', 1, true);
+
+  sampleTurboModule
+    .syncFunctionResult(
+      sampleTurboModule
+        .syncFunction('something', 2, false)
+    );
+
+  sampleTurboModule
+    .constants(
+      sampleTurboModule.constantString,
+      sampleTurboModule.constantInt
+    );
+
+  sampleTurboModule
+    .succeeded();
+} catch (err) {
+  sampleTurboModule.onError(typeof err);
+}


### PR DESCRIPTION
## Implemented

- `REACT_SYNC_METHOD`
- `REACT_CONSTANT`
- Add test cases to Microsoft.ReactNative.IntegrationTests

## Not Yet Implemented

- `OneCallback` and `TwoCallbacks` for `REACT_METHOD`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5171)