### PR TITLE
Include "nuget.exe" as Package Dependency of react-native-windows

### DIFF
--- a/change/nuget-exe-2020-07-02-03-17-13-better-nuget.json
+++ b/change/nuget-exe-2020-07-02-03-17-13-better-nuget.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Include \"nuget.exe\" as Package Dependency of react-native-windows",
+  "packageName": "nuget-exe",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-02T10:17:10.014Z"
+}

--- a/change/react-native-windows-2020-07-02-03-17-13-better-nuget.json
+++ b/change/react-native-windows-2020-07-02-03-17-13-better-nuget.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Include \"nuget.exe\" as Package Dependency of react-native-windows",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-02T10:17:13.358Z"
+}

--- a/packages/nuget-exe/.gitignore
+++ b/packages/nuget-exe/.gitignore
@@ -1,0 +1,1 @@
+/nuget-*.exe

--- a/packages/nuget-exe/just-task.js
+++ b/packages/nuget-exe/just-task.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ * @ts-check
+ */
+
+const fs = require('fs');
+const https = require('https');
+const {argv, task, cleanTask, logger, option} = require('just-scripts');
+
+const NUGET_VERSION = '4.9.2';
+const nugetBinary = `./nuget-${NUGET_VERSION}.exe`;
+const nugetUrl = `https://dist.nuget.org/win-x86-commandline/v${NUGET_VERSION}/nuget.exe`;
+
+option('clean');
+
+task('clean', cleanTask(nugetBinary));
+
+task('build', async () => {
+  if (argv.clean || !fs.existsSync(nugetBinary)) {
+    logger.info(`Downloading NuGet binary from "${nugetUrl}"`);
+    await downloadFile(nugetUrl, nugetBinary);
+  }
+});
+
+function downloadFile(url, dest) {
+  const destFile = fs.createWriteStream(dest);
+
+  return new Promise((resolve, reject) => {
+    https
+      .get(url)
+      .on('response', res => res.pipe(destFile))
+      .on('finish', () => {
+        destFile.on('finish', () => {
+          destFile.close();
+          resolve();
+        });
+      })
+      .on('error', err => {
+        fs.unlink(dest, () => reject(err));
+      });
+  });
+}

--- a/packages/nuget-exe/package.json
+++ b/packages/nuget-exe/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nuget-exe",
+  "version": "4.9.1",
+  "description": "Repackaged NuGet.exe bianry",
+  "main": "nuget-4.9.2.exe",
+  "repository": "https://github.com/microsoft/react-native-windows",
+  "license": "MIT",
+  "scripts": {
+    "build": "just-scripts build",
+    "clean": "just-scripts clean"
+  },
+  "devDependencies": {
+    "just-scripts": "^0.36.1"
+  },
+  "files": [
+    "nuget-4.9.2.exe"
+  ]
+}

--- a/packages/nuget-exe/package.json
+++ b/packages/nuget-exe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuget-exe",
   "version": "4.9.1",
-  "description": "Repackaged NuGet.exe bianry",
+  "description": "Repackaged NuGet.exe binary",
   "main": "nuget-4.9.2.exe",
   "repository": "https://github.com/microsoft/react-native-windows",
   "license": "MIT",

