### PR TITLE
Revert to new experimentalNuGetDependency Naming

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -60,7 +60,7 @@ steps:
         artifactName: NuGetTestFeed
         downloadPath: $(System.DefaultWorkingDirectory)
     - script: |
-        echo ##vso[task.setvariable variable=nugetInitArguments]--experimentalNugetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed --nuGetTestVersion ${{ parameters.version }}
+        echo ##vso[task.setvariable variable=nugetInitArguments]--experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed --nuGetTestVersion ${{ parameters.version }}
       displayName: 'Configure additional args for nuget'
   - ${{ if not(eq(parameters.useNuGet, true)) }}:
     - script: |

--- a/change/react-native-windows-2020-07-07-11-27-33-experimental-nuget.json
+++ b/change/react-native-windows-2020-07-07-11-27-33-experimental-nuget.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rever to new experimentalNuGetDependency Naming",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-07T18:27:33.473Z"
+}

--- a/change/react-native-windows-init-2020-07-07-11-27-33-experimental-nuget.json
+++ b/change/react-native-windows-init-2020-07-07-11-27-33-experimental-nuget.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rever to new experimentalNuGetDependency Naming",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-07T18:27:29.088Z"
+}

--- a/docs/testing-nuget-packages.md
+++ b/docs/testing-nuget-packages.md
@@ -41,7 +41,7 @@ Today we support the following projects as a NuGet package:
    1. `npx react-native init MyProj`
    1. cd `MyProj`
    1. Apply the react-native-windows template:
-      1. `node z:\src\r3\packages\react-native-windows-init\lib-commonjs\Cli.js --version 0.0.0 --useDevMode --overwrite  --language cs --experimentalNugetDependency --nuGetTestFeed c:\temp\RnWNuGetTesting\feed --nuGetTestVersion 0.0.1-MyTest001 `
+      1. `node z:\src\r3\packages\react-native-windows-init\lib-commonjs\Cli.js --version 0.0.0 --useDevMode --overwrite  --language cs --experimentalNuGetDependency --nuGetTestFeed c:\temp\RnWNuGetTesting\feed --nuGetTestVersion 0.0.1-MyTest001 `
          > See below for a breakdown of the arguments:
 1. Do your testing
 
@@ -71,6 +71,6 @@ This script has many options, but let's break down the ones from the sample:
 * `--version 0.0.0 --useDevMode`: The version doesn't matter when using dev mode, which means that the npm package is used that is registred as the dev package using `yarn link` per instructions above. This saves copying all the output files to your package directory, to your yarn cache. It is also a lot faster and since it is a link, you can make changes to your enlistment i.e. to `vnext\StyleSheets` and you don't have to reinstall between testing
 * `--overwrite`: This just overwites files that already exist instead of prompting. This is very usefull when running the script multiple times to test the templates or to code that emits the template.
 * `--language cs`: this is one of the public flags to generate a cs project instead of a cpp project. 
-* `--experimentalNugetDependency`: This is the critical one to let the template emit referneces to NuGet package rather than source pacakges. When we make it the default this will likely be renamed back to source for those that need a tight loop between test projects from template and the product code for developers working 'on' react-native-windows. If it proves that the sample and test apps we have in the repo satisfy this need, it can be removed and the tempaltes can be cleaned up by removing a lot of the conditionals bewteen the two.
+* `--experimentalNuGetDependency`: This is the critical one to let the template emit referneces to NuGet package rather than source pacakges. When we make it the default this will likely be renamed back to source for those that need a tight loop between test projects from template and the product code for developers working 'on' react-native-windows. If it proves that the sample and test apps we have in the repo satisfy this need, it can be removed and the tempaltes can be cleaned up by removing a lot of the conditionals bewteen the two.
 * `--nuGetTestFeed c:\temp\RnWNugetTesting\feed`: This flag adds an extra feed to the nuget.config so that for local testing you can use a different feed. This is the default location that is pushed to by the `PublishNugetPackagesLocally.cmd` script.
 * `--nuGetTestVersion 0.0.1-MyTest001`: By default the NuGet version matches the react-native version. For testing this can be cumbersome. Therefore this flag allows you to specify the version number for the NuGet packages. 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -55,7 +55,7 @@ const argv = yargs
       describe: 'Overwrite any existing files without prompting',
       default: false,
     },
