### PR TITLE
Add ReactDispatcher tests

### DIFF
--- a/change/react-native-windows-2020-07-10-14-20-55-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-07-10-14-20-55-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add ReactDispatcher tests",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-10T21:20:55.334Z"
+}

--- a/vnext/Desktop.ABITests/Application.manifest
+++ b/vnext/Desktop.ABITests/Application.manifest
@@ -21,6 +21,10 @@
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
+        name="Microsoft.ReactNative.ReactDispatcherHelper"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
         name="Microsoft.ReactNative.ReactNativeHost"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="DynamicReaderWriterTests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MemoryTrackerTests.cpp" />
+    <ClCompile Include="ReactDispatcherTests.cpp" />
     <ClCompile Include="ReactModuleBuilderTests.cpp" />
     <ClCompile Include="ReactPackageBuilderTests.cpp" />
     <ClCompile Include="SimpleMessageQueue.cpp" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="ReactPackageBuilderTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ReactDispatcherTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/vnext/Desktop.ABITests/ReactDispatcherTests.cpp
+++ b/vnext/Desktop.ABITests/ReactDispatcherTests.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <winrt/Microsoft.Internal.h>
+#include <winrt/Microsoft.ReactNative.h>
+
+#include <chrono>
+#include <future>
+
+using namespace std::chrono_literals;
+using namespace winrt;
+using namespace winrt::Microsoft::ReactNative;
+
+namespace ABITests {
+
+TEST_CLASS (ReactDispatcherTests) {
+ public:
+  TEST_METHOD(HasThreadAccess_FalseForTestThread) {
+    IReactDispatcher dispatcher = ReactDispatcherHelper::CreateSerialDispatcher();
+    TestCheck(!dispatcher.HasThreadAccess());
+  }
+  TEST_METHOD(Post_CallbackGetsExecuted) {
+    IReactDispatcher dispatcher = ReactDispatcherHelper::CreateSerialDispatcher();
+    std::promise<void> callbackExecutionPromise;
+    auto callbackExecuted = callbackExecutionPromise.get_future();
+
+    dispatcher.Post([&callbackExecutionPromise] { callbackExecutionPromise.set_value(); });
+
+    TestCheckEqual(std::future_status::ready, callbackExecuted.wait_for(500ms));
+  }
+};
+
+} // namespace ABITests

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -247,6 +247,9 @@
     <ClInclude Include="..\Microsoft.ReactNative\IReactContext.h">
       <DependentUpon>..\Microsoft.ReactNative\IReactContext.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="..\Microsoft.ReactNative\IReactDispatcher.h">
+      <DependentUpon>..\Microsoft.ReactNative\IReactDispatcher.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="..\Microsoft.ReactNative\JsiReader.h">
       <DependentUpon>..\Microsoft.ReactNative\IJSValueReader.idl</DependentUpon>
     </ClInclude>


### PR DESCRIPTION
This change exposes the ReactDispatcherHelper class through the ABI of the Win32 DLL and adds tests for an IReactDispatcher implementation it creates.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5507)