--- a/vnext/local-cli/src/runWindows/runWindows.ts
+++ b/vnext/local-cli/src/runWindows/runWindows.ts
@@ -81,7 +81,7 @@ async function runWindows(
     }
 
     try {
-      await build.restoreNuGetPackages(options, slnFile, verbose);
+      await build.restoreNuGetPackages(slnFile, verbose);
     } catch (e) {
       newError('Failed to restore the NuGet packages: ' + e.toString());
       ExitProcessWithError(options.logging);

--- a/vnext/local-cli/src/runWindows/utils/build.ts
+++ b/vnext/local-cli/src/runWindows/utils/build.ts
@@ -4,19 +4,13 @@
  * @format
  */
 
-import * as fs from 'fs';
-import * as https from 'https';
-import * as os from 'os';
 import * as path from 'path';
 
 import * as MSBuildTools from './msbuildtools';
 import Version from './version';
 import {commandWithProgress, newSpinner, newError} from './commandWithProgress';
-import * as util from 'util';
 import {RunWindowsOptions, BuildConfig, BuildArch} from '../runWindowsOptions';
 import {Config} from '@react-native-community/cli-types';
-
-const existsAsync = util.promisify(fs.exists);
 
 export async function buildSolution(
   slnFile: string,
@@ -48,18 +42,16 @@ export async function buildSolution(
 }
 
 async function nugetRestore(
-  nugetPath: string,
   slnFile: string,
   verbose: boolean,
   msbuildVersion: string,
 ) {
   const text = 'Restoring NuGet packages ';
   const spinner = newSpinner(text);
-  console.log(nugetPath);
   await commandWithProgress(
     spinner,
     text,
-    nugetPath,
+    require.resolve('nuget-exe'),
     [
       'restore',
       `${slnFile}`,
@@ -73,30 +65,9 @@ async function nugetRestore(
   );
 }
 
-export async function restoreNuGetPackages(
-  options: RunWindowsOptions,
-  slnFile: string,
-  verbose: boolean,
-) {
-  const nugetPath = path.join(os.tmpdir(), 'nuget.4.9.2.exe');
-
-  if (!(await existsAsync(nugetPath))) {
-    const spinner = newSpinner('Downloading NuGet Binary');
-    await downloadFileWithRetry(
-      'https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe',
-      nugetPath,
-      1 /*retries*/,
-    );
-    spinner.succeed();
-  }
-
+export async function restoreNuGetPackages(slnFile: string, verbose: boolean) {
   const msbuildTools = MSBuildTools.findAvailableVersion('x86', verbose);
-  await nugetRestore(
-    nugetPath,
-    slnFile,
-    verbose,
-    msbuildTools.installationVersion,
-  );
+  await nugetRestore(slnFile, verbose, msbuildTools.installationVersion);
 }
 
 const configErrorString = 'Error: ';
@@ -174,39 +145,4 @@ export function parseMsBuildProps(
     }
   }
   return result;
-}
-
-async function downloadFileWithRetry(
-  url: string,
-  dest: string,
-  retries: number,
-) {
-  for (let retryCount = 0; ; ++retryCount) {
-    try {
-      return await downloadFile(url, dest);
-    } catch (ex) {
-      if (retryCount === retries) {
-        throw ex;
-      }
-    }
-  }
-}
-
-function downloadFile(url: string, dest: string) {
-  const destFile = fs.createWriteStream(dest);
-
-  return new Promise((resolve, reject) => {
-    https
-      .get(url)
-      .on('response', res => res.pipe(destFile))
-      .on('finish', () => {
-        destFile.on('finish', () => {
-          destFile.close();
-          resolve();
-        });
-      })
-      .on('error', err => {
-        fs.unlink(dest, () => reject(err));
-      });
-  });
 }

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -32,6 +32,7 @@
     "mustache": "^4.0.1",
     "ora": "^3.4.0",
     "prop-types": "^15.7.2",
+    "nuget-exe": "4.9.1",
     "regenerator-runtime": "^0.13.2",
     "semver": "^7.1.3",
     "shelljs": "^0.7.8",


### PR DESCRIPTION
Fixes #5404

The nuget.exe CLI tool is not provided as part of a Visual Studio installation, and we cannot use the MSBuild built-in functionality without PackageReference. We used to have logic in run-windows to download a NuGet binary if one isn't present, or try to find one if not installed.

We can leverage npm to ensure we have a working version of NuGet instead. This change adds some build logic to publish NuGet to the NPM registry and ensure react-native-windows downloads the NuGet package during installation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5418)