### PR TITLE
[0.62] Fix run-windows NuGet Errors in CI By Using Deterministic Binary (#5330) (and fix experimentalNuGet react-native-windows-init)

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -76,7 +76,7 @@ steps:
   - task: CmdLine@2
     displayName: Apply windows template
     inputs:
-      script: npx react-native-windows-init --version $(npmTag) --overwrite --language ${{ parameters.language }} --experimentalNugetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
+      script: npx react-native-windows-init --version $(npmTag) --overwrite --language ${{ parameters.language }} --experimentalNuGetDependency ${{ parameters.experimentalNugetDependency }} ${{ parameters.additionalInitArguments }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - task: PowerShell@2

--- a/change/react-native-windows-2020-06-24-08-27-10-fix-nuget.json
+++ b/change/react-native-windows-2020-06-24-08-27-10-fix-nuget.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use Deterministic NuGet Binary",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-24T15:27:10.726Z"
+}

--- a/change/react-native-windows-2020-06-24-08-27-10-fix-nuget.json
+++ b/change/react-native-windows-2020-06-24-08-27-10-fix-nuget.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Use Deterministic NuGet Binary",
   "packageName": "react-native-windows",
   "email": "ngerlem@microsoft.com",

--- a/vnext/local-cli/generate-windows.js
+++ b/vnext/local-cli/generate-windows.js
@@ -26,7 +26,7 @@ function generateWindows (projectDir, name, ns, options) {
     path.join(__dirname, 'generator-windows', 'templates'),
     projectDir,
     name,
-    { ns, overwrite: options.overwrite, language: options.language, experimentalNugetDependency: options.experimentalNugetDependency }
+    { ns, overwrite: options.overwrite, language: options.language, experimentalNugetDependency: options.experimentalNuGetDependency }
   );
 }
 

--- a/vnext/local-cli/runWindows/utils/build.js
+++ b/vnext/local-cli/runWindows/utils/build.js
@@ -7,9 +7,9 @@
 'use strict';
 
 const fs = require('fs');
+const https = require('https');
 const os = require('os');
 const path = require('path');
-const {execSync} = require('child_process');
 const glob = require('glob');
 const MSBuildTools = require('./msbuildtools');
 const Version = require('./version');
@@ -65,51 +65,25 @@ async function nugetRestore(nugetPath, slnFile, verbose, msbuildVersion) {
 }
 
 async function restoreNuGetPackages(options, slnFile, verbose) {
-  let nugetPath =
-    options.nugetPath || path.join(os.tmpdir(), 'nuget.4.9.2.exe');
-
-  const ensureNugetSpinner = newSpinner('Locating NuGet executable');
-  if (!(await existsAsync(nugetPath))) {
-    try {
-      nugetPath = execSync('where nuget')
-        .toString()
-        .trim();
-    } catch {}
-  }
+  const nugetPath = path.join(os.tmpdir(), 'nuget.4.9.2.exe');
 
   if (!(await existsAsync(nugetPath))) {
-    await commandWithProgress(
-      ensureNugetSpinner,
-      'Downloading NuGet Binary',
-      'powershell',
-      `$progressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue; Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe -outfile ${nugetPath}`.split(
-        ' ',
-      ),
-      verbose,
+    const spinner = newSpinner('Downloading NuGet Binary');
+    await downloadFileWithRetry(
+      'https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe',
+      nugetPath,
+      1 /*retries*/,
     );
-  }
-  ensureNugetSpinner.succeed('Found NuGet Binary');
-
-  if (verbose) {
-    console.log(`Using Nuget: ${nugetPath}`);
+    spinner.succeed();
   }
 
   const msbuildTools = MSBuildTools.findAvailableVersion('x86', verbose);
-  try {
-    await nugetRestore(
-      nugetPath,
-      slnFile,
-      verbose,
-      msbuildTools.installationVersion,
-    );
-  } catch (e) {
-    if (!options.isRetryingNuget) {
-      const retryOptions = Object.assign({isRetryingNuget: true}, options);
-      fs.unlinkSync(nugetPath);
-      return restoreNuGetPackages(retryOptions, slnFile, verbose);
-    }
-    throw e;
-  }
+  await nugetRestore(
+    nugetPath,
+    slnFile,
+    verbose,
+    msbuildTools.installationVersion,
+  );
 }
 
 function getSolutionFile(options) {
@@ -136,6 +110,37 @@ function parseMsBuildProps(options) {
     }
   }
   return result;
+}
+
+async function downloadFileWithRetry(url, dest, retries) {
+  for (let retryCount = 0; ; ++retryCount) {
+    try {
+      return await downloadFile(url, dest);
+    } catch (ex) {
+      if (retryCount === retries) {
+        throw ex;
+      }
+    }
+  }
+}
+
+function downloadFile(url, dest) {
+  const destFile = fs.createWriteStream(dest);
+
+  return new Promise((resolve, reject) => {
+    https
+      .get(url)
+      .on('response', res => res.pipe(destFile))
+      .on('finish', () => {
+        destFile.on('finish', () => {
+          destFile.close();
+          resolve();
+        });
+      })
+      .on('error', err => {
+        fs.unlink(dest, () => reject(err));
+      });
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
* Try to Fix CI NuGet Errors

This change makes us use a deterministic NuGet binary that we always download. We remove the NuGetPath option which isn't exposed as a CLI option, and don't trust any local NuGet exe because we can't guarantee version. Instead of wrapping the entire logic in a recursive retry when downloading the binary, we isolate retries to just downloading the binary itself. We remove some of the blanket catches, command output parsing, and delegation to PowerShell instead of JS functions that were somehow leading to executing the whole command when trying to locate it?

Haven't tested locally. Will tell what CI thinks.

* Change files

* Rename changelog entry

* Close the write stream

* Https

* Make sure both streams finish sucessfully

* Update netcore version as azure devops images drop support

* Remove accidentally generated headers

Co-authored-by: Danny van Velzen 🁴 <dannyvv@microsoft.com>

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5401)