### PR TITLE
Implement REACT_METHOD + Callback/TwoCallbacks for turbo module

### DIFF
--- a/change/react-native-windows-2020-06-15-17-03-11-pull_request.json
+++ b/change/react-native-windows-2020-06-15-17-03-11-pull_request.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Implement REACT_METHOD + Callback/TwoCallbacks for turbo module",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-16T00:03:11.520Z"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -9,6 +9,30 @@ try {
     .promiseFunction('something', 1, true);
 
   sampleTurboModule
+    .oneCallback(1, 2, function (r) {
+      sampleTurboModule
+        .oneCallbackResult(r);
+    });
+
+  sampleTurboModule
+    .twoCallbacks(true, 123, 'Failed', function (r) {
+      sampleTurboModule
+        .twoCallbacksResolved(r);
+    }, function (r) {
+      sampleTurboModule
+        .twoCallbacksRejected(r);
+    });
+
+  sampleTurboModule
+    .twoCallbacks(false, 123, 'Failed', function (r) {
+      sampleTurboModule
+        .twoCallbacksResolved(r);
+    }, function (r) {
+      sampleTurboModule
+        .twoCallbacksRejected(r);
+    });
+
+  sampleTurboModule
     .syncFunctionResult(
       sampleTurboModule
         .syncFunction('something', 2, false)

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -197,9 +197,10 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                     rejectFunction = {runtime, args[count - 1]};
                   }
 
-                  auto makeCallback = [&runtime](const facebook::jsi::Value &callbackValue) -> MethodResultCallback {
-                    return [&runtime, callbackFunction = callbackValue.asObject(runtime).asFunction(runtime)](
-                               const IJSValueWriter &writer) {
+                  auto makeCallback = [&runtime](
+                                          const facebook::jsi::Value &callbackValue) noexcept->MethodResultCallback {
+                    return [&runtime, callbackFunction = callbackValue.asObject(runtime).asFunction(runtime) ](
+                        const IJSValueWriter &writer) noexcept {
                       auto result = writer.as<JsiWriter>()->MoveResult();
                       VerifyElseCrash(result.isObject() && result.asObject(runtime).isArray(runtime));
                       auto jsArray = result.asObject(runtime).asArray(runtime);


### PR DESCRIPTION
- Turbo module enables `REACT_METHOD` for Callback and TwoCallbacks.
- I think the design of `MethodReturnType` needs to be changed after we totally drop native module, because the current signature cannot describe all kinds of functions that turbo module allows.
- There are conversions doing `(jsi::Value*, size_t) <--> jsi::Array)` for function arguments. It can be removed by changing `JsiReader` and `JsiWriter`. I will do this in another pull request.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5221)