### PR TITLE
Fix warnings of signed/unsigned comparison mismatches on x86 builds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "**/lib": true,
     "**/dist": true
   },
-  // "editor.formatOnSave": true,
+  "editor.formatOnSave": true,
   "eslint.format.enable": true,
   "eslint.packageManager": "yarn",
   "eslint.enable": true,
@@ -47,7 +47,7 @@
   "clang-format.assumeFilename": "${workspaceFolder}/.clang-format",
   "clang-format.executable": "${workspaceRoot}/vnext/node_modules/.bin/clang-format",
   "typescript.tsdk": "node_modules\\typescript\\lib",
-  // "editor.codeActionsOnSave": {
-  //   "source.fixAll.eslint": true
-  // }
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "**/lib": true,
     "**/dist": true
   },
-  "editor.formatOnSave": true,
+  // "editor.formatOnSave": true,
   "eslint.format.enable": true,
   "eslint.packageManager": "yarn",
   "eslint.enable": true,
@@ -47,7 +47,7 @@
   "clang-format.assumeFilename": "${workspaceFolder}/.clang-format",
   "clang-format.executable": "${workspaceRoot}/vnext/node_modules/.bin/clang-format",
   "typescript.tsdk": "node_modules\\typescript\\lib",
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+  // "editor.codeActionsOnSave": {
+  //   "source.fixAll.eslint": true
+  // }
 }

