### PR TITLE
Remove delayload dependencies on some winrt apisets, to reduce warning count

### DIFF
--- a/change/react-native-windows-2020-06-29-17-13-10-master.json
+++ b/change/react-native-windows-2020-06-29-17-13-10-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove delayload dependencies on some winrt apisets, to reduce warning count",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-30T00:13:09.974Z"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -91,7 +91,7 @@
         %(AdditionalDependencies)
       </AdditionalDependencies>
       <AdditionalDependencies>WindowsApp_downlevel.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-string-l1-1-0.dll;ChakraCore.Debugger.DLL;ChakraCore.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>ChakraCore.Debugger.DLL;ChakraCore.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">


### PR DESCRIPTION
These were introduced initially with PR #2867. The comment states it was for Win7. Since Win7 is no longer supported and it seems there is no code that uses it (hence the warnings:)
```
##[warning]LINK(0,0): Warning LNK4199: /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-0.dll ignored; no imports found from api-ms-win-core-winrt-error-l1-1-0.dll
##[warning]LINK(0,0): Warning LNK4199: /DELAYLOAD:api-ms-win-core-winrt-error-l1-1-1.dll ignored; no imports found from api-ms-win-core-winrt-error-l1-1-1.dll
##[warning]LINK(0,0): Warning LNK4199: /DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll ignored; no imports found from api-ms-win-core-winrt-string-l1-1-0.dll
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5383)