### PR TITLE
Add ReactNotificationService test

### DIFF
--- a/change/react-native-windows-2020-07-13-15-28-45-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-07-13-15-28-45-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add ReactNotificationService tests",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T22:28:45.730Z"
+}

--- a/vnext/Desktop.ABITests/Application.manifest
+++ b/vnext/Desktop.ABITests/Application.manifest
@@ -29,6 +29,10 @@
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
+        name="Microsoft.ReactNative.ReactNotificationServiceHelper"
+        threadingModel="both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
         name="Microsoft.ReactNative.ReactPropertyBagHelper"
         threadingModel="both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -142,8 +142,9 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="PerfTests.cpp" />
-    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactPropertyBagTests.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactNativeHostTests.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactNotificationServiceTests.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactPropertyBagTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SimpleMessageQueue.h" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -262,6 +262,9 @@
     <ClInclude Include="..\Microsoft.ReactNative\IReactModuleBuilder.h">
       <DependentUpon>..\Microsoft.ReactNative\IReactModuleBuilder.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="..\Microsoft.ReactNative\IReactNotificationService.h">
+      <DependentUpon>..\Microsoft.ReactNative\IReactNotificationService.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="..\Microsoft.ReactNative\ReactNativeHost.h">
       <DependentUpon>..\Microsoft.ReactNative\ReactNativeHost.idl</DependentUpon>
     </ClInclude>


### PR DESCRIPTION
The Win32 DLL was already being build with the IReactNotificationService (RNS) interface definition and and implementation thereof; this change uses a test shared with the UWP DLL to demonstrate that the RNS implementation in the Win32 DLL is usable.  

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5517)