### PR TITLE
[0.61] Disable V8 globally; turn it on only for Desktop builds

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -106,6 +106,7 @@ jobs:
   - job: RnwNativeBuildUniversal
     displayName: Build Universal
     dependsOn: RnwNpmPublish
+    timeoutInMinutes: 90
     strategy:
       matrix:
         X64Debug:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -94,6 +94,7 @@ jobs:
           msbuildArguments:
             /p:RNW_PKG_VERSION_STR="$(RNW_PKG_VERSION_STR)"
             /p:RNW_PKG_VERSION="$(RNW_PKG_VERSION)"
+            /p:USE_V8=true
 
       - template: templates/publish-build-artifacts-for-nuget.yml
         parameters:

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -51,6 +51,8 @@ steps:
         /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
         /p:BaseIntDir=$(BaseIntDir)
+        /maxCpuCount:1
+        /p:CL_MPCount=1
         ${{parameters.msbuildArguments}}
 
   - task: PublishBuildArtifacts@1

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -303,6 +303,7 @@ jobs:
           msbuildArguments:
             /p:RNW_PKG_VERSION_STR="Private Build"
             /p:RNW_PKG_VERSION="1000,0,0,0"
+            /p:USE_V8=true
 
       - task: CmdLine@2
         displayName: Build react-native-win32 RNTester bundle

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -53,7 +53,7 @@ jobs:
         #  BuildPlatform: ARM64
     pool:
       vmImage: $(VmImage)
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
     cancelTimeoutInMinutes: 5
 
     steps:
@@ -113,7 +113,7 @@ jobs:
           BuildPlatform: x64
     pool:
       vmImage: $(VmImage)
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
     cancelTimeoutInMinutes: 5
 
     steps:
@@ -208,7 +208,7 @@ jobs:
         ArmRelease:
           BuildConfiguration: Release
           BuildPlatform: ARM
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
     cancelTimeoutInMinutes: 5
     #pool:
     #  vmImage: $(VmImage)

--- a/change/react-native-windows-2020-06-16-16-10-02-0.61-stable.json
+++ b/change/react-native-windows-2020-06-16-16-10-02-0.61-stable.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Disable V8 by default",
+  "packageName": "react-native-windows",
+  "email": "tudorm@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T23:10:02.316Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -27,7 +27,7 @@
     <HERMES_Version Condition="'$(HERMES_Version)' == ''">0.1.6</HERMES_Version>
     <HERMES_Package Condition="'$(HERMES_Package)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HERMES_Version)</HERMES_Package>
 
-    <USE_V8 Condition="'$(USE_V8)' == '' AND '$(Platform)' != 'ARM' AND '$(Platform)' != 'ARM64'">true</USE_V8>
+    <USE_V8 Condition="'$(USE_V8)' == ''">false</USE_V8>
     <V8_Version Condition="'$(V8_Version)' == ''">0.2.7</V8_Version>
     <V8_Package Condition="'$(V8_Package)' == ''">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
 


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5258)