### PR TITLE
WinUI 3 Preview 1

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: npx react-native-windows-init --version $(npmTag) --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
+      script: npx react-native-windows-init --verbose --version $(npmTag) --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: PowerShell@2

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -542,12 +542,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: --useWinUI3 true
+          additionalInitArguments: '--useWinUI3 true'
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: --useWinUI3 true
+          additionalInitArguments: '--useWinUI3 true'
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -538,6 +538,16 @@ jobs:
         #  language: cs
         #  configuration: Release
         #  platform: arm64
+        WinUI3_X86DebugCpp:
+          language: cpp
+          configuration: Debug
+          platform: x86
+          additionalInitArguments: --useWinUI3
+        WinUI3_X86DebugCs:
+          language: cs
+          configuration: Debug
+          platform: x86
+          additionalInitArguments: --useWinUI3
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -476,12 +476,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: ${{ '--namespace MyCompany.MyApplication.MyComponent' }}
+          additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
         X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: ${{ '--namespace MyCompany.MyApplication.MyComponent' }}
+          additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
         #X86ReleaseCpp:
         #  language: cpp
         #  configuration: Release
@@ -542,12 +542,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: ${{ '--useWinUI3 true' }}
+          additionalInitArguments: --useWinUI3 true
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: ${{ '--useWinUI3 true' }}
+          additionalInitArguments: --useWinUI3 true
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
@@ -560,7 +560,7 @@ jobs:
           configuration: $(configuration)
           platform: $(platform)
           version: $(reactNativeVersion)
-          additionalInitArguments: $[ coalesce($(additionalInitArguments), '') ]
+          additionalInitArguments: $(additionalInitArguments)
 
   - job: CliInitExperimental
     displayName: Verify react-native init experimental

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -476,12 +476,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
+          additionalInitArguments: {{ '--namespace MyCompany.MyApplication.MyComponent' }}
         X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
+          additionalInitArguments: {{ '--namespace MyCompany.MyApplication.MyComponent' }}
         #X86ReleaseCpp:
         #  language: cpp
         #  configuration: Release
@@ -542,12 +542,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: '--useWinUI3 true'
+          additionalInitArguments: {{ '--useWinUI3 true' }}
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: '--useWinUI3 true'
+          additionalInitArguments: {{ '--useWinUI3 true' }}
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -476,12 +476,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: {{ '--namespace MyCompany.MyApplication.MyComponent' }}
+          additionalInitArguments: ${{ '--namespace MyCompany.MyApplication.MyComponent' }}
         X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: {{ '--namespace MyCompany.MyApplication.MyComponent' }}
+          additionalInitArguments: ${{ '--namespace MyCompany.MyApplication.MyComponent' }}
         #X86ReleaseCpp:
         #  language: cpp
         #  configuration: Release
@@ -542,12 +542,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: {{ '--useWinUI3 true' }}
+          additionalInitArguments: ${{ '--useWinUI3 true' }}
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: {{ '--useWinUI3 true' }}
+          additionalInitArguments: ${{ '--useWinUI3 true' }}
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -542,12 +542,12 @@ jobs:
           language: cpp
           configuration: Debug
           platform: x86
-          additionalInitArguments: --useWinUI3
+          additionalInitArguments: --useWinUI3 true
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
-          additionalInitArguments: --useWinUI3
+          additionalInitArguments: --useWinUI3 true
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -502,10 +502,12 @@ jobs:
           language: cpp
           configuration: Release
           platform: x64
+          additionalInitArguments: 
         X64ReleaseCs:
           language: cs
           configuration: Release
           platform: x64
+          additionalInitArguments: 
         #ArmDebugCpp:
         #  language: cpp
         #  configuration: Debug
@@ -518,10 +520,12 @@ jobs:
           language: cpp
           configuration: Release
           platform: arm
+          additionalInitArguments: 
         ArmReleaseCs:
           language: cs
           configuration: Release
           platform: arm
+          additionalInitArguments: 
         #Arm64DebugCpp:
         #  language: cpp
         #  configuration: Debug

--- a/change/react-native-windows-2020-06-23-14-52-51-winui3preview1.json
+++ b/change/react-native-windows-2020-06-23-14-52-51-winui3preview1.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "WinUI3 Preview 1",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-23T21:52:51.681Z"
+}

--- a/change/react-native-windows-init-2020-06-24-03-38-49-winui3preview1.json
+++ b/change/react-native-windows-init-2020-06-24-03-38-49-winui3preview1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "make cli strict and pass true to trailing bool param",
+  "packageName": "react-native-windows-init",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-24T10:38:48.959Z"
+}

