### PR TITLE
Fix various compiler warnings

### DIFF
--- a/change/react-native-windows-2020-06-29-13-30-32-master.json
+++ b/change/react-native-windows-2020-06-29-13-30-32-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix compile warnings",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-29T20:30:32.755Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/AutolinkedNativeModules.g.cpp
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/AutolinkedNativeModules.g.cpp
@@ -8,6 +8,7 @@ namespace winrt::Microsoft::ReactNative
 
 void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders)
 { 
+    UNREFERENCED_PARAMETER(packageProviders);
 }
 
 }

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/SampleAppCpp.vcxproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/SampleAppCpp.vcxproj
@@ -85,12 +85,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleLibraryCPP.vcxproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleLibraryCPP.vcxproj
@@ -61,12 +61,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/packages/playground/windows/playground-win32/AutolinkedNativeModules.g.cpp
+++ b/packages/playground/windows/playground-win32/AutolinkedNativeModules.g.cpp
@@ -8,6 +8,7 @@ namespace winrt::Microsoft::ReactNative
 
 void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders)
 { 
+    UNREFERENCED_PARAMETER(packageProviders);
 }
 
 }

--- a/packages/playground/windows/playground/AutolinkedNativeModules.g.cpp
+++ b/packages/playground/windows/playground/AutolinkedNativeModules.g.cpp
@@ -8,6 +8,7 @@ namespace winrt::Microsoft::ReactNative
 
 void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders)
 { 
+    UNREFERENCED_PARAMETER(packageProviders);
 }
 
 }

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -62,12 +62,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/vnext/Common/Common.vcxproj
+++ b/vnext/Common/Common.vcxproj
@@ -76,7 +76,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <GenerateManifest>false</GenerateManifest>
-    <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -53,7 +53,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(ReactNativeWindowsDir);$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -42,7 +42,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(FollyDir);$(ReactNativeWindowsDir)stubs;$(MSBuildProjectDirectory);$(ReactNativeDir)\ReactCommon;$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
     <!--
     Prevents Microsoft.Windows.CppWinRT.props from adding WindowsApp.lib reference, see
     WindowsApp_downleve.lib reference below.

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -44,7 +44,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include\Shared;$(ReactNativeWindowsDir)Desktop;$(ReactNativeWindowsDir)IntegrationTests;$(ReactNativeWindowsDir)JSI\Shared;$(MSBuildProjectDirectory);$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
@@ -40,7 +40,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
     <!--
     Prevents Microsoft.Windows.CppWinRT.props from adding WindowsApp.lib reference, see
     WindowsApp_downleve.lib reference below.

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -4,7 +4,7 @@
     <!--
       Disable WINRT_LEAN_AND_MEAN - Allow out-of-library interface implementations
     -->
-    <EnableWinRtLeanAndMean>false</NoWinRtLeanAndMean>
+    <EnableWinRtLeanAndMean>false</EnableWinRtLeanAndMean>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--
+      Disable WINRT_LEAN_AND_MEAN - Allow out-of-library interface implementations
+    -->
+    <EnableWinRtLeanAndMean>false</NoWinRtLeanAndMean>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -41,7 +47,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(ReactNativeWindowsDir)\Mso;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Desktop;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include\Shared;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(MSBuildThisFileDirectory);$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -62,13 +67,6 @@
         JSI_EXPORT=;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
-      <!--
-        WINRT_LEAN_AND_MEAN - Allow out-of-library interface implementations
-      -->
-      <UndefinePreprocessorDefinitions>
-        WINRT_LEAN_AND_MEAN;
-        %(UndefinePreprocessorDefinitions)
-      </UndefinePreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         $(VCInstallDir)UnitTest\include;
         %(AdditionalIncludeDirectories)

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -69,7 +69,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(FollyDir);$(ReactNativeWindowsDir)stubs;$(MSBuildProjectDirectory);$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)\Shared\tracing;$(ReactNativeWindowsDir)include\Shared;$(ReactNativeDir)\ReactCommon;$(ReactNativeWindowsDir)JSI\Shared;$(JSI_Source);$(ReactNativeDir)\ReactCommon\callinvoker;$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -31,7 +31,6 @@
   </ImportGroup>
   <PropertyGroup>
     <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)\Shared\tracing;$(ReactNativeWindowsDir)include\Shared;$(ReactNativeWindowsDir)Desktop;$(ReactNativeWindowsDir)IntegrationTests;$(ReactNativeWindowsDir)JSI\Shared;$(MSBuildProjectDirectory);$(ReactNativeDir)\ReactCommon\callinvoker;$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -44,7 +44,6 @@
     <!-- We need $(ReactNativeWindowsDir)Chakra for ChakraCoreDebugger.h.
     We should remove it from IncludePath once we retire the ChakraExecutor stack. -->
     <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj
