### PR TITLE
Implement Logbox module

### DIFF
--- a/change/react-native-windows-2020-06-10-20-32-34-logbox.json
+++ b/change/react-native-windows-2020-06-10-20-32-34-logbox.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implement logbox",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-11T03:32:34.962Z"
+}

--- a/packages/playground/Samples/rntester.tsx
+++ b/packages/playground/Samples/rntester.tsx
@@ -1,1 +1,3 @@
+require('react-native').unstable_enableLogBox();
+
 require('react-native-windows/RNTester');

--- a/packages/playground/Samples/rntester.tsx
+++ b/packages/playground/Samples/rntester.tsx
@@ -1,3 +1,3 @@
-require('react-native').unstable_enableLogBox();
+// require('react-native').unstable_enableLogBox();
 
 require('react-native-windows/RNTester');

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -61,6 +61,7 @@
     <Import Project="..\Shared\Shared.vcxitems" Label="Shared" />
     <Import Project="..\Chakra\Chakra.vcxitems" Label="Shared" />
     <Import Project="..\Mso\Mso.vcxitems" Label="Shared" />
+    <Import Project="..\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -335,6 +335,7 @@
     <ClInclude Include="Modules\DeviceInfoModule.h" />
     <ClInclude Include="Modules\DevSettingsModule.h" />
     <ClInclude Include="Modules\I18nManagerModule.h" />
+    <ClInclude Include="Modules\LogBoxModule.h" />
     <ClInclude Include="NativeModulesProvider.h" />
     <ClInclude Include="TurboModulesProvider.h" />
     <ClInclude Include="Pch\pch.h" />
@@ -517,6 +518,7 @@
     <ClCompile Include="Modules\DeviceInfoModule.cpp" />
     <ClCompile Include="Modules\DevSettingsModule.cpp" />
     <ClCompile Include="Modules\I18nManagerModule.cpp" />
+    <ClCompile Include="Modules\LogBoxModule.cpp" />
     <ClCompile Include="NativeModulesProvider.cpp" />
     <ClCompile Include="TurboModulesProvider.cpp" />
     <ClCompile Include="Pch\pch.cpp">

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClCompile Include="Modules\I18nManagerModule.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\LogBoxModule.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
     <ClCompile Include="NativeModulesProvider.cpp" />
     <ClCompile Include="TurboModulesProvider.cpp" />
     <ClCompile Include="Pch\pch.cpp">
@@ -617,6 +620,9 @@
       <Filter>Modules</Filter>
     </ClInclude>
     <ClInclude Include="Modules\I18nManagerModule.h">
+      <Filter>Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\LogBoxModule.h">
       <Filter>Modules</Filter>
     </ClInclude>
     <ClInclude Include="NativeModulesProvider.h" />

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -13,27 +13,27 @@
 
 namespace Microsoft::ReactNative {
 
-void LogBox::show() noexcept {
+void LogBox::Show() noexcept {
   if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context.Properties().Handle())) {
     return;
   }
 
   m_context.UIDispatcher().Post([weakThis = weak_from_this()] {
     if (auto strongThis = weakThis.lock()) {
-      strongThis->showOnUIThread();
+      strongThis->ShowOnUIThread();
     }
   });
 }
 