-    experimentalNugetDependency: {
+    experimentalNuGetDependency: {
       type: 'boolean',
       describe:
         '[Experimental] change to start consuming a NuGet containing a pre-built dll version of Microsoft.ReactNative',
@@ -329,10 +329,10 @@ function isProjectUsingYarn(cwd: string): boolean {
     const useDevMode = argv.useDevMode;
     let version = argv.version;
 
-    if (argv.useWinUI3 && argv.experimentalNugetDependency) {
+    if (argv.useWinUI3 && argv.experimentalNuGetDependency) {
       // WinUI3 is not yet compatible with NuGet packages
       console.error(
-        "Error: Incompatible options specified. Options '--useWinUI3' and '--experimentalNugetDependency' are incompatible",
+        "Error: Incompatible options specified. Options '--useWinUI3' and '--experimentalNuGetDependency' are incompatible",
       );
       process.exit(EXITCODE_INCOMPATIBLE_OPTIONS);
     }
@@ -430,7 +430,7 @@ You can either downgrade your version of ${chalk.green(
       language: argv.language as 'cs' | 'cpp',
       overwrite: argv.overwrite,
       verbose: argv.verbose,
-      experimentalNugetDependency: argv.experimentalNugetDependency,
+      experimentalNuGetDependency: argv.experimentalNuGetDependency,
       useWinUI3: argv.useWinUI3,
       nuGetTestVersion: argv.nuGetTestVersion,
       nuGetTestFeed: argv.nuGetTestFeed,

--- a/vnext/local-cli/src/generate-windows.ts
+++ b/vnext/local-cli/src/generate-windows.ts
@@ -31,7 +31,7 @@ import {
 export interface GenerateOptions {
   overwrite: boolean;
   language: 'cpp' | 'cs';
-  experimentalNugetDependency: boolean;
+  experimentalNuGetDependency: boolean;
   nuGetTestVersion?: string;
   nuGetTestFeed?: string;
   useWinUI3: boolean;

--- a/vnext/local-cli/src/generator-windows/index.ts
+++ b/vnext/local-cli/src/generator-windows/index.ts
@@ -130,7 +130,7 @@ export async function copyProjectTemplateAndReplace(
 
   const language = options.language;
   const namespaceCpp = toCppNamespace(namespace);
-  if (options.experimentalNugetDependency) {
+  if (options.experimentalNuGetDependency) {
     console.log('Using experimental NuGet dependency.');
   }
   if (options.useWinUI3) {
@@ -190,7 +190,7 @@ export async function copyProjectTemplateAndReplace(
     },
   ];
 
-  if (options.experimentalNugetDependency) {
+  if (options.experimentalNuGetDependency) {
     csNugetPackages.push({
       id: 'Microsoft.ReactNative.Managed',
       version: nugetVersion,
@@ -224,7 +224,7 @@ export async function copyProjectTemplateAndReplace(
     currentUser: currentUser,
     certificateThumbprint: certificateThumbprint,
 
-    useExperimentalNuget: options.experimentalNugetDependency,
+    useExperimentalNuget: options.experimentalNuGetDependency,
     nuGetTestFeed: options.nuGetTestFeed,
 
     // cpp template variables
@@ -329,7 +329,7 @@ export async function copyProjectTemplateAndReplace(
   }
 
   // Once we are publishing to nuget.org, this shouldn't be needed anymore
-  if (options.experimentalNugetDependency) {
+  if (options.experimentalNuGetDependency) {
     [
       {
         from: path.join(sharedPath, projDir, 'NuGet.Config'),


### PR DESCRIPTION
This flag was originally called "experimentalNugetDependency". Capitalization of this flag changed to "experimentalNuGetDependency", which broke its usage in 0.62. 0.62 was updated to the new capitalization, but the change was then later reverted to "experimentalNugetDependency", breaking its usage in 0.62 again.

Keep the naming that the most recent version of 0.62 expects.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5438)