### PR TITLE
Rename "master" packages to "canary"

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: npx react-native-windows-init --version master --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
+      script: npx react-native-windows-init --version canary --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: PowerShell@2

--- a/change/@office-iss-react-native-win32-2020-06-15-14-59-13-master-to-canary.json
+++ b/change/@office-iss-react-native-win32-2020-06-15-14-59-13-master-to-canary.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rename \"master\" packages to \"canary\"",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-15T21:59:11.649Z"
+}

--- a/change/react-native-windows-2020-06-15-14-59-13-master-to-canary.json
+++ b/change/react-native-windows-2020-06-15-14-59-13-master-to-canary.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rename \"master\" packages to \"canary\"",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-15T21:59:12.995Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -25,7 +25,7 @@
     "prompt-sync": "^4.2.0",
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-windows": "0.0.0-master.93"
+    "react-native-windows": "0.0.0-canary.93"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-windows": "0.0.0-master.93"
+    "react-native-windows": "0.0.0-canary.93"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-windows": "0.0.0-master.93"
+    "react-native-windows": "0.0.0-canary.93"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-iss/react-native-win32",
-  "version": "0.0.0-master.20",
+  "version": "0.0.0-canary.20",
   "description": "Implementation of react native on top of Office's Win32 platform.",
   "license": "MIT",
   "main": "./index.win32.js",
@@ -65,7 +65,7 @@
     "react-native": "^0.62.0-0"
   },
   "beachball": {
-    "defaultNpmTag": "master",
+    "defaultNpmTag": "canary",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows",
-  "version": "0.0.0-master.93",
+  "version": "0.0.0-canary.93",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -64,7 +64,7 @@
     "react-native": "^0.62.0-0"
   },
   "beachball": {
-    "defaultNpmTag": "master",
+    "defaultNpmTag": "canary",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
Fixes #4963

Will update docs and try to get the master dist-tag removed after. This would break anyone trying to use a caret version to update our master builds since we jumped backwards alphabetically semver-wise, but that was already unsupported and a very bad idea.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5216)