### PR TITLE
Use default brush for borders

### DIFF
--- a/change/react-native-windows-2020-06-15-12-36-45-border-black.json
+++ b/change/react-native-windows-2020-06-15-12-36-45-border-black.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "use default brush for border",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-15T19:36:45.167Z"
+}

--- a/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
+++ b/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
@@ -9,6 +9,28 @@
 namespace react {
 namespace uwp {
 
+DefaultBrushStore::DefaultBrushStore() {}
+
+DefaultBrushStore& DefaultBrushStore::Instance() {
+  static DefaultBrushStore instance;
+  return instance;
+}
+
+void DefaultBrushStore::Reset() {
+  m_defaultBorderBrush = nullptr;
+}
+
+xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
+  if (!m_defaultBorderBrush) {
+    m_defaultBorderBrush = xaml::Application::Current()
+        .Resources()
+        .Lookup(winrt::box_value(L"DefaultTextForegroundThemeBrush"))
+        .as<xaml::Media::Brush>();
+  }
+
+  return m_defaultBorderBrush;
+}
+
 void UpdateResourceBrush(
     const xaml::FrameworkElement &element,
     const std::wstring &resourceName,

--- a/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
+++ b/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
@@ -11,7 +11,7 @@ namespace uwp {
 
 DefaultBrushStore::DefaultBrushStore() {}
 
-DefaultBrushStore& DefaultBrushStore::Instance() {
+DefaultBrushStore &DefaultBrushStore::Instance() {
   static DefaultBrushStore instance;
   return instance;
 }
@@ -23,9 +23,9 @@ void DefaultBrushStore::Reset() {
 xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
   if (!m_defaultBorderBrush) {
     m_defaultBorderBrush = xaml::Application::Current()
-        .Resources()
-        .Lookup(winrt::box_value(L"DefaultTextForegroundThemeBrush"))
-        .as<xaml::Media::Brush>();
+                               .Resources()
+                               .Lookup(winrt::box_value(L"DefaultTextForegroundThemeBrush"))
+                               .as<xaml::Media::Brush>();
   }
 
   return m_defaultBorderBrush;

--- a/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
+++ b/vnext/ReactUWP/Utils/ResourceBrushUtils.cpp
@@ -12,7 +12,7 @@ namespace uwp {
 DefaultBrushStore::DefaultBrushStore() {}
 
 DefaultBrushStore &DefaultBrushStore::Instance() {
-  static DefaultBrushStore instance;
+  thread_local static DefaultBrushStore instance;
   return instance;
 }
 

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -9,6 +9,7 @@
 #include <UI.Xaml.Media.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.Interop.h>
+#include <Utils/PropertyUtils.h>
 
 // Needed for latest versions of C++/WinRT
 #if __has_include("ViewPanel.g.cpp")
@@ -302,9 +303,12 @@ void ViewPanel::FinalizeProperties() {
     else
       m_border.ClearValue(xaml::Controls::Border::BorderBrushProperty());
 
-    if (hasBorderThickness)
+    if (hasBorderThickness) {
       m_border.BorderThickness(BorderThickness());
-    else
+      if (!hasBorderBrush) {
+        m_border.BorderBrush(::react::uwp::GetDefaultBorderBrush());
+      }
+    }  else
       m_border.ClearValue(xaml::Controls::Border::BorderThicknessProperty());
 
     if (hasCornerRadius)

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -10,6 +10,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.Interop.h>
 #include <Utils/PropertyUtils.h>
+#include <utils/ResourceBrushUtils.h>
 
 // Needed for latest versions of C++/WinRT
 #if __has_include("ViewPanel.g.cpp")
@@ -306,7 +307,7 @@ void ViewPanel::FinalizeProperties() {
     if (hasBorderThickness) {
       m_border.BorderThickness(BorderThickness());
       if (!hasBorderBrush) {
-        m_border.BorderBrush(::react::uwp::GetDefaultBorderBrush());
+        m_border.BorderBrush(::react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());
       }
     }  else
       m_border.ClearValue(xaml::Controls::Border::BorderThicknessProperty());

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -308,7 +308,7 @@ void ViewPanel::FinalizeProperties() {
     if (hasBorderThickness) {
       m_border.BorderThickness(BorderThickness());
       if (!hasBorderBrush) {
-        // Borders draw something other than transparent on other platforms.
+        // Borders with no brush draw something other than transparent on other platforms.
         // To match, we'll use a default border brush if one isn't already set.
         // Note:  Keep this in sync with code in TryUpdateBorderProperties().
         m_border.BorderBrush(::react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -7,10 +7,10 @@
 #include "ViewPanel.h"
 
 #include <UI.Xaml.Media.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Interop.h>
 #include <Utils/PropertyUtils.h>
 #include <utils/ResourceBrushUtils.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Xaml.Interop.h>
 
 // Needed for latest versions of C++/WinRT
 #if __has_include("ViewPanel.g.cpp")
@@ -309,7 +309,7 @@ void ViewPanel::FinalizeProperties() {
       if (!hasBorderBrush) {
         m_border.BorderBrush(::react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());
       }
-    }  else
+    } else
       m_border.ClearValue(xaml::Controls::Border::BorderThicknessProperty());
 
     if (hasCornerRadius)

--- a/vnext/ReactUWP/Views/ViewPanel.cpp
+++ b/vnext/ReactUWP/Views/ViewPanel.cpp
@@ -301,12 +301,16 @@ void ViewPanel::FinalizeProperties() {
     // TODO: Can Binding be used here?
     if (hasBorderBrush)
       m_border.BorderBrush(BorderBrush());
-    else
+    else if (!hasBorderThickness) {
       m_border.ClearValue(xaml::Controls::Border::BorderBrushProperty());
+    }
 
     if (hasBorderThickness) {
       m_border.BorderThickness(BorderThickness());
       if (!hasBorderBrush) {
+        // Borders draw something other than transparent on other platforms.
+        // To match, we'll use a default border brush if one isn't already set.
+        // Note:  Keep this in sync with code in TryUpdateBorderProperties().
         m_border.BorderBrush(::react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());
       }
     } else

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -146,6 +146,13 @@ bool TryUpdateForeground(const T &element, const std::string &propertyName, cons
   return false;
 }
 
+inline xaml::Media::Brush GetDefaultBorderBrush() {
+  return xaml::Application::Current()
+      .Resources()
+      .Lookup(winrt::box_value(L"DefaultTextForegroundThemeBrush"))
+      .as<xaml::Media::Brush>();
+}
+
 template <class T>
 bool TryUpdateBorderProperties(
     ShadowNodeBase *node,
@@ -168,6 +175,9 @@ bool TryUpdateBorderProperties(
     if (iter != edgeTypeMap.end()) {
       if (propertyValue.isNumber()) {
         SetBorderThickness(node, element, iter->second, propertyValue.asDouble());
+        if (!element.BorderBrush()) {
+          element.BorderBrush(GetDefaultBorderBrush());
+        }
       } else if (propertyValue.isNull()) {
         SetBorderThickness(node, element, iter->second, 0);
       }

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -174,7 +174,7 @@ bool TryUpdateBorderProperties(
       if (propertyValue.isNumber()) {
         SetBorderThickness(node, element, iter->second, propertyValue.asDouble());
         if (propertyValue.asDouble() != 0 && !element.BorderBrush()) {
-          // Borders draw something other than transparent on other platforms.
+          // Borders with no brush draw something other than transparent on other platforms.
           // To match, we'll use a default border brush if one isn't already set.
           // Note:  Keep this in sync with code in ViewPanel::FinalizeProperties().
           element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -160,6 +160,7 @@ bool TryUpdateBorderProperties(
       element.BorderBrush(brush);
       UpdateControlBorderResourceBrushes(element, brush);
     } else if (propertyValue.isNull()) {
+      // If there's still a border thickness, use the default border brush.
       if (element.BorderThickness() != xaml::ThicknessHelper::FromUniformLength(0.0)) {
         element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());
       } else {
@@ -173,6 +174,9 @@ bool TryUpdateBorderProperties(
       if (propertyValue.isNumber()) {
         SetBorderThickness(node, element, iter->second, propertyValue.asDouble());
         if (propertyValue.asDouble() != 0 && !element.BorderBrush()) {
+          // Borders draw something other than transparent on other platforms.
+          // To match, we'll use a default border brush if one isn't already set.
+          // Note:  Keep this in sync with code in ViewPanel::FinalizeProperties().
           element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());
         }
       } else if (propertyValue.isNull()) {

--- a/vnext/include/ReactUWP/Utils/PropertyUtils.h
+++ b/vnext/include/ReactUWP/Utils/PropertyUtils.h
@@ -146,13 +146,6 @@ bool TryUpdateForeground(const T &element, const std::string &propertyName, cons
   return false;
 }
 
-inline xaml::Media::Brush GetDefaultBorderBrush() {
-  return xaml::Application::Current()
-      .Resources()
-      .Lookup(winrt::box_value(L"DefaultTextForegroundThemeBrush"))
-      .as<xaml::Media::Brush>();
-}
-
 template <class T>
 bool TryUpdateBorderProperties(
     ShadowNodeBase *node,
@@ -167,7 +160,11 @@ bool TryUpdateBorderProperties(
       element.BorderBrush(brush);
       UpdateControlBorderResourceBrushes(element, brush);
     } else if (propertyValue.isNull()) {
-      element.ClearValue(T::BorderBrushProperty());
+      if (element.BorderThickness() != xaml::ThicknessHelper::FromUniformLength(0.0)) {
+        element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());
+      } else {
+        element.ClearValue(T::BorderBrushProperty());
+      }
       UpdateControlBorderResourceBrushes(element, nullptr);
     }
   } else {
@@ -175,8 +172,8 @@ bool TryUpdateBorderProperties(
     if (iter != edgeTypeMap.end()) {
       if (propertyValue.isNumber()) {
         SetBorderThickness(node, element, iter->second, propertyValue.asDouble());
-        if (!element.BorderBrush()) {
-          element.BorderBrush(GetDefaultBorderBrush());
+        if (propertyValue.asDouble() != 0 && !element.BorderBrush()) {
+          element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());
         }
       } else if (propertyValue.isNull()) {
         SetBorderThickness(node, element, iter->second, 0);

--- a/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
+++ b/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
@@ -8,6 +8,7 @@
 namespace react {
 namespace uwp {
 
+// Helper singleton class to cache brushes used as defaults.
 class DefaultBrushStore {
  public:
   static DefaultBrushStore &Instance();

--- a/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
+++ b/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
@@ -8,6 +8,21 @@
 namespace react {
 namespace uwp {
 
+class DefaultBrushStore {
+public:
+  static DefaultBrushStore &Instance();
+  void Reset();
+
+  xaml::Media::Brush GetDefaultBorderBrush();
+
+private:
+  DefaultBrushStore();
+  DefaultBrushStore(const DefaultBrushStore &) = delete;
+  void operator=(const DefaultBrushStore &) = delete;
+
+  xaml::Media::Brush m_defaultBorderBrush = nullptr;
+};
+
 // Some XAML controls use additional resource-brushes that need to be
 // kept in sync with the Background, Foreground, and BorderBrush
 // DependencyProperties. RN clients (windows-included) that

--- a/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
+++ b/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
@@ -9,13 +9,13 @@ namespace react {
 namespace uwp {
 
 class DefaultBrushStore {
-public:
+ public:
   static DefaultBrushStore &Instance();
   void Reset();
 
   xaml::Media::Brush GetDefaultBorderBrush();
 
-private:
+ private:
   DefaultBrushStore();
   DefaultBrushStore(const DefaultBrushStore &) = delete;
   void operator=(const DefaultBrushStore &) = delete;

--- a/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
+++ b/vnext/include/ReactUWP/Utils/ResourceBrushUtils.h
@@ -8,7 +8,7 @@
 namespace react {
 namespace uwp {
 
-// Helper singleton class to cache brushes used as defaults.
+// Helper per-UI-thread singleton class to cache brushes used as defaults.
 class DefaultBrushStore {
  public:
   static DefaultBrushStore &Instance();


### PR DESCRIPTION
Fixes #4682

On other platforms, borders draw a solid color (black) by default if no brush color is specified.  On Windows, we are drawing transparent.

This change fixes the mismatch by using a default brush when no brush color is specified.  The default brush will be a theme brush that draws black on light theme, and white on dark theme.

A couple optimizations:
1 - the brush is cached in a per-UI-thread singleton class, as looking up the theme resource isn't free
2 - the default brush is only set if the border has thickness, to avoid the cost of setting a brush in the case where nothing draws

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5213)