### PR TITLE
Make IWebSocketResource methods noexcept

### DIFF
--- a/change/react-native-windows-2020-07-09-01-14-31-ws-noexcept.json
+++ b/change/react-native-windows-2020-07-09-01-14-31-ws-noexcept.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make IWebSocketResource methods noexcept.",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-09T08:14:31.125Z"
+}

--- a/vnext/Desktop.UnitTests/WebSocketMocks.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.cpp
@@ -10,55 +10,45 @@ MockWebSocketResource::~MockWebSocketResource() {}
 
 #pragma region IWebSocketResource overrides
 
-void MockWebSocketResource::Connect(const Protocols &protocols, const Options &options) /*override*/
+void MockWebSocketResource::Connect(const Protocols &protocols, const Options &options) noexcept  /*override*/
 {
   if (Mocks.Connect)
     return Mocks.Connect(protocols, options);
-
-  throw exception("Not implemented");
 }
 
-void MockWebSocketResource::Ping() /*override*/
+void MockWebSocketResource::Ping() noexcept  /*override*/
 {
   if (Mocks.Connect)
     return Mocks.Ping();
-
-  throw exception("Not implemented");
 }
 
-void MockWebSocketResource::Send(const string &message) /*override*/
+void MockWebSocketResource::Send(const string &message) noexcept  /*override*/
 {
   if (Mocks.Send)
     return Mocks.Send(message);
-
-  throw exception("Not implemented");
 }
 
-void MockWebSocketResource::SendBinary(const string &message) /*override*/
+void MockWebSocketResource::SendBinary(const string &message) noexcept  /*override*/
 {
   if (Mocks.SendBinary)
     return Mocks.SendBinary(message);
-
-  throw exception("Not implemented");
 }
 
-void MockWebSocketResource::Close(CloseCode code, const string &reason) /*override*/
+void MockWebSocketResource::Close(CloseCode code, const string &reason) noexcept  /*override*/
 {
   if (Mocks.Close)
     return Mocks.Close(code, reason);
-
-  throw exception("Not implemented");
 }
 
-IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const /*override*/
+IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const noexcept  /*override*/
 {
   if (Mocks.GetReadyState)
     return Mocks.GetReadyState();
 
-  throw exception("Not implemented");
+  return ReadyState::Connecting;
 }
 
-void MockWebSocketResource::SetOnConnect(function<void()> &&handler) /*override*/
+void MockWebSocketResource::SetOnConnect(function<void()> &&handler) noexcept  /*override*/
 {
   if (Mocks.SetOnConnect)
     return SetOnConnect(std::move(handler));
@@ -66,7 +56,7 @@ void MockWebSocketResource::SetOnConnect(function<void()> &&handler) /*override*
   m_connectHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnPing(function<void()> &&handler) /*override*/
+void MockWebSocketResource::SetOnPing(function<void()> &&handler) noexcept  /*override*/
 {
   if (Mocks.SetOnPing)
     return Mocks.SetOnPing(std::move(handler));
@@ -74,7 +64,7 @@ void MockWebSocketResource::SetOnPing(function<void()> &&handler) /*override*/
   m_pingHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnSend(function<void(size_t)> &&handler) /*override*/
+void MockWebSocketResource::SetOnSend(function<void(size_t)> &&handler) noexcept  /*override*/
 {
   if (Mocks.SetOnSend)
     return Mocks.SetOnSend(std::move(handler));
@@ -82,7 +72,7 @@ void MockWebSocketResource::SetOnSend(function<void(size_t)> &&handler) /*overri
   m_writeHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> &&handler) /*override*/
+void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> &&handler) noexcept  /*override*/
 {
   if (Mocks.SetOnMessage)
     return Mocks.SetOnMessage(std::move(handler));
@@ -90,7 +80,7 @@ void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> 
   m_readHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)> &&handler) /*override*/
+void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)> &&handler) noexcept  /*override*/
 {
   if (Mocks.SetOnClose)
     return Mocks.SetOnClose(std::move(handler));
@@ -98,7 +88,7 @@ void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)>
   m_closeHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnError(function<void(Error &&)> &&handler) /*override*/
