### PR TITLE
Upgrade to Boost 1.72

### DIFF
--- a/change/react-native-windows-2020-06-12-19-54-19-boost-1.72.json
+++ b/change/react-native-windows-2020-06-12-19-54-19-boost-1.72.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": " Upgrade to boost 1.72.0.",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-13T02:54:19.496Z"
+}

--- a/packages/E2ETest/packages.config
+++ b/packages/E2ETest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
 </packages>

--- a/packages/microsoft-reactnative-sampleapps/packages.config
+++ b/packages/microsoft-reactnative-sampleapps/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
 </packages>

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -121,7 +121,7 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppApp.targets"/>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="..\packages\Microsoft.VCRTForwarders.140.1.0.2-rc\build\native\Microsoft.VCRTForwarders.140.targets" Condition="Exists('..\packages\Microsoft.VCRTForwarders.140.1.0.2-rc\build\native\Microsoft.VCRTForwarders.140.targets')" />
     <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
@@ -131,7 +131,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VCRTForwarders.140.1.0.2-rc\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VCRTForwarders.140.1.0.2-rc\build\native\Microsoft.VCRTForwarders.140.targets'))" />
     <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
   </Target>

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -143,7 +143,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
@@ -154,7 +154,7 @@
     </PropertyGroup>
     <Warning Condition="'$(USE_V8)' != 'true'" Text="Building desktop project without USE_V8 (value is '$(USE_V8)')" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.43" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -120,7 +120,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
@@ -131,7 +131,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -142,7 +142,6 @@ TEST_CLASS (WebSocketIntegrationTest)
   }
 
   BEGIN_TEST_METHOD_ATTRIBUTE(PingClose)
-    TEST_IGNORE() //TODO: Remove before merging!
   END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(PingClose)
   {

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -141,6 +141,9 @@ TEST_CLASS (WebSocketIntegrationTest)
     Assert::IsTrue(closed);
   }
 
+  BEGIN_TEST_METHOD_ATTRIBUTE(PingClose)
+    TEST_IGNORE() //TODO: Remove before merging!
+  END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(PingClose)
   {
     auto server = make_shared<Test::WebSocketServer>(5556);
@@ -169,42 +172,6 @@ TEST_CLASS (WebSocketIntegrationTest)
 
     Assert::IsTrue(pinged);
     Assert::AreEqual({}, errorString);
-  }
-
-  // Emulate promise/future functionality.
-  // Fails when connecting to stock package bundler.
-  BEGIN_TEST_METHOD_ATTRIBUTE(WaitForBundlerResponseNoClose)
-  TEST_IGNORE()
-  END_TEST_METHOD_ATTRIBUTE()
-  TEST_METHOD(WaitForBundlerResponseNoClose) {
-    string url = "ws://localhost:8081/debugger-proxy?role=client";
-    // string url = "ws://localhost:5555/";
-    auto ws = IWebSocketResource::Make(url);
-    string json =
-        "{\"inject\":{},\"id\":1,\"method\":\"executeApplicationScript\",\"url\":\"http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=ios&dev=true\"}";
-    // string json = "{}";
-    std::mutex mutex;
-    condition_variable condition;
-    bool read = false;
-    bool connected = false;
-    bool wrote = false;
-    ws->SetOnConnect([&connected]() { connected = true; });
-    ws->SetOnSend([&wrote](size_t size) { wrote = true; });
-    ws->SetOnMessage([&mutex, &condition, &read](size_t size, const string &message) {
-      lock_guard<std::mutex> guard(mutex);
-      read = true;
-      condition.notify_all();
-    });
-
-    ws->Connect();
-    ws->Send(json);
-
-    unique_lock<std::mutex> lock(mutex);
-    condition.wait(lock);
-
-    Assert::IsTrue(connected);
-    Assert::IsTrue(wrote);
-    Assert::IsTrue(read);
   }
 
   TEST_METHOD(SendReceiveClose)

--- a/vnext/Desktop.IntegrationTests/packages.config
+++ b/vnext/Desktop.IntegrationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.43" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
@@ -77,14 +77,14 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
   </Target>
   <Target Name="GetTargetFileName" Returns="$(OutDir)$(TargetName).dll" />

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x64.def
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x64.def
@@ -4,11 +4,11 @@ EXPORTS
 ??0WebSocketServer@Test@React@Microsoft@@QEAA@G_N@Z
 ??0WebSocketServer@Test@React@Microsoft@@QEAA@H_N@Z
 ?Accept@WebSocketServer@Test@React@Microsoft@@AEAAXXZ
-?OnAccept@WebSocketServer@Test@React@Microsoft@@AEAAXVerror_code@system@boost@@@Z
+?OnAccept@WebSocketServer@Test@React@Microsoft@@AEAAXVerror_code@system@boost@@V?$basic_stream_socket@Vtcp@ip@asio@boost@@Vexecutor@34@@asio@7@@Z
 ?SetMessageFactory@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6A?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@$$QEAV12@@Z@std@@@Z
 ?SetOnConnection@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXXZ@std@@@Z
 ?SetOnError@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AX$$QEAUError@IWebSocketResource@React@Microsoft@@@Z@std@@@Z
-?SetOnHandshake@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXAEAU?$message@$0A@U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@@Z@std@@@Z
+?SetOnHandshake@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXAEAV?$message@$0A@U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@@Z@std@@@Z
 ?SetOnMessage@WebSocketServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z@std@@@Z
 ?Start@WebSocketServer@Test@React@Microsoft@@QEAAXXZ
 ?Stop@WebSocketServer@Test@React@Microsoft@@QEAAXXZ
@@ -17,8 +17,8 @@ EXPORTS
 ??0HttpServer@Test@React@Microsoft@@QEAA@$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@G@Z
 ??1HttpServer@Test@React@Microsoft@@QEAA@XZ
 ?Accept@HttpServer@Test@React@Microsoft@@QEAAXXZ
-?OnAccept@HttpServer@Test@React@Microsoft@@AEAAXVerror_code@system@boost@@@Z
-?SetOnGet@HttpServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6A?AU?$message@$0A@U?$basic_dynamic_body@V?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@AEBU?$message@$00U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@234@@Z@std@@@Z
+?OnAccept@HttpServer@Test@React@Microsoft@@AEAAXVerror_code@system@boost@@V?$basic_stream_socket@Vtcp@ip@asio@boost@@Vexecutor@34@@asio@7@@Z
+?SetOnGet@HttpServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6A?AV?$message@$0A@U?$basic_dynamic_body@V?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@AEBV?$message@$00U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@234@@Z@std@@@Z
 ?SetOnResponseSent@HttpServer@Test@React@Microsoft@@QEAAX$$QEAV?$function@$$A6AXXZ@std@@@Z
 ?Start@HttpServer@Test@React@Microsoft@@QEAAXXZ
 ?Stop@HttpServer@Test@React@Microsoft@@QEAAXXZ

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x86.def
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.x86.def
@@ -4,11 +4,11 @@ EXPORTS
 ??0WebSocketServer@Test@React@Microsoft@@QAE@G_N@Z
 ??0WebSocketServer@Test@React@Microsoft@@QAE@H_N@Z
 ?Accept@WebSocketServer@Test@React@Microsoft@@AAEXXZ
-?OnAccept@WebSocketServer@Test@React@Microsoft@@AAEXVerror_code@system@boost@@@Z
+?OnAccept@WebSocketServer@Test@React@Microsoft@@AAEXVerror_code@system@boost@@V?$basic_stream_socket@Vtcp@ip@asio@boost@@Vexecutor@34@@asio@7@@Z
 ?SetMessageFactory@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6G?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@$$QAV12@@Z@std@@@Z
 ?SetOnConnection@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXXZ@std@@@Z
 ?SetOnError@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GX$$QAUError@IWebSocketResource@React@Microsoft@@@Z@std@@@Z
-?SetOnHandshake@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXAAU?$message@$0A@U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@@Z@std@@@Z
+?SetOnHandshake@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXAAV?$message@$0A@U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@@Z@std@@@Z
 ?SetOnMessage@WebSocketServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z@std@@@Z
 ?Start@WebSocketServer@Test@React@Microsoft@@QAEXXZ
 ?Stop@WebSocketServer@Test@React@Microsoft@@QAEXXZ
@@ -17,8 +17,8 @@ EXPORTS
 ??0HttpServer@Test@React@Microsoft@@QAE@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@G@Z
 ??1HttpServer@Test@React@Microsoft@@QAE@XZ
 ?Accept@HttpServer@Test@React@Microsoft@@QAEXXZ