--- a/change/react-native-windows-2020-06-22-08-35-37-master.json
+++ b/change/react-native-windows-2020-06-22-08-35-37-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix warnings of signed/unsigned comparrison mismatches on x86 builds",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-22T15:35:37.030Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueTest.cpp
@@ -48,10 +48,10 @@ TEST_CLASS (JSValueTest) {
     TestCheck(intValue);
     TestCheck(doubleValue);
 
-    TestCheckEqual(1, objValue->size());
-    TestCheckEqual(1, jsValue["ObjValue"].PropertyCount());
-    TestCheckEqual(2, arrayValue->size());
-    TestCheckEqual(2, jsValue["ArrayValue"].ItemCount());
+    TestCheckEqual(1u, objValue->size());
+    TestCheckEqual(1u, jsValue["ObjValue"].PropertyCount());
+    TestCheckEqual(2u, arrayValue->size());
+    TestCheckEqual(2u, jsValue["ArrayValue"].ItemCount());
     TestCheckEqual("Hello", *stringValue);
     TestCheckEqual(true, *boolValue);
     TestCheckEqual(42, *intValue);
@@ -212,13 +212,13 @@ TEST_CLASS (JSValueTest) {
 
     TestCheck(jsValue["NullValue1"].IsNull());
     TestCheck(jsValue["NullValue2"].IsNull());
-    TestCheckEqual(1, jsValue["ObjValue"].PropertyCount());
+    TestCheckEqual(1u, jsValue["ObjValue"].PropertyCount());
     TestCheckEqual(2, jsValue["ObjValue"]["prop1"]);
-    TestCheckEqual(0, jsValue["ObjValueEmpty"].PropertyCount());
-    TestCheckEqual(2, jsValue["ArrayValue"].ItemCount());
+    TestCheckEqual(0u, jsValue["ObjValueEmpty"].PropertyCount());
+    TestCheckEqual(2u, jsValue["ArrayValue"].ItemCount());
     TestCheckEqual(1, jsValue["ArrayValue"][0]);
     TestCheckEqual(2, jsValue["ArrayValue"][1]);
-    TestCheckEqual(0, jsValue["ArrayValueEmpty"].ItemCount());
+    TestCheckEqual(0u, jsValue["ArrayValueEmpty"].ItemCount());
     TestCheckEqual("Hello", jsValue["StringValue1"]);
     TestCheckEqual("", jsValue["StringValue2"]);
     TestCheckEqual(true, jsValue["BoolValue"]);
@@ -250,13 +250,13 @@ TEST_CLASS (JSValueTest) {
     TestCheckEqual(JSValueType::Double, jsValue[8].Type());
 
     TestCheck(jsValue["NullValue"].IsNull());
-    TestCheckEqual(1, jsValue[1].PropertyCount());
+    TestCheckEqual(1u, jsValue[1].PropertyCount());
     TestCheckEqual(2, jsValue[1]["prop1"]);
-    TestCheckEqual(0, jsValue[2].PropertyCount());
-    TestCheckEqual(2, jsValue[3].ItemCount());
+    TestCheckEqual(0u, jsValue[2].PropertyCount());
+    TestCheckEqual(2u, jsValue[3].ItemCount());
     TestCheckEqual(1, jsValue[3][0]);
     TestCheckEqual(2, jsValue[3][1]);
-    TestCheckEqual(0, jsValue[4].ItemCount());
+    TestCheckEqual(0u, jsValue[4].ItemCount());
     TestCheckEqual("Hello", jsValue[5]);
     TestCheckEqual(true, jsValue[6]);
     TestCheckEqual(42, jsValue[7]);
@@ -290,10 +290,10 @@ TEST_CLASS (JSValueTest) {
     TestCheckEqual(JSValueType::Double, value11.Type());
 
     TestCheck(value01.IsNull());
-    TestCheckEqual(1, value02.TryGetObject()->size());
-    TestCheckEqual(0, value03.TryGetObject()->size());
-    TestCheckEqual(2, value04.TryGetArray()->size());
-    TestCheckEqual(0, value05.TryGetArray()->size());
+    TestCheckEqual(1u, value02.TryGetObject()->size());
+    TestCheckEqual(0u, value03.TryGetObject()->size());
+    TestCheckEqual(2u, value04.TryGetArray()->size());
+    TestCheckEqual(0u, value05.TryGetArray()->size());
     TestCheckEqual("Hello", *value06.TryGetString());
     TestCheckEqual(true, *value07.TryGetBoolean());
     TestCheckEqual(false, *value08.TryGetBoolean());
@@ -366,37 +366,37 @@ TEST_CLASS (JSValueTest) {
     TestCheckEqual(JSValueType::Double, value20.Type());
     TestCheckEqual(JSValueType::Double, value21.Type());
 
-    TestCheckEqual(3, value01.PropertyCount());
+    TestCheckEqual(3u, value01.PropertyCount());
     TestCheckEqual(nullptr, value01["prop1"]);
     TestCheckEqual(42, value01["prop2"]);
     TestCheckEqual("Hello", value01["prop3"]);
 
-    TestCheckEqual(3, value02.PropertyCount());
+    TestCheckEqual(3u, value02.PropertyCount());
     TestCheckEqual(nullptr, value02["prop1"]);
     TestCheckEqual(42, value02["prop2"]);
     TestCheckEqual("Hello", value02["prop3"]);
 
-    TestCheckEqual(1, value03.PropertyCount());
+    TestCheckEqual(1u, value03.PropertyCount());
     TestCheckEqual(3, value03["prop1"]);
 
-    TestCheckEqual(3, value04.ItemCount());
+    TestCheckEqual(3u, value04.ItemCount());
     TestCheckEqual(nullptr, value04[0]);
     TestCheckEqual(nullptr, value04[1]);
     TestCheckEqual(nullptr, value04[2]);
 
-    TestCheckEqual(1, value05.ItemCount());
+    TestCheckEqual(1u, value05.ItemCount());
     TestCheckEqual(3, value05[0]);
 
-    TestCheckEqual(2, value06.ItemCount());
+    TestCheckEqual(2u, value06.ItemCount());
     TestCheckEqual(42, value06[0]);
     TestCheckEqual(42, value06[1]);
 
-    TestCheckEqual(3, value07.ItemCount());
+    TestCheckEqual(3u, value07.ItemCount());
     TestCheckEqual(nullptr, value07[0]);
     TestCheckEqual(42, value07[1]);
     TestCheckEqual("Hello", value07[2]);
 
-    TestCheckEqual(3, value08.ItemCount());
+    TestCheckEqual(3u, value08.ItemCount());
     TestCheckEqual(nullptr, value08[0]);
     TestCheckEqual(42, value08[1]);
     TestCheckEqual("Hello", value08[2]);

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -108,12 +108,12 @@ struct SimpleNativeModule {
 
   REACT_METHOD(NegateDispatchQueueCallback)
   void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(NegateFutureCallback)
   void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(SayHelloCallback)
@@ -139,12 +139,12 @@ struct SimpleNativeModule {
 
   REACT_METHOD(StaticNegateDispatchQueueCallback)
   static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticNegateFutureCallback)
   static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticSayHelloCallback)
@@ -210,7 +210,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -224,7 +224,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -290,7 +290,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -304,7 +304,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -401,7 +401,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(NegateDispatchQueuePromise)
   void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -414,7 +414,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(NegateFuturePromise)
   void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([ x, result ]() noexcept {
+    Mso::PostFuture([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -483,7 +483,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(StaticNegateDispatchQueuePromise)
   static void StaticNegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -496,7 +496,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(StaticNegateFuturePromise)
   static void StaticNegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([ x, result ]() noexcept {
+    Mso::PostFuture([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -684,8 +684,10 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHello) {
-    m_builderMock.Call1(L"StaticSayHello", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Hello"); }));
+    m_builderMock.Call1(
+        L"StaticSayHello", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Hello");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -752,8 +754,10 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
-    m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
+    m_builderMock.Call1(
+        L"SayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Hello_2");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -794,8 +798,10 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
-    m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
+    m_builderMock.Call1(
+        L"StaticSayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Static Hello_2");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1068,8 +1074,10 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
-    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
-                        ]() noexcept { TestCheckFail(); }));
+    m_builderMock.Call2(
+        L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([]() noexcept {
+          TestCheckFail();
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1481,7 +1489,7 @@ TEST_CLASS (NativeModuleTest) {
     bool eventRaised = false;
     m_builderMock.ExpectEvent(
         L"RCTDeviceEventEmitter", L"OnNoArgEvent", [&eventRaised](React::JSValueArray const &args) noexcept {
-          TestCheckEqual(0, args.size());
+          TestCheckEqual(0u, args.size());
           eventRaised = true;
         });
 
@@ -1613,7 +1621,7 @@ TEST_CLASS (NativeModuleTest) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
         L"SimpleNativeModule", L"JSNoArgFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
-          TestCheckEqual(0, args.size());
+          TestCheckEqual(0u, args.size());
           functionCalled = true;
         });
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -108,12 +108,12 @@ struct SimpleNativeModule {
 
   REACT_METHOD(NegateDispatchQueueCallback)
   void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(NegateFutureCallback)
   void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(SayHelloCallback)
@@ -139,12 +139,12 @@ struct SimpleNativeModule {
 
   REACT_METHOD(StaticNegateDispatchQueueCallback)
   static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticNegateFutureCallback)
   static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticSayHelloCallback)
@@ -210,7 +210,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -224,7 +224,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([x, resolve, reject]() noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -290,7 +290,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -304,7 +304,7 @@ struct SimpleNativeModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([x, resolve, reject]() noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -401,7 +401,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(NegateDispatchQueuePromise)
   void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -414,7 +414,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(NegateFuturePromise)
   void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([x, result]() noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -483,7 +483,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(StaticNegateDispatchQueuePromise)
   static void StaticNegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -496,7 +496,7 @@ struct SimpleNativeModule {
 
   REACT_METHOD(StaticNegateFuturePromise)
   static void StaticNegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([x, result]() noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -684,10 +684,8 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHello) {
-    m_builderMock.Call1(
-        L"StaticSayHello", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Hello");
-        }));
+    m_builderMock.Call1(L"StaticSayHello", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Hello"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -754,10 +752,8 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
-    m_builderMock.Call1(
-        L"SayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Hello_2");
-        }));
+    m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -798,10 +794,8 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
-    m_builderMock.Call1(
-        L"StaticSayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Static Hello_2");
-        }));
+    m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1074,10 +1068,8 @@ TEST_CLASS (NativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
-    m_builderMock.Call2(
-        L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([]() noexcept {
-          TestCheckFail();
-        }));
+    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
+                        ]() noexcept { TestCheckFail(); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
@@ -99,11 +99,11 @@ struct SimpleNativeModule2 {
   }
 
   void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
   }
 
   void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
   }
 
   void SayHelloCallback(std::function<void(const std::string &)> const &resolve) noexcept {
@@ -124,11 +124,11 @@ struct SimpleNativeModule2 {
   }
 
   static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
   }
 
   static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
   }
 
   static void StaticSayHelloCallback(std::function<void(const std::string &)> const &resolve) noexcept {
@@ -186,7 +186,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -199,7 +199,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -259,7 +259,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -272,7 +272,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -357,7 +357,7 @@ struct SimpleNativeModule2 {
   }
 
   void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -369,7 +369,7 @@ struct SimpleNativeModule2 {
   }
 
   void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([ x, result ]() noexcept {
+    Mso::PostFuture([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -430,7 +430,7 @@ struct SimpleNativeModule2 {
   }
 
   static void StaticNegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -442,7 +442,7 @@ struct SimpleNativeModule2 {
   }
 
   static void StaticNegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([ x, result ]() noexcept {
+    Mso::PostFuture([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -690,8 +690,10 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHello) {
-    m_builderMock.Call1(L"StaticSayHello", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Hello"); }));
+    m_builderMock.Call1(
+        L"StaticSayHello", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Hello");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
@@ -759,8 +761,10 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
-    m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
+    m_builderMock.Call1(
+        L"SayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Hello_2");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -801,8 +805,10 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
-    m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
+    m_builderMock.Call1(
+        L"StaticSayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Static Hello_2");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1075,8 +1081,10 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
-    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
-                        ]() noexcept { TestCheckFail(); }));
+    m_builderMock.Call2(
+        L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([]() noexcept {
+          TestCheckFail();
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1488,7 +1496,7 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
     bool eventRaised = false;
     m_builderMock.ExpectEvent(
         L"RCTDeviceEventEmitter", L"OnNoArgEvent", [&eventRaised](React::JSValueArray const &args) noexcept {
-          TestCheckEqual(0, args.size());
+          TestCheckEqual(0u, args.size());
           eventRaised = true;
         });
 
@@ -1620,7 +1628,7 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
         L"SimpleNativeModule2", L"JSNoArgFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
-          TestCheckEqual(0, args.size());
+          TestCheckEqual(0u, args.size());
           functionCalled = true;
         });
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
@@ -99,11 +99,11 @@ struct SimpleNativeModule2 {
   }
 
   void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   void SayHelloCallback(std::function<void(const std::string &)> const &resolve) noexcept {
@@ -124,11 +124,11 @@ struct SimpleNativeModule2 {
   }
 
   static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   static void StaticSayHelloCallback(std::function<void(const std::string &)> const &resolve) noexcept {
@@ -186,7 +186,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -199,7 +199,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([x, resolve, reject]() noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -259,7 +259,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -272,7 +272,7 @@ struct SimpleNativeModule2 {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([x, resolve, reject]() noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -357,7 +357,7 @@ struct SimpleNativeModule2 {
   }
 
   void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -369,7 +369,7 @@ struct SimpleNativeModule2 {
   }
 
   void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([x, result]() noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -430,7 +430,7 @@ struct SimpleNativeModule2 {
   }
 
   static void StaticNegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -442,7 +442,7 @@ struct SimpleNativeModule2 {
   }
 
   static void StaticNegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([x, result]() noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -690,10 +690,8 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHello) {
-    m_builderMock.Call1(
-        L"StaticSayHello", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Hello");
-        }));
+    m_builderMock.Call1(L"StaticSayHello", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Hello"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
@@ -761,10 +759,8 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
-    m_builderMock.Call1(
-        L"SayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Hello_2");
-        }));
+    m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -805,10 +801,8 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
-    m_builderMock.Call1(
-        L"StaticSayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Static Hello_2");
-        }));
+    m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1081,10 +1075,8 @@ TEST_CLASS (NoAttributeNativeModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
-    m_builderMock.Call2(
-        L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([]() noexcept {
-          TestCheckFail();
-        }));
+    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
+                        ]() noexcept { TestCheckFail(); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -107,12 +107,12 @@ struct MyTurboModule {
 
   REACT_METHOD(NegateDispatchQueueCallback)
   void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(NegateFutureCallback)
   void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(SayHelloCallback)
@@ -138,12 +138,12 @@ struct MyTurboModule {
 
   REACT_METHOD(StaticNegateDispatchQueueCallback)
   static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticNegateFutureCallback)
   static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticSayHelloCallback)
@@ -209,7 +209,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -223,7 +223,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -289,7 +289,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -303,7 +303,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([ x, resolve, reject ]() noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -400,7 +400,7 @@ struct MyTurboModule {
 
   REACT_METHOD(NegateDispatchQueuePromise)
   void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -413,7 +413,7 @@ struct MyTurboModule {
 
   REACT_METHOD(NegateFuturePromise)
   void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([ x, result ]() noexcept {
+    Mso::PostFuture([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -482,7 +482,7 @@ struct MyTurboModule {
 
   REACT_METHOD(StaticNegateDispatchQueuePromise)
   static void StaticNegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -495,7 +495,7 @@ struct MyTurboModule {
 
   REACT_METHOD(StaticNegateFuturePromise)
   static void StaticNegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([ x, result ]() noexcept {
+    Mso::PostFuture([x, result]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -1279,8 +1279,10 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHello) {
-    m_builderMock.Call1(L"StaticSayHello", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Hello"); }));
+    m_builderMock.Call1(
+        L"StaticSayHello", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Hello");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1347,8 +1349,10 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
-    m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
+    m_builderMock.Call1(
+        L"SayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Hello_2");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1389,8 +1393,10 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
-    m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
-                        ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
+    m_builderMock.Call1(
+        L"StaticSayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
+          TestCheck(result == "Static Hello_2");
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1663,8 +1669,10 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
-    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
-                        ]() noexcept { TestCheckFail(); }));
+    m_builderMock.Call2(
+        L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([]() noexcept {
+          TestCheckFail();
+        }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -2076,7 +2084,7 @@ TEST_CLASS (TurboModuleTest) {
     bool eventRaised = false;
     m_builderMock.ExpectEvent(
         L"RCTDeviceEventEmitter", L"OnNoArgEvent", [&eventRaised](React::JSValueArray const &args) noexcept {
-          TestCheckEqual(0, args.size());
+          TestCheckEqual(0u, args.size());
           eventRaised = true;
         });
 
@@ -2208,7 +2216,7 @@ TEST_CLASS (TurboModuleTest) {
     bool functionCalled = false;
     m_builderMock.ExpectFunction(
         L"MyTurboModule", L"JSNoArgFunction", [&functionCalled](React::JSValueArray const &args) noexcept {
-          TestCheckEqual(0, args.size());
+          TestCheckEqual(0u, args.size());
           functionCalled = true;
         });
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -107,12 +107,12 @@ struct MyTurboModule {
 
   REACT_METHOD(NegateDispatchQueueCallback)
   void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(NegateFutureCallback)
   void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(SayHelloCallback)
@@ -138,12 +138,12 @@ struct MyTurboModule {
 
   REACT_METHOD(StaticNegateDispatchQueueCallback)
   static void StaticNegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticNegateFutureCallback)
   static void StaticNegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
-    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+    Mso::PostFuture([ x, resolve ]() noexcept { resolve(-x); });
   }
 
   REACT_METHOD(StaticSayHelloCallback)
@@ -209,7 +209,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -223,7 +223,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([x, resolve, reject]() noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -289,7 +289,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -303,7 +303,7 @@ struct MyTurboModule {
       int x,
       std::function<void(int)> const &resolve,
       std::function<void(std::string const &)> const &reject) noexcept {
-    Mso::PostFuture([x, resolve, reject]() noexcept {
+    Mso::PostFuture([ x, resolve, reject ]() noexcept {
       if (x >= 0) {
         resolve(-x);
       } else {
@@ -400,7 +400,7 @@ struct MyTurboModule {
 
   REACT_METHOD(NegateDispatchQueuePromise)
   void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -413,7 +413,7 @@ struct MyTurboModule {
 
   REACT_METHOD(NegateFuturePromise)
   void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([x, result]() noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -482,7 +482,7 @@ struct MyTurboModule {
 
   REACT_METHOD(StaticNegateDispatchQueuePromise)
   static void StaticNegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -495,7 +495,7 @@ struct MyTurboModule {
 
   REACT_METHOD(StaticNegateFuturePromise)
   static void StaticNegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
-    Mso::PostFuture([x, result]() noexcept {
+    Mso::PostFuture([ x, result ]() noexcept {
       if (x >= 0) {
         result.Resolve(-x);
       } else {
@@ -1279,10 +1279,8 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHello) {
-    m_builderMock.Call1(
-        L"StaticSayHello", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Hello");
-        }));
+    m_builderMock.Call1(L"StaticSayHello", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Hello"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1349,10 +1347,8 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_SayHelloCallback) {
-    m_builderMock.Call1(
-        L"SayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Hello_2");
-        }));
+    m_builderMock.Call1(L"SayHelloCallback", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Hello_2"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1393,10 +1389,8 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_StaticSayHelloCallback) {
-    m_builderMock.Call1(
-        L"StaticSayHelloCallback", std::function<void(const std::string &)>([](const std::string &result) noexcept {
-          TestCheck(result == "Static Hello_2");
-        }));
+    m_builderMock.Call1(L"StaticSayHelloCallback", std::function<void(const std::string &)>([
+                        ](const std::string &result) noexcept { TestCheck(result == "Static Hello_2"); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 
@@ -1669,10 +1663,8 @@ TEST_CLASS (TurboModuleTest) {
   }
 
   TEST_METHOD(TestMethodCall_TwoCallbacksZeroArgs1) {
-    m_builderMock.Call2(
-        L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([]() noexcept {
-          TestCheckFail();
-        }));
+    m_builderMock.Call2(L"TwoCallbacksZeroArgs1", std::function<void()>([]() noexcept {}), std::function<void()>([
+                        ]() noexcept { TestCheckFail(); }));
     TestCheck(m_builderMock.IsResolveCallbackCalled());
   }
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNonAbiValueTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNonAbiValueTests.cpp
@@ -106,7 +106,7 @@ TEST_CLASS (ReactNonAbiValueTests) {
 
   TEST_METHOD(NonAbiValue_operator_arrow) {
     ReactNonAbiValue<std::string> v1{std::in_place, "Hello"};
-    TestCheckEqual(5, v1->length());
+    TestCheckEqual(5u, v1->length());
   }
 
   TEST_METHOD(NonAbiValue_operator_call) {

--- a/vnext/Mso.UnitTests/errorCode/maybeTest.cpp
+++ b/vnext/Mso.UnitTests/errorCode/maybeTest.cpp
@@ -104,7 +104,7 @@ TEST_CLASS (MaybeTest) {
   TEST_METHOD(Maybe_ctor_ValueInPlaceInitList) {
     Mso::Maybe<std::vector<int>> m1{Mso::InPlaceTag(), {1, 2, 3, 4}};
     TestCheck(m1.IsValue());
-    TestCheckEqual(4, m1.GetValue().size());
+    TestCheckEqual(4u, m1.GetValue().size());
     TestCheckEqual(3, m1.GetValue()[2]);
   }
 

--- a/vnext/Mso.UnitTests/future/arrayViewTest.cpp
+++ b/vnext/Mso.UnitTests/future/arrayViewTest.cpp
@@ -13,13 +13,13 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(ArrayView_ctor_Default) {
     Mso::Async::ArrayView<int> a1;
     TestCheckEqual(nullptr, a1.Data());
-    TestCheckEqual(0, a1.Size());
+    TestCheckEqual(0u, a1.Size());
   }
 
   TEST_METHOD(ArrayView_ctor_Array) {
     int xs[] = {1, 2, 3};
     Mso::Async::ArrayView<int> a1(xs);
-    TestCheckEqual(3, a1.Size());
+    TestCheckEqual(3u, a1.Size());
     TestCheckEqual(1, a1[0]);
     TestCheckEqual(2, a1[1]);
     TestCheckEqual(3, a1[2]);
@@ -28,7 +28,7 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(ArrayView_ctor_initializer_list) {
     // We use lambda to avoid ArrayView use temporary objects.
     [](Mso::Async::ArrayView<int> a1) {
-      TestCheckEqual(3, a1.Size());
+      TestCheckEqual(3u, a1.Size());
       TestCheckEqual(1, a1[0]);
       TestCheckEqual(2, a1[1]);
       TestCheckEqual(3, a1[2]);
@@ -38,7 +38,7 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(ArrayView_ctor_vector) {
     std::vector<int> xs = {1, 2, 3};
     Mso::Async::ArrayView<int> a1(xs.data(), xs.size());
-    TestCheckEqual(3, a1.Size());
+    TestCheckEqual(3u, a1.Size());
     TestCheckEqual(1, a1[0]);
     TestCheckEqual(2, a1[1]);
     TestCheckEqual(3, a1[2]);
@@ -48,7 +48,7 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
     std::vector<int> xs = {1, 2, 3};
     Mso::Async::ArrayView<int> a1(xs.data(), xs.size());
     Mso::Async::ArrayView<int> a2(a1);
-    TestCheckEqual(3, a2.Size());
+    TestCheckEqual(3u, a2.Size());
     TestCheckEqual(1, a2[0]);
     TestCheckEqual(2, a2[1]);
     TestCheckEqual(3, a2[2]);
@@ -59,7 +59,7 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
     Mso::Async::ArrayView<int> a1(xs.data(), xs.size());
     Mso::Async::ArrayView<int> a2;
     a2 = a1;
-    TestCheckEqual(3, a2.Size());
+    TestCheckEqual(3u, a2.Size());
     TestCheckEqual(1, a2[0]);
     TestCheckEqual(2, a2[1]);
     TestCheckEqual(3, a2[2]);
@@ -69,14 +69,14 @@ TEST_CLASS_EX (ArrayViewTest, LibletAwareMemLeakDetection) {
     std::vector<int> xs = {1, 2, 3};
     Mso::Async::ArrayView<int> a1(xs.data(), xs.size());
     TestCheckEqual(xs.data(), a1.Data());
-    TestCheckEqual(3, a1.Size());
+    TestCheckEqual(3u, a1.Size());
   }
 
   TEST_METHOD(ArrayView_ConstData_Size) {
     std::vector<int> xs = {1, 2, 3};
     const auto a1 = Mso::Async::ArrayView<int>(xs.data(), xs.size());
     TestCheckEqual(xs.data(), a1.Data());
-    TestCheckEqual(3, a1.Size());
+    TestCheckEqual(3u, a1.Size());
   }
 
   TEST_METHOD(ArrayView_VoidData) {

--- a/vnext/Mso.UnitTests/future/futureFuncTest.cpp
+++ b/vnext/Mso.UnitTests/future/futureFuncTest.cpp
@@ -105,7 +105,7 @@ TEST_CLASS_EX (FutureFuncTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(MakeCompletedFutureEmplaced_InitializationList) {
     auto future = Mso::MakeCompletedFutureEmplaced<std::vector<int>>({1, 2, 3, 4});
     auto result = Mso::FutureWaitAndGetValue(future);
-    TestCheckEqual(4, result.size());
+    TestCheckEqual(4u, result.size());
     TestCheckEqual(2, result[1]);
   }
 // TODO: implement Mso::PotsTimer and Mso::WhenDoneOrTimeout

--- a/vnext/Mso.UnitTests/future/futureTestEx.cpp
+++ b/vnext/Mso.UnitTests/future/futureTestEx.cpp
@@ -192,9 +192,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Then_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -205,7 +205,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -214,9 +214,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Then_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -227,10 +227,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_Maybe) {
     bool invoked{false};
     auto future =
-        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
-          TestCheckEqual(3, value.GetValue().size());
+          TestCheckEqual(3u, value.GetValue().size());
         });
 
     Mso::FutureWait(future);
@@ -240,10 +240,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_MaybeRef) {
     bool invoked{false};
     auto future =
-        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
-          TestCheckEqual(3, value.TakeValue().size());
+          TestCheckEqual(3u, value.TakeValue().size());
         });
 
     Mso::FutureWait(future);
@@ -260,7 +260,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -282,9 +282,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_RValue) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -295,7 +295,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -304,9 +304,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -317,7 +317,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Error_Then_Maybe) {
     bool invoked{false};
     auto future =
-        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -330,7 +330,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Error_Then_MaybeRef) {
     bool invoked{false};
     auto future =
-        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -350,7 +350,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -362,7 +362,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -374,9 +374,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateVectorFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -387,7 +387,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateVectorFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -396,9 +396,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateVectorFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -408,10 +408,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
-      TestCheckEqual(3, value.GetValue().size());
+      TestCheckEqual(3u, value.GetValue().size());
     });
 
     Mso::FutureWait(future);
@@ -420,10 +420,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
-      TestCheckEqual(3, value.TakeValue().size());
+      TestCheckEqual(3u, value.TakeValue().size());
     });
 
     Mso::FutureWait(future);
@@ -440,7 +440,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateVoidFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -462,9 +462,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -475,7 +475,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateErrorVectorFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -484,9 +484,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -496,7 +496,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -508,7 +508,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -528,7 +528,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -540,7 +540,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -649,7 +649,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> && value) noexcept {
+                          [&](std::vector<int> &&value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -659,9 +659,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(3, value.size());
+                        TestCheckEqual(3u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -689,7 +689,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                           })
                       .Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(3, value.size());
+                        TestCheckEqual(3u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -705,7 +705,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> & value) noexcept {
+                          [&](std::vector<int> &value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -715,9 +715,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(3, value.size());
+                        TestCheckEqual(3u, value.size());
                         value[2] = 5; // to avoid OACR error about non-const parameter.
                       });
 
@@ -734,7 +734,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsValue());
                             return std::move(value);
@@ -745,10 +745,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(3, value.GetValue().size());
+                        TestCheckEqual(3u, value.GetValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -764,7 +764,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsValue());
                             return std::move(value);
@@ -775,10 +775,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(3, value.TakeValue().size());
+                        TestCheckEqual(3u, value.TakeValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -811,13 +811,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> && value) noexcept {
+                [&](Mso::Maybe<void> &&value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsValue());
                   return std::move(value);
                 })
             .Catch(Mso::Executors::Inline{}, [&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
               isInvoked[2] = true;
               TestCheck(value.IsValue());
             });
@@ -836,7 +836,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> & value) noexcept {
+                [&](Mso::Maybe<void> &value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsValue());
                   return std::move(value);
@@ -860,7 +860,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> && value) noexcept {
+                          [&](std::vector<int> &&value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -870,9 +870,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -900,7 +900,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                           })
                       .Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -916,7 +916,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> & value) noexcept {
+                          [&](std::vector<int> &value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -926,9 +926,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
 
@@ -945,7 +945,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -956,10 +956,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.GetValue().size());
+                        TestCheckEqual(2u, value.GetValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -975,7 +975,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -986,10 +986,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.TakeValue().size());
+                        TestCheckEqual(2u, value.TakeValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -1022,13 +1022,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> && value) noexcept {
+                [&](Mso::Maybe<void> &&value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsError());
                   return std::move(value);
                 })
             .Catch(Mso::Executors::Inline{}, [&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
               isInvoked[2] = true;
               TestCheck(value.IsValue());
             });
@@ -1047,7 +1047,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> & value) noexcept {
+                [&](Mso::Maybe<void> &value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsError());
                   return std::move(value);
@@ -1072,7 +1072,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVectorFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](std::vector<int> && value) noexcept {
+                [&](std::vector<int> &&value) noexcept {
                   isInvoked[0] = true;
                   return std::move(value);
                 })
@@ -1123,7 +1123,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> & value) noexcept {
+                          [&](std::vector<int> &value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1133,7 +1133,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -1151,7 +1151,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1162,7 +1162,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1181,18 +1181,18 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
                           })
                       .Catch(
                           Mso::Executors::Inline{},
-                          [&](Mso::ErrorCode && error) noexcept {
+                          [&](Mso::ErrorCode &&error) noexcept {
                             isInvoked[1] = true;
                             return std::move(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1231,7 +1231,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> && value) noexcept {
+                          [&](Mso::Maybe<void> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1242,7 +1242,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1261,7 +1261,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> & value) noexcept {
+                          [&](Mso::Maybe<void> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1272,7 +1272,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1291,7 +1291,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> && value) noexcept {
+                          [&](std::vector<int> &&value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1301,9 +1301,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -1331,7 +1331,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                           })
                       .Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -1347,7 +1347,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> & value) noexcept {
+                          [&](std::vector<int> &value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1357,9 +1357,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
 
@@ -1376,7 +1376,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1387,10 +1387,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.GetValue().size());
+                        TestCheckEqual(2u, value.GetValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -1406,7 +1406,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1417,10 +1417,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.TakeValue().size());
+                        TestCheckEqual(2u, value.TakeValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -1456,7 +1456,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> && value) noexcept {
+                          [&](Mso::Maybe<void> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1467,7 +1467,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<void>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -1485,7 +1485,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> & value) noexcept {
+                          [&](Mso::Maybe<void> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1515,7 +1515,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVectorFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](std::vector<int> && value) noexcept {
+                [&](std::vector<int> &&value) noexcept {
                   isInvoked[0] = true;
                   return std::move(value);
                 })
@@ -1566,7 +1566,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> & value) noexcept {
+                          [&](std::vector<int> &value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1576,7 +1576,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -1594,7 +1594,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1605,7 +1605,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1624,7 +1624,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1635,7 +1635,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1674,7 +1674,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> && value) noexcept {
+                          [&](Mso::Maybe<void> &&value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1685,7 +1685,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<void>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1704,7 +1704,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> & value) noexcept {
+                          [&](Mso::Maybe<void> &value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1715,7 +1715,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<void>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1732,7 +1732,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1740,9 +1740,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(3, value.size());
+                        TestCheckEqual(3u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -1766,7 +1766,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                       })
                       .Then([&](const std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(3, value.size());
+                        TestCheckEqual(3u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -1780,7 +1780,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1788,9 +1788,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(3, value.size());
+                        TestCheckEqual(3u, value.size());
                         value[2] = 5; // to avoid OACR error about non-const parameter.
                       });
 
@@ -1805,7 +1805,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
@@ -1814,10 +1814,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(3, value.GetValue().size());
+                        TestCheckEqual(3u, value.GetValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -1831,7 +1831,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
@@ -1840,10 +1840,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(3, value.TakeValue().size());
+                        TestCheckEqual(3u, value.TakeValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -1872,13 +1872,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVoidFuture()
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
                       })
                       .Catch([&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -1894,7 +1894,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVoidFuture()
-                      .Then([&](Mso::Maybe<void> & value) noexcept {
+                      .Then([&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
@@ -1916,7 +1916,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1924,9 +1924,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -1950,7 +1950,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                       })
                       .Then([&](const std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -1964,7 +1964,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1972,9 +1972,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
 
@@ -1989,7 +1989,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -1998,10 +1998,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.GetValue().size());
+                        TestCheckEqual(2u, value.GetValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -2015,7 +2015,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2024,10 +2024,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.TakeValue().size());
+                        TestCheckEqual(2u, value.TakeValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -2056,13 +2056,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
                       })
                       .Catch([&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -2078,7 +2078,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> & value) noexcept {
+                      .Then([&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2100,7 +2100,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2142,7 +2142,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2150,7 +2150,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -2166,7 +2166,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2175,7 +2175,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2192,7 +2192,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2201,7 +2201,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2236,7 +2236,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2245,7 +2245,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2262,7 +2262,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> & value) noexcept {
+                      .Then([&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2288,7 +2288,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2296,9 +2296,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -2322,7 +2322,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                       })
                       .Then([&](const std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                       });
 
     Mso::FutureWait(future);
@@ -2336,7 +2336,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2344,9 +2344,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
-                        TestCheckEqual(2, value.size());
+                        TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
 
@@ -2361,7 +2361,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2370,10 +2370,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.GetValue().size());
+                        TestCheckEqual(2u, value.GetValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -2387,7 +2387,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2396,10 +2396,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
-                        TestCheckEqual(2, value.TakeValue().size());
+                        TestCheckEqual(2u, value.TakeValue().size());
                       });
 
     Mso::FutureWait(future);
@@ -2431,7 +2431,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2440,7 +2440,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<void>();
                       })
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -2456,7 +2456,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> & value) noexcept {
+                      .Then([&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2481,7 +2481,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> && value) noexcept {
+                      .Then([&](std::vector<int> &&value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2523,7 +2523,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2531,7 +2531,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(error);
                       })
-                      .Then([&](std::vector<int> & value) noexcept {
+                      .Then([&](std::vector<int> &value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -2547,7 +2547,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2556,7 +2556,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(error);
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2573,7 +2573,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2582,7 +2582,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(error);
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2617,7 +2617,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2626,7 +2626,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<void>(error);
                       })
-                      .Then([&](Mso::Maybe<void> && value) noexcept {
+                      .Then([&](Mso::Maybe<void> &&value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2643,7 +2643,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> & value) noexcept {
+                      .Then([&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2652,7 +2652,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<void>(error);
                       })
-                      .Then([&](Mso::Maybe<void> & value) noexcept {
+                      .Then([&](Mso::Maybe<void> &value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2666,9 +2666,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Then_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -2680,7 +2680,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future =
         CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2689,9 +2689,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Then_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -2702,10 +2702,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Then_Maybe) {
     bool invoked{false};
     auto future =
-        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
-          TestCheckEqual(3, value.GetValue().size());
+          TestCheckEqual(3u, value.GetValue().size());
         });
 
     Mso::FutureWait(future);
@@ -2715,10 +2715,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Then_MaybeRef) {
     bool invoked{false};
     auto future =
-        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
-          TestCheckEqual(3, value.TakeValue().size());
+          TestCheckEqual(3u, value.TakeValue().size());
         });
 
     Mso::FutureWait(future);
@@ -2735,7 +2735,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -2758,9 +2758,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Error_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+        CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2772,7 +2772,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future =
         CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2781,12 +2781,11 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_Then_Ref) {
     bool invoked{false};
-    auto future =
-        CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
-          invoked = true;
-          TestCheckEqual(3, value.size());
-          value[2] = 5; // to avoid OACR error about non-const parameter.
-        });
+    auto future = CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+      invoked = true;
+      TestCheckEqual(3u, value.size());
+      value[2] = 5; // to avoid OACR error about non-const parameter.
+    });
 
     Mso::FutureWait(future);
     TestCheck(!invoked);
@@ -2795,7 +2794,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Error_Then_Maybe) {
     bool invoked{false};
     auto future = CreateErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2808,7 +2807,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Error_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2828,7 +2827,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2840,7 +2839,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_Then_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2853,9 +2852,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2867,7 +2866,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future =
         CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2877,9 +2876,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
         });
 
@@ -2890,7 +2889,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_Maybe) {
     bool invoked{false};
     auto future = CreateFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2903,7 +2902,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2924,7 +2923,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+        CreateFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2950,9 +2949,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+        CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2964,7 +2963,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future =
         CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -2973,12 +2972,11 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Then_Ref) {
     bool invoked{false};
-    auto future =
-        CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
-          invoked = true;
-          TestCheckEqual(3, value.size());
-          value[2] = 5; // to avoid OACR error about non-const parameter.
-        });
+    auto future = CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+      invoked = true;
+      TestCheckEqual(3u, value.size());
+      value[2] = 5; // to avoid OACR error about non-const parameter.
+    });
 
     Mso::FutureWait(future);
     TestCheck(invoked);
@@ -2987,10 +2985,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
-          TestCheckEqual(3, value.GetValue().size());
+          TestCheckEqual(3u, value.GetValue().size());
         });
 
     Mso::FutureWait(future);
@@ -3000,10 +2998,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
-          TestCheckEqual(3, value.TakeValue().size());
+          TestCheckEqual(3u, value.TakeValue().size());
         });
 
     Mso::FutureWait(future);
@@ -3020,7 +3018,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateMaybeVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -3044,9 +3042,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -3058,7 +3056,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
         Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -3068,9 +3066,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
         });
 
@@ -3081,7 +3079,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3094,7 +3092,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3115,7 +3113,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3141,9 +3139,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -3155,7 +3153,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
         Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -3165,9 +3163,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
         });
 
@@ -3178,7 +3176,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3191,7 +3189,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3212,7 +3210,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3225,7 +3223,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_MaybeVoidRef) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
+        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3238,9 +3236,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
+        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -3252,7 +3250,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateMaybeFailingVectorFutureFuture().Then(
         Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
         });
 
     Mso::FutureWait(future);
@@ -3262,9 +3260,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
           invoked = true;
-          TestCheckEqual(3, value.size());
+          TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
         });
 
@@ -3275,7 +3273,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3288,7 +3286,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3310,7 +3308,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
+        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3323,7 +3321,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_MaybeVoidRef) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
+        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3335,9 +3333,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3348,7 +3346,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3357,9 +3355,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3369,10 +3367,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
-      TestCheckEqual(3, value.GetValue().size());
+      TestCheckEqual(3u, value.GetValue().size());
     });
 
     Mso::FutureWait(future);
@@ -3381,10 +3379,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
-      TestCheckEqual(3, value.TakeValue().size());
+      TestCheckEqual(3u, value.TakeValue().size());
     });
 
     Mso::FutureWait(future);
@@ -3401,7 +3399,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -3423,9 +3421,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3436,7 +3434,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateErrorVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3445,9 +3443,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3457,7 +3455,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3469,7 +3467,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3489,7 +3487,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3501,7 +3499,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3513,9 +3511,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3526,7 +3524,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateFailingVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3535,9 +3533,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3547,7 +3545,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3559,7 +3557,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3579,7 +3577,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3591,7 +3589,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3603,9 +3601,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3616,7 +3614,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateMaybeVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3625,9 +3623,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3637,10 +3635,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
-      TestCheckEqual(3, value.GetValue().size());
+      TestCheckEqual(3u, value.GetValue().size());
     });
 
     Mso::FutureWait(future);
@@ -3649,10 +3647,10 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
-      TestCheckEqual(3, value.TakeValue().size());
+      TestCheckEqual(3u, value.TakeValue().size());
     });
 
     Mso::FutureWait(future);
@@ -3669,7 +3667,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateMaybeVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -3691,9 +3689,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3704,7 +3702,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3713,9 +3711,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3725,7 +3723,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3737,7 +3735,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3757,7 +3755,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3769,7 +3767,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3781,9 +3779,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3794,7 +3792,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3803,9 +3801,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3815,7 +3813,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3827,7 +3825,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3847,7 +3845,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3859,7 +3857,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3871,9 +3869,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3884,7 +3882,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool invoked{false};
     auto future = CreateMaybeFailingVectorFutureFuture().Then([&](const std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
     });
 
     Mso::FutureWait(future);
@@ -3893,9 +3891,9 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
       invoked = true;
-      TestCheckEqual(3, value.size());
+      TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
     });
 
@@ -3905,7 +3903,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3917,7 +3915,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3937,7 +3935,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
+    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3949,7 +3947,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
+    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -4296,7 +4294,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_Returns_Vector) {
     bool invoked{false};
     Mso::Future<std::vector<int>> future =
-        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> && value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> &&value) noexcept {
           invoked = true;
           return std::move(value);
         });
@@ -4329,7 +4327,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_Returns_MaybeVector) {
     bool invoked{false};
     Mso::Future<std::vector<int>> future =
-        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> && value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> &&value) noexcept {
           invoked = true;
           return Mso::Maybe<std::vector<int>>(std::move(value));
         });
@@ -4520,7 +4518,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Returns_Vector) {
     bool invoked{false};
-    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> && value) noexcept {
+    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
       return std::move(value);
     });
@@ -4551,7 +4549,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Returns_MaybeVector) {
     bool invoked{false};
-    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> && value) noexcept {
+    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> &&value) noexcept {
       invoked = true;
       return Mso::Maybe<std::vector<int>>(std::move(value));
     });

--- a/vnext/Mso.UnitTests/future/futureTestEx.cpp
+++ b/vnext/Mso.UnitTests/future/futureTestEx.cpp
@@ -192,7 +192,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Then_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -214,7 +214,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Then_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+    auto future = CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -227,7 +227,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_Maybe) {
     bool invoked{false};
     auto future =
-        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
           TestCheckEqual(3u, value.GetValue().size());
@@ -240,7 +240,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_MaybeRef) {
     bool invoked{false};
     auto future =
-        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
           TestCheckEqual(3u, value.TakeValue().size());
@@ -260,7 +260,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -282,7 +282,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_RValue) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -304,7 +304,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+    auto future = CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -317,7 +317,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Error_Then_Maybe) {
     bool invoked{false};
     auto future =
-        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -330,7 +330,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Error_Then_MaybeRef) {
     bool invoked{false};
     auto future =
-        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        CreateErrorVectorFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -350,7 +350,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -362,7 +362,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_Then_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateErrorVoidFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -374,7 +374,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateVectorFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -396,7 +396,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateVectorFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -408,7 +408,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
       TestCheckEqual(3u, value.GetValue().size());
@@ -420,7 +420,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateVectorFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
       TestCheckEqual(3u, value.TakeValue().size());
@@ -440,7 +440,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateVoidFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -462,7 +462,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -484,7 +484,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -496,7 +496,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -508,7 +508,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateErrorVectorFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -528,7 +528,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -540,7 +540,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Error_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateErrorVoidFuture().Then([&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -649,7 +649,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &&value) noexcept {
+                          [&](std::vector<int> && value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -659,7 +659,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(3u, value.size());
                       });
@@ -705,7 +705,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &value) noexcept {
+                          [&](std::vector<int> & value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -715,7 +715,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(3u, value.size());
                         value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -734,7 +734,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsValue());
                             return std::move(value);
@@ -745,7 +745,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(3u, value.GetValue().size());
@@ -764,7 +764,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsValue());
                             return std::move(value);
@@ -775,7 +775,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(3u, value.TakeValue().size());
@@ -811,13 +811,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> &&value) noexcept {
+                [&](Mso::Maybe<void> && value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsValue());
                   return std::move(value);
                 })
             .Catch(Mso::Executors::Inline{}, [&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
               isInvoked[2] = true;
               TestCheck(value.IsValue());
             });
@@ -836,7 +836,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> &value) noexcept {
+                [&](Mso::Maybe<void> & value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsValue());
                   return std::move(value);
@@ -860,7 +860,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &&value) noexcept {
+                          [&](std::vector<int> && value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -870,7 +870,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                       });
@@ -916,7 +916,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &value) noexcept {
+                          [&](std::vector<int> & value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -926,7 +926,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
@@ -945,7 +945,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -956,7 +956,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.GetValue().size());
@@ -975,7 +975,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -986,7 +986,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return std::vector<int>{1, 2};
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.TakeValue().size());
@@ -1022,13 +1022,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> &&value) noexcept {
+                [&](Mso::Maybe<void> && value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsError());
                   return std::move(value);
                 })
             .Catch(Mso::Executors::Inline{}, [&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+            .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
               isInvoked[2] = true;
               TestCheck(value.IsValue());
             });
@@ -1047,7 +1047,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVoidFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](Mso::Maybe<void> &value) noexcept {
+                [&](Mso::Maybe<void> & value) noexcept {
                   isInvoked[0] = true;
                   TestCheck(value.IsError());
                   return std::move(value);
@@ -1072,7 +1072,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVectorFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](std::vector<int> &&value) noexcept {
+                [&](std::vector<int> && value) noexcept {
                   isInvoked[0] = true;
                   return std::move(value);
                 })
@@ -1123,7 +1123,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &value) noexcept {
+                          [&](std::vector<int> & value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1133,7 +1133,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -1151,7 +1151,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1162,7 +1162,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1181,18 +1181,18 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
                           })
                       .Catch(
                           Mso::Executors::Inline{},
-                          [&](Mso::ErrorCode &&error) noexcept {
+                          [&](Mso::ErrorCode && error) noexcept {
                             isInvoked[1] = true;
                             return std::move(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1231,7 +1231,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> &&value) noexcept {
+                          [&](Mso::Maybe<void> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1242,7 +1242,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1261,7 +1261,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> &value) noexcept {
+                          [&](Mso::Maybe<void> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1272,7 +1272,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return error;
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1291,7 +1291,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &&value) noexcept {
+                          [&](std::vector<int> && value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1301,7 +1301,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                       });
@@ -1347,7 +1347,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &value) noexcept {
+                          [&](std::vector<int> & value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1357,7 +1357,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
@@ -1376,7 +1376,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1387,7 +1387,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.GetValue().size());
@@ -1406,7 +1406,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1417,7 +1417,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.TakeValue().size());
@@ -1456,7 +1456,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> &&value) noexcept {
+                          [&](Mso::Maybe<void> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1467,7 +1467,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<void>();
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -1485,7 +1485,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> &value) noexcept {
+                          [&](Mso::Maybe<void> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1515,7 +1515,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
         CreateErrorVectorFuture()
             .Then(
                 Mso::Executors::Inline{},
-                [&](std::vector<int> &&value) noexcept {
+                [&](std::vector<int> && value) noexcept {
                   isInvoked[0] = true;
                   return std::move(value);
                 })
@@ -1566,7 +1566,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](std::vector<int> &value) noexcept {
+                          [&](std::vector<int> & value) noexcept {
                             isInvoked[0] = true;
                             return std::move(value);
                           })
@@ -1576,7 +1576,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -1594,7 +1594,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1605,7 +1605,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1624,7 +1624,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVectorFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                          [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1635,7 +1635,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<std::vector<int>>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1674,7 +1674,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> &&value) noexcept {
+                          [&](Mso::Maybe<void> && value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1685,7 +1685,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<void>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -1704,7 +1704,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     auto future = CreateErrorVoidFuture()
                       .Then(
                           Mso::Executors::Inline{},
-                          [&](Mso::Maybe<void> &value) noexcept {
+                          [&](Mso::Maybe<void> & value) noexcept {
                             isInvoked[0] = true;
                             TestCheck(value.IsError());
                             return std::move(value);
@@ -1715,7 +1715,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                             isInvoked[1] = true;
                             return Mso::Maybe<void>(error);
                           })
-                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
+                      .Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -1732,7 +1732,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1740,7 +1740,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(3u, value.size());
                       });
@@ -1780,7 +1780,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1788,7 +1788,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(3u, value.size());
                         value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -1805,7 +1805,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
@@ -1814,7 +1814,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(3u, value.GetValue().size());
@@ -1831,7 +1831,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
@@ -1840,7 +1840,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>();
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(3u, value.TakeValue().size());
@@ -1872,13 +1872,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVoidFuture()
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
                       })
                       .Catch([&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -1894,7 +1894,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateVoidFuture()
-                      .Then([&](Mso::Maybe<void> &value) noexcept {
+                      .Then([&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsValue());
                         return std::move(value);
@@ -1916,7 +1916,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1924,7 +1924,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                       });
@@ -1964,7 +1964,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -1972,7 +1972,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
@@ -1989,7 +1989,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -1998,7 +1998,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.GetValue().size());
@@ -2015,7 +2015,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2024,7 +2024,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return std::vector<int>{1, 2};
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.TakeValue().size());
@@ -2056,13 +2056,13 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
                       })
                       .Catch([&](const Mso::ErrorCode & /*error*/) noexcept { isInvoked[1] = true; })
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -2078,7 +2078,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &value) noexcept {
+                      .Then([&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2100,7 +2100,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2142,7 +2142,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2150,7 +2150,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -2166,7 +2166,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2175,7 +2175,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2192,7 +2192,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2201,7 +2201,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2236,7 +2236,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2245,7 +2245,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return error;
                       })
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2262,7 +2262,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &value) noexcept {
+                      .Then([&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2288,7 +2288,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2296,7 +2296,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                       });
@@ -2336,7 +2336,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2344,7 +2344,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheckEqual(2u, value.size());
                         value[1] = 5; // to avoid OACR error about non-const parameter.
@@ -2361,7 +2361,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2370,7 +2370,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.GetValue().size());
@@ -2387,7 +2387,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2396,7 +2396,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(std::vector<int>{1, 2});
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                         TestCheckEqual(2u, value.TakeValue().size());
@@ -2431,7 +2431,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2440,7 +2440,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<void>();
                       })
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsValue());
                       });
@@ -2456,7 +2456,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &value) noexcept {
+                      .Then([&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2481,7 +2481,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &&value) noexcept {
+                      .Then([&](std::vector<int> && value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2523,7 +2523,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[0] = true;
                         return std::move(value);
                       })
@@ -2531,7 +2531,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(error);
                       })
-                      .Then([&](std::vector<int> &value) noexcept {
+                      .Then([&](std::vector<int> & value) noexcept {
                         isInvoked[2] = true;
                         value[1] = 5; // to avoid OACR error about non-const parameter.
                       });
@@ -2547,7 +2547,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2556,7 +2556,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(error);
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2573,7 +2573,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVectorFuture()
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2582,7 +2582,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<std::vector<int>>(error);
                       })
-                      .Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+                      .Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2617,7 +2617,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2626,7 +2626,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<void>(error);
                       })
-                      .Then([&](Mso::Maybe<void> &&value) noexcept {
+                      .Then([&](Mso::Maybe<void> && value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2643,7 +2643,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
     bool isInvoked[] = {false, false, false};
 
     auto future = CreateErrorVoidFuture()
-                      .Then([&](Mso::Maybe<void> &value) noexcept {
+                      .Then([&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[0] = true;
                         TestCheck(value.IsError());
                         return std::move(value);
@@ -2652,7 +2652,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
                         isInvoked[1] = true;
                         return Mso::Maybe<void>(error);
                       })
-                      .Then([&](Mso::Maybe<void> &value) noexcept {
+                      .Then([&](Mso::Maybe<void> & value) noexcept {
                         isInvoked[2] = true;
                         TestCheck(value.IsError());
                         TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2666,7 +2666,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Then_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -2689,7 +2689,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Then_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+    auto future = CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -2702,7 +2702,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Then_Maybe) {
     bool invoked{false};
     auto future =
-        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
           TestCheckEqual(3u, value.GetValue().size());
@@ -2715,7 +2715,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Then_MaybeRef) {
     bool invoked{false};
     auto future =
-        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        CreateVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
           TestCheckEqual(3u, value.TakeValue().size());
@@ -2735,7 +2735,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -2758,7 +2758,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Error_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+        CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
         });
@@ -2781,11 +2781,12 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_Then_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
-      invoked = true;
-      TestCheckEqual(3u, value.size());
-      value[2] = 5; // to avoid OACR error about non-const parameter.
-    });
+    auto future =
+        CreateErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+          invoked = true;
+          TestCheckEqual(3u, value.size());
+          value[2] = 5; // to avoid OACR error about non-const parameter.
+        });
 
     Mso::FutureWait(future);
     TestCheck(!invoked);
@@ -2794,7 +2795,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Error_Then_Maybe) {
     bool invoked{false};
     auto future = CreateErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2807,7 +2808,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Error_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2827,7 +2828,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2839,7 +2840,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_Then_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2852,7 +2853,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
         });
@@ -2876,7 +2877,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+        CreateFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -2889,7 +2890,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_Maybe) {
     bool invoked{false};
     auto future = CreateFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2902,7 +2903,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -2923,7 +2924,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Future_Failing_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+        CreateFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -2949,7 +2950,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+        CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
         });
@@ -2972,11 +2973,12 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Then_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
-      invoked = true;
-      TestCheckEqual(3u, value.size());
-      value[2] = 5; // to avoid OACR error about non-const parameter.
-    });
+    auto future =
+        CreateMaybeVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
+          invoked = true;
+          TestCheckEqual(3u, value.size());
+          value[2] = 5; // to avoid OACR error about non-const parameter.
+        });
 
     Mso::FutureWait(future);
     TestCheck(invoked);
@@ -2985,7 +2987,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
           TestCheckEqual(3u, value.GetValue().size());
@@ -2998,7 +3000,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsValue());
           TestCheckEqual(3u, value.TakeValue().size());
@@ -3018,7 +3020,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Then_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateMaybeVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -3042,7 +3044,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
         });
@@ -3066,7 +3068,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3079,7 +3081,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3092,7 +3094,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3113,7 +3115,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_ErrorMaybeFuture_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3139,7 +3141,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
         });
@@ -3163,7 +3165,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+        CreateMaybeErrorVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3176,7 +3178,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3189,7 +3191,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeErrorVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3210,7 +3212,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3223,7 +3225,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Error_Then_MaybeVoidRef) {
     bool invoked{false};
     auto future =
-        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
+        CreateMaybeErrorVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3236,7 +3238,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_RValue) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &&value) noexcept {
+        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> && value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
         });
@@ -3260,7 +3262,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_Ref) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> &value) noexcept {
+        CreateMaybeFailingVectorFutureFuture().Then(Mso::Executors::Inline{}, [&](std::vector<int> & value) noexcept {
           invoked = true;
           TestCheckEqual(3u, value.size());
           value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3273,7 +3275,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_Maybe) {
     bool invoked{false};
     auto future = CreateMaybeFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3286,7 +3288,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_MaybeRef) {
     bool invoked{false};
     auto future = CreateMaybeFailingVectorFutureFuture().Then(
-        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> &value) noexcept {
+        Mso::Executors::Inline{}, [&](Mso::Maybe<std::vector<int>> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3308,7 +3310,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_MaybeVoid) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &&value) noexcept {
+        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> && value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3321,7 +3323,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_MaybeFuture_Failing_Then_MaybeVoidRef) {
     bool invoked{false};
     auto future =
-        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> &value) noexcept {
+        CreateMaybeFailingVoidFutureFuture().Then(Mso::Executors::Inline{}, [&](Mso::Maybe<void> & value) noexcept {
           invoked = true;
           TestCheck(value.IsError());
           TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3333,7 +3335,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3355,7 +3357,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3367,7 +3369,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
       TestCheckEqual(3u, value.GetValue().size());
@@ -3379,7 +3381,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
       TestCheckEqual(3u, value.TakeValue().size());
@@ -3399,7 +3401,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -3421,7 +3423,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3443,7 +3445,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3455,7 +3457,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3467,7 +3469,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3487,7 +3489,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3499,7 +3501,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Error_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateErrorVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3511,7 +3513,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3533,7 +3535,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3545,7 +3547,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3557,7 +3559,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3577,7 +3579,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3589,7 +3591,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_Future_Failing_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateFailingVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3601,7 +3603,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3623,7 +3625,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3635,7 +3637,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
       TestCheckEqual(3u, value.GetValue().size());
@@ -3647,7 +3649,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateMaybeVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
       TestCheckEqual(3u, value.TakeValue().size());
@@ -3667,7 +3669,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateMaybeVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsValue());
     });
@@ -3689,7 +3691,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3711,7 +3713,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3723,7 +3725,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3735,7 +3737,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3755,7 +3757,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3767,7 +3769,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ErrorMaybeFuture_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3779,7 +3781,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3801,7 +3803,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3813,7 +3815,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3825,7 +3827,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateMaybeErrorVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3845,7 +3847,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3857,7 +3859,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Error_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateMaybeErrorVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3869,7 +3871,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_RValue) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> &&value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
     });
@@ -3891,7 +3893,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_Ref) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](std::vector<int> & value) noexcept {
       invoked = true;
       TestCheckEqual(3u, value.size());
       value[2] = 5; // to avoid OACR error about non-const parameter.
@@ -3903,7 +3905,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_Maybe) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &&value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3915,7 +3917,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_MaybeRef) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> &value) noexcept {
+    auto future = CreateMaybeFailingVectorFutureFuture().Then([&](Mso::Maybe<std::vector<int>> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -3935,7 +3937,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_MaybeVoid) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &&value) noexcept {
+    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> && value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.GetError()));
@@ -3947,7 +3949,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_MaybeFuture_Failing_ThenDefault_MaybeVoidRef) {
     bool invoked{false};
-    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> &value) noexcept {
+    auto future = CreateMaybeFailingVoidFutureFuture().Then([&](Mso::Maybe<void> & value) noexcept {
       invoked = true;
       TestCheck(value.IsError());
       TestCheck(Mso::CancellationErrorProvider().IsOwnedErrorCode(value.TakeError()));
@@ -4294,7 +4296,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_Returns_Vector) {
     bool invoked{false};
     Mso::Future<std::vector<int>> future =
-        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> &&value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> && value) noexcept {
           invoked = true;
           return std::move(value);
         });
@@ -4327,7 +4329,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
   TEST_METHOD(Future_Then_Returns_MaybeVector) {
     bool invoked{false};
     Mso::Future<std::vector<int>> future =
-        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> &&value) noexcept {
+        CreateVectorFuture().Then(Mso::Executors::Inline(), [&](std::vector<int> && value) noexcept {
           invoked = true;
           return Mso::Maybe<std::vector<int>>(std::move(value));
         });
@@ -4518,7 +4520,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Returns_Vector) {
     bool invoked{false};
-    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> &&value) noexcept {
+    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       return std::move(value);
     });
