### PR TITLE
Fix build errors for codegen unittest project when building in VS2019

### DIFF
--- a/change/react-native-windows-2020-06-26-15-45-16-master.json
+++ b/change/react-native-windows-2020-06-26-15-45-16-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix build errors for codegen unittest project when building in VS2019",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T22:45:16.637Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -49,8 +49,14 @@
 
   <Target Name="EnsureRuntimeDependenciesAreBuilt" AfterTargets="Build">
     <ItemGroup>
-      <_ReactNativeManagedCodeGenUnitTestRuntimeDependencies Include="..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />
       <_ReactNativeManagedCodeGenUnitTestRuntimeDependencies Include="..\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.csproj" />
+      <!--
+        This project should be built as well before the unittest can run, but when building in VS this sometimes gives the following error:
+          \vnext\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets(158,13): error MSB4006: There is a circular dependency in the target dependency graph involving target "ComputeGetResolvedWinMD". [\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
+        Microsoft.ReactNative.Managed.vcxproj is luckily a dependency of Microsoft.ReactNative.Managed.csproj so we can safely ommit it here.
+        
+        <_ReactNativeManagedCodeGenUnitTestRuntimeDependencies Include="..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />
+      -->
     </ItemGroup>
     <MSBuild
       Projects="@(_ReactNativeManagedCodeGenUnitTestRuntimeDependencies)" 


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5361)