### PR TITLE
Implement XAML version load guard

### DIFF
--- a/change/react-native-windows-2020-06-21-00-49-44-xamlGuard.json
+++ b/change/react-native-windows-2020-06-21-00-49-44-xamlGuard.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "add guard to ensure only one version of XAML is loaded",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-21T07:49:44.927Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -349,6 +349,7 @@
     <ClInclude Include="Views\ViewViewManager.h" />
     <ClInclude Include="Views\VirtualTextViewManager.h" />
     <ClInclude Include="Views\XamlFeatures.h" />
+    <ClInclude Include="XamlLoadState.h" />
     <ClInclude Include="XamlUIService.h">
       <DependentUpon>XamlUIService.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -529,6 +530,7 @@
     <ClCompile Include="Views\ViewViewManager.cpp" />
     <ClCompile Include="Views\VirtualTextViewManager.cpp" />
     <ClCompile Include="Views\XamlFeatures.cpp" />
+    <ClCompile Include="XamlLoadState.cpp" />
     <ClCompile Include="XamlUIService.cpp">
       <DependentUpon>XamlUIService.idl</DependentUpon>
       <SubType>Code</SubType>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -11,6 +11,7 @@
     <ClCompile Include="IReactNotificationService.cpp" />
     <ClCompile Include="NativeModulesProvider.cpp" />
     <ClCompile Include="TurboModulesProvider.cpp" />
+    <ClCompile Include="XamlLoadState.cpp" />
     <ClCompile Include="Pch\pch.cpp">
       <Filter>Pch</Filter>
     </ClCompile>
@@ -685,6 +686,7 @@
     <ClInclude Include="Utils\ValueUtils.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="XamlLoadState.h" />
     <ClInclude Include="XamlView.h" />
     <ClInclude Include="ReactHost\IReactInstance.h">
       <Filter>ReactHost</Filter>

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -15,7 +15,7 @@ std::ostream &operator<<(std::ostream &o, const XamlLoadState::XamlVersion &vers
   return o << version.m_major << "." << version.m_minor;
 }
 
