### PR TITLE
Add Microsoft.ReactNative.Cxx to the nuget package

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -141,7 +141,7 @@ jobs:
             $pkgVersion = $pkgJson.version
             $(Build.SourcesDirectory)\vnext\Scripts\StripAdditionalPlatformsFromNuspec.ps1 -slices ("$(BuildPlatform).$(BuildConfiguration)")
             Copy-Item -Force -Path vnext\Scripts\Microsoft.ReactNative.targets -Destination $(Build.SourcesDirectory)\vnext\target
-            nuget pack $(Build.SourcesDirectory)\vnext\Scripts\Microsoft.ReactNative.PR.nuspec -NonInteractive -OutputDirectory $(Build.StagingDirectory)/TestMSRNNuget -Properties "Configuration=Release;CommitId=0;version=$pkgVersion;id=Microsoft.ReactNative;nugetroot=$(Build.SourcesDirectory)\vnext\target;baseplatform=$(BuildPlatform);baseconfiguration=$(BuildConfiguration)" -Verbosity Detailed
+            nuget pack $(Build.SourcesDirectory)\vnext\Scripts\Microsoft.ReactNative.PR.nuspec -NonInteractive -OutputDirectory $(Build.StagingDirectory)/TestMSRNNuget -Properties "Configuration=Release;CommitId=0;version=$pkgVersion;id=Microsoft.ReactNative;nugetroot=$(Build.StagingDirectory);baseplatform=$(BuildPlatform);baseconfiguration=$(BuildConfiguration)" -Verbosity Detailed
         condition: eq('true', variables['TestMSRNNuget'])
 
       - task: PublishBuildArtifacts@1

--- a/change/react-native-windows-2020-06-11-13-06-37-msrncxxnuget.json
+++ b/change/react-native-windows-2020-06-11-13-06-37-msrncxxnuget.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add Microsoft.ReactNative.Cxx to the nugets.",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-11T20:06:37.842Z"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -21,6 +21,8 @@
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml"   target="lib\uap10.0"/> 
     -->
 
+    <file src="$nugetroot$\Microsoft.ReactNative.Cxx\**" target ="Microsoft.ReactNative.Cxx"/>
+
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\release" />
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\release" />
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\release" />

--- a/vnext/Scripts/ReactWin32.nuspec
+++ b/vnext/Scripts/ReactWin32.nuspec
@@ -61,5 +61,7 @@
 
     <file src="$nugetroot$\inc\include\**\*.*" target="inc\include" />
 
+    <file src="$nugetroot$\Microsoft.ReactNative.Cxx\**" target ="Microsoft.ReactNative.Cxx"/>
+
   </files>
 </package>

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -100,6 +100,9 @@ Get-ChildItem -Path $ReactWindowsRoot\Desktop.Test.DLL -Name -Recurse -Include $
 # include headers
 Copy-Item -Force -Recurse -Path $ReactWindowsRoot\include -Destination $TargetRoot\inc
 
+# Microsoft.ReactNative.CXX project
+Copy-Item -Force -Recurse -Path $ReactWindowsRoot\Microsoft.ReactNative.Cxx -Destination $TargetRoot\Microsoft.ReactNative.Cxx
+
 # NUSPEC
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\*.nuspec -Destination $TargetRoot
 


### PR DESCRIPTION
Long term native dependencies should come from the nuget, not the npm package.  This allows devs working on other platforms within cross platform packages to not have to download the native windows dependencies until they want to build windows.  Currently the native dependencies are part of the NPM package, which will have to continue to be the case until we can move to a binary distribution model.  But part of moving to a binary distribution model will be having a complete nuget for native consumption.

Stella recently tried to use only the nuget distribution and hit issues with writing custom native modules. This adds Microsoft.ReactNative.Cxx to the nuget -- which should unblock them.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5184)