-void LogBox::hide() noexcept {
+void LogBox::Hide() noexcept {
   m_context.UIDispatcher().Post([weakThis = weak_from_this()] {
     if (auto strongThis = weakThis.lock()) {
-      strongThis->hideOnUIThread();
+      strongThis->HideOnUIThread();
     }
   });
 }
 
-void LogBox::showOnUIThread() noexcept {
+void LogBox::ShowOnUIThread() noexcept {
   auto contextImpl = winrt::get_self<React::implementation::ReactContext>(m_context.Handle());
   auto weakInstance = static_cast<Mso::React::ReactContext *>(&contextImpl->GetInner())->GetInnerInstance();
   auto instance = weakInstance.GetStrongPtr();
@@ -83,7 +83,7 @@ void LogBox::showOnUIThread() noexcept {
   m_tokenClosed = m_popup.Closed([wkThis = weak_from_this()](
       auto const & /*sender*/, winrt::IInspectable const & /*args*/) noexcept {
     if (auto strongThis = wkThis.lock()) {
-      strongThis->hideOnUIThread();
+      strongThis->HideOnUIThread();
     }
   });
 
@@ -91,7 +91,7 @@ void LogBox::showOnUIThread() noexcept {
   m_popup.IsOpen(true);
 }
 
-void LogBox::hideOnUIThread() noexcept {
+void LogBox::HideOnUIThread() noexcept {
   if (m_popup) {
     m_popup.Closed(m_tokenClosed);
     m_sizeChangedRevoker.revoke();

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "LogBoxModule.h"
+
+#include "IReactContext.h"
+#include "ReactHost/ReactInstanceWin.h"
+#include "ReactNativeHost.h"
+#include "Utils/Helpers.h"
+
+#include <UI.Xaml.Controls.Primitives.h>
+
+namespace Microsoft::ReactNative {
+
+void LogBox::show() noexcept {
+  if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context.Properties().Handle())) {
+    return;
+  }
+
+  m_context.UIDispatcher().Post([weakThis = weak_from_this()] {
+    if (auto strongThis = weakThis.lock()) {
+      strongThis->showOnUIThread();
+    }
+  });
+}
+
+void LogBox::hide() noexcept {
+  m_context.UIDispatcher().Post([weakThis = weak_from_this()] {
+    if (auto strongThis = weakThis.lock()) {
+      strongThis->hideOnUIThread();
+    }
+  });
+}
+
+void LogBox::showOnUIThread() noexcept {
+  auto contextImpl = winrt::get_self<React::implementation::ReactContext>(m_context.Handle());
+  auto weakInstance = static_cast<Mso::React::ReactContext *>(&contextImpl->GetInner())->GetInnerInstance();
+  auto instance = weakInstance.GetStrongPtr();
+  if (!instance)
+    return;
+  auto weakHost = instance->GetHost();
+  auto host = weakHost.GetStrongPtr();
+  if (!host)
+    return;
+
+  m_logBoxContent = React::ReactRootView();
+  m_logBoxContent.ComponentName(L"LogBox");
+  m_logBoxContent.ReactNativeHost(winrt::make<winrt::Microsoft::ReactNative::implementation::ReactNativeHost>(*host));
+
+  m_popup = xaml::Controls::Primitives::Popup{};
+  xaml::FrameworkElement root{nullptr};
+
+  if (react::uwp::Is19H1OrHigher()) {
+    // XamlRoot added in 19H1 - is required to be set for XamlIsland scenarios
+    if (auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context.Properties().Handle())) {
+      m_popup.XamlRoot(xamlRoot);
+      root = xamlRoot.Content().as<xaml::FrameworkElement>();
+    }
+  }
+
+  if (!root) {
+    auto window = xaml::Window::Current();
+    root = window.Content().as<xaml::FrameworkElement>();
+  }
+
+  m_logBoxContent.MaxHeight(root.ActualSize().y);
+  m_logBoxContent.Height(root.ActualSize().y);
+  m_logBoxContent.MaxWidth(root.ActualSize().x);
+  m_logBoxContent.Width(root.ActualSize().x);
+  m_logBoxContent.UpdateLayout();
+
+  m_sizeChangedRevoker = root.SizeChanged(
+      winrt::auto_revoke, [wkThis = weak_from_this()](auto const & /*sender*/, xaml::SizeChangedEventArgs const &args) {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->m_logBoxContent.MaxHeight(args.NewSize().Height);
+          strongThis->m_logBoxContent.Height(args.NewSize().Height);
+          strongThis->m_logBoxContent.MaxWidth(args.NewSize().Width);
+          strongThis->m_logBoxContent.Width(args.NewSize().Width);
+        }
+      });
+
+  m_tokenClosed = m_popup.Closed([wkThis = weak_from_this()](
+      auto const & /*sender*/, winrt::IInspectable const & /*args*/) noexcept {
+    if (auto strongThis = wkThis.lock()) {
+      strongThis->hideOnUIThread();
+    }
+  });
+
+  m_popup.Child(m_logBoxContent);
+  m_popup.IsOpen(true);
+}
+
+void LogBox::hideOnUIThread() noexcept {
+  if (m_popup) {
+    m_popup.Closed(m_tokenClosed);
+    m_sizeChangedRevoker.revoke();
+    m_popup.IsOpen(false);
+    m_popup = nullptr;
+    m_logBoxContent = nullptr;
+  }
+}
+
+void LogBox::Initialize(React::ReactContext const &reactContext) noexcept {
+  m_context = reactContext;
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -34,19 +34,13 @@ void LogBox::Hide() noexcept {
 }
 
 void LogBox::ShowOnUIThread() noexcept {
-  auto contextImpl = winrt::get_self<React::implementation::ReactContext>(m_context.Handle());
-  auto weakInstance = static_cast<Mso::React::ReactContext *>(&contextImpl->GetInner())->GetInnerInstance();
-  auto instance = weakInstance.GetStrongPtr();
-  if (!instance)
-    return;
-  auto weakHost = instance->GetHost();
-  auto host = weakHost.GetStrongPtr();
+  auto host = React::implementation::ReactNativeHost::GetReactNativeHost(m_context.Properties());
   if (!host)
     return;
 
   m_logBoxContent = React::ReactRootView();
   m_logBoxContent.ComponentName(L"LogBox");
-  m_logBoxContent.ReactNativeHost(winrt::make<winrt::Microsoft::ReactNative::implementation::ReactNativeHost>(*host));
+  m_logBoxContent.ReactNativeHost(host);
 
   m_popup = xaml::Controls::Primitives::Popup{};
   xaml::FrameworkElement root{nullptr};

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <NativeModules.h>
+#include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Graphics.Display.h>
+
+namespace Microsoft::ReactNative {
+
+REACT_MODULE(LogBox)
+struct LogBox : public std::enable_shared_from_this<LogBox> {
+  REACT_INIT(Initialize)
+  void Initialize(React::ReactContext const &reactContext) noexcept;
+
+  REACT_METHOD(show) void show() noexcept;
+  REACT_METHOD(hide) void hide() noexcept;
+
+ private:
+  void showOnUIThread() noexcept;
+  void hideOnUIThread() noexcept;
+  void onPopupClosed() noexcept;
+
+  React::ReactContext m_context;
+  xaml::Controls::Primitives::Popup m_popup{nullptr};
+  React::ReactRootView m_logBoxContent{nullptr};
+  xaml::FrameworkElement::SizeChanged_revoker m_sizeChangedRevoker;
+  winrt::event_token m_tokenClosed;
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
@@ -14,13 +14,12 @@ struct LogBox : public std::enable_shared_from_this<LogBox> {
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &reactContext) noexcept;
 
-  REACT_METHOD(show) void show() noexcept;
-  REACT_METHOD(hide) void hide() noexcept;
+  REACT_METHOD(Show, L"show") void Show() noexcept;
+  REACT_METHOD(Hide, L"hide") void Hide() noexcept;
 
  private:
-  void showOnUIThread() noexcept;
-  void hideOnUIThread() noexcept;
-  void onPopupClosed() noexcept;
+  void ShowOnUIThread() noexcept;
+  void HideOnUIThread() noexcept;
 
   React::ReactContext m_context;
   xaml::Controls::Primitives::Popup m_popup{nullptr};

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -19,6 +19,7 @@
 #include "../../codegen/NativeDevSettingsSpec.g.h"
 #include "../../codegen/NativeDeviceInfoSpec.g.h"
 #include "../../codegen/NativeI18nManagerSpec.g.h"
+#include "../../codegen/NativeLogBoxSpec.g.h"
 #include "NativeModules.h"
 #include "NativeModulesProvider.h"
 #include "Unicode.h"
@@ -34,6 +35,7 @@
 #include "Modules/DevSettingsModule.h"
 #include "Modules/DeviceInfoModule.h"
 #include "Modules/I18nManagerModule.h"
+#include "Modules/LogBoxModule.h"
 
 #include <Utils/UwpPreparedScriptStore.h>
 #include <Utils/UwpScriptStore.h>
@@ -107,6 +109,10 @@ void ReactContext::DispatchEvent(int64_t viewTag, std::string &&eventName, folly
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     instance->DispatchEvent(viewTag, std::move(eventName), std::move(eventData));
   }
+}
+
+Mso::WeakPtr<ReactInstanceWin> ReactContext::GetInnerInstance() noexcept {
+  return m_reactInstance;
 }
 
 //=============================================================================================
@@ -247,6 +253,12 @@ void ReactInstanceWin::Initialize() noexcept {
               winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
                   ::Microsoft::ReactNative::AppState,
                   ::Microsoft::ReactNativeSpecs::AppStateSpec>());
+
+          nmp->AddModuleProvider(
+              L"LogBox",
+              winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
+                  ::Microsoft::ReactNative::LogBox,
+                  ::Microsoft::ReactNativeSpecs::LogBoxSpec>());
 
           if (m_options.UseWebDebugger()) {
             nmp->AddModuleProvider(
@@ -794,6 +806,10 @@ void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView)
   if (auto instanceWrapper = m_instanceWrapper.LoadWithLock()) {
     instanceWrapper->DetachRootView(rootView);
   }
+}
+
+const Mso::WeakPtr<IReactHost> ReactInstanceWin::GetHost() noexcept {
+  return m_weakReactHost;
 }
 
 Mso::CntPtr<IReactInstanceInternal> MakeReactInstance(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -111,10 +111,6 @@ void ReactContext::DispatchEvent(int64_t viewTag, std::string &&eventName, folly
   }
 }
 
-Mso::WeakPtr<ReactInstanceWin> ReactContext::GetInnerInstance() noexcept {
-  return m_reactInstance;
-}
-
 //=============================================================================================
 // LoadedCallbackGuard ensures that the OnReactInstanceLoaded is always called.
 // It calls OnReactInstanceLoaded in destructor with a cancellation error.
@@ -806,10 +802,6 @@ void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView)
   if (auto instanceWrapper = m_instanceWrapper.LoadWithLock()) {
     instanceWrapper->DetachRootView(rootView);
   }
-}
-
-const Mso::WeakPtr<IReactHost> ReactInstanceWin::GetHost() noexcept {
-  return m_weakReactHost;
 }
 
 Mso::CntPtr<IReactInstanceInternal> MakeReactInstance(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -47,6 +47,8 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   // when the ReactInstance is destroyed.
   void Destroy() noexcept;
 
+  Mso::WeakPtr<ReactInstanceWin> GetInnerInstance() noexcept;
+
  public: // IReactContext
   winrt::Microsoft::ReactNative::IReactPropertyBag Properties() noexcept override;
   winrt::Microsoft::ReactNative::IReactNotificationService Notifications() noexcept override;
@@ -82,6 +84,9 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
       facebook::react::IReactRootView *rootView,
       folly::dynamic &&initialProps) noexcept override;
   void DetachRootView(facebook::react::IReactRootView *rootView) noexcept override;
+
+ public: // Internal use only
+  const Mso::WeakPtr<IReactHost> GetHost() noexcept;
 
  private:
   friend MakePolicy;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -47,8 +47,6 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   // when the ReactInstance is destroyed.
   void Destroy() noexcept;
 
-  Mso::WeakPtr<ReactInstanceWin> GetInnerInstance() noexcept;
-
  public: // IReactContext
   winrt::Microsoft::ReactNative::IReactPropertyBag Properties() noexcept override;
   winrt::Microsoft::ReactNative::IReactNotificationService Notifications() noexcept override;
@@ -84,9 +82,6 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
       facebook::react::IReactRootView *rootView,
       folly::dynamic &&initialProps) noexcept override;
   void DetachRootView(facebook::react::IReactRootView *rootView) noexcept override;
-
- public: // Internal use only
-  const Mso::WeakPtr<IReactHost> GetHost() noexcept;
 
  private:
   friend MakePolicy;

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -23,7 +23,14 @@ using namespace xaml::Controls;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-ReactNativeHost::ReactNativeHost() noexcept : m_reactHost(Mso::React::MakeReactHost()) {}
+ReactNativeHost::ReactNativeHost() noexcept : m_reactHost{Mso::React::MakeReactHost()} {
+#if _DEBUG
+  facebook::react::InitializeLogging([](facebook::react::RCTLogLevel /*logLevel*/, const char *message) {
+    std::string str = std::string("ReactNative:") + message;
+    OutputDebugStringA(str.c_str());
+  });
+#endif
+}
 
 IVector<IReactPackageProvider> ReactNativeHost::PackageProviders() noexcept {
   return InstanceSettings().PackageProviders();

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -23,7 +23,9 @@ using namespace xaml::Controls;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-ReactNativeHost::ReactNativeHost() noexcept : m_reactHost{Mso::React::MakeReactHost()} {
+ReactNativeHost::ReactNativeHost() noexcept : ReactNativeHost(*Mso::React::MakeReactHost()) {}
+
+ReactNativeHost::ReactNativeHost(Mso::React::IReactHost &host) noexcept : m_reactHost(&host) {
 #if _DEBUG
   facebook::react::InitializeLogging([](facebook::react::RCTLogLevel /*logLevel*/, const char *message) {
     std::string str = std::string("ReactNative:") + message;

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.h
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.h
@@ -29,6 +29,7 @@ struct ReactNativeHost : ReactNativeHostT<ReactNativeHost> {
   Windows::Foundation::IAsyncAction UnloadInstance() noexcept;
 
  public:
+  ReactNativeHost(Mso::React::IReactHost &host) noexcept;
   Mso::React::IReactHost *ReactHost() noexcept;
 
  private:

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.h
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.h
@@ -8,6 +8,7 @@
 #include "NativeModulesProvider.h"
 #include "ReactHost/React.h"
 #include "ReactInstanceSettings.h"
+#include "ReactPropertyBag.h"
 #include "ViewManagersProvider.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
@@ -29,8 +30,8 @@ struct ReactNativeHost : ReactNativeHostT<ReactNativeHost> {
   Windows::Foundation::IAsyncAction UnloadInstance() noexcept;
 
  public:
-  ReactNativeHost(Mso::React::IReactHost &host) noexcept;
   Mso::React::IReactHost *ReactHost() noexcept;
+  static winrt::Microsoft::ReactNative::ReactNativeHost GetReactNativeHost(ReactPropertyBag const &properties) noexcept;
 
  private:
   Mso::CntPtr<Mso::React::IReactHost> m_reactHost;

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -60,7 +60,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_popup = xaml::Controls::Primitives::Popup{};
 
     const winrt::hstring xamlString =
-      LR"(
+        LR"(
         <Grid Background='#FF333333'
           xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
           xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
@@ -309,7 +309,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_stackPanel.Children().Clear();
     for (const auto frame : m_errorInfo.Callstack) {
       const winrt::hstring xamlFrameString =
-      LR"(
+          LR"(
           <StackPanel Margin='0,5,0,5'
             xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -60,31 +60,32 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_popup = xaml::Controls::Primitives::Popup{};
 
     const winrt::hstring xamlString =
-        L"<Grid Background='{ThemeResource ContentDialogBackground}'"
-        L"  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
-        L"  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'"
-        L"  RequestedTheme='Dark'>"
-        L"  <Grid.ColumnDefinitions>"
-        L"    <ColumnDefinition Width='*'/>"
-        L"    <ColumnDefinition Width='*'/>"
-        L"  </Grid.ColumnDefinitions>"
-        L"  <Grid.RowDefinitions>"
-        L"    <RowDefinition Height='*'/>"
-        L"    <RowDefinition Height='Auto'/>"
-        L"  </Grid.RowDefinitions>"
-        L"  <ScrollViewer Grid.Row='0' Grid.ColumnSpan='2' HorizontalAlignment='Stretch'>"
-        L"    <StackPanel HorizontalAlignment='Stretch'>"
-        L"      <StackPanel Background='#EECC0000' HorizontalAlignment='Stretch' Padding='15,35,15,15' x:Name='StackPanelUpper'>"
-        L"        <TextBlock x:Name='ErrorMessageText' FontSize='14' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>"
-        L"        <Border Padding='15,15,15,0'/>"
-        L"        <TextBlock x:Name='ErrorStackText' FontSize='12' FontFamily='Consolas' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>"
-        L"      </StackPanel>"
-        L"      <StackPanel HorizontalAlignment='Stretch' x:Name='StackPanel' Margin='15' />"
-        L"    </StackPanel>"
-        L"  </ScrollViewer>"
-        L"  <Button x:Name='DismissButton' Grid.Row='1' Grid.Column='0' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Dismiss</Button>"
-        L"  <Button x:Name='ReloadButton' Grid.Row='1' Grid.Column='2' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Reload (NYI)</Button>"
-        L"</Grid>";
+      LR"(
+        <Grid Background='#FF333333'
+          xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+          xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+          RequestedTheme='Dark'>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width='*'/>
+            <ColumnDefinition Width='*'/>
+          </Grid.ColumnDefinitions>
+          <Grid.RowDefinitions>
+            <RowDefinition Height='*'/>
+            <RowDefinition Height='Auto'/>
+          </Grid.RowDefinitions>
+          <ScrollViewer Grid.Row='0' Grid.ColumnSpan='2' HorizontalAlignment='Stretch'>
+            <StackPanel HorizontalAlignment='Stretch'>
+              <StackPanel Background='#FFF35369' HorizontalAlignment='Stretch' Padding='15,35,15,15' x:Name='StackPanelUpper'>
+                <TextBlock x:Name='ErrorMessageText' FontSize='14' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>
+                <Border Padding='15,15,15,0'/>
+                <TextBlock x:Name='ErrorStackText' FontSize='12' FontFamily='Consolas' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>
+              </StackPanel>
+              <StackPanel HorizontalAlignment='Stretch' x:Name='StackPanel' Margin='15' />
+            </StackPanel>
+          </ScrollViewer>
+          <Button x:Name='DismissButton' Grid.Row='1' Grid.Column='0' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Dismiss</Button>
+          <Button x:Name='ReloadButton' Grid.Row='1' Grid.Column='2' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Reload (NYI)</Button>
+        </Grid>)";
 
     m_redboxContent = winrt::unbox_value<xaml::Controls::Grid>(xaml::Markup::XamlReader::Load(xamlString));
     m_errorMessageText = m_redboxContent.FindName(L"ErrorMessageText").as<xaml::Controls::TextBlock>();
@@ -208,10 +209,9 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     // Finally, it's important to note that JS expressions of that are not of string type
     // need to be manually converted to string for them to get marshaled properly back here.
     webView.NavigationCompleted([=](IInspectable const &, auto const &) {
-      // #eecc0000 ARGB is #be0000 RGB (background doesn't seem to allow alpha channel in WebView)
       std::wstring jsExpression =
           L"(document.body.style.setProperty('color', 'white'), "
-          L"document.body.style.setProperty('background', '#be0000')) "
+          L"document.body.style.setProperty('background', '#f35369')) "
           L"|| document.documentElement.scrollHeight.toString()";
 
 #ifndef USE_WINUI3
@@ -309,13 +309,14 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_stackPanel.Children().Clear();
     for (const auto frame : m_errorInfo.Callstack) {
       const winrt::hstring xamlFrameString =
-          L"<StackPanel Margin='0,5,0,5'"
-          L"  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
-          L"  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'"
-          L"  >"
-          L"  <TextBlock x:Name='MethodText' FontSize='14' Foreground='White' TextWrapping='Wrap' FontFamily='Consolas'/>"
-          L"  <TextBlock x:Name='FrameText' FontSize='14' Foreground='Gray' TextWrapping='Wrap' FontFamily='Consolas'/>"
-          L"</StackPanel>";
+      LR"(
+          <StackPanel Margin='0,5,0,5'
+            xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+            xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+            >
+            <TextBlock x:Name='MethodText' FontSize='14' Foreground='White' TextWrapping='Wrap' FontFamily='Consolas'/>
+            <TextBlock x:Name='FrameText' FontSize='14' Foreground='Gray' TextWrapping='Wrap' FontFamily='Consolas'/>
+          </StackPanel>)";
       auto frameContent =
           winrt::unbox_value<xaml::Controls::StackPanel>(xaml::Markup::XamlReader::Load(xamlFrameString));
       auto methodText = frameContent.FindName(L"MethodText").as<xaml::Controls::TextBlock>();

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -61,7 +61,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 
     const winrt::hstring xamlString =
         LR"(
-        <Grid Background='#FF333333'
+        <Grid Background='#1A1A1A'
           xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
           xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
           RequestedTheme='Dark'>
@@ -75,7 +75,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
           </Grid.RowDefinitions>
           <ScrollViewer Grid.Row='0' Grid.ColumnSpan='2' HorizontalAlignment='Stretch'>
             <StackPanel HorizontalAlignment='Stretch'>
-              <StackPanel Background='#FFF35369' HorizontalAlignment='Stretch' Padding='15,35,15,15' x:Name='StackPanelUpper'>
+              <StackPanel Background='#D01926' HorizontalAlignment='Stretch' Padding='15,35,15,15' x:Name='StackPanelUpper'>
                 <TextBlock x:Name='ErrorMessageText' FontSize='14' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>
                 <Border Padding='15,15,15,0'/>
                 <TextBlock x:Name='ErrorStackText' FontSize='12' FontFamily='Consolas' Foreground='White' IsTextSelectionEnabled='true' TextWrapping='Wrap'/>
@@ -211,7 +211,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     webView.NavigationCompleted([=](IInspectable const &, auto const &) {
       std::wstring jsExpression =
           L"(document.body.style.setProperty('color', 'white'), "
-          L"document.body.style.setProperty('background', '#f35369')) "
+          L"document.body.style.setProperty('background', '#d01926')) "
           L"|| document.documentElement.scrollHeight.toString()";
 
 #ifndef USE_WINUI3

--- a/vnext/ReactUWP/Modules/NativeUIManager.cpp
+++ b/vnext/ReactUWP/Modules/NativeUIManager.cpp
@@ -874,25 +874,25 @@ void NativeUIManager::DoLayout() {
     // We will flip the root of the tree into RTL by forcing the root XAML node's FlowDirection to RightToLeft
     // which will inherit down the XAML tree, allowing all native controls to pick it up.
     YGNodeCalculateLayout(rootNode, actualWidth, actualHeight, YGDirectionLTR);
+  }
 
-    for (auto &tagToYogaNode : m_tagsToYogaNodes) {
-      int64_t tag = tagToYogaNode.first;
-      YGNodeRef yogaNode = tagToYogaNode.second.get();
+  for (auto &tagToYogaNode : m_tagsToYogaNodes) {
+    int64_t tag = tagToYogaNode.first;
+    YGNodeRef yogaNode = tagToYogaNode.second.get();
 
-      if (!YGNodeGetHasNewLayout(yogaNode))
-        continue;
-      YGNodeSetHasNewLayout(yogaNode, false);
+    if (!YGNodeGetHasNewLayout(yogaNode))
+      continue;
+    YGNodeSetHasNewLayout(yogaNode, false);
 
-      float left = YGNodeLayoutGetLeft(yogaNode);
-      float top = YGNodeLayoutGetTop(yogaNode);
-      float width = YGNodeLayoutGetWidth(yogaNode);
-      float height = YGNodeLayoutGetHeight(yogaNode);
+    float left = YGNodeLayoutGetLeft(yogaNode);
+    float top = YGNodeLayoutGetTop(yogaNode);
+    float width = YGNodeLayoutGetWidth(yogaNode);
+    float height = YGNodeLayoutGetHeight(yogaNode);
 
-      ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-      auto view = shadowNode.GetView();
-      auto pViewManager = shadowNode.GetViewManager();
-      pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
-    }
+    ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
+    auto view = shadowNode.GetView();
+    auto pViewManager = shadowNode.GetViewManager();
+    pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
   }
 }
 

--- a/vnext/ReactWindows-Desktop.sln
+++ b/vnext/ReactWindows-Desktop.sln
@@ -17,8 +17,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Desktop.DLL",
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "React.Windows.Desktop.UnitTests", "Desktop.UnitTests\React.Windows.Desktop.UnitTests.vcxproj", "{96CD24DC-91C2-480A-BC26-EE2250DA80D7}"
-	ProjectSection(ProjectDependencies) = postProject
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EEE39425-10FD-4DB3-924E-D31CDA3DCC73}"
 	ProjectSection(SolutionItems) = preProject
@@ -118,6 +116,7 @@ Global
 		Chakra\Chakra.vcxitems*{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}*SharedItemsImports = 4
 		Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
+		Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Mso\Mso.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{95048601-c3dc-475f-adf8-7c0c764c10d5}*SharedItemsImports = 4
 		Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
@@ -248,14 +247,6 @@ Global
 		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x64.Build.0 = Release|x64
 		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x86.ActiveCfg = Release|Win32
 		{1958CEAA-FBE0-44E3-8A99-90AD85531FFE}.Release|x86.Build.0 = Release|Win32
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Debug|x64.ActiveCfg = Debug|x64
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Debug|x64.Build.0 = Debug|x64
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Debug|x86.ActiveCfg = Debug|Win32
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Debug|x86.Build.0 = Debug|Win32
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Release|x64.ActiveCfg = Release|x64
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Release|x64.Build.0 = Release|x64
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Release|x86.ActiveCfg = Release|Win32
-		{3A1BE021-6877-481A-9C03-7C5A1224E897}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Logbox is a replacement of the YellowBox UI, used to display warnings.  It is currently available by calling 
```js
require('react-native').unstable_enableLogBox();
```

but it will be enabled by default in 0.63.

LogBox works by creating an additional ReactRootView, so it will provide some good test coverage of multi root view scenarios.  I also fixed an issue with layout when there are multiple rootviews, where we would attempt to layout a bunch of elements before they had layout run on them.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5175)