### PR TITLE
Don't try to run Jest Tests From the Repo Root

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ * @ts-check
+ */
+
+console.error(
+  "\x1b[31mThe react-native-windows-repo doesn't support running jest directly from its root. Please run 'yarn test' instead.\x1b[0m",
+);
+
+// Jest should support running across multiple-projects, but doesn't seem to
+// fully respect their configs when doing so. Don't run any tests if someone
+// tries to run Jest from the repo root (e.g. using the VS code with the Jest
+// extension opened to the repo root).
+module.exports = {
+  roots: [],
+};


### PR DESCRIPTION
Current behavior of running Jest from the Repo root is to enumerate quite a few tests in different packages, which then fail, as some aren't Jest tests and others need configuration. We test packages independently using Lerna already, so the main case where this comes up is if someone uses the Jest VS Code plugin with the repo open. I spend some time trying to coerce the Jest multi-project options to work correctly, but couldn't get reasonable behavior out of it. Instead we now print a warning and don't try to run anything.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5462)