### PR TITLE
Add DynamicReader, DynamicWriter tests [Core DLL]

### DIFF
--- a/change/react-native-windows-2020-07-07-17-23-33-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-07-07-17-23-33-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add tests for DynamicReader, DynamicWriter ",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-08T00:23:33.522Z"
+}

--- a/vnext/Desktop.ABITests/Application.manifest
+++ b/vnext/Desktop.ABITests/Application.manifest
@@ -17,6 +17,10 @@
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
+        name="Microsoft.Internal.TestController"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
         name="Microsoft.ReactNative.ReactNativeHost"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />

--- a/vnext/Desktop.ABITests/DynamicReaderWriterTests.cpp
+++ b/vnext/Desktop.ABITests/DynamicReaderWriterTests.cpp
@@ -68,20 +68,15 @@ TEST_CLASS (DynamicReaderWriterTests) {
   TEST_METHOD(WriteGetObject) {
     IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
 
-    auto namePropertyName = to_hstring(L"Name");
-    auto agePropertyName = to_hstring(L"Age");
-    auto marriedPropertyName = to_hstring(L"Married");
-    auto emptyPropertyName = to_hstring(L"");
-
     writer.WriteObjectBegin();
 
-    writer.WritePropertyName(namePropertyName);
+    writer.WritePropertyName(L"Name");
     writer.WriteString(L"Bob");
 
-    writer.WritePropertyName(agePropertyName);
+    writer.WritePropertyName(L"Age");
     writer.WriteInt64(32);
 
-    writer.WritePropertyName(marriedPropertyName);
+    writer.WritePropertyName(L"Married");
     writer.WriteBoolean(true);
 
     writer.WriteObjectEnd();
@@ -89,42 +84,45 @@ TEST_CLASS (DynamicReaderWriterTests) {
     IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
     TestCheckEqual(JSValueType::Object, reader.ValueType());
 
-    TestCheck(reader.GetNextObjectProperty(namePropertyName));
+    hstring propertyName;
+
+    TestCheck(reader.GetNextObjectProperty(/* out */ propertyName));
+    TestCheckEqual(L"Name", propertyName);
     TestCheckEqual(JSValueType::String, reader.ValueType());
     TestCheckEqual(L"Bob", reader.GetString());
+    propertyName.clear();
 
-    TestCheck(reader.GetNextObjectProperty(agePropertyName));
+    TestCheck(reader.GetNextObjectProperty(/* out */ propertyName));
+    TestCheckEqual(L"Age", propertyName);
     TestCheckEqual(JSValueType::Int64, reader.ValueType());
     TestCheckEqual(32, reader.GetInt64());
+    propertyName.clear();
 
-    TestCheck(reader.GetNextObjectProperty(marriedPropertyName));
+    TestCheck(reader.GetNextObjectProperty(/* out */ propertyName));
+    TestCheckEqual(L"Married", propertyName);
     TestCheckEqual(JSValueType::Boolean, reader.ValueType());
     TestCheckEqual(true, reader.GetBoolean());
+    propertyName.clear();
 
-    TestCheck(!reader.GetNextObjectProperty(emptyPropertyName));
+    TestCheck(!reader.GetNextObjectProperty(/* out */ propertyName));
   }
 
   TEST_METHOD(WriteGetObjectArrayMix) {
     IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
 
-    auto namePropertyName = to_hstring(L"Name");
-    auto countiesPropertyName = to_hstring(L"Counties");
-    auto areaPropertyName = to_hstring(L"Area");
-    auto emptyPropertyName = to_hstring(L"");
-
     writer.WriteObjectBegin();
 
-    writer.WritePropertyName(namePropertyName);
+    writer.WritePropertyName(L"Name");
     writer.WriteString(L"Washington");
 
-    writer.WritePropertyName(countiesPropertyName);
+    writer.WritePropertyName(L"Counties");
     writer.WriteArrayBegin();
     writer.WriteString(L"Snohomish");
     writer.WriteString(L"King");
     writer.WriteString(L"Pierce");
     writer.WriteArrayEnd();
 
-    writer.WritePropertyName(areaPropertyName);
+    writer.WritePropertyName(L"Area");
     writer.WriteInt64(184827);
 
     writer.WriteObjectEnd();
@@ -132,12 +130,18 @@ TEST_CLASS (DynamicReaderWriterTests) {
     IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
     TestCheckEqual(JSValueType::Object, reader.ValueType());
 
-    TestCheck(reader.GetNextObjectProperty(namePropertyName));
+    hstring propertyName;
+
+    TestCheck(reader.GetNextObjectProperty(/* out */ propertyName));
+    TestCheckEqual(L"Name", propertyName);
     TestCheckEqual(JSValueType::String, reader.ValueType());
     TestCheckEqual(L"Washington", reader.GetString());
+    propertyName.clear();
 
-    TestCheck(reader.GetNextObjectProperty(countiesPropertyName));
+    TestCheck(reader.GetNextObjectProperty(/* out */ propertyName));
+    TestCheckEqual(L"Counties", propertyName);
     TestCheckEqual(JSValueType::Array, reader.ValueType());
+    propertyName.clear();
 
     TestCheck(reader.GetNextArrayItem());
     TestCheckEqual(JSValueType::String, reader.ValueType());
@@ -153,10 +157,12 @@ TEST_CLASS (DynamicReaderWriterTests) {
 
     TestCheck(!reader.GetNextArrayItem());
 
-    TestCheck(reader.GetNextObjectProperty(areaPropertyName));
+    TestCheck(reader.GetNextObjectProperty(/* out */ propertyName));
+    TestCheckEqual(L"Area", propertyName);
     TestCheckEqual(184827, reader.GetInt64());
+    propertyName.clear();
 
-    TestCheck(!reader.GetNextObjectProperty(emptyPropertyName));
+    TestCheck(!reader.GetNextObjectProperty(/**/ propertyName));
   }
 
  private:

--- a/vnext/Desktop.ABITests/DynamicReaderWriterTests.cpp
+++ b/vnext/Desktop.ABITests/DynamicReaderWriterTests.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <winrt/Microsoft.Internal.h>
+#include <winrt/Microsoft.ReactNative.h>
+
+using namespace winrt;
+using namespace winrt::Microsoft::ReactNative;
+
+namespace ABITests {
+
+// The tests here are a development staging artifact owed to the incremental buildup of the C++/WinRT-based ABI of
+// the Win32 DLL. They (or their logical equivalent) should probably get rolled into other tests once C++/WinRT-based
+// instance management becomes available.
+TEST_CLASS (DynamicReaderWriterTests) {
+ public:
+  TEST_METHOD(WriteGetBoolean) {
+    TestScalar(&IJSValueWriter::WriteBoolean, &IJSValueReader::GetBoolean, JSValueType::Boolean, true);
+  }
+
+  TEST_METHOD(WriteGetInt64) {
+    TestScalar(&IJSValueWriter::WriteInt64, &IJSValueReader::GetInt64, JSValueType::Int64, static_cast<int64_t>(123));
+  }
+
+  TEST_METHOD(WriteGetDouble) {
+    TestScalar(&IJSValueWriter::WriteDouble, &IJSValueReader::GetDouble, JSValueType::Double, 3.14);
+  }
+
+  TEST_METHOD(WriteGetString) {
+    TestScalar<const param::hstring &, hstring>(
+        &IJSValueWriter::WriteString, &IJSValueReader::GetString, JSValueType::String, L"abc");
+  }
+
+  TEST_METHOD(WriteNull) {
+    IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
+    writer.WriteNull();
+    IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
+    TestCheckEqual(JSValueType::Null, reader.ValueType());
+  }
+
+  TEST_METHOD(WriteGetArray) {
+    IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
+    writer.WriteArrayBegin();
+    writer.WriteBoolean(true);
+    writer.WriteInt64(123);
+    writer.WriteString(L"abc");
+    writer.WriteArrayEnd();
+
+    IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+
+    TestCheck(reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Boolean, reader.ValueType());
+    TestCheckEqual(true, reader.GetBoolean());
+
+    TestCheck(reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::Int64, reader.ValueType());
+    TestCheckEqual(123, reader.GetInt64());
+
+    TestCheck(reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"abc", reader.GetString());
+
+    TestCheck(!reader.GetNextArrayItem());
+  }
+
+  TEST_METHOD(WriteGetObject) {
+    IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
+
+    auto namePropertyName = to_hstring(L"Name");
+    auto agePropertyName = to_hstring(L"Age");
+    auto marriedPropertyName = to_hstring(L"Married");
+    auto emptyPropertyName = to_hstring(L"");
+
+    writer.WriteObjectBegin();
+
+    writer.WritePropertyName(namePropertyName);
+    writer.WriteString(L"Bob");
+
+    writer.WritePropertyName(agePropertyName);
+    writer.WriteInt64(32);
+
+    writer.WritePropertyName(marriedPropertyName);
+    writer.WriteBoolean(true);
+
+    writer.WriteObjectEnd();
+
+    IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
+    TestCheckEqual(JSValueType::Object, reader.ValueType());
+
+    TestCheck(reader.GetNextObjectProperty(namePropertyName));
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"Bob", reader.GetString());
+
+    TestCheck(reader.GetNextObjectProperty(agePropertyName));
+    TestCheckEqual(JSValueType::Int64, reader.ValueType());
+    TestCheckEqual(32, reader.GetInt64());
+
+    TestCheck(reader.GetNextObjectProperty(marriedPropertyName));
+    TestCheckEqual(JSValueType::Boolean, reader.ValueType());
+    TestCheckEqual(true, reader.GetBoolean());
+
+    TestCheck(!reader.GetNextObjectProperty(emptyPropertyName));
+  }
+
+  TEST_METHOD(WriteGetObjectArrayMix) {
+    IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
+
+    auto namePropertyName = to_hstring(L"Name");
+    auto countiesPropertyName = to_hstring(L"Counties");
+    auto areaPropertyName = to_hstring(L"Area");
+    auto emptyPropertyName = to_hstring(L"");
+
+    writer.WriteObjectBegin();
+
+    writer.WritePropertyName(namePropertyName);
+    writer.WriteString(L"Washington");
+
+    writer.WritePropertyName(countiesPropertyName);
+    writer.WriteArrayBegin();
+    writer.WriteString(L"Snohomish");
+    writer.WriteString(L"King");
+    writer.WriteString(L"Pierce");
+    writer.WriteArrayEnd();
+
+    writer.WritePropertyName(areaPropertyName);
+    writer.WriteInt64(184827);
+
+    writer.WriteObjectEnd();
+
+    IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
+    TestCheckEqual(JSValueType::Object, reader.ValueType());
+
+    TestCheck(reader.GetNextObjectProperty(namePropertyName));
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"Washington", reader.GetString());
+
+    TestCheck(reader.GetNextObjectProperty(countiesPropertyName));
+    TestCheckEqual(JSValueType::Array, reader.ValueType());
+
+    TestCheck(reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"Snohomish", reader.GetString());
+
+    TestCheck(reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"King", reader.GetString());
+
+    TestCheck(reader.GetNextArrayItem());
+    TestCheckEqual(JSValueType::String, reader.ValueType());
+    TestCheckEqual(L"Pierce", reader.GetString());
+
+    TestCheck(!reader.GetNextArrayItem());
+
+    TestCheck(reader.GetNextObjectProperty(areaPropertyName));
+    TestCheckEqual(184827, reader.GetInt64());
+
+    TestCheck(!reader.GetNextObjectProperty(emptyPropertyName));
+  }
+
+ private:
+  template <class TWriterValue, class TReaderValue = TWriterValue>
+  void TestScalar(
+      void (IJSValueWriter::*writerMethod)(TWriterValue) const,
+      TReaderValue (IJSValueReader::*readerMethod)() const,
+      JSValueType runtimeType,
+      TWriterValue value) {
+    IJSValueWriter writer = Microsoft::Internal::TestController::CreateDynamicWriter();
+    (writer.*writerMethod)(value);
+
+    IJSValueReader reader = Microsoft::Internal::TestController::CreateDynamicReader(writer);
+    TestCheckEqual(runtimeType, reader.ValueType());
+    TestCheckEqual(value, (reader.*readerMethod)());
+  }
+};
+
+} // namespace ABITests

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -113,6 +113,9 @@
       <CppWinRTDynamicProjectWinMDReferences Include="$(OutputPath)..\React.Windows.Desktop\facebook.react.winmd">
         <WinMDPath>$(OutputPath)..\React.Windows.Desktop\facebook.react.winmd</WinMDPath>
       </CppWinRTDynamicProjectWinMDReferences>
+      <CppWinRTDynamicProjectWinMDReferences Include="$(OutputPath)..\React.Windows.Desktop\Microsoft.Internal.winmd">
+        <WinMDPath>$(OutputPath)..\React.Windows.Desktop\Microsoft.Internal.winmd</WinMDPath>
+      </CppWinRTDynamicProjectWinMDReferences>
       <CppWinRTDynamicProjectWinMDReferences Include="$(OutputPath)..\React.Windows.Desktop\Microsoft.ReactNative.winmd">
         <WinMDPath>$(OutputPath)..\React.Windows.Desktop\Microsoft.ReactNative.winmd</WinMDPath>
       </CppWinRTDynamicProjectWinMDReferences>
@@ -123,9 +126,10 @@
     Used by the 'CopyFilesToOutputDirectory' target (more specifically, its '_CopyFilesMarkedCopyLocal' dependency')
     to co-locate dependencies with the test binary.
      -->
-    <ReferenceCopyLocalPaths Include="$(OutputPath)..\React.Windows.Desktop.DLL\react-native-win32.dll"/>
+    <ReferenceCopyLocalPaths Include="$(OutputPath)..\React.Windows.Desktop.DLL\react-native-win32.dll" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="DynamicReaderWriterTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MemoryTrackerTests.cpp" />
     <ClCompile Include="SimpleMessageQueue.cpp" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -33,10 +33,16 @@
     <ClCompile Include="PerfTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ReactNativeHostTests.cpp">
+    <ClCompile Include="SimpleMessageQueue.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="SimpleMessageQueue.cpp">
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactPropertyBagTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactNativeHostTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DynamicReaderWriterTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -50,5 +56,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="Application.manifest" />
   </ItemGroup>
 </Project>

--- a/vnext/Desktop/ABI/TestController.cpp
+++ b/vnext/Desktop/ABI/TestController.cpp
@@ -1,0 +1,67 @@
+#include "pch.h"
+
+#include "DynamicReader.h"
+#include "DynamicWriter.h"
+#include "TestController.h"
+
+#include "Microsoft.Internal.TestController.g.cpp"
+
+using namespace winrt;
+
+namespace {
+
+// Extends the 'DynamicReader' class with the ability the manage the lifetime of the folly::dynamic value it's reading
+// from.
+struct DynamicWrapperReader : public winrt::implements<DynamicWrapperReader, Microsoft::ReactNative::IJSValueReader> {
+  DynamicWrapperReader(folly::dynamic &&value) : m_value{std::move(value)} {
+    m_innerReader = make<Microsoft::ReactNative::DynamicReader>(m_value);
+  }
+
+  Microsoft::ReactNative::JSValueType ValueType() noexcept {
+    return m_innerReader.ValueType();
+  }
+
+  bool GetNextObjectProperty(hstring &propertyName) noexcept {
+    return m_innerReader.GetNextObjectProperty(propertyName);
+  }
+
+  bool GetNextArrayItem() noexcept {
+    return m_innerReader.GetNextArrayItem();
+  }
+
+  hstring GetString() noexcept {
+    return m_innerReader.GetString();
+  }
+
+  bool GetBoolean() noexcept {
+    return m_innerReader.GetBoolean();
+  }
+
+  int64_t GetInt64() noexcept {
+    return m_innerReader.GetInt64();
+  }
+
+  double GetDouble() noexcept {
+    return m_innerReader.GetDouble();
+  }
+
+ private:
+  Microsoft::ReactNative::IJSValueReader m_innerReader;
+  folly::dynamic m_value;
+};
+
+} // namespace
+
+namespace winrt::Microsoft::Internal::implementation {
+
+Microsoft::ReactNative::IJSValueReader TestController::CreateDynamicReader(
+    Microsoft::ReactNative::IJSValueWriter writer) {
+  auto dw = writer.as<Microsoft::ReactNative::DynamicWriter>();
+  return make<DynamicWrapperReader>(dw->TakeValue());
+}
+
+Microsoft::ReactNative::IJSValueWriter TestController::CreateDynamicWriter() {
+  return make<winrt::Microsoft::ReactNative::DynamicWriter>();
+}
+
+} // namespace winrt::Microsoft::Internal::implementation

--- a/vnext/Desktop/ABI/TestController.h
+++ b/vnext/Desktop/ABI/TestController.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "Microsoft.Internal.TestController.g.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::Internal::implementation {
+struct TestController {
+  TestController() = default;
+
+  static Microsoft::ReactNative::IJSValueReader CreateDynamicReader(Microsoft::ReactNative::IJSValueWriter writer);
+  static Microsoft::ReactNative::IJSValueWriter CreateDynamicWriter();
+};
+} // namespace winrt::Microsoft::Internal::implementation
+
+namespace winrt::Microsoft::Internal::factory_implementation {
+struct TestController : TestControllerT<TestController, implementation::TestController> {};
+} // namespace winrt::Microsoft::Internal::factory_implementation

--- a/vnext/Desktop/ABI/TestController.idl
+++ b/vnext/Desktop/ABI/TestController.idl
@@ -1,0 +1,15 @@
+import "IJSValueReader.idl";
+import "IJSValueWriter.idl";
+
+namespace Microsoft.Internal {
+
+  // This class is a development staging artifact owed to the incremental buildup of the C++/WinRT-based ABI of
+  // the Win32 DLL. It enables testing of "peripheral" components prior to the availability of more "central" components
+  // (e.g. instance management components). This class should get removed once the peripheral components can get tested
+  // via the more central components.
+  static runtimeclass TestController {
+    static Microsoft.ReactNative.IJSValueReader CreateDynamicReader(Microsoft.ReactNative.IJSValueWriter writer);
+    static Microsoft.ReactNative.IJSValueWriter CreateDynamicWriter();
+  };
+
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -127,6 +127,7 @@
     <Midl Include="ABI\MessageQueue.idl" />
     <Midl Include="ABI\NativeLogging.idl" />
     <Midl Include="ABI\NativeTracing.idl" />
+    <Midl Include="ABI\TestController.idl" />
     <Midl Include="..\Microsoft.ReactNative\ReactNativeHost.idl" />
     <Midl Include="..\Microsoft.ReactNative\IReactPackageProvider.idl" />
     <Midl Include="..\Microsoft.ReactNative\ReactInstanceSettings.idl" />
@@ -161,6 +162,10 @@
     </ClCompile>
     <ClCompile Include="ABI\NativeTraceEventSource.cpp">
       <DependentUpon>ABI\NativeTracing.idl</DependentUpon>
+      <ObjectFileName>$(IntDir)\ABI\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="ABI\TestController.cpp">
+      <DependentUpon>ABI\TestController.idl</DependentUpon>
       <ObjectFileName>$(IntDir)\ABI\</ObjectFileName>
     </ClCompile>
     <ClCompile Include="..\Microsoft.ReactNative\ABICxxModule.cpp" />
@@ -212,6 +217,9 @@
     </ClInclude>
     <ClInclude Include="ABI\NativeTraceEventSource.h">
       <DependentUpon>ABI\NativeTracing.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ABI\TestController.h">
+      <DependentUpon>ABI\TestController.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="..\Microsoft.ReactNative\ReactNativeHost.h">
       <DependentUpon>..\Microsoft.ReactNative\ReactNativeHost.idl</DependentUpon>

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
@@ -81,6 +81,9 @@
     <Midl Include="ABI\NativeTracing.idl">
       <Filter>ABI</Filter>
     </Midl>
+    <Midl Include="ABI\TestController.idl">
+      <Filter>ABI</Filter>
+    </Midl>
     <Midl Include="..\Microsoft.ReactNative\ReactInstance.idl">
       <Filter>ABI</Filter>
     </Midl>
@@ -108,6 +111,9 @@
       <Filter>ABI</Filter>
     </ClCompile>
     <ClCompile Include="ABI\NativeTraceEventSource.cpp">
+      <Filter>ABI</Filter>
+    </ClCompile>
+    <ClCompile Include="ABI\TestController.cpp">
       <Filter>ABI</Filter>
     </ClCompile>
     <ClCompile Include="BeastWebSocketResource.cpp">
@@ -155,6 +161,9 @@
       <Filter>ABI</Filter>
     </ClInclude>
     <ClInclude Include="ABI\NativeTraceEventSource.h">
+      <Filter>ABI</Filter>
+    </ClInclude>
+    <ClInclude Include="ABI\TestController.h">
       <Filter>ABI</Filter>
     </ClInclude>
   </ItemGroup>

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -5,6 +5,7 @@
 
 #include "pch.h"
 #include "winrt/base.h"
+void* winrt_make_Microsoft_Internal_TestController();
 void* winrt_make_Microsoft_ReactNative_ReactDispatcherHelper();
 void* winrt_make_Microsoft_ReactNative_ReactInstanceSettings();
 void* winrt_make_Microsoft_ReactNative_ReactNativeHost();
@@ -31,6 +32,11 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     {
         return std::equal(left.rbegin(), left.rend(), right.rbegin(), right.rend());
     };
+
+    if (requal(name, L"Microsoft.Internal.TestController"))
+    {
+        return winrt_make_Microsoft_Internal_TestController();
+    }
 
     if (requal(name, L"Microsoft.ReactNative.ReactDispatcherHelper"))
     {


### PR DESCRIPTION
DynamicReader and DynamicWriter components are already being built into the Win32 DLL; this change adds tests for them. As DynamicReader and DynamicWriter can normally not be activated, this change adds a helper component ('Microsoft.Internal.TestController') that allows us to create these components for test purposes. Once the ABI has been fully built up, we should be able to test these components in different ways. At this point, the Microsoft.Internal.TestController component can be removed again.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5455)