-?OnAccept@HttpServer@Test@React@Microsoft@@AAEXVerror_code@system@boost@@@Z
-?SetOnGet@HttpServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6G?AU?$message@$0A@U?$basic_dynamic_body@V?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@ABU?$message@$00U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@234@@Z@std@@@Z
+?OnAccept@HttpServer@Test@React@Microsoft@@AAEXVerror_code@system@boost@@V?$basic_stream_socket@Vtcp@ip@asio@boost@@Vexecutor@34@@asio@7@@Z
+?SetOnGet@HttpServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6G?AV?$message@$0A@U?$basic_dynamic_body@V?$basic_multi_buffer@V?$allocator@D@std@@@beast@boost@@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@http@beast@boost@@ABV?$message@$00U?$basic_string_body@DU?$char_traits@D@std@@V?$allocator@D@2@@http@beast@boost@@V?$basic_fields@V?$allocator@D@std@@@234@@234@@Z@std@@@Z
 ?SetOnResponseSent@HttpServer@Test@React@Microsoft@@QAEX$$QAV?$function@$$A6GXXZ@std@@@Z
 ?Start@HttpServer@Test@React@Microsoft@@QAEXXZ
 ?Stop@HttpServer@Test@React@Microsoft@@QAEXXZ

--- a/vnext/Desktop.Test.DLL/packages.config
+++ b/vnext/Desktop.Test.DLL/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />
 </packages>

--- a/vnext/Desktop.UnitTests/BaseWebSocketTests.cpp
+++ b/vnext/Desktop.UnitTests/BaseWebSocketTests.cpp
@@ -9,7 +9,7 @@ using namespace boost::beast;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using boost::system::error_code;
-using Microsoft::React::Beast::Test::TestWebSocket;
+using Microsoft::React::Beast::Test::TestWebSocketResource;
 using std::future;
 using std::make_unique;
 using std::promise;
