### PR TITLE
Share ReactNativeHost::ReloadInstance impl between UWP and Win32

### DIFF
--- a/change/react-native-windows-2020-06-19-13-28-45-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-06-19-13-28-45-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Share ReactNativeHost::ReloadInstance impl between UWP and Win32",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-19T20:28:45.233Z"
+}

--- a/vnext/Desktop.ABITests/MemoryTrackerTests.cpp
+++ b/vnext/Desktop.ABITests/MemoryTrackerTests.cpp
@@ -18,7 +18,6 @@ namespace ABITests {
 TEST_CLASS(MemoryTrackerTests) {
  public:
   TEST_METHOD(Handler_AddedAndRemoved){
-    init_apartment(winrt::apartment_type::single_threaded);
     IMessageQueue callbackMessageQueue = ::winrt::make<SimpleMessageQueue>();
     MemoryTracker tracker{callbackMessageQueue};
 
@@ -31,7 +30,6 @@ TEST_CLASS(MemoryTrackerTests) {
 
 
   TEST_METHOD(CurrentMemoryUsage_ReturnsInitialValue) {
-    init_apartment(winrt::apartment_type::single_threaded);
     IMessageQueue callbackMessageQueue = ::winrt::make<SimpleMessageQueue>();
     MemoryTracker tracker{callbackMessageQueue};
 
@@ -41,7 +39,6 @@ TEST_CLASS(MemoryTrackerTests) {
   }
 
   TEST_METHOD(PeakMemoryUsage_ReturnsInitialValue) {
-    init_apartment(winrt::apartment_type::single_threaded);
     IMessageQueue callbackMessageQueue = ::winrt::make<SimpleMessageQueue>();
     MemoryTracker tracker{callbackMessageQueue};
 
@@ -51,8 +48,6 @@ TEST_CLASS(MemoryTrackerTests) {
 
  
   TEST_METHOD(ThresholdHandler_Called) {
-    init_apartment(winrt::apartment_type::single_threaded);
-
     IMessageQueue callbackMessageQueue = ::winrt::make<SimpleMessageQueue>();
     MemoryTracker tracker{callbackMessageQueue};
 

--- a/vnext/Desktop.ABITests/NativeLogEventTests.cpp
+++ b/vnext/Desktop.ABITests/NativeLogEventTests.cpp
@@ -27,8 +27,6 @@ TEST_CLASS (NativeLogEventTests) {
 
  public:
   TEST_METHOD(NativeLogEventHandler_Registered) {
-    init_apartment(winrt::apartment_type::single_threaded);
-
     // anticipatory, see TODO below
     std::vector<std::pair<::winrt::facebook::react::LogLevel, std::wstring>> logMessages;
 

--- a/vnext/Desktop.ABITests/NativeTraceEventTests.cpp
+++ b/vnext/Desktop.ABITests/NativeTraceEventTests.cpp
@@ -81,8 +81,6 @@ TEST_CLASS (NativeTraceEventTests) {
 
  public:
   TEST_METHOD(NativeTraceEventHandler_Registered) {
-    init_apartment(winrt::apartment_type::single_threaded);
-
     ::winrt::facebook::react::INativeTraceHandler handler = winrt::make<TestTraceHandler>();
 
     // anticipatory, see TODO below

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -63,6 +63,9 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);$(VCInstallDir)UnitTest\include;$(ReactNativeDir)\ReactCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!--
+        CORE_ABI - marks ABI elements that are shared between UWP and Win32 DLLs.
+      -->
       <PreprocessorDefinitions>
         _CONSOLE;
         CORE_ABI;

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -63,7 +63,11 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);$(VCInstallDir)UnitTest\include;$(ReactNativeDir)\ReactCommon;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>
+        _CONSOLE;
+        CORE_ABI;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <UseFullPaths>true</UseFullPaths>
       <CallingConvention>Cdecl</CallingConvention>
@@ -129,22 +133,23 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="PerfTests.cpp" />
-    <ClCompile Include="ReactNativeHostTests.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactPropertyBagTests.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactNativeHostTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SimpleMessageQueue.h" />
-    <ClInclude Include="MockReactPackageProvider.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="Application.manifest" />
     <None Include="packages.config" />
+    <JsBundleEntry Include="..\Microsoft.ReactNative.IntegrationTests\AddValues.js" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\Microsoft.ReactNative.IntegrationTests\TestBundle.targets" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -44,9 +44,6 @@
     <ClInclude Include="pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="MockReactPackageProvider.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="SimpleMessageQueue.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.cpp
+++ b/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.cpp
@@ -1,5 +1,3 @@
-#include "pch.h"
-
 #include "ChakraRuntimeHolder.h"
 
 #include <JSI/Shared/ChakraRuntimeFactory.h>

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -92,7 +92,7 @@
         JSI_EXPORT=;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);"$(ReactNativeWindowsDir)Microsoft.ReactNative";"$(ReactNativeWindowsDir)build\$(Platform)\$(Configuration)\Microsoft.ReactNative\Generated Files"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);"$(ReactNativeWindowsDir)Microsoft.ReactNative"</AdditionalIncludeDirectories>
       <AdditionalOptions>%(AdditionalOptions) /Zc:strictStrings /bigobj</AdditionalOptions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -103,6 +103,7 @@
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)\Microsoft.ReactNative;$(ReactNativeWindowsDir)\Microsoft.ReactNative.Cxx;</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CORE_ABI</PreprocessorDefinitions>
     </Midl>
   </ItemDefinitionGroup>
   <!-- TODO: Remove after https://github.com/microsoft/hermes-windows/issues/12 is fixed. -->
@@ -155,19 +156,30 @@
       <DependentUpon>ABI\NativeTracing.idl</DependentUpon>
       <ObjectFileName>$(IntDir)\ABI\</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\Microsoft.ReactNative\ReactNativeHost.cpp">
-      <DependentUpon>..\Microsoft.ReactNative\ReactNativeHost.idl</DependentUpon>
-    </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative\ABICxxModule.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\DynamicReader.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\DynamicWriter.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\IReactContext.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\IReactModuleBuilder.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\IReactNotificationService.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\IReactPropertyBag.cpp">
       <DependentUpon>..\Microsoft.ReactNative\IReactPropertyBag.idl</DependentUpon>
       <ObjectFileName>$(IntDir)\ABI\</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\ReactHost.cpp" />
-    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\MsoUtils.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\JsiReader.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\JsiWriter.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\NativeModulesProvider.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\AsyncActionQueue.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSBundle.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSBundle_Win32.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\MsoUtils.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\ReactHost.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactNativeHost.cpp">
+      <DependentUpon>..\Microsoft.ReactNative\ReactNativeHost.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative\ReactPackageBuilder.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\RedBox.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\TurboModulesProvider.cpp" />
     <ClCompile Include="CxxReactWin32\JSBigString.cpp" />
     <ClCompile Include="JSBigStringResourceDll.cpp" />
     <ClCompile Include="module.g.cpp" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -75,6 +75,7 @@
     <ClCompile>
       <!--
         BOOST_ASIO_HAS_IOCP - Force unique layout/size for boost::asio::basic_stream_socket<> subtypes.
+        CORE_ABI - marks ABI elements that are shared between UWP and Win32 DLLs.
       -->
       <PreprocessorDefinitions>
         BOOST_ASIO_HAS_IOCP;
@@ -103,7 +104,10 @@
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)\Microsoft.ReactNative;$(ReactNativeWindowsDir)\Microsoft.ReactNative.Cxx;</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>CORE_ABI</PreprocessorDefinitions>
+      <!--
+        CORE_ABI - marks ABI elements that are shared between UWP and Win32 DLLs.
+      -->
+      <PreprocessorDefinitions>CORE_ABI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </Midl>
   </ItemDefinitionGroup>
   <!-- TODO: Remove after https://github.com/microsoft/hermes-windows/issues/12 is fixed. -->

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
@@ -141,6 +141,8 @@
     <ClCompile Include="WebSocketResourceFactory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative\NativeModulesProvider.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\TurboModulesProvider.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABI\MemoryTracker.h">

--- a/vnext/Desktop/pch.h
+++ b/vnext/Desktop/pch.h
@@ -11,4 +11,4 @@
 #include <winrt/base.h>
 #include <mutex>
 
-#include "Base/CxxReactIncludes.h"
+#include <Base/CxxReactIncludes.h>

--- a/vnext/Desktop/pch.h
+++ b/vnext/Desktop/pch.h
@@ -10,3 +10,5 @@
 #include <windows.h>
 #include <winrt/base.h>
 #include <mutex>
+
+#include "Base/CxxReactIncludes.h"

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -60,12 +60,14 @@ struct ReactContext {
     m_handle.EmitJSEvent(eventEmitterName, eventName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
   }
 
+#ifndef CORE_ABI
   // Dispatch eventName event to the view.
   // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>
   void DispatchEvent(xaml::FrameworkElement const &view, std::wstring_view eventName, TArgs &&... args) const noexcept {
     m_handle.DispatchEvent(view, eventName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
   }
+#endif
 
   friend bool operator==(ReactContext const &left, ReactContext const &right) noexcept {
     return left.m_handle == right.m_handle;

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -119,6 +119,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="MockReactPackageProvider.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/MockReactPackageProvider.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/MockReactPackageProvider.h
@@ -8,7 +8,7 @@
 
 using namespace winrt::Microsoft::ReactNative;
 
-namespace ABITests {
+namespace ReactNativeIntegrationTests {
 
 class MockReactPackageProvider : public winrt::implements<MockReactPackageProvider, IReactPackageProvider> {
  public:
@@ -20,4 +20,4 @@ class MockReactPackageProvider : public winrt::implements<MockReactPackageProvid
   std::function<void(IReactPackageBuilder const &)> MockCreatePackage;
 };
 
-} // namespace ABITests
+} // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include <NativeModules.h>
+#include "MockReactPackageProvider.h"
 
 using namespace React;
 
@@ -45,6 +46,30 @@ struct TestPackageProvider : winrt::implements<TestPackageProvider, IReactPackag
 TEST_CLASS (ReactNativeHostTests) {
   TEST_METHOD(Activation_Succeeds) {
     TestCheckNoThrow(winrt::Microsoft::ReactNative::ReactNativeHost{});
+  }
+
+  TEST_METHOD(PackageProviders_AsConstructed_IsEmpty) {
+    ReactNativeHost host{};
+    TestCheckEqual(0u, host.PackageProviders().Size());
+  }
+
+  TEST_METHOD(PackageProviders_Append_ReflectsAddition) {
+    ReactNativeHost host{};
+    IReactPackageProvider packageProvider = ::winrt::make<MockReactPackageProvider>();
+    host.PackageProviders().Append(packageProvider);
+    TestCheckEqual(1u, host.PackageProviders().Size());
+  }
+
+  TEST_METHOD(InstanceSettings_BundleRootPathAsConstructed_IsEmpty) {
+    ReactNativeHost host{};
+    TestCheck(host.InstanceSettings().BundleRootPath().empty());
+  }
+
+  TEST_METHOD(InstanceSettings_BundleRootPathAsAssigned_MatchesAssignedValue) {
+    const wchar_t *path = L"a/b/c";
+    ReactNativeHost host{};
+    host.InstanceSettings().BundleRootPath(path);
+    TestCheckEqual(std::wstring_view{path}, (std::wstring_view)host.InstanceSettings().BundleRootPath());
   }
 
   SKIPTESTMETHOD(JsFunctionCall_Succeeds) {

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -4,7 +4,9 @@
 #include "pch.h"
 #include "IReactContext.h"
 #include "DynamicWriter.h"
+#ifndef CORE_ABI
 #include "XamlUIService.h"
+#endif
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -26,6 +28,7 @@ IReactDispatcher ReactContext::JSDispatcher() noexcept {
   return Properties().Get(ReactDispatcherHelper::JSDispatcherProperty()).try_as<IReactDispatcher>();
 }
 
+#ifndef CORE_ABI
 // Deprecated: Use XamlUIService directly.
 void ReactContext::DispatchEvent(
     xaml::FrameworkElement const &view,
@@ -39,6 +42,7 @@ void ReactContext::DispatchEvent(
     xamlUIService.DispatchEvent(view, eventName, eventDataArgWriter);
   }
 }
+#endif
 
 void ReactContext::CallJSFunction(
     hstring const &moduleName,

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -16,10 +16,12 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   IReactNotificationService Notifications() noexcept;
   IReactDispatcher UIDispatcher() noexcept;
   IReactDispatcher JSDispatcher() noexcept;
+#ifndef CORE_ABI
   void DispatchEvent(
       xaml::FrameworkElement const &view,
       hstring const &eventName,
       JSValueArgWriter const &eventDataArgWriter) noexcept;
+#endif
   void CallJSFunction(
       hstring const &moduleName,
       hstring const &methodName,

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -32,8 +32,10 @@ namespace Microsoft.ReactNative {
     // Get ReactDispatcherHelper::JSDispatcherProperty from the Properties property bag.
     IReactDispatcher JSDispatcher { get; };
 
+#ifndef CORE_ABI
     // Deprecated: Use DispatchEvent on XamlUIService instead
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
+#endif
 
     // Call JavaScript function methodName of moduleName.
     void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -3,17 +3,23 @@
 
 import "IReactContext.idl";
 import "IReactModuleBuilder.idl";
+#ifndef CORE_ABI
 import "IViewManager.idl";
+#endif
 
 namespace Microsoft.ReactNative {
 
   delegate Object ReactModuleProvider(IReactModuleBuilder moduleBuilder);
+#ifndef CORE_ABI
   delegate IViewManager ReactViewManagerProvider();
+#endif
 
   [webhosthidden]
   interface IReactPackageBuilder {
     void AddModule(String moduleName, ReactModuleProvider moduleProvider);
+#ifndef CORE_ABI
     void AddViewManager(String viewManagerName, ReactViewManagerProvider viewManagerProvider);
+#endif
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/NativeModulesProvider.cpp
@@ -8,7 +8,6 @@
 #include "IReactModuleBuilder.h"
 #include "Threading/MessageQueueThreadFactory.h"
 
-#include <ReactUWP/ReactUwp.h>
 #include <folly/json.h>
 
 #include "ReactHost/MsoUtils.h"

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.h
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.h
@@ -9,7 +9,6 @@
 #include "ReactHost/React.h"
 #include "ReactInstanceSettings.h"
 #include "ReactPropertyBag.h"
-#include "ViewManagersProvider.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -12,21 +12,28 @@ namespace winrt::Microsoft::ReactNative {
 
 ReactPackageBuilder::ReactPackageBuilder(
     std::shared_ptr<NativeModulesProvider> const &modulesProvider,
+#ifndef CORE_ABI
     std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
+#endif
     std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept
     : m_modulesProvider{modulesProvider},
+#ifndef CORE_ABI
       m_viewManagersProvider{viewManagersProvider},
-      m_turboModulesProvider{turboModulesProvider} {}
+#endif
+      m_turboModulesProvider{turboModulesProvider} {
+}
 
 void ReactPackageBuilder::AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept {
   m_modulesProvider->AddModuleProvider(moduleName, moduleProvider);
 }
 
+#ifndef CORE_ABI
 void ReactPackageBuilder::AddViewManager(
     hstring const &viewManagerName,
     ReactViewManagerProvider const &viewManagerProvider) noexcept {
   m_viewManagersProvider->AddViewManagerProvider(viewManagerName, viewManagerProvider);
 }
+#endif
 
 void ReactPackageBuilder::AddTurboModule(
     hstring const &moduleName,

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -4,7 +4,9 @@
 
 #include "NativeModulesProvider.h"
 #include "TurboModulesProvider.h"
+#ifndef CORE_ABI
 #include "ViewManagersProvider.h"
+#endif
 #include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::Microsoft::ReactNative {
@@ -13,17 +15,23 @@ struct ReactPackageBuilder
     : winrt::implements<ReactPackageBuilder, IReactPackageBuilder, IReactPackageBuilderExperimental> {
   ReactPackageBuilder(
       std::shared_ptr<NativeModulesProvider> const &modulesProvider,
+#ifndef CORE_ABI
       std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
+#endif
       std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept;
 
  public: // IReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+#ifndef CORE_ABI
   void AddViewManager(hstring const &viewManagerName, ReactViewManagerProvider const &viewManagerProvider) noexcept;
+#endif
   void AddTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
 
  private:
   std::shared_ptr<NativeModulesProvider> m_modulesProvider;
+#ifndef CORE_ABI
   std::shared_ptr<ViewManagersProvider> m_viewManagersProvider;
+#endif
   std::shared_ptr<TurboModulesProvider> m_turboModulesProvider;
 };
 

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -4,27 +4,32 @@
 #include "RedBox.h"
 #include <boost/algorithm/string.hpp>
 #include <functional/functor.h>
-#include <winrt/Windows.ApplicationModel.Core.h>
-#include <winrt/Windows.Data.Json.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.System.h>
-#include <winrt/Windows.UI.Core.h>
-#include <winrt/Windows.Web.Http.h>
 #include <regex>
-#include "CppWinRTIncludes.h"
 #include "Unicode.h"
-#include "Utils/Helpers.h"
 
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
+
+#ifndef CORE_ABI
 #include <UI.Xaml.Controls.Primitives.h>
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Markup.h>
+#include <winrt/Windows.ApplicationModel.Core.h>
+#include <winrt/Windows.Data.Json.h>
+#include <winrt/Windows.System.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.Web.Http.h>
+#include "CppWinRTIncludes.h"
+#include "Utils/Helpers.h"
+#endif
 
 using namespace winrt::Windows::Foundation;
 
 namespace Mso::React {
 
+#ifndef CORE_ABI
 struct RedBox : public std::enable_shared_from_this<RedBox> {
   RedBox(
       const Mso::WeakPtr<IReactHost> &weakReactHost,
@@ -507,6 +512,7 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
   std::vector<std::shared_ptr<RedBox>> m_redBoxes; // Protected by m_lockRedBox
   const Mso::WeakPtr<IReactHost> m_weakReactHost;
 };
+#endif
 
 struct RedBoxErrorFrameInfo
     : public winrt::implements<RedBoxErrorFrameInfo, winrt::Microsoft::ReactNative::IRedBoxErrorFrameInfo> {
@@ -600,10 +606,12 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
   return std::make_shared<RedBoxHandler>(redBoxHandler);
 }
 
+#ifndef CORE_ABI
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
     Mso::DispatchQueue &&uiQueue) noexcept {
   return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost), std::move(uiQueue));
 }
+#endif
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBox.h
+++ b/vnext/Microsoft.ReactNative/RedBox.h
@@ -10,8 +10,9 @@ namespace Mso::React {
 std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
     winrt::Microsoft::ReactNative::IRedBoxHandler const &redBoxHandler) noexcept;
 
+#ifndef CORE_ABI
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
     Mso::DispatchQueue &&uiQueue) noexcept;
-
+#endif
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "TurboModulesProvider.h"
 #include <ReactCommon/TurboModuleUtils.h>
+#include <crash/verifyElseCrash.h>
 #include "JsiReader.h"
 #include "JsiWriter.h"
 


### PR DESCRIPTION
Incremental change to share more code in the ReactNativeHost::ReloadInstance() execution path between the UWP and the Win32 DLL. This change does not yet allow to execute JS code through the Win32 C++/WinRT ABI; complexity in the instance management will probably require a few more incremental changes before this goal can be achieved. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5288)