@@ -4549,7 +4551,7 @@ TEST_CLASS_EX (FutureTestEx, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Future_ThenDefault_Returns_MaybeVector) {
     bool invoked{false};
-    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> &&value) noexcept {
+    Mso::Future<std::vector<int>> future = CreateVectorFuture().Then([&](std::vector<int> && value) noexcept {
       invoked = true;
       return Mso::Maybe<std::vector<int>>(std::move(value));
     });

--- a/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
@@ -185,23 +185,23 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
     // modify original vector and see that the Promise still has the original copy.
     vec.push_back(4);
 
-    auto future1 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future1 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
       std::vector<int> v1 = std::move(value);
-      TestCheckEqual(3, v1.size());
+      TestCheckEqual(3u, v1.size());
     });
-    auto future2 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future2 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
       std::vector<int> v1 = std::move(value);
-      TestCheckEqual(3, v1.size());
+      TestCheckEqual(3u, v1.size());
     });
-    auto future3 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future3 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
       std::vector<int> v1 = std::move(value);
-      TestCheckEqual(3, v1.size());
+      TestCheckEqual(3u, v1.size());
     });
 
     Mso::FutureWait(future1);
     Mso::FutureWait(future2);
     Mso::FutureWait(future3);
-    TestCheckEqual(4, vec.size());
+    TestCheckEqual(4u, vec.size());
   }
 
   TEST_METHOD(PromiseGroup_SetValue_Moves) {
@@ -212,17 +212,17 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
     TestCheck(vec.empty());
 
-    auto future1 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future1 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
       std::vector<int> v1 = std::move(value);
-      TestCheckEqual(3, v1.size());
+      TestCheckEqual(3u, v1.size());
     });
