### PR TITLE
Optimize TurboModulesProvider to not performing unnecessary (Value*, size_t) <--> Array conversions

### DIFF
--- a/change/react-native-windows-2020-06-16-23-39-51-pull_request_2.json
+++ b/change/react-native-windows-2020-06-16-23-39-51-pull_request_2.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Optimize TurboModulesProvider to not performing unnecessary (Value*, size_t) <--> Array conversions",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-17T06:39:51.077Z"
+}

--- a/vnext/Microsoft.ReactNative.ComponentTests/CommonReaderTest.h
+++ b/vnext/Microsoft.ReactNative.ComponentTests/CommonReaderTest.h
@@ -308,17 +308,20 @@ struct NestedObjectWithPrimitiveValues {
     RunReaderTest<ReaderTestCases::name>(); \
   }
 
-#define IMPORT_READER_TEST_CASES                          \
-  IMPORT_READER_TEST_CASE(PrimitiveNull)                  \
-  IMPORT_READER_TEST_CASE(PrimitiveBoolean)               \
-  IMPORT_READER_TEST_CASE(PrimitiveInt)                   \
-  IMPORT_READER_TEST_CASE(PrimitiveDouble)                \
-  IMPORT_READER_TEST_CASE(PrimitiveString)                \
-  IMPORT_READER_TEST_CASE(EmptyArray)                     \
-  IMPORT_READER_TEST_CASE(ArrayWitnOneElement)            \
-  IMPORT_READER_TEST_CASE(ArrayWitnMultipleElement)       \
-  IMPORT_READER_TEST_CASE(EmptyNestedArray)               \
-  IMPORT_READER_TEST_CASE(NestedArrayWithPrimitiveValues) \
-  IMPORT_READER_TEST_CASE(EmptyObject)                    \
-  IMPORT_READER_TEST_CASE(SimpleObject)                   \
+#define IMPORT_ARGUMENT_READER_TEST_CASES           \
+  IMPORT_READER_TEST_CASE(EmptyArray)               \
+  IMPORT_READER_TEST_CASE(ArrayWitnOneElement)      \
+  IMPORT_READER_TEST_CASE(ArrayWitnMultipleElement) \
+  IMPORT_READER_TEST_CASE(EmptyNestedArray)         \
+  IMPORT_READER_TEST_CASE(NestedArrayWithPrimitiveValues)
+
+#define IMPORT_READER_TEST_CASES            \
+  IMPORT_READER_TEST_CASE(PrimitiveNull)    \
+  IMPORT_READER_TEST_CASE(PrimitiveBoolean) \
+  IMPORT_READER_TEST_CASE(PrimitiveInt)     \
+  IMPORT_READER_TEST_CASE(PrimitiveDouble)  \
+  IMPORT_READER_TEST_CASE(PrimitiveString)  \
+  IMPORT_ARGUMENT_READER_TEST_CASES         \
+  IMPORT_READER_TEST_CASE(EmptyObject)      \
+  IMPORT_READER_TEST_CASE(SimpleObject)     \
   IMPORT_READER_TEST_CASE(NestedObjectWithPrimitiveValues)

--- a/vnext/Microsoft.ReactNative.ComponentTests/JsiArgumentReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.ComponentTests/JsiArgumentReaderTest.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <ChakraRuntime.h>
+#include <JsiReader.h>
+#include <JsiWriter.h>
+#include "CommonReaderTest.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+TEST_CLASS (JsiArgumentReaderTest) {
+  ::Microsoft::JSI::ChakraRuntime m_runtime;
+
+  JsiArgumentReaderTest() : m_runtime({}) {}
+
+  template <typename TCase>
+  void RunReaderTest() {
+    IJSValueWriter writer = winrt::make<JsiWriter>(m_runtime);
+    TCase::Write(writer);
+    const facebook::jsi::Value *args = nullptr;
+    size_t count = 0;
+    writer.as<JsiWriter>()->AccessResultAsArgs(args, count);
+    IJSValueReader reader = winrt::make<JsiReader>(m_runtime, args, count);
+    TCase::Read(reader);
+  }
+
+  IMPORT_ARGUMENT_READER_TEST_CASES
+};
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -180,6 +180,7 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <ItemGroup>
     <ClCompile Include="DynamicReaderTest.cpp" />
+    <ClCompile Include="JsiArgumentReaderTest.cpp" />
     <ClCompile Include="JsiReaderTest.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="pch/pch.cpp">

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="DynamicReaderTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="JsiArgumentReaderTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="JsiReaderTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
- `JsiReader` accepts `jsi::Value*, size_t` in constructor
- `JsiWriter` added `AccessResultAsArgs` for array root object
- Added test cases for above changes
- `TurboModulesProvider` uses above new API to eliminate unnecessary jsi object construction and copying

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5266)