### PR TITLE
Ensure lib-commonjs is packaged into react-native-platform-override

### DIFF
--- a/change/react-native-platform-override-2020-06-25-20-31-44-platform-override-lib.json
+++ b/change/react-native-platform-override-2020-06-25-20-31-44-platform-override-lib.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure lib-commonjs is packaged into react-native-platform-override",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T03:31:44.077Z"
+}

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -55,6 +55,10 @@
   "engines": {
     "node": ">=10"
   },
+  "files": [
+    "bin.js",
+    "lib-commonjs"
+  ],
   "beachball": {
     "disallowedChangeTypes": [
       "major"


### PR DESCRIPTION
Right now lib-commonjs isn't published in the public NPM package due to being in the gitignore. This makes it unusable outside of the repo. Package only the entry-point and built libs.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5347)