### PR TITLE
Do weekly rollup of stable branches

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -6,14 +6,14 @@ variables:
   - template: variables/vs2019.yml
 
 schedules:
-- cron: "0 0 * * *"
-  displayName: Nightly publish build
+- cron: "0 5 * * *" # 5AM Daily UTC (10PM Daily PST)
+  displayName: Nightly master publish build
   branches:
     include:
-    - master
+      - master
 
-trigger:
-  batch: true
+- cron: "0 5 * * 1" # 5AM Monday UTC (10PM Sunday PST)
+  displayName: Weekly stable publish build
   branches:
     include:
       - "*-stable"


### PR DESCRIPTION
We have a lot of versions with a single commit. Do a weekly rollup to avoid the current version spam we have.

Using a weekly rollup:
- We would have seen 7 preview releases of 0.62 instead of 17
- We would have seen 9 patch releases of 0.61 instead of 14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5340)