+void MockWebSocketResource::SetOnError(function<void(Error &&)> &&handler) noexcept  /*override*/
 {
   if (Mocks.SetOnError)
     return Mocks.SetOnError(std::move(handler));

--- a/vnext/Desktop.UnitTests/WebSocketMocks.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.cpp
@@ -10,37 +10,37 @@ MockWebSocketResource::~MockWebSocketResource() {}
 
 #pragma region IWebSocketResource overrides
 
-void MockWebSocketResource::Connect(const Protocols &protocols, const Options &options) noexcept  /*override*/
+void MockWebSocketResource::Connect(const Protocols &protocols, const Options &options) noexcept /*override*/
 {
   if (Mocks.Connect)
     return Mocks.Connect(protocols, options);
 }
 
-void MockWebSocketResource::Ping() noexcept  /*override*/
+void MockWebSocketResource::Ping() noexcept /*override*/
 {
   if (Mocks.Connect)
     return Mocks.Ping();
 }
 
-void MockWebSocketResource::Send(const string &message) noexcept  /*override*/
+void MockWebSocketResource::Send(const string &message) noexcept /*override*/
 {
   if (Mocks.Send)
     return Mocks.Send(message);
 }
 
-void MockWebSocketResource::SendBinary(const string &message) noexcept  /*override*/
+void MockWebSocketResource::SendBinary(const string &message) noexcept /*override*/
 {
   if (Mocks.SendBinary)
     return Mocks.SendBinary(message);
 }
 
-void MockWebSocketResource::Close(CloseCode code, const string &reason) noexcept  /*override*/
+void MockWebSocketResource::Close(CloseCode code, const string &reason) noexcept /*override*/
 {
   if (Mocks.Close)
     return Mocks.Close(code, reason);
 }
 
-IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const noexcept  /*override*/
+IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const noexcept /*override*/
 {
   if (Mocks.GetReadyState)
     return Mocks.GetReadyState();
@@ -48,7 +48,7 @@ IWebSocketResource::ReadyState MockWebSocketResource::GetReadyState() const noex
   return ReadyState::Connecting;
 }
 
-void MockWebSocketResource::SetOnConnect(function<void()> &&handler) noexcept  /*override*/
+void MockWebSocketResource::SetOnConnect(function<void()> &&handler) noexcept /*override*/
 {
   if (Mocks.SetOnConnect)
     return SetOnConnect(std::move(handler));
@@ -56,7 +56,7 @@ void MockWebSocketResource::SetOnConnect(function<void()> &&handler) noexcept  /
   m_connectHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnPing(function<void()> &&handler) noexcept  /*override*/
+void MockWebSocketResource::SetOnPing(function<void()> &&handler) noexcept /*override*/
 {
   if (Mocks.SetOnPing)
     return Mocks.SetOnPing(std::move(handler));
@@ -64,7 +64,7 @@ void MockWebSocketResource::SetOnPing(function<void()> &&handler) noexcept  /*ov
   m_pingHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnSend(function<void(size_t)> &&handler) noexcept  /*override*/
+void MockWebSocketResource::SetOnSend(function<void(size_t)> &&handler) noexcept /*override*/
 {
   if (Mocks.SetOnSend)
     return Mocks.SetOnSend(std::move(handler));
@@ -72,7 +72,7 @@ void MockWebSocketResource::SetOnSend(function<void(size_t)> &&handler) noexcept
   m_writeHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> &&handler) noexcept  /*override*/
+void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> &&handler) noexcept /*override*/
 {
   if (Mocks.SetOnMessage)
     return Mocks.SetOnMessage(std::move(handler));
@@ -80,7 +80,7 @@ void MockWebSocketResource::SetOnMessage(function<void(size_t, const string &)> 
   m_readHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)> &&handler) noexcept  /*override*/
+void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)> &&handler) noexcept /*override*/
 {
   if (Mocks.SetOnClose)
     return Mocks.SetOnClose(std::move(handler));
@@ -88,7 +88,7 @@ void MockWebSocketResource::SetOnClose(function<void(CloseCode, const string &)>
   m_closeHandler = std::move(handler);
 }
 
-void MockWebSocketResource::SetOnError(function<void(Error &&)> &&handler) noexcept  /*override*/
+void MockWebSocketResource::SetOnError(function<void(Error &&)> &&handler) noexcept /*override*/
 {
   if (Mocks.SetOnError)
     return Mocks.SetOnError(std::move(handler));

--- a/vnext/Desktop.UnitTests/WebSocketMocks.h
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.h
@@ -25,29 +25,29 @@ struct MockWebSocketResource : public IWebSocketResource {
 
 #pragma region IWebSocketResource overrides
 
-  void Connect(const Protocols &, const Options &) override;
+  void Connect(const Protocols &, const Options &) noexcept override;
 
-  void Ping() override;
+  void Ping() noexcept override;
 
-  void Send(const std::string &) override;
+  void Send(const std::string &) noexcept override;
 
-  void SendBinary(const std::string &) override;
+  void SendBinary(const std::string &) noexcept override;
 
-  void Close(CloseCode, const std::string &) override;
+  void Close(CloseCode, const std::string &) noexcept override;
 
-  ReadyState GetReadyState() const override;
+  ReadyState GetReadyState() const noexcept override;
 
-  void SetOnConnect(std::function<void()> &&onConnect) override;
+  void SetOnConnect(std::function<void()> &&onConnect) noexcept override;
 
-  void SetOnPing(std::function<void()> &&) override;
+  void SetOnPing(std::function<void()> &&) noexcept override;
 
-  void SetOnSend(std::function<void(std::size_t)> &&) override;
+  void SetOnSend(std::function<void(std::size_t)> &&) noexcept override;
 
-  void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&) override;
+  void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&) noexcept override;
 
-  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&) override;
+  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&) noexcept override;
 