--- a/packages/playground/windows/playground/App.cpp
+++ b/packages/playground/windows/playground/App.cpp
@@ -36,7 +36,7 @@ App::App() {
 /// will be used such as when the application is launched to open a specific file.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void App::OnLaunched(LaunchActivatedEventArgs const &e) {
+void App::OnLaunched(activation::LaunchActivatedEventArgs const &e) {
   Frame frame{};
   Window::Current().Content(frame);
   Window::Current().Activate();

--- a/packages/playground/windows/playground/App.h
+++ b/packages/playground/windows/playground/App.h
@@ -1,11 +1,17 @@
 #pragma once
 #include "App.xaml.g.h"
 
+#ifdef USE_WINUI3
+namespace activation = winrt::Microsoft::UI::Xaml;
+#else
+namespace activation = winrt::Windows::ApplicationModel::Activation;
+#endif
+
 namespace winrt::playground::implementation {
 struct App : AppT<App> {
   App();
 
-  void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &);
+  void OnLaunched(activation::LaunchActivatedEventArgs const &);
   void OnSuspending(IInspectable const &, Windows::ApplicationModel::SuspendingEventArgs const &);
   void OnNavigationFailed(IInspectable const &, xaml::Navigation::NavigationFailedEventArgs const &);
 };

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -81,7 +81,6 @@
   </ImportGroup>
   <ImportGroup Label="ReactNativeWindowsPropertySheets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props"/>
-    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   </ImportGroup>
   <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!=''" />
   <PropertyGroup Label="UserMacros" />

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-  <package id="Microsoft.WinUI" version="3.0.0-alpha.200210.0" targetFramework="native"/>
+  <package id="Microsoft.WinUI" version="3.0.0-preview1.200515.3" targetFramework="native"/>
 </packages>

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -24,7 +24,7 @@ const NPM_REGISTRY_URL = validUrl.isUri(npmConfReg)
   : 'http://registry.npmjs.org';
 const npm = new Registry({registry: NPM_REGISTRY_URL});
 
-const argv = yargs.version(false).options({
+const argv = yargs.version(false).strict(true).options({
   version: {
     type: 'string',
     describe: 'The version of react-native-windows to use.',

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -63,7 +63,7 @@ const argv = yargs.version(false).strict(true).options({
       'Link rather than Add/Install the react-native-windows package. This option is for the development workflow of the developers working on react-native-windows.',
     hidden: true,
   },
-}).argv;
+}).check((a, o) => { if (a._.length != 0) { throw `Unrecognized option ${a._}`; }; return true }).argv;
 
 if (argv.verbose) {
   console.log(argv);

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -60,10 +60,14 @@ const argv = yargs.version(false).strict(true).options({
   useDevMode: {
     type: 'boolean',
     describe:
-      'Link rather than Add/Install the react-native-windows package. This option is for the developement workflow of the developers working on react-native-windows.',
+      'Link rather than Add/Install the react-native-windows package. This option is for the development workflow of the developers working on react-native-windows.',
     hidden: true,
   },
 }).argv;
+
+if (argv.verbose) {
+  console.log(argv);
+}
 
 const EXITCODE_UNSUPPORTED_VERION_RN = 3;
 const EXITCODE_USER_CANCEL = 4;

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -6,7 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
+#if !USE_WINUI3
 using Windows.UI.Xaml;
+#else
+using Microsoft.UI.Xaml;
+#endif
 
 namespace Microsoft.ReactNative.Managed.UnitTests
 {

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/UnitTestApp.xaml.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/UnitTestApp.xaml.cs
@@ -3,10 +3,16 @@
 
 using System;
 using Windows.ApplicationModel;
+#if !USE_WINUI3
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+#else
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+#endif
 
 namespace Microsoft.ReactNative.Managed.UnitTests
 {
@@ -30,11 +36,17 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     /// will be used such as when the application is launched to open a specific file.
     /// </summary>
     /// <param name="e">Details about the launch request and process.</param>
-    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    protected override void OnLaunched(LaunchActivatedEventArgs e_)
     {
+      Windows.ApplicationModel.Activation.LaunchActivatedEventArgs e =
+#if USE_WINUI3
+        e_.UWPLaunchActivatedEventArgs;
+#else
+        e_;
+#endif
 
 #if DEBUG
-      if (System.Diagnostics.Debugger.IsAttached)
+      if (global::System.Diagnostics.Debugger.IsAttached)
       {
         this.DebugSettings.EnableFrameRateCounter = true;
       }
@@ -51,7 +63,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
         rootFrame.NavigationFailed += OnNavigationFailed;
 
-        if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
+        if (e.PreviousExecutionState == Windows.ApplicationModel.Activation.ApplicationExecutionState.Terminated)
         {
           //TODO: Load state from previously suspended application
         }

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -641,7 +641,6 @@
     <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
-    <Import Project="$(SolutionDir)packages\Microsoft.Web.WebView2.0.8.355\build\native\Microsoft.Web.WebView2.targets" Condition="'$(UseWinUI3)'=='true' And Exists('$(SolutionDir)packages\Microsoft.Web.WebView2.0.8.355\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -18,7 +18,6 @@
 
 using namespace winrt;
 using namespace Windows::ApplicationModel;
-using namespace Windows::ApplicationModel::Activation;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 using namespace Windows::UI::Core;
@@ -100,16 +99,24 @@ void ReactApplication::JavaScriptBundleFile(hstring const &value) noexcept {
   InstanceSettings().JavaScriptBundleFile(value);
 }
 
-void ReactApplication::OnActivated(IActivatedEventArgs const &e) {
-  if (e.Kind() == ActivationKind::Protocol) {
-    auto protocolActivatedEventArgs{e.as<ProtocolActivatedEventArgs>()};
+void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
+  if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
+    auto protocolActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
     react::uwp::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
     this->OnCreate(e);
   }
 }
 
-void ReactApplication::OnLaunched(LaunchActivatedEventArgs const &e) {
-  base_type::OnLaunched(e);
+void ReactApplication::OnLaunched(LaunchActivatedEventArgs const &e_) {
+  base_type::OnLaunched(e_);
+  Windows::ApplicationModel::Activation::LaunchActivatedEventArgs e =
+#ifdef USE_WINUI3
+      e_.UWPLaunchActivatedEventArgs();
+#else
+      e_;
+#endif // USE_WINUI3
+      
+
   this->OnCreate(e);
 }
 
@@ -149,7 +156,7 @@ void ApplyArguments(ReactNative::ReactNativeHost const &host, std::wstring const
 /// specific file.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void ReactApplication::OnCreate(IActivatedEventArgs const &e) {
+void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
 #if defined _DEBUG
   if (IsDebuggerPresent()) {
     this->DebugSettings().EnableFrameRateCounter(TRUE);
@@ -159,12 +166,12 @@ void ReactApplication::OnCreate(IActivatedEventArgs const &e) {
 #endif
 
   bool isPrelaunchActivated = false;
-  if (auto prelauchActivatedArgs = e.try_as<IPrelaunchActivatedEventArgs>()) {
+  if (auto prelauchActivatedArgs = e.try_as<Windows::ApplicationModel::Activation::IPrelaunchActivatedEventArgs>()) {
     isPrelaunchActivated = prelauchActivatedArgs.PrelaunchActivated();
   }
 
   hstring args;
-  if (auto lauchActivatedArgs = e.try_as<ILaunchActivatedEventArgs>()) {
+  if (auto lauchActivatedArgs = e.try_as<activation::ILaunchActivatedEventArgs>()) {
     args = lauchActivatedArgs.Arguments();
   }
 
@@ -183,7 +190,7 @@ void ReactApplication::OnCreate(IActivatedEventArgs const &e) {
 
     rootFrame.NavigationFailed({this, &ReactApplication::OnNavigationFailed});
 
-    if (e.PreviousExecutionState() == ApplicationExecutionState::Terminated) {
+    if (e.PreviousExecutionState() == Windows::ApplicationModel::Activation::ApplicationExecutionState::Terminated) {
       // Restore the saved session state only when appropriate, scheduling the
       // final launch steps after the restore is complete
     }

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -107,7 +107,7 @@ void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActiv
   }
 }
 
-void ReactApplication::OnLaunched(LaunchActivatedEventArgs const &e_) {
+void ReactApplication::OnLaunched(activation::LaunchActivatedEventArgs const &e_) {
   base_type::OnLaunched(e_);
   Windows::ApplicationModel::Activation::LaunchActivatedEventArgs e =
 #ifdef USE_WINUI3

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -115,7 +115,6 @@ void ReactApplication::OnLaunched(LaunchActivatedEventArgs const &e_) {
 #else
       e_;
 #endif // USE_WINUI3
-      
 
   this->OnCreate(e);
 }

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -7,7 +7,6 @@
 #include <CppWinRTIncludes.h>
 #include "ReactNativeHost.h"
 
-
 #ifdef USE_WINUI3
 namespace activation = xaml;
 #else
@@ -26,28 +25,32 @@ namespace winrt::Microsoft::ReactNative::implementation {
 // It must be updated if the shape of generated ReactApplication_base is changed in future.
 // The only difference is that this class has no default constructor.
 template <typename D, typename... I>
-struct __declspec(empty_bases) NoDefaultCtorReactApplication_base
-    : implements<
-          D,
-          Microsoft::ReactNative::ReactApplication,
-          composable,
-          composing,
-          xaml::IApplicationOverrides,
+struct __declspec(empty_bases) NoDefaultCtorReactApplication_base : implements<
+                                                                        D,
+                                                                        Microsoft::ReactNative::ReactApplication,
+                                                                        composable,
+                                                                        composing,
+                                                                        xaml::IApplicationOverrides,
 #ifndef USE_WINUI3
-  xaml::IApplicationOverrides2,
+                                                                        xaml::IApplicationOverrides2,
 #endif
-          I...>,
-      impl::require<D, xaml::IApplication
-  #ifndef USE_WINUI3
-  , xaml::IApplication2, xaml::IApplication3
-  #endif
-      >,
-      impl::base<D, xaml::Application>,
-      xaml::IApplicationOverridesT<D>
+                                                                        I...>,
+                                                                    impl::require<
+                                                                        D,
+                                                                        xaml::IApplication
 #ifndef USE_WINUI3
-      , xaml::IApplicationOverrides2T<D>
+                                                                        ,
+                                                                        xaml::IApplication2,
+                                                                        xaml::IApplication3
 #endif
-  {
+                                                                        >,
+                                                                    impl::base<D, xaml::Application>,
+                                                                    xaml::IApplicationOverridesT<D>
+#ifndef USE_WINUI3
+    ,
+                                                                    xaml::IApplicationOverrides2T<D>
+#endif
+{
   using base_type = NoDefaultCtorReactApplication_base;
   using class_type = Microsoft::ReactNative::ReactApplication;
   using implements_type = typename NoDefaultCtorReactApplication_base::implements_type;
@@ -59,11 +62,14 @@ struct __declspec(empty_bases) NoDefaultCtorReactApplication_base
   }
 
  protected:
-  using dispatch = impl::dispatch_to_overridable<D, xaml::IApplicationOverrides
+  using dispatch = impl::dispatch_to_overridable<
+      D,
+      xaml::IApplicationOverrides
 #ifndef USE_WINUI3
-    , xaml::IApplicationOverrides2
+      ,
+      xaml::IApplicationOverrides2
 #endif
-  >;
+      >;
   auto overridable() noexcept {
     return dispatch::overridable(static_cast<D &>(*this));
   }

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -24,31 +24,27 @@ namespace winrt::Microsoft::ReactNative::implementation {
 // This class must match the generated ReactApplication_base.
 // It must be updated if the shape of generated ReactApplication_base is changed in future.
 // The only difference is that this class has no default constructor.
+
 template <typename D, typename... I>
-struct __declspec(empty_bases) NoDefaultCtorReactApplication_base : implements<
-                                                                        D,
-                                                                        Microsoft::ReactNative::ReactApplication,
-                                                                        composable,
-                                                                        composing,
-                                                                        xaml::IApplicationOverrides,
+struct __declspec(empty_bases) NoDefaultCtorReactApplication_base :
 #ifndef USE_WINUI3
-                                                                        xaml::IApplicationOverrides2,
-#endif
-                                                                        I...>,
-                                                                    impl::require<
-                                                                        D,
-                                                                        xaml::IApplication
-#ifndef USE_WINUI3
-                                                                        ,
-                                                                        xaml::IApplication2,
-                                                                        xaml::IApplication3
-#endif
-                                                                        >,
-                                                                    impl::base<D, xaml::Application>,
-                                                                    xaml::IApplicationOverridesT<D>
-#ifndef USE_WINUI3
-    ,
-                                                                    xaml::IApplicationOverrides2T<D>
+    implements<
+        D,
+        Microsoft::ReactNative::ReactApplication,
+        composable,
+        composing,
+        xaml::IApplicationOverrides,
+        xaml::IApplicationOverrides2,
+        I...>,
+    impl::require<D, xaml::IApplication, xaml::IApplication2, xaml::IApplication3>,
+    impl::base<D, xaml::Application>,
+    xaml::IApplicationOverridesT<D>,
+    xaml::IApplicationOverrides2T<D>
+#else
+    implements<D, Microsoft::ReactNative::ReactApplication, composable, composing, xaml::IApplicationOverrides, I...>,
+    impl::require<D, xaml::IApplication>,
+    impl::base<D, xaml::Application>,
+    xaml::IApplicationOverridesT<D>
 #endif
 {
   using base_type = NoDefaultCtorReactApplication_base;

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -7,6 +7,13 @@
 #include <CppWinRTIncludes.h>
 #include "ReactNativeHost.h"
 
+
+#ifdef USE_WINUI3
+namespace activation = xaml;
+#else
+namespace activation = winrt::Windows::ApplicationModel::Activation;
+#endif
+
 namespace winrt::Microsoft::ReactNative::implementation {
 
 // NoDefaultCtorReactApplication_base is a copy of the generated ReactApplication_base
@@ -26,12 +33,21 @@ struct __declspec(empty_bases) NoDefaultCtorReactApplication_base
           composable,
           composing,
           xaml::IApplicationOverrides,
-          xaml::IApplicationOverrides2,
+#ifndef USE_WINUI3
+  xaml::IApplicationOverrides2,
+#endif
           I...>,
-      impl::require<D, xaml::IApplication, xaml::IApplication2, xaml::IApplication3>,
+      impl::require<D, xaml::IApplication
+  #ifndef USE_WINUI3
+  , xaml::IApplication2, xaml::IApplication3
+  #endif
+      >,
       impl::base<D, xaml::Application>,
-      xaml::IApplicationOverridesT<D>,
-      xaml::IApplicationOverrides2T<D> {
+      xaml::IApplicationOverridesT<D>
+#ifndef USE_WINUI3
+      , xaml::IApplicationOverrides2T<D>
+#endif
+  {
   using base_type = NoDefaultCtorReactApplication_base;
   using class_type = Microsoft::ReactNative::ReactApplication;
   using implements_type = typename NoDefaultCtorReactApplication_base::implements_type;
@@ -43,7 +59,11 @@ struct __declspec(empty_bases) NoDefaultCtorReactApplication_base
   }
 
  protected:
-  using dispatch = impl::dispatch_to_overridable<D, xaml::IApplicationOverrides, xaml::IApplicationOverrides2>;
+  using dispatch = impl::dispatch_to_overridable<D, xaml::IApplicationOverrides
+#ifndef USE_WINUI3
+    , xaml::IApplicationOverrides2
+#endif
+  >;
   auto overridable() noexcept {
     return dispatch::overridable(static_cast<D &>(*this));
   }
@@ -72,7 +92,7 @@ struct ReactApplication : NoDefaultCtorReactApplication_base<ReactApplication> {
 
  public:
   void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
-  void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &e);
+  void OnLaunched(activation::LaunchActivatedEventArgs const &e);
   void OnSuspending(IInspectable const &, Windows::ApplicationModel::SuspendingEventArgs const &);
   void OnNavigationFailed(IInspectable const &, xaml::Navigation::NavigationFailedEventArgs const &);
 

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-  <package id="Microsoft.WinUI" version="3.0.0-alpha.200210.0" targetFramework="native"/>
-  <package id="Microsoft.Web.WebView2" version="0.8.355" targetFramework="native"/>
+  <package id="Microsoft.WinUI" version="3.0.0-preview1.200515.3" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
 </packages>

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -5,9 +5,12 @@
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI3 versioning">
+    <!-- This value is also used by the CLI, see \vnext\local-cli\generator-windows\index.js -->
+    <WinUI3Version>3.0.0-preview1.200515.3</WinUI3Version>
+
     <WinUIPackageName Condition="'$(UseWinUI3)'=='true'">Microsoft.WinUI</WinUIPackageName>
-    <WinUIPackageVersion Condition="'$(UseWinUI3)'=='true'">3.0.0-preview1.200515.3</WinUIPackageVersion>
-    <WinUIPackageProps  Condition="'$(UseWinUI3)'=='true'">$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).props</WinUIPackageProps>
+    <WinUIPackageVersion Condition="'$(UseWinUI3)'=='true'">$(WinUI3Version)</WinUIPackageVersion>
+    <WinUIPackageProps Condition="'$(UseWinUI3)'=='true'">$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).props</WinUIPackageProps>
 
     <WinUIPackageName Condition="'$(UseWinUI3)'!='true'">Microsoft.UI.Xaml</WinUIPackageName>
     <WinUIPackageVersion Condition="'$(UseWinUI3)'!='true'">2.3.191129002</WinUIPackageVersion>
@@ -29,7 +32,7 @@
     </Midl>
   </ItemDefinitionGroup>
 
-  <Target Name="PrintWinUIConfig" BeforeTargets="Midl;Build">
+  <Target Name="PrintWinUIConfig" BeforeTargets="Midl;Build;ResolveSDKReferences">
     <Message Text="UseWinUI3 = $(UseWinUI3)" />
     <Message Text="WinUIPackage = $(WinUIPackageName).$(WinUIPackageVersion)" />
   </Target>

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -6,7 +6,7 @@
 
   <PropertyGroup Label="WinUI3 versioning">
     <WinUIPackageName Condition="'$(UseWinUI3)'=='true'">Microsoft.WinUI</WinUIPackageName>
-    <WinUIPackageVersion Condition="'$(UseWinUI3)'=='true'">3.0.0-alpha.200210.0</WinUIPackageVersion>
+    <WinUIPackageVersion Condition="'$(UseWinUI3)'=='true'">3.0.0-preview1.200515.3</WinUIPackageVersion>
     <WinUIPackageProps  Condition="'$(UseWinUI3)'=='true'">$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).props</WinUIPackageProps>
 
     <WinUIPackageName Condition="'$(UseWinUI3)'!='true'">Microsoft.UI.Xaml</WinUIPackageName>

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -10,6 +10,13 @@
 
 #include <Utils/PropertyUtils.h>
 
+
+#ifdef USE_WINUI3
+#define TAB_INDEX_PROPERTY xaml::UIElement::TabIndexProperty
+#else
+#define TAB_INDEX_PROPERTY xaml::Controls::Control::TabIndexProperty
+#endif
+
 namespace react {
 namespace uwp {
 
@@ -32,7 +39,8 @@ void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlV
   TransferProperty(oldView, newView, xaml::Controls::Control::BorderThicknessProperty());
   TransferProperty(oldView, newView, xaml::Controls::Control::PaddingProperty());
   TransferProperty(oldView, newView, xaml::Controls::Control::ForegroundProperty());
-  TransferProperty(oldView, newView, xaml::Controls::Control::TabIndexProperty());
+  TransferProperty(oldView, newView, TAB_INDEX_PROPERTY());
+
   // Control.CornerRadius is only supported on >= RS5
   if (oldView.try_as<xaml::Controls::Control>() && newView.try_as<xaml::Controls::Control>()) {
     TransferProperty(oldView, newView, xaml::Controls::Control::CornerRadiusProperty());
@@ -60,11 +68,11 @@ bool ControlViewManager::UpdateProperty(
     } else if (propertyName == "tabIndex") {
       if (propertyValue.isNumber()) {
         auto tabIndex = propertyValue.asDouble();
-        if (tabIndex == static_cast<int32_t>(tabIndex))
-          control.ClearValue(xaml::Controls::Control::TabIndexProperty());
+        if (tabIndex == static_cast<int32_t>(tabIndex)) 
+          control.ClearValue(TAB_INDEX_PROPERTY());
         control.TabIndex(static_cast<int32_t>(tabIndex));
       } else if (propertyValue.isNull()) {
-        control.ClearValue(xaml::Controls::Control::TabIndexProperty());
+        control.ClearValue(TAB_INDEX_PROPERTY());
       }
     } else {
       ret = Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/ReactUWP/Views/ControlViewManager.cpp
+++ b/vnext/ReactUWP/Views/ControlViewManager.cpp
@@ -10,7 +10,6 @@
 
 #include <Utils/PropertyUtils.h>
 
-
 #ifdef USE_WINUI3
 #define TAB_INDEX_PROPERTY xaml::UIElement::TabIndexProperty
 #else
@@ -68,7 +67,7 @@ bool ControlViewManager::UpdateProperty(
     } else if (propertyName == "tabIndex") {
       if (propertyValue.isNumber()) {
         auto tabIndex = propertyValue.asDouble();
-        if (tabIndex == static_cast<int32_t>(tabIndex)) 
+        if (tabIndex == static_cast<int32_t>(tabIndex))
           control.ClearValue(TAB_INDEX_PROPERTY());
         control.TabIndex(static_cast<int32_t>(tabIndex));
       } else if (propertyValue.isNull()) {

--- a/vnext/ReactUWP/Views/FlyoutViewManager.cpp
+++ b/vnext/ReactUWP/Views/FlyoutViewManager.cpp
@@ -57,7 +57,7 @@ static const std::unordered_map<std::string, winrt::FlyoutPlacementMode> placeme
 template <>
 struct json_type_traits<winrt::FlyoutPlacementMode> {
   static winrt::FlyoutPlacementMode parseJson(const folly::dynamic &json) {
-    auto placementMode = !!(winrt::Flyout().try_as<winrt::IFlyoutBase5>()) ? placementModeRS5 : placementModeMinVersion;
+    auto placementMode = react::uwp::IsRS5OrHigher() ? placementModeRS5 : placementModeMinVersion;
     auto iter = placementMode.find(json.asString());
 
     if (iter != placementMode.end()) {
@@ -145,7 +145,7 @@ void FlyoutShadowNode::createView() {
   Super::createView();
 
   m_flyout = winrt::Flyout();
-  m_isFlyoutShowOptionsSupported = !!(m_flyout.try_as<winrt::IFlyoutBase5>());
+  m_isFlyoutShowOptionsSupported = IsRS5OrHigher();
 
   if (m_isFlyoutShowOptionsSupported)
     m_showOptions = winrt::FlyoutShowOptions();
@@ -226,10 +226,10 @@ void FlyoutShadowNode::createView() {
       });
 
   // Set XamlRoot on the Flyout to handle XamlIsland/AppWindow scenarios.
-  if (auto flyoutBase6 = m_flyout.try_as<winrt::IFlyoutBase6>()) {
+  if (Is19H1OrHigher()) {
     if (auto instance = wkinstance.lock()) {
       if (auto xamlRoot = static_cast<NativeUIManager *>(instance->NativeUIManager())->tryGetXamlRoot()) {
-        flyoutBase6.XamlRoot(xamlRoot);
+        m_flyout.XamlRoot(xamlRoot);
       }
     }
   }

--- a/vnext/ReactUWP/Views/Image/BorderEffect.h
+++ b/vnext/ReactUWP/Views/Image/BorderEffect.h
@@ -1,12 +1,7 @@
 #pragma once
 
-#ifndef USE_WINUI3
-#include <Microsoft.UI.Composition.Effects.BorderEffect.g.h>
-#define BORDEREFFECT_NAMESPACE winrt::Microsoft::UI::Composition::Effects
-#else
 #define BORDEREFFECT_NAMESPACE winrt::Microsoft::ReactNative
 #include <BorderEffect.g.h>
-#endif
 
 #pragma warning(push)
 #pragma warning(disable : 28285 28196 6387 6319 26812)

--- a/vnext/ReactUWP/Views/Image/BorderEffect.h
+++ b/vnext/ReactUWP/Views/Image/BorderEffect.h
@@ -19,8 +19,16 @@ class BorderEffect
  public:
   DECLARE_D2D_GUID(CLSID_D2D1Border);
   DECLARE_SINGLE_SOURCE(Source);
-  DECLARE_POD_PROPERTY(ExtendX, winrt::Microsoft::ReactNative::CanvasEdgeBehavior, winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Clamp, true);
-  DECLARE_POD_PROPERTY(ExtendY, winrt::Microsoft::ReactNative::CanvasEdgeBehavior, winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Clamp, true);
+  DECLARE_POD_PROPERTY(
+      ExtendX,
+      winrt::Microsoft::ReactNative::CanvasEdgeBehavior,
+      winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Clamp,
+      true);
+  DECLARE_POD_PROPERTY(
+      ExtendY,
+      winrt::Microsoft::ReactNative::CanvasEdgeBehavior,
+      winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Clamp,
+      true);
   DECLARE_NAMED_PROPERTY_MAPPING(
       {L"ExtendX", D2D1_BORDER_PROP_EDGE_MODE_X, PropertyMapping::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT},
       {L"ExtendY", D2D1_BORDER_PROP_EDGE_MODE_Y, PropertyMapping::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT});

--- a/vnext/ReactUWP/Views/Image/BorderEffect.h
+++ b/vnext/ReactUWP/Views/Image/BorderEffect.h
@@ -19,8 +19,8 @@ class BorderEffect
  public:
   DECLARE_D2D_GUID(CLSID_D2D1Border);
   DECLARE_SINGLE_SOURCE(Source);
-  DECLARE_POD_PROPERTY(ExtendX, winrt::CanvasEdgeBehavior, winrt::CanvasEdgeBehavior::Clamp, true);
-  DECLARE_POD_PROPERTY(ExtendY, winrt::CanvasEdgeBehavior, winrt::CanvasEdgeBehavior::Clamp, true);
+  DECLARE_POD_PROPERTY(ExtendX, winrt::Microsoft::ReactNative::CanvasEdgeBehavior, winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Clamp, true);
+  DECLARE_POD_PROPERTY(ExtendY, winrt::Microsoft::ReactNative::CanvasEdgeBehavior, winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Clamp, true);
   DECLARE_NAMED_PROPERTY_MAPPING(
       {L"ExtendX", D2D1_BORDER_PROP_EDGE_MODE_X, PropertyMapping::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT},
       {L"ExtendY", D2D1_BORDER_PROP_EDGE_MODE_Y, PropertyMapping::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT});

--- a/vnext/ReactUWP/Views/Image/Microsoft.UI.Composition.Effects_Impl.h
+++ b/vnext/ReactUWP/Views/Image/Microsoft.UI.Composition.Effects_Impl.h
@@ -22,7 +22,6 @@ using namespace ABI::Windows::Graphics::Effects;
 } // namespace abi
 
 namespace winrt {
-using namespace winrt::Microsoft::UI::Composition::Effects;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Graphics::Effects;
 using namespace winrt::Windows::UI;

--- a/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
+++ b/vnext/ReactUWP/Views/Image/ReactImageBrush.cpp
@@ -156,8 +156,8 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
   if (!m_effectBrush) {
     auto borderEffect{winrt::make<BORDEREFFECT_NAMESPACE::implementation::BorderEffect>()};
 
-    borderEffect.ExtendX(winrt::CanvasEdgeBehavior::Wrap);
-    borderEffect.ExtendY(winrt::CanvasEdgeBehavior::Wrap);
+    borderEffect.ExtendX(winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Wrap);
+    borderEffect.ExtendY(winrt::Microsoft::ReactNative::CanvasEdgeBehavior::Wrap);
 
     comp::CompositionEffectSourceParameter borderEffectSourceParameter{L"source"};
     borderEffect.Source(borderEffectSourceParameter);

--- a/vnext/ReactUWP/Views/SIPEventHandler.cpp
+++ b/vnext/ReactUWP/Views/SIPEventHandler.cpp
@@ -54,7 +54,7 @@ void SIPEventHandler::InitializeCoreInputView() {
       m_coreInputView = winrt::CoreInputView::GetForUIContext(uiElement.UIContext());
     } else
 #endif
-      /// TODO: Figure out how to use SIP in WinUI 3 and island
+    /// TODO: Figure out how to use SIP in WinUI 3 and island
     {
       m_coreInputView = winrt::CoreInputView::GetForCurrentView();
     }

--- a/vnext/ReactUWP/Views/SIPEventHandler.cpp
+++ b/vnext/ReactUWP/Views/SIPEventHandler.cpp
@@ -47,11 +47,15 @@ void SIPEventHandler::InitializeCoreInputView() {
       return; // CoreInputView is only supported on >= RS3.
     }
 
+#ifndef USE_WINUI3
     if (Is19H1OrHigher()) {
       // 19H1 and higher supports island scenarios
       auto uiElement(xamlView.as<xaml::UIElement>());
       m_coreInputView = winrt::CoreInputView::GetForUIContext(uiElement.UIContext());
-    } else {
+    } else
+#endif
+      /// TODO: Figure out how to use SIP in WinUI 3 and island
+    {
       m_coreInputView = winrt::CoreInputView::GetForCurrentView();
     }
 

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -16,10 +16,17 @@
 
 #include <IReactInstance.h>
 
+#ifdef USE_WINUI3
+  namespace winrt { namespace Microsoft { namespace UI { namespace Xaml { namespace Controls {
+    using IPasswordBox4 = ::xaml::Controls::IPasswordBox;
+    using ITextBox6 = ::xaml::Controls::ITextBox;
+  }}}}};
+#endif
+
 namespace winrt {
-using namespace xaml;
-using namespace xaml::Shapes;
-using namespace xaml::Media;
+  using namespace xaml;
+  using namespace xaml::Media;
+  using namespace xaml::Shapes;
 } // namespace winrt
 
 namespace react {
@@ -159,6 +166,7 @@ void TextInputShadowNode::dispatchTextInputChangeEvent(winrt::hstring newText) {
   }
 }
 
+
 void TextInputShadowNode::registerEvents() {
   auto control = GetView().as<xaml::Controls::Control>();
   auto wkinstance = GetViewManager()->GetReactInstance();
@@ -182,6 +190,8 @@ void TextInputShadowNode::registerEvents() {
         winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
   } else {
     m_textBoxTextChangingRevoker = {};
+
+
     if (control.try_as<xaml::Controls::IPasswordBox4>()) {
       m_passwordBoxPasswordChangingRevoker = control.as<xaml::Controls::IPasswordBox4>().PasswordChanging(
           winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -17,18 +17,10 @@
 #include <IReactInstance.h>
 
 #ifdef USE_WINUI3
-namespace winrt {
-namespace Microsoft {
-namespace UI {
-namespace Xaml {
-namespace Controls {
+namespace winrt::Microsoft::UI::Xaml::Controls {
 using IPasswordBox4 = ::xaml::Controls::IPasswordBox;
 using ITextBox6 = ::xaml::Controls::ITextBox;
-} // namespace Controls
-} // namespace Xaml
-} // namespace UI
-} // namespace Microsoft
-}; // namespace winrt
+}; // namespace winrt::Microsoft::UI::Xaml::Controls
 #endif
 
 namespace winrt {

--- a/vnext/ReactUWP/Views/TextInputViewManager.cpp
+++ b/vnext/ReactUWP/Views/TextInputViewManager.cpp
@@ -17,16 +17,24 @@
 #include <IReactInstance.h>
 
 #ifdef USE_WINUI3
-  namespace winrt { namespace Microsoft { namespace UI { namespace Xaml { namespace Controls {
-    using IPasswordBox4 = ::xaml::Controls::IPasswordBox;
-    using ITextBox6 = ::xaml::Controls::ITextBox;
-  }}}}};
+namespace winrt {
+namespace Microsoft {
+namespace UI {
+namespace Xaml {
+namespace Controls {
+using IPasswordBox4 = ::xaml::Controls::IPasswordBox;
+using ITextBox6 = ::xaml::Controls::ITextBox;
+} // namespace Controls
+} // namespace Xaml
+} // namespace UI
+} // namespace Microsoft
+}; // namespace winrt
 #endif
 
 namespace winrt {
-  using namespace xaml;
-  using namespace xaml::Media;
-  using namespace xaml::Shapes;
+using namespace xaml;
+using namespace xaml::Media;
+using namespace xaml::Shapes;
 } // namespace winrt
 
 namespace react {
@@ -166,7 +174,6 @@ void TextInputShadowNode::dispatchTextInputChangeEvent(winrt::hstring newText) {
   }
 }
 
-
 void TextInputShadowNode::registerEvents() {
   auto control = GetView().as<xaml::Controls::Control>();
   auto wkinstance = GetViewManager()->GetReactInstance();
@@ -190,7 +197,6 @@ void TextInputShadowNode::registerEvents() {
         winrt::auto_revoke, [=](auto &&, auto &&) { m_nativeEventCount++; });
   } else {
     m_textBoxTextChangingRevoker = {};
-
 
     if (control.try_as<xaml::Controls::IPasswordBox4>()) {
       m_passwordBoxPasswordChangingRevoker = control.as<xaml::Controls::IPasswordBox4>().PasswordChanging(

--- a/vnext/ReactUWP/Views/cppwinrt/BorderEffect.idl
+++ b/vnext/ReactUWP/Views/cppwinrt/BorderEffect.idl
@@ -7,13 +7,8 @@
 // to generate new headers
 #include "NamespaceRedirect.h"
 
-#ifndef USE_WINUI3
-namespace Microsoft.UI.Composition.Effects
-#else
 namespace Microsoft.ReactNative
-#endif
 {
-#ifndef USE_WINUI3
     [version(1)]
     typedef enum CanvasEdgeBehavior
     {
@@ -21,23 +16,19 @@ namespace Microsoft.ReactNative
         Wrap = (int)1,
         Mirror = (int)2
     } CanvasEdgeBehavior;
-#endif
 
     runtimeclass BorderEffect;
 
+
     [version(1)]
-#ifndef USE_WINUI3
     [uuid(31602441-15db-5b4a-98dd-ba4247548b40), exclusiveto(BorderEffect)]
-#else
-    [uuid(d21ed48b-9d10-40d1-a6f6-e6bfca14a050), exclusiveto(BorderEffect)]
-#endif
     interface IBorderEffect : IInspectable
     {
-        [propget] HRESULT ExtendX([out, retval] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior* value);
-        [propput] HRESULT ExtendX([in] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior value);
+        [propget] HRESULT ExtendX([out, retval] Microsoft.ReactNative.CanvasEdgeBehavior* value);
+        [propput] HRESULT ExtendX([in] Microsoft.ReactNative.CanvasEdgeBehavior value);
 
-        [propget] HRESULT ExtendY([out, retval] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior* value);
-        [propput] HRESULT ExtendY([in] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior value);
+        [propget] HRESULT ExtendY([out, retval] Microsoft.ReactNative.CanvasEdgeBehavior* value);
+        [propput] HRESULT ExtendY([in] Microsoft.ReactNative.CanvasEdgeBehavior value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);

--- a/vnext/ReactUWP/packages.config
+++ b/vnext/ReactUWP/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-  <package id="Microsoft.WinUI" version="3.0.0-alpha.200210.0" targetFramework="native"/>
+  <package id="Microsoft.WinUI" version="3.0.0-preview1.200515.3" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
 </packages>

--- a/vnext/local-cli/config/configUtils.js
+++ b/vnext/local-cli/config/configUtils.js
@@ -306,4 +306,5 @@ module.exports = {
   getProjectName: getProjectName,
   getProjectNamespace: getProjectNamespace,
   getProjectGuid: getProjectGuid,
+  findPropertyValue: findPropertyValue,
 };

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -8,6 +8,11 @@ const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const {
+  readProjectFile,
+  findPropertyValue,
+} = require('../config/configUtils');
+
+const {
   createDir,
   copyAndReplaceAll,
   copyAndReplaceWithChangedCallback,
@@ -89,6 +94,10 @@ function copyProjectTemplateAndReplace(
   const xamlNamespace = options.useWinUI3 ? 'Microsoft.UI.Xaml' : 'Windows.UI.Xaml';
   const xamlNamespaceCpp = toCppNamespace(xamlNamespace);
 
+  const winui3PropsPath = require.resolve('react-native-windows/PropertySheets/WinUI.props', {paths: [process.cwd()]});
+  const winui3Props = readProjectFile(winui3PropsPath);
+  const winui3Version = findPropertyValue(winui3Props, 'WinUI3Version');
+
   const cppNugetPackages = [
     {
       id: 'Microsoft.Windows.CppWinRT',
@@ -99,7 +108,7 @@ function copyProjectTemplateAndReplace(
     },
     {
       id: options.useWinUI3 ? 'Microsoft.WinUI' : 'Microsoft.UI.Xaml',
-      version: options.useWinUI3 ? '3.0.0-alpha.200210.0' : '2.3.191129002',
+      version: options.useWinUI3 ? winui3Version : '2.3.191129002',
       hasProps: false, // WinUI/MUX props and targets get handled by RNW's WinUI.props.
       hasTargets: false,
     },

--- a/vnext/local-cli/generator-windows/templates/cpp/proj/MyApp.vcxproj
+++ b/vnext/local-cli/generator-windows/templates/cpp/proj/MyApp.vcxproj
@@ -94,7 +94,7 @@
   </ImportGroup>
   <ImportGroup Label="ReactNativeWindowsPropertySheets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props')" />
-    <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!=''" />
+    <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('..\packages\$(WinUIPackageProps)')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
@@ -13,7 +13,6 @@ using namespace {{ xamlNamespaceCpp }};
 using namespace {{ xamlNamespaceCpp }}::Controls;
 using namespace {{ xamlNamespaceCpp }}::Navigation;
 using namespace Windows::ApplicationModel;
-using namespace Windows::ApplicationModel::Activation;
 
 /// <summary>
 /// Initializes the singleton application object.  This is the first line of
@@ -50,7 +49,7 @@ App::App() noexcept
 /// will be used such as when the application is launched to open a specific file.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void App::OnLaunched(LaunchActivatedEventArgs const& e)
+void App::OnLaunched(activation::LaunchActivatedEventArgs const& e)
 {
     super::OnLaunched(e);
 

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.h
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.h
@@ -1,14 +1,20 @@
 #pragma once
 
 #include "App.xaml.g.h"
-
 // clang-format off
+{{#useWinUI3}}
+namespace activation = winrt::Microsoft::UI::Xaml;
+{{/useWinUI3}}
+{{^useWinUI3}}
+namespace activation = winrt::Windows::ApplicationModel::Activation;
+{{/useWinUI3}}
+
 namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct App : AppT<App>
     {
         App() noexcept;
-        void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const&);
+        void OnLaunched(activation::LaunchActivatedEventArgs const&);
         void OnSuspending(IInspectable const&, Windows::ApplicationModel::SuspendingEventArgs const&);
         void OnNavigationFailed(IInspectable const&, {{ xamlNamespaceCpp }}::Navigation::NavigationFailedEventArgs const&);
       private:

--- a/vnext/local-cli/generator-windows/templates/cs/src/App.xaml.cs
+++ b/vnext/local-cli/generator-windows/templates/cs/src/App.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.ReactNative;
+{{^useWinUI3}}
 using Windows.ApplicationModel.Activation;
+{{/useWinUI3}}
 using {{ xamlNamespace }};
 using {{ xamlNamespace }}.Controls;
 


### PR DESCRIPTION
- Update WinUI 3 flavor to target Preview 1
- the CI had a bug where we were not passing additionalInitArguments, instead we were passing the string `$[ coalesce($(additionalInitArguments), '') ]$`
- the CLI used to not reject unknown arguments/commands, which wrongly made the previous issue go unnoticed, so I fixed that
- Made the CLI use the WinUI 3 version from WinUI.props



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5309)