### PR TITLE
Use XamlRoot's compositor on WinUI3

### DIFF
--- a/change/react-native-windows-2020-07-10-00-43-28-islandsCompositor.json
+++ b/change/react-native-windows-2020-07-10-00-43-28-islandsCompositor.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Start using xamlroot's compositor when available for islands to work. This enables most of playground win32 for rnw-on-winui3 for a pre-preview 2 build",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-10T07:43:27.873Z"
+}

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -328,7 +328,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) 
 constexpr PCWSTR c_windowClassName = L"MS_REACTNATIVE_PLAYGROUND_WIN32";
 
 int RunPlayground(int showCmd, bool useWebDebugger) {
-  constexpr PCWSTR appName = L"React Native Playground (Win32)";
+#ifdef USE_WINUI3
+    constexpr PCWSTR appName = L"React Native Playground (Win32 WinUI3)";
+#else
+    constexpr PCWSTR appName = L"React Native Playground (Win32)";
+#endif
 
   winrt::init_apartment(winrt::apartment_type::single_threaded);
 

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -329,9 +329,9 @@ constexpr PCWSTR c_windowClassName = L"MS_REACTNATIVE_PLAYGROUND_WIN32";
 
 int RunPlayground(int showCmd, bool useWebDebugger) {
 #ifdef USE_WINUI3
-    constexpr PCWSTR appName = L"React Native Playground (Win32 WinUI3)";
+  constexpr PCWSTR appName = L"React Native Playground (Win32 WinUI3)";
 #else
-    constexpr PCWSTR appName = L"React Native Playground (Win32)";
+  constexpr PCWSTR appName = L"React Native Playground (Win32)";
 #endif
 
   winrt::init_apartment(winrt::apartment_type::single_threaded);

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -531,6 +531,7 @@
     <ClCompile Include="Views\VirtualTextViewManager.cpp" />
     <ClCompile Include="Views\XamlFeatures.cpp" />
     <ClCompile Include="XamlLoadState.cpp" />
+    <ClCompile Include="XamlView.cpp" />
     <ClCompile Include="XamlUIService.cpp">
       <DependentUpon>XamlUIService.idl</DependentUpon>
       <SubType>Code</SubType>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -12,6 +12,7 @@
     <ClCompile Include="NativeModulesProvider.cpp" />
     <ClCompile Include="TurboModulesProvider.cpp" />
     <ClCompile Include="XamlLoadState.cpp" />
+    <ClCompile Include="XamlView.cpp" />
     <ClCompile Include="Pch\pch.cpp">
       <Filter>Pch</Filter>
     </ClCompile>

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
@@ -13,6 +13,8 @@ ValueAnimatedNode::ValueAnimatedNode(
     const folly::dynamic &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
+  // TODO: Islands - need to get the XamlView associated with this animation in order to
+  // use the compositor react::uwp::GetCompositor(xamlView)
   m_propertySet = xaml::Window::Current().Compositor().CreatePropertySet();
   m_propertySet.InsertScalar(
       s_valueName, static_cast<float>(config.find(s_jsValueName).dereference().second.asDouble()));
@@ -22,6 +24,8 @@ ValueAnimatedNode::ValueAnimatedNode(
 
 ValueAnimatedNode::ValueAnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
+  // TODO: Islands - need to get the XamlView associated with this animation in order to
+  // use the compositor react::uwp::GetCompositor(xamlView)
   m_propertySet = xaml::Window::Current().Compositor().CreatePropertySet();
   m_propertySet.InsertScalar(s_valueName, 0.0);
   m_propertySet.InsertScalar(s_offsetName, 0.0);

--- a/vnext/Microsoft.ReactNative/Views/ExpressionAnimationStore.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ExpressionAnimationStore.cpp
@@ -13,7 +13,7 @@ namespace uwp {
 
 // Expression for computing the center point of a UIElement, produces a vector3
 // with 2D translation to center.
-comp::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpression() {
+comp::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpression(comp::Compositor compositor) {
   /*
 
   // Because of a bug in the Composition system, we cannot cache this
@@ -42,7 +42,7 @@ comp::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpress
   // The way we obtain the center of an element is by using the ActualSize façade. However this was only added in 19h1
   // An expression animation that refers to a non-existent property (e.g. in RS5) will crash, so use the CenterPoint as
   // a fallback. This might be wrong but at least we won't crash.
-  return xaml::Window::Current().Compositor().CreateExpressionAnimation(
+  return compositor.CreateExpressionAnimation(
       g_HasActualSizeProperty == TriBit::Set
           ? L"vector3(0.5 * uielement.ActualSize.x, 0.5 * uielement.ActualSize.y, 0)"
           : L"vector3(uielement.CenterPoint.X, uielement.CenterPoint.Y, uielement.CenterPoint.Z)");
@@ -50,9 +50,9 @@ comp::ExpressionAnimation ExpressionAnimationStore::GetElementCenterPointExpress
 
 // Expression for applying a TransformMatrix about the centerpoint of a
 // UIElement, produces a Matrix4x4 with overall transform.
-comp::ExpressionAnimation ExpressionAnimationStore::GetTransformCenteringExpression() {
+comp::ExpressionAnimation ExpressionAnimationStore::GetTransformCenteringExpression(comp::Compositor compositor) {
   if (m_transformCenteringExpression == nullptr) {
-    m_transformCenteringExpression = xaml::Window::Current().Compositor().CreateExpressionAnimation(
+    m_transformCenteringExpression = compositor.CreateExpressionAnimation(
         L"Matrix4x4.CreateFromTranslation(-PS.center) * PS.transform * Matrix4x4.CreateFromTranslation(PS.center)");
   }
 

--- a/vnext/Microsoft.ReactNative/Views/ExpressionAnimationStore.h
+++ b/vnext/Microsoft.ReactNative/Views/ExpressionAnimationStore.h
@@ -14,8 +14,8 @@ namespace uwp {
 // resolved, so they can be reused.
 class ExpressionAnimationStore {
  public:
-  comp::ExpressionAnimation GetElementCenterPointExpression();
-  comp::ExpressionAnimation GetTransformCenteringExpression();
+  comp::ExpressionAnimation GetElementCenterPointExpression(comp::Compositor compositor);
+  comp::ExpressionAnimation GetTransformCenteringExpression(comp::Compositor compositor);
 
  private:
   // Compositor bug, see notes in GetElementCenterPointExpression()

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -209,7 +209,7 @@ bool FrameworkElementViewManager::UpdateProperty(
           transformMatrix.m43 = static_cast<float>(propertyValue[14].asDouble());
           transformMatrix.m44 = static_cast<float>(propertyValue[15].asDouble());
 
-          element.Loaded([=](auto&&, auto&&) -> auto {
+          element.Loaded([=](auto &&, auto &&) -> auto {
             ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
           });
         } else if (propertyValue.isNull()) {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -209,7 +209,9 @@ bool FrameworkElementViewManager::UpdateProperty(
           transformMatrix.m43 = static_cast<float>(propertyValue[14].asDouble());
           transformMatrix.m44 = static_cast<float>(propertyValue[15].asDouble());
 
-          ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
+          element.Loaded([=](auto&&, auto&&) -> auto {
+            ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
+          });
         } else if (propertyValue.isNull()) {
           element.TransformMatrix(winrt::Windows::Foundation::Numerics::float4x4::identity());
         }

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -209,9 +209,13 @@ bool FrameworkElementViewManager::UpdateProperty(
           transformMatrix.m43 = static_cast<float>(propertyValue[14].asDouble());
           transformMatrix.m44 = static_cast<float>(propertyValue[15].asDouble());
 
-          element.Loaded([=](auto &&, auto &&) -> auto {
+          if (!element.IsLoaded()) {
+            element.Loaded([=](auto &&, auto &&) -> auto {
+              ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
+            });
+          } else {
             ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
-          });
+          }
         } else if (propertyValue.isNull()) {
           element.TransformMatrix(winrt::Windows::Foundation::Numerics::float4x4::identity());
         }

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -539,7 +539,8 @@ void FrameworkElementViewManager::StartTransformAnimation(
     comp::CompositionPropertySet transformPS) {
   auto instance = GetReactInstance().lock();
   assert(instance != nullptr);
-  auto expression = instance->GetExpressionAnimationStore().GetTransformCenteringExpression();
+  auto expression =
+      instance->GetExpressionAnimationStore().GetTransformCenteringExpression(react::uwp::GetCompositor(uielement));
   expression.SetReferenceParameter(L"PS", transformPS);
   expression.Target(L"TransformMatrix");
   uielement.StartAnimation(expression);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -165,6 +165,8 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   if (auto strong_this{weak_this.get()}) {
     if (strong_this->m_useCompositionBrush) {
       const auto compositionBrush{ReactImageBrush::Create()};
+      // GetCompositor relies on the element's XamlRoot which is only set once the object enters the tree.
+      // This in turn happens before ReactImageBrush::GetOrCreateSurfaceBrush is called.
       strong_this->Loaded([=](auto &&, auto &&) -> auto {
         compositionBrush->Compositor(react::uwp::GetCompositor(*this));
       });

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -12,6 +12,7 @@
 #include <winrt/Windows.Web.Http.Headers.h>
 #include <winrt/Windows.Web.Http.h>
 
+#include "XamlView.h"
 #include "Unicode.h"
 #include "cdebug.h"
 
@@ -164,6 +165,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   if (auto strong_this{weak_this.get()}) {
     if (strong_this->m_useCompositionBrush) {
       const auto compositionBrush{ReactImageBrush::Create()};
+      strong_this->Loaded([=](auto &&, auto &&) -> auto { compositionBrush->Compositor(react::uwp::GetCompositor(*this)); });
       compositionBrush->ResizeMode(strong_this->m_resizeMode);
 
       const auto surface = fromStream ? winrt::LoadedImageSurface::StartLoadFromStream(memoryStream)

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -167,9 +167,13 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
       const auto compositionBrush{ReactImageBrush::Create()};
       // GetCompositor relies on the element's XamlRoot which is only set once the object enters the tree.
       // This in turn happens before ReactImageBrush::GetOrCreateSurfaceBrush is called.
-      strong_this->Loaded([=](auto &&, auto &&) -> auto {
+      if (!strong_this->IsLoaded()) {
+        strong_this->Loaded([=](auto &&, auto &&) -> auto {
+          compositionBrush->Compositor(react::uwp::GetCompositor(*this));
+        });
+      } else {
         compositionBrush->Compositor(react::uwp::GetCompositor(*this));
-      });
+      }
       compositionBrush->ResizeMode(strong_this->m_resizeMode);
 
       const auto surface = fromStream ? winrt::LoadedImageSurface::StartLoadFromStream(memoryStream)

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -12,8 +12,8 @@
 #include <winrt/Windows.Web.Http.Headers.h>
 #include <winrt/Windows.Web.Http.h>
 
-#include "XamlView.h"
 #include "Unicode.h"
+#include "XamlView.h"
 #include "cdebug.h"
 
 namespace winrt {
@@ -165,7 +165,9 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   if (auto strong_this{weak_this.get()}) {
     if (strong_this->m_useCompositionBrush) {
       const auto compositionBrush{ReactImageBrush::Create()};
-      strong_this->Loaded([=](auto &&, auto &&) -> auto { compositionBrush->Compositor(react::uwp::GetCompositor(*this)); });
+      strong_this->Loaded([=](auto &&, auto &&) -> auto {
+        compositionBrush->Compositor(react::uwp::GetCompositor(*this));
+      });
       compositionBrush->ResizeMode(strong_this->m_resizeMode);
 
       const auto surface = fromStream ? winrt::LoadedImageSurface::StartLoadFromStream(memoryStream)

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
@@ -131,7 +131,7 @@ comp::CompositionStretch ReactImageBrush::ResizeModeToStretch() {
 comp::CompositionSurfaceBrush ReactImageBrush::GetOrCreateSurfaceBrush() {
   // If it doesn't exist, create it
   if (!CompositionBrush()) {
-    comp::CompositionSurfaceBrush surfaceBrush{xaml::Window::Current().Compositor().CreateSurfaceBrush()};
+    comp::CompositionSurfaceBrush surfaceBrush{m_compositor.CreateSurfaceBrush()};
     surfaceBrush.Surface(m_loadedImageSurface);
 
     return surfaceBrush;
@@ -163,7 +163,7 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
     borderEffect.Source(borderEffectSourceParameter);
 
     comp::CompositionEffectFactory effectFactory{
-        xaml::Window::Current().Compositor().CreateEffectFactory(borderEffect)};
+        m_compositor.CreateEffectFactory(borderEffect)};
     m_effectBrush = effectFactory.CreateBrush();
 
     m_effectBrush.SetSourceParameter(L"source", surfaceBrush);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
@@ -162,8 +162,7 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
     comp::CompositionEffectSourceParameter borderEffectSourceParameter{L"source"};
     borderEffect.Source(borderEffectSourceParameter);
 
-    comp::CompositionEffectFactory effectFactory{
-        m_compositor.CreateEffectFactory(borderEffect)};
+    comp::CompositionEffectFactory effectFactory{m_compositor.CreateEffectFactory(borderEffect)};
     m_effectBrush = effectFactory.CreateBrush();
 
     m_effectBrush.SetSourceParameter(L"source", surfaceBrush);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.h
@@ -37,6 +37,10 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
 
   void Source(xaml::Media::LoadedImageSurface const &value);
 
+  void Compositor(comp::Compositor const &compositor) {
+    m_compositor = compositor;
+  }
+
  private:
   void UpdateCompositionBrush();
   bool IsImageSmallerThanView();
@@ -44,6 +48,7 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
   comp::CompositionSurfaceBrush GetOrCreateSurfaceBrush();
   comp::CompositionEffectBrush GetOrCreateEffectBrush(comp::CompositionSurfaceBrush const &surfaceBrush);
 
+  comp::Compositor m_compositor;
   react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
   winrt::Windows::Foundation::Size m_availableSize{};
   xaml::Media::LoadedImageSurface m_loadedImageSurface{nullptr};

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.cpp
@@ -103,7 +103,7 @@ void ShadowNodeBase::ReparentView(XamlView view) {
 
 comp::CompositionPropertySet ShadowNodeBase::EnsureTransformPS() {
   if (m_transformPS == nullptr) {
-    m_transformPS = xaml::Window::Current().Compositor().CreatePropertySet();
+    m_transformPS = GetCompositor(GetView()).CreatePropertySet();
     UpdateTransformPS();
   }
 
@@ -124,7 +124,8 @@ void ShadowNodeBase::UpdateTransformPS() {
     m_transformPS.InsertVector3(L"center", {0, 0, 0});
     auto instance = GetViewManager()->GetReactInstance().lock();
     assert(instance != nullptr);
-    auto centeringAnimation = instance->GetExpressionAnimationStore().GetElementCenterPointExpression();
+    auto centeringAnimation =
+        instance->GetExpressionAnimationStore().GetElementCenterPointExpression(GetCompositor(GetView()));
     centeringAnimation.SetExpressionReferenceParameter(L"uielement", uielement);
     m_transformPS.StartAnimation(L"center", centeringAnimation);
 

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -28,9 +28,9 @@ comp::Compositor GetCompositor(const XamlView &view) {
   else {
     return TryGetXamlRoot(view).Compositor();
   }
-#else
-  throw std::exception("Could not get a compositor instance");
 #endif
+
+  throw std::exception("Could not get a compositor instance");
 }
 
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -3,8 +3,8 @@
 
 #include "pch.h"
 #include "XamlView.h"
-#include <UI.Xaml.Documents.h>
 #include <UI.Xaml.Controls.Primitives.h>
+#include <UI.Xaml.Documents.h>
 
 namespace react::uwp {
 

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "XamlView.h"
+#include <UI.Xaml.Documents.h>
+#include <UI.Xaml.Controls.Primitives.h>
+
+namespace react::uwp {
+
+xaml::XamlRoot TryGetXamlRoot(const XamlView &view) {
+  xaml::XamlRoot root{nullptr};
+  if (auto uielement = view.try_as<xaml::UIElement>()) {
+    root = uielement.XamlRoot();
+  } else if (auto textelement = view.try_as<xaml::Documents::TextElement>()) {
+    root = textelement.XamlRoot();
+  } else if (auto flyout = view.try_as<xaml::Controls::Primitives::FlyoutBase>()) {
+    root = flyout.XamlRoot();
+  }
+  return root;
+}
+
+comp::Compositor GetCompositor(const XamlView &view) {
+  if (auto window = xaml::Window::Current()) {
+    return window.Compositor();
+  }
+#ifdef USE_WINUI3
+  else {
+    return TryGetXamlRoot(view).Compositor();
+  }
+#else
+  throw std::exception("Could not get a compositor instance");
+#endif
+}
+
+} // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -37,5 +37,8 @@ inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
   return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
+xaml::XamlRoot TryGetXamlRoot(const XamlView &view);
+comp::Compositor GetCompositor(const XamlView &view);
+
 } // namespace uwp
 } // namespace react


### PR DESCRIPTION
This change switches RNW to use the compositor from the XamlRoot instead of using the one from the current Window object since there won't be one in islands scenarios. This has a couple of interesting consequences:
- you can only get the xamlroot for an object once it has entered the tree so getting the xamlroot and the compositor need to be deferred
- still want to use system xaml's window compositor since system xamlroot doesn't have a compositor asociated with it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5499)