### PR TITLE
Implement REACT_CONSTANT as getConstants sync method for turbo module

### DIFF
--- a/change/react-native-windows-2020-06-29-23-55-00-tm-const.json
+++ b/change/react-native-windows-2020-06-29-23-55-00-tm-const.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implement REACT_CONSTANT as getConstants sync method for turbo module",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-30T06:55:00.189Z"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -22,6 +22,12 @@ struct SampleTurboModule {
   REACT_CONSTANT(m_constantInt, L"constantInt")
   const int m_constantInt{3};
 
+  REACT_CONSTANT_PROVIDER(GetConstants)
+  void GetConstants(React::ReactConstantProvider &provider) noexcept {
+    provider.Add(L"constantString2", L"Hello");
+    provider.Add(L"constantInt2", 10);
+  }
+
   REACT_METHOD(Succeeded, L"succeeded")
   void Succeeded() noexcept {
     succeededSignal.set_value(true);
@@ -61,8 +67,8 @@ struct SampleTurboModule {
   }
 
   REACT_METHOD(Constants, L"constants")
-  void Constants(std::string a, int b) noexcept {
-    auto resultString = (std::stringstream() << a << ", " << b).str();
+  void Constants(std::string a, int b, std::string c, int d) noexcept {
+    auto resultString = (std::stringstream() << a << ", " << b << ", " << c << ", " << d).str();
     constantsSignal.set_value(resultString);
   }
 
@@ -125,7 +131,7 @@ struct SampleTurboModuleSpec : TurboModuleSpec {
       Method<void(std::string) noexcept>{3, L"promiseFunctionResult"},
       SyncMethod<std::string(std::string, int, bool) noexcept>{4, L"syncFunction"},
       Method<void(std::string) noexcept>{5, L"syncFunctionResult"},
-      Method<void(std::string, int) noexcept>{6, L"constants"},
+      Method<void(std::string, int, std::string, int) noexcept>{6, L"constants"},
       Method<void(int, int, const std::function<void(int)> &) noexcept>{7, L"oneCallback"},
       Method<void(int) noexcept>{8, L"oneCallbackResult"},
       Method<void(
@@ -192,7 +198,7 @@ TEST_CLASS (TurboModuleTests) {
     TestCheckEqual(true, SampleTurboModule::succeededSignal.get_future().get());
     TestCheckEqual("something, 1, true", SampleTurboModule::promiseFunctionSignal.get_future().get());
     TestCheckEqual("something, 2, false", SampleTurboModule::syncFunctionSignal.get_future().get());
-    TestCheckEqual("constantString, 3", SampleTurboModule::constantsSignal.get_future().get());
+    TestCheckEqual("constantString, 3, Hello, 10", SampleTurboModule::constantsSignal.get_future().get());
     TestCheckEqual(3, SampleTurboModule::oneCallbackSignal.get_future().get());
     TestCheckEqual(123, SampleTurboModule::twoCallbacksResolvedSignal.get_future().get());
     TestCheckEqual("Failed", SampleTurboModule::twoCallbacksRejectedSignal.get_future().get());

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -42,7 +42,9 @@ try {
   sampleTurboModule
     .constants(
       c.constantString,
-      c.constantInt
+      c.constantInt,
+      c.constantString2,
+      c.constantInt2
     );
 
   sampleTurboModule

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -38,10 +38,11 @@ try {
         .syncFunction('something', 2, false)
     );
 
+  const c = sampleTurboModule.getConstants();
   sampleTurboModule
     .constants(
-      sampleTurboModule.constantString,
-      sampleTurboModule.constantInt
+      c.constantString,
+      c.constantInt
     );
 
   sampleTurboModule

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -30,77 +30,35 @@ struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBu
   }
 
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept {
-    m_constantProviderList.push_back(constantProvider);
+    EnsureMemberNotSet("getConstants", false);
+    m_constantProviders.push_back(constantProvider);
   }
 
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept {
     auto key = to_string(name);
-    EnsureMemberNotSet(key);
+    EnsureMemberNotSet(key, true);
     m_methods.insert({key, {returnType, method}});
   }
 
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept {
     auto key = to_string(name);
-    EnsureMemberNotSet(key);
+    EnsureMemberNotSet(key, true);
     m_syncMethods.insert({key, method});
-  }
-
-  facebook::jsi::Value GetConstantOrUndefined(facebook::jsi::Runtime &runtime, const std::string &key) noexcept {
-    // unfortunately it is no way to cache constants
-    // because destructor of jsi::Value must be executed in the JavaScript engine thread
-    // which is not possible to guarantee if constants are cached in this class
-    // so here all constant providers are executed once to know the property name
-    // and then whenever a constant is required, run the constant provider again to get the value
-    if (!m_constantsEvaluated) {
-      m_constantsEvaluated = true;
-
-      for (auto cp : m_constantProviderList) {
-        // one constant provider writes one property to the writer
-        auto writer = winrt::make<JsiWriter>(runtime);
-        writer.WriteObjectBegin();
-        cp(writer);
-        writer.WriteObjectEnd();
-
-        // so it is safe just to read the first property name
-        auto constantObject = writer.as<JsiWriter>()->MoveResult().asObject(runtime);
-        auto propertyNames = constantObject.getPropertyNames(runtime);
-        auto firstPropertyName = propertyNames.getValueAtIndex(runtime, 0).asString(runtime);
-        auto cpKey = firstPropertyName.utf8(runtime);
-        EnsureMemberNotSet(cpKey);
-
-        // save the constant provider
-        m_constantProviders.insert({cpKey, cp});
-      }
-    }
-
-    auto it = m_constantProviders.find(key);
-    if (it == m_constantProviders.end()) {
-      return facebook::jsi::Value::undefined();
-    }
-
-    auto writer = winrt::make<JsiWriter>(runtime);
-    writer.WriteObjectBegin();
-    it->second(writer);
-    writer.WriteObjectEnd();
-
-    // the constant provider producing {foo:constant} is stored at m_constantProviders.find("foo");
-    // so no need to check again
-    auto constantObject = writer.as<JsiWriter>()->MoveResult().asObject(runtime);
-    return constantObject.getProperty(runtime, key.c_str());
   }
 
  public:
   std::unordered_map<std::string, TurboModuleMethodInfo> m_methods;
   std::unordered_map<std::string, SyncMethodDelegate> m_syncMethods;
-  std::unordered_map<std::string, ConstantProviderDelegate> m_constantProviders;
-  std::vector<ConstantProviderDelegate> m_constantProviderList;
+  std::vector<ConstantProviderDelegate> m_constantProviders;
   bool m_constantsEvaluated = false;
 
  private:
-  void EnsureMemberNotSet(const std::string &key) noexcept {
+  void EnsureMemberNotSet(const std::string &key, bool checkingMethod) noexcept {
     VerifyElseCrash(m_methods.find(key) == m_methods.end());
     VerifyElseCrash(m_syncMethods.find(key) == m_syncMethods.end());
-    VerifyElseCrash(m_constantProviders.find(key) == m_constantProviders.end());
+    if (checkingMethod && key == "getConstants") {
+      VerifyElseCrash(m_constantProviders.size() == 0);
+    }
   }
 
  private:
@@ -126,6 +84,28 @@ class TurboModuleImpl : public facebook::react::TurboModule {
     // it is not safe to assume that "runtime" never changes, so members are not cached here
     auto tmb = m_moduleBuilder.as<TurboModuleBuilder>();
     auto key = propName.utf8(runtime);
+
+    if (key == "getConstants" && tmb->m_constantProviders.size() > 0) {
+      // try to find getConstants if there is any constant
+      return facebook::jsi::Function::createFromHostFunction(
+          runtime,
+          propName,
+          0,
+          [&runtime, tmb](
+              facebook::jsi::Runtime &rt,
+              const facebook::jsi::Value &thisVal,
+              const facebook::jsi::Value *args,
+              size_t count) {
+            // collect all constants to an object
+            auto writer = winrt::make<JsiWriter>(runtime);
+            writer.WriteObjectBegin();
+            for (auto cp : tmb->m_constantProviders) {
+              cp(writer);
+            }
+            writer.WriteObjectEnd();
+            return writer.as<JsiWriter>()->MoveResult();
+          });
+    }
 
     {
       // try to find a Method
@@ -251,8 +231,8 @@ class TurboModuleImpl : public facebook::react::TurboModule {
       }
     }
 
-    // returns undefined if the constant doesn't exist
-    return tmb->GetConstantOrUndefined(runtime, key);
+    // returns undefined if the expected member is not found
+    return facebook::jsi::Value::undefined();
   }
 
  private:


### PR DESCRIPTION
- `REACT_CONSTANT` and `REACT_CONSTANT_PROVIDER` in turbo module is only for migrating native modules
- When these macros are used, `getConstants` functions will be added to the turbo module
- If `REACT_METHOD` or `REACT_SYNC_METHOD` is defined using the name `getConstants`, adding constants will crash

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5388)