-    auto future2 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future2 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
       std::vector<int> v1 = std::move(value);
-      TestCheckEqual(3, v1.size());
+      TestCheckEqual(3u, v1.size());
     });
-    auto future3 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
+    auto future3 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
       std::vector<int> v1 = std::move(value);
-      TestCheckEqual(3, v1.size());
+      TestCheckEqual(3u, v1.size());
     });
 
     Mso::FutureWait(future1);
@@ -272,16 +272,16 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
     vec.push_back(4);
 
     auto future1 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future2 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future3 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
 
     Mso::FutureWait(future1);
     Mso::FutureWait(future2);
     Mso::FutureWait(future3);
-    TestCheckEqual(4, vec.size());
+    TestCheckEqual(4u, vec.size());
   }
 
   TEST_METHOD(PromiseGroup_TrySetValue_Moves) {
@@ -293,11 +293,11 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
     TestCheck(vec.empty());
 
     auto future1 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future2 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future3 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
 
     Mso::FutureWait(future1);
     Mso::FutureWait(future2);
@@ -354,11 +354,11 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
     p1.EmplaceValue({1, 2, 3});
 
     auto future1 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future2 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future3 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
 
     Mso::FutureWait(future1);
     Mso::FutureWait(future2);
@@ -451,11 +451,11 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
     TestCheck(p1.TryEmplaceValue({1, 2, 3}));
 
     auto future1 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future2 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
     auto future3 =
-        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        p1.AddFuture().Then([&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
 
     Mso::FutureWait(future1);
     Mso::FutureWait(future2);

--- a/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseGroupTest.cpp
@@ -185,15 +185,15 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
     // modify original vector and see that the Promise still has the original copy.
     vec.push_back(4);
 
-    auto future1 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future1 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
       std::vector<int> v1 = std::move(value);
       TestCheckEqual(3u, v1.size());
     });
-    auto future2 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future2 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
       std::vector<int> v1 = std::move(value);
       TestCheckEqual(3u, v1.size());
     });
