### PR TITLE
Add multi-window/thread support to Playground-Win32

### DIFF
--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -5,9 +5,9 @@
 #include <shobjidl.h>
 #include <windows.h>
 
-#include <memory>
-
 #include <filesystem>
+#include <memory>
+#include <thread>
 
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime
@@ -25,6 +25,8 @@
 namespace WUX = winrt::Windows::UI::Xaml;
 namespace WUXC = WUX::Controls;
 namespace WUXH = WUX::Hosting;
+
+int RunPlayground(int showCmd, bool useWebDebugger);
 
 struct WindowData {
   static HINSTANCE s_instance;
@@ -106,6 +108,15 @@ struct WindowData {
           rootElement.Children().Append(m_reactRootView);
         }
 
+        break;
+      }
+      case IDM_NEWWINDOW: {
+        std::thread playgroundThread{([]() {
+          // For subsequent RN windows do not use the web debugger by default,
+          // since one instance can be connected to it at a time.
+          RunPlayground(SW_SHOW, false);
+        })};
+        playgroundThread.detach();
         break;
       }
       case IDM_ABOUT:
@@ -306,7 +317,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) 
   return DefWindowProc(hwnd, message, wparam, lparam);
 }
 
-_Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR /* commandLine */, int showCmd) {
+int RunPlayground(int showCmd, bool useWebDebugger) {
   constexpr PCWSTR appName = L"React Native Playground (Win32)";
   constexpr PCWSTR windowClassName = L"MS_REACTNATIVE_PLAYGROUND_WIN32";
 
@@ -314,22 +325,25 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
 
   WUXH::DesktopWindowXamlSource desktopXamlSource;
 
-  WNDCLASSEXW wcex = {};
-  wcex.cbSize = sizeof(WNDCLASSEX);
-  wcex.style = CS_HREDRAW | CS_VREDRAW;
-  wcex.lpfnWndProc = &WndProc;
-  wcex.cbClsExtra = DLGWINDOWEXTRA;
-  wcex.cbWndExtra = 0;
-  wcex.hInstance = instance;
-  wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
-  wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
-  wcex.lpszMenuName = MAKEINTRESOURCEW(IDC_PLAYGROUND_WIN32);
-  wcex.lpszClassName = windowClassName;
-  ATOM classId = RegisterClassEx(&wcex);
+  static ATOM classId{[windowClassName]() {
+    WNDCLASSEXW wcex = {};
+    wcex.cbSize = sizeof(WNDCLASSEX);
+    wcex.style = CS_HREDRAW | CS_VREDRAW;
+    wcex.lpfnWndProc = &WndProc;
+    wcex.cbClsExtra = DLGWINDOWEXTRA;
+    wcex.cbWndExtra = 0;
+    wcex.hInstance = WindowData::s_instance;
+    wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wcex.lpszMenuName = MAKEINTRESOURCEW(IDC_PLAYGROUND_WIN32);
+    wcex.lpszClassName = windowClassName;
+    return RegisterClassEx(&wcex);
+  }()};
   WINRT_VERIFY(classId);
   winrt::check_win32(!classId);
 
   auto windowData = std::make_unique<WindowData>(desktopXamlSource);
+  windowData->m_useWebDebugger = useWebDebugger;
 
   auto xamlContent = WUXC::Grid();
   desktopXamlSource.Content(xamlContent);
@@ -344,7 +358,7 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
       CW_USEDEFAULT,
       nullptr,
       nullptr,
-      instance,
+      WindowData::s_instance,
       windowData.get());
 
   WINRT_VERIFY(hwnd);
@@ -355,7 +369,7 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   UpdateWindow(hwnd);
   SetFocus(hwnd);
 
-  HACCEL hAccelTable = LoadAccelerators(instance, MAKEINTRESOURCE(IDC_PLAYGROUND_WIN32));
+  HACCEL hAccelTable = LoadAccelerators(WindowData::s_instance, MAKEINTRESOURCE(IDC_PLAYGROUND_WIN32));
 
   MSG msg = {};
   while (GetMessage(&msg, nullptr, 0, 0)) {
@@ -375,4 +389,8 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   winrt::uninit_apartment();
 
   return (int)msg.wParam;
+}
+
+_Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR /* commandLine */, int showCmd) {
+  return RunPlayground(showCmd, true);
 }

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -317,31 +317,14 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) 
   return DefWindowProc(hwnd, message, wparam, lparam);
 }
 
