### PR TITLE
Fix issue running react-native-windows-init with yarn

### DIFF
--- a/change/react-native-windows-init-2020-06-23-18-14-45-yarninit.json
+++ b/change/react-native-windows-init-2020-06-23-18-14-45-yarninit.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix issue running react-native-windows-init with yarn",
+  "packageName": "react-native-windows-init",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-24T01:14:45.540Z"
+}


### PR DESCRIPTION
Fixes #5296 

`yarn add react-native-windows@^0.62.0-0` seems to fail depending on the exact contents of package.json.  This changes the init script to manually add the dependency to package.json, then run `yarn` instead of using `yarn add`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5323)