-  void SetOnError(std::function<void(Error &&)> &&) override;
+  void SetOnError(std::function<void(Error &&)> &&) noexcept override;
 
 #pragma endregion IWebSocketResource overrides
 

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -314,7 +314,7 @@ websocket::close_code BaseWebSocketResource<SocketLayer, Stream>::ToBeastCloseCo
 #pragma region IWebSocketResource members
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::Connect(const Protocols &protocols, const Options &options) {
+void BaseWebSocketResource<SocketLayer, Stream>::Connect(const Protocols &protocols, const Options &options) noexcept {
   // "Cannot call Connect more than once");
   assert(ReadyState::Connecting == m_readyState);
 
@@ -374,7 +374,7 @@ void BaseWebSocketResource<SocketLayer, Stream>::OnConnect(
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::Close(CloseCode code, const string &reason) {
+void BaseWebSocketResource<SocketLayer, Stream>::Close(CloseCode code, const string &reason) noexcept {
   if (m_closeRequested)
     return;
 
@@ -391,12 +391,12 @@ void BaseWebSocketResource<SocketLayer, Stream>::Close(CloseCode code, const str
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::Send(const string &message) {
+void BaseWebSocketResource<SocketLayer, Stream>::Send(const string &message) noexcept {
   EnqueueWrite(std::move(message), false);
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SendBinary(const string &base64String) {
+void BaseWebSocketResource<SocketLayer, Stream>::SendBinary(const string &base64String) noexcept {
   m_stream->binary(true);
 
   string message;
@@ -418,7 +418,7 @@ void BaseWebSocketResource<SocketLayer, Stream>::SendBinary(const string &base64
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::Ping() {
+void BaseWebSocketResource<SocketLayer, Stream>::Ping() noexcept {
   if (ReadyState::Closed == m_readyState)
     return;
 
@@ -432,37 +432,39 @@ void BaseWebSocketResource<SocketLayer, Stream>::Ping() {
 #pragma region Handler setters
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SetOnConnect(function<void()> &&handler) {
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnConnect(function<void()> &&handler) noexcept {
   m_connectHandler = handler;
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SetOnPing(function<void()> &&handler) {
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnPing(function<void()> &&handler) noexcept {
   m_pingHandler = handler;
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SetOnSend(function<void(size_t)> &&handler) {
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnSend(function<void(size_t)> &&handler) noexcept {
   m_writeHandler = handler;
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SetOnMessage(function<void(size_t, const string &)> &&handler) {
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnMessage(
+    function<void(size_t, const string &)> &&handler) noexcept {
   m_readHandler = handler;
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SetOnClose(function<void(CloseCode, const string &)> &&handler) {
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnClose(
+    function<void(CloseCode, const string &)> &&handler) noexcept {
   m_closeHandler = handler;
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SetOnError(function<void(Error &&)> &&handler) {
+void BaseWebSocketResource<SocketLayer, Stream>::SetOnError(function<void(Error &&)> &&handler) noexcept {
   m_errorHandler = handler;
 }
 
 template <typename SocketLayer, typename Stream>
-IWebSocketResource::ReadyState BaseWebSocketResource<SocketLayer, Stream>::GetReadyState() const {
+IWebSocketResource::ReadyState BaseWebSocketResource<SocketLayer, Stream>::GetReadyState() const noexcept {
   return m_readyState;
 }
 

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -149,66 +149,66 @@ class BaseWebSocketResource : public IWebSocketResource {
   virtual std::shared_ptr<BaseWebSocketResource<SocketLayer, Stream>> SharedFromThis() = 0;
 
  public:
-  ~BaseWebSocketResource() override;
+  ~BaseWebSocketResource() noexcept override;
 
 #pragma region IWebSocketResource
 
   /// <summary>
   /// <see cref="IWebSocketResource::Connect" />
   /// </summary>
-  void Connect(const Protocols &protocols, const Options &options) override;
+  void Connect(const Protocols &protocols, const Options &options) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Ping" />
   /// </summary>
-  void Ping() override;
+  void Ping() noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Send" />
   /// </summary>
-  void Send(const std::string &message) override;
+  void Send(const std::string &message) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SendBinary" />
   /// </summary>
-  void SendBinary(const std::string &base64String) override;
+  void SendBinary(const std::string &base64String) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Close" />
   /// </summary>
-  void Close(CloseCode code, const std::string &reason) override;
+  void Close(CloseCode code, const std::string &reason) noexcept override;
 
-  ReadyState GetReadyState() const override;
+  ReadyState GetReadyState() const noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnConnect" />
   /// </summary>
-  void SetOnConnect(std::function<void()> &&handler) override;
+  void SetOnConnect(std::function<void()> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnPing" />
   /// </summary>
-  void SetOnPing(std::function<void()> &&handler) override;
+  void SetOnPing(std::function<void()> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnSend" />
   /// </summary>
-  void SetOnSend(std::function<void(std::size_t)> &&handler) override;
+  void SetOnSend(std::function<void(std::size_t)> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnMessage" />
   /// </summary>
-  void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) override;
+  void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnClose" />
   /// </summary>
-  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) override;
+  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnError" />
   /// </summary>
-  void SetOnError(std::function<void(Error &&)> &&handler) override;
+  void SetOnError(std::function<void(Error &&)> &&handler) noexcept override;
 
 #pragma endregion IWebSocketResource
 };

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -86,7 +86,7 @@ struct IWebSocketResource {
   static std::shared_ptr<IWebSocketResource>
   Make(const std::string &url, bool legacyImplementation = false, bool acceptSelfSigned = false);
 
-  virtual ~IWebSocketResource() {}
+  virtual ~IWebSocketResource() noexcept {}
 
   /// <summary>
   /// Establishes a continuous connection with the remote endpoint.
@@ -98,12 +98,12 @@ struct IWebSocketResource {
   /// HTTP header fields passed by the remote endpoint, to be used in the
   /// handshake process.
   /// </param>
-  virtual void Connect(const Protocols &protocols = {}, const Options &options = {}) = 0;
+  virtual void Connect(const Protocols &protocols = {}, const Options &options = {}) noexcept = 0;
 
   /// <summary>
   /// Sends a ping frame to the remote endpoint.
   /// </summary>
-  virtual void Ping() = 0;
+  virtual void Ping() noexcept = 0;
 
   /// <summary>
   /// Sends a text message to the remote endpoint.
@@ -111,7 +111,7 @@ struct IWebSocketResource {
   /// <param name="message">
   /// UTF8-encoded string of arbitrary length.
   /// </param>
-  virtual void Send(const std::string &message) = 0;
+  virtual void Send(const std::string &message) noexcept = 0;
 
   /// <summary>
   /// Sends a non-plain-text message to the remote endpoint.
@@ -119,7 +119,7 @@ struct IWebSocketResource {
   /// <param name="base64String">
   /// Binary message encoded in Base64 format.
   /// </param>
-  virtual void SendBinary(const std::string &base64String) = 0;
+  virtual void SendBinary(const std::string &base64String) noexcept = 0;
 
   /// <summary>
   /// Terminates this resource's connection to the remote endpoint.
@@ -129,19 +129,19 @@ struct IWebSocketResource {
   /// </param>
   /// <param name="reason">
   /// </param>
-  virtual void Close(CloseCode code = CloseCode::Normal, const std::string &reason = {}) = 0;
+  virtual void Close(CloseCode code = CloseCode::Normal, const std::string &reason = {}) noexcept = 0;
 
   /// <returns>
   /// Current public state as defined in the <c>ReadyState</c> enum.
   /// </returns>
-  virtual ReadyState GetReadyState() const = 0;
+  virtual ReadyState GetReadyState() const noexcept = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on a successful connection.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnConnect(std::function<void()> &&handler) = 0;
+  virtual void SetOnConnect(std::function<void()> &&handler) noexcept = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on a successful ping to the remote
@@ -149,14 +149,14 @@ struct IWebSocketResource {
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnPing(std::function<void()> &&handler) = 0;
+  virtual void SetOnPing(std::function<void()> &&handler) noexcept = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on a message sending.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnSend(std::function<void(std::size_t)> &&handler) = 0;
+  virtual void SetOnSend(std::function<void(std::size_t)> &&handler) noexcept = 0;
 
   /// <summary>
   /// Sets the optional custom behavior to run when there is an incoming
@@ -164,21 +164,21 @@ struct IWebSocketResource {
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) = 0;
+  virtual void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) noexcept = 0;
 
   /// <summary>
   /// Sets the optional custom behavior to run when this instance is closed.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) = 0;
+  virtual void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) noexcept = 0;
 
   /// <summary>
   /// Sets the optional custom behavior on an error condition.
   /// </summary>
   /// <param name="handler">
   /// </param>
-  virtual void SetOnError(std::function<void(Error &&)> &&handler) = 0;
+  virtual void SetOnError(std::function<void(Error &&)> &&handler) noexcept = 0;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -358,7 +358,7 @@ void WinRTWebSocketResource::Synchronize()
 
 #pragma region IWebSocketResource
 
-void WinRTWebSocketResource::Connect(const Protocols& protocols, const Options& options)
+void WinRTWebSocketResource::Connect(const Protocols& protocols, const Options& options) noexcept
 {
   m_readyState = ReadyState::Connecting;
 
@@ -378,26 +378,26 @@ void WinRTWebSocketResource::Connect(const Protocols& protocols, const Options& 
   PerformConnect();
 }
 
-void WinRTWebSocketResource::Ping()
+void WinRTWebSocketResource::Ping() noexcept
 {
   PerformPing();
 }
 
-void WinRTWebSocketResource::Send(const string& message)
+void WinRTWebSocketResource::Send(const string& message) noexcept
 {
   m_writeQueue.push({ message, false });
 
   PerformWrite();
 }
 
-void WinRTWebSocketResource::SendBinary(const string& base64String)
+void WinRTWebSocketResource::SendBinary(const string& base64String) noexcept
 {
   m_writeQueue.push({ base64String, true });
 
   PerformWrite();
 }
 
-void WinRTWebSocketResource::Close(CloseCode code, const string& reason)
+void WinRTWebSocketResource::Close(CloseCode code, const string& reason) noexcept
 {
   if (m_readyState == ReadyState::Closing || m_readyState == ReadyState::Closed)
     return;
@@ -410,37 +410,37 @@ void WinRTWebSocketResource::Close(CloseCode code, const string& reason)
   PerformClose();
 }
 
-IWebSocketResource::ReadyState WinRTWebSocketResource::GetReadyState() const
+IWebSocketResource::ReadyState WinRTWebSocketResource::GetReadyState() const noexcept
 {
   return m_readyState;
 }
 
-void WinRTWebSocketResource::SetOnConnect(function<void()>&& handler)
+void WinRTWebSocketResource::SetOnConnect(function<void()>&& handler) noexcept
 {
   m_connectHandler = std::move(handler);
 }
 
-void WinRTWebSocketResource::SetOnPing(function<void()>&& handler)
+void WinRTWebSocketResource::SetOnPing(function<void()>&& handler) noexcept
 {
   m_pingHandler = std::move(handler);
 }
 
-void WinRTWebSocketResource::SetOnSend(function<void(size_t)>&& handler)
+void WinRTWebSocketResource::SetOnSend(function<void(size_t)>&& handler) noexcept
 {
   m_writeHandler = std::move(handler);
 }
 
-void WinRTWebSocketResource::SetOnMessage(function<void(size_t, const string&)>&& handler)
+void WinRTWebSocketResource::SetOnMessage(function<void(size_t, const string&)>&& handler) noexcept
 {
   m_readHandler = std::move(handler);
 }
 
-void WinRTWebSocketResource::SetOnClose(function<void(CloseCode, const string&)>&& handler)
+void WinRTWebSocketResource::SetOnClose(function<void(CloseCode, const string&)>&& handler) noexcept
 {
   m_closeHandler = std::move(handler);
 }
 
-void WinRTWebSocketResource::SetOnError(function<void(Error&&)>&& handler)
+void WinRTWebSocketResource::SetOnError(function<void(Error&&)>&& handler) noexcept
 {
   m_errorHandler = std::move(handler);
 }

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -86,7 +86,7 @@ namespace
 namespace Microsoft::React
 {
 
-WinRTWebSocketResource::WinRTWebSocketResource(IMessageWebSocket&& socket, IDataWriter&& writer, Uri&& uri, vector<ChainValidationResult> &&certExeptions)
+WinRTWebSocketResource::WinRTWebSocketResource(IMessageWebSocket&& socket, IDataWriter&& writer, Uri&& uri, vector<ChainValidationResult> &&certExeptions) noexcept
   : m_uri{ std::move(uri) }
   , m_socket{ std::move(socket) }
   , m_writer{ std::move(writer) }
@@ -99,17 +99,17 @@ WinRTWebSocketResource::WinRTWebSocketResource(IMessageWebSocket&& socket, IData
   }
 }
 
-WinRTWebSocketResource::WinRTWebSocketResource(IMessageWebSocket&& socket, Uri&& uri, vector<ChainValidationResult> certExeptions)
+WinRTWebSocketResource::WinRTWebSocketResource(IMessageWebSocket&& socket, Uri&& uri, vector<ChainValidationResult> certExeptions) noexcept
   : WinRTWebSocketResource(std::move(socket), DataWriter{ socket.OutputStream() }, std::move(uri), std::move(certExeptions))
 {
 }
 
-WinRTWebSocketResource::WinRTWebSocketResource(const string& urlString, vector<ChainValidationResult> &&certExeptions)
+WinRTWebSocketResource::WinRTWebSocketResource(const string& urlString, vector<ChainValidationResult> &&certExeptions) noexcept
   : WinRTWebSocketResource(MessageWebSocket{}, Uri{ Utf8ToUtf16(urlString) }, std::move(certExeptions))
 {
 }
 
-WinRTWebSocketResource::~WinRTWebSocketResource() /*override*/
+WinRTWebSocketResource::~WinRTWebSocketResource() noexcept /*override*/
 {
   Close(CloseCode::GoingAway, "Disposed");
 
@@ -118,7 +118,7 @@ WinRTWebSocketResource::~WinRTWebSocketResource() /*override*/
 
 #pragma region Private members
 
-IAsyncAction WinRTWebSocketResource::PerformConnect()
+IAsyncAction WinRTWebSocketResource::PerformConnect() noexcept
 {
   auto self = shared_from_this();
   try
@@ -146,7 +146,7 @@ IAsyncAction WinRTWebSocketResource::PerformConnect()
   self->m_connectRequested = false;
 }
 
-fire_and_forget WinRTWebSocketResource::PerformPing()
+fire_and_forget WinRTWebSocketResource::PerformPing() noexcept
 {
   auto self = shared_from_this();
   try
@@ -185,7 +185,7 @@ fire_and_forget WinRTWebSocketResource::PerformPing()
   }
 }
 
-fire_and_forget WinRTWebSocketResource::PerformWrite()
+fire_and_forget WinRTWebSocketResource::PerformWrite() noexcept
 {
   auto self = shared_from_this();
   if (self->m_writeQueue.empty())
@@ -253,7 +253,7 @@ fire_and_forget WinRTWebSocketResource::PerformWrite()
   }
 }
 
-fire_and_forget WinRTWebSocketResource::PerformClose()
+fire_and_forget WinRTWebSocketResource::PerformClose() noexcept
 {
   co_await resume_background();
 
@@ -345,7 +345,7 @@ void WinRTWebSocketResource::OnMessageReceived(IWebSocket const& sender, IMessag
   }
 }
 
-void WinRTWebSocketResource::Synchronize()
+void WinRTWebSocketResource::Synchronize() noexcept
 {
   // Ensure sequence of other operations
   if (m_connectRequested)

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -47,30 +47,32 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   WinRTWebSocketResource(
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Foundation::Uri &&uri,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions) noexcept;
 
-  winrt::Windows::Foundation::IAsyncAction PerformConnect();
-  winrt::fire_and_forget PerformPing();
-  winrt::fire_and_forget PerformWrite();
-  winrt::fire_and_forget PerformClose();
+  winrt::Windows::Foundation::IAsyncAction PerformConnect() noexcept;
+  winrt::fire_and_forget PerformPing() noexcept;
+  winrt::fire_and_forget PerformWrite() noexcept;
+  winrt::fire_and_forget PerformClose() noexcept;
 
   void OnMessageReceived(
       winrt::Windows::Networking::Sockets::IWebSocket const &sender,
       winrt::Windows::Networking::Sockets::IMessageWebSocketMessageReceivedEventArgs const &args);
-  void Synchronize();
+  void Synchronize() noexcept;
 
  public:
   WinRTWebSocketResource(
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Storage::Streams::IDataWriter &&writer,
       winrt::Windows::Foundation::Uri &&uri,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
+          &&certExeptions) noexcept;
 
   WinRTWebSocketResource(
       const std::string &urlString,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
+          &&certExeptions) noexcept;
 
-  ~WinRTWebSocketResource() override;
+  ~WinRTWebSocketResource() noexcept override;
 
 #pragma region IWebSocketResource
 

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -77,59 +77,59 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   /// <summary>
   /// <see cref="IWebSocketResource::Connect" />
   /// </summary>
-  void Connect(const Protocols &protocols, const Options &options) override;
+  void Connect(const Protocols &protocols, const Options &options) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Ping" />
   /// </summary>
-  void Ping() override;
+  void Ping() noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Send" />
   /// </summary>
-  void Send(const std::string &message) override;
+  void Send(const std::string &message) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SendBinary" />
   /// </summary>
-  void SendBinary(const std::string &base64String) override;
+  void SendBinary(const std::string &base64String) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Close" />
   /// </summary>
-  void Close(CloseCode code, const std::string &reason) override;
+  void Close(CloseCode code, const std::string &reason) noexcept override;
 
-  ReadyState GetReadyState() const override;
+  ReadyState GetReadyState() const noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnConnect" />
   /// </summary>
-  void SetOnConnect(std::function<void()> &&handler) override;
+  void SetOnConnect(std::function<void()> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnPing" />
   /// </summary>
-  void SetOnPing(std::function<void()> &&handler) override;
+  void SetOnPing(std::function<void()> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnSend" />
   /// </summary>
-  void SetOnSend(std::function<void(std::size_t)> &&handler) override;
+  void SetOnSend(std::function<void(std::size_t)> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnMessage" />
   /// </summary>
-  void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) override;
+  void SetOnMessage(std::function<void(std::size_t, const std::string &)> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnClose" />
   /// </summary>
-  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) override;
+  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SetOnError" />
   /// </summary>
-  void SetOnError(std::function<void(Error &&)> &&handler) override;
+  void SetOnError(std::function<void(Error &&)> &&handler) noexcept override;
 
 #pragma endregion IWebSocketResource
 };


### PR DESCRIPTION
`IWebSocketResource` implementations are already expected to signal error conditions through the provided error handler.
We should assure no exceptions will be thrown by this interface.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5487)