-    auto future3 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future3 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
       std::vector<int> v1 = std::move(value);
       TestCheckEqual(3u, v1.size());
     });
@@ -212,15 +212,15 @@ TEST_CLASS_EX (PromiseGroupTest, LibletAwareMemLeakDetection) {
 
     TestCheck(vec.empty());
 
-    auto future1 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future1 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
       std::vector<int> v1 = std::move(value);
       TestCheckEqual(3u, v1.size());
     });
-    auto future2 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future2 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
       std::vector<int> v1 = std::move(value);
       TestCheckEqual(3u, v1.size());
     });
-    auto future3 = p1.AddFuture().Then([&](std::vector<int> &value) noexcept {
+    auto future3 = p1.AddFuture().Then([&](std::vector<int> & value) noexcept {
       std::vector<int> v1 = std::move(value);
       TestCheckEqual(3u, v1.size());
     });

--- a/vnext/Mso.UnitTests/future/promiseTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseTest.cpp
@@ -175,10 +175,10 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
     vec.push_back(4);
 
     auto future = p1.AsFuture().Then(
-        Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
 
     Mso::FutureWait(future);
-    TestCheckEqual(4, vec.size());
+    TestCheckEqual(4u, vec.size());
   }
 
   TEST_METHOD(Promise_SetValue_Moves) {
@@ -190,7 +190,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_SetValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });
@@ -201,7 +201,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_SetValue_ObserveMoved_Vector) {
     Mso::Promise<std::vector<std::unique_ptr<int>>> p1;
-    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> && value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> &&value) noexcept {
       std::vector<std::unique_ptr<int>> v =
           std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v[0] == 5);
