### PR TITLE
Migrate 'AppState' to turbo module

### DIFF
--- a/change/react-native-windows-2020-06-30-12-50-33-tm-as.json
+++ b/change/react-native-windows-2020-06-30-12-50-33-tm-as.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Migrate 'AppState' to turbo module",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-30T19:50:33.772Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -188,7 +188,7 @@ void ReactInstanceWin::LoadModules(
 
   registerTurboModule(L"Alert", winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::Alert>());
 
-  registerNativeModule(
+  registerTurboModule(
       L"AppState",
       winrt::Microsoft::ReactNative::
           MakeTurboModuleProvider<::Microsoft::ReactNative::AppState, ::Microsoft::ReactNativeSpecs::AppStateSpec>());


### PR DESCRIPTION
- Migrate 'AppState' to turbo module

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5395)