### PR TITLE
Unify storage for sourceBundleHost/Port and debugHost

### DIFF
--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -3,4 +3,4 @@ steps:
   - task: CmdLine@2
     displayName: midgard-yarn (faster yarn install)
     inputs:
-      script: npx midgard-yarn@1.23.5 --network-concurrency 20
+      script: npx midgard-yarn@1.23.5 --network-concurrency 20 --frozen-lockfile

--- a/change/react-native-windows-2020-06-25-13-28-13-sourceBundleSettings.json
+++ b/change/react-native-windows-2020-06-25-13-28-13-sourceBundleSettings.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Unify storage for sourceBundleHost/Port and debugHost",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-25T20:28:13.636Z"
+}

--- a/vnext/IntegrationTests/TestRunner.cpp
+++ b/vnext/IntegrationTests/TestRunner.cpp
@@ -70,7 +70,6 @@ TestResult TestRunner::RunTest(string &&bundlePath, string &&appName, NativeLogg
     // TestRunner implementation.
     shared_ptr<DevSettings> devSettings = make_shared<DevSettings>();
     devSettings->useWebDebugger = false; // WebSocketJSExecutor can't register native log hooks.
-    devSettings->debugHost = "localhost:8081";
     devSettings->liveReloadCallback = []() {}; // Enables ChakraExecutor
     devSettings->errorCallback = [&result](string message) {
       result.Message = Microsoft::Common::Unicode::Utf8ToUtf16(message);

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -108,7 +108,7 @@ struct ReactDevOptions {
   //! {EXTENSION} = ".bundle"
   //! Specify a value for a component, or leave empty to use the default.
   std::string SourceBundleHost; // Host domain (without port) for the bundler server. Default: "localhost".
-  std::string SourceBundlePort; // Host port for the bundler server. Default: "8081".
+  uint16_t SourceBundlePort{0}; // Host port for the bundler server. Default: "8081".
   std::string SourceBundleName; // Bundle name without any extension (e.g. "index.win32"). Default: "index.{PLATFORM}"
   std::string SourceBundleExtension; // Bundle name extension. Default: ".bundle".
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -24,6 +24,7 @@
 #include "NativeModulesProvider.h"
 #include "Unicode.h"
 
+#include <ReactWindowsCore/DevServerHelper.h>
 #include <ReactWindowsCore/ViewManager.h>
 #include <dispatchQueue/dispatchQueue.h>
 #include "DevMenu.h"
@@ -203,7 +204,8 @@ void ReactInstanceWin::Initialize() noexcept {
 
           auto devSettings = std::make_shared<facebook::react::DevSettings>();
           devSettings->useJITCompilation = m_options.EnableJITCompilation;
-          devSettings->debugHost = GetDebugHost();
+          devSettings->sourceBundleHost = m_options.DeveloperSettings.SourceBundleHost;
+          devSettings->sourceBundlePort = m_options.DeveloperSettings.SourceBundlePort;
           devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName;
           devSettings->liveReloadCallback = GetLiveReloadCallback();
           devSettings->errorCallback = GetErrorCallback();
@@ -363,8 +365,11 @@ void ReactInstanceWin::Initialize() noexcept {
                   STRING(RN_PLATFORM),
                   m_options.DeveloperSettings.SourceBundleName.empty() ? m_options.Identity
                                                                        : m_options.DeveloperSettings.SourceBundleName,
-                  GetSourceBundleHost(),
-                  GetSourceBundlePort(),
+                  m_options.DeveloperSettings.SourceBundleHost.empty()
+                      ? m_options.DeveloperSettings.SourceBundleHost
+                      : facebook::react::DevServerHelper::DefaultPackagerHost,
+                  m_options.DeveloperSettings.SourceBundlePort ? m_options.DeveloperSettings.SourceBundlePort
+                                                               : facebook::react::DevServerHelper::DefaultPackagerPort,
                   m_isFastReloadEnabled);
               m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
             }
@@ -617,29 +622,6 @@ std::function<void()> ReactInstanceWin::GetLiveReloadCallback() noexcept {
     return Mso::MakeWeakMemberStdFunction(this, &ReactInstanceWin::OnLiveReload);
   }
   return std::function<void()>{};
-}
-
-std::string ReactInstanceWin::GetSourceBundleHost() noexcept {
-  const ReactDevOptions &devOptions = m_options.DeveloperSettings;
-  return !devOptions.SourceBundleHost.empty() ? devOptions.SourceBundleHost : "localhost";
-}
-
-std::string ReactInstanceWin::GetSourceBundlePort() noexcept {
-  const ReactDevOptions &devOptions = m_options.DeveloperSettings;
-  return !devOptions.SourceBundlePort.empty() ? devOptions.SourceBundlePort : "8081";
-}
-
-std::string ReactInstanceWin::GetDebugHost() noexcept {
-  std::string debugHost;
-  const ReactDevOptions &devOptions = m_options.DeveloperSettings;
-  if (!devOptions.DebugHost.empty()) {
-    debugHost = devOptions.DebugHost;
-  } else {
-    debugHost = GetSourceBundleHost();
-    debugHost.append(":");
-    debugHost.append(GetSourceBundlePort());
-  }
-  return debugHost;
 }
 
 std::string ReactInstanceWin::GetBytecodeFileName() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -104,9 +104,6 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
   void InitUIMessageThread() noexcept;
   void InitUIManager() noexcept;
   std::string GetBytecodeFileName() noexcept;
-  std::string GetDebugHost() noexcept;
-  std::string GetSourceBundleHost() noexcept;
-  std::string GetSourceBundlePort() noexcept;
   std::function<void()> GetLiveReloadCallback() noexcept;
   std::function<void(std::string)> GetErrorCallback() noexcept;
   facebook::react::NativeLoggingHook GetLoggingCallback() noexcept;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
@@ -80,4 +80,21 @@ void ReactInstanceSettings::EnableDeveloperMenu(bool value) noexcept {
   UseDeveloperSupport(value);
 }
 
+hstring ReactInstanceSettings::DebugHost() noexcept {
+  std::wstring dhost(SourceBundleHost());
+  dhost.append(L":");
+  dhost.append(std::to_wstring(SourceBundlePort()));
+  return hstring(dhost);
+}
+
+void ReactInstanceSettings::DebugHost(hstring const &value) noexcept {
+  std::wstring dhost(value);
+  auto colonPos = dhost.find(L':');
+  if (colonPos != std::wstring::npos) {
+    SourceBundleHost(hstring(dhost.substr(0, colonPos)));
+    dhost.erase(0, colonPos + 1);
+    SourceBundlePort(static_cast<uint16_t>(std::stoi(dhost)));
+  }
+}
+
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -107,7 +107,6 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   bool m_enableJITCompilation{true};
   bool m_enableByteCodeCaching{false};
   hstring m_byteCodeFileUri{};
-  hstring m_debugHost{};
   hstring m_debugBundlePath{};
   hstring m_bundleRootPath{};
   uint16_t m_debuggerPort{9229};

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -191,14 +191,6 @@ inline void ReactInstanceSettings::ByteCodeFileUri(hstring const &value) noexcep
   m_byteCodeFileUri = value;
 }
 
-inline hstring ReactInstanceSettings::DebugHost() noexcept {
-  return m_debugHost;
-}
-
-inline void ReactInstanceSettings::DebugHost(hstring const &value) noexcept {
-  m_debugHost = value;
-}
-
 inline hstring ReactInstanceSettings::DebugBundlePath() noexcept {
   return m_debugBundlePath;
 }

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -115,8 +115,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
     reactOptions.RedBoxHandler = Mso::React::CreateRedBoxHandler(m_instanceSettings.RedBoxHandler());
   }
   reactOptions.DeveloperSettings.SourceBundleHost = to_string(m_instanceSettings.SourceBundleHost());
