### PR TITLE
Fix file lock issue with MSBuild's `/bl` flag and the metro bundler

### DIFF
--- a/change/react-native-windows-2020-06-11-17-03-06-master.json
+++ b/change/react-native-windows-2020-06-11-17-03-06-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix file lock issue wiht msbuild /bl flag and the metro bundler",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-12T00:03:06.389Z"
+}

--- a/vnext/metro.config.js
+++ b/vnext/metro.config.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const rnwPath = __dirname;
 const {resolve} = require('metro-resolver');
+const blacklist = require('metro-config/src/defaults/blacklist');
 
 function reactNativePlatformResolver(platformImplementations) {
   return (context, _realModuleName, platform, moduleName) => {
@@ -49,6 +50,10 @@ module.exports = {
       // Redirect react-native-windows to this folder
       'react-native-windows': rnwPath,
     },
+    blacklistRE: blacklist([
+      // Avoid error EBUSY: resource busy or locked, open '...\vnext\msbuild.ProjectImports.zip' when building 'vnext\Microsoft.ReactNative.sln' with '/bl'
+      /.*\.ProjectImports\.zip/,
+    ]),
   },
 
   transformer: {


### PR DESCRIPTION
Periodically there is a locking issue when building `vnext/Microsoft.ReactNative.sln` when building with flag `/bl`. This flag tells msbuild to construct  a detailed binary log. As it is constructing the log it is creating a .zip file to contain all the build specs. In the solution the IntegrationTest project runs the metro bundler. This one tries to open the .zip file and gets a file access violationand fails the build.
This change adds it to the metro config's exclusion list so it won't try to read that zip file.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5186)