### PR TITLE
Try to work around Pipelines Network Flakiness Causing Test Timeouts

### DIFF
--- a/change/react-native-platform-override-2020-07-09-23-08-06-less-flakey.json
+++ b/change/react-native-platform-override-2020-07-09-23-08-06-less-flakey.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Try to work around Pipelines Network Flakiness Causing Test Timeouts",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-10T06:08:06.357Z"
+}

--- a/packages/react-native-platform-override/jest.e2e.config.js
+++ b/packages/react-native-platform-override/jest.e2e.config.js
@@ -20,5 +20,5 @@ module.exports = {
   testRegex: '/e2etest/.*\\.test',
 
   // Default timeout of a test in milliseconds
-  testTimeout: 120000,
+  testTimeout: 300000,
 };

--- a/packages/react-native-platform-override/just-task.js
+++ b/packages/react-native-platform-override/just-task.js
@@ -13,7 +13,7 @@ require('@rnw-scripts/just-task');
 task('unitTest', jestTask({config: './jest.config.js', _: ['--verbose']}));
 task(
   'endToEndTest',
-  jestTask({config: './jest.e2e.config.js', _: ['--verbose']}),
+  jestTask({config: './jest.e2e.config.js', runInBand: true, _: ['--verbose']}),
 );
 
 task('test', series('unitTest', 'endToEndTest'));


### PR DESCRIPTION
Fixes #5471

Run react-native-platform-override tests sequentially to avoid saturating too many resources at once, and give an even more liberal timeout. Locally, running sequentially with a clean scratch repo does increase e2e test time from 40s to 60s.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5496)