### PR TITLE
C# projects to use XAML version from WinUI.props

### DIFF
--- a/change/react-native-windows-2020-06-23-00-34-32-winui3preview1.json
+++ b/change/react-native-windows-2020-06-23-00-34-32-winui3preview1.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "update csproj to use versions from winui.props",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-23T07:34:32.230Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
@@ -114,6 +114,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
+  <Import Project="..\PropertySheets\WinUI.props" />
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
@@ -164,6 +165,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk">
       <Version>16.5.0</Version>
     </PackageReference>
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(UseWinUI3)'=='true'"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">

--- a/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
+++ b/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
@@ -147,7 +147,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.WinUI" Version="3.0.0-alpha.200210.0" Condition="'$(UseWinUI3)'=='true'"/>
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(UseWinUI3)'=='true'"/>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '16.0' ">
     <VisualStudioVersion>16.0</VisualStudioVersion>


### PR DESCRIPTION
Follow up from PR #5260 , make use of versions defined in WinUI.props for C# projects.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5308)