### PR TITLE
run-windows cannot find built app with default init app

### DIFF
--- a/change/react-native-windows-2020-07-08-13-10-31-deploy2.json
+++ b/change/react-native-windows-2020-07-08-13-10-31-deploy2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "run-windows cannot find built app with default init app",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-08T20:10:31.064Z"
+}

--- a/vnext/local-cli/src/runWindows/utils/deploy.ts
+++ b/vnext/local-cli/src/runWindows/utils/deploy.ts
@@ -105,9 +105,7 @@ function getAppxManifestPath(options: RunWindowsOptions) {
     options.arch
   }/${configuration},${configuration}/*,target/${
     options.arch
-  }/${configuration},${
-    options.arch
-  }/${configuration}/*}/AppxManifest.xml`;
+  }/${configuration},${options.arch}/${configuration}/*}/AppxManifest.xml`;
   const appxPath = glob.sync(path.join(options.root, appxManifestGlob))[0];
 
   if (!appxPath) {

--- a/vnext/local-cli/src/runWindows/utils/deploy.ts
+++ b/vnext/local-cli/src/runWindows/utils/deploy.ts
@@ -105,7 +105,9 @@ function getAppxManifestPath(options: RunWindowsOptions) {
     options.arch
   }/${configuration},${configuration}/*,target/${
     options.arch
-  }/${configuration}}/AppxManifest.xml`;
+  }/${configuration},${
+    options.arch
+  }/${configuration}/*}/AppxManifest.xml`;
   const appxPath = glob.sync(path.join(options.root, appxManifestGlob))[0];
 
   if (!appxPath) {


### PR DESCRIPTION
Repo:

```
npx react-native init myapp --template react-native@^0.62
cd myapp
npx react-native-windows-init
yarn windows --release --arch x64
```

Result:
Cannot deploy the app -- cannot find AppxManifest.xml

The logic in the run-window CLI code to find the manifest is looking at various locations that we've used within RNW, but doesn't look at the default location that VS projects build to.  This code change adds the default location to the list of places it looks for it.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5466)