### PR TITLE
Enforce null/undefined safety for the CLI

### DIFF
--- a/change/react-native-windows-2020-07-01-01-14-21-null-safety.json
+++ b/change/react-native-windows-2020-07-01-01-14-21-null-safety.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enforce null/undefined safety for the CLI",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-01T08:14:21.490Z"
+}

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -4,6 +4,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8B88FFAE-4DBC-49A2-AFA5-D2477D4AD189}</ProjectGuid>
     <RootNamespace>Playground</RootNamespace>
+    <ProjectName>playgroundwin32</ProjectName>
     <Keyword>Win32Proj</Keyword>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>

--- a/vnext/local-cli/.npmignore
+++ b/vnext/local-cli/.npmignore
@@ -1,1 +1,2 @@
-# Make sure to include JS builds outputs nornmally hidden by the gitignore
+/.gitignore
+/src

--- a/vnext/local-cli/src/config/configUtils.ts
+++ b/vnext/local-cli/src/config/configUtils.ts
@@ -269,16 +269,20 @@ export function importProjectExists(
 
 /**
  * Gets the name of the project from the project contents.
+ * @param projectPath The project file path to check.
  * @param projectContents The XML project contents.
  * @return The project name.
  */
-export function getProjectName(projectContents: Node): string {
+export function getProjectName(
+  projectPath: string,
+  projectContents: Node,
+): string {
   const name =
     findPropertyValue(projectContents, 'ProjectName') ||
     findPropertyValue(projectContents, 'AssemblyName');
 
   if (name === null) {
-    throw new Error('Could not determine project name');
+    throw new Error(`Could not determine name of project ${projectPath}`);
   }
 
   return name;
@@ -286,13 +290,17 @@ export function getProjectName(projectContents: Node): string {
 
 /**
  * Gets the namespace of the project from the project contents.
+ * @param projectPath The project file path to check.
  * @param projectContents The XML project contents.
  * @return The project namespace.
  */
-export function getProjectNamespace(projectContents: Node): string {
+export function getProjectNamespace(
+  projectPath: string,
+  projectContents: Node,
+): string {
   const namespace = findPropertyValue(projectContents, 'RootNamespace');
   if (namespace === null) {
-    throw new Error('Could not find RootNamespace in project');
+    throw new Error(`Could not determine namespace of project ${projectPath}`);
   }
 
   return namespace;
@@ -300,13 +308,17 @@ export function getProjectNamespace(projectContents: Node): string {
 
 /**
  * Gets the guid of the project from the project contents.
+ * @param projectPath The project file path to check.
  * @param projectContents The XML project contents.
  * @return The project guid.
  */
-export function getProjectGuid(projectContents: Node): string {
+export function getProjectGuid(
+  projectPath: string,
+  projectContents: Node,
+): string {
   const guid = findPropertyValue(projectContents, 'ProjectGuid');
   if (guid === null) {
-    throw new Error('Could not find ProjectGuid in project');
+    throw new Error(`Could not determine GUID of project ${projectPath}`);
   }
 
   return guid;

--- a/vnext/local-cli/src/config/dependencyConfig.ts
+++ b/vnext/local-cli/src/config/dependencyConfig.ts
@@ -78,10 +78,10 @@ export interface ProjectDependency {
   projectName: string;
   projectLang: 'cpp' | 'cs';
   projectGuid: string;
-  cppHeaders?: string[];
-  cppPackageProviders?: string[];
-  csNamespaces?: string[];
-  csPackageProviders?: string[];
+  cppHeaders: string[];
+  cppPackageProviders: string[];
+  csNamespaces: string[];
+  csPackageProviders: string[];
 }
 
 export interface NuGetPackageDependency {
@@ -97,8 +97,8 @@ export interface WindowsDependencyConfig {
   folder: string;
   sourceDir?: string;
   solutionFile: string | null;
-  projects?: ProjectDependency[];
-  nugetPackages?: NuGetPackageDependency[];
+  projects: ProjectDependency[];
+  nugetPackages: NuGetPackageDependency[];
 }
 
 /**
@@ -122,14 +122,14 @@ export function dependencyConfigWindows(
 
   var result: WindowsDependencyConfig = {
     folder,
-    projects: usingManualProjectsOverride ? userConfig.projects : [],
+    projects: usingManualProjectsOverride ? userConfig.projects! : [],
     solutionFile: null,
     nugetPackages: usingManualNugetPackagesOverride
-      ? userConfig.nugetPackages
+      ? userConfig.nugetPackages!
       : [],
   };
 
-  var sourceDir = null;
+  let sourceDir: string | null = null;
   if (usingManualProjectsOverride && result.projects.length > 0) {
     // Manaully provided projects, so extract the sourceDir
     if (!('sourceDir' in userConfig)) {
@@ -139,7 +139,7 @@ export function dependencyConfigWindows(
       sourceDir =
         'Error: Source dir is required if projects are specified, but it is null in react-native.config.';
     } else {
-      sourceDir = path.join(folder, userConfig.sourceDir);
+      sourceDir = path.join(folder, userConfig.sourceDir!);
     }
   } else if (!usingManualProjectsOverride) {
     // No manually provided projects, try to find sourceDir
@@ -147,13 +147,12 @@ export function dependencyConfigWindows(
   }
 
   if (
-    sourceDir === null &&
-    result.projects.length === 0 &&
-    result.nugetPackages.length === 0
+    sourceDir === null ||
+    (result.projects.length === 0 && result.nugetPackages.length === 0)
   ) {
     // Nothing to look for here, bail
     return null;
-  } else if (sourceDir !== null && sourceDir.startsWith('Error: ')) {
+  } else if (sourceDir.startsWith('Error: ')) {
     // Source dir error, bail with error
     result.sourceDir = sourceDir;
     return result;
@@ -166,7 +165,7 @@ export function dependencyConfigWindows(
   var solutionFile = null;
   if (usingManualSolutionFile && userConfig.solutionFile !== null) {
     // Manually provided solutionFile, so extract it
-    solutionFile = path.join(sourceDir, userConfig.solutionFile);
+    solutionFile = path.join(sourceDir, userConfig.solutionFile!);
   } else if (!usingManualSolutionFile) {
     // No manually provided solutionFile, try to find it
     const foundSolutions = configUtils.findSolutionFiles(sourceDir);

--- a/vnext/local-cli/src/config/dependencyConfig.ts
+++ b/vnext/local-cli/src/config/dependencyConfig.ts
@@ -206,14 +206,21 @@ export function dependencyConfigWindows(
       const projectContents = configUtils.readProjectFile(projectFile);
 
       // Calculating (auto) items
-      project.projectName = configUtils.getProjectName(projectContents);
+      project.projectName = configUtils.getProjectName(
+        projectFile,
+        projectContents,
+      );
       project.projectLang = configUtils.getProjectLanguage(projectFile);
-      project.projectGuid = configUtils.getProjectGuid(projectContents);
+      project.projectGuid = configUtils.getProjectGuid(
+        projectFile,
+        projectContents,
+      );
 
       if (project.directDependency) {
         // Calculating more (auto) items
 
         const projectNamespace = configUtils.getProjectNamespace(
+          projectFile,
           projectContents,
         );
         const cppNamespace = projectNamespace.replace(/\./g, '::');
@@ -241,11 +248,20 @@ export function dependencyConfigWindows(
 
       const projectContents = configUtils.readProjectFile(projectFile);
 
-      const projectName = configUtils.getProjectName(projectContents);
+      const projectName = configUtils.getProjectName(
+        projectFile,
+        projectContents,
+      );
 
-      const projectGuid = configUtils.getProjectGuid(projectContents);
+      const projectGuid = configUtils.getProjectGuid(
+        projectFile,
+        projectContents,
+      );
 
-      const projectNamespace = configUtils.getProjectNamespace(projectContents);
+      const projectNamespace = configUtils.getProjectNamespace(
+        projectFile,
+        projectContents,
+      );
 
       const directDependency = true;
 

--- a/vnext/local-cli/src/config/projectConfig.ts
+++ b/vnext/local-cli/src/config/projectConfig.ts
@@ -175,9 +175,15 @@ export function projectConfigWindows(
     const projectContents = configUtils.readProjectFile(projectFile);
 
     // Add missing (auto) items
-    result.project.projectName = configUtils.getProjectName(projectContents);
+    result.project.projectName = configUtils.getProjectName(
+      projectFile,
+      projectContents,
+    );
     result.project.projectLang = configUtils.getProjectLanguage(projectFile);
-    result.project.projectGuid = configUtils.getProjectGuid(projectContents);
+    result.project.projectGuid = configUtils.getProjectGuid(
+      projectFile,
+      projectContents,
+    );
   }
 
   return result as WindowsProjectConfig;

--- a/vnext/local-cli/src/config/projectConfig.ts
+++ b/vnext/local-cli/src/config/projectConfig.ts
@@ -75,7 +75,7 @@ type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
 export function projectConfigWindows(
   folder: string,
   userConfig: Partial<WindowsProjectConfig> = {},
-): WindowsProjectConfig {
+): WindowsProjectConfig | null {
   if (userConfig === null) {
     return null;
   }
@@ -83,7 +83,7 @@ export function projectConfigWindows(
   const usingManualOverride = 'sourceDir' in userConfig;
 
   const sourceDir = usingManualOverride
-    ? path.join(folder, userConfig.sourceDir)
+    ? path.join(folder, userConfig.sourceDir!)
     : configUtils.findWindowsFolder(folder);
 
   if (sourceDir === null) {
@@ -116,7 +116,7 @@ export function projectConfigWindows(
         projectFile:
           'Error: Project is required but not specified in react-native.config.',
       };
-    } else if (userConfig.project === null) {
+    } else if (!userConfig.project) {
       result.project = {
         projectFile: 'Error: Project is null in react-native.config.',
       };
@@ -171,7 +171,7 @@ export function projectConfigWindows(
   }
 
   if (validProject) {
-    const projectFile = path.join(sourceDir, result.project.projectFile);
+    const projectFile = path.join(sourceDir, result.project.projectFile!);
     const projectContents = configUtils.readProjectFile(projectFile);
 
     // Add missing (auto) items

--- a/vnext/local-cli/src/generator-common/index.ts
+++ b/vnext/local-cli/src/generator-common/index.ts
@@ -10,14 +10,15 @@ import * as path from 'path';
 import * as mustache from 'mustache';
 
 /**
- * Text to replace, + config options
+ * Text to replace, + config PromptOptions
  */
 export type Replacements = {
   useMustache?: boolean;
   regExpPatternsToRemove?: RegExp[];
-} & Record<string, string>;
+  [key: string]: any;
+};
 
-interface Options {
+interface PromptOptions {
   echo?: string;
   ask?: string;
   value?: string;
@@ -27,9 +28,9 @@ interface Options {
 const term = 13; // carriage return
 
 function prompt(
-  ask?: string | Options,
-  value?: string | Options,
-  opts?: Options,
+  ask?: string | PromptOptions,
+  value?: string | PromptOptions,
+  opts?: PromptOptions,
 ): string {
   let insert = 0;
   opts = opts || {};

--- a/vnext/local-cli/src/generator-common/index.ts
+++ b/vnext/local-cli/src/generator-common/index.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as mustache from 'mustache';
 
 /**
- * Text to replace, + config PromptOptions
+ * Text to replace, + config options
  */
 export type Replacements = {
   useMustache?: boolean;

--- a/vnext/local-cli/src/generator-common/index.ts
+++ b/vnext/local-cli/src/generator-common/index.ts
@@ -28,7 +28,7 @@ const term = 13; // carriage return
 
 function prompt(
   ask?: string | Options,
-  value?: string,
+  value?: string | Options,
   opts?: Options,
 ): string {
   let insert = 0;
@@ -94,10 +94,6 @@ function prompt(
       process.stdout.write('^C\n');
       fs.closeSync(fd);
       process.exit(130);
-      if (process.stdin.setRawMode) {
-        process.stdin.setRawMode(/*!*/ !!wasRaw);
-      }
-      return null;
     }
 
     // catch the terminating character
@@ -154,7 +150,7 @@ function prompt(
     process.stdin.setRawMode(!!wasRaw);
   }
 
-  return str || value || '';
+  return str || (value as string) || '';
 }
 
 function walk(current: string): string[] {

--- a/vnext/local-cli/src/runWindows/runWindows.ts
+++ b/vnext/local-cli/src/runWindows/runWindows.ts
@@ -56,9 +56,6 @@ async function runWindows(
     }
   }
 
-  // Either use the specified root or get the default one
-  options.root = options.root || config.root;
-
   // Get the solution file
   const slnFile = build.getAppSolutionFile(options, config);
 

--- a/vnext/local-cli/src/runWindows/utils/autolink.ts
+++ b/vnext/local-cli/src/runWindows/utils/autolink.ts
@@ -28,7 +28,7 @@ const templateRoot = path.join(__dirname, '../../../templates');
  * @param message The message to log.
  * @param verbose Whether or not verbose logging is enabled.
  */
-function verboseMessage(message: string, verbose: boolean) {
+function verboseMessage(message: any, verbose: boolean) {
   if (verbose) {
     console.log(message);
   }
@@ -175,7 +175,7 @@ async function updateAutoLink(
     }
 
     verboseMessage('Found Windows app project, config:', verbose);
-    verboseMessage(windowsAppConfig.toString(), verbose);
+    verboseMessage(windowsAppConfig, verbose);
 
     const alwaysRequired: Array<keyof WindowsProjectConfig> = [
       'folder',
@@ -254,15 +254,16 @@ async function updateAutoLink(
           `${chalk.bold(dependencyName)} has Windows implementation, config:`,
           verbose,
         );
-        verboseMessage(windowsDependency.toString(), verbose);
+        verboseMessage(windowsDependency, verbose);
 
         var dependencyIsValid = true;
 
-        dependencyIsValid =
+        dependencyIsValid = !!(
           dependencyIsValid &&
           'sourceDir' in windowsDependency &&
-          windowsDependency.sourceDir !== null &&
-          !windowsDependency.sourceDir.startsWith('Error: ');
+          windowsDependency.sourceDir &&
+          !windowsDependency.sourceDir.startsWith('Error: ')
+        );
 
         if (
           'projects' in windowsDependency &&
@@ -274,11 +275,12 @@ async function updateAutoLink(
               'directDependency',
             ];
             itemsToCheck.forEach(item => {
-              dependencyIsValid =
+              dependencyIsValid = !!(
                 dependencyIsValid &&
                 item in project &&
-                project[item] !== null &&
-                !project[item].toString().startsWith('Error: ');
+                project[item] &&
+                !project[item]!.toString().startsWith('Error: ')
+              );
             });
           });
         }
@@ -390,7 +392,7 @@ async function updateAutoLink(
         if (project.directDependency) {
           const dependencyProjectFile = path.join(
             windowsDependencies[dependencyName].folder,
-            windowsDependencies[dependencyName].sourceDir,
+            windowsDependencies[dependencyName].sourceDir!,
             project.projectFile,
           );
 
@@ -439,7 +441,7 @@ async function updateAutoLink(
       windowsDependencies[dependencyName].projects.forEach(project => {
         const dependencyProjectFile = path.join(
           windowsDependencies[dependencyName].folder,
-          windowsDependencies[dependencyName].sourceDir,
+          windowsDependencies[dependencyName].sourceDir!,
           project.projectFile,
         );
 

--- a/vnext/local-cli/src/runWindows/utils/autolink.ts
+++ b/vnext/local-cli/src/runWindows/utils/autolink.ts
@@ -168,9 +168,9 @@ async function updateAutoLink(
           path.join(windowsAppConfig.folder, windowsAppConfig.sourceDir),
           projFile,
         ),
-        projectName: configUtils.getProjectName(projectContents),
+        projectName: configUtils.getProjectName(projFile, projectContents),
         projectLang: configUtils.getProjectLanguage(projFile),
-        projectGuid: configUtils.getProjectGuid(projectContents),
+        projectGuid: configUtils.getProjectGuid(projFile, projectContents),
       };
     }
 

--- a/vnext/local-cli/src/runWindows/utils/build.ts
+++ b/vnext/local-cli/src/runWindows/utils/build.ts
@@ -24,8 +24,8 @@ export async function buildSolution(
   buildArch: BuildArch,
   msBuildProps: Record<string, string>,
   verbose: boolean,
-  target: string,
-  buildLogDirectory: string,
+  target?: string,
+  buildLogDirectory?: string,
 ) {
   const minVersion = new Version(10, 0, 18362, 0);
   const allVersions = MSBuildTools.getAllAvailableUAPVersions();

--- a/vnext/local-cli/src/runWindows/utils/commandWithProgress.ts
+++ b/vnext/local-cli/src/runWindows/utils/commandWithProgress.ts
@@ -85,12 +85,12 @@ export function commandWithProgress(
     const cp = spawn(command, args, spawnOptions);
     let firstErrorLine: string | null = null;
     if (!verbose) {
-      cp.stdout.on('data', chunk => {
+      cp.stdout!.on('data', chunk => {
         const text = chunk.toString();
         setSpinnerText(spinner, taskDoingName + ': ', text);
       });
-      cp.stderr.on('data', chunk => {
-        const text = chunk.toString();
+      cp.stderr!.on('data', chunk => {
+        const text: string = chunk.toString();
         if (!firstErrorLine) {
           firstErrorLine = text;
         }

--- a/vnext/local-cli/src/runWindows/utils/deploy.ts
+++ b/vnext/local-cli/src/runWindows/utils/deploy.ts
@@ -205,7 +205,7 @@ export async function deployToDesktop(
 
   // This path is maintained and VS has promised to keep it valid.
   const vsWherePath = path.join(
-    process.env['ProgramFiles(x86)'] || process.env.ProgramFiles,
+    process.env['ProgramFiles(x86)'] || process.env.ProgramFiles!,
     '/Microsoft Visual Studio/Installer/vswhere.exe',
   );
 
@@ -243,15 +243,7 @@ export async function deployToDesktop(
   }
 
   if (options.directDebugging) {
-    const port = parseInt(options.directDebugging, 10);
-    if (!isNaN(port) && port > 1024 && port < 65535) {
-      args.push('--direct-debugging', port.toString());
-    } else {
-      newError(
-        'Direct debugging port not specified, invalid or out of bounds.',
-      );
-      process.exit(1);
-    }
+    args.push('--direct-debugging', options.directDebugging.toString());
   }
 
   await runPowerShellScriptFunction(

--- a/vnext/local-cli/src/runWindows/utils/vstools.ts
+++ b/vnext/local-cli/src/runWindows/utils/vstools.ts
@@ -137,7 +137,7 @@ export function addProjectToSolution(
     '\tGlobalSection(SolutionConfigurationPlatforms) = preSolution',
     '\tEndGlobalSection',
     false,
-  ).map(line => line.match(/\s+([\w|]+)\s=/)[1]);
+  ).map(line => line.match(/\s+([\w|]+)\s=/)![1]);
 
   let projectConfigLines: string[] = [];
 

--- a/vnext/local-cli/src/runWindows/utils/winappdeploytool.ts
+++ b/vnext/local-cli/src/runWindows/utils/winappdeploytool.ts
@@ -92,7 +92,7 @@ export default class WinAppDeployTool {
     const devices = matchedLines.map((line, arrayIndex) => {
       const match = line.match(LINE_TEST);
       if (!match) {
-        throw new Error('Unexpwcted format of "devices" output');
+        throw new Error('Unexpected format of "devices" output');
       }
 
       const ip = match[1];

--- a/vnext/local-cli/src/runWindows/utils/winappdeploytool.ts
+++ b/vnext/local-cli/src/runWindows/utils/winappdeploytool.ts
@@ -14,18 +14,14 @@ function sortDevices(l: DeviceInfo, r: DeviceInfo): number {
 }
 
 class DeviceInfo {
-  public guid?: string;
-  public ip?: string;
+  constructor(
+    public readonly name: string,
+    public readonly guid: string,
+    public readonly ip: string,
 
-  public readonly name: string;
-  private index: number;
-  private type: string;
-
-  constructor(deviceIndex: number, deviceName: string, deviceType: string) {
-    this.index = deviceIndex;
-    this.name = deviceName;
-    this.type = deviceType;
-  }
+    private index: number,
+    private type: string,
+  ) {}
 
   toString() {
     return `${this.index}. ${this.name} (${this.type})`;
@@ -39,7 +35,7 @@ export default class WinAppDeployTool {
     const programFilesPath =
       process.env['ProgramFiles(x86)'] || process.env.ProgramFiles;
     this.path = path.join(
-      programFilesPath,
+      programFilesPath!,
       'Windows Kits',
       '10',
       'bin',
@@ -95,15 +91,16 @@ export default class WinAppDeployTool {
 
     const devices = matchedLines.map((line, arrayIndex) => {
       const match = line.match(LINE_TEST);
+      if (!match) {
+        throw new Error('Unexpwcted format of "devices" output');
+      }
+
       const ip = match[1];
       const guid = match[2];
       const name = match[3];
       const type = 'device';
 
-      const deviceInfo = new DeviceInfo(arrayIndex, name, type);
-      deviceInfo.ip = ip;
-      deviceInfo.guid = guid;
-
+      const deviceInfo = new DeviceInfo(name, guid, ip, arrayIndex, type);
       return deviceInfo;
     });
 

--- a/vnext/local-cli/tsconfig.json
+++ b/vnext/local-cli/tsconfig.json
@@ -2,15 +2,15 @@
   "extends": "@rnw-scripts/ts-config",
   "compilerOptions": {
     "outDir": "lib-commonjs",
-    "strict": false,
-    "noImplicitReturns": false,
-    "noImplicitAny": true,
     "lib": [
       "DOM",
       "ES6",
       "DOM.Iterable",
       "ES2019.String"
-    ]
+    ],
+
+    // Not clean
+    "strictFunctionTypes": false,
   },
   "include": ["src"],
 }


### PR DESCRIPTION
This change continues the TS work, and brings the CLI close to the level of strictness of other TS projects in the repo. The main change here is around the strictNullChecks rule, where we will now see compile time failures if null can be propagated when not declared.

A couple strategies were taken to fix these:
- Fix up types or init ordering to make it easy to reason about nullability
- Throw exceptions where we used to previously propagate unchecked null values
- Mark some things as allowed to be dull
- Add a smattering of the "!" operator to assert to the compiler that we know something is not null

There were a couple of other quick fixes around not publishing unneeded sources, not coercing object to strings that we log, and ensuring the RunWindows BuildArch is exact.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5399)