### PR TITLE
Fix remote debugging with web debugging in Playground.

### DIFF
--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -54,8 +54,8 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseFastRefresh(x_UseFastRefreshCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerPort(static_cast<uint16_t>(std::stoi(std::wstring(x_DebuggerPort().Text()))));
-  if (!bundlerHostname.empty()) {
-    host.InstanceSettings().DebugHost(bundlerHostname);
+  if (!m_bundlerHostname.empty()) {
+    host.InstanceSettings().DebugHost(m_bundlerHostname);
   }
 
   // Nudge the ReactNativeHost to create the instance and wrapping context
@@ -77,7 +77,7 @@ void winrt::playground::implementation::MainPage::x_entryPointCombo_SelectionCha
 }
 
 void MainPage::OnNavigatedTo(xaml::Navigation::NavigationEventArgs const &e) {
-  bundlerHostname = unbox_value<hstring>(e.Parameter());
+  m_bundlerHostname = unbox_value<hstring>(e.Parameter());
 }
 
 Microsoft::ReactNative::ReactNativeHost MainPage::Host() noexcept {

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -54,6 +54,9 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseFastRefresh(x_UseFastRefreshCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerPort(static_cast<uint16_t>(std::stoi(std::wstring(x_DebuggerPort().Text()))));
+  if (!debugHost.empty()) {
+    host.InstanceSettings().DebugHost(debugHost);
+  }
 
   // Nudge the ReactNativeHost to create the instance and wrapping context
   host.ReloadInstance();
@@ -71,6 +74,10 @@ void winrt::playground::implementation::MainPage::x_entryPointCombo_SelectionCha
       x_rootComponentNameCombo().SelectedIndex(1);
     }
   }
+}
+
+void MainPage::OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs &e) {
+  debugHost = unbox_value<hstring>(e.Parameter());
 }
 
 Microsoft::ReactNative::ReactNativeHost MainPage::Host() noexcept {

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -54,8 +54,8 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseFastRefresh(x_UseFastRefreshCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerPort(static_cast<uint16_t>(std::stoi(std::wstring(x_DebuggerPort().Text()))));
-  if (!debugHost.empty()) {
-    host.InstanceSettings().DebugHost(debugHost);
+  if (!bundlerHostname.empty()) {
+    host.InstanceSettings().DebugHost(bundlerHostname);
   }
 
   // Nudge the ReactNativeHost to create the instance and wrapping context
@@ -76,8 +76,8 @@ void winrt::playground::implementation::MainPage::x_entryPointCombo_SelectionCha
   }
 }
 
-void MainPage::OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs &e) {
-  debugHost = unbox_value<hstring>(e.Parameter());
+void MainPage::OnNavigatedTo(xaml::Navigation::NavigationEventArgs const &e) {
+  bundlerHostname = unbox_value<hstring>(e.Parameter());
 }
 
 Microsoft::ReactNative::ReactNativeHost MainPage::Host() noexcept {

--- a/packages/playground/windows/playground/MainPage.h
+++ b/packages/playground/windows/playground/MainPage.h
@@ -17,11 +17,13 @@ struct MainPage : MainPageT<MainPage> {
   Windows::Foundation::Collections::IVector<Microsoft::ReactNative::IReactPackageProvider> m_packageProviders;
 
   bool m_useWebDebugger{false};
+  winrt::hstring debugHost;
 
  public:
   void x_entryPointCombo_SelectionChanged(
       winrt::Windows::Foundation::IInspectable const &sender,
       xaml::Controls::SelectionChangedEventArgs const &e);
+  void OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs &e);
 };
 
 } // namespace winrt::playground::implementation

--- a/packages/playground/windows/playground/MainPage.h
+++ b/packages/playground/windows/playground/MainPage.h
@@ -17,13 +17,13 @@ struct MainPage : MainPageT<MainPage> {
   Windows::Foundation::Collections::IVector<Microsoft::ReactNative::IReactPackageProvider> m_packageProviders;
 
   bool m_useWebDebugger{false};
-  winrt::hstring debugHost;
+  winrt::hstring bundlerHostname;
 
  public:
   void x_entryPointCombo_SelectionChanged(
       winrt::Windows::Foundation::IInspectable const &sender,
       xaml::Controls::SelectionChangedEventArgs const &e);
-  void OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs &e);
+  void OnNavigatedTo(xaml::Navigation::NavigationEventArgs const &e);
 };
 
 } // namespace winrt::playground::implementation

--- a/packages/playground/windows/playground/MainPage.h
+++ b/packages/playground/windows/playground/MainPage.h
@@ -16,8 +16,7 @@ struct MainPage : MainPageT<MainPage> {
   Microsoft::ReactNative::ReactInstanceSettings m_instanceSettings;
   Windows::Foundation::Collections::IVector<Microsoft::ReactNative::IReactPackageProvider> m_packageProviders;
 
-  bool m_useWebDebugger{false};
-  winrt::hstring bundlerHostname;
+  winrt::hstring m_bundlerHostname;
 
  public:
   void x_entryPointCombo_SelectionChanged(

--- a/packages/playground/windows/playground/Package.appxmanifest
+++ b/packages/playground/windows/playground/Package.appxmanifest
@@ -45,5 +45,6 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer"/>
   </Capabilities>
 </Package>


### PR DESCRIPTION
Fixes #5112.
To remote debug the Playground app follow the steps in the wiki: https://github.com/microsoft/react-native-windows/wiki/VS-Remote-Debugging
Don't forget to open the port on the host machine.
This implementation is based on #3535.
Limitations:
- There is no way to specify only the hostname or only the port, you have to specify both.
- Not sure what I am missing but running `yarn change` gives me the following error so I couldn't update the changelog:
![Annotation 2020-06-23 192843](https://user-images.githubusercontent.com/12337821/85491773-f8a58c00-b588-11ea-9c2f-447850382fa0.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5327)