@@ -66,7 +66,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -40,12 +40,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->
@@ -61,18 +59,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -39,12 +39,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -35,12 +35,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -63,12 +63,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Include Warnings.props after Microsoft.Cpp.props to change default WarningLevel -->

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -39,12 +39,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/vnext/Mso.UnitTests/object/objectRefCountTest.cpp
+++ b/vnext/Mso.UnitTests/object/objectRefCountTest.cpp
@@ -242,6 +242,8 @@ TEST_CLASS (ObjectRefCountTest) {
     TestAssert::IsTrue(obj.IsEmpty());
   }
 
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code
   TEST_METHOD(ObjectRefCount_Make_CtorThrows) {
     Mso::CntPtr<ObjectRefCountSample4Throw> obj;
     bool deleted = false;
@@ -261,6 +263,7 @@ TEST_CLASS (ObjectRefCountTest) {
     TestAssert::IsTrue(deleted); // If InitializeThis throws then destructor must be called.
     TestAssert::IsTrue(obj.IsEmpty());
   }
+#pragma warning(pop)
 
   TEST_METHOD(ObjectRefCount_MakeElseNull) {
     bool deleted = false;
@@ -363,6 +366,8 @@ TEST_CLASS (ObjectRefCountTest) {
     TestAssert::IsTrue(obj.IsEmpty());
   }
 
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code
   TEST_METHOD(ObjectRefCount_MakeAlloc_CtorThrows) {
     Mso::CntPtr<ObjectRefCountSample41Throw> obj;
     AllocTestState state = {};
@@ -386,6 +391,7 @@ TEST_CLASS (ObjectRefCountTest) {
     AssertAllocState(state); // If InitializeThis throws then destructor must be called.
     TestAssert::IsTrue(obj.IsEmpty());
   }
+#pragma warning(pop)
 
   TEST_METHOD(ObjectRefCount_MakeAllocElseNull) {
     AllocTestState state = {};

--- a/vnext/Mso.UnitTests/object/objectWithWeakRefTest.cpp
+++ b/vnext/Mso.UnitTests/object/objectWithWeakRefTest.cpp
@@ -287,6 +287,8 @@ TEST_CLASS (ObjectWithWeakRefTest) {
     TestAssert::IsTrue(deleted);
   }
 
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code
   TESTMETHOD_REQUIRES_SEH(ObjectWithWeakRef_Make_CannotAllocate) {
     Mso::CntPtr<ObjectWithWeakRefSample3CannotAllocate> obj;
     TestAssert::ExpectVEC([&]() noexcept { obj = Mso::Make<ObjectWithWeakRefSample3CannotAllocate>(); });
@@ -313,6 +315,7 @@ TEST_CLASS (ObjectWithWeakRefTest) {
     TestAssert::IsTrue(deleted); // If InitializeThis throws then destructor must be called.
     TestAssert::IsTrue(obj.IsEmpty());
   }
+#pragma warning(pop)
 
   TEST_METHOD(ObjectWithWeakRef_MakeElseNull) {
     bool deleted = false;
@@ -401,6 +404,8 @@ TEST_CLASS (ObjectWithWeakRefTest) {
     AssertAllocState(state);
   }
 
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code
   TESTMETHOD_REQUIRES_SEH(ObjectWithWeakRef_MakeAlloc_CannotAllocate) {
     Mso::CntPtr<ObjectWithWeakRefSample31CannotAllocate> obj;
     TestAssert::ExpectVEC([&]() noexcept {
@@ -435,6 +440,7 @@ TEST_CLASS (ObjectWithWeakRefTest) {
     AssertAllocState(state); // If InitializeThis throws then destructor must be called.
     TestAssert::IsTrue(obj.IsEmpty());
   }
+#pragma warning(pop)
 
   TEST_METHOD(ObjectWithWeakRef_MakeAllocElseNull) {
     AllocTestState state = {};

--- a/vnext/Mso/motifCpp/motifCppTest.h
+++ b/vnext/Mso/motifCpp/motifCppTest.h
@@ -201,6 +201,9 @@ inline uint32_t FilterCrashExceptions(uint32_t exceptionCode) noexcept {
   return EXCEPTION_EXECUTE_HANDLER;
 }
 
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code might be hit if the linker determines the lambda is quaranteed to
+                                // throw an exception
 template <class TLambda>
 inline bool ExpectCrashCore(TLambda const &lambda) {
   __try {
@@ -210,6 +213,7 @@ inline bool ExpectCrashCore(TLambda const &lambda) {
     return true;
   }
 }
+#pragma warning(pop)
 
 template <class TLambda>
 inline void

--- a/vnext/Mso/object/make.h
+++ b/vnext/Mso/object/make.h
@@ -117,6 +117,8 @@ namespace MakePolicy {
 /// ThrowCtor MakePolicy passes all parameters to the constructor.
 /// ThrowCtor::Make may throw an exception if constructor throws.
 /// To allow this class to access private constructor add "friend MakePolicy;" to your class.
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code might be hit if the linkers determines the constructor will throw.
 struct ThrowCtor {
   static const bool IsNoExcept = false;
 
@@ -127,6 +129,7 @@ struct ThrowCtor {
     memoryGuard.ObjMemory = nullptr; // Memory is now controlled by the object. Set to null to avoid memory destruction.
   }
 };
+#pragma warning(pop)
 
 /// NoThrowCtor MakePolicy passes all parameters to the constructor.
 /// NoThrowCtor::Make does not throw exception and crashes the app if constructor throws.

--- a/vnext/Mso/object/make.h
+++ b/vnext/Mso/object/make.h
@@ -18,6 +18,10 @@ namespace Mso {
 
   Method Make is noexcept depending on the Make policy IsNoExcept value.
 */
+#pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code might be hit in a few cases in this file: If the linkers determines
+                                // ValidateObject throws, or when some of the lambda's are inlined...
+
 template <typename T, typename TResult = T, typename... TArgs>
 inline Mso::CntPtr<TResult> Make(TArgs &&... args) noexcept(T::MakePolicy::IsNoExcept) {
   typename T::RefCountPolicy::template MemoryGuard<T> memoryGuard = {};
@@ -117,8 +121,6 @@ namespace MakePolicy {
 /// ThrowCtor MakePolicy passes all parameters to the constructor.
 /// ThrowCtor::Make may throw an exception if constructor throws.
 /// To allow this class to access private constructor add "friend MakePolicy;" to your class.
-#pragma warning(push)
-#pragma warning(disable : 4702) // unreachable code might be hit if the linkers determines the constructor will throw.
 struct ThrowCtor {
   static const bool IsNoExcept = false;
 
@@ -129,7 +131,6 @@ struct ThrowCtor {
     memoryGuard.ObjMemory = nullptr; // Memory is now controlled by the object. Set to null to avoid memory destruction.
   }
 };
-#pragma warning(pop)
 
 /// NoThrowCtor MakePolicy passes all parameters to the constructor.
 /// NoThrowCtor::Make does not throw exception and crashes the app if constructor throws.
@@ -188,6 +189,8 @@ struct MakeAllocator {
     Mso::Memory::Free(ptr);
   }
 };
+
+#pragma warning(pop)
 
 } // namespace Mso
 

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -13,6 +13,9 @@
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <GenerateProjectSpecificOutputFolder>false</GenerateProjectSpecificOutputFolder>
     <CharacterSet>Unicode</CharacterSet>
+    <EnableWinRtLeanAndMean Condition="'$(EnableWinRtLeanAndMean)' == ''">true</EnableWinRtLeanAndMean>
+    <LinkIncremental Condition="'$(LinkIncremental)' == '' and '$(Configuration)'=='Debug'" Label="Configuration">true</LinkIncremental>
+    <LinkIncremental Condition="'$(LinkIncremental)' == '' and '$(Configuration)'=='Release'" Label="Configuration">false</LinkIncremental>
   </PropertyGroup>
 
   <PropertyGroup Label="Desktop">
@@ -95,6 +98,9 @@
         BOOST_SYSTEM_SOURCE;
         GTEST_HAS_RTTI=0;
         WIN32_LEAN_AND_MEAN;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(EnableWinRtLeanAndMean)' == 'true'">
         WINRT_LEAN_AND_MEAN;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -161,7 +161,7 @@ function copyProjectTemplateAndReplace(
     autolinkCsUsingNamespaces: '',
     autolinkCsReactPacakgeProviders: '',
     autolinkCppIncludes: '',
-    autolinkCppPackageProviders: '',
+    autolinkCppPackageProviders: '\n    UNREFERENCED_PARAMETER(packageProviders);', // CODESYNC: vnext\local-cli\runWindows\utils\autolink.js
   };
 
   [

--- a/vnext/local-cli/runWindows/utils/autolink.js
+++ b/vnext/local-cli/runWindows/utils/autolink.js
@@ -325,7 +325,7 @@ async function updateAutoLink(args, config, options) {
       if (cppPackageProviders === '') {
         // There are no windows dependencies, this would result in warning. C4100: 'packageProviders': unreferenced formal parameter.
         // therefore add a usage.
-        cppPackageProviders = '\n    UNREFERENCED_PARAMETER(packageProviders);';
+        cppPackageProviders = '\n    UNREFERENCED_PARAMETER(packageProviders);'; // CODESYNC: vnext\local-cli\generator-windows\index.js
       }
 
       const cppFileName = 'AutolinkedNativeModules.g.cpp';

--- a/vnext/local-cli/runWindows/utils/autolink.js
+++ b/vnext/local-cli/runWindows/utils/autolink.js
@@ -322,6 +322,12 @@ async function updateAutoLink(args, config, options) {
         });
       }
 
+      if (cppPackageProviders === '') {
+        // There are no windows dependencies, this would result in warning. C4100: 'packageProviders': unreferenced formal parameter.
+        // therefore add a usage.
+        cppPackageProviders = '\n    UNREFERENCED_PARAMETER(packageProviders);';
+      }
+
       const cppFileName = 'AutolinkedNativeModules.g.cpp';
 
       const srcCppFile = path.join(


### PR DESCRIPTION
We still have ~80 warnings in our CI Ouptut. This addresses:
* Linker Warnings for using both LTCG and Incremental
* Compiler warnings about define and then undefined WinRtLeanAndMean
* Compiler warnings about for unreacheable code

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5368)