### PR TITLE
Run NativeModules 2.0 in JS thread

### DIFF
--- a/change/react-native-windows-2020-06-16-14-33-30-PR-NativeModule_JSQueue.json
+++ b/change/react-native-windows-2020-06-16-14-33-30-PR-NativeModule_JSQueue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Run NativeModules 2.0 in JS thread",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T21:33:30.305Z"
+}

--- a/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
@@ -22,29 +22,20 @@ namespace winrt::Microsoft::ReactNative {
 -------------------------------------------------------------------------------*/
 std::vector<facebook::react::NativeModuleDescription> NativeModulesProvider::GetModules(
     Mso::CntPtr<Mso::React::IReactContext> const &reactContext,
-    std::shared_ptr<facebook::react::MessageQueueThread> const & /*defaultQueueThread*/) {
-  // std::shared_ptr<facebook::react::MessageQueueThread>
-  // queueThread(defaultQueueThread);
+    std::shared_ptr<facebook::react::MessageQueueThread> const &defaultQueueThread) {
   std::vector<facebook::react::NativeModuleDescription> modules;
-
-  if (m_modulesWorkerQueue == nullptr) {
-    // TODO: The queue provided is the UIMessageQueueThread which isn't needed
-    // for native modules. As a workaround for now let's just use a new worker
-    // message queue.
-    m_modulesWorkerQueue = react::uwp::MakeSerialQueueThread();
-  }
 
   auto winrtReactContext = winrt::make<implementation::ReactContext>(Mso::Copy(reactContext));
 
   for (auto &entry : m_moduleProviders) {
     modules.emplace_back(
         entry.first,
-        [ moduleName = entry.first, moduleProvider = entry.second, winrtReactContext ]() noexcept {
+        [moduleName = entry.first, moduleProvider = entry.second, winrtReactContext]() noexcept {
           IReactModuleBuilder moduleBuilder = winrt::make<ReactModuleBuilder>(winrtReactContext);
           auto providedModule = moduleProvider(moduleBuilder);
           return moduleBuilder.as<ReactModuleBuilder>()->MakeCxxModule(moduleName, providedModule);
         },
-        m_modulesWorkerQueue);
+        defaultQueueThread);
   }
 
   return modules;

--- a/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
@@ -30,7 +30,7 @@ std::vector<facebook::react::NativeModuleDescription> NativeModulesProvider::Get
   for (auto &entry : m_moduleProviders) {
     modules.emplace_back(
         entry.first,
-        [moduleName = entry.first, moduleProvider = entry.second, winrtReactContext]() noexcept {
+        [ moduleName = entry.first, moduleProvider = entry.second, winrtReactContext ]() noexcept {
           IReactModuleBuilder moduleBuilder = winrt::make<ReactModuleBuilder>(winrtReactContext);
           auto providedModule = moduleProvider(moduleBuilder);
           return moduleBuilder.as<ReactModuleBuilder>()->MakeCxxModule(moduleName, providedModule);

--- a/vnext/Microsoft.ReactNative/NativeModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/NativeModulesProvider.h
@@ -19,7 +19,6 @@ class NativeModulesProvider final : public Mso::React::NativeModuleProvider2 {
 
  private:
   std::map<std::string, ReactModuleProvider> m_moduleProviders;
-  std::shared_ptr<facebook::react::MessageQueueThread> m_modulesWorkerQueue{nullptr};
   IReactPackageBuilder m_packageBuilder;
 };
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -295,7 +295,7 @@ void ReactInstanceWin::Initialize() noexcept {
                   ::Microsoft::ReactNative::I18nManager,
                   ::Microsoft::ReactNativeSpecs::I18nManagerSpec>());
 
-          auto modules = nmp->GetModules(m_reactContext, m_batchingUIThread);
+          auto modules = nmp->GetModules(m_reactContext, m_jsMessageThread.Load());
           cxxModules.insert(
               cxxModules.end(), std::make_move_iterator(modules.begin()), std::make_move_iterator(modules.end()));
 


### PR DESCRIPTION
This PR addresses the issue #5211.
The NativeModules 2.0 are the native module implementation on top of the ABI-safe API.
Unlike the usual ReactNative native modules, they did not have ability to associate a message queue with them and always run on a special background serial queue. As we moving towards the TurboModules implementation that always run on JS queue, we change the NativeModules 2.0 to always run on the JS queue too. This way the NativeModules 2.0 and the upcoming TurboModules will have exactly the same threading model: run native code on the JS queue. 

Closes #5211

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5237)