### PR TITLE
Disable RNIntegrationTests::Logging

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -407,6 +407,7 @@ jobs:
       Desktop.IntegrationTests.Filter: >
         (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&
         (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
+        (FullyQualifiedName!=RNTesterIntegrationTests::Dummy)&
         (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
         (FullyQualifiedName!=RNTesterIntegrationTests::Logging)&
         (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -401,13 +401,14 @@ jobs:
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
     variables:
-      #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage).
+      #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage,WebSocket,Logging).
       #5265 - WebSocketModuleIntegrationTest::WebSocketModule_Ping fails for Release
       #5412 - Disable XHRSample due to intermittedly crashing the test process
       Desktop.IntegrationTests.Filter: >
         (FullyQualifiedName!~WebSocketJSExecutorIntegrationTest)&
-        (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
         (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
+        (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
+        (FullyQualifiedName!=RNTesterIntegrationTests::Logging)&
         (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
         (FullyQualifiedName!=RNTesterIntegrationTests::XHRSample)&
         (FullyQualifiedName!~WebSocketModule_)&
@@ -530,12 +531,12 @@ jobs:
           language: cpp
           configuration: Release
           platform: x64
-          additionalInitArguments: 
+          additionalInitArguments:
         X64ReleaseCs:
           language: cs
           configuration: Release
           platform: x64
-          additionalInitArguments: 
+          additionalInitArguments:
         #ArmDebugCpp:
         #  language: cpp
         #  configuration: Debug
@@ -548,12 +549,12 @@ jobs:
           language: cpp
           configuration: Release
           platform: arm
-          additionalInitArguments: 
+          additionalInitArguments:
         ArmReleaseCs:
           language: cs
           configuration: Release
           platform: arm
-          additionalInitArguments: 
+          additionalInitArguments:
         #Arm64DebugCpp:
         #  language: cpp
         #  configuration: Debug


### PR DESCRIPTION
This test started failing consistently.
Disabling while the test runner gets rewritten.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5433)