### PR TITLE
Don't `eslint` nor `flow check` the target folder

### DIFF
--- a/change/react-native-windows-2020-06-15-18-01-44-master.json
+++ b/change/react-native-windows-2020-06-15-18-01-44-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't lint target folder and don't flow check node_modules packages",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T01:01:44.414Z"
+}

--- a/vnext/.eslintignore
+++ b/vnext/.eslintignore
@@ -1,11 +1,12 @@
+**/node_modules
 /dist
 /flow
+/index.*
+/jest
 /lib
 /Libraries
-**/node_modules
 /packages
 /ReactCopies
 /RNTester
-/index.*
 /RNTester.*
-/jest
+/target

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -68,6 +68,10 @@
 ; Ignore react-native files in node_modules since they are copied into project root
 .*/node_modules/react-native/.*
 
+; Ignore react-native-windows' target folder. Flow is not compiled with long path support and after running unittests these folders have long paths
+.*/node_modules/react-native-windows/target/.*
+.target/.*
+
 ; These files dont need to be checked and just increase the build time
 .*/node_modules/microsoft-reactnative-sampleapps/.*
 
@@ -82,7 +86,6 @@
 
 ; Ignore unexpected extra "@providesModule"
 .*/node_modules/.*/node_modules/fbjs/.*
-
 
 ; These should not be required directly
 ; require from fbjs/lib instead: require('fbjs/lib/warning')


### PR DESCRIPTION
The target folder in vnext contains the build output from the windows modules. It also contains the unittest temp locatoins. These can frequently generate long paths. It seems that flow.exe is not compiled with long path support for windows and fails on those folders. Eslint also throws a bunch of warnings about the long paths if it encounters them.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5226)