### PR TITLE
Fix empty host getting passed to HMR client when SourceBundleHost not specified

### DIFF
--- a/change/react-native-windows-2020-06-26-12-03-46-fixhmr.json
+++ b/change/react-native-windows-2020-06-26-12-03-46-fixhmr.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix empty host getting passed to HMR client when SourceBundleHost not specified",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T19:03:46.706Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -366,8 +366,8 @@ void ReactInstanceWin::Initialize() noexcept {
                   m_options.DeveloperSettings.SourceBundleName.empty() ? m_options.Identity
                                                                        : m_options.DeveloperSettings.SourceBundleName,
                   m_options.DeveloperSettings.SourceBundleHost.empty()
-                      ? m_options.DeveloperSettings.SourceBundleHost
-                      : facebook::react::DevServerHelper::DefaultPackagerHost,
+                      ? facebook::react::DevServerHelper::DefaultPackagerHost
+                      : m_options.DeveloperSettings.SourceBundleHost,
                   m_options.DeveloperSettings.SourceBundlePort ? m_options.DeveloperSettings.SourceBundlePort
                                                                : facebook::react::DevServerHelper::DefaultPackagerPort,
                   m_isFastReloadEnabled);


### PR DESCRIPTION
Fallout from my previous PR #5203

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5359)