### PR TITLE
Add ReactPackageProvider tests

### DIFF
--- a/change/react-native-windows-2020-07-14-14-02-41-ms-rnw-staging.json
+++ b/change/react-native-windows-2020-07-14-14-02-41-ms-rnw-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add ReactPackageProvider tests",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-14T21:02:41.637Z"
+}

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="ReactDispatcherTests.cpp" />
     <ClCompile Include="ReactModuleBuilderTests.cpp" />
     <ClCompile Include="ReactPackageBuilderTests.cpp" />
+    <ClCompile Include="ReactPackageProviderTests.cpp" />
     <ClCompile Include="SimpleMessageQueue.cpp" />
     <ClCompile Include="NativeLogEventTests.cpp" />
     <ClCompile Include="NativeTraceEventTests.cpp" />

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj.filters
@@ -54,6 +54,15 @@
     <ClCompile Include="ReactDispatcherTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactInstanceSettingsTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative.IntegrationTests\ReactNotificationServiceTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ReactPackageProviderTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/vnext/Desktop.ABITests/ReactPackageProviderTests.cpp
+++ b/vnext/Desktop.ABITests/ReactPackageProviderTests.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <winrt/Microsoft.Internal.h>
+#include <winrt/Microsoft.ReactNative.h>
+#include <winrt/Windows.Foundation.Collections.h>
+
+using namespace winrt;
+using namespace winrt::Microsoft::ReactNative;
+
+namespace ABITests {
+
+struct MockPackageProvider : implements<MockPackageProvider, IReactPackageProvider> {
+  void CreatePackage(IReactPackageBuilder builder) {
+    OnCreatePackage(builder);
+  }
+
+  std::function<void(IReactPackageBuilder)> OnCreatePackage;
+};
+
+// The tests here are a development staging artifact owed to the incremental buildup of the C++/WinRT-based ABI of
+// the Win32 DLL. They (or their logical equivalent) should probably get rolled into other tests once C++/WinRT-based
+// instance management becomes available.
+TEST_CLASS (ReactPackageProviderTests) {
+ public:
+  TEST_METHOD(CreatePackage_IsCallable) {
+    int createPackageCallCount = 0;
+    auto provider = make<MockPackageProvider>();
+    provider.as<MockPackageProvider>()->OnCreatePackage = [&createPackageCallCount](IReactPackageBuilder builder) {
+      ++createPackageCallCount;
+    };
+
+    ReactInstanceSettings settings;
+    settings.PackageProviders().Append(provider);
+    TestCheckEqual(1ul, settings.PackageProviders().Size());
+
+    IReactPackageBuilder builder = Microsoft::Internal::TestController::CreateReactPackageBuilder();
+    settings.PackageProviders().GetAt(0).CreatePackage(builder);
+    TestCheckEqual(1, createPackageCallCount);
+  }
+};
+
+} // namespace ABITests


### PR DESCRIPTION
The Win32 DLL was already being build with the IReactPackageProvider interface definition; this change adds a test to demonstrate that user code can implement that interface and register the respective implementation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5522)