### PR TITLE
Fix JSValueReaderGenerator runtime error for read-only properties

### DIFF
--- a/change/react-native-windows-2020-06-21-16-56-44-FixCSNullRef.json
+++ b/change/react-native-windows-2020-06-21-16-56-44-FixCSNullRef.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix JSValueReaderGenerator runtime error for read-only properties",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-21T23:56:43.976Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed/JSValueReaderGenerator.cs
+++ b/vnext/Microsoft.ReactNative.Managed/JSValueReaderGenerator.cs
@@ -302,7 +302,7 @@ namespace Microsoft.ReactNative.Managed
       var properties =
         from property in classType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
         let propertySetter = property.SetMethod
-        where propertySetter.IsPublic
+        where propertySetter != null && propertySetter.IsPublic
         select new { property.Name, Type = property.PropertyType };
       var members = fields.Concat(properties).ToArray();
 


### PR DESCRIPTION
When we implement a C# ReactNative application in 0.61 or 0.62 we are getting a runtime error for the  property read `propertySetter.IsPublic` when the `propertySetter` is null. 
In this PR we fix the issue by checking the `propertySetter` null value first.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5291)