@@ -30,7 +30,7 @@ TEST_CLASS(BaseWebSocketTest){
   END_TEST_CLASS_ATTRIBUTE()
 
   TEST_METHOD(CreateAndSetHandlers){
-    auto ws = make_unique<TestWebSocket>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
 
     Assert::IsFalse(nullptr == ws);
     ws->SetOnConnect([]() {});
@@ -44,7 +44,7 @@ TEST_CLASS(BaseWebSocketTest){
   TEST_METHOD(ConnectSucceeds) {
     string errorMessage;
     bool connected = false;
-    auto ws = make_unique<TestWebSocket>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected = true; });
 
@@ -58,7 +58,7 @@ TEST_CLASS(BaseWebSocketTest){
   TEST_METHOD(ConnectFails) {
     string errorMessage;
     bool connected = false;
-    auto ws = make_unique<TestWebSocket>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected = true; });
     ws->SetConnectResult([]() -> error_code {
@@ -78,7 +78,7 @@ TEST_CLASS(BaseWebSocketTest){
   TEST_METHOD(HandshakeFails) {
     string errorMessage;
     bool connected = false;
-    auto ws = make_unique<TestWebSocket>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected = true; });
     ws->SetHandshakeResult([](string, string) -> error_code {
@@ -99,7 +99,7 @@ TEST_CLASS(BaseWebSocketTest){
     string errorMessage;
     promise<void> connected;
     bool closed = false;
-    auto ws = make_unique<TestWebSocket>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected.set_value(); });
     ws->SetOnClose(

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -48,14 +48,15 @@
       <SDLCheck>true</SDLCheck>
       <!-- See //https://stackoverflow.com/questions/42847103/stdtr1-with-visual-studio-2017. -->
       <PreprocessorDefinitions>
-        BOOST_ASIO_HAS_IOCP;
-        GTEST_LANG_CXX11=1;
-        _WIN32_WINNT=$(WinVer);
-        WIN32;
-        _WINDOWS;
-        FOLLY_NO_CONFIG;
-        NOMINMAX;
         _HAS_AUTO_PTR_ETC;
+        _WIN32_WINNT=$(WinVer);
+        _WINSOCK_DEPRECATED_NO_WARNINGS;
+        _WINDOWS;
+        WIN32;
+        BOOST_ASIO_HAS_IOCP;
+        FOLLY_NO_CONFIG;
+        GTEST_LANG_CXX11=1;
+        NOMINMAX;
         CHAKRACORE;
         RN_EXPORT=;
         JSI_EXPORT=;
@@ -127,7 +128,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
@@ -136,7 +137,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />

--- a/vnext/Desktop.UnitTests/packages.config
+++ b/vnext/Desktop.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -49,8 +49,8 @@ BaseWebSocketResource<SocketLayer, Stream>::~BaseWebSocketResource() {
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::Handshake() {
-  ////TODO: Enable?
-  ////m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
+  //TODO: Enable if we want a configurable timeout.
+  //m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
   m_stream->async_handshake(
       m_url.host, m_url.Target(), bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnHandshake, SharedFromThis()));
 }

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -473,15 +473,15 @@ WebSocketResource::WebSocketResource(Url &&url) : BaseWebSocketResource(std::mov
 
 #pragma endregion WebSocketResource members
 
-#pragma region SecureWebSocket members
+#pragma region SecureWebSocketResource members
 
-SecureWebSocket::SecureWebSocket(Url &&url) : BaseWebSocketResource(std::move(url)) {
+SecureWebSocketResource::SecureWebSocketResource(Url &&url) : BaseWebSocketResource(std::move(url)) {
   auto ssl = ssl::context(ssl::context::sslv23_client);
   this->m_stream = make_unique<websocket::stream<ssl_stream<tcp_stream>>>(this->m_context, ssl);
   this->m_stream->auto_fragment(false); // ISS:2906963 Re-enable message fragmenting.
 }
 
-void SecureWebSocket::Handshake() {
+void SecureWebSocketResource::Handshake() {
   this->m_stream->next_layer().async_handshake(ssl::stream_base::client, [this](error_code ec) {
     if (ec && this->m_errorHandler) {
       this->m_errorHandler({ec.message(), ErrorType::Connection});
@@ -491,7 +491,7 @@ void SecureWebSocket::Handshake() {
   });
 }
 
-#pragma endregion SecureWebSocket members
+#pragma endregion SecureWebSocketResource members
 
 namespace Test {
 
@@ -637,7 +637,7 @@ void TestWebSocket::SetCloseResult(function<error_code()> &&resultFunc) {
 
 } // namespace Beast
 
-} // namespace Microsoft::React
+} // namespace Microsoft::React::Beast
 
 namespace boost::beast {
 

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -3,15 +3,13 @@
 
 #include "pch.h"
 
-#pragma warning(push)
-#pragma warning(disable : 4996) // std::copy::_Unchecked_iterators::_Deprecate
-
 #include "BeastWebSocketResource.h"
 
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/ostream_iterator.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
+#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/connect.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
 #include "Unicode.h"
@@ -20,8 +18,8 @@ using namespace boost::archive::iterators;
 using namespace boost::asio;
 using namespace boost::beast;
 
-using boost::asio::ip::basic_resolver_iterator;
 using boost::asio::ip::tcp;
+using boost::asio::async_initiate;
 
 using std::function;
 using std::make_unique;
@@ -29,7 +27,7 @@ using std::size_t;
 using std::string;
 using std::unique_ptr;
 
-using boostecr = boost::system::error_code const &;
+//using boostecr = boost::system::error_code const &;
 
 namespace Microsoft::React {
 
@@ -37,12 +35,12 @@ namespace Beast {
 
 #pragma region BaseWebSocketResource members
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::BaseWebSocketResource(Url &&url)
+template <typename SocketLayer, typename Stream>
+BaseWebSocketResource<SocketLayer, Stream>::BaseWebSocketResource(Url &&url)
     : m_url{std::move(url)} {}
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::~BaseWebSocketResource() {
+template <typename SocketLayer, typename Stream>
+BaseWebSocketResource<SocketLayer, Stream>::~BaseWebSocketResource() {
   if (!m_context.stopped()) {
     if (!m_closeRequested)
       Close(CloseCode::GoingAway, "Terminating instance");
@@ -51,68 +49,83 @@ BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::~BaseWebSocketRe
   }
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Handshake(
-    const IWebSocketResource::Options &options) {
-  m_stream->async_handshake_ex(
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::Handshake() {
+  ////TODO: Enable?
+  ////m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
+  m_stream->async_handshake(
       m_url.host,
       m_url.Target(),
-      // Header handler
-      [options = std::move(options)](websocket::request_type &req) {
-        // Collect headers
-        for (const auto &header : options) {
-          req.insert(Microsoft::Common::Unicode::Utf16ToUtf8(header.first), header.second);
-        }
-      },
-      // Handshake handler
-      [this](boostecr ec) {
-        if (ec) {
-          if (m_errorHandler)
-            m_errorHandler({ec.message(), ErrorType::Handshake});
-        } else {
-          m_handshakePerformed = true;
-          m_readyState = ReadyState::Open;
-
-          if (m_connectHandler)
-            m_connectHandler();
-
-          // Start read cycle.
-          PerformRead();
-
-          // Perform writes, if enqueued.
-          if (!m_writeRequests.empty())
-            PerformWrite();
-
-          // Perform pings, if enqueued.
-          if (m_pingRequests > 0)
-            PerformPing();
-
-          // Perform close, if requested.
-          if (m_closeRequested && !m_closeInProgress)
-            PerformClose();
-        }
-      }); // async_handshake_ex
+      bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnHandshake, this)
+  );
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformRead() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnHandshake(error_code ec)
+{
+  if (ec)
+  {
+    if (m_errorHandler)
+      m_errorHandler({ ec.message(), ErrorType::Handshake });
+  }
+  else
+  {
+    m_handshakePerformed = true;
+    m_readyState = ReadyState::Open;
+
+    if (m_connectHandler)
+      m_connectHandler();
+
+    // Start read cycle.
+    PerformRead();
+
+    // Perform writes, if enqueued.
+    if (!m_writeRequests.empty())
+      PerformWrite();
+
+    // Perform pings, if enqueued.
+    if (m_pingRequests > 0)
+      PerformPing();
+
+    // Perform close, if requested.
+    if (m_closeRequested && !m_closeInProgress)
+      PerformClose();
+  }
+}
+
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::PerformRead() {
   if (ReadyState::Closing == m_readyState || ReadyState::Closed == m_readyState) {
     return;
   }
 
   // Check if there are more bytes available than a header length (2).
-  m_stream->async_read(m_bufferIn, [this](boostecr ec, size_t size) {
-    if (error::operation_aborted == ec) {
-      // Nothing to do.
-    } else if (ec) {
-      if (m_errorHandler)
-        m_errorHandler({ec.message(), ErrorType::Receive});
-    } else {
-      string message{buffers_to_string(m_bufferIn.data())};
+  m_stream->async_read(
+    m_bufferIn,
+    bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnRead, this)
+  );
+}
 
-      if (m_stream->got_binary()) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnRead(error_code ec, size_t size)
+{
+  if (boost::asio::error::operation_aborted == ec)
+  {
+      // Nothing to do.
+  }
+  else if (ec)
+  {
+    if (m_errorHandler)
+      m_errorHandler({ ec.message(), ErrorType::Receive });
+    }
+    else
+    {
+      string message{ buffers_to_string(m_bufferIn.data()) };
+
+    if (m_stream->got_binary())
+    {
         // ISS:2906983
-        typedef base64_from_binary<transform_width<const char *, 6, 8>> encode_base64;
+        typedef base64_from_binary<transform_width<const char*, 6, 8>> encode_base64;
 
         // NOTE: Encoding the base64 string makes the message's length different
         // from the 'size' argument.
@@ -132,11 +145,11 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformRead
 
     // Enqueue another read.
     PerformRead();
-  }); // async_read
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformWrite() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::PerformWrite()
+{
   assert(!m_writeRequests.empty());
   assert(!m_writeInProgress);
   m_writeInProgress = true;
@@ -148,14 +161,25 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformWrit
 
   // Auto-fragment disabled. Adjust write buffer to the largest message length
   // processed.
-  if (request.first.length() > m_stream->write_buffer_size())
-    m_stream->write_buffer_size(request.first.length());
+  if (request.first.length() > m_stream->write_buffer_bytes())
+    m_stream->write_buffer_bytes(request.first.length());
 
-  m_stream->async_write(buffer(request.first), [this](boostecr ec, size_t size) {
-    if (ec) {
-      if (m_errorHandler)
-        m_errorHandler({ec.message(), ErrorType::Send});
-    } else {
+  m_stream->async_write(
+    buffer(request.first),
+    bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnWrite, this)
+    );
+}
+
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnWrite(error_code ec, size_t size)
+{
+  if (ec)
+  {
+    if (m_errorHandler)
+        m_errorHandler({ ec.message(), ErrorType::Send });
+    }
+    else
+    {
       if (m_writeHandler)
         m_writeHandler(size);
     }
@@ -164,54 +188,73 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformWrit
 
     if (!m_writeRequests.empty())
       PerformWrite();
-  });
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformPing() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::PerformPing()
+{
   assert(m_pingRequests > 0);
   assert(!m_pingInProgress);
   m_pingInProgress = true;
 
   --m_pingRequests;
 
-  m_stream->async_ping(websocket::ping_data(), [this](boostecr ec) {
-    if (ec) {
-      if (m_errorHandler)
-        m_errorHandler({ec.message(), ErrorType::Ping});
-    } else if (m_pingHandler)
-      m_pingHandler();
+  m_stream->async_ping(
+    websocket::ping_data(),
+    bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnPing, this)
+  );
+}
+
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnPing(error_code ec)
+{
+  if (ec)
+  {
+    if (m_errorHandler)
+        m_errorHandler({ ec.message(), ErrorType::Ping });
+  }
+  else if (m_pingHandler)
+    m_pingHandler();
 
     m_pingInProgress = false;
 
     if (m_pingRequests > 0)
       PerformPing();
-  });
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::PerformClose() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::PerformClose() {
   m_closeInProgress = true;
   m_readyState = ReadyState::Closing;
 
-  m_stream->async_close(ToBeastCloseCode(m_closeCodeRequest), [this](boostecr ec) {
-    if (ec) {
-      if (m_errorHandler)
-        m_errorHandler({ec.message(), ErrorType::Close});
-    } else {
-      m_readyState = ReadyState::Closed;
-
-      if (m_closeHandler)
-        m_closeHandler(m_closeCodeRequest, m_closeReasonRequest);
-    }
-  });
+  m_stream->async_close(
+    ToBeastCloseCode(m_closeCodeRequest),
+    bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnClose, this)
+  );
 
   // Synchronize context thread.
   Stop();
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Stop() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnClose(error_code ec)
+{
+  if (ec)
+  {
+    if (m_errorHandler)
+        m_errorHandler({ ec.message(), ErrorType::Close });
+  }
+  else
+  {
+      m_readyState = ReadyState::Closed;
+
+      if (m_closeHandler)
+        m_closeHandler(m_closeCodeRequest, m_closeReasonRequest);
+  }
+}
+
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::Stop() {
   if (m_workGuard)
     m_workGuard->reset();
 
@@ -219,9 +262,11 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Stop() {
     m_contextThread.join();
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::EnqueueWrite(const string &message, bool binary) {
-  post(m_context, [this, message = std::move(message), binary]() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::EnqueueWrite(const string &message, bool binary)
+{
+  post(m_context, [this, message = std::move(message), binary]()
+  {
     m_writeRequests.emplace(std::move(message), binary);
 
     if (!m_writeInProgress && ReadyState::Open == m_readyState)
@@ -229,8 +274,8 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::EnqueueWrit
   });
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-websocket::close_code BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::ToBeastCloseCode(
+template <typename SocketLayer, typename Stream>
+websocket::close_code BaseWebSocketResource<SocketLayer, Stream>::ToBeastCloseCode(
     IWebSocketResource::CloseCode closeCode) {
   static_assert(
       static_cast<uint16_t>(IWebSocketResource::CloseCode::Abnormal) ==
@@ -302,54 +347,82 @@ websocket::close_code BaseWebSocketResource<Protocol, SocketLayer, Stream, Resol
 
 #pragma region IWebSocketResource members
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Connect(
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::Connect(
     const Protocols &protocols,
     const Options &options) {
   // "Cannot call Connect more than once");
   assert(ReadyState::Connecting == m_readyState);
 
-  if (!protocols.empty()) {
-    for (auto &protocol : protocols) {
+  //TODO: Enable?
+  //m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
+  m_stream->set_option(websocket::stream_base::decorator(
+    [options = std::move(options)](websocket::request_type& req)
+  {
+    // Collect headers
+    for (const auto& header : options)
+    {
+      req.insert(Microsoft::Common::Unicode::Utf16ToUtf8(header.first), header.second);
+    }
+  }));
+
+  if (!protocols.empty())
+  {
+    for (auto &protocol : protocols)
+    {
       // ISS:2152951 - collect protocols
     }
   }
 
-  Resolver resolver(m_context);
+  tcp::resolver resolver(m_context);
   resolver.async_resolve(
       m_url.host,
       m_url.port,
-      [this, options = std::move(options)](boostecr ec, typename Resolver::results_type results) {
-        if (ec) {
-          if (m_errorHandler)
-            m_errorHandler({ec.message(), ErrorType::Resolution});
+      bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnResolve, this)
+  );
 
-          return;
-        }
-
-        // Connect
-        async_connect(
-            m_stream->lowest_layer(),
-            results.begin(),
-            results.end(),
-            [this, options = std::move(options)](boostecr ec, const basic_resolver_iterator<Protocol> &) {
-              if (ec) {
-                if (m_errorHandler)
-                  m_errorHandler({ec.message(), ErrorType::Connection});
-              } else {
-                Handshake(std::move(options));
-              }
-            }); // async_connect
-      }); // async_resolve
-
-  m_contextThread = std::thread([this]() {
+  m_contextThread = std::thread([this]()
+  {
     m_workGuard = make_unique<executor_work_guard<io_context::executor_type>>(make_work_guard(m_context));
     m_context.run();
   });
-} // void Connect
+}
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Close(CloseCode code, const string &reason) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnResolve(error_code ec, typename tcp::resolver::results_type results)
+{
+  if (ec)
+  {
+    if (m_errorHandler)
+      m_errorHandler({ ec.message(), ErrorType::Resolution });
+
+    return;
+  }
+
+        // Connect
+  get_lowest_layer(*m_stream).async_connect(
+    results,
+    bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnConnect, this)
+  );
+}
+
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::OnConnect(error_code ec, tcp::resolver::results_type::endpoint_type endpoints)
+{
+  if (ec)
+  {
+    if (m_errorHandler)
+      m_errorHandler({ ec.message(), ErrorType::Connection });
+  }
+  else
+  {
+    Handshake();
+  }
+}
+
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::Close(CloseCode code, const string &reason)
+{
   if (m_closeRequested)
     return;
 
@@ -365,24 +438,27 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Close(Close
     Stop(); // Synchronize the context thread.
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Send(const string &message) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::Send(const string &message) {
   EnqueueWrite(std::move(message), false);
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SendBinary(const string &base64String) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SendBinary(const string &base64String) {
   m_stream->binary(true);
 
   string message;
-  try {
+  try
+  {
     typedef transform_width<binary_from_base64<string::const_iterator>, 8, 6> decode_base64;
 
     // A correctly formed base64 string should have from 0 to three '=' trailing
     // characters. Skip those.
     size_t padSize = std::count(base64String.begin(), base64String.end(), '=');
     message = string(decode_base64(base64String.begin()), decode_base64(base64String.end() - padSize));
-  } catch (const std::exception &) {
+  }
+  catch (const std::exception &)
+  {
     if (m_errorHandler)
       m_errorHandler({"", ErrorType::Send});
 
@@ -392,8 +468,9 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SendBinary(
   EnqueueWrite(std::move(message), true);
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Ping() {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::Ping()
+{
   if (ReadyState::Closed == m_readyState)
     return;
 
@@ -406,40 +483,47 @@ void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::Ping() {
 
 #pragma region Handler setters
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnConnect(function<void()> &&handler) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnConnect(function<void()> &&handler)
+{
   m_connectHandler = handler;
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnPing(function<void()> &&handler) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnPing(function<void()> &&handler)
+{
   m_pingHandler = handler;
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnSend(function<void(size_t)> &&handler) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnSend(function<void(size_t)> &&handler)
+{
   m_writeHandler = handler;
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnMessage(
-    function<void(size_t, const string &)> &&handler) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnMessage(
+    function<void(size_t, const string &)> &&handler)
+{
   m_readHandler = handler;
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnClose(
-    function<void(CloseCode, const string &)> &&handler) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnClose(
+    function<void(CloseCode, const string &)> &&handler)
+{
   m_closeHandler = handler;
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-void BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::SetOnError(function<void(Error &&)> &&handler) {
+template <typename SocketLayer, typename Stream>
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnError(function<void(Error &&)> &&handler)
+{
   m_errorHandler = handler;
 }
 
-template <typename Protocol, typename SocketLayer, typename Stream, typename Resolver>
-IWebSocketResource::ReadyState BaseWebSocketResource<Protocol, SocketLayer, Stream, Resolver>::GetReadyState() const {
+template <typename SocketLayer, typename Stream>
+IWebSocketResource::ReadyState BaseWebSocketResource<SocketLayer, Stream>::GetReadyState() const
+{
   return m_readyState;
 }
 
@@ -449,30 +533,38 @@ IWebSocketResource::ReadyState BaseWebSocketResource<Protocol, SocketLayer, Stre
 
 #pragma region WebSocketResource members
 
-WebSocketResource::WebSocketResource(Url &&url) : BaseWebSocketResource(std::move(url)) {
-  this->m_stream = make_unique<websocket::stream<basic_stream_socket<tcp>>>(this->m_context);
+WebSocketResource::WebSocketResource(Url &&url) : BaseWebSocketResource(std::move(url))
+{
+  this->m_stream = make_unique<websocket::stream<boost::beast::tcp_stream>>(this->m_context);
   this->m_stream->auto_fragment(false); // ISS:2906963 Re-enable message fragmenting.
 }
 
-#pragma endregion
+#pragma endregion WebSocketResource members
 
 #pragma region SecureWebSocket members
 
-SecureWebSocket::SecureWebSocket(Url &&url) : BaseWebSocketResource(std::move(url)) {
+SecureWebSocket::SecureWebSocket(Url &&url) : BaseWebSocketResource(std::move(url))
+{
   auto ssl = ssl::context(ssl::context::sslv23_client);
-  this->m_stream = make_unique<websocket::stream<ssl::stream<tcp::socket>>>(this->m_context, ssl);
+  this->m_stream = make_unique<websocket::stream<ssl_stream<tcp_stream>>>(this->m_context, ssl);
   this->m_stream->auto_fragment(false); // ISS:2906963 Re-enable message fragmenting.
 }
 
-void SecureWebSocket::Handshake(const IWebSocketResource::Options &options) {
+void SecureWebSocket::Handshake()
+{
   this->m_stream->next_layer().async_handshake(
-      ssl::stream_base::client, [this, options = std::move(options)](boostecr ec) {
-        if (ec && this->m_errorHandler) {
-          this->m_errorHandler({ec.message(), IWebSocketResource::ErrorType::Connection});
-        } else {
-          BaseWebSocketResource::Handshake(std::move(options));
+    ssl::stream_base::client,
+    [this](error_code ec)
+    {
+      if (ec && this->m_errorHandler)
+      {
+        this->m_errorHandler({ec.message(), ErrorType::Connection});
+      }
+      else
+      {
+        BaseWebSocketResource::Handshake();
         }
-      });
+    });
 }
 
 #pragma endregion SecureWebSocket members
@@ -492,106 +584,157 @@ io_context::executor_type MockStream::get_executor() noexcept {
   return m_context.get_executor();
 }
 
-MockStream::lowest_layer_type &MockStream::lowest_layer() {
-  return *this;
-}
-
-MockStream::lowest_layer_type const &MockStream::lowest_layer() const {
-  return *this;
-}
-
 void MockStream::binary(bool value) {}
 
-bool MockStream::got_binary() const {
+bool MockStream::got_binary() const
+{
   return false;
 }
 
-bool MockStream::got_text() const {
+bool MockStream::got_text() const
+{
   return !got_binary();
 }
 
-void MockStream::write_buffer_size(size_t amount) {}
+void MockStream::write_buffer_bytes(size_t amount) {}
 
-size_t MockStream::write_buffer_size() const {
+size_t MockStream::write_buffer_bytes() const
+{
   return 8;
 }
 
-template <class RequestDecorator, class HandshakeHandler>
+void MockStream::set_option(websocket::stream_base::decorator opt) {}
+
+void MockStream::get_option(websocket::stream_base::timeout& opt) {}
+
+void MockStream::set_option(websocket::stream_base::timeout const& opt) {}
+
+void MockStream::set_option(websocket::permessage_deflate const& o) {}
+
+void MockStream::get_option(websocket::permessage_deflate& o) {}
+
+template<class RangeConnectHandler>
+BOOST_ASIO_INITFN_RESULT_TYPE(RangeConnectHandler, void(error_code, tcp::endpoint))
+MockStream::async_connect(
+  tcp::resolver::iterator const& endpoints,
+  RangeConnectHandler&& handler)
+{
+  return async_initiate<RangeConnectHandler, void(error_code, tcp::endpoint)>(
+    [](RangeConnectHandler&& handler, MockStream* ms, tcp::resolver::iterator it)
+    {
+      tcp::endpoint ep;//TODO: make modifiable.
+      post(ms->get_executor(), bind_handler(std::move(handler), ms->ConnectResult(), ep));
+    },
+    handler,
+    this,
+    endpoints
+  );
+}
+
+template <class HandshakeHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(HandshakeHandler, void(error_code))
-MockStream::async_handshake_ex(
+MockStream::async_handshake(
     boost::string_view host,
     boost::string_view target,
-    RequestDecorator const &decorator,
-    HandshakeHandler &&handler) {
-  BOOST_BEAST_HANDLER_INIT(HandshakeHandler, void(error_code));
-  post(
-      get_executor(),
-      bind_handler(std::move(init.completion_handler), HandshakeResult(host.to_string(), target.to_string())));
-
-  return init.result.get();
+    HandshakeHandler &&handler)
+{
+  return async_initiate<HandshakeHandler, void(error_code)>(
+    [](HandshakeHandler&& handler, MockStream* ms, string h, string t)
+    {
+      post(ms->get_executor(), bind_handler(std::move(handler), ms->HandshakeResult(h, t)));
+    },
+    handler,
+    this,
+    host.to_string(),
+    target.to_string()
+  );
 }
 
 template <class DynamicBuffer, class ReadHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(ReadHandler, void(error_code, size_t))
-MockStream::async_read(DynamicBuffer &buffer, ReadHandler &&handler) {
+MockStream::async_read(DynamicBuffer &buffer, ReadHandler &&handler)
+{
   error_code ec;
   size_t size;
   std::tie(ec, size) = ReadResult();
 
-  BOOST_BEAST_HANDLER_INIT(ReadHandler, void(error_code, size_t));
-  post(get_executor(), bind_handler(std::move(init.completion_handler), ec, size));
-
-  return init.result.get();
+  return async_initiate<ReadHandler, void(error_code, size_t)>(
+    [ec, size](ReadHandler&& handler, MockStream* ms)
+    {
+      post(ms->get_executor(), bind_handler(std::move(handler), ec, size));
+    },
+    handler,
+    this
+  );
 }
 
 template <class ConstBufferSequence, class WriteHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(WriteHandler, void(error_code, size_t))
-MockStream::async_write(ConstBufferSequence const &buffers, WriteHandler &&handler) {
+MockStream::async_write(ConstBufferSequence const &buffers, WriteHandler &&handler)
+{
   error_code ec;
   size_t size;
-  std::tie(ec, size) = ReadResult();
+  std::tie(ec, size) = ReadResult();//TODO: Why in async_write?
 
-  BOOST_BEAST_HANDLER_INIT(WriteHandler, void(error_code, size_t));
-  post(get_executor(), bind_handler(std::move(init.completion_handler), ec, size));
-
-  return init.result.get();
+  return async_initiate<WriteHandler, void(error_code, size_t)>(
+    [ec, size](WriteHandler&& handler, MockStream* ms)
+    {
+      post(ms->get_executor(), bind_handler(std::move(handler), ec, size));
+    },
+    handler,
+    this
+  );
 }
 
 template <class WriteHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(WriteHandler, void(error_code))
-MockStream::async_ping(websocket::ping_data const &payload, WriteHandler &&handler) {
-  BOOST_BEAST_HANDLER_INIT(WriteHandler, void(error_code));
-  post(get_executor(), bind_handler(std::move(init.completion_handler), PingResult()));
-
-  return init.result.get();
+MockStream::async_ping(websocket::ping_data const &payload, WriteHandler &&handler)
+{
+  return async_initiate<WriteHandler, void(error_code)>(
+    [](WriteHandler&& handler, MockStream* ms)
+    {
+      post(ms->get_executor(), bind_handler(std::move(handler), ms->PingResult()));
+    },
+    handler,
+    this
+  );
 }
 
 template <class CloseHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(CloseHandler, void(error_code))
-MockStream::async_close(websocket::close_reason const &cr, CloseHandler &&handler) {
-  BOOST_BEAST_HANDLER_INIT(CloseHandler, void(error_code));
-  post(get_executor(), bind_handler(std::move(init.completion_handler), CloseResult()));
-
-  return init.result.get();
+MockStream::async_close(websocket::close_reason const &cr, CloseHandler &&handler)
+{
+  return async_initiate<CloseHandler, void(error_code)>(
+    [](CloseHandler&& handler, MockStream* ms)
+    {
+      post(ms->get_executor(), bind_handler(std::move(handler), ms->CloseResult()));
+    },
+    handler,
+    this
+  );
 }
 
 #pragma endregion MockStream
 
 #pragma region TestWebSocket
 
-TestWebSocket::TestWebSocket(Url &&url) : BaseWebSocketResource(std::move(url)) {
+TestWebSocket::TestWebSocket(Url &&url) : BaseWebSocketResource(std::move(url))
+{
   m_stream = make_unique<MockStream>(m_context);
 }
 
-void TestWebSocket::SetConnectResult(function<error_code()> &&resultFunc) {
+void TestWebSocket::SetConnectResult(function<error_code()> &&resultFunc)
+{
   m_stream->ConnectResult = std::move(resultFunc);
 }
 
-void TestWebSocket::SetHandshakeResult(function<error_code(string, string)> &&resultFunc) {
+void TestWebSocket::SetHandshakeResult(function<error_code(string, string)> &&resultFunc)
+{
   m_stream->HandshakeResult = std::move(resultFunc);
 }
 
-void TestWebSocket::SetCloseResult(function<error_code()> &&resultFunc) {
+void TestWebSocket::SetCloseResult(function<error_code()> &&resultFunc)
+{
   m_stream->CloseResult = std::move(resultFunc);
 }
 
@@ -602,19 +745,12 @@ void TestWebSocket::SetCloseResult(function<error_code()> &&resultFunc) {
 
 } // namespace Microsoft::React
 
-namespace boost::asio {
+namespace boost::beast {
 
-// See <boost/asio/connect.hpp>(776)
-template <typename Iterator, typename IteratorConnectHandler>
-BOOST_ASIO_INITFN_RESULT_TYPE(IteratorConnectHandler, void(error_code, Iterator))
-async_connect(
-    Microsoft::React::Beast::Test::MockStream &s,
-    Iterator begin,
-    Iterator end,
-    BOOST_ASIO_MOVE_ARG(IteratorConnectHandler) handler) {
-  handler(s.ConnectResult(), {});
+Microsoft::React::Beast::Test::MockStream::lowest_layer_type&
+get_lowest_layer(
+    Microsoft::React::Beast::Test::MockStream &s) noexcept {
+  return s;
 }
 
-} // namespace boost::asio
-
-#pragma warning(pop)
+} // namespace boost::beast

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -49,10 +49,12 @@ BaseWebSocketResource<SocketLayer, Stream>::~BaseWebSocketResource() {
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::Handshake() {
-  //TODO: Enable if we want a configurable timeout.
-  //m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
+  // TODO: Enable if we want a configurable timeout.
+  // m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
   m_stream->async_handshake(
-      m_url.host, m_url.Target(), bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnHandshake, SharedFromThis()));
+      m_url.host,
+      m_url.Target(),
+      bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnHandshake, SharedFromThis()));
 }
 
 template <typename SocketLayer, typename Stream>
@@ -91,7 +93,8 @@ void BaseWebSocketResource<SocketLayer, Stream>::PerformRead() {
   }
 
   // Check if there are more bytes available than a header length (2).
-  m_stream->async_read(m_bufferIn, bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnRead, SharedFromThis()));
+  m_stream->async_read(
+      m_bufferIn, bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnRead, SharedFromThis()));
 }
 
 template <typename SocketLayer, typename Stream>
@@ -145,7 +148,8 @@ void BaseWebSocketResource<SocketLayer, Stream>::PerformWrite() {
     m_stream->write_buffer_bytes(request.first.length());
 
   m_stream->async_write(
-      buffer(request.first), bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnWrite, SharedFromThis()));
+      buffer(request.first),
+      bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnWrite, SharedFromThis()));
 }
 
 template <typename SocketLayer, typename Stream>
@@ -173,7 +177,8 @@ void BaseWebSocketResource<SocketLayer, Stream>::PerformPing() {
   --m_pingRequests;
 
   m_stream->async_ping(
-      websocket::ping_data(), bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnPing, SharedFromThis()));
+      websocket::ping_data(),
+      bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnPing, SharedFromThis()));
 }
 
 template <typename SocketLayer, typename Stream>
@@ -330,7 +335,9 @@ void BaseWebSocketResource<SocketLayer, Stream>::Connect(const Protocols &protoc
 
   tcp::resolver resolver(m_context);
   resolver.async_resolve(
-      m_url.host, m_url.port, bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnResolve, SharedFromThis()));
+      m_url.host,
+      m_url.port,
+      bind_front_handler(&BaseWebSocketResource<SocketLayer, Stream>::OnResolve, SharedFromThis()));
 
   m_contextThread = std::thread([self = SharedFromThis()]() {
     self->m_workGuard = make_unique<executor_work_guard<io_context::executor_type>>(make_work_guard(self->m_context));
@@ -629,7 +636,8 @@ MockStream::async_close(websocket::close_reason const &cr, CloseHandler &&handle
 
 #pragma region TestWebSocket
 
-shared_ptr<Beast::BaseWebSocketResource<std::nullptr_t, MockStream>> TestWebSocketResource::SharedFromThis()  /*override*/
+shared_ptr<Beast::BaseWebSocketResource<std::nullptr_t, MockStream>>
+TestWebSocketResource::SharedFromThis() /*override*/
 {
   return this->shared_from_this();
 }

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -216,7 +216,7 @@ class WebSocketResource : public BaseWebSocketResource<> {
   WebSocketResource(Url &&url);
 };
 
-class SecureWebSocket : public BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>> {
+class SecureWebSocketResource : public BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>> {
 #pragma region BaseWebSocketResource overrides
 
   void Handshake() override;
@@ -224,7 +224,7 @@ class SecureWebSocket : public BaseWebSocketResource<boost::beast::ssl_stream<bo
 #pragma endregion
 
  public:
-  SecureWebSocket(Url &&url);
+  SecureWebSocketResource(Url &&url);
 };
 
 namespace Test {

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -146,7 +146,7 @@ class BaseWebSocketResource : public IWebSocketResource {
   /// </param>
   virtual void Handshake();
 
-  virtual std::shared_ptr<const BaseWebSocketResource<SocketLayer, Stream>> SharedFromThis() const = 0;
+  virtual std::shared_ptr<BaseWebSocketResource<SocketLayer, Stream>> SharedFromThis() = 0;
 
  public:
   ~BaseWebSocketResource() override;
@@ -217,7 +217,7 @@ class WebSocketResource : public BaseWebSocketResource<>, public std::enable_sha
 
 #pragma region BaseWebSocketResource overrides
 
-  std::shared_ptr<const BaseWebSocketResource<>> SharedFromThis() const override;
+  std::shared_ptr<BaseWebSocketResource<>> SharedFromThis() override;
 
 #pragma endregion BaseWebSocketResource overrides
 
@@ -232,8 +232,8 @@ class SecureWebSocketResource : public BaseWebSocketResource<boost::beast::ssl_s
 
   void Handshake() override;
 
-  std::shared_ptr<const BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>>> SharedFromThis()
-      const override;
+  std::shared_ptr<BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>>> SharedFromThis()
+      override;
 
 #pragma endregion BaseWebSocketResource overrides
 
@@ -329,7 +329,7 @@ class TestWebSocketResource : public BaseWebSocketResource<
 
 #pragma region BaseWebSocketResource overrides
 
-  std::shared_ptr<const BaseWebSocketResource<std::nullptr_t, MockStream>> SharedFromThis() const override;
+  std::shared_ptr<BaseWebSocketResource<std::nullptr_t, MockStream>> SharedFromThis() override;
 
 #pragma endregion BaseWebSocketResource overrides
 

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -3,12 +3,11 @@
 
 #pragma once
 
-#include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/core/multi_buffer.hpp>
+#include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/ssl.hpp>
-#include <boost/beast/websocket/ssl.hpp>
-#include <boost/beast/websocket/ssl.hpp>
 #include <boost/beast/websocket.hpp>
+#include <boost/beast/websocket/ssl.hpp>
 #include <queue>
 #include <thread>
 #include "IWebSocketResource.h"
@@ -94,7 +93,7 @@ class BaseWebSocketResource : public IWebSocketResource {
 
   boost::beast::websocket::close_code ToBeastCloseCode(IWebSocketResource::CloseCode closeCode);
 
-  #pragma region Async handlers
+#pragma region Async handlers
 
   void OnResolve(boost::beast::error_code ec, typename boost::asio::ip::tcp::resolver::results_type results);
 
@@ -110,7 +109,7 @@ class BaseWebSocketResource : public IWebSocketResource {
 
   void OnPing(boost::beast::error_code ec);
 
-  #pragma endregion Async handlers
+#pragma endregion Async handlers
 
  protected:
   /// <summary>
@@ -217,8 +216,7 @@ class WebSocketResource : public BaseWebSocketResource<> {
   WebSocketResource(Url &&url);
 };
 
-class SecureWebSocket
-    : public BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>> {
+class SecureWebSocket : public BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>> {
 #pragma region BaseWebSocketResource overrides
 
   void Handshake() override;
@@ -246,9 +244,9 @@ class MockStream {
 
   boost::asio::io_context::executor_type get_executor() noexcept;
 
-//  lowest_layer_type &lowest_layer();
+  //  lowest_layer_type &lowest_layer();
 
-//  lowest_layer_type const &lowest_layer() const;
+  //  lowest_layer_type const &lowest_layer() const;
 
   void binary(bool value);
 
@@ -262,21 +260,19 @@ class MockStream {
 
   void set_option(boost::beast::websocket::stream_base::decorator opt);
 
-  void get_option(boost::beast::websocket::stream_base::timeout& opt);
+  void get_option(boost::beast::websocket::stream_base::timeout &opt);
 
-  void set_option(boost::beast::websocket::stream_base::timeout const& opt);
+  void set_option(boost::beast::websocket::stream_base::timeout const &opt);
 
-  void set_option(boost::beast::websocket::permessage_deflate const& o);
+  void set_option(boost::beast::websocket::permessage_deflate const &o);
 
-  void get_option(boost::beast::websocket::permessage_deflate& o);
+  void get_option(boost::beast::websocket::permessage_deflate &o);
 
 #pragma region boost::beast::basic_stream mocks
 
-template<class RangeConnectHandler>
-BOOST_ASIO_INITFN_RESULT_TYPE(RangeConnectHandler, void(boost::system::error_code, boost::asio::ip::tcp::endpoint))
-async_connect(
-  boost::asio::ip::tcp::resolver::iterator const& endpoints,
-  RangeConnectHandler&& handler);
+  template <class RangeConnectHandler>
+  BOOST_ASIO_INITFN_RESULT_TYPE(RangeConnectHandler, void(boost::system::error_code, boost::asio::ip::tcp::endpoint))
+  async_connect(boost::asio::ip::tcp::resolver::iterator const &endpoints, RangeConnectHandler &&handler);
 
 #pragma endregion boost::beast::basic_stream mocks
 
@@ -284,10 +280,7 @@ async_connect(
 
   template <class HandshakeHandler>
   BOOST_ASIO_INITFN_RESULT_TYPE(HandshakeHandler, void(boost::system::error_code))
-  async_handshake(
-      boost::beast::string_view host,
-      boost::beast::string_view target,
-      HandshakeHandler &&handler);
+  async_handshake(boost::beast::string_view host, boost::beast::string_view target, HandshakeHandler &&handler);
 
   template <class DynamicBuffer, class ReadHandler>
   BOOST_ASIO_INITFN_RESULT_TYPE(ReadHandler, void(boost::system::error_code, std::size_t))
@@ -315,12 +308,9 @@ async_connect(
   std::function<boost::system::error_code()> CloseResult;
 };
 
-class TestWebSocket : public  BaseWebSocketResource
-                              <
-                                std::nullptr_t, // Unused. MockStream works as its own next/lowest layer.
-                                MockStream
-                              >
-{
+class TestWebSocket : public BaseWebSocketResource<
+                          std::nullptr_t, // Unused. MockStream works as its own next/lowest layer.
+                          MockStream> {
  public:
   TestWebSocket(facebook::react::Url &&url);
 

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -214,28 +214,25 @@ class BaseWebSocketResource : public IWebSocketResource {
 };
 
 class WebSocketResource : public BaseWebSocketResource<>, public std::enable_shared_from_this<WebSocketResource> {
-
 #pragma region BaseWebSocketResource overrides
 
   std::shared_ptr<BaseWebSocketResource<>> SharedFromThis() override;
 
 #pragma endregion BaseWebSocketResource overrides
 
-public:
+ public:
   WebSocketResource(Url &&url);
 };
 
 class SecureWebSocketResource : public BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>>,
                                 public std::enable_shared_from_this<SecureWebSocketResource> {
-
 #pragma region BaseWebSocketResource overrides
 
   void Handshake() override;
 
   void OnSslHandshake(boost::beast::error_code ec);
 
-  std::shared_ptr<BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>>> SharedFromThis()
-      override;
+  std::shared_ptr<BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>>> SharedFromThis() override;
 
 #pragma endregion BaseWebSocketResource overrides
 
@@ -325,17 +322,16 @@ class MockStream {
 };
 
 class TestWebSocketResource : public BaseWebSocketResource<
-                                      std::nullptr_t, // Unused. MockStream works as its own next/lowest layer.
-                                      MockStream>,
+                                  std::nullptr_t, // Unused. MockStream works as its own next/lowest layer.
+                                  MockStream>,
                               public std::enable_shared_from_this<TestWebSocketResource> {
-
 #pragma region BaseWebSocketResource overrides
 
   std::shared_ptr<BaseWebSocketResource<std::nullptr_t, MockStream>> SharedFromThis() override;
 
 #pragma endregion BaseWebSocketResource overrides
 
-public:
+ public:
   TestWebSocketResource(facebook::react::Url &&url);
 
   void SetConnectResult(std::function<boost::system::error_code()> &&resultFunc);

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -232,6 +232,8 @@ class SecureWebSocketResource : public BaseWebSocketResource<boost::beast::ssl_s
 
   void Handshake() override;
 
+  void OnSslHandshake(boost::beast::error_code ec);
+
   std::shared_ptr<BaseWebSocketResource<boost::beast::ssl_stream<boost::beast::tcp_stream>>> SharedFromThis()
       override;
 

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -241,7 +241,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
@@ -268,7 +268,7 @@
     </PropertyGroup>
     <Warning Condition="'$(USE_V8)' != 'true'" Text="Building desktop project without USE_V8 (value is '$(USE_V8)')" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -16,7 +16,7 @@ namespace Microsoft::React {
 /*static*/
 shared_ptr<IWebSocketResource>
 IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned) {
-  if (false) {
+  if (false) { //TODO: Revert before merging!
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (acceptSelfSigned) {
       certExceptions.emplace_back(

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -16,7 +16,7 @@ namespace Microsoft::React {
 /*static*/
 shared_ptr<IWebSocketResource>
 IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned) {
-  if (false) { //TODO: Revert before merging!
+  if (false) { // TODO: Revert before merging!
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (acceptSelfSigned) {
       certExceptions.emplace_back(

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -16,7 +16,7 @@ namespace Microsoft::React {
 /*static*/
 shared_ptr<IWebSocketResource>
 IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned) {
-  if (!legacyImplementation) {
+  if (false) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (acceptSelfSigned) {
       certExceptions.emplace_back(

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -37,7 +37,7 @@ IWebSocketResource::Make(const string &urlString, bool legacyImplementation, boo
       if (url.port.empty())
         url.port = "443";
 
-      return make_shared<Beast::SecureWebSocket>(std::move(url));
+      return make_shared<Beast::SecureWebSocketResource>(std::move(url));
     } else {
       throw std::invalid_argument((string("Incorrect URL scheme: ") + url.scheme).c_str());
     }

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -16,7 +16,7 @@ namespace Microsoft::React {
 /*static*/
 shared_ptr<IWebSocketResource>
 IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned) {
-  if (false) { // TODO: Revert before merging!
+  if (!legacyImplementation) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (acceptSelfSigned) {
       certExceptions.emplace_back(

--- a/vnext/Desktop/packages.config
+++ b/vnext/Desktop/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.43" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -276,13 +276,13 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
   </Target>
   <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
     <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" />

--- a/vnext/Folly/packages.config
+++ b/vnext/Folly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
 </packages>

--- a/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
+++ b/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
@@ -89,13 +89,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
   </Target>
   <Target Name="Test">
     <Exec Command="$(OutDir)$(TargetFileName)" IgnoreStandardErrorWarningFormat="true" />

--- a/vnext/IntegrationTests/packages.config
+++ b/vnext/IntegrationTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
 </packages>

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -118,7 +118,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" />
@@ -131,7 +131,7 @@
     </PropertyGroup>
     <Warning Condition="'$(USE_V8)' != 'true'" Text="Building desktop project without USE_V8 (value is '$(USE_V8)')" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.43\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.13\build\native\Microsoft.ChakraCore.vc140.targets'))" />

--- a/vnext/JSI.Desktop.UnitTests/packages.config
+++ b/vnext/JSI.Desktop.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.43" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.13" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -243,7 +243,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
@@ -251,7 +251,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />

--- a/vnext/Microsoft.ReactNative.ComponentTests/packages.config
+++ b/vnext/Microsoft.ReactNative.ComponentTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -664,7 +664,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets" Condition="'$(UseWinUI3)'!='true' And Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.WinUI.3.0.0-alpha.200210.0\build\native\Microsoft.WinUI.targets" Condition="'$(UseWinUI3)'=='true' And Exists('$(SolutionDir)packages\Microsoft.WinUI.3.0.0-alpha.200210.0\build\native\Microsoft.WinUI.targets')" />
@@ -676,7 +676,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="'$(UseWinUI3)'!='true' And !Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-alpha.200210.0" targetFramework="native"/>
   <package id="Microsoft.Web.WebView2" version="0.8.355" targetFramework="native"/>

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -105,7 +105,7 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
   </ImportGroup>
   <ItemGroup>
     <ClInclude Include="$(JSI_SourcePath)\jsi\instrumentation.h" />
@@ -199,7 +199,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
   </Target>
   <Target Name="EnsureNodeModuleBuildImports" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(ReactNativePackageDir)')" Text="This project references code in the node_modules folder that is missing on this computer.  Use `yarn install` to download them." />

--- a/vnext/ReactCommon/packages.config
+++ b/vnext/ReactCommon/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
 </packages>

--- a/vnext/ReactUWP/packages.config
+++ b/vnext/ReactUWP/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-alpha.200210.0" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />

--- a/vnext/Test/HttpServer.h
+++ b/vnext/Test/HttpServer.h
@@ -1,21 +1,24 @@
+// clang-format off
 #pragma once
 
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
+#include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/http.hpp>
 
 #include <thread>
 
-namespace Microsoft::React::Test {
+namespace Microsoft::React::Test
+{
 
 #pragma region Utility functions
 
-boost::beast::multi_buffer CreateStringResponseBody(std::string &&content);
+boost::beast::multi_buffer CreateStringResponseBody(std::string&& content);
 
 #pragma endregion Utility functions
 
-struct HttpCallbacks {
+struct HttpCallbacks
+{
   std::function<void()> OnResponseSent;
   std::function<boost::beast::http::response<boost::beast::http::dynamic_body>(
       const boost::beast::http::request<boost::beast::http::string_body> &)>
@@ -26,23 +29,23 @@ struct HttpCallbacks {
 // Represents a client session in within an owning server instance.
 // Generates and submits the appropriate HTTP response.
 ///
-class HttpSession : public std::enable_shared_from_this<HttpSession> {
-  boost::asio::ip::tcp::socket &m_socket;
-  boost::asio::strand<boost::asio::io_context::executor_type> m_strand;
+class HttpSession : public std::enable_shared_from_this<HttpSession>
+{
+  boost::beast::tcp_stream m_stream;
   boost::beast::flat_buffer m_buffer;
   boost::beast::http::request<boost::beast::http::string_body> m_request;
   std::shared_ptr<boost::beast::http::response<boost::beast::http::dynamic_body>> m_response; // Generic response
-  HttpCallbacks &m_callbacks;
+  HttpCallbacks& m_callbacks;
 
   void Read();
   void Respond();
   void Close();
 
   void OnRead(boost::system::error_code ec, std::size_t transferred);
-  void OnWrite(boost::system::error_code ec, std::size_t transferred, bool close);
+  void OnWrite(bool close, boost::system::error_code ec, std::size_t transferred);
 
  public:
-  HttpSession(boost::asio::ip::tcp::socket &socket, HttpCallbacks &callbacks);
+  HttpSession(boost::asio::ip::tcp::socket&& socket, HttpCallbacks &callbacks);
 
   ~HttpSession();
 
@@ -54,15 +57,15 @@ class HttpSession : public std::enable_shared_from_this<HttpSession> {
 // Accepts client connections and dispatches sessions for each incoming
 // connection.
 ///
-class HttpServer : public std::enable_shared_from_this<HttpServer> {
+class HttpServer : public std::enable_shared_from_this<HttpServer>
+{
   std::thread m_contextThread;
   boost::asio::io_context m_context;
   boost::asio::ip::tcp::acceptor m_acceptor;
-  boost::asio::ip::tcp::socket m_socket;
   HttpCallbacks m_callbacks;
   std::vector<std::shared_ptr<HttpSession>> m_sessions;
 
-  void OnAccept(boost::system::error_code ec);
+  void OnAccept(boost::system::error_code ec, boost::asio::ip::tcp::socket socket);
 
  public:
   ///

--- a/vnext/Test/React.Windows.Test.vcxproj
+++ b/vnext/Test/React.Windows.Test.vcxproj
@@ -71,14 +71,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets" Condition="Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.68.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.OpenSSL.StdCall.Static.1.0.2-p.2\build\native\ReactWindows.OpenSSL.StdCall.Static.targets'))" />
   </Target>
 </Project>

--- a/vnext/Test/WebSocketServer.h
+++ b/vnext/Test/WebSocketServer.h
@@ -1,29 +1,37 @@
+// clang-format off
 #pragma once
 
 #include <IWebSocketResource.h>
 #include <boost/asio/strand.hpp>
+#include <boost/beast/core/multi_buffer.hpp>
+#include <boost/beast/core/tcp_stream.hpp>
+#include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
 #include <thread>
 
-namespace Microsoft::React::Test {
+namespace Microsoft::React::Test
+{
 
-struct WebSocketServiceCallbacks {
+struct WebSocketServiceCallbacks
+{
   std::function<void()> OnConnection;
-  std::function<void(boost::beast::websocket::response_type &)> OnHandshake;
+  std::function<void(boost::beast::websocket::response_type&)> OnHandshake;
   std::function<void(std::string)> OnMessage;
-  std::function<std::string(std::string &&)> MessageFactory;
-  std::function<void(IWebSocketResource::Error &&)> OnError;
+  std::function<std::string(std::string&&)> MessageFactory;
+  std::function<void(IWebSocketResource::Error&&)> OnError;
 };
 
-struct IWebSocketSession {
+struct IWebSocketSession
+{
   virtual ~IWebSocketSession() {}
 
   virtual void Start() = 0;
 };
 
 template <typename SocketLayer>
-class BaseWebSocketSession : public IWebSocketSession {
+class BaseWebSocketSession : public IWebSocketSession
+{
   enum class State : std::size_t { Started, Stopped };
 
   boost::beast::multi_buffer m_buffer;
@@ -31,46 +39,48 @@ class BaseWebSocketSession : public IWebSocketSession {
   WebSocketServiceCallbacks &m_callbacks;
   State m_state;
 
-  std::function<void(IWebSocketResource::Error &&)> m_errorHandler;
+  std::function<void(IWebSocketResource::Error&&)> m_errorHandler;
 
   void Read();
 
   void OnAccept(boost::system::error_code ec);
-  void OnHandshake(boost::beast::websocket::response_type &response);
+  void OnHandshake(boost::beast::websocket::response_type& response);
   void OnRead(boost::system::error_code ec, std::size_t transferred);
   void OnWrite(boost::system::error_code ec, std::size_t transferred);
 
  protected:
   std::shared_ptr<boost::beast::websocket::stream<SocketLayer>> m_stream;
-  std::shared_ptr<boost::asio::strand<boost::asio::io_context::executor_type>> m_strand;
 
   void Accept();
 
   virtual std::shared_ptr<BaseWebSocketSession<SocketLayer>> SharedFromThis() = 0;
 
  public:
-  BaseWebSocketSession(WebSocketServiceCallbacks &callbacks);
+  BaseWebSocketSession(WebSocketServiceCallbacks& callbacks);
   ~BaseWebSocketSession();
 
   virtual void Start() override;
 };
 
-class WebSocketSession : public std::enable_shared_from_this<WebSocketSession>,
-                         public BaseWebSocketSession<boost::asio::ip::tcp::socket> {
-  std::shared_ptr<BaseWebSocketSession<boost::asio::ip::tcp::socket>> SharedFromThis() override;
+class WebSocketSession :
+  public std::enable_shared_from_this<WebSocketSession>,
+  public BaseWebSocketSession<boost::beast::tcp_stream>
+{
+  std::shared_ptr<BaseWebSocketSession<boost::beast::tcp_stream>> SharedFromThis() override;
 
  public:
-  WebSocketSession(boost::asio::ip::tcp::socket socket, WebSocketServiceCallbacks &callbacks);
+  WebSocketSession(boost::asio::ip::tcp::socket socket, WebSocketServiceCallbacks& callbacks);
   ~WebSocketSession();
 };
 
-class SecureWebSocketSession : public std::enable_shared_from_this<SecureWebSocketSession>,
-                               public BaseWebSocketSession<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> {
-  std::shared_ptr<BaseWebSocketSession<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>> SharedFromThis()
-      override;
+class SecureWebSocketSession :
+  public std::enable_shared_from_this<SecureWebSocketSession>,
+  public BaseWebSocketSession<boost::beast::ssl_stream<boost::beast::tcp_stream>>
+{
+  std::shared_ptr<BaseWebSocketSession<boost::beast::ssl_stream<boost::beast::tcp_stream>>> SharedFromThis() override;
 
  public:
-  SecureWebSocketSession(boost::asio::ip::tcp::socket socket, WebSocketServiceCallbacks &callbacks);
+  SecureWebSocketSession(boost::asio::ip::tcp::socket socket, WebSocketServiceCallbacks& callbacks);
   ~SecureWebSocketSession();
 
   void OnSslHandshake(boost::system::error_code ec);
@@ -82,18 +92,18 @@ class SecureWebSocketSession : public std::enable_shared_from_this<SecureWebSock
 #pragma endregion IWebSocketSession
 };
 
-class WebSocketServer : public std::enable_shared_from_this<WebSocketServer> {
+class WebSocketServer : public std::enable_shared_from_this<WebSocketServer>
+{
   std::thread m_contextThread;
   boost::asio::io_context m_context;
   boost::asio::ip::tcp::acceptor m_acceptor;
-  boost::asio::ip::tcp::socket m_socket;
   WebSocketServiceCallbacks m_callbacks;
   std::vector<std::shared_ptr<IWebSocketSession>> m_sessions;
   bool m_isSecure;
 
   void Accept();
 
-  void OnAccept(boost::system::error_code ec);
+  void OnAccept(boost::system::error_code ec, boost::asio::ip::tcp::socket socket);
 
  public:
   WebSocketServer(std::uint16_t port, bool isSecure);
@@ -102,11 +112,11 @@ class WebSocketServer : public std::enable_shared_from_this<WebSocketServer> {
   void Start();
   void Stop();
 
-  void SetOnConnection(std::function<void()> &&func);
-  void SetOnHandshake(std::function<void(boost::beast::websocket::response_type &)> &&func);
-  void SetOnMessage(std::function<void(std::string)> &&func);
-  void SetMessageFactory(std::function<std::string(std::string &&)> &&func);
-  void SetOnError(std::function<void(IWebSocketResource::Error &&)> &&func);
+  void SetOnConnection(std::function<void()>&& func);
+  void SetOnHandshake(std::function<void(boost::beast::websocket::response_type&)>&& func);
+  void SetOnMessage(std::function<void(std::string)>&& func);
+  void SetMessageFactory(std::function<std::string(std::string&&)>&& func);
+  void SetOnError(std::function<void(IWebSocketResource::Error&&)>&& func);
 };
 
 } // namespace Microsoft::React::Test

--- a/vnext/Test/packages.config
+++ b/vnext/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.68.0.0" targetFramework="native" />
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.2" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Supersedes #3602.

See:
- https://www.boost.org/users/history/version_1_69_0.html
- https://www.boost.org/users/history/version_1_70_0.html
- https://www.boost.org/users/history/version_1_71_0.html
- https://www.boost.org/users/history/version_1_72_0.html

Major improvements have been released since the current version used by React Native Windows (1.68).

- Largely improved networking API (Beast). Makes our networking components more readable and maintainable (hence the refactored classes).
- TLS v1.3 explicit support (currently using SSL 2.3).
- ASIO Allocation improvements specific to Windows, including potential memory leak fixes.
- Beast (ergo WebSockets) support for configurable timeout behavior.
- Updated ASIO APIs for posting asynchronous operations.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5200)