### PR TITLE
Migrate "Alert" to turbo module

### DIFF
--- a/change/@office-iss-react-native-win32-2020-06-29-13-50-34-tm-migrate.json
+++ b/change/@office-iss-react-native-win32-2020-06-29-13-50-34-tm-migrate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update Alert.(windows|win32).js to enable turbo module",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-29T20:50:34.775Z"
+}

--- a/change/react-native-windows-2020-06-29-12-14-42-tm-migrate.json
+++ b/change/react-native-windows-2020-06-29-12-14-42-tm-migrate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Migrate \"Alert\" to turbo module",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-29T19:14:42.539Z"
+}

--- a/packages/react-native-win32/src/Libraries/Alert/Alert.win32.js
+++ b/packages/react-native-win32/src/Libraries/Alert/Alert.win32.js
@@ -11,8 +11,8 @@
 'use strict';
 
 // [Windows
-const NativeModules = require('../BatchedBridge/NativeModules');
-const PLYAlertManager = NativeModules.PLYAlertManager;
+import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+const AlertNative = TurboModuleRegistry.getEnforcing('Alert');
 // Windows]
 
 export type AlertType =

--- a/packages/react-native-win32/src/Libraries/Alert/Alert.win32.js
+++ b/packages/react-native-win32/src/Libraries/Alert/Alert.win32.js
@@ -12,7 +12,7 @@
 
 // [Windows
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
-const AlertNative = TurboModuleRegistry.getEnforcing('Alert');
+const PLYAlertManager = TurboModuleRegistry.getEnforcing('Alert');
 // Windows]
 
 export type AlertType =

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -169,6 +169,59 @@ ReactInstanceWin::ReactInstanceWin(
 
 ReactInstanceWin::~ReactInstanceWin() noexcept {}
 
+void ReactInstanceWin::LoadModules(
+    const std::shared_ptr<winrt::Microsoft::ReactNative::NativeModulesProvider> &nativeModulesProvider,
+    const std::shared_ptr<winrt::Microsoft::ReactNative::TurboModulesProvider> &turboModulesProvider) noexcept {
+  auto registerNativeModule = [&nativeModulesProvider](
+      const wchar_t *name, const ReactModuleProvider &provider) noexcept {
+    nativeModulesProvider->AddModuleProvider(name, provider);
+  };
+
+  auto registerTurboModule = [ this, &nativeModulesProvider, &turboModulesProvider ](
+      const wchar_t *name, const ReactModuleProvider &provider) noexcept {
+    if (m_options.UseWebDebugger()) {
+      nativeModulesProvider->AddModuleProvider(name, provider);
+    } else {
+      turboModulesProvider->AddModuleProvider(name, provider);
+    }
+  };
+
+  registerTurboModule(L"Alert", winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::Alert>());
+
+  registerNativeModule(
+      L"AppState",
+      winrt::Microsoft::ReactNative::
+          MakeTurboModuleProvider<::Microsoft::ReactNative::AppState, ::Microsoft::ReactNativeSpecs::AppStateSpec>());
+
+  registerNativeModule(
+      L"LogBox",
+      winrt::Microsoft::ReactNative::
+          MakeTurboModuleProvider<::Microsoft::ReactNative::LogBox, ::Microsoft::ReactNativeSpecs::LogBoxSpec>());
+
+  registerTurboModule(
+      L"Clipboard",
+      winrt::Microsoft::ReactNative::
+          MakeTurboModuleProvider<::Microsoft::ReactNative::Clipboard, ::Microsoft::ReactNativeSpecs::ClipboardSpec>());
+
+  registerNativeModule(
+      L"DeviceInfo",
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
+          ::Microsoft::ReactNative::DeviceInfo,
+          ::Microsoft::ReactNativeSpecs::DeviceInfoSpec>());
+
+  registerNativeModule(
+      L"DevSettings",
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
+          ::Microsoft::ReactNative::DevSettings,
+          ::Microsoft::ReactNativeSpecs::DevSettingsSpec>());
+
+  registerNativeModule(
+      L"I18nManager",
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
+          ::Microsoft::ReactNative::I18nManager,
+          ::Microsoft::ReactNativeSpecs::I18nManagerSpec>());
+}
+
 //! Initialize() is called from the native queue.
 void ReactInstanceWin::Initialize() noexcept {
   InitJSMessageThread();
@@ -243,59 +296,13 @@ void ReactInstanceWin::Initialize() noexcept {
 
           auto nmp = std::make_shared<winrt::Microsoft::ReactNative::NativeModulesProvider>();
 
-          nmp->AddModuleProvider(
-              L"Alert", winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::Alert>());
-
-          nmp->AddModuleProvider(
-              L"AppState",
-              winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                  ::Microsoft::ReactNative::AppState,
-                  ::Microsoft::ReactNativeSpecs::AppStateSpec>());
-
-          nmp->AddModuleProvider(
-              L"LogBox",
-              winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                  ::Microsoft::ReactNative::LogBox,
-                  ::Microsoft::ReactNativeSpecs::LogBoxSpec>());
-
-          if (m_options.UseWebDebugger()) {
-            nmp->AddModuleProvider(
-                L"Clipboard",
-                winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                    ::Microsoft::ReactNative::Clipboard,
-                    ::Microsoft::ReactNativeSpecs::ClipboardSpec>());
-          } else {
-            m_options.TurboModuleProvider->AddModuleProvider(
-                L"Clipboard",
-                winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                    ::Microsoft::ReactNative::Clipboard,
-                    ::Microsoft::ReactNativeSpecs::ClipboardSpec>());
-          }
-
           ::Microsoft::ReactNative::DevSettings::SetReload(
               strongThis->Options(), [weakReactHost = m_weakReactHost]() noexcept {
                 if (auto reactHost = weakReactHost.GetStrongPtr()) {
                   reactHost->ReloadInstance();
                 }
               });
-
-          nmp->AddModuleProvider(
-              L"DeviceInfo",
-              winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                  ::Microsoft::ReactNative::DeviceInfo,
-                  ::Microsoft::ReactNativeSpecs::DeviceInfoSpec>());
-
-          nmp->AddModuleProvider(
-              L"DevSettings",
-              winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                  ::Microsoft::ReactNative::DevSettings,
-                  ::Microsoft::ReactNativeSpecs::DevSettingsSpec>());
-
-          nmp->AddModuleProvider(
-              L"I18nManager",
-              winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-                  ::Microsoft::ReactNative::I18nManager,
-                  ::Microsoft::ReactNativeSpecs::I18nManagerSpec>());
+          LoadModules(nmp, m_options.TurboModuleProvider);
 
           auto modules = nmp->GetModules(m_reactContext, m_jsMessageThread.Load());
           cxxModules.insert(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -15,6 +15,11 @@
 
 #include <tuple>
 
+namespace winrt::Microsoft::ReactNative {
+class NativeModulesProvider;
+class TurboModulesProvider;
+} // namespace winrt::Microsoft::ReactNative
+
 namespace Mso::React {
 
 static_assert(
@@ -94,6 +99,9 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
       Mso::Promise<void> &&whenCreated,
       Mso::Promise<void> &&whenLoaded,
       Mso::VoidFunctor &&updateUI) noexcept;
+  void LoadModules(
+      const std::shared_ptr<winrt::Microsoft::ReactNative::NativeModulesProvider> &nativeModulesProvider,
+      const std::shared_ptr<winrt::Microsoft::ReactNative::TurboModulesProvider> &turboModulesProvider) noexcept;
   void Initialize() noexcept override;
   ~ReactInstanceWin() override;
 

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -6,8 +6,8 @@
  */
 'use strict';
 
-const NativeModules = require('../BatchedBridge/NativeModules');
-const AlertNative = NativeModules.Alert;
+import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+const AlertNative = TurboModuleRegistry.getEnforcing('Alert');
 
 export type AlertType =
   | 'default'
@@ -39,7 +39,7 @@ class Alert {
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const validButtons: Buttons = buttons
       ? buttons.slice(0, 3)
-      : [{text: 'OK'}];
+      : [{ text: 'OK' }];
     const buttonPositive = validButtons.pop();
     const buttonNegative = validButtons.pop();
     const buttonNeutral = validButtons.pop();

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -39,7 +39,7 @@ class Alert {
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const validButtons: Buttons = buttons
       ? buttons.slice(0, 3)
-      : [{ text: 'OK' }];
+      : [{text: 'OK'}];
     const buttonPositive = validButtons.pop();
     const buttonNegative = validButtons.pop();
     const buttonNeutral = validButtons.pop();


### PR DESCRIPTION
- Extract module registration as a new method
- Migrate "Alert" to turbo module

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5382)