+constexpr PCWSTR c_windowClassName = L"MS_REACTNATIVE_PLAYGROUND_WIN32";
+
 int RunPlayground(int showCmd, bool useWebDebugger) {
   constexpr PCWSTR appName = L"React Native Playground (Win32)";
-  constexpr PCWSTR windowClassName = L"MS_REACTNATIVE_PLAYGROUND_WIN32";
 
   winrt::init_apartment(winrt::apartment_type::single_threaded);
 
   WUXH::DesktopWindowXamlSource desktopXamlSource;
-
-  static ATOM classId{[windowClassName]() {
-    WNDCLASSEXW wcex = {};
-    wcex.cbSize = sizeof(WNDCLASSEX);
-    wcex.style = CS_HREDRAW | CS_VREDRAW;
-    wcex.lpfnWndProc = &WndProc;
-    wcex.cbClsExtra = DLGWINDOWEXTRA;
-    wcex.cbWndExtra = 0;
-    wcex.hInstance = WindowData::s_instance;
-    wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
-    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
-    wcex.lpszMenuName = MAKEINTRESOURCEW(IDC_PLAYGROUND_WIN32);
-    wcex.lpszClassName = windowClassName;
-    return RegisterClassEx(&wcex);
-  }()};
-  WINRT_VERIFY(classId);
-  winrt::check_win32(!classId);
-
   auto windowData = std::make_unique<WindowData>(desktopXamlSource);
   windowData->m_useWebDebugger = useWebDebugger;
 
@@ -349,7 +332,7 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
   desktopXamlSource.Content(xamlContent);
 
   HWND hwnd = CreateWindow(
-      windowClassName,
+      c_windowClassName,
       appName,
       WS_OVERLAPPEDWINDOW,
       CW_USEDEFAULT,
@@ -391,6 +374,21 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
   return (int)msg.wParam;
 }
 
-_Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR /* commandLine */, int showCmd) {
+_Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE /* instance */, HINSTANCE, PSTR /* commandLine */, int showCmd) {
+  WNDCLASSEXW wcex = {};
+  wcex.cbSize = sizeof(WNDCLASSEX);
+  wcex.style = CS_HREDRAW | CS_VREDRAW;
+  wcex.lpfnWndProc = &WndProc;
+  wcex.cbClsExtra = DLGWINDOWEXTRA;
+  wcex.cbWndExtra = 0;
+  wcex.hInstance = WindowData::s_instance;
+  wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
+  wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+  wcex.lpszMenuName = MAKEINTRESOURCEW(IDC_PLAYGROUND_WIN32);
+  wcex.lpszClassName = c_windowClassName;
+  ATOM classId = RegisterClassEx(&wcex);
+  WINRT_VERIFY(classId);
+  winrt::check_win32(!classId);
+
   return RunPlayground(showCmd, true);
 }

--- a/packages/playground/windows/playground-win32/Playground-Win32.rc
+++ b/packages/playground/windows/playground-win32/Playground-Win32.rc
@@ -55,6 +55,7 @@ BEGIN
     POPUP "&File"
     BEGIN
         MENUITEM "&Open Javascript File...\tCtrl+O", IDM_OPENJSFILE
+        MENUITEM "&New Window\tCtrl+N",         IDM_NEWWINDOW
         MENUITEM "&Refresh\tF5",                IDM_REFRESH
         MENUITEM SEPARATOR
         MENUITEM "&Settings...\tAlt+S",         IDM_SETTINGS
@@ -77,6 +78,7 @@ IDC_PLAYGROUND_WIN32 ACCELERATORS
 BEGIN
     "?",            IDM_ABOUT,              ASCII,  ALT
     "/",            IDM_ABOUT,              ASCII,  ALT
+    "N",            IDM_NEWWINDOW,          VIRTKEY, CONTROL
     "O",            IDM_OPENJSFILE,         VIRTKEY, CONTROL
     "S",            IDM_SETTINGS,           VIRTKEY, ALT
     VK_F5,          IDM_REFRESH,            VIRTKEY 

--- a/packages/playground/windows/playground-win32/resource.h
+++ b/packages/playground/windows/playground-win32/resource.h
@@ -24,6 +24,7 @@
 #define IDM_OPENJSFILE 102
 #define IDM_SETTINGS 103
 #define IDM_REFRESH 104
+#define IDM_NEWWINDOW 105
 
 // Next default values for new objects
 //


### PR DESCRIPTION
With this change you can now hit Ctrl-N to open new playground-win32 windows (new thread, new react host/instance) and hit Ctrl-O to open samples in them.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5470)