### PR TITLE
Normalize override manifests to unix paths

### DIFF
--- a/change/@office-iss-react-native-win32-2020-07-06-17-39-31-unix-path-manifests.json
+++ b/change/@office-iss-react-native-win32-2020-07-06-17-39-31-unix-path-manifests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Normalize override manifests to unix paths",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-07T00:39:29.865Z"
+}

--- a/change/react-native-platform-override-2020-07-06-17-39-31-unix-path-manifests.json
+++ b/change/react-native-platform-override-2020-07-06-17-39-31-unix-path-manifests.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Normalize override manifests to unix paths",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-07T00:39:23.580Z"
+}

--- a/change/react-native-windows-2020-07-06-17-39-31-unix-path-manifests.json
+++ b/change/react-native-windows-2020-07-06-17-39-31-unix-path-manifests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Normalize override manifests to unix paths",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-07T00:39:31.163Z"
+}

--- a/packages/react-native-platform-override/src/Override.ts
+++ b/packages/react-native-platform-override/src/Override.ts
@@ -67,7 +67,7 @@ export class PlatformOverride implements Override {
   }
 
   serialize(): Serialized.PlatformOverride {
-    return {type: 'platform', file: this.overrideFile};
+    return {type: 'platform', file: unixPath(this.overrideFile)};
   }
 
   name(): string {
@@ -141,8 +141,8 @@ abstract class BaseFileOverride implements Override {
 
   protected serialzeBase() {
     return {
-      file: this.overrideFile,
-      baseFile: this.baseFile,
+      file: unixPath(this.overrideFile),
+      baseFile: unixPath(this.baseFile),
       baseVersion: this.baseVersion,
       baseHash: this.baseHash,
     };
@@ -296,4 +296,8 @@ export function deserializeOverride(ovr: Serialized.Override): Override {
     case 'patch':
       return PatchOverride.fromSerialized(ovr);
   }
+}
+
+function unixPath(dir: string): string {
+  return dir.replace(/\\/g, '/');
 }

--- a/packages/react-native-platform-override/src/test/Override.test.ts
+++ b/packages/react-native-platform-override/src/test/Override.test.ts
@@ -64,6 +64,12 @@ const fileOverrides: TestCase<OverrideConstructor>[] = [
   patchOverride,
 ];
 
+const baseFileOverrides: TestCase<OverrideConstructor>[] = [
+  copyOverride,
+  derivedOverride,
+  patchOverride,
+];
+
 test.each(fileOverrides)('name - %s', (_, ovrClass, args) => {
   const override = new ovrClass({...args, file: 'bar.windows.js'});
   expect(override.name()).toBe('bar.windows.js');
@@ -93,3 +99,20 @@ test.each(fileOverrides)('%s Serialization Roundtrip', (_, ovrClass, args) => {
   const override = new ovrClass(args);
   expect(deserializeOverride(override.serialize())).toEqual(override);
 });
+
+test.each(fileOverrides)(
+  '%s Override File Serializes To Unix Path',
+  (_, ovrClass, args) => {
+    const override = new ovrClass({...args, file: 'path\\to\\bar.windows.js'});
+    expect(override.serialize().file).toEqual('path/to/bar.windows.js');
+  },
+);
+
+test.each(baseFileOverrides)(
+  '%s Base File Serializes To Unix Path',
+  (_, ovrClass, args) => {
+    const override = new ovrClass({...args, baseFile: 'path\\to\\bar.js'});
+    const serialized = override.serialize() as any;
+    expect(serialized.baseFile).toEqual('path/to/bar.js');
+  },
+);

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -13,450 +13,450 @@
     },
     {
       "type": "platform",
-      "file": "src\\index.win32.js"
+      "file": "src/index.win32.js"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Alert\\Alert.win32.js",
-      "baseFile": "Libraries\\Alert\\Alert.js",
+      "file": "src/Libraries/Alert/Alert.win32.js",
+      "baseFile": "Libraries/Alert/Alert.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.win32.js",
-      "baseFile": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.android.js",
+      "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
+      "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "840be6f49fe36a3bcfb568eb285bf860f0dd441d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\AccessibilityInfo\\NativeAccessibilityInfo.win32.js",
-      "baseFile": "Libraries\\Components\\AccessibilityInfo\\NativeAccessibilityInfo.js",
+      "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
+      "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b3e2c37d96de6f00066495267f7c32d6e9d3f840",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Button\\ButtonWin32.Props.ts"
+      "file": "src/Libraries/Components/Button/ButtonWin32.Props.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Button\\ButtonWin32.tsx"
+      "file": "src/Libraries/Components/Button/ButtonWin32.tsx"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\CheckBox\\CheckBox.win32.js",
-      "baseFile": "Libraries\\Components\\CheckBox\\CheckBox.android.js",
+      "file": "src/Libraries/Components/CheckBox/CheckBox.win32.js",
+      "baseFile": "Libraries/Components/CheckBox/CheckBox.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "278d7049749ba8b5f3840f21ef6b3d528183829f",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\DatePicker\\DatePickerIOS.win32.js",
-      "baseFile": "Libraries\\Components\\DatePicker\\DatePickerIOS.android.js",
+      "file": "src/Libraries/Components/DatePicker/DatePickerIOS.win32.js",
+      "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea",
       "issue": 4378
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.win32.js",
-      "baseFile": "Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.ios.js",
+      "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.win32.js",
+      "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc",
       "issue": 4378
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.js",
-      "baseFile": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.ios.js",
+      "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js",
+      "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\EnterString.win32.tsx"
+      "file": "src/Libraries/Components/EnterString.win32.tsx"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\MaskedView\\MaskedViewIOS.win32.js",
-      "baseFile": "Libraries\\Components\\MaskedView\\MaskedViewIOS.android.js",
+      "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.win32.js",
+      "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b",
       "issue": 4378
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Picker\\Picker.win32.tsx"
+      "file": "src/Libraries/Components/Picker/Picker.win32.tsx"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\Picker\\PickerAndroid.js",
-      "baseFile": "Libraries\\Components\\Picker\\PickerAndroid.ios.js",
+      "file": "src/Libraries/Components/Picker/PickerAndroid.js",
+      "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\Picker\\PickerIOS.js",
-      "baseFile": "Libraries\\Components\\Picker\\PickerIOS.android.js",
+      "file": "src/Libraries/Components/Picker/PickerIOS.js",
+      "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6",
       "issue": 4378
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.js",
-      "baseFile": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.ios.js",
+      "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js",
+      "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.win32.js",
-      "baseFile": "Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.android.js",
+      "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.win32.js",
+      "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\SafeAreaView\\SafeAreaView.win32.js",
-      "baseFile": "Libraries\\Components\\SafeAreaView\\SafeAreaView.js",
+      "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
+      "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.js",
-      "baseFile": "Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.android.js",
+      "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.js",
+      "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": 4378
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Text\\TextWin32.Props.ts"
+      "file": "src/Libraries/Components/Text/TextWin32.Props.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Text\\TextWin32.tsx"
+      "file": "src/Libraries/Components/Text/TextWin32.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\TextInput\\Tests\\TextInputTest.tsx"
+      "file": "src/Libraries/Components/TextInput/Tests/TextInputTest.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\TextInput\\TextInput.Types.win32.ts"
+      "file": "src/Libraries/Components/TextInput/TextInput.Types.win32.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\TextInput\\TextInput.win32.tsx",
-      "baseFile": "Libraries\\Components\\TextInput\\TextInput.js",
+      "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
+      "baseFile": "Libraries/Components/TextInput/TextInput.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a50310f6dee460f7d1a53e0f1a21dbac9cf02094",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\TextInput\\TextInputState.win32.js",
-      "baseFile": "Libraries\\Components\\TextInput\\TextInputState.js",
+      "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
+      "baseFile": "Libraries/Components/TextInput/TextInputState.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\ToastAndroid\\ToastAndroid.win32.js",
-      "baseFile": "Libraries\\Components\\ToastAndroid\\ToastAndroid.ios.js",
+      "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.win32.js",
+      "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0",
       "issue": 4378
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Touchable\\Tests\\TouchableWin32Test.tsx"
+      "file": "src/Libraries/Components/Touchable/Tests/TouchableWin32Test.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableNativeFeedback.Props.ts"
+      "file": "src/Libraries/Components/Touchable/TouchableNativeFeedback.Props.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableNativeFeedback.win32.tsx"
+      "file": "src/Libraries/Components/Touchable/TouchableNativeFeedback.win32.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableWin32.Props.tsx"
+      "file": "src/Libraries/Components/Touchable/TouchableWin32.Props.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableWin32.tsx"
+      "file": "src/Libraries/Components/Touchable/TouchableWin32.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableWin32.Types.tsx"
+      "file": "src/Libraries/Components/Touchable/TouchableWin32.Types.tsx"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\View\\ReactNativeViewAttributes.win32.js",
-      "baseFile": "Libraries\\Components\\View\\ReactNativeViewAttributes.js",
+      "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
+      "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\View\\ReactNativeViewViewConfig.win32.js",
-      "baseFile": "Libraries\\Components\\View\\ReactNativeViewViewConfig.js",
+      "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
+      "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\View\\Tests\\ViewWin32Test.tsx"
+      "file": "src/Libraries/Components/View/Tests/ViewWin32Test.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\View\\ViewWin32.Props.ts"
+      "file": "src/Libraries/Components/View/ViewWin32.Props.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\View\\ViewWin32.tsx"
+      "file": "src/Libraries/Components/View/ViewWin32.tsx"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\core\\ReactNativeVersionCheck.win32.js",
-      "baseFile": "Libraries\\core\\ReactNativeVersionCheck.js",
+      "file": "src/Libraries/core/ReactNativeVersionCheck.win32.js",
+      "baseFile": "Libraries/core/ReactNativeVersionCheck.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "599ad6d6c8485cd453cd926cdf89f06640d439f6",
       "issue": 5170
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Image\\Image.win32.js",
-      "baseFile": "Libraries\\Image\\Image.ios.js",
+      "file": "src/Libraries/Image/Image.win32.js",
+      "baseFile": "Libraries/Image/Image.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "26acff268b815c7b3c5da0d6c9c009073b202ea8",
       "issue": 4320
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\ImageTypes.ts"
+      "file": "src/Libraries/Image/ImageTypes.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Image\\NativeImageLoaderWin32.js",
-      "baseFile": "Libraries\\Image\\NativeImageLoaderIOS.js",
+      "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
+      "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6161ce89a0b45b24e8df69aa108af22a7b591483",
       "issue": 4320
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\resolveAssetSource.win32.js"
+      "file": "src/Libraries/Image/resolveAssetSource.win32.js"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\ImageWin32Test.tsx"
+      "file": "src/Libraries/Image/Tests/ImageWin32Test.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\dpitest.png"
+      "file": "src/Libraries/Image/Tests/img/dpitest.png"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\dpitest@1.5x.png"
+      "file": "src/Libraries/Image/Tests/img/dpitest@1.5x.png"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\dpitest@2x.png"
+      "file": "src/Libraries/Image/Tests/img/dpitest@2x.png"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\dpitest@3x.png"
+      "file": "src/Libraries/Image/Tests/img/dpitest@3x.png"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\en-us\\dpitest.png"
+      "file": "src/Libraries/Image/Tests/img/en-us/dpitest.png"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\en-us\\dpitest@1.5x.png"
+      "file": "src/Libraries/Image/Tests/img/en-us/dpitest@1.5x.png"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Image\\Tests\\img\\en-us\\dpitest@3x.png"
+      "file": "src/Libraries/Image/Tests/img/en-us/dpitest@3x.png"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Inspector\\Inspector.win32.js",
-      "baseFile": "Libraries\\Inspector\\Inspector.js",
+      "file": "src/Libraries/Inspector/Inspector.win32.js",
+      "baseFile": "Libraries/Inspector/Inspector.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "565fbf7ad692b85438aadfb43b88000bef112999",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Inspector\\InspectorOverlay.win32.js",
-      "baseFile": "Libraries\\Inspector\\InspectorOverlay.js",
+      "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
+      "baseFile": "Libraries/Inspector/InspectorOverlay.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b8535e8c605e6c0e940aae6c04f0d573eaa4788e",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Network\\RCTNetworking.win32.js",
-      "baseFile": "Libraries\\Network\\RCTNetworking.android.js",
+      "file": "src/Libraries/Network/RCTNetworking.win32.js",
+      "baseFile": "Libraries/Network/RCTNetworking.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "9ba4db01878648ef181dfd51debd821a837f56b3",
       "issue": 4318
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\PersonaCoin\\PersonaCoin.tsx"
+      "file": "src/Libraries/PersonaCoin/PersonaCoin.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\PersonaCoin\\PersonaCoinPropTypes.ts"
+      "file": "src/Libraries/PersonaCoin/PersonaCoinPropTypes.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\PersonaCoin\\PersonaCoinTypes.ts"
+      "file": "src/Libraries/PersonaCoin/PersonaCoinTypes.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Settings\\Settings.win32.js",
-      "baseFile": "Libraries\\Settings\\Settings.android.js",
+      "file": "src/Libraries/Settings/Settings.win32.js",
+      "baseFile": "Libraries/Settings/Settings.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\StyleSheet\\PlatformColorValueTypes.win32.js"
+      "file": "src/Libraries/StyleSheet/PlatformColorValueTypes.win32.js"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\StyleSheet\\PlatformColorValueTypesWin32.d.ts"
+      "file": "src/Libraries/StyleSheet/PlatformColorValueTypesWin32.d.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\StyleSheet\\PlatformColorValueTypesWin32.js"
+      "file": "src/Libraries/StyleSheet/PlatformColorValueTypesWin32.js"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\StyleSheet\\StyleSheet.win32.js",
-      "baseFile": "Libraries\\StyleSheet\\StyleSheet.js",
+      "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
+      "baseFile": "Libraries/StyleSheet/StyleSheet.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "073367bc043b5e7e9db6ec046da088e750d3693c",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\StyleSheet\\StyleSheetValidation.win32.js",
-      "baseFile": "Libraries\\StyleSheet\\StyleSheetValidation.js",
+      "file": "src/Libraries/StyleSheet/StyleSheetValidation.win32.js",
+      "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\BackHandler.win32.ts",
-      "baseFile": "Libraries\\Utilities\\BackHandler.android.js",
+      "file": "src/Libraries/Utilities/BackHandler.win32.ts",
+      "baseFile": "Libraries/Utilities/BackHandler.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b1633b6bb5e3dc842011b09f778626c39bf6b654",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\DeviceInfo.win32.js",
-      "baseFile": "Libraries\\Utilities\\DeviceInfo.js",
+      "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
+      "baseFile": "Libraries/Utilities/DeviceInfo.js",
       "baseVersion": "0.61.5",
       "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\Dimensions.win32.js",
-      "baseFile": "Libraries\\Utilities\\Dimensions.js",
+      "file": "src/Libraries/Utilities/Dimensions.win32.js",
+      "baseFile": "Libraries/Utilities/Dimensions.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\NativePlatformConstantsWin.js",
-      "baseFile": "Libraries\\Utilities\\NativePlatformConstantsIOS.js",
+      "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
+      "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
       "baseVersion": "0.61.5",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\Platform.win32.js",
-      "baseFile": "Libraries\\Utilities\\Platform.android.js",
+      "file": "src/Libraries/Utilities/Platform.win32.js",
+      "baseFile": "Libraries/Utilities/Platform.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\APIExamples\\AccessibilityExampleWin32.tsx"
+      "file": "src/RNTester/APIExamples/AccessibilityExampleWin32.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\APIExamples\\ThemingModuleAPI.tsx"
+      "file": "src/RNTester/APIExamples/ThemingModuleAPI.tsx"
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\components\\ListExampleShared.win32.js",
-      "baseFile": "RNTester\\js\\components\\ListExampleShared.js",
+      "file": "src/RNTester/js/components/ListExampleShared.win32.js",
+      "baseFile": "RNTester/js/components/ListExampleShared.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\components\\RNTesterExampleFilter.win32.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterExampleFilter.js",
+      "file": "src/RNTester/js/components/RNTesterExampleFilter.win32.js",
+      "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples\\ColorGradientWin32Example.js"
+      "file": "src/RNTester/js/examples/ColorGradientWin32Example.js"
     },
     {
       "type": "derived",
-      "file": "src\\RNTester\\js\\RNTesterApp.win32.js",
-      "baseFile": "RNTester\\js\\RNTesterApp.ios.js",
+      "file": "src/RNTester/js/RNTesterApp.win32.js",
+      "baseFile": "RNTester/js/RNTesterApp.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
     {
       "type": "derived",
-      "file": "src\\RNTester\\js\\utils\\RNTesterList.win32.js",
-      "baseFile": "RNTester\\js\\utils\\RNTesterList.android.js",
+      "file": "src/RNTester/js/utils/RNTesterList.win32.js",
+      "baseFile": "RNTester/js/utils/RNTesterList.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "65c3876bdbc2755cd568b2779ed962fa7a4edf6a",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\typings-index.ts"
+      "file": "src/typings-index.ts"
     }
   ]
 }

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -20,2164 +20,2164 @@
     },
     {
       "type": "patch",
-      "file": "DeforkingPatches\\ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.cpp",
-      "baseFile": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.cpp",
+      "file": "DeforkingPatches/ReactCommon/turbomodule/samples/SampleTurboCxxModule.cpp",
+      "baseFile": "ReactCommon/turbomodule/samples/SampleTurboCxxModule.cpp",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b8840ecbf1d0a61d5e13d6f9690722e41cacb7ab",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "DeforkingPatches\\ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.h",
-      "baseFile": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.h",
+      "file": "DeforkingPatches/ReactCommon/turbomodule/samples/SampleTurboCxxModule.h",
+      "baseFile": "ReactCommon/turbomodule/samples/SampleTurboCxxModule.h",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "2e4e38798e5504d891342e46da17ef3b073123d8",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "DeforkingPatches\\ReactCommon\\yoga\\yoga\\Yoga.cpp",
-      "baseFile": "ReactCommon\\yoga\\yoga\\Yoga.cpp",
+      "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
+      "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "99b23af03df9e59e1c42cd9e026ebb4c4df75cb4",
       "issue": 3994
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\AccessibilityManagerTest.js",
-      "baseFile": "IntegrationTests\\AccessibilityManagerTest.js",
+      "file": "ReactCopies/IntegrationTests/AccessibilityManagerTest.js",
+      "baseFile": "IntegrationTests/AccessibilityManagerTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "7e9b6ece04612d18f0a8bf7e8b7cecae815facd9",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\AppEventsTest.js",
-      "baseFile": "IntegrationTests\\AppEventsTest.js",
+      "file": "ReactCopies/IntegrationTests/AppEventsTest.js",
+      "baseFile": "IntegrationTests/AppEventsTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "f4ba0683d08a550ee8af612519740a8b36e704ed",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\AsyncStorageTest.js",
-      "baseFile": "IntegrationTests\\AsyncStorageTest.js",
+      "file": "ReactCopies/IntegrationTests/AsyncStorageTest.js",
+      "baseFile": "IntegrationTests/AsyncStorageTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "363ad4689a7058e7ab525d1b3243390377c33c17",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\blue_square.png",
-      "baseFile": "IntegrationTests\\blue_square.png",
+      "file": "ReactCopies/IntegrationTests/blue_square.png",
+      "baseFile": "IntegrationTests/blue_square.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a565f34729e4cd9c421401dc0ad825755d1ccb3b",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\GlobalEvalWithSourceUrlTest.js",
-      "baseFile": "IntegrationTests\\GlobalEvalWithSourceUrlTest.js",
+      "file": "ReactCopies/IntegrationTests/GlobalEvalWithSourceUrlTest.js",
+      "baseFile": "IntegrationTests/GlobalEvalWithSourceUrlTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "57af3fe84649f53262ea8503004dc1bfea4011ca",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\ImageCachePolicyTest.js",
-      "baseFile": "IntegrationTests\\ImageCachePolicyTest.js",
+      "file": "ReactCopies/IntegrationTests/ImageCachePolicyTest.js",
+      "baseFile": "IntegrationTests/ImageCachePolicyTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6e77238435d9a4d4d299ae0082bdf6c69d83138b",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\ImageSnapshotTest.js",
-      "baseFile": "IntegrationTests\\ImageSnapshotTest.js",
+      "file": "ReactCopies/IntegrationTests/ImageSnapshotTest.js",
+      "baseFile": "IntegrationTests/ImageSnapshotTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "f12b95ca9839786a9f1412a40437b4bf563d3bbd",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\IntegrationTestHarnessTest.js",
-      "baseFile": "IntegrationTests\\IntegrationTestHarnessTest.js",
+      "file": "ReactCopies/IntegrationTests/IntegrationTestHarnessTest.js",
+      "baseFile": "IntegrationTests/IntegrationTestHarnessTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "dd0f896ae5e5d3d0d4c85ae3a79b3a4b7bc64a52",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\IntegrationTestsApp.js",
-      "baseFile": "IntegrationTests\\IntegrationTestsApp.js",
+      "file": "ReactCopies/IntegrationTests/IntegrationTestsApp.js",
+      "baseFile": "IntegrationTests/IntegrationTestsApp.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "5be58c2fa844770c24722dbaf776510b3032250c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\launchWebSocketServer.command",
-      "baseFile": "IntegrationTests\\launchWebSocketServer.command",
+      "file": "ReactCopies/IntegrationTests/launchWebSocketServer.command",
+      "baseFile": "IntegrationTests/launchWebSocketServer.command",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "dadf0e006def5f367c28c6d631cc1ccb75e91d08",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\LayoutEventsTest.js",
-      "baseFile": "IntegrationTests\\LayoutEventsTest.js",
+      "file": "ReactCopies/IntegrationTests/LayoutEventsTest.js",
+      "baseFile": "IntegrationTests/LayoutEventsTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "d8797c6d795b0b4290c6c8b72565c67449fdf705",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\LoggingTestModule.js",
-      "baseFile": "IntegrationTests\\LoggingTestModule.js",
+      "file": "ReactCopies/IntegrationTests/LoggingTestModule.js",
+      "baseFile": "IntegrationTests/LoggingTestModule.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b0f05079cabf5bb6a0d51c7dc4623b77530468b8",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\PromiseTest.js",
-      "baseFile": "IntegrationTests\\PromiseTest.js",
+      "file": "ReactCopies/IntegrationTests/PromiseTest.js",
+      "baseFile": "IntegrationTests/PromiseTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "cbc73ff575b8878584d731c1370a3e9cdbc04969",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\PropertiesUpdateTest.js",
-      "baseFile": "IntegrationTests\\PropertiesUpdateTest.js",
+      "file": "ReactCopies/IntegrationTests/PropertiesUpdateTest.js",
+      "baseFile": "IntegrationTests/PropertiesUpdateTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "c94c31a78383cb5cc05cebef8d6bc278c2e52b69",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\RCTRootViewIntegrationTestApp.js",
-      "baseFile": "IntegrationTests\\RCTRootViewIntegrationTestApp.js",
+      "file": "ReactCopies/IntegrationTests/RCTRootViewIntegrationTestApp.js",
+      "baseFile": "IntegrationTests/RCTRootViewIntegrationTestApp.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "aa938ff6fc8c50e3d5b5c3a6b07f71918564e3fd",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\ReactContentSizeUpdateTest.js",
-      "baseFile": "IntegrationTests\\ReactContentSizeUpdateTest.js",
+      "file": "ReactCopies/IntegrationTests/ReactContentSizeUpdateTest.js",
+      "baseFile": "IntegrationTests/ReactContentSizeUpdateTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e4e00a14c7f8b0531905ae19ca1be388125a7cb3",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\red_square.png",
-      "baseFile": "IntegrationTests\\red_square.png",
+      "file": "ReactCopies/IntegrationTests/red_square.png",
+      "baseFile": "IntegrationTests/red_square.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "50c9e4290c1c9d1595916ab23909d9cadc453624",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\SimpleSnapshotTest.js",
-      "baseFile": "IntegrationTests\\SimpleSnapshotTest.js",
+      "file": "ReactCopies/IntegrationTests/SimpleSnapshotTest.js",
+      "baseFile": "IntegrationTests/SimpleSnapshotTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "41def466dc7d40a240c0ba1e389fbb9a48b6f91b",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\SizeFlexibilityUpdateTest.js",
-      "baseFile": "IntegrationTests\\SizeFlexibilityUpdateTest.js",
+      "file": "ReactCopies/IntegrationTests/SizeFlexibilityUpdateTest.js",
+      "baseFile": "IntegrationTests/SizeFlexibilityUpdateTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "7417761c322e1c0387619440d1959b98835a4927",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\SyncMethodTest.js",
-      "baseFile": "IntegrationTests\\SyncMethodTest.js",
+      "file": "ReactCopies/IntegrationTests/SyncMethodTest.js",
+      "baseFile": "IntegrationTests/SyncMethodTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "5a2a4552bf47a623164cc759de7f9c00776209fb",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\TimersTest.js",
-      "baseFile": "IntegrationTests\\TimersTest.js",
+      "file": "ReactCopies/IntegrationTests/TimersTest.js",
+      "baseFile": "IntegrationTests/TimersTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "fea3fd11d8272429d17fe27b94880d444ef67383",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\websocket_integration_test_server.js",
-      "baseFile": "IntegrationTests\\websocket_integration_test_server.js",
+      "file": "ReactCopies/IntegrationTests/websocket_integration_test_server.js",
+      "baseFile": "IntegrationTests/websocket_integration_test_server.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "8f7c09b9b4939c74c164bcf9fca5d148c9b52aba",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\IntegrationTests\\WebSocketTest.js",
-      "baseFile": "IntegrationTests\\WebSocketTest.js",
+      "file": "ReactCopies/IntegrationTests/WebSocketTest.js",
+      "baseFile": "IntegrationTests/WebSocketTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "d651f74f1fe387b5754fb04e5f0f5035431b33bc",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\bandaged.png",
-      "baseFile": "RNTester\\js\\assets\\bandaged.png",
+      "file": "ReactCopies/RNTester/js/assets/bandaged.png",
+      "baseFile": "RNTester/js/assets/bandaged.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "05190e1992b1635e39500125461a1180657d9b8c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\bunny.png",
-      "baseFile": "RNTester\\js\\assets\\bunny.png",
+      "file": "ReactCopies/RNTester/js/assets/bunny.png",
+      "baseFile": "RNTester/js/assets/bunny.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "64c6f6e28badf2b83b8902057a73e2e34a481dd3",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\call.png",
-      "baseFile": "RNTester\\js\\assets\\call.png",
+      "file": "ReactCopies/RNTester/js/assets/call.png",
+      "baseFile": "RNTester/js/assets/call.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "bc2dec8927b085527a657733e2f56e007530d0d0",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\dislike.png",
-      "baseFile": "RNTester\\js\\assets\\dislike.png",
+      "file": "ReactCopies/RNTester/js/assets/dislike.png",
+      "baseFile": "RNTester/js/assets/dislike.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e02300e0a5b2fc0b0d112fa7cadd039f6905b0ef",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\fist.png",
-      "baseFile": "RNTester\\js\\assets\\fist.png",
+      "file": "ReactCopies/RNTester/js/assets/fist.png",
+      "baseFile": "RNTester/js/assets/fist.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "38ff6472df526a0c4a2a9e0713813d82d6ed6331",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\flowers.png",
-      "baseFile": "RNTester\\js\\assets\\flowers.png",
+      "file": "ReactCopies/RNTester/js/assets/flowers.png",
+      "baseFile": "RNTester/js/assets/flowers.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "ddeacabb5d337a520546c3aa3da35ae3315d0d44",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\flux@3x.png",
-      "baseFile": "RNTester\\js\\assets\\flux@3x.png",
+      "file": "ReactCopies/RNTester/js/assets/flux@3x.png",
+      "baseFile": "RNTester/js/assets/flux@3x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "d82a16b53a7e17efa656aba2c24ddd1faa542af8",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\hawk.png",
-      "baseFile": "RNTester\\js\\assets\\hawk.png",
+      "file": "ReactCopies/RNTester/js/assets/hawk.png",
+      "baseFile": "RNTester/js/assets/hawk.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "21d23198462e15475492dc677e32e2caf770ca49",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\heart.png",
-      "baseFile": "RNTester\\js\\assets\\heart.png",
+      "file": "ReactCopies/RNTester/js/assets/heart.png",
+      "baseFile": "RNTester/js/assets/heart.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "efa9e0be625f282d1753898a9a56cb58ca842cce",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\helloworld.html",
-      "baseFile": "RNTester\\js\\assets\\helloworld.html",
+      "file": "ReactCopies/RNTester/js/assets/helloworld.html",
+      "baseFile": "RNTester/js/assets/helloworld.html",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a8ed0ec343c0668402211c120e2cd8ab9fe10522",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\imageMask.png",
-      "baseFile": "RNTester\\js\\assets\\imageMask.png",
+      "file": "ReactCopies/RNTester/js/assets/imageMask.png",
+      "baseFile": "RNTester/js/assets/imageMask.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "70461576894f565ff53808df997bb744d051e49c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\like.png",
-      "baseFile": "RNTester\\js\\assets\\like.png",
+      "file": "ReactCopies/RNTester/js/assets/like.png",
+      "baseFile": "RNTester/js/assets/like.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e43eb241fccdcb4ef0eacfc01acc4c23e8e4534f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\liking.png",
-      "baseFile": "RNTester\\js\\assets\\liking.png",
+      "file": "ReactCopies/RNTester/js/assets/liking.png",
+      "baseFile": "RNTester/js/assets/liking.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "25525619085f30341b22ec4a729919d63d439a0c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\messagingtest.html",
-      "baseFile": "RNTester\\js\\assets\\messagingtest.html",
+      "file": "ReactCopies/RNTester/js/assets/messagingtest.html",
+      "baseFile": "RNTester/js/assets/messagingtest.html",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "95ff65ab8a9c7a50ab79d8f87460b559b3400dfc",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\party.png",
-      "baseFile": "RNTester\\js\\assets\\party.png",
+      "file": "ReactCopies/RNTester/js/assets/party.png",
+      "baseFile": "RNTester/js/assets/party.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "6de86090ad3a591dea6b1f7cf03fbd3ec223427a",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\poke.png",
-      "baseFile": "RNTester\\js\\assets\\poke.png",
+      "file": "ReactCopies/RNTester/js/assets/poke.png",
+      "baseFile": "RNTester/js/assets/poke.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e052afd42df69556eab24388e2ff7f5b43ee7976",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\relay@3x.png",
-      "baseFile": "RNTester\\js\\assets\\relay@3x.png",
+      "file": "ReactCopies/RNTester/js/assets/relay@3x.png",
+      "baseFile": "RNTester/js/assets/relay@3x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a326f79fd1d1cd578b53057b66a6afb3e904c473",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\slider-left.png",
-      "baseFile": "RNTester\\js\\assets\\slider-left.png",
+      "file": "ReactCopies/RNTester/js/assets/slider-left.png",
+      "baseFile": "RNTester/js/assets/slider-left.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "6785b1a2035420568b8864ed3c31ad0a99674381",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\slider-left@2x.png",
-      "baseFile": "RNTester\\js\\assets\\slider-left@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/slider-left@2x.png",
+      "baseFile": "RNTester/js/assets/slider-left@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "25947718981a2096052934a4666b47cd3748866b",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\slider-right.png",
-      "baseFile": "RNTester\\js\\assets\\slider-right.png",
+      "file": "ReactCopies/RNTester/js/assets/slider-right.png",
+      "baseFile": "RNTester/js/assets/slider-right.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b7078c3be5a104e4ac56f1e543f4572903f9cfac",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\slider-right@2x.png",
-      "baseFile": "RNTester\\js\\assets\\slider-right@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/slider-right@2x.png",
+      "baseFile": "RNTester/js/assets/slider-right@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "41a0a72be88810c2495384392dc102b1df989345",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\slider.png",
-      "baseFile": "RNTester\\js\\assets\\slider.png",
+      "file": "ReactCopies/RNTester/js/assets/slider.png",
+      "baseFile": "RNTester/js/assets/slider.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "0d1da60452bee3861d774022f724ac06550ea760",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\slider@2x.png",
-      "baseFile": "RNTester\\js\\assets\\slider@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/slider@2x.png",
+      "baseFile": "RNTester/js/assets/slider@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "1dd9bcb5afe0899428161e746c9907083f3e079f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\superlike.png",
-      "baseFile": "RNTester\\js\\assets\\superlike.png",
+      "file": "ReactCopies/RNTester/js/assets/superlike.png",
+      "baseFile": "RNTester/js/assets/superlike.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "7f54445d4b334ff63872d4368d4815384f22b0a4",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\trees.jpg",
-      "baseFile": "RNTester\\js\\assets\\trees.jpg",
+      "file": "ReactCopies/RNTester/js/assets/trees.jpg",
+      "baseFile": "RNTester/js/assets/trees.jpg",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "ec21aab670cc3b9a58f2a0ffe555f1225b215b02",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\tumblr_mfqekpMktw1rn90umo1_500.gif",
-      "baseFile": "RNTester\\js\\assets\\tumblr_mfqekpMktw1rn90umo1_500.gif",
+      "file": "ReactCopies/RNTester/js/assets/tumblr_mfqekpMktw1rn90umo1_500.gif",
+      "baseFile": "RNTester/js/assets/tumblr_mfqekpMktw1rn90umo1_500.gif",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "c37cb848c6651f4312a50e4911ee0298840a6ddd",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\uie_comment_highlighted@2x.png",
-      "baseFile": "RNTester\\js\\assets\\uie_comment_highlighted@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/uie_comment_highlighted@2x.png",
+      "baseFile": "RNTester/js/assets/uie_comment_highlighted@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "98329ddec64b2da11cf9a2ae551f0c619afac506",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\uie_comment_normal@2x.png",
-      "baseFile": "RNTester\\js\\assets\\uie_comment_normal@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/uie_comment_normal@2x.png",
+      "baseFile": "RNTester/js/assets/uie_comment_normal@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b73657b0db39a24357b38814f7863572afa0056f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\uie_thumb_big.png",
-      "baseFile": "RNTester\\js\\assets\\uie_thumb_big.png",
+      "file": "ReactCopies/RNTester/js/assets/uie_thumb_big.png",
+      "baseFile": "RNTester/js/assets/uie_thumb_big.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "25525619085f30341b22ec4a729919d63d439a0c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\uie_thumb_normal@2x.png",
-      "baseFile": "RNTester\\js\\assets\\uie_thumb_normal@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/uie_thumb_normal@2x.png",
+      "baseFile": "RNTester/js/assets/uie_thumb_normal@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "6e24abc1425f0435d53140c34b45b54ca842b39e",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\uie_thumb_selected@2x.png",
-      "baseFile": "RNTester\\js\\assets\\uie_thumb_selected@2x.png",
+      "file": "ReactCopies/RNTester/js/assets/uie_thumb_selected@2x.png",
+      "baseFile": "RNTester/js/assets/uie_thumb_selected@2x.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "5e62b899e2ff87e4fcf9d222cdd0d667d5e3e097",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\assets\\victory.png",
-      "baseFile": "RNTester\\js\\assets\\victory.png",
+      "file": "ReactCopies/RNTester/js/assets/victory.png",
+      "baseFile": "RNTester/js/assets/victory.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "3a818eb64eb69e6ea762a1b03c9bb5ecfde1b063",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\createExamplePage.js",
-      "baseFile": "RNTester\\js\\components\\createExamplePage.js",
+      "file": "ReactCopies/RNTester/js/components/createExamplePage.js",
+      "baseFile": "RNTester/js/components/createExamplePage.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "836b9e0333c0ef17a839812abc23943f8ee10b7c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\ListExampleShared.js",
-      "baseFile": "RNTester\\js\\components\\ListExampleShared.js",
+      "file": "ReactCopies/RNTester/js/components/ListExampleShared.js",
+      "baseFile": "RNTester/js/components/ListExampleShared.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterBlock.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterBlock.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterBlock.js",
+      "baseFile": "RNTester/js/components/RNTesterBlock.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "17c9f765c96cc397808f208e157dc70199c48d96",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterButton.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterButton.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterButton.js",
+      "baseFile": "RNTester/js/components/RNTesterButton.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "8f17fd037696c0d8e9233452268c03ad7bd7f4c1",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterExampleContainer.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterExampleContainer.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterExampleContainer.js",
+      "baseFile": "RNTester/js/components/RNTesterExampleContainer.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "9458078acead81ba71a8dd5c12c7eb35b50cf3bf",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterExampleFilter.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterExampleFilter.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterExampleFilter.js",
+      "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterExampleList.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterExampleList.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterExampleList.js",
+      "baseFile": "RNTester/js/components/RNTesterExampleList.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "fc507321dc5cb53be93df517ba5c4b1acd0074f4",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterPage.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterPage.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterPage.js",
+      "baseFile": "RNTester/js/components/RNTesterPage.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "fdf2ec847d34a16755ea0247e2f9923a07526a74",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterSettingSwitchRow.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterSettingSwitchRow.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterSettingSwitchRow.js",
+      "baseFile": "RNTester/js/components/RNTesterSettingSwitchRow.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "9e993de8787350250bea33ded80a08d95d3f447d",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterTheme.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterTheme.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterTheme.js",
+      "baseFile": "RNTester/js/components/RNTesterTheme.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "1cdca09edb4fd1f16a206fed02417b29a1f4f729",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\RNTesterTitle.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterTitle.js",
+      "file": "ReactCopies/RNTester/js/components/RNTesterTitle.js",
+      "baseFile": "RNTester/js/components/RNTesterTitle.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b092dfda9934add8e308623d11637d75170b250e",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\TextInlineView.js",
-      "baseFile": "RNTester\\js\\components\\TextInlineView.js",
+      "file": "ReactCopies/RNTester/js/components/TextInlineView.js",
+      "baseFile": "RNTester/js/components/TextInlineView.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "f0b82d0b7f0a49d0b3e5e967419a373e6000fcdb",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\components\\TextLegend.js",
-      "baseFile": "RNTester\\js\\components\\TextLegend.js",
+      "file": "ReactCopies/RNTester/js/components/TextLegend.js",
+      "baseFile": "RNTester/js/components/TextLegend.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "2565a04059f10129418e3b272fc0a8c65b750423",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Accessibility\\AccessibilityAndroidExample.android.js",
-      "baseFile": "RNTester\\js\\examples\\Accessibility\\AccessibilityAndroidExample.android.js",
+      "file": "ReactCopies/RNTester/js/examples/Accessibility/AccessibilityAndroidExample.android.js",
+      "baseFile": "RNTester/js/examples/Accessibility/AccessibilityAndroidExample.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "5a2287fc471d4dc91e1a7eadfdf0f751a33b5d00",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Accessibility\\AccessibilityExample.js",
-      "baseFile": "RNTester\\js\\examples\\Accessibility\\AccessibilityExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Accessibility/AccessibilityExample.js",
+      "baseFile": "RNTester/js/examples/Accessibility/AccessibilityExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a2eed02e44cb61c0d7965f5ab4f4834839042256",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Accessibility\\AccessibilityIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\Accessibility\\AccessibilityIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Accessibility/AccessibilityIOSExample.js",
+      "baseFile": "RNTester/js/examples/Accessibility/AccessibilityIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0d440fac60d699bd1e30dce2c6f372e27b378928",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Accessibility\\check.png",
-      "baseFile": "RNTester\\js\\examples\\Accessibility\\check.png",
+      "file": "ReactCopies/RNTester/js/examples/Accessibility/check.png",
+      "baseFile": "RNTester/js/examples/Accessibility/check.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "2ea651496270420523a0c7eb386b7912859fceb4",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Accessibility\\mixed.png",
-      "baseFile": "RNTester\\js\\examples\\Accessibility\\mixed.png",
+      "file": "ReactCopies/RNTester/js/examples/Accessibility/mixed.png",
+      "baseFile": "RNTester/js/examples/Accessibility/mixed.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "04b4d0bd9c21df33f57560a87af27d5059510b92",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Accessibility\\uncheck.png",
-      "baseFile": "RNTester\\js\\examples\\Accessibility\\uncheck.png",
+      "file": "ReactCopies/RNTester/js/examples/Accessibility/uncheck.png",
+      "baseFile": "RNTester/js/examples/Accessibility/uncheck.png",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "c030543efd9fd21830ad532901a599444d90a106",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ActionSheetIOS\\ActionSheetIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\ActionSheetIOS\\ActionSheetIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js",
+      "baseFile": "RNTester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e0b2f2e7d07a7c14e1e78ca78b0750e41bf6509d",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ActivityIndicator\\ActivityIndicatorExample.js",
-      "baseFile": "RNTester\\js\\examples\\ActivityIndicator\\ActivityIndicatorExample.js",
+      "file": "ReactCopies/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample.js",
+      "baseFile": "RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "35e927da609f8dc530fbf169be04e70144964491",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Alert\\AlertExample.js",
-      "baseFile": "RNTester\\js\\examples\\Alert\\AlertExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Alert/AlertExample.js",
+      "baseFile": "RNTester/js/examples/Alert/AlertExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1911b0f4735a15c61e6f0216f438e4a7cdf574da",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Alert\\AlertIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\Alert\\AlertIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Alert/AlertIOSExample.js",
+      "baseFile": "RNTester/js/examples/Alert/AlertIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b4f224f1cabaca98738e6b551b15abff886cc204",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedExample.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedExample.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e48e20f84efd3fcdc07a9d2cb9f8fec30f6b8e9c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExApp.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExApp.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExApp.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExApp.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "73fb3c79a412ccff62014a2191b57382d630c477",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExBobble.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExBobble.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExBobble.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExBobble.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "4ceca70698546ed511708bb909c098f24d95d047",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExChained.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExChained.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExChained.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExChained.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "f5424d58ab5a68a19b8a533ef2a9d98d916bdd6a",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExScroll.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExScroll.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExScroll.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExScroll.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a11c96214384a3140c5bbd1105a6b44f68524b36",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExSet.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExSet.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExSet.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExSet.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "beb6465fc39557971d476dc9c4ae94e37debace9",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExSlides.md",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExSlides.md",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExSlides.md",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExSlides.md",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "3e04ec5d3adba039575452edebb3ee91718d64f1",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExTilt.js",
-      "baseFile": "RNTester\\js\\examples\\Animated\\AnimatedGratuitousApp\\AnExTilt.js",
+      "file": "ReactCopies/RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExTilt.js",
+      "baseFile": "RNTester/js/examples/Animated/AnimatedGratuitousApp/AnExTilt.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "f0dd20c4ddbf7eb04cd5cea8b54faec166e48d55",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Appearance\\AppearanceExample.js",
-      "baseFile": "RNTester\\js\\examples\\Appearance\\AppearanceExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Appearance/AppearanceExample.js",
+      "baseFile": "RNTester/js/examples/Appearance/AppearanceExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "eab5f809a5850473be01d444291cff645fd989af",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\AppState\\AppStateExample.js",
-      "baseFile": "RNTester\\js\\examples\\AppState\\AppStateExample.js",
+      "file": "ReactCopies/RNTester/js/examples/AppState/AppStateExample.js",
+      "baseFile": "RNTester/js/examples/AppState/AppStateExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "86ec2f64d0940d7e161bb60672f7c479ed04a012",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\AsyncStorage\\AsyncStorageExample.js",
-      "baseFile": "RNTester\\js\\examples\\AsyncStorage\\AsyncStorageExample.js",
+      "file": "ReactCopies/RNTester/js/examples/AsyncStorage/AsyncStorageExample.js",
+      "baseFile": "RNTester/js/examples/AsyncStorage/AsyncStorageExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1e53319e5662b21de209d0f7bd19daff09398718",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Border\\BorderExample.js",
-      "baseFile": "RNTester\\js\\examples\\Border\\BorderExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Border/BorderExample.js",
+      "baseFile": "RNTester/js/examples/Border/BorderExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0bb13b8219f257e798b450bb1e89f06fb9a468bf",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\BoxShadow\\BoxShadowExample.js",
-      "baseFile": "RNTester\\js\\examples\\BoxShadow\\BoxShadowExample.js",
+      "file": "ReactCopies/RNTester/js/examples/BoxShadow/BoxShadowExample.js",
+      "baseFile": "RNTester/js/examples/BoxShadow/BoxShadowExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0b4b7840db2799b4e6fa1df01645b03a08668e71",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Button\\ButtonExample.js",
-      "baseFile": "RNTester\\js\\examples\\Button\\ButtonExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Button/ButtonExample.js",
+      "baseFile": "RNTester/js/examples/Button/ButtonExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6b33dddcb894b903e40430178fe92cc11a52fdc9",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\CheckBox\\CheckBoxExample.js",
-      "baseFile": "RNTester\\js\\examples\\CheckBox\\CheckBoxExample.js",
+      "file": "ReactCopies/RNTester/js/examples/CheckBox/CheckBoxExample.js",
+      "baseFile": "RNTester/js/examples/CheckBox/CheckBoxExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "18589e2dfd093a5646d9f26b6506a16b2fea244f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Clipboard\\ClipboardExample.js",
-      "baseFile": "RNTester\\js\\examples\\Clipboard\\ClipboardExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Clipboard/ClipboardExample.js",
+      "baseFile": "RNTester/js/examples/Clipboard/ClipboardExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b02c550fdd43545dfa1ea2f540cc2c8c2a6c147f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Crash\\CrashExample.js",
-      "baseFile": "RNTester\\js\\examples\\Crash\\CrashExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Crash/CrashExample.js",
+      "baseFile": "RNTester/js/examples/Crash/CrashExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6327f8bb9205e9e5a758883de8f8585e6754e4f6",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\DatePicker\\DatePickerAndroidExample.js",
-      "baseFile": "RNTester\\js\\examples\\DatePicker\\DatePickerAndroidExample.js",
+      "file": "ReactCopies/RNTester/js/examples/DatePicker/DatePickerAndroidExample.js",
+      "baseFile": "RNTester/js/examples/DatePicker/DatePickerAndroidExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "271a411037bd9c0f73e9d5d2999747562c9eb8c8",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\DatePicker\\DatePickerIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\DatePicker\\DatePickerIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/DatePicker/DatePickerIOSExample.js",
+      "baseFile": "RNTester/js/examples/DatePicker/DatePickerIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e1fa645dd346c786b1ab525ec70c785f6d398177",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\DevSettings\\DevSettingsExample.js",
-      "baseFile": "RNTester\\js\\examples\\DevSettings\\DevSettingsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/DevSettings/DevSettingsExample.js",
+      "baseFile": "RNTester/js/examples/DevSettings/DevSettingsExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0c0ac188afcc618026b351335cccb77054f47033",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Dimensions\\DimensionsExample.js",
-      "baseFile": "RNTester\\js\\examples\\Dimensions\\DimensionsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Dimensions/DimensionsExample.js",
+      "baseFile": "RNTester/js/examples/Dimensions/DimensionsExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "bc8a74395f567618e97587c5f284c9099aa451d2",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\FlatList\\FlatListExample.js",
-      "baseFile": "RNTester\\js\\examples\\FlatList\\FlatListExample.js",
+      "file": "ReactCopies/RNTester/js/examples/FlatList/FlatListExample.js",
+      "baseFile": "RNTester/js/examples/FlatList/FlatListExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "9b261e33adf348eef0b316aeaf566dc3f7221819",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Image\\ImageCapInsetsExample.js",
-      "baseFile": "RNTester\\js\\examples\\Image\\ImageCapInsetsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Image/ImageCapInsetsExample.js",
+      "baseFile": "RNTester/js/examples/Image/ImageCapInsetsExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "37de940f539aa8c6bf34d6177edce98317330a14",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Image\\ImageExample.js",
-      "baseFile": "RNTester\\js\\examples\\Image\\ImageExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Image/ImageExample.js",
+      "baseFile": "RNTester/js/examples/Image/ImageExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "06463270a6ff6cb071f94ee09d645c21c9a3fbdd",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\InputAccessoryView\\InputAccessoryViewExample.js",
-      "baseFile": "RNTester\\js\\examples\\InputAccessoryView\\InputAccessoryViewExample.js",
+      "file": "ReactCopies/RNTester/js/examples/InputAccessoryView/InputAccessoryViewExample.js",
+      "baseFile": "RNTester/js/examples/InputAccessoryView/InputAccessoryViewExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "2036e943d5adac52b999a47135b6068418480099",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\JSResponderHandlerExample\\JSResponderHandlerExample.js",
-      "baseFile": "RNTester\\js\\examples\\JSResponderHandlerExample\\JSResponderHandlerExample.js",
+      "file": "ReactCopies/RNTester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js",
+      "baseFile": "RNTester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "124fa74039360d065ce715e385a4b3d66d7e2472",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\KeyboardAvoidingView\\KeyboardAvoidingViewExample.js",
-      "baseFile": "RNTester\\js\\examples\\KeyboardAvoidingView\\KeyboardAvoidingViewExample.js",
+      "file": "ReactCopies/RNTester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js",
+      "baseFile": "RNTester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "51c767138cdc96a2910867bb7d80f842458aac1f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Layout\\LayoutAnimationExample.js",
-      "baseFile": "RNTester\\js\\examples\\Layout\\LayoutAnimationExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Layout/LayoutAnimationExample.js",
+      "baseFile": "RNTester/js/examples/Layout/LayoutAnimationExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "9aec8306b035f6fe2094c7981752b8ee5e9852cf",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Layout\\LayoutEventsExample.js",
-      "baseFile": "RNTester\\js\\examples\\Layout\\LayoutEventsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Layout/LayoutEventsExample.js",
+      "baseFile": "RNTester/js/examples/Layout/LayoutEventsExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "c6032e679e86a4fbd19b3619cb128a7953c8c629",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Layout\\LayoutExample.js",
-      "baseFile": "RNTester\\js\\examples\\Layout\\LayoutExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Layout/LayoutExample.js",
+      "baseFile": "RNTester/js/examples/Layout/LayoutExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a26ce736293444edd9c9a009c8b4e271821823e8",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Linking\\LinkingExample.js",
-      "baseFile": "RNTester\\js\\examples\\Linking\\LinkingExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Linking/LinkingExample.js",
+      "baseFile": "RNTester/js/examples/Linking/LinkingExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "2ac26529307cb35a282dc9a50595ddfe7dfbf3b6",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\MaskedView\\MaskedViewExample.js",
-      "baseFile": "RNTester\\js\\examples\\MaskedView\\MaskedViewExample.js",
+      "file": "ReactCopies/RNTester/js/examples/MaskedView/MaskedViewExample.js",
+      "baseFile": "RNTester/js/examples/MaskedView/MaskedViewExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "0037fd4bcb89679d0e3fe5f36baf1f3bd690a0b4",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Modal\\ModalExample.js",
-      "baseFile": "RNTester\\js\\examples\\Modal\\ModalExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Modal/ModalExample.js",
+      "baseFile": "RNTester/js/examples/Modal/ModalExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1b72a261fad314d8402017f436f11b4b42f61ad7",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\MultiColumn\\MultiColumnExample.js",
-      "baseFile": "RNTester\\js\\examples\\MultiColumn\\MultiColumnExample.js",
+      "file": "ReactCopies/RNTester/js/examples/MultiColumn/MultiColumnExample.js",
+      "baseFile": "RNTester/js/examples/MultiColumn/MultiColumnExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e88842348da52b562a04e5c2bc38012cb6a8d66a",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\NativeAnimation\\NativeAnimationsExample.js",
-      "baseFile": "RNTester\\js\\examples\\NativeAnimation\\NativeAnimationsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/NativeAnimation/NativeAnimationsExample.js",
+      "baseFile": "RNTester/js/examples/NativeAnimation/NativeAnimationsExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "ed4c7f19c5cbe22c7b144511a4bfe9a841490820",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\NewAppScreen\\NewAppScreenExample.js",
-      "baseFile": "RNTester\\js\\examples\\NewAppScreen\\NewAppScreenExample.js",
+      "file": "ReactCopies/RNTester/js/examples/NewAppScreen/NewAppScreenExample.js",
+      "baseFile": "RNTester/js/examples/NewAppScreen/NewAppScreenExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e5e25b9a20b65a9df8f6fc22b1c297faaa0265e7",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\OrientationChange\\OrientationChangeExample.js",
-      "baseFile": "RNTester\\js\\examples\\OrientationChange\\OrientationChangeExample.js",
+      "file": "ReactCopies/RNTester/js/examples/OrientationChange/OrientationChangeExample.js",
+      "baseFile": "RNTester/js/examples/OrientationChange/OrientationChangeExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "7d9b3e3829e9f6777580062172ba0f10e1ae837c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\PanResponder\\PanResponderExample.js",
-      "baseFile": "RNTester\\js\\examples\\PanResponder\\PanResponderExample.js",
+      "file": "ReactCopies/RNTester/js/examples/PanResponder/PanResponderExample.js",
+      "baseFile": "RNTester/js/examples/PanResponder/PanResponderExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "450bed7e598c21825e447e2b44ceb45dc54d7ca0",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\PermissionsAndroid\\PermissionsExample.js",
-      "baseFile": "RNTester\\js\\examples\\PermissionsAndroid\\PermissionsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/PermissionsAndroid/PermissionsExample.js",
+      "baseFile": "RNTester/js/examples/PermissionsAndroid/PermissionsExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "12f3d08e16ca9476964666204312b7845b08e935",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Picker\\PickerExample.js",
-      "baseFile": "RNTester\\js\\examples\\Picker\\PickerExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Picker/PickerExample.js",
+      "baseFile": "RNTester/js/examples/Picker/PickerExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "acab010e85e1b21b22cbba03f2b6c41c620376bf",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Picker\\PickerIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\Picker\\PickerIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Picker/PickerIOSExample.js",
+      "baseFile": "RNTester/js/examples/Picker/PickerIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "d3eb07974fcec825ab92faf232320f0a7e767708",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\PlatformColor\\PlatformColorExample.js",
-      "baseFile": "RNTester\\js\\examples\\PlatformColor\\PlatformColorExample.js",
+      "file": "ReactCopies/RNTester/js/examples/PlatformColor/PlatformColorExample.js",
+      "baseFile": "RNTester/js/examples/PlatformColor/PlatformColorExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "f1c2babe02e11d237dbab875b8a7cd63fce048b6",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\PointerEvents\\PointerEventsExample.js",
-      "baseFile": "RNTester\\js\\examples\\PointerEvents\\PointerEventsExample.js",
+      "file": "ReactCopies/RNTester/js/examples/PointerEvents/PointerEventsExample.js",
+      "baseFile": "RNTester/js/examples/PointerEvents/PointerEventsExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6e981af4c0ee1d67f6a6f236ce1a2bad27768ad6",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Pressable\\PressableExample.js",
-      "baseFile": "RNTester\\js\\examples\\Pressable\\PressableExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Pressable/PressableExample.js",
+      "baseFile": "RNTester/js/examples/Pressable/PressableExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e6cccf697079e00d66726dac5902cd53b10a7627",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ProgressBarAndroid\\ProgressBarAndroidExample.android.js",
-      "baseFile": "RNTester\\js\\examples\\ProgressBarAndroid\\ProgressBarAndroidExample.android.js",
+      "file": "ReactCopies/RNTester/js/examples/ProgressBarAndroid/ProgressBarAndroidExample.android.js",
+      "baseFile": "RNTester/js/examples/ProgressBarAndroid/ProgressBarAndroidExample.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6c9a6e763bd2357c945993b1e797182c767df6d3",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ProgressViewIOS\\ProgressViewIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\ProgressViewIOS\\ProgressViewIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/ProgressViewIOS/ProgressViewIOSExample.js",
+      "baseFile": "RNTester/js/examples/ProgressViewIOS/ProgressViewIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "ee9cc131b08073485b15e36845d1973ceaba487d",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\PushNotificationIOS\\PushNotificationIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\PushNotificationIOS\\PushNotificationIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/PushNotificationIOS/PushNotificationIOSExample.js",
+      "baseFile": "RNTester/js/examples/PushNotificationIOS/PushNotificationIOSExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "cdd83d7bff210ce68e44cc33479bcb90b42346fa",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\RCTRootView\\RCTRootViewIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\RCTRootView\\RCTRootViewIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/RCTRootView/RCTRootViewIOSExample.js",
+      "baseFile": "RNTester/js/examples/RCTRootView/RCTRootViewIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "065905e35c6a0c5b4701457bf1d10069ce494d9b",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\RefreshControl\\RefreshControlExample.js",
-      "baseFile": "RNTester\\js\\examples\\RefreshControl\\RefreshControlExample.js",
+      "file": "ReactCopies/RNTester/js/examples/RefreshControl/RefreshControlExample.js",
+      "baseFile": "RNTester/js/examples/RefreshControl/RefreshControlExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "1936951adac92dbb0007511ce75e4d9979b6df52",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\RootViewSizeFlexibilityExample\\RootViewSizeFlexibilityExampleApp.js",
-      "baseFile": "RNTester\\js\\examples\\RootViewSizeFlexibilityExample\\RootViewSizeFlexibilityExampleApp.js",
+      "file": "ReactCopies/RNTester/js/examples/RootViewSizeFlexibilityExample/RootViewSizeFlexibilityExampleApp.js",
+      "baseFile": "RNTester/js/examples/RootViewSizeFlexibilityExample/RootViewSizeFlexibilityExampleApp.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1603d875f0f86abbf8d6917306f2dffabf66cd6f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\RTL\\RTLExample.js",
-      "baseFile": "RNTester\\js\\examples\\RTL\\RTLExample.js",
+      "file": "ReactCopies/RNTester/js/examples/RTL/RTLExample.js",
+      "baseFile": "RNTester/js/examples/RTL/RTLExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "70a65dc896406e7ad971f0a9a770b7ea30f43b9e",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\SafeAreaView\\SafeAreaViewExample.js",
-      "baseFile": "RNTester\\js\\examples\\SafeAreaView\\SafeAreaViewExample.js",
+      "file": "ReactCopies/RNTester/js/examples/SafeAreaView/SafeAreaViewExample.js",
+      "baseFile": "RNTester/js/examples/SafeAreaView/SafeAreaViewExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "7b5070580f37fcc8655132ea46836315112804d7",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ScrollView\\ScrollViewAnimatedExample.js",
-      "baseFile": "RNTester\\js\\examples\\ScrollView\\ScrollViewAnimatedExample.js",
+      "file": "ReactCopies/RNTester/js/examples/ScrollView/ScrollViewAnimatedExample.js",
+      "baseFile": "RNTester/js/examples/ScrollView/ScrollViewAnimatedExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b576419d4212baaed4a075c9ec8e165520338155",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ScrollView\\ScrollViewExample.js",
-      "baseFile": "RNTester\\js\\examples\\ScrollView\\ScrollViewExample.js",
+      "file": "ReactCopies/RNTester/js/examples/ScrollView/ScrollViewExample.js",
+      "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1840fda2dd4591883df92d28c1e1aeabff190f7f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ScrollView\\ScrollViewSimpleExample.js",
-      "baseFile": "RNTester\\js\\examples\\ScrollView\\ScrollViewSimpleExample.js",
+      "file": "ReactCopies/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js",
+      "baseFile": "RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a06abec9de61c3d865c3c8e5c8dc5ea847048c39",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\SectionList\\SectionListExample.js",
-      "baseFile": "RNTester\\js\\examples\\SectionList\\SectionListExample.js",
+      "file": "ReactCopies/RNTester/js/examples/SectionList/SectionListExample.js",
+      "baseFile": "RNTester/js/examples/SectionList/SectionListExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e183ca0fc0a040c08de3e3ee974d350eafa93bb7",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\SegmentedControlIOS\\SegmentedControlIOSExample.js",
-      "baseFile": "RNTester\\js\\examples\\SegmentedControlIOS\\SegmentedControlIOSExample.js",
+      "file": "ReactCopies/RNTester/js/examples/SegmentedControlIOS/SegmentedControlIOSExample.js",
+      "baseFile": "RNTester/js/examples/SegmentedControlIOS/SegmentedControlIOSExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "87f0bdb4a67dae58a8f09518cd2d2fd64518fb95",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\SetPropertiesExample\\SetPropertiesExampleApp.js",
-      "baseFile": "RNTester\\js\\examples\\SetPropertiesExample\\SetPropertiesExampleApp.js",
+      "file": "ReactCopies/RNTester/js/examples/SetPropertiesExample/SetPropertiesExampleApp.js",
+      "baseFile": "RNTester/js/examples/SetPropertiesExample/SetPropertiesExampleApp.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "779f1d5e5a7f51f32b1ac036ae4b64c959ae362d",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Share\\ShareExample.js",
-      "baseFile": "RNTester\\js\\examples\\Share\\ShareExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Share/ShareExample.js",
+      "baseFile": "RNTester/js/examples/Share/ShareExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "6f72b1154abf2c8860f964b6c6bbe12ec700328f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Slider\\SliderExample.js",
-      "baseFile": "RNTester\\js\\examples\\Slider\\SliderExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Slider/SliderExample.js",
+      "baseFile": "RNTester/js/examples/Slider/SliderExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e0d6f303de34d1cf44f36a3d80574a2727841881",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Snapshot\\SnapshotExample.js",
-      "baseFile": "RNTester\\js\\examples\\Snapshot\\SnapshotExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Snapshot/SnapshotExample.js",
+      "baseFile": "RNTester/js/examples/Snapshot/SnapshotExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "37b9a1824df72c4dafd3cd3358f87f939f0af011",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Snapshot\\SnapshotViewIOS.android.js",
-      "baseFile": "RNTester\\js\\examples\\Snapshot\\SnapshotViewIOS.android.js",
+      "file": "ReactCopies/RNTester/js/examples/Snapshot/SnapshotViewIOS.android.js",
+      "baseFile": "RNTester/js/examples/Snapshot/SnapshotViewIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "17e99533d014d90cb6dfac6bd7e8e3d8746c28c0",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Snapshot\\SnapshotViewIOS.ios.js",
-      "baseFile": "RNTester\\js\\examples\\Snapshot\\SnapshotViewIOS.ios.js",
+      "file": "ReactCopies/RNTester/js/examples/Snapshot/SnapshotViewIOS.ios.js",
+      "baseFile": "RNTester/js/examples/Snapshot/SnapshotViewIOS.ios.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "ad5dd3e15e14f81a62b764a94f027d0ffa6c7484",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\StatusBar\\StatusBarExample.js",
-      "baseFile": "RNTester\\js\\examples\\StatusBar\\StatusBarExample.js",
+      "file": "ReactCopies/RNTester/js/examples/StatusBar/StatusBarExample.js",
+      "baseFile": "RNTester/js/examples/StatusBar/StatusBarExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a57bbfdd7a70d65f9190b2696fd95d45d86f2639",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Switch\\SwitchExample.js",
-      "baseFile": "RNTester\\js\\examples\\Switch\\SwitchExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Switch/SwitchExample.js",
+      "baseFile": "RNTester/js/examples/Switch/SwitchExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "b8987deb1226c7a1dce3aa27db61e3faf8a7b65f",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Text\\TextExample.android.js",
-      "baseFile": "RNTester\\js\\examples\\Text\\TextExample.android.js",
+      "file": "ReactCopies/RNTester/js/examples/Text/TextExample.android.js",
+      "baseFile": "RNTester/js/examples/Text/TextExample.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "980897967a2429d13a224899451c61f6bf9c42a2",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Text\\TextExample.ios.js",
-      "baseFile": "RNTester\\js\\examples\\Text\\TextExample.ios.js",
+      "file": "ReactCopies/RNTester/js/examples/Text/TextExample.ios.js",
+      "baseFile": "RNTester/js/examples/Text/TextExample.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "91e6208698ae454e8e49acbf6fe5b759a5ae1c96",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TextInput\\TextInputExample.android.js",
-      "baseFile": "RNTester\\js\\examples\\TextInput\\TextInputExample.android.js",
+      "file": "ReactCopies/RNTester/js/examples/TextInput/TextInputExample.android.js",
+      "baseFile": "RNTester/js/examples/TextInput/TextInputExample.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "6bb89e55e32912825c7b551ecf958613b6b74a7e",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TextInput\\TextInputExample.ios.js",
-      "baseFile": "RNTester\\js\\examples\\TextInput\\TextInputExample.ios.js",
+      "file": "ReactCopies/RNTester/js/examples/TextInput/TextInputExample.ios.js",
+      "baseFile": "RNTester/js/examples/TextInput/TextInputExample.ios.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "ac1111252d0c6e0637ddd11f240d9a90dbab9a93",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TextInput\\TextInputSharedExamples.js",
-      "baseFile": "RNTester\\js\\examples\\TextInput\\TextInputSharedExamples.js",
+      "file": "ReactCopies/RNTester/js/examples/TextInput/TextInputSharedExamples.js",
+      "baseFile": "RNTester/js/examples/TextInput/TextInputSharedExamples.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "39979efc27f605596e1d4172a654778d7926833a",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Timer\\TimerExample.js",
-      "baseFile": "RNTester\\js\\examples\\Timer\\TimerExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Timer/TimerExample.js",
+      "baseFile": "RNTester/js/examples/Timer/TimerExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "3c623452fd9a3878fd78e5d7c11b71928ee46704",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\ToastAndroid\\ToastAndroidExample.android.js",
-      "baseFile": "RNTester\\js\\examples\\ToastAndroid\\ToastAndroidExample.android.js",
+      "file": "ReactCopies/RNTester/js/examples/ToastAndroid/ToastAndroidExample.android.js",
+      "baseFile": "RNTester/js/examples/ToastAndroid/ToastAndroidExample.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e37f2111883e8093000086655b8679e4fd77d558",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Touchable\\TouchableExample.js",
-      "baseFile": "RNTester\\js\\examples\\Touchable\\TouchableExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Touchable/TouchableExample.js",
+      "baseFile": "RNTester/js/examples/Touchable/TouchableExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "d838beaced4bbaa22a74f494215e529c9db2c267",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Transform\\TransformExample.js",
-      "baseFile": "RNTester\\js\\examples\\Transform\\TransformExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Transform/TransformExample.js",
+      "baseFile": "RNTester/js/examples/Transform/TransformExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "7d75fd3d92f3b35e45a0d054ced6605dba3cfb22",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TransparentHitTest\\TransparentHitTestExample.js",
-      "baseFile": "RNTester\\js\\examples\\TransparentHitTest\\TransparentHitTestExample.js",
+      "file": "ReactCopies/RNTester/js/examples/TransparentHitTest/TransparentHitTestExample.js",
+      "baseFile": "RNTester/js/examples/TransparentHitTest/TransparentHitTestExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "9348d498b882cb604e4e75fc120e4c2c4979ef83",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TurboModule\\SampleTurboModuleExample.js",
-      "baseFile": "RNTester\\js\\examples\\TurboModule\\SampleTurboModuleExample.js",
+      "file": "ReactCopies/RNTester/js/examples/TurboModule/SampleTurboModuleExample.js",
+      "baseFile": "RNTester/js/examples/TurboModule/SampleTurboModuleExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "ae2d8e98c7f78825691562559943cf149ef1514c",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TurboModule\\TurboModuleExample.js",
-      "baseFile": "RNTester\\js\\examples\\TurboModule\\TurboModuleExample.js",
+      "file": "ReactCopies/RNTester/js/examples/TurboModule/TurboModuleExample.js",
+      "baseFile": "RNTester/js/examples/TurboModule/TurboModuleExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "04e690b3f0773e6a419a49d5e7851fc45c8e812d",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\TVEventHandler\\TVEventHandlerExample.js",
-      "baseFile": "RNTester\\js\\examples\\TVEventHandler\\TVEventHandlerExample.js",
+      "file": "ReactCopies/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js",
+      "baseFile": "RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "e55e2dc4773e49536c97c1ab93509406b506bbc4",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\Vibration\\VibrationExample.js",
-      "baseFile": "RNTester\\js\\examples\\Vibration\\VibrationExample.js",
+      "file": "ReactCopies/RNTester/js/examples/Vibration/VibrationExample.js",
+      "baseFile": "RNTester/js/examples/Vibration/VibrationExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "779b679edccda54711fa8c56ba1542e67039d36b",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\View\\ViewExample.js",
-      "baseFile": "RNTester\\js\\examples\\View\\ViewExample.js",
+      "file": "ReactCopies/RNTester/js/examples/View/ViewExample.js",
+      "baseFile": "RNTester/js/examples/View/ViewExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "2883fb236a49da83cb59fb6871a11665779036e0",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\WebSocket\\http_test_server.js",
-      "baseFile": "RNTester\\js\\examples\\WebSocket\\http_test_server.js",
+      "file": "ReactCopies/RNTester/js/examples/WebSocket/http_test_server.js",
+      "baseFile": "RNTester/js/examples/WebSocket/http_test_server.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "6eb8c797c0050daf1a10719498190e89e830728a",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\WebSocket\\websocket_test_server.js",
-      "baseFile": "RNTester\\js\\examples\\WebSocket\\websocket_test_server.js",
+      "file": "ReactCopies/RNTester/js/examples/WebSocket/websocket_test_server.js",
+      "baseFile": "RNTester/js/examples/WebSocket/websocket_test_server.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "cd2631854be06fc7dc9a1ec8b651d3832d9cb128",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\WebSocket\\WebSocketExample.js",
-      "baseFile": "RNTester\\js\\examples\\WebSocket\\WebSocketExample.js",
+      "file": "ReactCopies/RNTester/js/examples/WebSocket/WebSocketExample.js",
+      "baseFile": "RNTester/js/examples/WebSocket/WebSocketExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "7a903bb700536f68bb045f937bbc9fcc183739a7",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExample.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExample.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExample.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1c39f9023a859a9db69a2a8b7adb0062b36afdef",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExampleAbortController.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExampleAbortController.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExampleAbortController.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExampleAbortController.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "d5a28325dd1771b3e0ae73dd1d6eaa1ef25ec142",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExampleBinaryUpload.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExampleBinaryUpload.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExampleBinaryUpload.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExampleBinaryUpload.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "3044359af0b9431ecc245c344093acaaa547b265",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExampleDownload.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExampleDownload.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExampleDownload.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExampleDownload.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "262fd54c16022e23f9ccfeaa929908268bad73cf",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExampleFetch.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExampleFetch.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExampleFetch.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExampleFetch.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "109159d5f7f3d51b8a74bca77ac74b79498e52f5",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExampleHeaders.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExampleHeaders.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExampleHeaders.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExampleHeaders.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1b54482ec2bd7fb2b44aa35ab95bb468f7c3cbd6",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\examples\\XHR\\XHRExampleOnTimeOut.js",
-      "baseFile": "RNTester\\js\\examples\\XHR\\XHRExampleOnTimeOut.js",
+      "file": "ReactCopies/RNTester/js/examples/XHR/XHRExampleOnTimeOut.js",
+      "baseFile": "RNTester/js/examples/XHR/XHRExampleOnTimeOut.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "4be5f89cc28c75fdd0c5acc41c43e30c107d0688",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\RNTesterApp.android.js",
-      "baseFile": "RNTester\\js\\RNTesterApp.android.js",
+      "file": "ReactCopies/RNTester/js/RNTesterApp.android.js",
+      "baseFile": "RNTester/js/RNTesterApp.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "561a3fbff83a0f710b223bb7814e56dfbd8f97ec",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\RNTesterApp.ios.js",
-      "baseFile": "RNTester\\js\\RNTesterApp.ios.js",
+      "file": "ReactCopies/RNTester/js/RNTesterApp.ios.js",
+      "baseFile": "RNTester/js/RNTesterApp.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\types\\RNTesterTypes.js",
-      "baseFile": "RNTester\\js\\types\\RNTesterTypes.js",
+      "file": "ReactCopies/RNTester/js/types/RNTesterTypes.js",
+      "baseFile": "RNTester/js/types/RNTesterTypes.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a0a91739d9093ea289b18b6a4463eed92f3ac7aa",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\utils\\RNTesterActions.js",
-      "baseFile": "RNTester\\js\\utils\\RNTesterActions.js",
+      "file": "ReactCopies/RNTester/js/utils/RNTesterActions.js",
+      "baseFile": "RNTester/js/utils/RNTesterActions.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "2ff99aba3e6a9de3bef13b267bae3d6ce487d4cc",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\utils\\RNTesterList.android.js",
-      "baseFile": "RNTester\\js\\utils\\RNTesterList.android.js",
+      "file": "ReactCopies/RNTester/js/utils/RNTesterList.android.js",
+      "baseFile": "RNTester/js/utils/RNTesterList.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "65c3876bdbc2755cd568b2779ed962fa7a4edf6a",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\utils\\RNTesterList.ios.js",
-      "baseFile": "RNTester\\js\\utils\\RNTesterList.ios.js",
+      "file": "ReactCopies/RNTester/js/utils/RNTesterList.ios.js",
+      "baseFile": "RNTester/js/utils/RNTesterList.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "526ca50e0e5d2809c471d0a2fd7131d5262613e1",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\utils\\RNTesterNavigationReducer.js",
-      "baseFile": "RNTester\\js\\utils\\RNTesterNavigationReducer.js",
+      "file": "ReactCopies/RNTester/js/utils/RNTesterNavigationReducer.js",
+      "baseFile": "RNTester/js/utils/RNTesterNavigationReducer.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "f3cc979585ff0eb8e5878c587f9dad31151e7fcd",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\utils\\RNTesterStatePersister.js",
-      "baseFile": "RNTester\\js\\utils\\RNTesterStatePersister.js",
+      "file": "ReactCopies/RNTester/js/utils/RNTesterStatePersister.js",
+      "baseFile": "RNTester/js/utils/RNTesterStatePersister.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "ac3b4bce847c43ba033e5f4b1cbe17f3e837f295",
       "issue": 4054
     },
     {
       "type": "copy",
-      "file": "ReactCopies\\RNTester\\js\\utils\\URIActionMap.js",
-      "baseFile": "RNTester\\js\\utils\\URIActionMap.js",
+      "file": "ReactCopies/RNTester/js/utils/URIActionMap.js",
+      "baseFile": "RNTester/js/utils/URIActionMap.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "8158050a00a7bd38409d1ec152608751655c9bff",
       "issue": 4054
     },
     {
       "type": "platform",
-      "file": "src\\index.windows.ts"
+      "file": "src/index.windows.ts"
     },
     {
       "type": "patch",
-      "file": "src\\IntegrationTests\\AsyncStorageTest.windesktop.js",
-      "baseFile": "IntegrationTests\\AsyncStorageTest.js",
+      "file": "src/IntegrationTests/AsyncStorageTest.windesktop.js",
+      "baseFile": "IntegrationTests/AsyncStorageTest.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "363ad4689a7058e7ab525d1b3243390377c33c17",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\IntegrationTests\\DummyTest.js"
+      "file": "src/IntegrationTests/DummyTest.js"
     },
     {
       "type": "platform",
-      "file": "src\\IntegrationTests\\LoggingTest.js"
+      "file": "src/IntegrationTests/LoggingTest.js"
     },
     {
       "type": "platform",
-      "file": "src\\IntegrationTests\\XHRTest.js"
+      "file": "src/IntegrationTests/XHRTest.js"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Alert\\Alert.windesktop.js",
-      "baseFile": "Libraries\\Alert\\Alert.js",
+      "file": "src/Libraries/Alert/Alert.windesktop.js",
+      "baseFile": "Libraries/Alert/Alert.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Alert\\Alert.windows.js",
-      "baseFile": "Libraries\\Alert\\Alert.js",
+      "file": "src/Libraries/Alert/Alert.windows.js",
+      "baseFile": "Libraries/Alert/Alert.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\AppTheme\\AppTheme.ts"
+      "file": "src/Libraries/AppTheme/AppTheme.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\AppTheme\\AppThemeTypes.ts"
+      "file": "src/Libraries/AppTheme/AppThemeTypes.ts"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.windesktop.js",
-      "baseFile": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.android.js",
+      "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windesktop.js",
+      "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "840be6f49fe36a3bcfb568eb285bf860f0dd441d",
       "issue": 4578
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.windows.js",
-      "baseFile": "Libraries\\Components\\AccessibilityInfo\\AccessibilityInfo.android.js",
+      "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
+      "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "840be6f49fe36a3bcfb568eb285bf860f0dd441d",
       "issue": 4578
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\Button.windesktop.js",
-      "baseFile": "Libraries\\Components\\Button.js",
+      "file": "src/Libraries/Components/Button.windesktop.js",
+      "baseFile": "Libraries/Components/Button.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "1bb31cc95e6e4b71ff09f024dd102a9717925e51",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\Button.windows.js",
-      "baseFile": "Libraries\\Components\\Button.js",
+      "file": "src/Libraries/Components/Button.windows.js",
+      "baseFile": "Libraries/Components/Button.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "1bb31cc95e6e4b71ff09f024dd102a9717925e51",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\CheckBox\\CheckBox.windesktop.js",
-      "baseFile": "Libraries\\Components\\CheckBox\\CheckBox.ios.js",
+      "file": "src/Libraries/Components/CheckBox/CheckBox.windesktop.js",
+      "baseFile": "Libraries/Components/CheckBox/CheckBox.ios.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "4b84d656391d454ba3409df56c05b6bfca64ad55",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Components\\CheckBox\\CheckBox.windows.js",
-      "baseFile": "Libraries\\Components\\CheckBox\\CheckBox.android.js",
+      "file": "src/Libraries/Components/CheckBox/CheckBox.windows.js",
+      "baseFile": "Libraries/Components/CheckBox/CheckBox.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "278d7049749ba8b5f3840f21ef6b3d528183829f",
       "issue": 4694
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\CheckBox\\CheckBoxProps.ts"
+      "file": "src/Libraries/Components/CheckBox/CheckBoxProps.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\DatePicker\\DatePicker.tsx"
+      "file": "src/Libraries/Components/DatePicker/DatePicker.tsx"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\DatePicker\\DatePickerIOS.windesktop.js",
-      "baseFile": "Libraries\\Components\\DatePicker\\DatePickerIOS.android.js",
+      "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windesktop.js",
+      "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\DatePicker\\DatePickerIOS.windows.js",
-      "baseFile": "Libraries\\Components\\DatePicker\\DatePickerIOS.android.js",
+      "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windows.js",
+      "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\DatePicker\\DatePickerProps.ts"
+      "file": "src/Libraries/Components/DatePicker/DatePickerProps.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.windesktop.js",
-      "baseFile": "Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.ios.js",
+      "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windesktop.js",
+      "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.windows.js",
-      "baseFile": "Libraries\\Components\\DatePickerAndroid\\DatePickerAndroid.ios.js",
+      "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windows.js",
+      "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.windesktop.js",
-      "baseFile": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.ios.js",
+      "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windesktop.js",
+      "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.windows.js",
-      "baseFile": "Libraries\\Components\\DrawerAndroid\\DrawerLayoutAndroid.ios.js",
+      "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js",
+      "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Flyout\\Flyout.tsx"
+      "file": "src/Libraries/Components/Flyout/Flyout.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Flyout\\FlyoutProps.ts"
+      "file": "src/Libraries/Components/Flyout/FlyoutProps.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Glyph\\Glyph.tsx"
+      "file": "src/Libraries/Components/Glyph/Glyph.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Glyph\\GlyphProps.ts"
+      "file": "src/Libraries/Components/Glyph/GlyphProps.ts"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Keyboard\\KeyboardExt.tsx"
+      "file": "src/Libraries/Components/Keyboard/KeyboardExt.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Keyboard\\KeyboardExtProps.ts"
+      "file": "src/Libraries/Components/Keyboard/KeyboardExtProps.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\MaskedView\\MaskedViewIOS.windesktop.js",
-      "baseFile": "Libraries\\Components\\MaskedView\\MaskedViewIOS.android.js",
+      "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windesktop.js",
+      "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\MaskedView\\MaskedViewIOS.windows.js",
-      "baseFile": "Libraries\\Components\\MaskedView\\MaskedViewIOS.android.js",
+      "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windows.js",
+      "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\Picker\\Picker.windows.js",
-      "baseFile": "Libraries\\Components\\Picker\\Picker.js",
+      "file": "src/Libraries/Components/Picker/Picker.windows.js",
+      "baseFile": "Libraries/Components/Picker/Picker.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "8efa98a764d4e80b835ca0dbf1cf3a8b6f01ffe4",
       "issue": 4611
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\Picker\\PickerAndroid.windesktop.js",
-      "baseFile": "Libraries\\Components\\Picker\\PickerAndroid.ios.js",
+      "file": "src/Libraries/Components/Picker/PickerAndroid.windesktop.js",
+      "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\Picker\\PickerAndroid.windows.js",
-      "baseFile": "Libraries\\Components\\Picker\\PickerAndroid.ios.js",
+      "file": "src/Libraries/Components/Picker/PickerAndroid.windows.js",
+      "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\Picker\\PickerIOS.windesktop.js",
-      "baseFile": "Libraries\\Components\\Picker\\PickerIOS.android.js",
+      "file": "src/Libraries/Components/Picker/PickerIOS.windesktop.js",
+      "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\Picker\\PickerIOS.windows.js",
-      "baseFile": "Libraries\\Components\\Picker\\PickerIOS.android.js",
+      "file": "src/Libraries/Components/Picker/PickerIOS.windows.js",
+      "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Picker\\PickerProps.ts"
+      "file": "src/Libraries/Components/Picker/PickerProps.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\Picker\\PickerWindows.tsx",
-      "baseFile": "Libraries\\Components\\Picker\\PickerIOS.ios.js",
+      "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
+      "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "f15d5ab6c73a202608d66eb90f41497cb1fc6dc4",
       "issue": 4611
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Popup\\Popup.tsx"
+      "file": "src/Libraries/Components/Popup/Popup.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\Popup\\PopupProps.ts"
+      "file": "src/Libraries/Components/Popup/PopupProps.ts"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.windesktop.js",
-      "baseFile": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.ios.js",
+      "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windesktop.js",
+      "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.windows.js",
-      "baseFile": "Libraries\\Components\\ProgressBarAndroid\\ProgressBarAndroid.ios.js",
+      "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
+      "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.windesktop.js",
-      "baseFile": "Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.android.js",
+      "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windesktop.js",
+      "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.windows.js",
-      "baseFile": "Libraries\\Components\\ProgressViewIOS\\ProgressViewIOS.android.js",
+      "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windows.js",
+      "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\RefreshControl\\RefreshControl.windows.js",
-      "baseFile": "Libraries\\Components\\RefreshControl\\RefreshControl.js",
+      "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
+      "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "61f351ccc7fbfc340adb9b0cab22497d978ba26d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\SafeAreaView\\SafeAreaView.windesktop.js",
-      "baseFile": "Libraries\\Components\\SafeAreaView\\SafeAreaView.js",
+      "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windesktop.js",
+      "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\SafeAreaView\\SafeAreaView.windows.js",
-      "baseFile": "Libraries\\Components\\SafeAreaView\\SafeAreaView.js",
+      "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
+      "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.windesktop.js",
-      "baseFile": "Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.android.js",
+      "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windesktop.js",
+      "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.windows.js",
-      "baseFile": "Libraries\\Components\\SegmentedControlIOS\\SegmentedControlIOS.android.js",
+      "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
+      "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\TextInput\\TextInput.windesktop.js",
-      "baseFile": "Libraries\\Components\\TextInput\\TextInput.js",
+      "file": "src/Libraries/Components/TextInput/TextInput.windesktop.js",
+      "baseFile": "Libraries/Components/TextInput/TextInput.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a50310f6dee460f7d1a53e0f1a21dbac9cf02094",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\TextInput\\TextInput.windows.js",
-      "baseFile": "Libraries\\Components\\TextInput\\TextInput.js",
+      "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
+      "baseFile": "Libraries/Components/TextInput/TextInput.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a50310f6dee460f7d1a53e0f1a21dbac9cf02094",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\TextInput\\TextInputState.windows.js",
-      "baseFile": "Libraries\\Components\\TextInput\\TextInputState.js",
+      "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
+      "baseFile": "Libraries/Components/TextInput/TextInputState.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ToastAndroid\\ToastAndroid.windesktop.js",
-      "baseFile": "Libraries\\Components\\ToastAndroid\\ToastAndroid.ios.js",
+      "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windesktop.js",
+      "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Components\\ToastAndroid\\ToastAndroid.windows.js",
-      "baseFile": "Libraries\\Components\\ToastAndroid\\ToastAndroid.ios.js",
+      "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
+      "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableHighlight.windows.js",
-      "baseFile": "Libraries\\Components\\Touchable\\TouchableHighlight.js",
+      "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
+      "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b03a273535705ec4a1e979ec0adf06c90b8938e5",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableOpacity.windows.js",
-      "baseFile": "Libraries\\Components\\Touchable\\TouchableOpacity.js",
+      "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
+      "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "e9b3b0a49be45f4030f34f7c91f5a47c01b50582",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\Touchable\\TouchableWithoutFeedback.windows.js",
-      "baseFile": "Libraries\\Components\\Touchable\\TouchableWithoutFeedback.js",
+      "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
+      "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "8fef33cd9edce5725695ca1e7fd9705916578799",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\View\\ReactNativeViewViewConfig.windows.js",
-      "baseFile": "Libraries\\Components\\View\\ReactNativeViewViewConfig.js",
+      "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
+      "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\View\\ViewAccessibility.windows.js",
-      "baseFile": "Libraries\\Components\\View\\ViewAccessibility.js",
+      "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
+      "baseFile": "Libraries/Components/View/ViewAccessibility.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Components\\View\\ViewPropTypes.windows.js",
-      "baseFile": "Libraries\\Components\\View\\ViewPropTypes.js",
+      "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
+      "baseFile": "Libraries/Components/View/ViewPropTypes.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "28c010eda90627523d2aba884e4f4f8892d9fe37",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\View\\ViewWindows.tsx"
+      "file": "src/Libraries/Components/View/ViewWindows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Components\\View\\ViewWindowsProps.ts"
+      "file": "src/Libraries/Components/View/ViewWindowsProps.ts"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\core\\setUpDeveloperTools.windesktop.js",
-      "baseFile": "Libraries\\core\\setUpDeveloperTools.js",
+      "file": "src/Libraries/core/setUpDeveloperTools.windesktop.js",
+      "baseFile": "Libraries/core/setUpDeveloperTools.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "dac10e7b4ec4b65b658f26aeeedc05cc975a53cd",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\DeprecatedPropTypes\\DeprecatedViewAccessibility.windows.js",
-      "baseFile": "Libraries\\DeprecatedPropTypes\\DeprecatedViewAccessibility.js",
+      "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
+      "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Image\\Image.windesktop.js",
-      "baseFile": "Libraries\\Image\\Image.ios.js",
+      "file": "src/Libraries/Image/Image.windesktop.js",
+      "baseFile": "Libraries/Image/Image.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "26acff268b815c7b3c5da0d6c9c009073b202ea8"
     },
     {
       "type": "copy",
-      "file": "src\\Libraries\\Image\\Image.windows.js",
-      "baseFile": "Libraries\\Image\\Image.ios.js",
+      "file": "src/Libraries/Image/Image.windows.js",
+      "baseFile": "Libraries/Image/Image.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "26acff268b815c7b3c5da0d6c9c009073b202ea8",
       "issue": 4590
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Inspector\\InspectorOverlay.windesktop.js",
-      "baseFile": "Libraries\\Inspector\\InspectorOverlay.js",
+      "file": "src/Libraries/Inspector/InspectorOverlay.windesktop.js",
+      "baseFile": "Libraries/Inspector/InspectorOverlay.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "b8535e8c605e6c0e940aae6c04f0d573eaa4788e",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Lists\\VirtualizedList.windows.js",
-      "baseFile": "Libraries\\Lists\\VirtualizedList.js",
+      "file": "src/Libraries/Lists/VirtualizedList.windows.js",
+      "baseFile": "Libraries/Lists/VirtualizedList.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "dd3f2413c3e51f3faca34ebb71635dbdeb716e47",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Network\\RCTNetworking.windesktop.js"
+      "file": "src/Libraries/Network/RCTNetworking.windesktop.js"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Network\\RCTNetworking.windows.js"
+      "file": "src/Libraries/Network/RCTNetworking.windows.js"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Network\\RCTNetworkingWinShared.js",
-      "baseFile": "Libraries\\Network\\RCTNetworking.ios.js",
+      "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
+      "baseFile": "Libraries/Network/RCTNetworking.ios.js",
       "baseVersion": "0.61.5",
       "baseHash": "fa5d7d307e25d22d699a1d2d1eec9c0ac79ba928",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\NewAppScreen\\components\\DebugInstructions.windows.js",
-      "baseFile": "Libraries\\NewAppScreen\\components\\DebugInstructions.js",
+      "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
+      "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\NewAppScreen\\components\\ReloadInstructions.windows.js",
-      "baseFile": "Libraries\\NewAppScreen\\components\\ReloadInstructions.js",
+      "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
+      "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Pressability\\Pressability.windows.js",
-      "baseFile": "Libraries\\Pressability\\Pressability.js",
+      "file": "src/Libraries/Pressability/Pressability.windows.js",
+      "baseFile": "Libraries/Pressability/Pressability.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "a3e33cfe943788b47933ea2c7a807326c8545492",
       "issue": 4379
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Settings\\Settings.windesktop.js",
-      "baseFile": "Libraries\\Settings\\Settings.android.js",
+      "file": "src/Libraries/Settings/Settings.windesktop.js",
+      "baseFile": "Libraries/Settings/Settings.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Settings\\Settings.windows.js",
-      "baseFile": "Libraries\\Settings\\Settings.android.js",
+      "file": "src/Libraries/Settings/Settings.windows.js",
+      "baseFile": "Libraries/Settings/Settings.android.js",
       "baseVersion": "0.61.5",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\StyleSheet\\PlatformColorValueTypes.windesktop.js"
+      "file": "src/Libraries/StyleSheet/PlatformColorValueTypes.windesktop.js"
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\StyleSheet\\PlatformColorValueTypes.windows.js"
+      "file": "src/Libraries/StyleSheet/PlatformColorValueTypes.windows.js"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\StyleSheet\\StyleSheetValidation.windows.js",
-      "baseFile": "Libraries\\StyleSheet\\StyleSheetValidation.js",
+      "file": "src/Libraries/StyleSheet/StyleSheetValidation.windows.js",
+      "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Types\\CoreEventTypes.js",
-      "baseFile": "Libraries\\Types\\CoreEventTypes.js",
+      "file": "src/Libraries/Types/CoreEventTypes.js",
+      "baseFile": "Libraries/Types/CoreEventTypes.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "83b203d547d9bdc57a8f3346ecee6f6e34b25f5d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Utilities\\Appearance.windows.js",
-      "baseFile": "Libraries\\Utilities\\Appearance.js",
+      "file": "src/Libraries/Utilities/Appearance.windows.js",
+      "baseFile": "Libraries/Utilities/Appearance.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "48bccf750042813b47f882d6467b20b178dcbc72",
       "issue": 5270
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\BackHandler.windesktop.js",
-      "baseFile": "Libraries\\Utilities\\BackHandler.ios.js",
+      "file": "src/Libraries/Utilities/BackHandler.windesktop.js",
+      "baseFile": "Libraries/Utilities/BackHandler.ios.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "aa2d482b80ae66104d632c75c24646fdcbe916af",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\BackHandler.windows.js",
-      "baseFile": "Libraries\\Utilities\\BackHandler.android.js",
+      "file": "src/Libraries/Utilities/BackHandler.windows.js",
+      "baseFile": "Libraries/Utilities/BackHandler.android.js",
       "baseVersion": "0.62.2",
       "baseHash": "b1633b6bb5e3dc842011b09f778626c39bf6b654",
       "issue": 4629
     },
     {
       "type": "platform",
-      "file": "src\\Libraries\\Utilities\\DebugEnvironment.js"
+      "file": "src/Libraries/Utilities/DebugEnvironment.js"
     },
     {
       "type": "patch",
-      "file": "src\\Libraries\\Utilities\\HMRClient.windesktop.js",
-      "baseFile": "Libraries\\Utilities\\HMRClient.js",
+      "file": "src/Libraries/Utilities/HMRClient.windesktop.js",
+      "baseFile": "Libraries/Utilities/HMRClient.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "76e71abd8c4128cbdf212291b1d8d8994deb3da0",
       "issue": 4087
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\NativePlatformConstantsWin.js",
-      "baseFile": "Libraries\\Utilities\\NativePlatformConstantsIOS.js",
+      "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
+      "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
       "baseVersion": "0.61.5",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\Platform.windesktop.js",
-      "baseFile": "Libraries\\Utilities\\Platform.android.js",
+      "file": "src/Libraries/Utilities/Platform.windesktop.js",
+      "baseFile": "Libraries/Utilities/Platform.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f"
     },
     {
       "type": "derived",
-      "file": "src\\Libraries\\Utilities\\Platform.windows.js",
-      "baseFile": "Libraries\\Utilities\\Platform.android.js",
+      "file": "src/Libraries/Utilities/Platform.windows.js",
+      "baseFile": "Libraries/Utilities/Platform.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester.ts"
+      "file": "src/RNTester.ts"
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\components\\ListExampleShared.windows.js",
-      "baseFile": "RNTester\\js\\components\\ListExampleShared.js",
+      "file": "src/RNTester/js/components/ListExampleShared.windows.js",
+      "baseFile": "RNTester/js/components/ListExampleShared.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\components\\RNTesterExampleList.windows.js",
-      "baseFile": "RNTester\\js\\components\\RNTesterExampleList.js",
+      "file": "src/RNTester/js/components/RNTesterExampleList.windows.js",
+      "baseFile": "RNTester/js/components/RNTesterExampleList.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "fc507321dc5cb53be93df517ba5c4b1acd0074f4",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Accessibility\\AccessibilityExampleWindows.tsx"
+      "file": "src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\AsyncStorage\\AsyncStorageExampleWindows.tsx"
+      "file": "src/RNTester/js/examples-win/AsyncStorage/AsyncStorageExampleWindows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\CustomView\\CustomViewExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/CustomView/CustomViewExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\DatePicker\\DatePickerExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/DatePicker/DatePickerExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\FastText\\FastTextExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/FastText/FastTextExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Flyout\\FlyoutExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/Flyout/FlyoutExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Glyph\\GlyphExample.tsx"
+      "file": "src/RNTester/js/examples-win/Glyph/GlyphExample.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Keyboard\\KeyboardExample.tsx"
+      "file": "src/RNTester/js/examples-win/Keyboard/KeyboardExample.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Keyboard\\KeyboardExtensionExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/Keyboard/KeyboardExtensionExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Keyboard\\KeyboardFocusExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/Keyboard/KeyboardFocusExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Picker\\PickerWindowsExample.tsx"
+      "file": "src/RNTester/js/examples-win/Picker/PickerWindowsExample.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Popup\\PopupExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/Popup/PopupExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Text\\TextExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/Text/TextExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\Theming\\ThemingExample.windows.tsx"
+      "file": "src/RNTester/js/examples-win/Theming/ThemingExample.windows.tsx"
     },
     {
       "type": "platform",
-      "file": "src\\RNTester\\js\\examples-win\\TransferProperties\\TransferPropertiesExample.tsx"
+      "file": "src/RNTester/js/examples-win/TransferProperties/TransferPropertiesExample.tsx"
     },
     {
       "type": "derived",
-      "file": "src\\RNTester\\js\\examples\\PlatformColor\\PlatformColorExample.windows.js",
-      "baseFile": "RNTester\\js\\examples\\PlatformColor\\PlatformColorExample.js",
+      "file": "src/RNTester/js/examples/PlatformColor/PlatformColorExample.windows.js",
+      "baseFile": "RNTester/js/examples/PlatformColor/PlatformColorExample.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "f1c2babe02e11d237dbab875b8a7cd63fce048b6",
       "issue": 4055
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\examples\\RTL\\RTLExample.windows.js",
-      "baseFile": "RNTester\\js\\examples\\RTL\\RTLExample.js",
+      "file": "src/RNTester/js/examples/RTL/RTLExample.windows.js",
+      "baseFile": "RNTester/js/examples/RTL/RTLExample.js",
       "baseVersion": "0.62.2",
       "baseHash": "70a65dc896406e7ad971f0a9a770b7ea30f43b9e",
       "issue": 4678
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\examples\\ScrollView\\ScrollViewExample.windows.js",
-      "baseFile": "RNTester\\js\\examples\\ScrollView\\ScrollViewExample.js",
+      "file": "src/RNTester/js/examples/ScrollView/ScrollViewExample.windows.js",
+      "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "1840fda2dd4591883df92d28c1e1aeabff190f7f",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
-      "file": "src\\RNTester\\js\\examples\\View\\ViewExample.windows.js",
-      "baseFile": "RNTester\\js\\examples\\View\\ViewExample.js",
+      "file": "src/RNTester/js/examples/View/ViewExample.windows.js",
+      "baseFile": "RNTester/js/examples/View/ViewExample.js",
       "baseVersion": "0.61.5",
       "baseHash": "2883fb236a49da83cb59fb6871a11665779036e0",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
-      "file": "src\\RNTester\\js\\RNTesterApp.windows.js",
-      "baseFile": "RNTester\\js\\RNTesterApp.ios.js",
+      "file": "src/RNTester/js/RNTesterApp.windows.js",
+      "baseFile": "RNTester/js/RNTesterApp.ios.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
     {
       "type": "derived",
-      "file": "src\\RNTester\\js\\utils\\RNTesterList.windows.ts",
-      "baseFile": "RNTester\\js\\utils\\RNTesterList.android.js",
+      "file": "src/RNTester/js/utils/RNTesterList.windows.ts",
+      "baseFile": "RNTester/js/utils/RNTesterList.android.js",
       "baseVersion": "0.0.0-56cf99a96",
       "baseHash": "65c3876bdbc2755cd568b2779ed962fa7a4edf6a",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "platform",
-      "file": "src\\typings-index.ts"
+      "file": "src/typings-index.ts"
     }
   ]
 }


### PR DESCRIPTION
We internally keep normalized paths for overrides, but this ends up being a bit confusing in contrast to Unix style globs, and ideally the serialized path representation should be constant. Normalize to Unix style paths.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5434)