-  reactOptions.DeveloperSettings.SourceBundlePort =
-      m_instanceSettings.SourceBundlePort() != 0 ? std::to_string(m_instanceSettings.SourceBundlePort()) : "";
+  reactOptions.DeveloperSettings.SourceBundlePort = m_instanceSettings.SourceBundlePort();
 
   reactOptions.ByteCodeFileUri = to_string(m_instanceSettings.ByteCodeFileUri());
   reactOptions.EnableByteCodeCaching = m_instanceSettings.EnableByteCodeCaching();

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -5,6 +5,7 @@
 #include <boost/algorithm/string.hpp>
 #include <functional/functor.h>
 #include <regex>
+#include "DevServerHelper.h"
 #include "Unicode.h"
 
 #include <winrt/Windows.Foundation.Collections.h>
@@ -333,13 +334,9 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
                               IInspectable const & /*sender*/, xaml::Input::TappedRoutedEventArgs const & /*e*/) {
         if (auto reactHost = weakReactHost.GetStrongPtr()) {
           auto devSettings = reactHost->Options().DeveloperSettings;
-          std::string stackFrameUri = "http://";
-          stackFrameUri.append(devSettings.SourceBundleHost.empty() ? "localhost" : devSettings.SourceBundleHost);
-          stackFrameUri.append(":");
-          stackFrameUri.append(devSettings.SourceBundlePort.empty() ? "8081" : devSettings.SourceBundlePort);
-          stackFrameUri.append("/open-stack-frame");
-
-          Uri uri{Microsoft::Common::Unicode::Utf8ToUtf16(stackFrameUri)};
+          Uri uri{
+              Microsoft::Common::Unicode::Utf8ToUtf16(facebook::react::DevServerHelper::get_PackagerOpenStackFrameUrl(
+                  devSettings.SourceBundleHost, devSettings.SourceBundlePort))};
           winrt::Windows::Web::Http::HttpClient httpClient{};
           winrt::Windows::Data::Json::JsonObject payload{};
 

--- a/vnext/ReactWindowsCore/DevServerHelper.h
+++ b/vnext/ReactWindowsCore/DevServerHelper.h
@@ -15,45 +15,68 @@ class DevServerHelper {
  public:
   DevServerHelper() = default;
 
-  static std::string get_WebsocketProxyUrl(const std::string &debugHost) {
-    return string_format(WebsocketProxyUrlFormat, GetDeviceLocalHost(debugHost).c_str());
+  static std::string get_WebsocketProxyUrl(const std::string &sourceBundleHost, const uint16_t sourceBundlePort) {
+    return string_format(WebsocketProxyUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
   }
 
-  static std::string get_LaunchDevToolsCommandUrl(const std::string &debugHost) {
-    return string_format(LaunchDevToolsCommandUrlFormat, GetDeviceLocalHost(debugHost).c_str());
+  static std::string get_LaunchDevToolsCommandUrl(
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort) {
+    return string_format(
+        LaunchDevToolsCommandUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
   }
 
   static std::string get_BundleUrl(
-      const std::string &debugHost,
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort,
       const std::string &jsbundle,
       const std::string &platform,
       const std::string &dev,
       const std::string &hot) {
     return string_format(
         BundleUrlFormat,
-        GetDeviceLocalHost(debugHost).c_str(),
+        GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str(),
         jsbundle.c_str(),
         platform.c_str(),
         dev.c_str(),
         hot.c_str());
   }
 
-  static std::string get_OnChangeEndpointUrl(const std::string &debugHost) {
-    return string_format(OnChangeEndpointUrlFormat, GetDeviceLocalHost(debugHost).c_str());
+  static std::string get_OnChangeEndpointUrl(const std::string &sourceBundleHost, const uint16_t sourceBundlePort) {
+    return string_format(OnChangeEndpointUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
   }
+
+  static std::string get_PackagerConnectionUrl(const std::string &sourceBundleHost, const uint16_t sourceBundlePort) {
+    return string_format(PackagerConnectionUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
+  }
+
+  static std::string get_PackagerOpenStackFrameUrl(
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort) {
+    return string_format(PackagerConnectionUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
+  }
+
+  static constexpr const char DefaultPackagerHost[] = "localhost";
+  static const uint16_t DefaultPackagerPort = 8081;
 
  private:
-  static std::string GetDeviceLocalHost(const std::string &debugHost) {
-    return debugHost.empty() ? s_DeviceLocalhost : debugHost;
+  static std::string GetDeviceLocalHost(const std::string &sourceBundleHost, const uint16_t sourceBundlePort) {
+    return string_format(
+        DeviceLocalHostFormat,
+        sourceBundleHost.empty() ? DefaultPackagerHost : sourceBundleHost.c_str(),
+        sourceBundlePort ? sourceBundlePort : DefaultPackagerPort);
   }
 
-  static constexpr const char s_DeviceLocalhost[] = "localhost:8081";
+  static constexpr const char DeviceLocalHostFormat[] = "%s:%d";
   static constexpr const char BundleUrlFormat[] = "http://%s/%s.bundle?platform=%s&dev=%s&hot=%s&inlineSourceMap=true";
   static constexpr const char SourceMapUrlFormat[] = "http://%s/%s.map?platform=%s&dev=%s&hot=%s";
   static constexpr const char LaunchDevToolsCommandUrlFormat[] = "http://%s/launch-js-devtools";
   static constexpr const char OnChangeEndpointUrlFormat[] = "http://%s/onchange";
   static constexpr const char WebsocketProxyUrlFormat[] = "ws://%s/debugger-proxy?role=client";
+  static constexpr const char PackagerConnectionUrlFormat[] = "ws://%s/message";
   static constexpr const char PackagerStatusUrlFormat[] = "http://%s/status";
+  static constexpr const char PackagerOpenStackFrameUrlFormat[] = "https://%s/open-stack-frame";
+
   static constexpr const char PackagerOkStatus[] = "packager-status:running";
   const int LongPollFailureDelayMs = 5000;
 

--- a/vnext/ReactWindowsCore/DevServerHelper.h
+++ b/vnext/ReactWindowsCore/DevServerHelper.h
@@ -53,7 +53,8 @@ class DevServerHelper {
   static std::string get_PackagerOpenStackFrameUrl(
       const std::string &sourceBundleHost,
       const uint16_t sourceBundlePort) {
-    return string_format(PackagerConnectionUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
+    return string_format(
+        PackagerOpenStackFrameUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
   }
 
   static constexpr const char DefaultPackagerHost[] = "localhost";

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -44,7 +44,8 @@ using ChakraBundleUrlMetadataMap = std::map<std::string, ChakraBundleMetadata>;
 
 struct DevSettings {
   bool useJITCompilation{true};
-  std::string debugHost;
+  uint16_t sourceBundlePort{0};
+  std::string sourceBundleHost;
   std::string debugBundlePath;
   std::string platformName{STRING(RN_PLATFORM)};
   std::function<void()> liveReloadCallback;

--- a/vnext/ReactWindowsCore/DevSupportManager.cpp
+++ b/vnext/ReactWindowsCore/DevSupportManager.cpp
@@ -72,7 +72,9 @@ std::future<std::pair<std::string, bool>> DownloadFromAsync(const std::string &u
 }
 
 void DevSupportManager::LaunchDevTools(const facebook::react::DevSettings &settings) {
-  DownloadFromAsync(facebook::react::DevServerHelper::get_LaunchDevToolsCommandUrl(settings.debugHost)).get();
+  DownloadFromAsync(facebook::react::DevServerHelper::get_LaunchDevToolsCommandUrl(
+                        settings.sourceBundleHost, settings.sourceBundlePort))
+      .get();
 }
 
 std::future<void> DevSupportManager::CreatePackagerConnection(const facebook::react::DevSettings &settings) {
@@ -116,7 +118,8 @@ std::future<void> DevSupportManager::CreatePackagerConnection(const facebook::re
       });
 
   winrt::Windows::Foundation::Uri uri(
-      Microsoft::Common::Unicode::Utf8ToUtf16("ws://" + settings.debugHost + "/message"));
+      Microsoft::Common::Unicode::Utf8ToUtf16(facebook::react::DevServerHelper::get_PackagerConnectionUrl(
+          settings.sourceBundleHost, settings.sourceBundlePort)));
   auto async = m_ws.ConnectAsync(uri);
 
 #ifdef DEFAULT_CPPWINRT_EXCEPTIONS
@@ -141,7 +144,8 @@ facebook::react::JSECreator DevSupportManager::LoadJavaScriptInProxyMode(const f
       try {
         websocketJSE
             ->ConnectAsync(
-                facebook::react::DevServerHelper::get_WebsocketProxyUrl(settings.debugHost),
+                facebook::react::DevServerHelper::get_WebsocketProxyUrl(
+                    settings.sourceBundleHost, settings.sourceBundlePort),
                 settings.errorCallback,
                 settings.waitingForDebuggerCallback,
                 settings.debuggerAttachCallback)
@@ -212,10 +216,14 @@ std::future<winrt::Windows::Web::Http::HttpStatusCode> PollForLiveReload(const s
   co_return responseMessage.StatusCode();
 }
 
-void DevSupportManager::StartPollingLiveReload(const std::string &debugHost, std::function<void()> onChangeCallback) {
+void DevSupportManager::StartPollingLiveReload(
+    const std::string &sourceBundleHost,
+    const uint16_t sourceBundlePort,
+    std::function<void()> onChangeCallback) {
   m_cancellation_token = false;
 
-  std::string refreshUrl = facebook::react::DevServerHelper::get_OnChangeEndpointUrl(debugHost);
+  std::string refreshUrl =
+      facebook::react::DevServerHelper::get_OnChangeEndpointUrl(sourceBundleHost, sourceBundlePort);
   auto task = [refreshUrl, onChangeCallback = move(onChangeCallback), this](const std::atomic_bool &cancelled) {
     while (!cancelled) {
       try {
@@ -249,14 +257,15 @@ void DevSupportManager::StopPollingLiveReload() {
 }
 
 std::string DevSupportManager::GetJavaScriptFromServer(
-    const std::string &debugHost,
+    const std::string &sourceBundleHost,
+    const uint16_t sourceBundlePort,
     const std::string &jsBundleName,
     const std::string &platform) {
   // Reset exception state since client is requesting new service
   m_exceptionCaught = false;
 
   auto bundleUrl = facebook::react::DevServerHelper::get_BundleUrl(
-      debugHost, jsBundleName, platform, "true" /*dev*/, "false" /*hot*/);
+      sourceBundleHost, sourceBundlePort, jsBundleName, platform, "true" /*dev*/, "false" /*hot*/);
   try {
     std::string s;
     bool success;

--- a/vnext/ReactWindowsCore/DevSupportManager.h
+++ b/vnext/ReactWindowsCore/DevSupportManager.h
@@ -30,10 +30,14 @@ class DevSupportManager : public facebook::react::IDevSupportManager {
 
   virtual facebook::react::JSECreator LoadJavaScriptInProxyMode(const facebook::react::DevSettings &settings) override;
   virtual std::string GetJavaScriptFromServer(
-      const std::string &debugHost,
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort,
       const std::string &jsBundleName,
       const std::string &platform) override;
-  virtual void StartPollingLiveReload(const std::string &debugHost, std::function<void()> onChangeCallback) override;
+  virtual void StartPollingLiveReload(
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort,
+      std::function<void()> onChangeCallback) override;
   virtual void StopPollingLiveReload() override;
   virtual bool HasException() override {
     return m_exceptionCaught;

--- a/vnext/ReactWindowsCore/IDevSupportManager.h
+++ b/vnext/ReactWindowsCore/IDevSupportManager.h
@@ -17,10 +17,14 @@ struct DevSettings;
 struct IDevSupportManager {
   virtual JSECreator LoadJavaScriptInProxyMode(const DevSettings &settings) = 0;
   virtual std::string GetJavaScriptFromServer(
-      const std::string &debugHost,
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort,
       const std::string &jsBundleName,
       const std::string &platform) = 0;
-  virtual void StartPollingLiveReload(const std::string &debugHost, std::function<void()> onChangeCallback) = 0;
+  virtual void StartPollingLiveReload(
+      const std::string &sourceBundleHost,
+      const uint16_t sourceBundlePort,
+      std::function<void()> onChangeCallback) = 0;
   virtual void StopPollingLiveReload() = 0;
   virtual bool HasException() = 0;
 };

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -497,7 +497,8 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       // First attempt to get download the Js locally, to catch any bundling
       // errors before attempting to load the actual script.
       auto jsBundleString = m_devManager->GetJavaScriptFromServer(
-          m_devSettings->debugHost,
+          m_devSettings->sourceBundleHost,
+          m_devSettings->sourceBundlePort,
           m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,
           m_devSettings->platformName);
 
@@ -507,7 +508,8 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       }
 
       auto bundleUrl = DevServerHelper::get_BundleUrl(
-          m_devSettings->debugHost,
+          m_devSettings->sourceBundleHost,
+          m_devSettings->sourceBundlePort,
           m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,
           m_devSettings->platformName,
           /*dev*/ "true",
@@ -613,7 +615,8 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
   // list
   std::string bundleUrl = (m_devSettings->useWebDebugger || m_devSettings->liveReloadCallback)
       ? DevServerHelper::get_BundleUrl(
-            m_devSettings->debugHost,
+            m_devSettings->sourceBundleHost,
+            m_devSettings->sourceBundlePort,
             m_devSettings->debugBundlePath,
             m_devSettings->platformName,
             "true" /*dev*/,
@@ -653,7 +656,8 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
 void InstanceImpl::RegisterForReloadIfNecessary() noexcept {
   // setup polling for live reload
   if (!m_devManager->HasException() && !m_devSettings->useFastRefresh && m_devSettings->liveReloadCallback != nullptr) {
-    m_devManager->StartPollingLiveReload(m_devSettings->debugHost, m_devSettings->liveReloadCallback);
+    m_devManager->StartPollingLiveReload(
+        m_devSettings->sourceBundleHost, m_devSettings->sourceBundlePort, m_devSettings->liveReloadCallback);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,14 +2463,6 @@
     "@microsoft/tsdoc" "0.12.19"
     "@rushstack/node-core-library" "3.24.3"
 
-"@microsoft/api-extractor-model@7.8.8":
-  version "7.8.8"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.8.8.tgz#4ba1974c9b1e2d6b65daf56f6149c88d0a784680"
-  integrity sha512-oiUkYZmBUUd1afxkOXDgdaz/ROnNQT72xHE1ALHJzlCUWnAhQcWjVUOr9WnigIOJp1fiwfA6F2l1wUgDzFQ6Iw==
-  dependencies:
-    "@microsoft/tsdoc" "0.12.19"
-    "@rushstack/node-core-library" "3.24.1"
-
 "@microsoft/api-extractor@^7.3.8":
   version "7.8.14"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.8.14.tgz#1c97a439bbe1154cf089a355f5c1a838c70848b7"
@@ -2724,19 +2716,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz#e42b1bef12d2415411519fd528e64b593b1363dc"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
 
-"@rushstack/node-core-library@3.24.1":
-  version "3.24.1"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.24.1.tgz#4da7d59e9555c633f4cfdd4e4f097e5348891eb7"
-  integrity sha512-A21eDQwXAD9bZnvJZIEIhD171EQEWWo2afRs0sSUJ5FpMFpoDwx5DOY4hDE7dnczSKRmKsiDBV8hTSKhJrsw/A==
-  dependencies:
-    "@types/node" "10.17.13"
-    colors "~1.2.1"
-    fs-extra "~7.0.1"
-    jju "~1.4.0"
-    semver "~5.3.0"
-    timsort "~0.3.0"
-    z-schema "~3.18.3"
-
 "@rushstack/node-core-library@3.24.3":
   version "3.24.3"
   resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.24.3.tgz#f8226740176d2df899c74ceda68df66a3360a3f2"
@@ -2749,15 +2728,6 @@
     semver "~5.3.0"
     timsort "~0.3.0"
     z-schema "~3.18.3"
-
-"@rushstack/ts-command-line@4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.4.2.tgz#8e2518b41045ba91275c2bfc872ec9cdaa074adf"
-  integrity sha512-iJ6wV+ICaE252J2snVPDiX4pz1r25CY1Ua/3QE4nd+lD+80hv6i6JLCDdmkculgYRXkAxvYXRtriD4JfqvgdKA==
-  dependencies:
-    "@types/argparse" "1.0.38"
-    argparse "~1.0.9"
-    colors "~1.2.1"
 
 "@rushstack/ts-command-line@4.4.4":
   version "4.4.4"


### PR DESCRIPTION
Fixes #5203 

We have two settings on the instance settings.  We have DebugHost which is a string of format <host>:<port> which specifies the location of the packager.  We also have SourceBundleHost and SourceBundlePort, which is essentially the same thing, split out as two properties.

Internally we are inconsistent on which of these properties we use, which leads to issues like #5203, where some features dont work properly unless you set both of these properties to the same thing.   This change modifies the settings object so that setting DebugHost stores the data in the SourceBundleHost and SourceBundlePort property.  Thus preventing the settings from getting out of sync.  I also went through and ensured that we are using a shared source for the default values, as some of those values were repeated in a couple of places within the code.

I think long term we should remove DebugHost as a setting, since its a duplicate of the other settings. -- but for now we can keep both around.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5344)