@@ -255,10 +255,10 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
     vec.push_back(4);
 
     auto future = p1.AsFuture().Then(
-        Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept { TestCheckEqual(3, value.size()); });
+        Mso::Executors::Inline{}, [&](const std::vector<int> &value) noexcept { TestCheckEqual(3u, value.size()); });
 
     Mso::FutureWait(future);
-    TestCheckEqual(4, vec.size());
+    TestCheckEqual(4u, vec.size());
   }
 
   TEST_METHOD(Promise_TrySetValue_Moves) {
@@ -270,7 +270,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TrySetValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });
@@ -281,7 +281,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TrySetValue_ObserveMoved_Vector) {
     Mso::Promise<std::vector<std::unique_ptr<int>>> p1;
-    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> && value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> &&value) noexcept {
       std::vector<std::unique_ptr<int>> v =
           std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v[0] == 5);
@@ -335,7 +335,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_EmplaceValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });
@@ -418,7 +418,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TryEmplaceValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });

--- a/vnext/Mso.UnitTests/future/promiseTest.cpp
+++ b/vnext/Mso.UnitTests/future/promiseTest.cpp
@@ -190,7 +190,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_SetValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });
@@ -201,7 +201,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_SetValue_ObserveMoved_Vector) {
     Mso::Promise<std::vector<std::unique_ptr<int>>> p1;
-    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> &&value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> && value) noexcept {
       std::vector<std::unique_ptr<int>> v =
           std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v[0] == 5);
