### PR TITLE
Increase Timeout for react-native-platform-override e2etest

### DIFF
--- a/change/react-native-platform-override-2020-07-06-18-11-21-more-timeout.json
+++ b/change/react-native-platform-override-2020-07-06-18-11-21-more-timeout.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Increase Timeout for react-native-platform-override e2etest",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-07T01:11:21.672Z"
+}

--- a/packages/react-native-platform-override/jest.e2e.config.js
+++ b/packages/react-native-platform-override/jest.e2e.config.js
@@ -20,5 +20,5 @@ module.exports = {
   testRegex: '/e2etest/.*\\.test',
 
   // Default timeout of a test in milliseconds
-  testTimeout: 60000,
+  testTimeout: 120000,
 };

--- a/packages/react-native-platform-override/just-task.js
+++ b/packages/react-native-platform-override/just-task.js
@@ -10,7 +10,10 @@ const {jestTask, series, task} = require('just-scripts');
 
 require('@rnw-scripts/just-task');
 
-task('unitTest', jestTask({config: './jest.config.js'}));
-task('endToEndTest', jestTask({config: './jest.e2e.config.js'}));
+task('unitTest', jestTask({config: './jest.config.js', _: ['--verbose']}));
+task(
+  'endToEndTest',
+  jestTask({config: './jest.e2e.config.js', _: ['--verbose']}),
+);
 
 task('test', series('unitTest', 'endToEndTest'));


### PR DESCRIPTION
These tests touch the network and have some variability. A recent CI run showed a test timing out. Increase the timeout, and enable verbose logging so we can see how long individual tests are taking (some seem to take much longer on CI than locally).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5435)