### PR TITLE
Migrate 'DevSettings' to turbo module

### DIFF
--- a/change/react-native-windows-2020-06-29-23-03-19-tm-devsettings.json
+++ b/change/react-native-windows-2020-06-29-23-03-19-tm-devsettings.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Migrate 'DevSettings' to turbo module",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-30T06:03:19.173Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -209,7 +209,7 @@ void ReactInstanceWin::LoadModules(
           ::Microsoft::ReactNative::DeviceInfo,
           ::Microsoft::ReactNativeSpecs::DeviceInfoSpec>());
 
-  registerNativeModule(
+  registerTurboModule(
       L"DevSettings",
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
           ::Microsoft::ReactNative::DevSettings,


### PR DESCRIPTION
- Migrate 'DevSettings' to turbo module
- Unable to test in playground because
  - add menu is not implemented
  - reload crashes when web debugger is not checked, regardless if 'DevSettings' is registered as either a native module or a turbo module, so this issue is not related to turbo module
  - at least native methods are called

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5386)