@@ -270,7 +270,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TrySetValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });
@@ -281,7 +281,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TrySetValue_ObserveMoved_Vector) {
     Mso::Promise<std::vector<std::unique_ptr<int>>> p1;
-    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> &&value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::vector<std::unique_ptr<int>> && value) noexcept {
       std::vector<std::unique_ptr<int>> v =
           std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v[0] == 5);
@@ -335,7 +335,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_EmplaceValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });
@@ -418,7 +418,7 @@ TEST_CLASS_EX (PromiseTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(Promise_TryEmplaceValue_ObserveMoved) {
     Mso::Promise<std::unique_ptr<int>> p1;
-    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> &&value) noexcept {
+    auto future = p1.AsFuture().Then([&](std::unique_ptr<int> && value) noexcept {
       std::unique_ptr<int> v = std::move(value); // We can move value because only one continuation is allowed.
       TestCheck(*v == 5);
     });

--- a/vnext/Mso.UnitTests/future/whenAllTest.cpp
+++ b/vnext/Mso.UnitTests/future/whenAllTest.cpp
@@ -28,7 +28,7 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(WhenAll_Init_Empty) {
     auto fr = Mso::WhenAll<int>({}).Then([](Mso::Async::ArrayView<int> result) noexcept {
-      TestCheckEqual(0, result.Size());
+      TestCheckEqual(0u, result.Size());
       return 42;
     });
 
@@ -53,8 +53,8 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
 
     auto fr = Mso::WhenAll({f1, f2}).Then([](Mso::Async::ArrayView<double> r) noexcept {
       // Check value alignment
-      TestCheckEqual(0, reinterpret_cast<uintptr_t>(&r[0]) & (sizeof(double) - 1));
-      TestCheckEqual(0, reinterpret_cast<uintptr_t>(&r[1]) & (sizeof(double) - 1));
+      TestCheckEqual(0u, reinterpret_cast<uintptr_t>(&r[0]) & (sizeof(double) - 1));
+      TestCheckEqual(0u, reinterpret_cast<uintptr_t>(&r[1]) & (sizeof(double) - 1));
       return r[0] + r[1];
     });
 
@@ -68,9 +68,9 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
 
     auto fr = Mso::WhenAll({f1, f2, f3}).Then([](Mso::Async::ArrayView<double> r) noexcept {
       // Check value alignment
-      TestCheckEqual(0, reinterpret_cast<uintptr_t>(&r[0]) & (sizeof(double) - 1));
-      TestCheckEqual(0, reinterpret_cast<uintptr_t>(&r[1]) & (sizeof(double) - 1));
-      TestCheckEqual(0, reinterpret_cast<uintptr_t>(&r[2]) & (sizeof(double) - 1));
+      TestCheckEqual(0u, reinterpret_cast<uintptr_t>(&r[0]) & (sizeof(double) - 1));
+      TestCheckEqual(0u, reinterpret_cast<uintptr_t>(&r[1]) & (sizeof(double) - 1));
+      TestCheckEqual(0u, reinterpret_cast<uintptr_t>(&r[2]) & (sizeof(double) - 1));
       return r[0] + r[1] + r[2];
     });
 
@@ -115,7 +115,7 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(WhenAll_Vector_Empty) {
     auto fr = Mso::WhenAll(std::vector<Mso::Future<int>>()).Then([](Mso::Async::ArrayView<int> r) noexcept {
-      TestCheckEqual(0, r.Size());
+      TestCheckEqual(0u, r.Size());
       return 42;
     });
 
@@ -234,10 +234,10 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(WhenAll_Tuple_Three) {
     auto f1 = Mso::PostFuture([]() noexcept { return 47; });
-    auto f2 = Mso::PostFuture([]() noexcept->std::string { return "82"; });
-    auto f3 = Mso::PostFuture([]() noexcept->double { return 32.5; });
+    auto f2 = Mso::PostFuture([]() noexcept -> std::string { return "82"; });
+    auto f3 = Mso::PostFuture([]() noexcept -> double { return 32.5; });
 
-    auto fr = Mso::WhenAll(f1, f2, f3).Then([](std::tuple<int, std::string, double> && result) noexcept {
+    auto fr = Mso::WhenAll(f1, f2, f3).Then([](std::tuple<int, std::string, double> &&result) noexcept {
       TestCheck(std::get<0>(result) == 47);
       TestCheck(std::stoi(std::get<1>(result)) == 82);
       TestCheck(int(std::get<2>(result)) == 32);
@@ -250,7 +250,7 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(WhenAll_Tuple_Two_Error) {
     Mso::ManualResetEvent complete;
     auto f1 = Mso::MakeFailedFuture<int>(Mso::CancellationErrorProvider().MakeErrorCode(true));
-    auto f2 = Mso::PostFuture([&]() noexcept->std::string {
+    auto f2 = Mso::PostFuture([&]() noexcept -> std::string {
       complete.Wait();
       return "82";
     });

--- a/vnext/Mso.UnitTests/future/whenAllTest.cpp
+++ b/vnext/Mso.UnitTests/future/whenAllTest.cpp
@@ -234,10 +234,10 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
 
   TEST_METHOD(WhenAll_Tuple_Three) {
     auto f1 = Mso::PostFuture([]() noexcept { return 47; });
-    auto f2 = Mso::PostFuture([]() noexcept -> std::string { return "82"; });
-    auto f3 = Mso::PostFuture([]() noexcept -> double { return 32.5; });
+    auto f2 = Mso::PostFuture([]() noexcept->std::string { return "82"; });
+    auto f3 = Mso::PostFuture([]() noexcept->double { return 32.5; });
 
-    auto fr = Mso::WhenAll(f1, f2, f3).Then([](std::tuple<int, std::string, double> &&result) noexcept {
+    auto fr = Mso::WhenAll(f1, f2, f3).Then([](std::tuple<int, std::string, double> && result) noexcept {
       TestCheck(std::get<0>(result) == 47);
       TestCheck(std::stoi(std::get<1>(result)) == 82);
       TestCheck(int(std::get<2>(result)) == 32);
@@ -250,7 +250,7 @@ TEST_CLASS_EX (WhenAllTest, LibletAwareMemLeakDetection) {
   TEST_METHOD(WhenAll_Tuple_Two_Error) {
     Mso::ManualResetEvent complete;
     auto f1 = Mso::MakeFailedFuture<int>(Mso::CancellationErrorProvider().MakeErrorCode(true));
-    auto f2 = Mso::PostFuture([&]() noexcept -> std::string {
+    auto f2 = Mso::PostFuture([&]() noexcept->std::string {
       complete.Wait();
       return "82";
     });


### PR DESCRIPTION
This PR fixes some of the warnings that are gumming up our CI results page. This PR particularly addresses the signed int vs unsigned int comparison warnings in our unit tests in the x86 builds.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5295)