### PR TITLE
[0.62] run-windows cannot find built app with default init app (#5466)

### DIFF
--- a/change/react-native-windows-2020-07-08-13-10-31-deploy2.json
+++ b/change/react-native-windows-2020-07-08-13-10-31-deploy2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "run-windows cannot find built app with default init app",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-08T20:10:31.064Z"
+}

--- a/change/react-native-windows-2020-07-08-13-10-31-deploy2.json
+++ b/change/react-native-windows-2020-07-08-13-10-31-deploy2.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "run-windows cannot find built app with default init app",
   "packageName": "react-native-windows",
   "email": "acoates@microsoft.com",

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -98,7 +98,7 @@ function getAppxManifestPath(options) {
     options.arch
   }/${configuration},${configuration}/*,target/${
     options.arch
-  }/${configuration}}/AppxManifest.xml`;
+  }/${configuration},${options.arch}/${configuration}/*}/AppxManifest.xml`;
   const appxPath = glob.sync(path.join(options.root, appxManifestGlob))[0];
 
   if (!appxPath) {


### PR DESCRIPTION
Port of #5466 to 0.62

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5504)