-XamlLoadState::XamlDialect XamlLoadState::XamlVersion::GetMode() const {
+XamlLoadState::XamlDialect XamlLoadState::XamlVersion::GetMode() const noexcept {
   switch (m_major) {
     case 2:
       return XamlDialect::SystemXAML;

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include "unicode.h"
 
-#ifdef DEBUG
+#ifdef XAML_GUARD
 
 constexpr std::wstring_view systemXamlDllName{L"Windows.UI.Xaml.dll"};
 constexpr std::wstring_view winUIDllName{L"Microsoft.UI.Xaml.dll"};
@@ -102,11 +102,11 @@ LDR_DLL_NOTIFICATION_FUNCTION XamlLoadNotification;
 
 XamlLoadState::XamlVersion XamlLoadState::GetXamlVersion(const std::wstring &path) {
   DWORD dwHandle;
-  DWORD size = GetFileVersionInfoSizeW(path.c_str(), &dwHandle);
+  DWORD size = GetFileVersionInfoSizeExW(0, path.c_str(), &dwHandle);
   std::string buffer;
   buffer.reserve(size);
 
-  if (GetFileVersionInfo(path.c_str(), 0, size, const_cast<char *>(buffer.c_str()))) {
+  if (GetFileVersionInfoExW(0, path.c_str(), 0, size, const_cast<char *>(buffer.c_str()))) {
     VS_FIXEDFILEINFO *fileInfo;
     UINT len{};
     if (VerQueryValueW(buffer.c_str(), L"\\", (void **)&fileInfo, &len)) {

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -1,0 +1,184 @@
+#include "pch.h"
+#include "XamlLoadState.h"
+#include <sstream>
+
+XamlLoadState XamlLoadState::g_Instance;
+
+constexpr std::wstring_view wux{L"Windows.UI.Xaml.dll"};
+constexpr std::wstring_view mux{L"Microsoft.UI.Xaml.dll"};
+
+#pragma region NT APIs
+
+typedef LONG NTSTATUS;
+
+typedef struct _UNICODE_STRING {
+  USHORT Length;
+  USHORT MaximumLength;
+  PWSTR Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef UNICODE_STRING const* PCUNICODE_STRING;
+
+typedef struct _LDR_DLL_LOADED_NOTIFICATION_DATA {
+    ULONG Flags;                    //Reserved.
+    PCUNICODE_STRING FullDllName;   //The full path name of the DLL module.
+    PCUNICODE_STRING BaseDllName;   //The base file name of the DLL module.
+    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
+    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
+} LDR_DLL_LOADED_NOTIFICATION_DATA, *PLDR_DLL_LOADED_NOTIFICATION_DATA;
+
+typedef struct _LDR_DLL_UNLOADED_NOTIFICATION_DATA {
+    ULONG Flags;                    //Reserved.
+    PCUNICODE_STRING FullDllName;   //The full path name of the DLL module.
+    PCUNICODE_STRING BaseDllName;   //The base file name of the DLL module.
+    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
+    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
+} LDR_DLL_UNLOADED_NOTIFICATION_DATA, *PLDR_DLL_UNLOADED_NOTIFICATION_DATA;
+
+typedef union _LDR_DLL_NOTIFICATION_DATA {
+    LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
+    LDR_DLL_UNLOADED_NOTIFICATION_DATA Unloaded;
+} LDR_DLL_NOTIFICATION_DATA, *PLDR_DLL_NOTIFICATION_DATA;
+
+typedef LDR_DLL_NOTIFICATION_DATA const* PCLDR_DLL_NOTIFICATION_DATA;
+
+typedef VOID CALLBACK LDR_DLL_NOTIFICATION_FUNCTION(
+    _In_     ULONG                       NotificationReason,
+    _In_     PCLDR_DLL_NOTIFICATION_DATA NotificationData,
+    _In_opt_ PVOID                       Context
+    );
+
+typedef LDR_DLL_NOTIFICATION_FUNCTION* PLDR_DLL_NOTIFICATION_FUNCTION;
+
+#define LDR_DLL_NOTIFICATION_REASON_LOADED 1
+
+NTSTATUS NTAPI LdrRegisterDllNotification(
+  _In_     ULONG                          Flags,
+  _In_     PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction,
+  _In_opt_ PVOID                          Context,
+  _Out_    PVOID                          *Cookie
+);
+
+NTSTATUS NTAPI LdrUnregisterDllNotification(
+  _In_ PVOID Cookie
+);
+
+#pragma endregion
+
+LDR_DLL_NOTIFICATION_FUNCTION MyNotificationFunction;
+
+#define NTDLL_FUNCTION(name) \
+  reinterpret_cast<decltype(&name)>(GetProcAddress(ntdll, #name))
+
+std::string XamlLoadState::GetXamlVersion(PCWSTR path) {
+  DWORD dwHandle;
+  DWORD size = GetFileVersionInfoSizeW(path, &dwHandle);
+  std::string buffer;
+  buffer.reserve(size);
+  
+  if (GetFileVersionInfo(path, 0, size, const_cast<char*>(buffer.c_str()))) {
+    VS_FIXEDFILEINFO* fileInfo;
+    UINT len{};
+    if (VerQueryValueW(buffer.c_str(), L"\\", (void**)&fileInfo, &len)) {
+      const DWORD ls = fileInfo->dwFileVersionMS & 0x3fff;
+      DWORD ms = fileInfo->dwFileVersionMS >> 16;
+      // WinUI 3 Alpha has version 10.0.10011.16384. Convert 10.0 to 3.0
+      if (ms == 10) {
+        ms = 3;
+      }
+      std::stringstream v;
+      v << ms << "." << ls;
+      return v.str();
+    }
+  }
+
+  return {};
+}
+
+XamlLoadState::XamlLoadState() {
+  HMODULE mod{nullptr};
+
+  if (GetModuleHandle(wux.data())) {
+    RegisterDll(wux.data(), nullptr);
+  }
+  mod = GetModuleHandle(mux.data());
+  if (mod) {
+    wchar_t path[MAX_PATH]{};
+    if (GetModuleFileNameW(mod, path, ARRAYSIZE(path))) {
+      RegisterDll(mux.data(), path);
+    }    
+  }
+
+  auto ntdll = GetModuleHandle(L"ntdll.dll");
+  auto pfn = NTDLL_FUNCTION(LdrRegisterDllNotification);
+  (*pfn)(0, MyNotificationFunction, nullptr, &m_cookie);
+}
+
+XamlLoadState::~XamlLoadState() {
+  auto ntdll = GetModuleHandle(L"ntdll.dll");
+  auto pfn = NTDLL_FUNCTION(LdrUnregisterDllNotification);
+  (*pfn)(m_cookie);
+}
+
+void XamlLoadState::RegisterDll(PCWSTR DllName, PCWSTR path) {
+  if (wux == DllName) {
+    switch (m_mode) {
+      case XamlDialect::Unknown:
+        m_mode = XamlDialect::SystemXAML;
+        return;
+      case XamlDialect::SystemXAML:
+        // should never get here
+        return;
+      case XamlDialect::WinUI:
+        throw std::exception("XAML dialect mismatch - WinUI 3 already loaded when attempting to load WUX");
+    }
+  } else if (mux == DllName) {
+    std::string newVersion = GetXamlVersion(path);
+    switch (m_mode) {
+      case XamlDialect::Unknown:
+        m_version = newVersion;
+        switch (m_version[0]) {
+          case '2':
+            m_mode = XamlDialect::SystemXAML;
+            break;
+          case '3':
+            m_mode = XamlDialect::WinUI;
+            break;
+          default:
+            throw std::exception("Unknown XAML version");
+            break;
+        }
+        break;
+
+      case XamlDialect::SystemXAML:
+        if (m_version == "" && newVersion[0] == '2') {
+          m_version = newVersion;
+        } else {
+          /* we've either:
+             -  loaded WUX and we're trying to load WinUI 3
+             -  loaded WinUI 2.x and we're trying to load WinUI 3 or a different WinUI 2.x
+             */
+          throw std::exception("XAML dialect mismatch");
+        }
+        break;
+
+      case XamlDialect::WinUI:
+        throw std::exception("WinUI 3 already loaded");
+        break;
+
+      default:
+        throw std::exception("Unexpected");
+    }
+  }
+}
+
+VOID CALLBACK MyNotificationFunction(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA data, void *context) {
+  if (reason == LDR_DLL_NOTIFICATION_REASON_LOADED) {
+    auto name = data->Loaded.BaseDllName->Buffer;
+    auto path = data->Loaded.FullDllName->Buffer;
+    if (name != nullptr) {
+      XamlLoadState::g_Instance.RegisterDll(name, path);
+    }
+  }
+}
+

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -206,4 +206,3 @@ VOID CALLBACK XamlLoadNotification(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA dat
 #else
 VOID CALLBACK XamlLoadNotification(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA data, void *context) {}
 #endif // DEBUG
-

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -6,6 +6,8 @@
 #include <sstream>
 #include "unicode.h"
 
+#ifdef DEBUG
+
 constexpr std::wstring_view systemXamlDllName{L"Windows.UI.Xaml.dll"};
 constexpr std::wstring_view winUIDllName{L"Microsoft.UI.Xaml.dll"};
 
@@ -191,7 +193,6 @@ void XamlLoadState::RegisterDll(PCWSTR DllName, PCWSTR path) {
   }
 }
 
-#ifdef DEBUG
 XamlLoadState XamlLoadState::g_Instance;
 
 VOID CALLBACK XamlLoadNotification(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA data, void *context) {
@@ -203,6 +204,5 @@ VOID CALLBACK XamlLoadNotification(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA dat
     }
   }
 }
-#else
-VOID CALLBACK XamlLoadNotification(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA data, void *context) {}
+
 #endif // DEBUG

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -17,69 +17,64 @@ typedef struct _UNICODE_STRING {
   PWSTR Buffer;
 } UNICODE_STRING, *PUNICODE_STRING;
 
-typedef UNICODE_STRING const* PCUNICODE_STRING;
+typedef UNICODE_STRING const *PCUNICODE_STRING;
 
 typedef struct _LDR_DLL_LOADED_NOTIFICATION_DATA {
-    ULONG Flags;                    //Reserved.
-    PCUNICODE_STRING FullDllName;   //The full path name of the DLL module.
-    PCUNICODE_STRING BaseDllName;   //The base file name of the DLL module.
-    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
-    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
+  ULONG Flags; // Reserved.
+  PCUNICODE_STRING FullDllName; // The full path name of the DLL module.
+  PCUNICODE_STRING BaseDllName; // The base file name of the DLL module.
+  PVOID DllBase; // A pointer to the base address for the DLL in memory.
+  ULONG SizeOfImage; // The size of the DLL image, in bytes.
 } LDR_DLL_LOADED_NOTIFICATION_DATA, *PLDR_DLL_LOADED_NOTIFICATION_DATA;
 
 typedef struct _LDR_DLL_UNLOADED_NOTIFICATION_DATA {
-    ULONG Flags;                    //Reserved.
-    PCUNICODE_STRING FullDllName;   //The full path name of the DLL module.
-    PCUNICODE_STRING BaseDllName;   //The base file name of the DLL module.
-    PVOID DllBase;                  //A pointer to the base address for the DLL in memory.
-    ULONG SizeOfImage;              //The size of the DLL image, in bytes.
+  ULONG Flags; // Reserved.
+  PCUNICODE_STRING FullDllName; // The full path name of the DLL module.
+  PCUNICODE_STRING BaseDllName; // The base file name of the DLL module.
+  PVOID DllBase; // A pointer to the base address for the DLL in memory.
+  ULONG SizeOfImage; // The size of the DLL image, in bytes.
 } LDR_DLL_UNLOADED_NOTIFICATION_DATA, *PLDR_DLL_UNLOADED_NOTIFICATION_DATA;
 
 typedef union _LDR_DLL_NOTIFICATION_DATA {
-    LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
-    LDR_DLL_UNLOADED_NOTIFICATION_DATA Unloaded;
+  LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
+  LDR_DLL_UNLOADED_NOTIFICATION_DATA Unloaded;
 } LDR_DLL_NOTIFICATION_DATA, *PLDR_DLL_NOTIFICATION_DATA;
 
-typedef LDR_DLL_NOTIFICATION_DATA const* PCLDR_DLL_NOTIFICATION_DATA;
+typedef LDR_DLL_NOTIFICATION_DATA const *PCLDR_DLL_NOTIFICATION_DATA;
 
 typedef VOID CALLBACK LDR_DLL_NOTIFICATION_FUNCTION(
-    _In_     ULONG                       NotificationReason,
-    _In_     PCLDR_DLL_NOTIFICATION_DATA NotificationData,
-    _In_opt_ PVOID                       Context
-    );
+    _In_ ULONG NotificationReason,
+    _In_ PCLDR_DLL_NOTIFICATION_DATA NotificationData,
+    _In_opt_ PVOID Context);
 
-typedef LDR_DLL_NOTIFICATION_FUNCTION* PLDR_DLL_NOTIFICATION_FUNCTION;
+typedef LDR_DLL_NOTIFICATION_FUNCTION *PLDR_DLL_NOTIFICATION_FUNCTION;
 
 #define LDR_DLL_NOTIFICATION_REASON_LOADED 1
 
 NTSTATUS NTAPI LdrRegisterDllNotification(
-  _In_     ULONG                          Flags,
-  _In_     PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction,
-  _In_opt_ PVOID                          Context,
-  _Out_    PVOID                          *Cookie
-);
+    _In_ ULONG Flags,
+    _In_ PLDR_DLL_NOTIFICATION_FUNCTION NotificationFunction,
+    _In_opt_ PVOID Context,
+    _Out_ PVOID *Cookie);
 
-NTSTATUS NTAPI LdrUnregisterDllNotification(
-  _In_ PVOID Cookie
-);
+NTSTATUS NTAPI LdrUnregisterDllNotification(_In_ PVOID Cookie);
 
 #pragma endregion
 
 LDR_DLL_NOTIFICATION_FUNCTION MyNotificationFunction;
 
-#define NTDLL_FUNCTION(name) \
-  reinterpret_cast<decltype(&name)>(GetProcAddress(ntdll, #name))
+#define NTDLL_FUNCTION(name) reinterpret_cast<decltype(&name)>(GetProcAddress(ntdll, #name))
 
 std::string XamlLoadState::GetXamlVersion(PCWSTR path) {
   DWORD dwHandle;
   DWORD size = GetFileVersionInfoSizeW(path, &dwHandle);
   std::string buffer;
   buffer.reserve(size);
-  
-  if (GetFileVersionInfo(path, 0, size, const_cast<char*>(buffer.c_str()))) {
-    VS_FIXEDFILEINFO* fileInfo;
+
+  if (GetFileVersionInfo(path, 0, size, const_cast<char *>(buffer.c_str()))) {
+    VS_FIXEDFILEINFO *fileInfo;
     UINT len{};
-    if (VerQueryValueW(buffer.c_str(), L"\\", (void**)&fileInfo, &len)) {
+    if (VerQueryValueW(buffer.c_str(), L"\\", (void **)&fileInfo, &len)) {
       const DWORD ls = fileInfo->dwFileVersionMS & 0x3fff;
       DWORD ms = fileInfo->dwFileVersionMS >> 16;
       // WinUI 3 Alpha has version 10.0.10011.16384. Convert 10.0 to 3.0
@@ -106,7 +101,7 @@ XamlLoadState::XamlLoadState() {
     wchar_t path[MAX_PATH]{};
     if (GetModuleFileNameW(mod, path, ARRAYSIZE(path))) {
       RegisterDll(mux.data(), path);
-    }    
+    }
   }
 
   auto ntdll = GetModuleHandle(L"ntdll.dll");
@@ -181,4 +176,3 @@ VOID CALLBACK MyNotificationFunction(ULONG reason, PCLDR_DLL_NOTIFICATION_DATA d
     }
   }
 }
-

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -3,9 +3,7 @@
 
 #pragma once
 
-// Turn this off if you'd like to disable XAML versioning guard.
-#define XAML_GUARD
-
+namespace react::uwp {
 /// <summary>
 /// Implements a guard to ensure that only one XAML dll gets loaded in the current process.
 /// This is important because different XAML dlls are not inter-operable.
@@ -30,16 +28,17 @@ struct XamlLoadState {
   XamlLoadState();
   ~XamlLoadState();
 
-#ifdef XAML_GUARD
+#ifndef DISABLE_XAML_GUARD
   static XamlLoadState g_Instance;
 #endif
 
-  void RegisterDll(PCWSTR DllName, PCWSTR path);
+  void RegisterDll(PCWSTR dllName, PCWSTR path);
 
  private:
   XamlVersion m_version;
   XamlDialect m_mode{XamlDialect::Unknown};
   void *m_cookie;
 
-  static XamlVersion GetXamlVersion(const std::wstring &path);
+  static XamlVersion GetXamlVersion(const std::wstring &path) noexcept;
 };
+}

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -1,0 +1,26 @@
+#pragma once
+
+/// <summary>
+/// Implements a guard to ensure that only one XAML dll gets loaded in the current process.
+/// This is important because different XAML dlls are not inter-operable.
+/// It relies on APIs and types that are part of the WDK and not usually available via the UWP SDKs,
+/// but the docs allow calling these APIs via GetProcAddress.
+/// </summary>
+struct XamlLoadState {
+  enum class XamlDialect {
+    Unknown = -1,
+    SystemXAML = 1,
+    WinUI = 2,
+  };
+  std::string m_version{};
+  XamlDialect m_mode{XamlDialect::Unknown};
+  void *m_cookie;
+
+  void RegisterDll(PCWSTR DllName, PCWSTR path);
+  static std::string GetXamlVersion(PCWSTR path);
+  XamlLoadState();
+  ~XamlLoadState();
+
+  static XamlLoadState g_Instance;
+};
+

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+// Turn this off if you'd like to disable XAML versioning guard.
+#define XAML_GUARD
+
 /// <summary>
 /// Implements a guard to ensure that only one XAML dll gets loaded in the current process.
 /// This is important because different XAML dlls are not inter-operable.
@@ -27,7 +30,7 @@ struct XamlLoadState {
   XamlLoadState();
   ~XamlLoadState();
 
-#ifdef DEBUG
+#ifdef XAML_GUARD
   static XamlLoadState g_Instance;
 #endif
 

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -41,4 +41,4 @@ struct XamlLoadState {
 
   static XamlVersion GetXamlVersion(const std::wstring &path) noexcept;
 };
-}
+} // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -23,4 +23,3 @@ struct XamlLoadState {
 
   static XamlLoadState g_Instance;
 };
-

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 /// <summary>
@@ -12,14 +15,28 @@ struct XamlLoadState {
     SystemXAML = 1,
     WinUI = 2,
   };
-  std::string m_version{};
-  XamlDialect m_mode{XamlDialect::Unknown};
-  void *m_cookie;
 
-  void RegisterDll(PCWSTR DllName, PCWSTR path);
-  static std::string GetXamlVersion(PCWSTR path);
+  struct XamlVersion {
+    uint16_t m_major{};
+    uint16_t m_minor{};
+    std::wstring m_path{};
+    XamlDialect GetMode() const;
+    XamlDialect GetKnownMode() const;
+  };
+
   XamlLoadState();
   ~XamlLoadState();
 
+#ifdef DEBUG
   static XamlLoadState g_Instance;
+#endif
+
+  void RegisterDll(PCWSTR DllName, PCWSTR path);
+
+ private:
+  XamlVersion m_version;
+  XamlDialect m_mode{XamlDialect::Unknown};
+  void *m_cookie;
+
+  static XamlVersion GetXamlVersion(const std::wstring &path);
 };

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -20,7 +20,7 @@ struct XamlLoadState {
     uint16_t m_major{};
     uint16_t m_minor{};
     std::wstring m_path{};
-    XamlDialect GetMode() const;
+    XamlDialect GetMode() const noexcept;
     XamlDialect GetKnownMode() const;
   };
 


### PR DESCRIPTION
Fixes #5214 

This adds a mechanism to ensure we only load one of these options:
- System XAML
- System XAML + WinUI 2.x (but only one version of WinUI 2.x)
- WinUI 3

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5290)