### PR TITLE
Add ReactPackageBuilder tests

### DIFF
--- a/change/react-native-windows-2020-07-09-19-01-16-abi-safety.json
+++ b/change/react-native-windows-2020-07-09-19-01-16-abi-safety.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add ReactPackageBuilder tests",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-10T02:01:16.609Z"
+}

--- a/change/react-native-windows-2020-07-09-19-16-26-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-07-09-19-16-26-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add ReactPackageBuilder tests",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-10T02:16:26.286Z"
+}

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MemoryTrackerTests.cpp" />
     <ClCompile Include="ReactModuleBuilderTests.cpp" />
+    <ClCompile Include="ReactPackageBuilderTests.cpp" />
     <ClCompile Include="SimpleMessageQueue.cpp" />
     <ClCompile Include="NativeLogEventTests.cpp" />
     <ClCompile Include="NativeTraceEventTests.cpp" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="ReactModuleBuilderTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ReactPackageBuilderTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/vnext/Desktop.ABITests/ReactPackageBuilderTests.cpp
+++ b/vnext/Desktop.ABITests/ReactPackageBuilderTests.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <winrt/Microsoft.Internal.h>
+#include <winrt/Microsoft.ReactNative.h>
+
+using namespace winrt;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Microsoft::ReactNative;
+
+namespace ABITests {
+
+// The tests here are a development staging artifact owed to the incremental buildup of the C++/WinRT-based ABI of
+// the Win32 DLL. They (or their logical equivalent) should probably get rolled into other tests once C++/WinRT-based
+// instance management becomes available.
+TEST_CLASS (ReactPackageBuilderTests) {
+ public:
+  TEST_METHOD(AddModule_IsCallable) {
+    IReactPackageBuilder builder = Microsoft::Internal::TestController::CreateReactPackageBuilder();
+    builder.AddModule(
+        /* moduleName*/ L"ModuleName",
+        /* moduleProvider */ [](Microsoft::ReactNative::IReactModuleBuilder const &moduleBuilder) {
+          return IInspectable{};
+        });
+  }
+};
+
+} // namespace ABITests

--- a/vnext/Desktop/ABI/TestController.h
+++ b/vnext/Desktop/ABI/TestController.h
@@ -14,6 +14,7 @@ struct TestController {
   static Microsoft::ReactNative::IReactContext CreateTestContext();
   static Microsoft::ReactNative::IReactModuleBuilder CreateReactModuleBuilder(
       Microsoft::ReactNative::IReactContext context);
+  static Microsoft::ReactNative::IReactPackageBuilder CreateReactPackageBuilder();
 };
 } // namespace winrt::Microsoft::Internal::implementation
 

--- a/vnext/Desktop/ABI/TestController.idl
+++ b/vnext/Desktop/ABI/TestController.idl
@@ -2,6 +2,7 @@ import "IJSValueReader.idl";
 import "IJSValueWriter.idl";
 import "IReactContext.idl";
 import "IReactModuleBuilder.idl";
+import "IReactPackageBuilder.idl";
 
 namespace Microsoft.Internal {
 
@@ -14,6 +15,7 @@ namespace Microsoft.Internal {
     static Microsoft.ReactNative.IJSValueWriter CreateDynamicWriter();
     static Microsoft.ReactNative.IReactContext CreateTestContext();
     static Microsoft.ReactNative.IReactModuleBuilder CreateReactModuleBuilder(Microsoft.ReactNative.IReactContext context);
+    static Microsoft.ReactNative.IReactPackageBuilder CreateReactPackageBuilder();
   };
 
 }


### PR DESCRIPTION
An IReactPackageBuilder implementation had already been built into the Win32 DLL; this change simply adds tests to ensure that it can get exposed through the C++/WinRT ABI.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5489)