### PR TITLE
Add ReactModuleBuilder tests

### DIFF
--- a/change/react-native-windows-2020-07-09-16-24-07-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-07-09-16-24-07-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add ReactModuleBuilder tests",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-09T23:24:07.655Z"
+}

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="DynamicReaderWriterTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MemoryTrackerTests.cpp" />
+    <ClCompile Include="ReactModuleBuilderTests.cpp" />
     <ClCompile Include="SimpleMessageQueue.cpp" />
     <ClCompile Include="NativeLogEventTests.cpp" />
     <ClCompile Include="NativeTraceEventTests.cpp" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="DynamicReaderWriterTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ReactModuleBuilderTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/vnext/Desktop.ABITests/ReactModuleBuilderTests.cpp
+++ b/vnext/Desktop.ABITests/ReactModuleBuilderTests.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <winrt/Microsoft.Internal.h>
+#include <winrt/Microsoft.ReactNative.h>
+
+using namespace winrt;
+using namespace winrt::Microsoft::ReactNative;
+
+namespace ABITests {
+
+// The tests here are a development staging artifact owed to the incremental buildup of the C++/WinRT-based ABI of
+// the Win32 DLL. They (or their logical equivalent) should probably get rolled into other tests once C++/WinRT-based
+// instance management becomes available.
+TEST_CLASS (ReactModuleBuilderTests) {
+ public:
+  ReactModuleBuilderTests() {
+    IReactContext context = Microsoft::Internal::TestController::CreateTestContext();
+    m_builder = Microsoft::Internal::TestController::CreateReactModuleBuilder(context);
+  }
+
+  TEST_METHOD(AddConstantProvider_IsCallable) {
+    m_builder.AddConstantProvider([](Microsoft::ReactNative::IJSValueWriter const &constantWriter) {});
+  }
+
+  TEST_METHOD(AddInitializer_IsCallable) {
+    m_builder.AddInitializer([](Microsoft::ReactNative::IReactContext const &reactContext) {});
+  }
+
+  TEST_METHOD(AddMethod_IsCallable) {
+    m_builder.AddMethod(
+        /* name */ L"MethodName",
+        /* returnType */ Microsoft::ReactNative::MethodReturnType::Void,
+        /* method */
+        [](Microsoft::ReactNative::IJSValueReader const &inputReader,
+           Microsoft::ReactNative::IJSValueWriter const &outputWriter,
+           Microsoft::ReactNative::MethodResultCallback const &resolve,
+           Microsoft::ReactNative::MethodResultCallback const &reject) {});
+  }
+
+  TEST_METHOD(AddSyncMethod_IsCallable) {
+    m_builder.AddSyncMethod(
+        /* name */ L"MethodName",
+        /* method */
+        [](Microsoft::ReactNative::IJSValueReader const &inputReader,
+           Microsoft::ReactNative::IJSValueWriter const &outputWriter) {});
+  }
+
+ private:
+  IReactModuleBuilder m_builder;
+};
+
+} // namespace ABITests

--- a/vnext/Desktop/ABI/TestController.h
+++ b/vnext/Desktop/ABI/TestController.h
@@ -11,6 +11,9 @@ struct TestController {
 
   static Microsoft::ReactNative::IJSValueReader CreateDynamicReader(Microsoft::ReactNative::IJSValueWriter writer);
   static Microsoft::ReactNative::IJSValueWriter CreateDynamicWriter();
+  static Microsoft::ReactNative::IReactContext CreateTestContext();
+  static Microsoft::ReactNative::IReactModuleBuilder CreateReactModuleBuilder(
+      Microsoft::ReactNative::IReactContext context);
 };
 } // namespace winrt::Microsoft::Internal::implementation
 

--- a/vnext/Desktop/ABI/TestController.idl
+++ b/vnext/Desktop/ABI/TestController.idl
@@ -1,5 +1,7 @@
 import "IJSValueReader.idl";
 import "IJSValueWriter.idl";
+import "IReactContext.idl";
+import "IReactModuleBuilder.idl";
 
 namespace Microsoft.Internal {
 
@@ -10,6 +12,8 @@ namespace Microsoft.Internal {
   static runtimeclass TestController {
     static Microsoft.ReactNative.IJSValueReader CreateDynamicReader(Microsoft.ReactNative.IJSValueWriter writer);
     static Microsoft.ReactNative.IJSValueWriter CreateDynamicWriter();
+    static Microsoft.ReactNative.IReactContext CreateTestContext();
+    static Microsoft.ReactNative.IReactModuleBuilder CreateReactModuleBuilder(Microsoft.ReactNative.IReactContext context);
   };
 
 }


### PR DESCRIPTION
An IReactModuleBuilder implementation had already been built into the Win32 DLL; this change simply adds tests to ensure that it can get exposed through the C++/WinRT ABI. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5486)