### PR TITLE
Speed up package installation

### DIFF
--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -2,6 +2,7 @@
 
 parameters:
   debug: false
+  usePRShortCuts: false
 
   # NuGet & MSBuild
   project:
@@ -27,6 +28,7 @@ steps:
       installVsComponents: ${{ parameters.installVsComponents }}
       yarnBuildCmd: ${{ parameters.yarnBuildCmd }}
       debug: ${{ parameters.debug }}
+      usePRShortCuts: ${{ parameters.usePRShortCuts }}
 
   - task: NuGetCommand@2
     displayName: NuGet restore

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -2,6 +2,7 @@
 parameters:
   name: ''
   BuildPlatform: x86 # ARM, x86, x64
+  usePRShortCuts: false
 
 jobs:
   - job: ${{ parameters.name }}
@@ -25,6 +26,8 @@ jobs:
         submodules: false
             
       - template: prepare-env.yml
+        parameters:
+          usePRShortCuts: ${{ parameters.usePRShortCuts }}
 
       - task: CmdLine@2
         displayName: Set LocalDumps

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -3,11 +3,13 @@
 parameters:
   yarnBuildCmd: build
   debug: false
+  usePRShortCuts: false
 
   # Visual Studio Installer
   vsComponents: ''
   listVsComponents: false
   installVsComponents: false
+  
 
 steps:
   - task: PowerShell@2
@@ -22,6 +24,19 @@ steps:
       targetType: inline # filePath | inline
       script: |
         Get-WmiObject Win32_LogicalDisk
+
+  - task: powershell@2
+    displayName: "Disable defender on Yarn and NuGet folders"
+    inputs:
+      targetType: inline
+      script: |
+        Write-Host "Excluding midgard-yarn cache folder"
+        Add-MpPreference -ExclusionPath "\.yarnCache"
+        Write-Host "Excluding nuget cache folder"
+        Add-MpPreference -ExclusionPath "$env:userProfile\.nuget"
+        Write-Host "Excluding source folder"
+        Add-MpPreference -ExclusionPath "$(Build.SourcesDirectory)"
+    condition: and(succeeded(), ${{ parameters.usePRShortCuts }})
 
   - task: NuGetToolInstaller@0
     inputs:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -13,6 +13,8 @@ variables:
   - template: variables/vs2019.yml
   - name: reactNativeVersion
     value: 0.0.0-56cf99a96
+  - name: usePRShortCuts
+    value: true
 
 jobs:
   - job: Setup
@@ -77,6 +79,7 @@ jobs:
         parameters:
           yarnBuildCmd: build
           project: vnext/Microsoft.ReactNative.sln
+          usePRShortCuts: ${{ variables.usePRShortCuts }}
 
       - powershell: |
           Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
@@ -188,6 +191,8 @@ jobs:
         submodules: false
 
       - template: templates/prepare-env.yml
+        parameters: 
+          usePRShortCuts: ${{ variables.usePRShortCuts }}
 
       - task: NuGetCommand@2
         displayName: NuGet restore - Playground
@@ -238,6 +243,8 @@ jobs:
         submodules: false
 
       - template: templates/prepare-env.yml
+        parameters: 
+          usePRShortCuts: ${{ variables.usePRShortCuts }}
 
       - task: NuGetCommand@2
         displayName: NuGet restore - Playground
@@ -339,6 +346,8 @@ jobs:
         submodules: false
 
       - template: templates/prepare-env.yml
+        parameters: 
+          usePRShortCuts: ${{ variables.usePRShortCuts }}
 
       - task: NuGetCommand@2
         displayName: NuGet restore - SampleApps
@@ -420,6 +429,7 @@ jobs:
         parameters:
           yarnBuildCmd: build
           project: vnext/ReactWindows-Desktop.sln
+          usePRShortCuts: ${{ variables.usePRShortCuts }}
 
       - task: CmdLine@2
         displayName: Build react-native-win32 RNTester bundle
@@ -669,6 +679,7 @@ jobs:
     parameters:
       name: E2ETest
       BuildPlatform: x64
+      usePRShortCuts: ${{ variables.usePRShortCuts }}
 
   - job: RNWNugetPR
     displayName: Build and Pack NuGet


### PR DESCRIPTION
Speed up package installation by adding packages caches to defender exclude list.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5396)