### PR TITLE
Prevent --useWinUI3 and --experimentalNugetDependency from being used at the same time in react-native-windows-init

### DIFF
--- a/change/react-native-windows-init-2020-06-22-09-35-38-master.json
+++ b/change/react-native-windows-init-2020-06-22-09-35-38-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Prevent --useWinUI3 and --experimentalNugetDependency from being used at the same time in react-native-windows-init",
+  "packageName": "react-native-windows-init",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-22T16:35:37.975Z"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -72,6 +72,7 @@ const EXITCODE_UNKNOWN_ERROR = 6;
 const EXITCODE_NO_PACKAGE_JSON = 7;
 const EXITCODE_NO_LATEST_RNW = 8;
 const EXITCODE_NO_AUTO_MATCHING_RNW = 9;
+const EXITCODE_INCOMPATIBLE_OPTIONS = 10;
 
 function reactNativeWindowsGeneratePath() {
   return require.resolve('react-native-windows/local-cli/generate-windows.js', {
@@ -258,6 +259,14 @@ function isProjectUsingYarn(cwd: string) {
     const ns = argv.namespace || name;
     const useDevMode = argv.useDevMode;
     let version = argv.version;
+
+    if (argv.useWinUI3 && argv.experimentalNugetDependency) {
+      // WinUI3 is not yet compatible with nuget packages
+      console.error(
+        "Error: Incompatible options specified. Options '--useWinUI3' and '--experimentalNugetDependency' are incompatible",
+      );
+      process.exit(EXITCODE_INCOMPATIBLE_OPTIONS);
+    }
 
     if (!version) {
       const rnVersion = getReactNativeVersion();


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5297)