### PR TITLE
Fix #4809: Remove the /flow folder from the shipping npm package

### DIFF
--- a/change/react-native-windows-2020-07-01-20-42-11-master.json
+++ b/change/react-native-windows-2020-07-01-20-42-11-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix #4809: Remove the /flow folder from the shipping npm package",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-02T03:42:11.707Z"
+}

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -88,7 +88,6 @@
     "/Chakra",
     "/Common",
     "/DeforkingPatches",
-    "/flow",
     "/Folly",
     "/include",
     "/JSI",


### PR DESCRIPTION
I did a search for any file with `import` or `require` of flow that would hit this folder and found none.
I did a search in *.*proj, *.props and *.targets as well as common script files and could not find a reference to this folder.

Therefore I am confident this folder is not needed to be shipped within the react-native-windows npm package.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5414)