### PR TITLE
Update react-native-windows-init to support 'linking' the react-native-windows package for development

### DIFF
--- a/change/react-native-windows-init-2020-06-17-19-17-04-master.json
+++ b/change/react-native-windows-init-2020-06-17-19-17-04-master.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "> This change is only intended for developers working on react-native-windows, it is not intended   for end-developers 'using' react-native-windows.",
+  "comment": "This change is only intended for developers working on react-native-windows, it is not intended for end-developers 'using' react-native-windows.",
   "packageName": "react-native-windows-init",
   "email": "dannyvv@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/react-native-windows-init-2020-06-17-19-17-04-master.json
+++ b/change/react-native-windows-init-2020-06-17-19-17-04-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "> This change is only intended for developers working on react-native-windows, it is not intended   for end-developers 'using' react-native-windows.",
+  "packageName": "react-native-windows-init",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-18T02:17:03.925Z"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -256,8 +256,8 @@ function isProjectUsingYarn(cwd: string) {
   try {
     const name = getReactNativeAppName();
     const ns = argv.namespace || name;
+    const useDevMode = argv.useDevMode;
     let version = argv.version;
-    let useDevMode = argv.useDevMode;
 
     if (!version) {
       const rnVersion = getReactNativeVersion();

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -57,6 +57,12 @@ const argv = yargs.version(false).options({
     hidden: true,
     default: false,
   },
+  useDevMode: {
+    type: 'boolean',
+    describe:
+      'Link rather than Add/Install the react-native-windows package. This option is for the developement workflow of the developers working on react-native-windows.',
+    hidden: true,
+  },
 }).argv;
 
 const EXITCODE_UNSUPPORTED_VERION_RN = 3;
@@ -251,6 +257,7 @@ function isProjectUsingYarn(cwd: string) {
     const name = getReactNativeAppName();
     const ns = argv.namespace || name;
     let version = argv.version;
+    let useDevMode = argv.useDevMode;
 
     if (!version) {
       const rnVersion = getReactNativeVersion();
@@ -339,7 +346,11 @@ You can either downgrade your version of ${chalk.green(
     }
 
     const pkgmgr = isProjectUsingYarn(process.cwd())
-      ? 'yarn add'
+      ? useDevMode
+        ? 'yarn link'
+        : 'yarn add'
+      : useDevMode
+      ? 'npm link'
       : 'npm install --save';
     const execOptions = argv.verbose ? {stdio: 'inherit' as 'inherit'} : {};
     console.log(
@@ -347,7 +358,10 @@ You can either downgrade your version of ${chalk.green(
         version,
       )}...`,
     );
-    execSync(`${pkgmgr} "react-native-windows@${version}"`, execOptions);
+    const pkgIdentity = useDevMode
+      ? 'react-native-windows'
+      : `react-native-windows@${version}`;
+    execSync(`${pkgmgr} ${pkgIdentity}`, execOptions);
     console.log(
       chalk.green(
         `react-native-windows@${chalk.cyan(


### PR DESCRIPTION
    > This change is only intended for developers working on react-native-windows, it is not intended
      for end-developers 'using' react-native-windows.

    The script for generating the templates is picked from the local\cli folder as defined in the react-native-windows package that the common-cli script install.
    So to test any changes there one has to link the version you are using. The common
    feature for this is [`npm link`](https://docs.npmjs.com/cli/link) or [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link/).
    This allows one to 'register' their local dev enlistment as a package and use it from a test project.

    Steps to test:
    1. From [react-native-windows] enlistment
       1. `yarn build`
          This updates any built files (like ts to js etc.)
       1. `pushd vnext && yarn link`
          The react-native-windows package is defined in vnext folder
          This advertizes the project to the local yarn registry.
          This only has to happen once, for future changes `yarn build` is enough.
          If the link fails that the version is already registered, you can edit pacakge.json to have a unique version.
    1. From the client app
       1. `node <rnw-enlistment-root>\packages\react-native-windows-init\lib-commonjs\Cli.js p4 --version 0.0.0 --useDevMode <OtherOptions>`
          linking ignores any version, so just pick 0.0.0 to avoid the default version being looked up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5276)