### PR TITLE
Speed up finding Google TestAdapter extension in VS folder

### DIFF
--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -1,6 +1,6 @@
 variables:
   VmImage: windows-2019
   MSBuildVersion: 16.0
-  GoogleTestAdapterPathExpression: '(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\" -Recurse -Include GoogleTestAdapter.Core.dll).Directory.FullName'
+  GoogleTestAdapterPathExpression: '(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\" -Directory | Where-Object -FilterScript { Test-Path $_\GoogleTestAdapter.Core.dll}).FullName'
   BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:
   runCodesignValidationInjection: false


### PR DESCRIPTION
Performing the recursive directory search in the existing script can take between 2 and 3 minutes, with this changes it is down to 1 second!

This updated script takes advantage of knowing that the dll is only in the root folder, so we list all directories in the extension folder and then filter it to the one which has the testadapter dll.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5403)