### PR TITLE
Add support for `Task` and `Task<T>` async methods for C# native modules

### DIFF
--- a/change/react-native-windows-2020-07-14-14-48-07-master.json
+++ b/change/react-native-windows-2020-07-14-14-48-07-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for `Task` and `Task<T>` async methods for C# native modules.",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-14T21:48:07.511Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/index.windows.js
+++ b/packages/microsoft-reactnative-sampleapps/index.windows.js
@@ -149,6 +149,23 @@ class SampleApp extends Component {
 
     NativeModules.SampleModuleCS.callDistanceFunction({x: 22, y: 23}, {x: 55, y: 65});
 
+    NativeModules.SampleModuleCS.TaskNoArgs()
+      .then(getCallback('SampleModuleCS.TaskNoArgs then => '))
+      .catch(getErrorCallback('SampleModuleCS.TaskNoArgs catch => '));
+
+    NativeModules.SampleModuleCS.TaskTwoArgs(11, 200)
+      .then(getCallback('SampleModuleCS.TaskTwoArgs then => '))
+      .catch(getErrorCallback('SampleModuleCS.TaskTwoArgs catch => '));
+
+    NativeModules.SampleModuleCS.TaskOfTNoArgs()
+      .then(getCallback('SampleModuleCS.TaskOfTNoArgs then => '))
+      .catch(getErrorCallback('SampleModuleCS.TaskOfTNoArgs catch => '));
+
+    NativeModules.SampleModuleCS.TaskOfTTwoArgs(11, 200)
+      .then(getCallback('SampleModuleCS.TaskOfTTwoArgs then => '))
+      .catch(getErrorCallback('SampleModuleCS.TaskOfTTwoArgs catch => '));
+
+
     log('SampleModuleCS.SyncReturnMethod => ' + NativeModules.SampleModuleCS.SyncReturnMethod());
 
     log('SampleModuleCS.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCS.SyncReturnMethodWithArgs(numberArg));

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
@@ -226,6 +226,35 @@ namespace SampleLibraryCS
 
         #endregion
 
+        #region Methods using Task
+
+        [ReactMethod]
+        public Task TaskNoArgs()
+        {
+            return Task<int>.Factory.StartNew(() => 42);
+        }
+
+        [ReactMethod]
+        public async Task TaskTwoArgs(int x, int y)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+        }
+
+        [ReactMethod]
+        public Task<int> TaskOfTNoArgs()
+        {
+            return Task<int>.Factory.StartNew(() => 42);
+        }
+
+        [ReactMethod]
+        public async Task<int> TaskOfTTwoArgs(int x, int y)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+            return x + y;
+        }
+
+        #endregion
+
         #region Synchronous Methods
 
         [ReactSyncMethod]

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Analysis/ModuleMethodAnalysisTests.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Analysis/ModuleMethodAnalysisTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Linq;
+using Microsoft.ReactNative.Managed.CodeGen.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SymbolDisplayFormat = Microsoft.CodeAnalysis.SymbolDisplayFormat;
+
 namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.Analysis
 {
   [TestClass]
@@ -21,7 +24,11 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.Analysis
       Assert.IsTrue(result);
 
       Assert.AreEqual(1, module.Methods.Count);
-      Assert.AreEqual("Test", module.Methods.First().Name);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("void", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Void, method.ReturnStyle);
     }
 
     [TestMethod]
@@ -38,7 +45,11 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.Analysis
       Assert.IsTrue(result);
 
       Assert.AreEqual(1, module.Methods.Count);
-      Assert.AreEqual("Test", module.Methods.First().Name);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(3, method.EffectiveParameters.Count);
+      Assert.AreEqual("void", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.ReturnValue, method.ReturnStyle);
     }
 
     [TestMethod]
@@ -54,7 +65,11 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.Analysis
       Assert.IsTrue(result);
 
       Assert.AreEqual(1, module.Methods.Count);
-      Assert.AreEqual("MyTest", module.Methods.First().Name);
+      var method = module.Methods.First();
+      Assert.AreEqual("MyTest", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("void", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Void, method.ReturnStyle);
     }
 
     [TestMethod]
@@ -70,7 +85,206 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.Analysis
       Assert.IsTrue(result);
 
       Assert.AreEqual(1, module.Methods.Count);
-      Assert.AreEqual("MyTest", module.Methods.First().Name);
+      var method = module.Methods.First();
+      Assert.AreEqual("MyTest", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("void", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Void, method.ReturnStyle);
+    }
+    
+    [TestMethod]
+    public void TaskMethod()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public Task Test()
+        {
+          return Task.FromResult(0);
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("void", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Task, method.ReturnStyle);
+    }
+    
+    [TestMethod]
+    public void TaskOfIntMethod()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public Task<int> Test()
+        {
+          return Task.FromResult(0);
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Task, method.ReturnStyle);
+    }
+    
+    [TestMethod]
+    public void PromiseMethodOnlyArg()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public void Test(IReactPromise<int> promise)
+        {
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Promise, method.ReturnStyle);
+    }
+
+    [TestMethod]
+    public void PromiseMethodTwoArgs()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public string Test(int z, string a0, IReactPromise<int> promise)
+        {
+          return string.Empty;
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(2, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Promise, method.ReturnStyle);
+    }
+    
+    [TestMethod]
+    public void SingleCallbackMethodOnlyArg()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public void Test(Action<int> callback)
+        {
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Callback, method.ReturnStyle);
+    }
+
+    [TestMethod]
+    public void SingleCallbackMethodTwoArgs()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public string Test(int z, string a0, Action<int> callback)
+        {
+          return string.Empty;
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(2, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.Callback, method.ReturnStyle);
+    }
+
+    [TestMethod]
+    public void DoubleCallbackMethodOnlyArgs()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public void Test(Action<int> callback, Action<string> reject)
+        {
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(0, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.TwoCallbacks, method.ReturnStyle);
+    }
+
+    [TestMethod]
+    public void DoubleCallbackMethodTwoArgs()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactMethod]
+        public string Test(int z, string a0, Action<int> callback, Action<string> reject)
+        {
+          return string.Empty;
+        }
+        ");
+      var result = codeAnalyzer.TryExtractModule(type, out var module);
+      Assert.IsTrue(result);
+
+      Assert.AreEqual(1, module.Methods.Count);
+      var method = module.Methods.First();
+      Assert.AreEqual("Test", method.Name);
+      Assert.AreEqual(2, method.EffectiveParameters.Count);
+      Assert.AreEqual("int", method.EffectiveReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat));
+      Assert.AreEqual(ReactMethod.MethodReturnStyle.TwoCallbacks, method.ReturnStyle);
+    }
+
+    [TestMethod]
+    public void TaskNotAllowedOnSyncMethods()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactSyncMethod]
+        public Task TaskNoArgs()
+        {
+          return Task.FromResult(42);
+        }
+        ");
+      codeAnalyzer.TryExtractModule(type, out var module);
+
+      ExpectSingleError(codeAnalyzer, DiagnosticDescriptors.MethodShouldNotReturnTaskWhenSynchronous);
+    }
+
+    [TestMethod]
+    public void TaskOfTNotAllowedOnSyncMethods()
+    {
+      var (codeAnalyzer, type) = AnalyzeModuleFile(@"
+        [ReactSyncMethod]
+        public Task<int> TaskOfTNoArgs()
+        {
+          return Task.FromResult(42);
+        }
+        ");
+      codeAnalyzer.TryExtractModule(type, out var module);
+
+      ExpectSingleError(codeAnalyzer, DiagnosticDescriptors.MethodShouldNotReturnTaskWhenSynchronous);
     }
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
@@ -28,6 +28,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests
         {
             var csCode = @"
 using System;
+using System.Threading.Tasks;
 using Microsoft.ReactNative.Managed;
 
 [ReactModule]

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenInitializerTests.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenInitializerTests.cs
@@ -8,106 +8,16 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
 {
   [TestClass]
-  public class CodeGenMethodTests : CodeGenTestBase
+  public class CodeGenInitializerTests : CodeGenTestBase
   {
 
     [TestMethod]
-    public void NoParamReturnVoid()
-    {
-      TestMethod("public void Method() {}");
-    }
-
-    [TestMethod]
-    public void OneParamReturnVoid()
-    {
-      TestMethod("public void Method(int x) {}");
-    }
-
-    [TestMethod]
-    public void ThreeParamReturnVoid()
-    {
-      TestMethod("public void Method(int x, string y, double z) {}");
-    }
-
-    [TestMethod]
-    public void NoParamReturnInt()
-    {
-      TestMethod("public int Method() { return 42; }");
-    }
-
-    [TestMethod]
-    public void OneParamReturnInt()
-    {
-      TestMethod("public int Method(int x) { return 42; }");
-    }
-
-    [TestMethod]
-    public void ThreeParamReturnInt()
-    {
-      TestMethod("public int Method(int x, string y, double z) { return 42; }");
-    }
-
-    [TestMethod]
-    public void PromiseParamReturnVoid()
-    {
-      TestMethod("public void Method(IReactPromise<int> promise) {}");
-    }
-
-    [TestMethod]
-    public void IntParamAndPromiseParamReturnVoid()
-    {
-      TestMethod("public void Method(int x, IReactPromise<int> promise) {}");
-    }
-
-    [TestMethod]
-    public void DoublePromiseParamReturnVoid()
-    {
-      TestMethod("public void Method(IReactPromise<string> p1, IReactPromise<int> p2) {}");
-    }
-    
-    [TestMethod]
-    public void IntParamAndDoublePromiseParamReturnVoid()
-    {
-      TestMethod("public void Method(int x, IReactPromise<string> p1, IReactPromise<int> p2) {}");
-    }
-
-    [TestMethod]
-    public void SingleArgCallbackParamReturnVoid()
-    {
-      TestMethod("public void Method(Action<int> cb1) { }");
-    }
-
-    [TestMethod]
-    public void IntParamAndSingleArgCallbackParamReturnVoid()
-    {
-      TestMethod("public void Method(int x, Action<int> cb1) { }");
-    }
-
-    [TestMethod]
-    public void DoubleArgCallbackParamReturnVoid()
-    {
-      TestMethod("public void Method(Action<int> cb1, Action<int> cb2) { }");
-    }
-
-    [TestMethod]
-    public void IntParamAndDoubleArgCallbackParamReturnVoid()
-    {
-      TestMethod("public void Method(int x, Action<int> cb1, Action<int> cb2) { }");
-    }
-
-    private void TestMethod(string methodDecl)
-    {
-      TestMethod(methodDecl, isSynchronous: true);
-      TestMethod(methodDecl, isSynchronous: false);
-    }
-
-    private void TestMethod(string methodDecl, bool isSynchronous)
+    public void RegularCase()
     {
       TestCodeGen<IMethodSymbol>(
-        methodDecl,
+        "public void Initialize(ReactContext context) {}",
         (codeGen, symbol) =>
-          codeGen.AddMethod(new ReactMethod(symbol, "MyMethod", isSynchronous: isSynchronous)),
-        lkgName: isSynchronous ? "Sync" : "Async");
+          codeGen.AddInitializer(new ReactInitializer(symbol)));
     }
 
   }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenMethodTests.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenMethodTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.ReactNative.Managed.CodeGen.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -8,16 +10,158 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
 {
   [TestClass]
-  public class CodeGenInitializerTests : CodeGenTestBase
+  public class CodeGenMethodTests : CodeGenTestBase
   {
 
     [TestMethod]
-    public void RegularCase()
+    public void NoParamReturnVoid()
+    {
+      TestMethod("public void Method() {}", ReactMethod.MethodReturnStyle.Void);
+    }
+
+    [TestMethod]
+    public void OneParamReturnVoid()
+    {
+      TestMethod("public void Method(int x) {}", ReactMethod.MethodReturnStyle.Void);
+    }
+
+    [TestMethod]
+    public void ThreeParamReturnVoid()
+    {
+      TestMethod("public void Method(int x, string y, double z) {}", ReactMethod.MethodReturnStyle.Void);
+    }
+
+    [TestMethod]
+    public void NoParamReturnInt()
+    {
+      TestMethod("public int Method() { return 42; }", ReactMethod.MethodReturnStyle.ReturnValue);
+    }
+
+    [TestMethod]
+    public void OneParamReturnInt()
+    {
+      TestMethod("public int Method(int x) { return 42; }", ReactMethod.MethodReturnStyle.ReturnValue);
+    }
+
+    [TestMethod]
+    public void ThreeParamReturnInt()
+    {
+      TestMethod("public int Method(int x, string y, double z) { return 42; }", ReactMethod.MethodReturnStyle.ReturnValue);
+    }
+
+    [TestMethod]
+    public void PromiseParamReturnVoid()
+    {
+      TestMethod("public void Method(IReactPromise<int> promise) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
+    public void IntParamAndPromiseParamReturnVoid()
+    {
+      TestMethod("public void Method(int x, IReactPromise<int> promise) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
+    public void DoublePromiseParamReturnVoid()
+    {
+      TestMethod("public void Method(IReactPromise<string> p1, IReactPromise<int> p2) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
+    public void IntParamAndDoublePromiseParamReturnVoid()
+    {
+      TestMethod("public void Method(int x, IReactPromise<string> p1, IReactPromise<int> p2) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
+    public void SingleArgCallbackParamReturnVoid()
+    {
+      TestMethod("public void Method(Action<int> cb1) { }", ReactMethod.MethodReturnStyle.Callback);
+    }
+
+    [TestMethod]
+    public void IntParamAndSingleArgCallbackParamReturnVoid()
+    {
+      TestMethod("public void Method(int x, Action<int> cb1) { }", ReactMethod.MethodReturnStyle.Callback);
+    }
+
+    [TestMethod]
+    public void DoubleArgCallbackParamReturnVoid()
+    {
+      TestMethod("public void Method(Action<int> cb1, Action<int> cb2) { }", ReactMethod.MethodReturnStyle.TwoCallbacks);
+    }
+
+    [TestMethod]
+    public void IntParamAndDoubleArgCallbackParamReturnVoid()
+    {
+      TestMethod("public void Method(int x, Action<int> cb1, Action<int> cb2) { }", ReactMethod.MethodReturnStyle.TwoCallbacks);
+    }
+
+    [TestMethod]
+    public void ZeroArgTask()
+    {
+      TestMethod("public Task Method() { return Task.FromResult(42); }", ReactMethod.MethodReturnStyle.Task, isSynchronous: false);
+    }
+
+    [TestMethod]
+    public void TwoArgsTask()
+    {
+      TestMethod("public Task Method(int x, int y) { return Task.FromResult(42); }", ReactMethod.MethodReturnStyle.Task, isSynchronous: false);
+    }
+
+    [TestMethod]
+    public void ZeroArgTaskOfInt()
+    {
+      TestMethod("public Task<int> Method() { return Task.FromResult(42); }", ReactMethod.MethodReturnStyle.Task, isSynchronous: false);
+    }
+
+    [TestMethod]
+    public void TwoArgsTaskOfInt()
+    {
+      TestMethod("public Task<int> Method(int x, int y) { return Task.FromResult(42); }", ReactMethod.MethodReturnStyle.Task, isSynchronous: false);
+    }
+
+    private void TestMethod(string methodDecl, ReactMethod.MethodReturnStyle returnStyle)
+    {
+      TestMethod(methodDecl, returnStyle, isSynchronous: true);
+      TestMethod(methodDecl, returnStyle, isSynchronous: false);
+    }
+
+    private void TestMethod(string methodDecl, ReactMethod.MethodReturnStyle returnStyle, bool isSynchronous)
     {
       TestCodeGen<IMethodSymbol>(
-        "public void Initialize(ReactContext context) {}",
+        methodDecl,
         (codeGen, symbol) =>
-          codeGen.AddInitializer(new ReactInitializer(symbol)));
+        {
+          var returnType = symbol.ReturnType;
+          var parameters = new List<IParameterSymbol>(symbol.Parameters);
+          switch (returnStyle)
+          {
+            case ReactMethod.MethodReturnStyle.Promise:
+            case ReactMethod.MethodReturnStyle.Callback:
+              returnType = ((INamedTypeSymbol)parameters[parameters.Count - 1].Type).TypeArguments[0];
+              parameters.RemoveAt(parameters.Count - 1);
+              break;
+            case ReactMethod.MethodReturnStyle.TwoCallbacks:
+              returnType = ((INamedTypeSymbol)parameters[parameters.Count - 2].Type).TypeArguments[0];
+              parameters.RemoveRange(parameters.Count - 2, 2);
+              break;
+            case ReactMethod.MethodReturnStyle.Task:
+              var namedReturnType = ((INamedTypeSymbol) returnType);
+              returnType = namedReturnType.TypeArguments.Any()
+                ? ((INamedTypeSymbol) returnType).TypeArguments[0]
+                : codeGen.ReactTypes.SystemVoid;
+              break;
+          }
+          return codeGen.AddMethod(new ReactMethod(
+            symbol,
+            "MyMethod",
+            isSynchronous: isSynchronous,
+            returnStyle: returnStyle,
+            effectiveReturnType: returnType,
+            effectiveParameters: parameters));
+        },
+        lkgName: isSynchronous ? "Sync" : "Async");
     }
 
   }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--DoubleArgCallbackParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--DoubleArgCallbackParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::System.Action<int> arg0, out global::System.Action<int> arg1);
-    module.Method(arg0, arg1);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method((value) => resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)), (value) => reject(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--DoublePromiseParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--DoublePromiseParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::Microsoft.ReactNative.Managed.IReactPromise<string> arg0, out global::Microsoft.ReactNative.Managed.IReactPromise<int> arg1);
-    module.Method(arg0, arg1);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::Microsoft.ReactNative.Managed.IReactPromise<string> arg0);
+    module.Method(arg0, new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndDoubleArgCallbackParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndDoubleArgCallbackParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out global::System.Action<int> arg1, out global::System.Action<int> arg2);
-    module.Method(arg0, arg1, arg2);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0);
+    module.Method(arg0, (value) => resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)), (value) => reject(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndDoublePromiseParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndDoublePromiseParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out global::Microsoft.ReactNative.Managed.IReactPromise<string> arg1, out global::Microsoft.ReactNative.Managed.IReactPromise<int> arg2);
-    module.Method(arg0, arg1, arg2);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out global::Microsoft.ReactNative.Managed.IReactPromise<string> arg1);
+    module.Method(arg0, arg1, new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndPromiseParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndPromiseParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out global::Microsoft.ReactNative.Managed.IReactPromise<int> arg1);
-    module.Method(arg0, arg1);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0);
+    module.Method(arg0, new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndSingleArgCallbackParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--IntParamAndSingleArgCallbackParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out global::System.Action<int> arg1);
-    module.Method(arg0, arg1);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0);
+    module.Method(arg0, (value) => resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::Microsoft.ReactNative.Managed.IReactPromise<int> arg0);
-    module.Method(arg0);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method(new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--SingleArgCallbackParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--SingleArgCallbackParamReturnVoid--Sync.lkg
@@ -1,7 +1,7 @@
 moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
 {
-    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::System.Action<int> arg0);
-    module.Method(arg0);
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method((value) => resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)));
 }
 
 );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--TwoArgsTask--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--TwoArgsTask--Async.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out int arg1);
+    global::System.Threading.Tasks.Task result = module.Method(arg0, arg1);
+    global::Microsoft.ReactNative.Managed.ReactTaskExtensions.ContinueWith(result, writer, resolve, reject);
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--TwoArgsTaskOfInt--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--TwoArgsTaskOfInt--Async.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out int arg0, out int arg1);
+    global::System.Threading.Tasks.Task<int> result = module.Method(arg0, arg1);
+    global::Microsoft.ReactNative.Managed.ReactTaskExtensions.ContinueWith(result, writer, resolve, reject);
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ZeroArgTask--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ZeroArgTask--Async.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    global::System.Threading.Tasks.Task result = module.Method();
+    global::Microsoft.ReactNative.Managed.ReactTaskExtensions.ContinueWith(result, writer, resolve, reject);
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ZeroArgTaskOfInt--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ZeroArgTaskOfInt--Async.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    global::System.Threading.Tasks.Task<int> result = module.Method();
+    global::Microsoft.ReactNative.Managed.ReactTaskExtensions.ContinueWith(result, writer, resolve, reject);
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
@@ -19,861 +19,867 @@ using System.Threading.Tasks.Dataflow;
 
 namespace Microsoft.ReactNative.Managed.CodeGen
 {
-  /// <summary>
-  /// Primary class 
-  /// </summary>
-  public class CodeAnalyzer
-  {
-    public int ConcurrencyLevel { get; set; } = DataflowBlockOptions.Unbounded;
-
-    private readonly CancellationToken m_cancellationToken;
-
-    private readonly ConcurrentBag<SyntaxTree> m_syntaxTrees = new ConcurrentBag<SyntaxTree>();
-    private readonly ConcurrentBag<MetadataReference> m_metadataReferences = new ConcurrentBag<MetadataReference>();
-
-    private Compilation? m_compilation { get; set; }
-
-    private ReactTypes? m_reactTypes;
-    internal ReactTypes ReactTypes
+    /// <summary>
+    /// Primary class 
+    /// </summary>
+    public class CodeAnalyzer
     {
-      get
-      {
-        Contract.Assert(m_reactTypes != null);
-        return m_reactTypes;
-      }
-    }
+        public int ConcurrencyLevel { get; set; } = DataflowBlockOptions.Unbounded;
 
+        private readonly CancellationToken m_cancellationToken;
 
-    private readonly List<Diagnostic> m_diagnostics = new List<Diagnostic>();
-    public IEnumerable<Diagnostic> Diagnostics => m_diagnostics;
+        private readonly ConcurrentBag<SyntaxTree> m_syntaxTrees = new ConcurrentBag<SyntaxTree>();
+        private readonly ConcurrentBag<MetadataReference> m_metadataReferences = new ConcurrentBag<MetadataReference>();
 
-    public CodeAnalyzer(CancellationToken cancellationToken)
-    {
-      m_cancellationToken = cancellationToken;
-    }
+        private Compilation? m_compilation { get; set; }
 
-    internal void AddSyntaxTree(SyntaxTree syntaxTree)
-    {
-      m_syntaxTrees.Add(syntaxTree);
-    }
-
-    public async Task ParseSourceFilesAsync(IEnumerable<string> sourceFiles, IEnumerable<string>? preprocessorSymbols)
-    {
-      var csharpParseOptions = new CSharpParseOptions(
-        preprocessorSymbols: preprocessorSymbols,
-        languageVersion: LanguageVersion.Latest);
-
-      var block = new ActionBlock<string>(async file =>
-      {
-        string text = await File.ReadAllTextAsync(file, m_cancellationToken);
-        AddSyntaxTree(CSharpSyntaxTree.ParseText(text, path: file, options: csharpParseOptions));
-      },
-      new ExecutionDataflowBlockOptions()
-      {
-        MaxDegreeOfParallelism = ConcurrencyLevel,
-        CancellationToken = m_cancellationToken,
-      });
-      foreach (var sourceFile in sourceFiles)
-      {
-        block.Post(sourceFile);
-      }
-
-      block.Complete();
-      await block.Completion;
-    }
-
-    public async Task LoadMetadataReferencesAsync(IEnumerable<string> references)
-    {
-      var block = new ActionBlock<string>(file =>
+        private ReactTypes? m_reactTypes;
+        internal ReactTypes ReactTypes
         {
-          m_metadataReferences.Add(MetadataReference.CreateFromFile(file));
-        },
-        new ExecutionDataflowBlockOptions()
-        {
-          MaxDegreeOfParallelism = ConcurrencyLevel,
-          CancellationToken = m_cancellationToken,
-        });
-      foreach (var reference in references.Distinct())
-      {
-        block.Post(reference);
-      }
-
-      block.Complete();
-      await block.Completion;
-    }
-
-    public bool TryCompileAndCheckForErrors()
-    {
-      Contract.Assert(m_syntaxTrees.Any(), "Expected to have syntax trees loaded");
-      Contract.Assert(m_metadataReferences.Any(), "Expected to have references loaded");
-
-      m_compilation = CSharpCompilation.Create(
-        "temp",
-        m_syntaxTrees,
-        m_metadataReferences,
-        new CSharpCompilationOptions(OutputKind.WindowsRuntimeMetadata)
-      );
-
-      Contract.Assert(m_compilation != null, "Expect Microsoft.Net.Compilers to always return a compilation unit.");
-
-      m_diagnostics.AddRange(m_compilation
-        .GetDiagnostics(m_cancellationToken)
-        .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
-        );
-      if (m_diagnostics.Count > 0)
-      {
-        return false;
-      }
-
-      return ReactTypes.TryLoad(m_compilation, m_diagnostics, out m_reactTypes);
-    }
-
-    internal IEnumerable<INamedTypeSymbol> GetAllTypes()
-    {
-      Contract.Assert(m_compilation != null, "Expected to have a compilation. Must call CompileAndCheckForErrors first");
-
-      var allTypes = new List<INamedTypeSymbol>();
-      CollectTypes(m_compilation.Assembly.GlobalNamespace, allTypes);
-      return allTypes;
-    }
-
-    public ReactAssembly AnalyzeAndConstructAssemblyModel()
-    {
-      Contract.Assert(m_compilation != null, "Expected to have a compilation. Must call CompileAndCheckForErrors first");
-
-      var assembly = new ReactAssembly();
-      var proceseedTypes = new HashSet<ITypeSymbol>();
-
-      foreach (var type in GetAllTypes())
-      {
-        if (TryExtractModule(type, out var module))
-        {
-          assembly.Modules.Add(module);
-        }
-
-        if (IsViewManager(type))
-        {
-          assembly.ViewManagers.Add(type);
-        }
-
-        // Proactively register serializable types.
-        switch (type.TypeKind)
-        {
-          case TypeKind.Enum:
-            assembly.SerializableTypes.Add(type, type.TypeKind);
-            break;
-        }
-
-        // Register extension methods
-        if (type.MightContainExtensionMethods)
-        {
-          foreach (var member in type.GetMembers())
-          {
-            if (member is IMethodSymbol method)
+            get
             {
-              if (method.IsExtensionMethod &&
-                  method.Parameters.Length == 2 &&
-                  !(method.Parameters[1].Type is ITypeParameterSymbol))
+                Contract.Assert(m_reactTypes != null);
+                return m_reactTypes;
+            }
+        }
+
+
+        private readonly List<Diagnostic> m_diagnostics = new List<Diagnostic>();
+        public IEnumerable<Diagnostic> Diagnostics => m_diagnostics;
+
+        public CodeAnalyzer(CancellationToken cancellationToken)
+        {
+            m_cancellationToken = cancellationToken;
+        }
+
+        internal void AddSyntaxTree(SyntaxTree syntaxTree)
+        {
+            m_syntaxTrees.Add(syntaxTree);
+        }
+
+        public async Task ParseSourceFilesAsync(IEnumerable<string> sourceFiles, IEnumerable<string>? preprocessorSymbols)
+        {
+            var csharpParseOptions = new CSharpParseOptions(
+              preprocessorSymbols: preprocessorSymbols,
+              languageVersion: LanguageVersion.Latest);
+
+            var block = new ActionBlock<string>(async file =>
+            {
+                string text = await File.ReadAllTextAsync(file, m_cancellationToken);
+                AddSyntaxTree(CSharpSyntaxTree.ParseText(text, path: file, options: csharpParseOptions));
+            },
+            new ExecutionDataflowBlockOptions()
+            {
+                MaxDegreeOfParallelism = ConcurrencyLevel,
+                CancellationToken = m_cancellationToken,
+            });
+            foreach (var sourceFile in sourceFiles)
+            {
+                block.Post(sourceFile);
+            }
+
+            block.Complete();
+            await block.Completion;
+        }
+
+        public async Task LoadMetadataReferencesAsync(IEnumerable<string> references)
+        {
+            var block = new ActionBlock<string>(file =>
               {
-                if (method.Parameters[0].Type.Equals(ReactTypes.JSValueReader, SymbolEqualityComparer.Default) &&
-                    method.Parameters[1].RefKind == RefKind.Out)
+                  m_metadataReferences.Add(MetadataReference.CreateFromFile(file));
+              },
+              new ExecutionDataflowBlockOptions()
+              {
+                  MaxDegreeOfParallelism = ConcurrencyLevel,
+                  CancellationToken = m_cancellationToken,
+              });
+            foreach (var reference in references.Distinct())
+            {
+                block.Post(reference);
+            }
+
+            block.Complete();
+            await block.Completion;
+        }
+
+        public bool TryCompileAndCheckForErrors()
+        {
+            Contract.Assert(m_syntaxTrees.Any(), "Expected to have syntax trees loaded");
+            Contract.Assert(m_metadataReferences.Any(), "Expected to have references loaded");
+
+            m_compilation = CSharpCompilation.Create(
+              "temp",
+              m_syntaxTrees,
+              m_metadataReferences,
+              new CSharpCompilationOptions(OutputKind.WindowsRuntimeMetadata)
+            );
+
+            Contract.Assert(m_compilation != null, "Expect Microsoft.Net.Compilers to always return a compilation unit.");
+
+            m_diagnostics.AddRange(m_compilation
+              .GetDiagnostics(m_cancellationToken)
+              .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+              );
+            if (m_diagnostics.Count > 0)
+            {
+                return false;
+            }
+
+            return ReactTypes.TryLoad(m_compilation, m_diagnostics, out m_reactTypes);
+        }
+
+        internal IEnumerable<INamedTypeSymbol> GetAllTypes()
+        {
+            Contract.Assert(m_compilation != null, "Expected to have a compilation. Must call CompileAndCheckForErrors first");
+
+            var allTypes = new List<INamedTypeSymbol>();
+            CollectTypes(m_compilation.Assembly.GlobalNamespace, allTypes);
+            return allTypes;
+        }
+
+        public ReactAssembly AnalyzeAndConstructAssemblyModel()
+        {
+            Contract.Assert(m_compilation != null, "Expected to have a compilation. Must call CompileAndCheckForErrors first");
+
+            var assembly = new ReactAssembly();
+            var proceseedTypes = new HashSet<ITypeSymbol>();
+
+            foreach (var type in GetAllTypes())
+            {
+                if (TryExtractModule(type, out var module))
                 {
-                  assembly.JSReaderFunctions.Add(method.Parameters[1].Type, method);
+                    assembly.Modules.Add(module);
                 }
-                else if (method.Parameters[0].Type.Equals(ReactTypes.JSValueWriter, SymbolEqualityComparer.Default))
+
+                if (IsViewManager(type))
                 {
-                  assembly.JSWriterFunctions.Add(method.Parameters[1].Type, method);
+                    assembly.ViewManagers.Add(type);
                 }
-              }
+
+                // Proactively register serializable types.
+                switch (type.TypeKind)
+                {
+                    case TypeKind.Enum:
+                        assembly.SerializableTypes.Add(type, type.TypeKind);
+                        break;
+                }
+
+                // Register extension methods
+                if (type.MightContainExtensionMethods)
+                {
+                    foreach (var member in type.GetMembers())
+                    {
+                        if (member is IMethodSymbol method)
+                        {
+                            if (method.IsExtensionMethod &&
+                                method.Parameters.Length == 2 &&
+                                !(method.Parameters[1].Type is ITypeParameterSymbol))
+                            {
+                                if (method.Parameters[0].Type.Equals(ReactTypes.JSValueReader, SymbolEqualityComparer.Default) &&
+                                    method.Parameters[1].RefKind == RefKind.Out)
+                                {
+                                    assembly.JSReaderFunctions.Add(method.Parameters[1].Type, method);
+                                }
+                                else if (method.Parameters[0].Type.Equals(ReactTypes.JSValueWriter, SymbolEqualityComparer.Default))
+                                {
+                                    assembly.JSWriterFunctions.Add(method.Parameters[1].Type, method);
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
 
-      foreach (var module in assembly.Modules)
-      {
-        foreach (var method in module.Methods)
-        {
-          AddSerializableMethod(method.Method);
-        }
-
-        foreach (var constant in module.Constants)
-        {
-          if (constant.Symbol is IFieldSymbol field)
-          {
-            AddSerializableType(field.Type);
-          }
-          else if (constant.Symbol is IPropertySymbol property)
-          {
-            AddSerializableType(property.Type);
-          }
-        }
-
-        foreach (var callback in module.Events.Union<ReactCallback>(module.Functions))
-        {
-          foreach (var param in callback.CallbackParameters)
-          {
-            AddSerializableType(param.Type);
-          }
-        }
-      }
-
-      void AddSerializableMethod(IMethodSymbol method)
-      {
-        AddSerializableType(method.ReturnType);
-        foreach (var param in method.Parameters)
-        {
-          AddSerializableType(param.Type);
-        }
-      }
-
-      void AddSerializableType(ITypeSymbol type)
-      {
-        if (proceseedTypes.Contains(type))
-        {
-          return;
-        }
-
-        proceseedTypes.Add(type);
-
-        if (type is INamedTypeSymbol namedType)
-        {
-          if (type.TypeKind == TypeKind.Delegate)
-          {
-            Contract.Assert(namedType.DelegateInvokeMethod != null);
-
-            AddSerializableMethod(namedType.DelegateInvokeMethod);
-          }
-          else if (type.ContainingAssembly.Equals(m_compilation.Assembly, SymbolEqualityComparer.Default))
-          {
-            if (namedType.TypeKind == TypeKind.Class)
+            foreach (var module in assembly.Modules)
             {
-              // Check that classes have a default constructor.
-              if (!namedType
-                .GetMembers()
-                .Any(member =>
-                  member is IMethodSymbol method &&
-                  method.MethodKind == MethodKind.Constructor &&
-                  method.Parameters.Length == 0))
-              {
+                foreach (var method in module.Methods)
+                {
+                    AddSerializableMethod(method.Method);
+                }
 
-              }
+                foreach (var constant in module.Constants)
+                {
+                    if (constant.Symbol is IFieldSymbol field)
+                    {
+                        AddSerializableType(field.Type);
+                    }
+                    else if (constant.Symbol is IPropertySymbol property)
+                    {
+                        AddSerializableType(property.Type);
+                    }
+                }
+
+                foreach (var callback in module.Events.Union<ReactCallback>(module.Functions))
+                {
+                    foreach (var param in callback.CallbackParameters)
+                    {
+                        AddSerializableType(param.Type);
+                    }
+                }
             }
 
-            assembly.SerializableTypes.Add(namedType, namedType.TypeKind);
-          }
-        }
-      }
-
-      return assembly;
-    }
-
-    internal bool IsViewManager(INamedTypeSymbol type)
-    {
-      return !type.IsAbstract && type.AllInterfaces.Any(iface => iface.Equals(ReactTypes.IViewManagerType, SymbolEqualityComparer.Default));
-    }
-
-    internal bool TryExtractModule(INamedTypeSymbol type, [NotNullWhen(returnValue: true)] out ReactModule? module)
-    {
-      if (TryFindAttribute(type, ReactTypes.ReactModuleAttribute, out var attr))
-      {
-        string? moduleName = null;
-        string? eventEmitterName = null;
-
-        if (attr.ConstructorArguments.Length > 0)
-        {
-          moduleName = attr.ConstructorArguments[0].Value as string;
-        }
-
-        foreach (var namedArgument in attr.NamedArguments)
-        {
-          switch (namedArgument.Key)
-          {
-            case nameof(ReactModuleAttribute.ModuleName):
-              moduleName = namedArgument.Value.Value as string;
-              break;
-            case nameof(ReactModuleAttribute.EventEmitterName):
-              eventEmitterName = namedArgument.Value.Value as string;
-              break;
-            default:
-              var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
-              m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.UnexpectedPropertyInAttribute, location ?? Location.None, namedArgument.Key, attr.AttributeClass?.Name));
-              module = null;
-              return false;
-          }
-        }
-
-        moduleName ??= type.Name;
-        eventEmitterName ??= ReactNativeNames.DefaultEventEmitterName;
-
-        module = new ReactModule(type, moduleName, eventEmitterName);
-
-        foreach (var member in type.GetMembers())
-        {
-          if (member is IMethodSymbol method)
-          {
-            if (TryExtractMethod(method, out var asyncMethod))
+            void AddSerializableMethod(IMethodSymbol method)
             {
-              module.Methods.Add(asyncMethod);
+                AddSerializableType(method.ReturnType);
+                foreach (var param in method.Parameters)
+                {
+                    AddSerializableType(param.Type);
+                }
             }
-            else if (TryExtractSyncMethod(method, out var syncMethod))
+
+            void AddSerializableType(ITypeSymbol type)
             {
-              module.Methods.Add(syncMethod);
+                if (proceseedTypes.Contains(type))
+                {
+                    return;
+                }
+
+                proceseedTypes.Add(type);
+
+                if (type is INamedTypeSymbol namedType)
+                {
+                    if (type.TypeKind == TypeKind.Delegate)
+                    {
+                        Contract.Assert(namedType.DelegateInvokeMethod != null);
+
+                        AddSerializableMethod(namedType.DelegateInvokeMethod);
+                    }
+                    else if (type.ContainingAssembly.Equals(m_compilation.Assembly, SymbolEqualityComparer.Default))
+                    {
+                        if (namedType.TypeKind == TypeKind.Class)
+                        {
+                            // Check that classes have a default constructor.
+                            if (!namedType
+                              .GetMembers()
+                              .Any(member =>
+                                member is IMethodSymbol method &&
+                                method.MethodKind == MethodKind.Constructor &&
+                                method.Parameters.Length == 0))
+                            {
+
+                            }
+                        }
+
+                        assembly.SerializableTypes.Add(namedType, namedType.TypeKind);
+                    }
+                }
             }
-            else if (TryExtractInitializer(method, out var initializer))
+
+            return assembly;
+        }
+
+        internal bool IsViewManager(INamedTypeSymbol type)
+        {
+            return !type.IsAbstract && type.AllInterfaces.Any(iface => iface.Equals(ReactTypes.IViewManagerType, SymbolEqualityComparer.Default));
+        }
+
+        internal bool TryExtractModule(INamedTypeSymbol type, [NotNullWhen(returnValue: true)] out ReactModule? module)
+        {
+            if (TryFindAttribute(type, ReactTypes.ReactModuleAttribute, out var attr))
             {
-              module.Initializers.Add(initializer);
+                string? moduleName = null;
+                string? eventEmitterName = null;
+
+                if (attr.ConstructorArguments.Length > 0)
+                {
+                    moduleName = attr.ConstructorArguments[0].Value as string;
+                }
+
+                foreach (var namedArgument in attr.NamedArguments)
+                {
+                    switch (namedArgument.Key)
+                    {
+                        case nameof(ReactModuleAttribute.ModuleName):
+                            moduleName = namedArgument.Value.Value as string;
+                            break;
+                        case nameof(ReactModuleAttribute.EventEmitterName):
+                            eventEmitterName = namedArgument.Value.Value as string;
+                            break;
+                        default:
+                            var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
+                            m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.UnexpectedPropertyInAttribute, location ?? Location.None, namedArgument.Key, attr.AttributeClass?.Name));
+                            module = null;
+                            return false;
+                    }
+                }
+
+                moduleName ??= type.Name;
+                eventEmitterName ??= ReactNativeNames.DefaultEventEmitterName;
+
+                module = new ReactModule(type, moduleName, eventEmitterName);
+
+                foreach (var member in type.GetMembers())
+                {
+                    if (member is IMethodSymbol method)
+                    {
+                        if (TryExtractMethod(method, out var asyncMethod))
+                        {
+                            module.Methods.Add(asyncMethod);
+                        }
+                        else if (TryExtractSyncMethod(method, out var syncMethod))
+                        {
+                            module.Methods.Add(syncMethod);
+                        }
+                        else if (TryExtractInitializer(method, out var initializer))
+                        {
+                            module.Initializers.Add(initializer);
+                        }
+                        else if (TryExtractConstantProvider(method, out var constantProvider))
+                        {
+                            module.ConstantProviders.Add(constantProvider);
+                        }
+                    }
+                    else if (member is IPropertySymbol || member is IFieldSymbol)
+                    {
+                        if (TryExtractConstant(member, out var constant))
+                        {
+                            module.Constants.Add(constant);
+                        }
+                        else if (TryExtractEvent(member, eventEmitterName, out var evnt))
+                        {
+                            module.Events.Add(evnt);
+                        }
+                        else if (TryExtractFunction(member, moduleName, out var function))
+                        {
+                            module.Functions.Add(function);
+                        }
+                    }
+                }
+
+                return true;
             }
-            else if (TryExtractConstantProvider(method, out var constantProvider))
+
+            module = null;
+            return false;
+        }
+
+        private bool TryExtractMethod(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactMethod? reactMethod)
+        {
+            return TryExtractMethodFromAttributeData(method, ReactTypes.ReactMethodAttribute, synchronous: false, out reactMethod);
+        }
+
+        private bool TryExtractSyncMethod(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactMethod? reactMethod)
+        {
+            return TryExtractMethodFromAttributeData(method, ReactTypes.ReactSyncMethodAttribute, synchronous: true, out reactMethod);
+        }
+
+        private bool TryExtractMethodFromAttributeData(
+          IMethodSymbol method,
+          INamedTypeSymbol attributeType,
+          bool synchronous,
+          [NotNullWhen(returnValue: true)] out ReactMethod? reactMethod)
+        {
+            Contract.Requires(m_reactTypes != null);
+
+            if (TryFindAttribute(method, attributeType, out var attr))
             {
-              module.ConstantProviders.Add(constantProvider);
+                string? name = null;
+                if (attr.ConstructorArguments.Length > 0)
+                {
+                    name = attr.ConstructorArguments[0].Value as string;
+                }
+
+                foreach (var namedArgument in attr.NamedArguments)
+                {
+                    switch (namedArgument.Key)
+                    {
+                        case nameof(ReactMethodAttribute.MethodName):
+                            name = namedArgument.Value.Value as string;
+                            break;
+                        default:
+                            var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
+                            m_diagnostics.Add(Diagnostic.Create(
+                              DiagnosticDescriptors.UnexpectedPropertyInAttribute,
+                              location ?? Location.None,
+                              namedArgument.Key,
+                              attr.AttributeClass?.Name));
+                            reactMethod = null;
+                            return false;
+                    }
+                }
+
+                ReactMethod.MethodReturnStyle? returnStyle = null;
+
+                // Compute the effective parameters
+                var effectiveParameters = new List<IParameterSymbol>();
+                ITypeSymbol effectiveReturnType = m_reactTypes.SystemVoid;
+                var parameters = method.Parameters;
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    var param = parameters[i];
+                    bool skipReadingArg = false;
+
+                    if (!synchronous) // IsSynchronous methods don't have support for the callbacks
+                    {
+                        if (i == parameters.Length - 1)
+                        {
+                            if (IsPromiseType(parameters[i].Type, out var promiseGenericType))
+                            {
+                                returnStyle = ReactMethod.MethodReturnStyle.Promise;
+                                effectiveReturnType = promiseGenericType;
+                                skipReadingArg = true;
+                            }
+
+                            // if the last argument is a callback, assume this is the resolve or resolve function
+                            if (IsSingleArgCallback(parameters[i].Type, out var currentCallBackType))
+                            {
+                                ITypeSymbol? previousCallBackType = null;
+                                var isReject = parameters.Length >= 2 &&
+                                               IsSingleArgCallback(parameters[i - 1].Type, out previousCallBackType);
+                                effectiveReturnType = isReject
+                                  ? previousCallBackType!
+                                  : currentCallBackType!;
+                                returnStyle = isReject
+                                  ? ReactMethod.MethodReturnStyle.TwoCallbacks
+                                  : ReactMethod.MethodReturnStyle.Callback;
+
+                                skipReadingArg = true;
+                            }
+                        }
+                        else if (i == parameters.Length - 2)
+                        {
+                            // if the last 2 argument are callbacks, assume this is the resolve function
+                            if (IsSingleArgCallback(parameters[i].Type, out var resolveCallBackType) &&
+                                IsSingleArgCallback(parameters[i + 1].Type, out _))
+                            {
+                                effectiveReturnType = resolveCallBackType;
+                                returnStyle = ReactMethod.MethodReturnStyle.TwoCallbacks;
+                                skipReadingArg = true;
+                            }
+                        }
+                    }
+
+                    if (!skipReadingArg)
+                    {
+                        effectiveParameters.Add(param);
+                    }
+                }
+
+                if (returnStyle == null)
+                {
+                    if (IsTaskType(method.ReturnType, out var taskReturnType))
+                    {
+                        if (synchronous)
+                        {
+                            m_diagnostics.Add(Diagnostic.Create(
+                              DiagnosticDescriptors.MethodShouldNotReturnTaskWhenSynchronous,
+                              method.GetLocation() ?? Location.None,
+                              method.Name,
+                              attr.AttributeClass?.Name));
+                            reactMethod = null;
+                            return false;
+                        }
+
+                        effectiveReturnType = taskReturnType;
+                        returnStyle = ReactMethod.MethodReturnStyle.Task;
+                    }
+                    else if (method.ReturnsVoid)
+                    {
+                        returnStyle = ReactMethod.MethodReturnStyle.Void;
+                    }
+                    else
+                    {
+                        returnStyle = ReactMethod.MethodReturnStyle.ReturnValue;
+                    }
+                }
+
+                name ??= method.Name;
+
+                reactMethod = new ReactMethod(method, name, returnStyle.Value, effectiveReturnType, effectiveParameters, synchronous);
+                return true;
             }
-          }
-          else if (member is IPropertySymbol || member is IFieldSymbol)
-          {
-            if (TryExtractConstant(member, out var constant))
+
+            reactMethod = null;
+            return false;
+        }
+
+        private bool TryExtractConstantProvider(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactConstantProvider? constantProvider)
+        {
+            constantProvider = null;
+            if (TryFindAttribute(method, ReactTypes.ReactConstantProviderAttribute, out _))
             {
-              module.Constants.Add(constant);
+                if (!IsAccessible(method))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.ConstantProviderMustBePublicOrInternal,
+                        method.GetLocation(),
+                        method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        method.Name,
+                        method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        method.DeclaredAccessibility
+                      ));
+                    return false;
+                }
+
+                if (!method.ReturnsVoid)
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.ConstantProviderMustReturnVoid,
+                        method.GetLocation(),
+                        method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        method.Name,
+                        method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                      ));
+                    return false;
+                }
+
+                if (method.Parameters.Length != 1 || !method.Parameters[0].Type.Equals(ReactTypes.ReactConstantProvider, SymbolEqualityComparer.Default))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.ConstantProviderMustHaveOneParameterOfTypeReactContext,
+                        method.GetLocation(),
+                        ReactTypes.ReactConstantProvider.ToDisplayParts(SymbolDisplayFormat.FullyQualifiedFormat),
+                        method.Parameters.Length.ToString(CultureInfo.InvariantCulture),
+                        method.Name,
+                        method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                      ));
+                    return false;
+                }
+
+                constantProvider = new ReactConstantProvider(method);
+                return true;
             }
-            else if (TryExtractEvent(member, eventEmitterName, out var evnt))
+
+            constantProvider = null;
+            return false;
+        }
+
+        private bool TryExtractInitializer(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactInitializer? initializer)
+        {
+            initializer = null;
+            if (TryFindAttribute(method, ReactTypes.ReactInitializerAttribute, out _))
             {
-              module.Events.Add(evnt);
+                if (!IsAccessible(method))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.InitializersMustBePublicOrInternal,
+                        method.GetLocation(),
+                        method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        method.Name,
+                        method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        method.DeclaredAccessibility
+                      ));
+                    return false;
+                }
+
+                if (!method.ReturnsVoid)
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.InitializersMustReturnVoid,
+                        method.GetLocation(),
+                        method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        method.Name,
+                        method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                        ));
+                    return false;
+                }
+
+                if (method.Parameters.Length != 1 || !method.Parameters[0].Type.Equals(ReactTypes.ReactContext, SymbolEqualityComparer.Default))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.InitializersMustHaveOneParameterOfTypeReactContext,
+                        method.GetLocation(),
+                        ReactTypes.ReactContext.ToDisplayParts(SymbolDisplayFormat.FullyQualifiedFormat),
+                        method.Parameters.Length.ToString(CultureInfo.InvariantCulture),
+                        method.Name,
+                        method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+                      ));
+                    return false;
+                }
+
+                initializer = new ReactInitializer(method);
+                return true;
             }
-            else if (TryExtractFunction(member, moduleName, out var function))
+
+            return false;
+        }
+
+        private bool TryExtractConstant(ISymbol symbol, [NotNullWhen(returnValue: true)] out ReactConstant? constant)
+        {
+            if (TryFindAttribute(symbol, ReactTypes.ReactConstantAttribute, out var attr))
             {
-              module.Functions.Add(function);
+                string? name = null;
+                if (attr.ConstructorArguments.Length > 0)
+                {
+                    name = attr.ConstructorArguments[0].Value as string;
+                }
+
+                foreach (var namedArgument in attr.NamedArguments)
+                {
+                    switch (namedArgument.Key)
+                    {
+                        case nameof(ReactConstantAttribute.ConstantName):
+                            name = namedArgument.Value.Value as string;
+                            break;
+                        default:
+                            var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
+                            m_diagnostics.Add(Diagnostic.Create(
+                              DiagnosticDescriptors.UnexpectedPropertyInAttribute,
+                              location ?? Location.None,
+                              namedArgument.Key,
+                              attr.AttributeClass?.Name));
+                            constant = null;
+                            return false;
+                    }
+                }
+
+                name ??= symbol.Name;
+
+                if (!IsAccessible(symbol))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.ConstantsMustBePublicOrInternal,
+                        symbol.GetLocation(),
+                        symbol.Name,
+                        symbol.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        symbol.DeclaredAccessibility
+                      ));
+                    constant = null;
+                    return false;
+                }
+
+                if (symbol is IPropertySymbol property && (property.GetMethod == null || !IsAccessible(property.GetMethod)))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.ConstantsMustBeGettable,
+                        symbol.GetLocation(),
+                        property.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+                    constant = null;
+                    return false;
+                }
+
+                constant = new ReactConstant(symbol, name);
+                return true;
             }
-          }
+
+            constant = null;
+            return false;
         }
 
-        return true;
-      }
-
-      module = null;
-      return false;
-    }
-
-    private bool TryExtractMethod(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactMethod? reactMethod)
-    {
-      return TryExtractMethodFromAttributeData(method, ReactTypes.ReactMethodAttribute, synchronous: false, out reactMethod);
-    }
-
-    private bool TryExtractSyncMethod(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactMethod? reactMethod)
-    {
-      return TryExtractMethodFromAttributeData(method, ReactTypes.ReactSyncMethodAttribute, synchronous: true, out reactMethod);
-    }
-
-    private bool TryExtractMethodFromAttributeData(
-      IMethodSymbol method,
-      INamedTypeSymbol attributeType,
-      bool synchronous,
-      [NotNullWhen(returnValue: true)] out ReactMethod? reactMethod)
-    {
-      if (TryFindAttribute(method, attributeType, out var attr))
-      {
-        string? name = null;
-        if (attr.ConstructorArguments.Length > 0)
+        private bool TryExtractEvent(ISymbol symbol, string defaultEventEmitterName, [NotNullWhen(returnValue: true)] out ReactEvent? reactEvent)
         {
-          name = attr.ConstructorArguments[0].Value as string;
-        }
-
-        foreach (var namedArgument in attr.NamedArguments)
-        {
-          switch (namedArgument.Key)
-          {
-            case nameof(ReactMethodAttribute.MethodName):
-              name = namedArgument.Value.Value as string;
-              break;
-            default:
-              var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
-              m_diagnostics.Add(Diagnostic.Create(
-                DiagnosticDescriptors.UnexpectedPropertyInAttribute,
-                location ?? Location.None,
-                namedArgument.Key,
-                attr.AttributeClass?.Name));
-              reactMethod = null;
-              return false;
-          }
-        }
-
-        ReactMethod.MethodReturnStyle? returnStyle = null;
-
-        // Compute the effective parameters
-        var effectiveParameters = new List<IParameterSymbol>();
-        ITypeSymbol effectiveReturnType = m_reactTypes.SystemVoid;
-        var parameters = method.Parameters;
-        for (int i = 0; i < parameters.Length; i++)
-        {
-          var param = parameters[i];
-          bool skipReadingArg = false;
-
-          if (!synchronous) // IsSynchronous methods don't have support for the callbacks
-          {
-            if (i == parameters.Length - 1)
+            if (TryExtractCallback(symbol, defaultEventEmitterName, ReactTypes.ReactEventAttribute, out var callbackParameters, out var name, out var declaredModuleName))
             {
-              if (IsPromiseType(parameters[i].Type, out var promiseGenericType))
-              {
-                returnStyle = ReactMethod.MethodReturnStyle.Promise;
-                effectiveReturnType = promiseGenericType;
-                skipReadingArg = true;
-              }
-
-              // if the last argument is a callback, assume this is the resolve or resolve function
-              if (IsSingleArgCallback(parameters[i].Type, out var currentCallBackType))
-              {
-                ITypeSymbol? previousCallBackType = null;
-                var isReject = parameters.Length >= 2 &&
-                               IsSingleArgCallback(parameters[i - 1].Type, out previousCallBackType);
-                effectiveReturnType = isReject
-                  ? previousCallBackType!
-                  : currentCallBackType!;
-                returnStyle = isReject
-                  ? ReactMethod.MethodReturnStyle.TwoCallbacks
-                  : ReactMethod.MethodReturnStyle.Callback;
-
-                skipReadingArg = true;
-              }
+                reactEvent = new ReactEvent(symbol, callbackParameters, name, declaredModuleName);
+                return true;
             }
-            else if (i == parameters.Length - 2)
+
+            reactEvent = null;
+            return false;
+        }
+
+        private bool TryExtractFunction(ISymbol symbol, string moduleName, [NotNullWhen(returnValue: true)] out ReactFunction? function)
+        {
+            if (TryExtractCallback(symbol, moduleName, ReactTypes.ReactFunctionAttribute, out var callbackParameters, out var name, out var declaredModuleName))
             {
-              // if the last 2 argument are callbacks, assume this is the resolve function
-              if (IsSingleArgCallback(parameters[i].Type, out var resolveCallBackType) &&
-                  IsSingleArgCallback(parameters[i + 1].Type, out _))
-              {
-                effectiveReturnType = resolveCallBackType;
-                returnStyle = ReactMethod.MethodReturnStyle.TwoCallbacks;
-                skipReadingArg = true;
-              }
+                function = new ReactFunction(symbol, callbackParameters, name, declaredModuleName);
+                return true;
             }
-          }
 
-          if (!skipReadingArg)
-          {
-            effectiveParameters.Add(param);
-          }
+            function = null;
+            return false;
         }
 
-        if (returnStyle == null)
+        private bool TryExtractCallback(
+          ISymbol symbol,
+          string defaultCallbackContextName,
+          INamedTypeSymbol attribute,
+          out ImmutableArray<IParameterSymbol> callbackParameters,
+          [NotNullWhen(returnValue: true)] out string? name,
+          [NotNullWhen(returnValue: true)] out string? callbackContextName)
         {
-          if (IsTaskType(method.ReturnType, out var taskReturnType))
-          {
-            if (synchronous)
+            callbackParameters = default;
+            name = null;
+            callbackContextName = null;
+
+            if (TryFindAttribute(symbol, attribute, out var attr))
             {
-              m_diagnostics.Add(Diagnostic.Create(
-                DiagnosticDescriptors.MethodShouldNotReturnTaskWhenSynchronous,
-                method.GetLocation() ?? Location.None,
-                method.Name,
-                attr.AttributeClass?.Name));
-              reactMethod = null;
-              return false;
+                name = null;
+                callbackContextName = null;
+                if (attr.ConstructorArguments.Length > 0)
+                {
+                    name = attr.ConstructorArguments[0].Value as string;
+                }
+
+                foreach (var namedArgument in attr.NamedArguments)
+                {
+                    switch (namedArgument.Key)
+                    {
+                        case nameof(ReactFunctionAttribute.FunctionName):
+                        case nameof(ReactEventAttribute.EventName):
+                            name = namedArgument.Value.Value as string;
+                            break;
+                        case nameof(ReactFunctionAttribute.ModuleName):
+                        case nameof(ReactEventAttribute.EventEmitterName):
+                            callbackContextName = namedArgument.Value.Value as string;
+                            break;
+                        default:
+                            var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
+                            m_diagnostics.Add(Diagnostic.Create(
+                              DiagnosticDescriptors.UnexpectedPropertyInAttribute,
+                              location ?? Location.None,
+                              namedArgument.Key,
+                              attr.AttributeClass?.Name));
+                            return false;
+                    }
+                }
+
+                ITypeSymbol? type = null;
+                switch (symbol)
+                {
+                    case IPropertySymbol property:
+                        type = property.Type;
+
+                        if (property.SetMethod == null || !IsAccessible(property.SetMethod))
+                        {
+                            m_diagnostics.Add(
+                              Diagnostic.Create(DiagnosticDescriptors.CallbacksMustBeSettable,
+                                symbol.GetLocation(),
+                                property.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                                symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+                            return false;
+                        }
+
+                        break;
+                    case IFieldSymbol field:
+                        type = field.Type;
+                        break;
+                    default:
+                        throw Contract.AssertFailure("Unsupported symbol");
+                }
+
+                if (!IsAccessible(symbol))
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.CallbackMustBePublicOrInternal,
+                        symbol.GetLocation(),
+                        symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat),
+                        symbol.DeclaredAccessibility));
+                    return false;
+                }
+
+                if (!(type is INamedTypeSymbol namedType) || namedType.DelegateInvokeMethod == null)
+                {
+                    m_diagnostics.Add(
+                      Diagnostic.Create(DiagnosticDescriptors.CallbackTypeMustBeDelegate,
+                        symbol.GetLocation(),
+                        type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        symbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+                    return false;
+                }
+
+                if (!namedType.DelegateInvokeMethod.ReturnsVoid)
+                {
+                    var location = symbol.Locations.FirstOrDefault();
+                    m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CallbackDelegateMustReturnVoid, location,
+                      symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                      symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat),
+                      namedType.DelegateInvokeMethod.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+                    return false;
+                }
+
+                name ??= symbol.Name;
+                callbackContextName ??= defaultCallbackContextName;
+                callbackParameters = namedType.DelegateInvokeMethod.Parameters;
+
+                return true;
             }
 
-            effectiveReturnType = taskReturnType;
-            returnStyle = ReactMethod.MethodReturnStyle.Task;
-          }
-          else if (method.ReturnsVoid)
-          {
-            returnStyle = ReactMethod.MethodReturnStyle.Void;
-          }
-          else
-          {
-            returnStyle = ReactMethod.MethodReturnStyle.ReturnValue;
-          }
+            return false;
         }
 
-        name ??= method.Name;
-
-        reactMethod = new ReactMethod(method, name, returnStyle.Value, effectiveReturnType, effectiveParameters, synchronous);
-        return true;
-      }
-
-      reactMethod = null;
-      return false;
-    }
-
-    private bool TryExtractConstantProvider(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactConstantProvider? constantProvider)
-    {
-      constantProvider = null;
-      if (TryFindAttribute(method, ReactTypes.ReactConstantProviderAttribute, out _))
-      {
-        if (!IsAccessible(method))
+        private static void CollectTypes(INamespaceSymbol namespaceSymbol, ICollection<INamedTypeSymbol> result)
         {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.ConstantProviderMustBePublicOrInternal,
-              method.GetLocation(),
-              method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              method.Name,
-              method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              method.DeclaredAccessibility
-            ));
-          return false;
-        }
-
-        if (!method.ReturnsVoid)
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.ConstantProviderMustReturnVoid,
-              method.GetLocation(),
-              method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              method.Name,
-              method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
-            ));
-          return false;
-        }
-
-        if (method.Parameters.Length != 1 || !method.Parameters[0].Type.Equals(ReactTypes.ReactConstantProvider, SymbolEqualityComparer.Default))
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.ConstantProviderMustHaveOneParameterOfTypeReactContext,
-              method.GetLocation(),
-              ReactTypes.ReactConstantProvider.ToDisplayParts(SymbolDisplayFormat.FullyQualifiedFormat),
-              method.Parameters.Length.ToString(CultureInfo.InvariantCulture),
-              method.Name,
-              method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
-            ));
-          return false;
-        }
-
-        constantProvider = new ReactConstantProvider(method);
-        return true;
-      }
-
-      constantProvider = null;
-      return false;
-    }
-
-    private bool TryExtractInitializer(IMethodSymbol method, [NotNullWhen(returnValue: true)] out ReactInitializer? initializer)
-    {
-      initializer = null;
-      if (TryFindAttribute(method, ReactTypes.ReactInitializerAttribute, out _))
-      {
-        if (!IsAccessible(method))
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.InitializersMustBePublicOrInternal,
-              method.GetLocation(),
-              method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              method.Name,
-              method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              method.DeclaredAccessibility
-            ));
-          return false;
-        }
-
-        if (!method.ReturnsVoid)
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.InitializersMustReturnVoid,
-              method.GetLocation(),
-              method.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              method.Name,
-              method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
-              ));
-          return false;
-        }
-
-        if (method.Parameters.Length != 1 || !method.Parameters[0].Type.Equals(ReactTypes.ReactContext, SymbolEqualityComparer.Default))
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.InitializersMustHaveOneParameterOfTypeReactContext,
-              method.GetLocation(),
-              ReactTypes.ReactContext.ToDisplayParts(SymbolDisplayFormat.FullyQualifiedFormat),
-              method.Parameters.Length.ToString(CultureInfo.InvariantCulture),
-              method.Name,
-              method.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
-            ));
-          return false;
-        }
-
-        initializer = new ReactInitializer(method);
-        return true;
-      }
-
-      return false;
-    }
-
-    private bool TryExtractConstant(ISymbol symbol, [NotNullWhen(returnValue: true)] out ReactConstant? constant)
-    {
-      if (TryFindAttribute(symbol, ReactTypes.ReactConstantAttribute, out var attr))
-      {
-        string? name = null;
-        if (attr.ConstructorArguments.Length > 0)
-        {
-          name = attr.ConstructorArguments[0].Value as string;
-        }
-
-        foreach (var namedArgument in attr.NamedArguments)
-        {
-          switch (namedArgument.Key)
-          {
-            case nameof(ReactConstantAttribute.ConstantName):
-              name = namedArgument.Value.Value as string;
-              break;
-            default:
-              var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
-              m_diagnostics.Add(Diagnostic.Create(
-                DiagnosticDescriptors.UnexpectedPropertyInAttribute,
-                location ?? Location.None,
-                namedArgument.Key,
-                attr.AttributeClass?.Name));
-              constant = null;
-              return false;
-          }
-        }
-
-        name ??= symbol.Name;
-
-        if (!IsAccessible(symbol))
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.ConstantsMustBePublicOrInternal,
-              symbol.GetLocation(),
-              symbol.Name,
-              symbol.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              symbol.DeclaredAccessibility
-            ));
-          constant = null;
-          return false;
-        }
-
-        if (symbol is IPropertySymbol property && (property.GetMethod == null || !IsAccessible(property.GetMethod)))
-        {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.ConstantsMustBeGettable,
-              symbol.GetLocation(),
-              property.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
-          constant = null;
-          return false;
-        }
-
-        constant = new ReactConstant(symbol, name);
-        return true;
-      }
-
-      constant = null;
-      return false;
-    }
-
-    private bool TryExtractEvent(ISymbol symbol, string defaultEventEmitterName, [NotNullWhen(returnValue: true)] out ReactEvent? reactEvent)
-    {
-      if (TryExtractCallback(symbol, defaultEventEmitterName, ReactTypes.ReactEventAttribute, out var callbackParameters, out var name, out var declaredModuleName))
-      {
-        reactEvent = new ReactEvent(symbol, callbackParameters, name, declaredModuleName);
-        return true;
-      }
-
-      reactEvent = null;
-      return false;
-    }
-
-    private bool TryExtractFunction(ISymbol symbol, string moduleName, [NotNullWhen(returnValue: true)] out ReactFunction? function)
-    {
-      if (TryExtractCallback(symbol, moduleName, ReactTypes.ReactFunctionAttribute, out var callbackParameters, out var name, out var declaredModuleName))
-      {
-        function = new ReactFunction(symbol, callbackParameters, name, declaredModuleName);
-        return true;
-      }
-
-      function = null;
-      return false;
-    }
-
-    private bool TryExtractCallback(
-      ISymbol symbol,
-      string defaultCallbackContextName,
-      INamedTypeSymbol attribute,
-      out ImmutableArray<IParameterSymbol> callbackParameters,
-      [NotNullWhen(returnValue: true)] out string? name,
-      [NotNullWhen(returnValue: true)] out string? callbackContextName)
-    {
-      callbackParameters = default;
-      name = null;
-      callbackContextName = null;
-
-      if (TryFindAttribute(symbol, attribute, out var attr))
-      {
-        name = null;
-        callbackContextName = null;
-        if (attr.ConstructorArguments.Length > 0)
-        {
-          name = attr.ConstructorArguments[0].Value as string;
-        }
-
-        foreach (var namedArgument in attr.NamedArguments)
-        {
-          switch (namedArgument.Key)
-          {
-            case nameof(ReactFunctionAttribute.FunctionName):
-            case nameof(ReactEventAttribute.EventName):
-              name = namedArgument.Value.Value as string;
-              break;
-            case nameof(ReactFunctionAttribute.ModuleName):
-            case nameof(ReactEventAttribute.EventEmitterName):
-              callbackContextName = namedArgument.Value.Value as string;
-              break;
-            default:
-              var location = attr.ApplicationSyntaxReference?.SyntaxTree.GetLocation(attr.ApplicationSyntaxReference.Span);
-              m_diagnostics.Add(Diagnostic.Create(
-                DiagnosticDescriptors.UnexpectedPropertyInAttribute,
-                location ?? Location.None,
-                namedArgument.Key,
-                attr.AttributeClass?.Name));
-              return false;
-          }
-        }
-
-        ITypeSymbol? type = null;
-        switch (symbol)
-        {
-          case IPropertySymbol property:
-            type = property.Type;
-
-            if (property.SetMethod == null || !IsAccessible(property.SetMethod))
+            foreach (var type in namespaceSymbol.GetTypeMembers())
             {
-              m_diagnostics.Add(
-                Diagnostic.Create(DiagnosticDescriptors.CallbacksMustBeSettable,
-                  symbol.GetLocation(),
-                  property.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-                  symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
-              return false;
+                CollectTypes(type, result);
             }
 
-            break;
-          case IFieldSymbol field:
-            type = field.Type;
-            break;
-          default:
-            throw Contract.AssertFailure("Unsupported symbol");
+            foreach (var childNs in namespaceSymbol.GetNamespaceMembers())
+            {
+                CollectTypes(childNs, result);
+            }
         }
 
-        if (!IsAccessible(symbol))
+        private static void CollectTypes(INamedTypeSymbol type, ICollection<INamedTypeSymbol> result)
         {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.CallbackMustBePublicOrInternal,
-              symbol.GetLocation(),
-              symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat),
-              symbol.DeclaredAccessibility));
-          return false;
+            result.Add(type);
+
+            foreach (var nested in type.GetTypeMembers())
+            {
+                CollectTypes(nested, result);
+            }
         }
 
-        if (!(type is INamedTypeSymbol namedType) || namedType.DelegateInvokeMethod == null)
+        private bool TryFindAttribute(ISymbol symbol, INamedTypeSymbol attributeType, out AttributeData attr)
         {
-          m_diagnostics.Add(
-            Diagnostic.Create(DiagnosticDescriptors.CallbackTypeMustBeDelegate,
-              symbol.GetLocation(),
-              type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-              symbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
-          return false;
+            attr = symbol.GetAttributes().FirstOrDefault(potentialMatch => potentialMatch.AttributeClass != null && potentialMatch.AttributeClass.Equals(attributeType, SymbolEqualityComparer.Default));
+            return attr != null;
         }
 
-        if (!namedType.DelegateInvokeMethod.ReturnsVoid)
+        private bool IsAccessible(ISymbol symbol)
         {
-          var location = symbol.Locations.FirstOrDefault();
-          m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CallbackDelegateMustReturnVoid, location,
-            symbol.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-            symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat),
-            namedType.DelegateInvokeMethod.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
-          return false;
+            return symbol.DeclaredAccessibility == Accessibility.Public ||
+                   symbol.DeclaredAccessibility == Accessibility.Internal;
         }
 
-        name ??= symbol.Name;
-        callbackContextName ??= defaultCallbackContextName;
-        callbackParameters = namedType.DelegateInvokeMethod.Parameters;
+        private bool IsPromiseType(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? typeParameter)
+        {
+            Contract.Requires(m_reactTypes != null);
 
-        return true;
-      }
+            if (type != null &&
+                type is INamedTypeSymbol namedType &&
+                namedType.IsGenericType &&
+                namedType.ConstructUnboundGenericType()
+                  .Equals(m_reactTypes.IReactPromise.ConstructUnboundGenericType(), SymbolEqualityComparer.Default))
+            {
+                typeParameter = namedType.TypeArguments[0];
+                return true;
+            }
 
-      return false;
+            typeParameter = null;
+            return false;
+        }
+
+        private bool IsTaskType(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? taskReturnType)
+        {
+            Contract.Requires(m_reactTypes != null);
+
+            if (type.Equals(m_reactTypes.Task, SymbolEqualityComparer.Default))
+            {
+                taskReturnType = m_reactTypes.SystemVoid;
+                return true;
+            }
+
+            if (type != null &&
+                type is INamedTypeSymbol namedType &&
+                namedType.IsGenericType &&
+                namedType.ConstructUnboundGenericType()
+                  .Equals(m_reactTypes.TaskOfT, SymbolEqualityComparer.Default))
+            {
+                taskReturnType = namedType.TypeArguments[0];
+                return true;
+            }
+
+            taskReturnType = null;
+            return false;
+        }
+
+        private static bool IsSingleArgCallback(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? parameterType)
+        {
+            if (type is INamedTypeSymbol namedType &&
+                namedType.DelegateInvokeMethod != null &&
+                namedType.DelegateInvokeMethod.Parameters.Length == 1
+            )
+            {
+                parameterType = namedType.DelegateInvokeMethod.Parameters[0].Type;
+                return true;
+            }
+
+            parameterType = null;
+            return false;
+        }
     }
-
-    private static void CollectTypes(INamespaceSymbol namespaceSymbol, ICollection<INamedTypeSymbol> result)
-    {
-      foreach (var type in namespaceSymbol.GetTypeMembers())
-      {
-        CollectTypes(type, result);
-      }
-
-      foreach (var childNs in namespaceSymbol.GetNamespaceMembers())
-      {
-        CollectTypes(childNs, result);
-      }
-    }
-
-    private static void CollectTypes(INamedTypeSymbol type, ICollection<INamedTypeSymbol> result)
-    {
-      result.Add(type);
-
-      foreach (var nested in type.GetTypeMembers())
-      {
-        CollectTypes(nested, result);
-      }
-    }
-
-    private bool TryFindAttribute(ISymbol symbol, INamedTypeSymbol attributeType, out AttributeData attr)
-    {
-      attr = symbol.GetAttributes().FirstOrDefault(potentialMatch => potentialMatch.AttributeClass != null && potentialMatch.AttributeClass.Equals(attributeType, SymbolEqualityComparer.Default));
-      return attr != null;
-    }
-
-    private bool IsAccessible(ISymbol symbol)
-    {
-      return symbol.DeclaredAccessibility == Accessibility.Public ||
-             symbol.DeclaredAccessibility == Accessibility.Internal;
-    }
-
-    private bool IsPromiseType(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? typeParameter)
-    {
-      if (type != null &&
-          type is INamedTypeSymbol namedType &&
-          namedType.IsGenericType &&
-          namedType.ConstructUnboundGenericType()
-            .Equals(m_reactTypes.IReactPromise.ConstructUnboundGenericType(), SymbolEqualityComparer.Default))
-      {
-        typeParameter = namedType.TypeArguments[0];
-        return true;
-      }
-
-      typeParameter = null;
-      return false;
-    }
-
-    private bool IsTaskType(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? taskReturnType)
-    {
-      if (type == m_reactTypes.Task)
-      {
-        taskReturnType = m_reactTypes.SystemVoid;
-        return true;
-      }
-
-      if (type != null &&
-          type is INamedTypeSymbol namedType &&
-          namedType.IsGenericType &&
-          namedType.ConstructUnboundGenericType()
-            .Equals(m_reactTypes.TaskOfT, SymbolEqualityComparer.Default))
-      {
-        taskReturnType = namedType.TypeArguments[0];
-        return true;
-      }
-
-      taskReturnType = null;
-      return false;
-    }
-
-    private static bool IsSingleArgCallback(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? parameterType)
-    {
-      if (type is INamedTypeSymbol namedType &&
-          namedType.DelegateInvokeMethod != null &&
-          namedType.DelegateInvokeMethod.Parameters.Length == 1
-      )
-      {
-        parameterType = namedType.DelegateInvokeMethod.Parameters[0].Type;
-        return true;
-      }
-
-      parameterType = null;
-      return false;
-    }
-  }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Module.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Module.cs
@@ -1,501 +1,474 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.ReactNative.Managed.CodeGen.Model;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Microsoft.ReactNative.Managed.CodeGen.SyntaxHelpers;
 
 namespace Microsoft.ReactNative.Managed.CodeGen
 {
-  public partial class CodeGenerator
-  {
-    internal MemberDeclarationSyntax CreateModules(IEnumerable<ReactModule> modules)
+    public partial class CodeGenerator
     {
-      var addModuleStatements = new List<StatementSyntax>();
-      foreach (var module in modules)
-      {
-        var addMemberStatements = new List<StatementSyntax>();
-
-        // generates:
-        //  MyModule module = new MyModule();
-        addMemberStatements.Add(
-          LocalDeclarationStatement(module.ModuleType, ReactNativeNames.Module, ObjectCreationExpression(module.ModuleType)));
-
-        if (module.Constants.Any())
+        internal MemberDeclarationSyntax CreateModules(IEnumerable<ReactModule> modules)
         {
-          addMemberStatements.Add(AddConstants(module.Constants));
-        }
-
-        foreach (var constantProvider in module.ConstantProviders)
-        {
-          addMemberStatements.Add(AddConstantProvider(constantProvider));
-        }
-
-        foreach (var method in module.Methods)
-        {
-          addMemberStatements.Add(AddMethod(method));
-        }
-
-        foreach (var evnt in module.Events)
-        {
-          addMemberStatements.Add(AddEvent(evnt));
-        }
-
-        foreach (var function in module.Functions)
-        {
-          addMemberStatements.Add(AddFunction(function));
-        }
-
-        foreach (var initializer in module.Initializers)
-        {
-          addMemberStatements.Add(AddInitializer(initializer));
-        }
-
-        // generates
-        //  return module;
-        addMemberStatements.Add(
-          ReturnStatement(IdentifierName(ReactNativeNames.Module)));
-
-        // Generates:
-        //    packageBuilder.AddModule("MyViewManager", () => new global::MyApp.ViewManager);
-        addModuleStatements.Add(
-          InvocationStatement(
-            MemberAccessExpression(ReactNativeNames.PackageBuilderId, ReactNativeNames.AddModule),
-
-            LiteralExpression(module.ModuleName),
-            ParenthesizedLambdaExpression(
-              parameterList: ParameterList(
-                  Parameter(ReactNativeNames.ModuleBuilder)
-                    .WithType(m_reactTypes.IReactModuleBuilder.ToTypeSyntax())),
-                block: Block(
-                  addMemberStatements),
-                expressionBody: null)
-          )
-        );
-      }
-
-      // Generates:
-      //    internal void CreateModules(IPackageBuilder packageBuilder)
-      //    {
-      //       ... registrationCalls (ses above)
-      //    }
-      return MethodDeclaration(
-          PredefinedType(Token(SyntaxKind.VoidKeyword)),
-          ReactNativeNames.CreateModules)
-        .AddModifiers(
-          Token(SyntaxKind.InternalKeyword))
-        .AddParameterListParameters(
-          GetPackageBuilderArgument())
-        .WithBody(
-          Block(
-            addModuleStatements));
-    }
-
-    internal StatementSyntax AddConstants(IEnumerable<ReactConstant> constants)
-    {
-      // place all constants in a single constant provider
-      var statements = new List<StatementSyntax>();
-
-      // constants
-      foreach (var constant in constants)
-      {
-        // generates:
-        //   JSValueWriter.WriteObjectProperty(writer, "MyConst", module.MyConst);
-        statements.Add(
-          InvocationStatement(
-            MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteObjectPropertyMethodName),
-            IdentifierName(ReactNativeNames.WriterLocalName),
-            LiteralExpression(constant.Name),
-            MemberAccessExpression(ReactNativeNames.Module, Identifier(constant.Symbol.Name))));
-      }
-
-      // generates:
-      //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => { ... } );
-      return InvocationStatement(
-          MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
-
-          ParenthesizedLambdaExpression(
-            parameterList: ParameterList(
-                Parameter(ReactNativeNames.WriterLocalName)
-                  .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
-            block: Block(
-              statements),
-            expressionBody: null
-          )
-        );
-    }
-
-    internal StatementSyntax AddConstantProvider(ReactConstantProvider constantProvider)
-    {
-      // generates:
-      //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => {
-      //     var provider = new ReactConstantProvider(writer);
-      //     module.ConstantProviderName(provider);
-      //  });
-
-      return InvocationStatement(
-        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
-
-        ParenthesizedLambdaExpression(
-          parameterList: ParameterList(
-              Parameter(ReactNativeNames.WriterLocalName)
-                .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
-          block: Block(
-            LocalDeclarationStatement(
-              m_reactTypes.ReactConstantProvider,
-              ReactNativeNames.ProviderLocalName,
-              ObjectCreationExpression(
-                m_reactTypes.ReactConstantProvider,
-                IdentifierName(ReactNativeNames.WriterLocalName))),
-            InvocationStatement(
-              MemberAccessExpression(ReactNativeNames.Module, Identifier(constantProvider.Method.Name)),
-              IdentifierName(ReactNativeNames.ProviderLocalName))),
-          expressionBody: null
-        )
-      );
-    }
-
-    internal StatementSyntax AddMethod(ReactMethod method)
-    {
-      var statements = new List<StatementSyntax>();
-
-      string methodReturnType = "Void";
-
-      var parameters = method.Method.Parameters;
-
-      var readArgsArguments = new List<ArgumentSyntax>(parameters.Length);
-      readArgsArguments.Add(Argument(IdentifierName(ReactNativeNames.ReaderLocalName)));
-      var args = new List<ExpressionSyntax>(parameters.Length);
-
-      // generates:
-      //   (out ArgType0 arg0, out ArgType1 arg1, ...);
-      // as well as
-      //   (arg0, arg1, ... )
-      for (int i = 0; i < parameters.Length; i++)
-      {
-        var param = parameters[i];
-        bool skipReadingArg = false;
-
-        if (!method.IsSynchronous) // IsSynchronous methods don't have support for the callbacks
-        {
-          if (i == parameters.Length - 1)
-          {
-            if (IsPromiseType(parameters[i].Type, out var typeParameter))
+            var addModuleStatements = new List<StatementSyntax>();
+            foreach (var module in modules)
             {
-              // outArgs: Do not add an extra out parameter to be extracted from the JS side
+                var addMemberStatements = new List<StatementSyntax>();
 
-              // generates:
-              //    new ReactPromise<TResult>(writer, resolve, reject)
-              // to (arg0, arg1, ...) to be passed when calling the remoted method.
-              args.Add(ObjectCreationExpression(
-                m_reactTypes.ReactPromise.Construct(typeParameter),
-                IdentifierName(ReactNativeNames.WriterLocalName),
-                IdentifierName(ReactNativeNames.ResolveLocalName),
-                IdentifierName(ReactNativeNames.RejectLocalName)
-              ));
-              methodReturnType = "Promise";
-              skipReadingArg = true;
+                // generates:
+                //  MyModule module = new MyModule();
+                addMemberStatements.Add(
+                  LocalDeclarationStatement(module.ModuleType, ReactNativeNames.Module, ObjectCreationExpression(module.ModuleType)));
+
+                if (module.Constants.Any())
+                {
+                    addMemberStatements.Add(AddConstants(module.Constants));
+                }
+
+                foreach (var constantProvider in module.ConstantProviders)
+                {
+                    addMemberStatements.Add(AddConstantProvider(constantProvider));
+                }
+
+                foreach (var method in module.Methods)
+                {
+                    addMemberStatements.Add(AddMethod(method));
+                }
+
+                foreach (var evnt in module.Events)
+                {
+                    addMemberStatements.Add(AddEvent(evnt));
+                }
+
+                foreach (var function in module.Functions)
+                {
+                    addMemberStatements.Add(AddFunction(function));
+                }
+
+                foreach (var initializer in module.Initializers)
+                {
+                    addMemberStatements.Add(AddInitializer(initializer));
+                }
+
+                // generates
+                //  return module;
+                addMemberStatements.Add(
+                  ReturnStatement(IdentifierName(ReactNativeNames.Module)));
+
+                // Generates:
+                //    packageBuilder.AddModule("MyViewManager", () => new global::MyApp.ViewManager);
+                addModuleStatements.Add(
+                  InvocationStatement(
+                    MemberAccessExpression(ReactNativeNames.PackageBuilderId, ReactNativeNames.AddModule),
+
+                    LiteralExpression(module.ModuleName),
+                    ParenthesizedLambdaExpression(
+                      parameterList: ParameterList(
+                          Parameter(ReactNativeNames.ModuleBuilder)
+                            .WithType(m_reactTypes.IReactModuleBuilder.ToTypeSyntax())),
+                        block: Block(
+                          addMemberStatements),
+                        expressionBody: null)
+                  )
+                );
             }
 
-            // if the last argument is a callback, assume this is the resolve or resolve function
-            if (IsSingleArgCallback(parameters[i].Type, out _))
+            // Generates:
+            //    internal void CreateModules(IPackageBuilder packageBuilder)
+            //    {
+            //       ... registrationCalls (ses above)
+            //    }
+            return MethodDeclaration(
+                PredefinedType(Token(SyntaxKind.VoidKeyword)),
+                ReactNativeNames.CreateModules)
+              .AddModifiers(
+                Token(SyntaxKind.InternalKeyword))
+              .AddParameterListParameters(
+                GetPackageBuilderArgument())
+              .WithBody(
+                Block(
+                  addModuleStatements));
+        }
+
+        internal StatementSyntax AddConstants(IEnumerable<ReactConstant> constants)
+        {
+            // place all constants in a single constant provider
+            var statements = new List<StatementSyntax>();
+
+            // constants
+            foreach (var constant in constants)
             {
-              var isReject = parameters.Length >= 2 &&
-                             IsSingleArgCallback(parameters[i - 1].Type, out _);
-              args.Add(GeneratePromiseInvocation(isReject));
-              methodReturnType = isReject ? "TwoCallbacks" : "Callback";
-              skipReadingArg = true;
+                // generates:
+                //   JSValueWriter.WriteObjectProperty(writer, "MyConst", module.MyConst);
+                statements.Add(
+                  InvocationStatement(
+                    MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteObjectPropertyMethodName),
+                    IdentifierName(ReactNativeNames.WriterLocalName),
+                    LiteralExpression(constant.Name),
+                    MemberAccessExpression(ReactNativeNames.Module, Identifier(constant.Symbol.Name))));
             }
-          }
-          else if (i == parameters.Length - 2)
-          {
-            // if the last 2 argument is a callback, assume this is the resolve function
-            if (IsSingleArgCallback(parameters[i].Type, out _) &&
-                IsSingleArgCallback(parameters[i + 1].Type, out _))
-            {
-              args.Add(GeneratePromiseInvocation(isReject: false));
-              skipReadingArg = true;
-            }
-          }
+
+            // generates:
+            //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => { ... } );
+            return InvocationStatement(
+                MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
+
+                ParenthesizedLambdaExpression(
+                  parameterList: ParameterList(
+                      Parameter(ReactNativeNames.WriterLocalName)
+                        .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
+                  block: Block(
+                    statements),
+                  expressionBody: null
+                )
+              );
         }
 
-        if (!skipReadingArg)
+        internal StatementSyntax AddConstantProvider(ReactConstantProvider constantProvider)
         {
-          var variableName = "arg" + i.ToString(CultureInfo.InvariantCulture);
+            // generates:
+            //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => {
+            //     var provider = new ReactConstantProvider(writer);
+            //     module.ConstantProviderName(provider);
+            //  });
 
-          readArgsArguments.Add(Argument(
-            nameColon: null,
-            refKindKeyword: Token(SyntaxKind.OutKeyword),
-            expression: DeclarationExpression(
-              param.Type.ToTypeSyntax(),
-              SingleVariableDesignation(
-                Identifier(variableName))
-            )
-          ));
+            return InvocationStatement(
+              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
 
-          args.Add(IdentifierName(variableName));
-        }
-      }
-
-      // generates:
-      //  reader.ReadArgs( ... )
-      statements.Add(InvocationStatement(
-        MemberAccessExpression(m_reactTypes.JSValueReader, ReactNativeNames.ReadArgsMethodName),
-        readArgsArguments));
-
-      var methodCall = InvocationStatement(
-        MemberAccessExpression(ReactNativeNames.Module, Identifier(method.Method.Name)),
-        args.ToArray()
-      );
-
-      if (method.Method.ReturnsVoid)
-      {
-        // generate:
-        //   module.MyMethod(arg0, arg1, ...)
-        statements.Add(methodCall);
-      }
-      else
-      {
-        methodReturnType = "Callback";
-        // generate:
-        //   MyResult result = module.MyMethod(arg0, arg1, ...);
-        statements.Add(
-          LocalDeclarationStatement(
-            method.Method.ReturnType,
-            ReactNativeNames.ResultLocalName,
-            methodCall.Expression));
-        // generate:
-        //   writer.WriteArgs(result);
-        var writeArgs = InvocationExpression(
-          MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
-          IdentifierName(ReactNativeNames.WriterLocalName),
-          IdentifierName(ReactNativeNames.ResultLocalName));
-
-        if (method.IsSynchronous)
-        {
-          statements.Add(ExpressionStatement(writeArgs));
-        }
-        else
-        {
-          // generate:
-          //   resolve(.. writeargs ..);
-          statements.Add(
-            InvocationStatement(
-              IdentifierName(ReactNativeNames.ResolveLocalName),
-              writeArgs
-            ));
-        }
-      }
-
-      if (method.IsSynchronous)
-      {
-        // generate:
-        //   moduleBuilder.AddSyncMethod(
-        //    "MyMethod",
-        //    (
-        //    IJSValueReader reader,
-        //    IJSValueWriter writer) =>
-        //    {
-        //       .... statements
-        //    }
-        return InvocationStatement(
-          MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddSyncMethod),
-          LiteralExpression(method.Name),
-          ParenthesizedLambdaExpression(
-            parameterList:
-            ParameterList(
-              Parameter(ReactNativeNames.ReaderLocalName)
-                .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax()),
-              Parameter(ReactNativeNames.WriterLocalName)
-                .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
-            block: Block(statements),
-            expressionBody: null));
-      }
-      else
-      {
-        // generate:
-        //   moduleBuilder.AddMethod(
-        //    "MyMethod",
-        //    MethodReturnType.xxx,
-        //    (
-        //    IJSValueReader reader,
-        //    IJSValueWriter writer,
-        //    MethodResultCallback resolve,
-        //    MethodResultCallback reject) =>
-        //    {
-        //       .... statements
-        //    }
-        return InvocationStatement(
-          MemberAccessExpression(
-            ReactNativeNames.ModuleBuilder,
-            method.IsSynchronous ? ReactNativeNames.AddSyncMethod : ReactNativeNames.AddMethod),
-          LiteralExpression(method.Name),
-          MemberAccessExpression(
-            SyntaxKind.SimpleMemberAccessExpression,
-            m_reactTypes.MethodReturnType.ToTypeSyntax(),
-            SyntaxFactory.IdentifierName(methodReturnType)),
-          ParenthesizedLambdaExpression(
-            parameterList:
-            ParameterList(
-              Parameter(ReactNativeNames.ReaderLocalName)
-                .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax()),
-              Parameter(ReactNativeNames.WriterLocalName)
-                .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax()),
-              Parameter(ReactNativeNames.ResolveLocalName)
-                .WithType(m_reactTypes.MethodResultCallback.ToTypeSyntax()),
-              Parameter(ReactNativeNames.RejectLocalName)
-                .WithType(m_reactTypes.MethodResultCallback.ToTypeSyntax())),
-            block: Block(
-              statements),
-            expressionBody: null));
-      }
-    }
-
-    internal ExpressionSyntax GeneratePromiseInvocation(bool isReject)
-    {
-      // generates:
-      //    value1 => resolve|reject(JSValueWriter.WriteArgs(writer, value1)
-      return ParenthesizedLambdaExpression(
-        parameterList: ParameterList(
-          SeparatedList<ParameterSyntax>(
-            new[]
-            {
-              Parameter(ReactNativeNames.ValueLocalName)
-            })),
-        block: null,
-        expressionBody: InvocationExpression(
-          IdentifierName(isReject ? ReactNativeNames.RejectLocalName : ReactNativeNames.ResolveLocalName),
-          InvocationExpression(
-            MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
-            IdentifierName(ReactNativeNames.WriterLocalName),
-            IdentifierName(ReactNativeNames.ValueLocalName))
-          )
-        );
-    }
-
-    private bool IsPromiseType(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? typeParameter)
-    {
-      if (type != null &&
-             type is INamedTypeSymbol namedType &&
-             namedType.IsGenericType &&
-             namedType.ConstructUnboundGenericType()
-               .Equals(m_reactTypes.IReactPromise.ConstructUnboundGenericType(), SymbolEqualityComparer.Default))
-      {
-        typeParameter = namedType.TypeArguments[0];
-        return true;
-      }
-
-      typeParameter = null;
-      return false;
-    }
-
-    private bool IsSingleArgCallback(ITypeSymbol type, [NotNullWhen(returnValue: true)] out ITypeSymbol? parameterType)
-    {
-      if (type is INamedTypeSymbol namedType &&
-          namedType.DelegateInvokeMethod != null &&
-          namedType.DelegateInvokeMethod.Parameters.Length == 1
-          )
-      {
-        parameterType = namedType.DelegateInvokeMethod.Parameters[0].Type;
-        return true;
-      }
-
-      parameterType = null;
-      return false;
-    }
-
-    internal StatementSyntax AddEvent(ReactEvent evnt)
-    {
-      // generates:
-      //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
-      //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsEvent("eventEmitterName", "eventName", arg0, arg1, ...);
-      return InvocationStatement(
-        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
-        ParenthesizedLambdaExpression(
-          parameterList: ParameterList(
-            Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
-          block: null,
-          expressionBody: GenerateCallback(evnt, ReactNativeNames.EmitJSEventFunctionName)));
-    }
-
-    internal StatementSyntax AddFunction(ReactFunction function)
-    {
-      // generates:
-      //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
-      //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsFunction("moduleName", "eventName", arg0, arg1, ...);
-      return InvocationStatement(
-        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
-        ParenthesizedLambdaExpression(
-          parameterList: ParameterList(
-            Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
-          block: null,
-          expressionBody: GenerateCallback(function, ReactNativeNames.CallJSFunctionFunctionName)));
-    }
-
-    internal StatementSyntax AddInitializer(ReactInitializer initializer)
-    {
-      // generates:
-      //    moduleBuilder.AddInitializer((IReactContext reactContext) => module.initializerMethod(new ReactContext(reactContext)));
-      return InvocationStatement(
-        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
-        ParenthesizedLambdaExpression(
-          parameterList: ParameterList(
-            Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
-          block: null,
-          expressionBody: InvocationExpression(
-            MemberAccessExpression(ReactNativeNames.Module, Identifier(initializer.Method.Name)),
-            ObjectCreationExpression(m_reactTypes.ReactContext, IdentifierName((ReactNativeNames.ReactContextLocalName)))
-            )));
-    }
-
-    private ExpressionSyntax GenerateCallback(ReactCallback callback, SyntaxToken contextCallbackMethod)
-    {
-
-      var lambdaParams = new List<ParameterSyntax>(callback.CallbackParameters.Length);
-      var arguments = new List<ArgumentSyntax>(callback.CallbackParameters.Length);
-      arguments.Add(Argument(IdentifierName(ReactNativeNames.WriterLocalName)));
-
-      for (int i = 0; i < callback.CallbackParameters.Length; i++)
-      {
-        var paramType = callback.CallbackParameters[i].Type;
-        var identifierName = "arg" + i.ToString(CultureInfo.InvariantCulture);
-
-        lambdaParams.Add(Parameter(Identifier(identifierName)).WithType(paramType.ToTypeSyntax()));
-        arguments.Add(Argument(IdentifierName(identifierName)));
-      }
-
-      // generates:
-      //  module.<callackName> = (ArgType0 arg0, ArgType1 arg0, ...) =>
-      //    reactContext.<contextCallbackMethod>(
-      //      eventEmitterName,
-      //      eventName,
-      //      writer => writer.WriteArgs(arg0, arg1, ...)
-      //      )
-      return
-        AssignmentExpression(
-          SyntaxKind.SimpleAssignmentExpression,
-          MemberAccessExpression(ReactNativeNames.Module, Identifier(callback.Symbol.Name)),
-          ParenthesizedLambdaExpression(
-            parameterList: ParameterList(lambdaParams.ToArray()),
-            block: null,
-            expressionBody: InvocationExpression(
-              MemberAccessExpression(ReactNativeNames.ReactContextLocalName, contextCallbackMethod),
-              LiteralExpression(callback.CallbackContextName),
-              LiteralExpression(callback.Name),
               ParenthesizedLambdaExpression(
-                parameterList: ParameterList(Parameter(ReactNativeNames.WriterLocalName)),
+                parameterList: ParameterList(
+                    Parameter(ReactNativeNames.WriterLocalName)
+                      .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
+                block: Block(
+                  LocalDeclarationStatement(
+                    m_reactTypes.ReactConstantProvider,
+                    ReactNativeNames.ProviderLocalName,
+                    ObjectCreationExpression(
+                      m_reactTypes.ReactConstantProvider,
+                      IdentifierName(ReactNativeNames.WriterLocalName))),
+                  InvocationStatement(
+                    MemberAccessExpression(ReactNativeNames.Module, Identifier(constantProvider.Method.Name)),
+                    IdentifierName(ReactNativeNames.ProviderLocalName))),
+                expressionBody: null
+              )
+            );
+        }
+
+        internal StatementSyntax AddMethod(ReactMethod method)
+        {
+            var statements = new List<StatementSyntax>();
+
+            var parameters = method.Method.Parameters;
+
+            var readArgsArguments = new List<ArgumentSyntax>(parameters.Length);
+            readArgsArguments.Add(Argument(IdentifierName(ReactNativeNames.ReaderLocalName)));
+            var args = new List<ExpressionSyntax>(parameters.Length);
+
+            // generates:
+            //   (out ArgType0 arg0, out ArgType1 arg1, ...);
+            // as well as
+            //   (arg0, arg1, ... )
+            for (int i = 0; i < method.EffectiveParameters.Count; i++)
+            {
+                var param = method.EffectiveParameters[i];
+                var variableName = "arg" + i.ToString(CultureInfo.InvariantCulture);
+
+                readArgsArguments.Add(Argument(
+                  nameColon: null,
+                  refKindKeyword: Token(SyntaxKind.OutKeyword),
+                  expression: DeclarationExpression(
+                    param.Type.ToTypeSyntax(),
+                    SingleVariableDesignation(
+                      Identifier(variableName))
+                  )
+                ));
+
+                args.Add(IdentifierName(variableName));
+            }
+
+            switch (method.ReturnStyle)
+            {
+                case ReactMethod.MethodReturnStyle.Promise:
+                    args.Add(ObjectCreationExpression(
+                      m_reactTypes.ReactPromise.Construct(method.EffectiveReturnType),
+                      IdentifierName(ReactNativeNames.WriterLocalName),
+                      IdentifierName(ReactNativeNames.ResolveLocalName),
+                      IdentifierName(ReactNativeNames.RejectLocalName)
+                    ));
+                    break;
+                case ReactMethod.MethodReturnStyle.Callback:
+                    args.Add(GeneratePromiseInvocation(isReject: false));
+                    break;
+                case ReactMethod.MethodReturnStyle.TwoCallbacks:
+                    args.Add(GeneratePromiseInvocation(isReject: false));
+                    args.Add(GeneratePromiseInvocation(isReject: true));
+                    break;
+            }
+
+            // generates:
+            //  reader.ReadArgs( ... )
+            statements.Add(InvocationStatement(
+              MemberAccessExpression(m_reactTypes.JSValueReader, ReactNativeNames.ReadArgsMethodName),
+              readArgsArguments));
+
+            var methodCall = InvocationStatement(
+              MemberAccessExpression(ReactNativeNames.Module, Identifier(method.Method.Name)),
+              args.ToArray()
+            );
+
+            if (method.Method.ReturnsVoid)
+            {
+                // generate:
+                //   module.MyMethod(arg0, arg1, ...)
+                statements.Add(methodCall);
+            }
+            else
+            {
+                // generate:
+                //   MyResult result = module.MyMethod(arg0, arg1, ...);
+                statements.Add(
+                  LocalDeclarationStatement(
+                    method.Method.ReturnType,
+                    ReactNativeNames.ResultLocalName,
+                    methodCall.Expression));
+
+                if (method.ReturnStyle == ReactMethod.MethodReturnStyle.Task)
+                {
+                    // generate:
+                    //  ReactTaskExtension.ContinueWith(result, writer, resolve, reject);
+                    statements.Add(InvocationStatement(
+                      MemberAccessExpression(m_reactTypes.ReactTaskExtensions, ReactNativeNames.ContinueWith),
+                      IdentifierName(ReactNativeNames.ResultLocalName),
+                      IdentifierName(ReactNativeNames.WriterLocalName),
+                      IdentifierName(ReactNativeNames.ResolveLocalName),
+                      IdentifierName(ReactNativeNames.RejectLocalName)
+                      ));
+                }
+                else
+                {
+                    // generate:
+                    //   writer.WriteArgs(result);
+                    var writeArgs = InvocationExpression(
+                      MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
+                      IdentifierName(ReactNativeNames.WriterLocalName),
+                      IdentifierName(ReactNativeNames.ResultLocalName));
+
+                    if (method.IsSynchronous)
+                    {
+                        statements.Add(ExpressionStatement(writeArgs));
+                    }
+                    else
+                    {
+                        // generate:
+                        //   resolve(.. writeargs ..);
+                        statements.Add(
+                          InvocationStatement(
+                            IdentifierName(ReactNativeNames.ResolveLocalName),
+                            writeArgs
+                          ));
+                    }
+                }
+            }
+
+            if (method.IsSynchronous)
+            {
+                // generate:
+                //   moduleBuilder.AddSyncMethod(
+                //    "MyMethod",
+                //    (
+                //    IJSValueReader reader,
+                //    IJSValueWriter writer) =>
+                //    {
+                //       .... statements
+                //    }
+                return InvocationStatement(
+                  MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddSyncMethod),
+                  LiteralExpression(method.Name),
+                  ParenthesizedLambdaExpression(
+                    parameterList:
+                    ParameterList(
+                      Parameter(ReactNativeNames.ReaderLocalName)
+                        .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax()),
+                      Parameter(ReactNativeNames.WriterLocalName)
+                        .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
+                    block: Block(statements),
+                    expressionBody: null));
+            }
+            else
+            {
+                // generate:
+                //   moduleBuilder.AddMethod(
+                //    "MyMethod",
+                //    MethodReturnType.xxx,
+                //    (
+                //    IJSValueReader reader,
+                //    IJSValueWriter writer,
+                //    MethodResultCallback resolve,
+                //    MethodResultCallback reject) =>
+                //    {
+                //       .... statements
+                //    }
+                return InvocationStatement(
+                  MemberAccessExpression(
+                    ReactNativeNames.ModuleBuilder,
+                    method.IsSynchronous ? ReactNativeNames.AddSyncMethod : ReactNativeNames.AddMethod),
+                  LiteralExpression(method.Name),
+                  MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    m_reactTypes.MethodReturnType.ToTypeSyntax(),
+                    SyntaxFactory.IdentifierName(GetMethodReturnTypeFromStyle(method.ReturnStyle))),
+                  ParenthesizedLambdaExpression(
+                    parameterList:
+                    ParameterList(
+                      Parameter(ReactNativeNames.ReaderLocalName)
+                        .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax()),
+                      Parameter(ReactNativeNames.WriterLocalName)
+                        .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax()),
+                      Parameter(ReactNativeNames.ResolveLocalName)
+                        .WithType(m_reactTypes.MethodResultCallback.ToTypeSyntax()),
+                      Parameter(ReactNativeNames.RejectLocalName)
+                        .WithType(m_reactTypes.MethodResultCallback.ToTypeSyntax())),
+                    block: Block(
+                      statements),
+                    expressionBody: null));
+            }
+        }
+
+        internal ExpressionSyntax GeneratePromiseInvocation(bool isReject)
+        {
+            // generates:
+            //    value1 => resolve|reject(JSValueWriter.WriteArgs(writer, value1)
+            return ParenthesizedLambdaExpression(
+              parameterList: ParameterList(
+                SeparatedList<ParameterSyntax>(
+                  new[]
+                  {
+              Parameter(ReactNativeNames.ValueLocalName)
+                  })),
+              block: null,
+              expressionBody: InvocationExpression(
+                IdentifierName(isReject ? ReactNativeNames.RejectLocalName : ReactNativeNames.ResolveLocalName),
+                InvocationExpression(
+                  MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
+                  IdentifierName(ReactNativeNames.WriterLocalName),
+                  IdentifierName(ReactNativeNames.ValueLocalName))
+                )
+              );
+        }
+
+        internal StatementSyntax AddEvent(ReactEvent evnt)
+        {
+            // generates:
+            //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
+            //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsEvent("eventEmitterName", "eventName", arg0, arg1, ...);
+            return InvocationStatement(
+              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+              ParenthesizedLambdaExpression(
+                parameterList: ParameterList(
+                  Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
+                block: null,
+                expressionBody: GenerateCallback(evnt, ReactNativeNames.EmitJSEventFunctionName)));
+        }
+
+        internal StatementSyntax AddFunction(ReactFunction function)
+        {
+            // generates:
+            //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
+            //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsFunction("moduleName", "eventName", arg0, arg1, ...);
+            return InvocationStatement(
+              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+              ParenthesizedLambdaExpression(
+                parameterList: ParameterList(
+                  Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
+                block: null,
+                expressionBody: GenerateCallback(function, ReactNativeNames.CallJSFunctionFunctionName)));
+        }
+
+        internal StatementSyntax AddInitializer(ReactInitializer initializer)
+        {
+            // generates:
+            //    moduleBuilder.AddInitializer((IReactContext reactContext) => module.initializerMethod(new ReactContext(reactContext)));
+            return InvocationStatement(
+              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+              ParenthesizedLambdaExpression(
+                parameterList: ParameterList(
+                  Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
                 block: null,
                 expressionBody: InvocationExpression(
-                  MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
-                  arguments
-                  )))));
+                  MemberAccessExpression(ReactNativeNames.Module, Identifier(initializer.Method.Name)),
+                  ObjectCreationExpression(m_reactTypes.ReactContext, IdentifierName((ReactNativeNames.ReactContextLocalName)))
+                  )));
+        }
+
+        private ExpressionSyntax GenerateCallback(ReactCallback callback, SyntaxToken contextCallbackMethod)
+        {
+
+            var lambdaParams = new List<ParameterSyntax>(callback.CallbackParameters.Length);
+            var arguments = new List<ArgumentSyntax>(callback.CallbackParameters.Length);
+            arguments.Add(Argument(IdentifierName(ReactNativeNames.WriterLocalName)));
+
+            for (int i = 0; i < callback.CallbackParameters.Length; i++)
+            {
+                var paramType = callback.CallbackParameters[i].Type;
+                var identifierName = "arg" + i.ToString(CultureInfo.InvariantCulture);
+
+                lambdaParams.Add(Parameter(Identifier(identifierName)).WithType(paramType.ToTypeSyntax()));
+                arguments.Add(Argument(IdentifierName(identifierName)));
+            }
+
+            // generates:
+            //  module.<callackName> = (ArgType0 arg0, ArgType1 arg0, ...) =>
+            //    reactContext.<contextCallbackMethod>(
+            //      eventEmitterName,
+            //      eventName,
+            //      writer => writer.WriteArgs(arg0, arg1, ...)
+            //      )
+            return
+              AssignmentExpression(
+                SyntaxKind.SimpleAssignmentExpression,
+                MemberAccessExpression(ReactNativeNames.Module, Identifier(callback.Symbol.Name)),
+                ParenthesizedLambdaExpression(
+                  parameterList: ParameterList(lambdaParams.ToArray()),
+                  block: null,
+                  expressionBody: InvocationExpression(
+                    MemberAccessExpression(ReactNativeNames.ReactContextLocalName, contextCallbackMethod),
+                    LiteralExpression(callback.CallbackContextName),
+                    LiteralExpression(callback.Name),
+                    ParenthesizedLambdaExpression(
+                      parameterList: ParameterList(Parameter(ReactNativeNames.WriterLocalName)),
+                      block: null,
+                      expressionBody: InvocationExpression(
+                        MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
+                        arguments
+                        )))));
+        }
+
+        private string GetMethodReturnTypeFromStyle(ReactMethod.MethodReturnStyle returnStyle)
+        {
+            switch (returnStyle)
+            {
+                case ReactMethod.MethodReturnStyle.Void:
+                    return "Void";
+                case ReactMethod.MethodReturnStyle.Task:
+                case ReactMethod.MethodReturnStyle.Promise:
+                    return "Promise";
+                case ReactMethod.MethodReturnStyle.Callback:
+                case ReactMethod.MethodReturnStyle.ReturnValue:
+                    return "Callback";
+                case ReactMethod.MethodReturnStyle.TwoCallbacks:
+                    return "TwoCallbacks";
+                default:
+                    throw new InvalidOperationException("Unexpected ReturnStyle");
+            }
+        }
     }
-  }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Module.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Module.cs
@@ -9,466 +9,465 @@ using Microsoft.ReactNative.Managed.CodeGen.Model;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Microsoft.ReactNative.Managed.CodeGen.SyntaxHelpers;
 
 namespace Microsoft.ReactNative.Managed.CodeGen
 {
-    public partial class CodeGenerator
+  public partial class CodeGenerator
+  {
+    internal MemberDeclarationSyntax CreateModules(IEnumerable<ReactModule> modules)
     {
-        internal MemberDeclarationSyntax CreateModules(IEnumerable<ReactModule> modules)
+      var addModuleStatements = new List<StatementSyntax>();
+      foreach (var module in modules)
+      {
+        var addMemberStatements = new List<StatementSyntax>();
+
+        // generates:
+        //  MyModule module = new MyModule();
+        addMemberStatements.Add(
+          LocalDeclarationStatement(module.ModuleType, ReactNativeNames.Module, ObjectCreationExpression(module.ModuleType)));
+
+        if (module.Constants.Any())
         {
-            var addModuleStatements = new List<StatementSyntax>();
-            foreach (var module in modules)
-            {
-                var addMemberStatements = new List<StatementSyntax>();
-
-                // generates:
-                //  MyModule module = new MyModule();
-                addMemberStatements.Add(
-                  LocalDeclarationStatement(module.ModuleType, ReactNativeNames.Module, ObjectCreationExpression(module.ModuleType)));
-
-                if (module.Constants.Any())
-                {
-                    addMemberStatements.Add(AddConstants(module.Constants));
-                }
-
-                foreach (var constantProvider in module.ConstantProviders)
-                {
-                    addMemberStatements.Add(AddConstantProvider(constantProvider));
-                }
-
-                foreach (var method in module.Methods)
-                {
-                    addMemberStatements.Add(AddMethod(method));
-                }
-
-                foreach (var evnt in module.Events)
-                {
-                    addMemberStatements.Add(AddEvent(evnt));
-                }
-
-                foreach (var function in module.Functions)
-                {
-                    addMemberStatements.Add(AddFunction(function));
-                }
-
-                foreach (var initializer in module.Initializers)
-                {
-                    addMemberStatements.Add(AddInitializer(initializer));
-                }
-
-                // generates
-                //  return module;
-                addMemberStatements.Add(
-                  ReturnStatement(IdentifierName(ReactNativeNames.Module)));
-
-                // Generates:
-                //    packageBuilder.AddModule("MyViewManager", () => new global::MyApp.ViewManager);
-                addModuleStatements.Add(
-                  InvocationStatement(
-                    MemberAccessExpression(ReactNativeNames.PackageBuilderId, ReactNativeNames.AddModule),
-
-                    LiteralExpression(module.ModuleName),
-                    ParenthesizedLambdaExpression(
-                      parameterList: ParameterList(
-                          Parameter(ReactNativeNames.ModuleBuilder)
-                            .WithType(m_reactTypes.IReactModuleBuilder.ToTypeSyntax())),
-                        block: Block(
-                          addMemberStatements),
-                        expressionBody: null)
-                  )
-                );
-            }
-
-            // Generates:
-            //    internal void CreateModules(IPackageBuilder packageBuilder)
-            //    {
-            //       ... registrationCalls (ses above)
-            //    }
-            return MethodDeclaration(
-                PredefinedType(Token(SyntaxKind.VoidKeyword)),
-                ReactNativeNames.CreateModules)
-              .AddModifiers(
-                Token(SyntaxKind.InternalKeyword))
-              .AddParameterListParameters(
-                GetPackageBuilderArgument())
-              .WithBody(
-                Block(
-                  addModuleStatements));
+          addMemberStatements.Add(AddConstants(module.Constants));
         }
 
-        internal StatementSyntax AddConstants(IEnumerable<ReactConstant> constants)
+        foreach (var constantProvider in module.ConstantProviders)
         {
-            // place all constants in a single constant provider
-            var statements = new List<StatementSyntax>();
-
-            // constants
-            foreach (var constant in constants)
-            {
-                // generates:
-                //   JSValueWriter.WriteObjectProperty(writer, "MyConst", module.MyConst);
-                statements.Add(
-                  InvocationStatement(
-                    MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteObjectPropertyMethodName),
-                    IdentifierName(ReactNativeNames.WriterLocalName),
-                    LiteralExpression(constant.Name),
-                    MemberAccessExpression(ReactNativeNames.Module, Identifier(constant.Symbol.Name))));
-            }
-
-            // generates:
-            //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => { ... } );
-            return InvocationStatement(
-                MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
-
-                ParenthesizedLambdaExpression(
-                  parameterList: ParameterList(
-                      Parameter(ReactNativeNames.WriterLocalName)
-                        .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
-                  block: Block(
-                    statements),
-                  expressionBody: null
-                )
-              );
+          addMemberStatements.Add(AddConstantProvider(constantProvider));
         }
 
-        internal StatementSyntax AddConstantProvider(ReactConstantProvider constantProvider)
+        foreach (var method in module.Methods)
         {
-            // generates:
-            //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => {
-            //     var provider = new ReactConstantProvider(writer);
-            //     module.ConstantProviderName(provider);
-            //  });
-
-            return InvocationStatement(
-              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
-
-              ParenthesizedLambdaExpression(
-                parameterList: ParameterList(
-                    Parameter(ReactNativeNames.WriterLocalName)
-                      .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
-                block: Block(
-                  LocalDeclarationStatement(
-                    m_reactTypes.ReactConstantProvider,
-                    ReactNativeNames.ProviderLocalName,
-                    ObjectCreationExpression(
-                      m_reactTypes.ReactConstantProvider,
-                      IdentifierName(ReactNativeNames.WriterLocalName))),
-                  InvocationStatement(
-                    MemberAccessExpression(ReactNativeNames.Module, Identifier(constantProvider.Method.Name)),
-                    IdentifierName(ReactNativeNames.ProviderLocalName))),
-                expressionBody: null
-              )
-            );
+          addMemberStatements.Add(AddMethod(method));
         }
 
-        internal StatementSyntax AddMethod(ReactMethod method)
+        foreach (var evnt in module.Events)
         {
-            var statements = new List<StatementSyntax>();
-
-            var parameters = method.Method.Parameters;
-
-            var readArgsArguments = new List<ArgumentSyntax>(parameters.Length);
-            readArgsArguments.Add(Argument(IdentifierName(ReactNativeNames.ReaderLocalName)));
-            var args = new List<ExpressionSyntax>(parameters.Length);
-
-            // generates:
-            //   (out ArgType0 arg0, out ArgType1 arg1, ...);
-            // as well as
-            //   (arg0, arg1, ... )
-            for (int i = 0; i < method.EffectiveParameters.Count; i++)
-            {
-                var param = method.EffectiveParameters[i];
-                var variableName = "arg" + i.ToString(CultureInfo.InvariantCulture);
-
-                readArgsArguments.Add(Argument(
-                  nameColon: null,
-                  refKindKeyword: Token(SyntaxKind.OutKeyword),
-                  expression: DeclarationExpression(
-                    param.Type.ToTypeSyntax(),
-                    SingleVariableDesignation(
-                      Identifier(variableName))
-                  )
-                ));
-
-                args.Add(IdentifierName(variableName));
-            }
-
-            switch (method.ReturnStyle)
-            {
-                case ReactMethod.MethodReturnStyle.Promise:
-                    args.Add(ObjectCreationExpression(
-                      m_reactTypes.ReactPromise.Construct(method.EffectiveReturnType),
-                      IdentifierName(ReactNativeNames.WriterLocalName),
-                      IdentifierName(ReactNativeNames.ResolveLocalName),
-                      IdentifierName(ReactNativeNames.RejectLocalName)
-                    ));
-                    break;
-                case ReactMethod.MethodReturnStyle.Callback:
-                    args.Add(GeneratePromiseInvocation(isReject: false));
-                    break;
-                case ReactMethod.MethodReturnStyle.TwoCallbacks:
-                    args.Add(GeneratePromiseInvocation(isReject: false));
-                    args.Add(GeneratePromiseInvocation(isReject: true));
-                    break;
-            }
-
-            // generates:
-            //  reader.ReadArgs( ... )
-            statements.Add(InvocationStatement(
-              MemberAccessExpression(m_reactTypes.JSValueReader, ReactNativeNames.ReadArgsMethodName),
-              readArgsArguments));
-
-            var methodCall = InvocationStatement(
-              MemberAccessExpression(ReactNativeNames.Module, Identifier(method.Method.Name)),
-              args.ToArray()
-            );
-
-            if (method.Method.ReturnsVoid)
-            {
-                // generate:
-                //   module.MyMethod(arg0, arg1, ...)
-                statements.Add(methodCall);
-            }
-            else
-            {
-                // generate:
-                //   MyResult result = module.MyMethod(arg0, arg1, ...);
-                statements.Add(
-                  LocalDeclarationStatement(
-                    method.Method.ReturnType,
-                    ReactNativeNames.ResultLocalName,
-                    methodCall.Expression));
-
-                if (method.ReturnStyle == ReactMethod.MethodReturnStyle.Task)
-                {
-                    // generate:
-                    //  ReactTaskExtension.ContinueWith(result, writer, resolve, reject);
-                    statements.Add(InvocationStatement(
-                      MemberAccessExpression(m_reactTypes.ReactTaskExtensions, ReactNativeNames.ContinueWith),
-                      IdentifierName(ReactNativeNames.ResultLocalName),
-                      IdentifierName(ReactNativeNames.WriterLocalName),
-                      IdentifierName(ReactNativeNames.ResolveLocalName),
-                      IdentifierName(ReactNativeNames.RejectLocalName)
-                      ));
-                }
-                else
-                {
-                    // generate:
-                    //   writer.WriteArgs(result);
-                    var writeArgs = InvocationExpression(
-                      MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
-                      IdentifierName(ReactNativeNames.WriterLocalName),
-                      IdentifierName(ReactNativeNames.ResultLocalName));
-
-                    if (method.IsSynchronous)
-                    {
-                        statements.Add(ExpressionStatement(writeArgs));
-                    }
-                    else
-                    {
-                        // generate:
-                        //   resolve(.. writeargs ..);
-                        statements.Add(
-                          InvocationStatement(
-                            IdentifierName(ReactNativeNames.ResolveLocalName),
-                            writeArgs
-                          ));
-                    }
-                }
-            }
-
-            if (method.IsSynchronous)
-            {
-                // generate:
-                //   moduleBuilder.AddSyncMethod(
-                //    "MyMethod",
-                //    (
-                //    IJSValueReader reader,
-                //    IJSValueWriter writer) =>
-                //    {
-                //       .... statements
-                //    }
-                return InvocationStatement(
-                  MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddSyncMethod),
-                  LiteralExpression(method.Name),
-                  ParenthesizedLambdaExpression(
-                    parameterList:
-                    ParameterList(
-                      Parameter(ReactNativeNames.ReaderLocalName)
-                        .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax()),
-                      Parameter(ReactNativeNames.WriterLocalName)
-                        .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax())),
-                    block: Block(statements),
-                    expressionBody: null));
-            }
-            else
-            {
-                // generate:
-                //   moduleBuilder.AddMethod(
-                //    "MyMethod",
-                //    MethodReturnType.xxx,
-                //    (
-                //    IJSValueReader reader,
-                //    IJSValueWriter writer,
-                //    MethodResultCallback resolve,
-                //    MethodResultCallback reject) =>
-                //    {
-                //       .... statements
-                //    }
-                return InvocationStatement(
-                  MemberAccessExpression(
-                    ReactNativeNames.ModuleBuilder,
-                    method.IsSynchronous ? ReactNativeNames.AddSyncMethod : ReactNativeNames.AddMethod),
-                  LiteralExpression(method.Name),
-                  MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    m_reactTypes.MethodReturnType.ToTypeSyntax(),
-                    SyntaxFactory.IdentifierName(GetMethodReturnTypeFromStyle(method.ReturnStyle))),
-                  ParenthesizedLambdaExpression(
-                    parameterList:
-                    ParameterList(
-                      Parameter(ReactNativeNames.ReaderLocalName)
-                        .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax()),
-                      Parameter(ReactNativeNames.WriterLocalName)
-                        .WithType(m_reactTypes.IJSValueWriter.ToTypeSyntax()),
-                      Parameter(ReactNativeNames.ResolveLocalName)
-                        .WithType(m_reactTypes.MethodResultCallback.ToTypeSyntax()),
-                      Parameter(ReactNativeNames.RejectLocalName)
-                        .WithType(m_reactTypes.MethodResultCallback.ToTypeSyntax())),
-                    block: Block(
-                      statements),
-                    expressionBody: null));
-            }
+          addMemberStatements.Add(AddEvent(evnt));
         }
 
-        internal ExpressionSyntax GeneratePromiseInvocation(bool isReject)
+        foreach (var function in module.Functions)
         {
-            // generates:
-            //    value1 => resolve|reject(JSValueWriter.WriteArgs(writer, value1)
-            return ParenthesizedLambdaExpression(
+          addMemberStatements.Add(AddFunction(function));
+        }
+
+        foreach (var initializer in module.Initializers)
+        {
+          addMemberStatements.Add(AddInitializer(initializer));
+        }
+
+        // generates
+        //  return module;
+        addMemberStatements.Add(
+          ReturnStatement(IdentifierName(ReactNativeNames.Module)));
+
+        // Generates:
+        //    packageBuilder.AddModule("MyViewManager", () => new global::MyApp.ViewManager);
+        addModuleStatements.Add(
+          InvocationStatement(
+            MemberAccessExpression(ReactNativeNames.PackageBuilderId, ReactNativeNames.AddModule),
+
+            LiteralExpression(module.ModuleName),
+            ParenthesizedLambdaExpression(
               parameterList: ParameterList(
-                SeparatedList<ParameterSyntax>(
-                  new[]
-                  {
+                  Parameter(ReactNativeNames.ModuleBuilder)
+                    .WithType(ReactTypes.IReactModuleBuilder.ToTypeSyntax())),
+                block: Block(
+                  addMemberStatements),
+                expressionBody: null)
+          )
+        );
+      }
+
+      // Generates:
+      //    internal void CreateModules(IPackageBuilder packageBuilder)
+      //    {
+      //       ... registrationCalls (ses above)
+      //    }
+      return MethodDeclaration(
+          PredefinedType(Token(SyntaxKind.VoidKeyword)),
+          ReactNativeNames.CreateModules)
+        .AddModifiers(
+          Token(SyntaxKind.InternalKeyword))
+        .AddParameterListParameters(
+          GetPackageBuilderArgument())
+        .WithBody(
+          Block(
+            addModuleStatements));
+    }
+
+    internal StatementSyntax AddConstants(IEnumerable<ReactConstant> constants)
+    {
+      // place all constants in a single constant provider
+      var statements = new List<StatementSyntax>();
+
+      // constants
+      foreach (var constant in constants)
+      {
+        // generates:
+        //   JSValueWriter.WriteObjectProperty(writer, "MyConst", module.MyConst);
+        statements.Add(
+          InvocationStatement(
+            MemberAccessExpression(ReactTypes.JSValueWriter, ReactNativeNames.WriteObjectPropertyMethodName),
+            IdentifierName(ReactNativeNames.WriterLocalName),
+            LiteralExpression(constant.Name),
+            MemberAccessExpression(ReactNativeNames.Module, Identifier(constant.Symbol.Name))));
+      }
+
+      // generates:
+      //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => { ... } );
+      return InvocationStatement(
+          MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
+
+          ParenthesizedLambdaExpression(
+            parameterList: ParameterList(
+                Parameter(ReactNativeNames.WriterLocalName)
+                  .WithType(ReactTypes.IJSValueWriter.ToTypeSyntax())),
+            block: Block(
+              statements),
+            expressionBody: null
+          )
+        );
+    }
+
+    internal StatementSyntax AddConstantProvider(ReactConstantProvider constantProvider)
+    {
+      // generates:
+      //  moduleBuilder.AddConstantProvider( (IJSValueWriter writer) => {
+      //     var provider = new ReactConstantProvider(writer);
+      //     module.ConstantProviderName(provider);
+      //  });
+
+      return InvocationStatement(
+        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddConstantProvider),
+
+        ParenthesizedLambdaExpression(
+          parameterList: ParameterList(
+              Parameter(ReactNativeNames.WriterLocalName)
+                .WithType(ReactTypes.IJSValueWriter.ToTypeSyntax())),
+          block: Block(
+            LocalDeclarationStatement(
+              ReactTypes.ReactConstantProvider,
+              ReactNativeNames.ProviderLocalName,
+              ObjectCreationExpression(
+                ReactTypes.ReactConstantProvider,
+                IdentifierName(ReactNativeNames.WriterLocalName))),
+            InvocationStatement(
+              MemberAccessExpression(ReactNativeNames.Module, Identifier(constantProvider.Method.Name)),
+              IdentifierName(ReactNativeNames.ProviderLocalName))),
+          expressionBody: null
+        )
+      );
+    }
+
+    internal StatementSyntax AddMethod(ReactMethod method)
+    {
+      var statements = new List<StatementSyntax>();
+
+      var parameters = method.Method.Parameters;
+
+      var readArgsArguments = new List<ArgumentSyntax>(parameters.Length);
+      readArgsArguments.Add(Argument(IdentifierName(ReactNativeNames.ReaderLocalName)));
+      var args = new List<ExpressionSyntax>(parameters.Length);
+
+      // generates:
+      //   (out ArgType0 arg0, out ArgType1 arg1, ...);
+      // as well as
+      //   (arg0, arg1, ... )
+      for (int i = 0; i < method.EffectiveParameters.Count; i++)
+      {
+        var param = method.EffectiveParameters[i];
+        var variableName = "arg" + i.ToString(CultureInfo.InvariantCulture);
+
+        readArgsArguments.Add(Argument(
+          nameColon: null,
+          refKindKeyword: Token(SyntaxKind.OutKeyword),
+          expression: DeclarationExpression(
+            param.Type.ToTypeSyntax(),
+            SingleVariableDesignation(
+              Identifier(variableName))
+          )
+        ));
+
+        args.Add(IdentifierName(variableName));
+      }
+
+      switch (method.ReturnStyle)
+      {
+        case ReactMethod.MethodReturnStyle.Promise:
+          args.Add(ObjectCreationExpression(
+            ReactTypes.ReactPromise.Construct(method.EffectiveReturnType),
+            IdentifierName(ReactNativeNames.WriterLocalName),
+            IdentifierName(ReactNativeNames.ResolveLocalName),
+            IdentifierName(ReactNativeNames.RejectLocalName)
+          ));
+          break;
+        case ReactMethod.MethodReturnStyle.Callback:
+          args.Add(GeneratePromiseInvocation(isReject: false));
+          break;
+        case ReactMethod.MethodReturnStyle.TwoCallbacks:
+          args.Add(GeneratePromiseInvocation(isReject: false));
+          args.Add(GeneratePromiseInvocation(isReject: true));
+          break;
+      }
+
+      // generates:
+      //  reader.ReadArgs( ... )
+      statements.Add(InvocationStatement(
+        MemberAccessExpression(ReactTypes.JSValueReader, ReactNativeNames.ReadArgsMethodName),
+        readArgsArguments));
+
+      var methodCall = InvocationStatement(
+        MemberAccessExpression(ReactNativeNames.Module, Identifier(method.Method.Name)),
+        args.ToArray()
+      );
+
+      if (method.Method.ReturnsVoid)
+      {
+        // generate:
+        //   module.MyMethod(arg0, arg1, ...)
+        statements.Add(methodCall);
+      }
+      else
+      {
+        // generate:
+        //   MyResult result = module.MyMethod(arg0, arg1, ...);
+        statements.Add(
+          LocalDeclarationStatement(
+            method.Method.ReturnType,
+            ReactNativeNames.ResultLocalName,
+            methodCall.Expression));
+
+        if (method.ReturnStyle == ReactMethod.MethodReturnStyle.Task)
+        {
+          // generate:
+          //  ReactTaskExtension.ContinueWith(result, writer, resolve, reject);
+          statements.Add(InvocationStatement(
+            MemberAccessExpression(ReactTypes.ReactTaskExtensions, ReactNativeNames.ContinueWith),
+            IdentifierName(ReactNativeNames.ResultLocalName),
+            IdentifierName(ReactNativeNames.WriterLocalName),
+            IdentifierName(ReactNativeNames.ResolveLocalName),
+            IdentifierName(ReactNativeNames.RejectLocalName)
+            ));
+        }
+        else
+        {
+          // generate:
+          //   writer.WriteArgs(result);
+          var writeArgs = InvocationExpression(
+            MemberAccessExpression(ReactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
+            IdentifierName(ReactNativeNames.WriterLocalName),
+            IdentifierName(ReactNativeNames.ResultLocalName));
+
+          if (method.IsSynchronous)
+          {
+            statements.Add(ExpressionStatement(writeArgs));
+          }
+          else
+          {
+            // generate:
+            //   resolve(.. writeargs ..);
+            statements.Add(
+              InvocationStatement(
+                IdentifierName(ReactNativeNames.ResolveLocalName),
+                writeArgs
+              ));
+          }
+        }
+      }
+
+      if (method.IsSynchronous)
+      {
+        // generate:
+        //   moduleBuilder.AddSyncMethod(
+        //    "MyMethod",
+        //    (
+        //    IJSValueReader reader,
+        //    IJSValueWriter writer) =>
+        //    {
+        //       .... statements
+        //    }
+        return InvocationStatement(
+          MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddSyncMethod),
+          LiteralExpression(method.Name),
+          ParenthesizedLambdaExpression(
+            parameterList:
+            ParameterList(
+              Parameter(ReactNativeNames.ReaderLocalName)
+                .WithType(ReactTypes.IJSValueReader.ToTypeSyntax()),
+              Parameter(ReactNativeNames.WriterLocalName)
+                .WithType(ReactTypes.IJSValueWriter.ToTypeSyntax())),
+            block: Block(statements),
+            expressionBody: null));
+      }
+      else
+      {
+        // generate:
+        //   moduleBuilder.AddMethod(
+        //    "MyMethod",
+        //    MethodReturnType.xxx,
+        //    (
+        //    IJSValueReader reader,
+        //    IJSValueWriter writer,
+        //    MethodResultCallback resolve,
+        //    MethodResultCallback reject) =>
+        //    {
+        //       .... statements
+        //    }
+        return InvocationStatement(
+          MemberAccessExpression(
+            ReactNativeNames.ModuleBuilder,
+            method.IsSynchronous ? ReactNativeNames.AddSyncMethod : ReactNativeNames.AddMethod),
+          LiteralExpression(method.Name),
+          MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            ReactTypes.MethodReturnType.ToTypeSyntax(),
+            SyntaxFactory.IdentifierName(GetMethodReturnTypeFromStyle(method.ReturnStyle))),
+          ParenthesizedLambdaExpression(
+            parameterList:
+            ParameterList(
+              Parameter(ReactNativeNames.ReaderLocalName)
+                .WithType(ReactTypes.IJSValueReader.ToTypeSyntax()),
+              Parameter(ReactNativeNames.WriterLocalName)
+                .WithType(ReactTypes.IJSValueWriter.ToTypeSyntax()),
+              Parameter(ReactNativeNames.ResolveLocalName)
+                .WithType(ReactTypes.MethodResultCallback.ToTypeSyntax()),
+              Parameter(ReactNativeNames.RejectLocalName)
+                .WithType(ReactTypes.MethodResultCallback.ToTypeSyntax())),
+            block: Block(
+              statements),
+            expressionBody: null));
+      }
+    }
+
+    internal ExpressionSyntax GeneratePromiseInvocation(bool isReject)
+    {
+      // generates:
+      //    value1 => resolve|reject(JSValueWriter.WriteArgs(writer, value1)
+      return ParenthesizedLambdaExpression(
+        parameterList: ParameterList(
+          SeparatedList<ParameterSyntax>(
+            new[]
+            {
               Parameter(ReactNativeNames.ValueLocalName)
-                  })),
-              block: null,
-              expressionBody: InvocationExpression(
-                IdentifierName(isReject ? ReactNativeNames.RejectLocalName : ReactNativeNames.ResolveLocalName),
-                InvocationExpression(
-                  MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
-                  IdentifierName(ReactNativeNames.WriterLocalName),
-                  IdentifierName(ReactNativeNames.ValueLocalName))
-                )
-              );
-        }
+            })),
+        block: null,
+        expressionBody: InvocationExpression(
+          IdentifierName(isReject ? ReactNativeNames.RejectLocalName : ReactNativeNames.ResolveLocalName),
+          InvocationExpression(
+            MemberAccessExpression(ReactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
+            IdentifierName(ReactNativeNames.WriterLocalName),
+            IdentifierName(ReactNativeNames.ValueLocalName))
+          )
+        );
+    }
 
-        internal StatementSyntax AddEvent(ReactEvent evnt)
-        {
-            // generates:
-            //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
-            //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsEvent("eventEmitterName", "eventName", arg0, arg1, ...);
-            return InvocationStatement(
-              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
-              ParenthesizedLambdaExpression(
-                parameterList: ParameterList(
-                  Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
-                block: null,
-                expressionBody: GenerateCallback(evnt, ReactNativeNames.EmitJSEventFunctionName)));
-        }
+    internal StatementSyntax AddEvent(ReactEvent evnt)
+    {
+      // generates:
+      //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
+      //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsEvent("eventEmitterName", "eventName", arg0, arg1, ...);
+      return InvocationStatement(
+        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+        ParenthesizedLambdaExpression(
+          parameterList: ParameterList(
+            Parameter(ReactNativeNames.ReactContextLocalName).WithType(ReactTypes.IReactContext.ToTypeSyntax())),
+          block: null,
+          expressionBody: GenerateCallback(evnt, ReactNativeNames.EmitJSEventFunctionName)));
+    }
 
-        internal StatementSyntax AddFunction(ReactFunction function)
-        {
-            // generates:
-            //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
-            //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsFunction("moduleName", "eventName", arg0, arg1, ...);
-            return InvocationStatement(
-              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
-              ParenthesizedLambdaExpression(
-                parameterList: ParameterList(
-                  Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
-                block: null,
-                expressionBody: GenerateCallback(function, ReactNativeNames.CallJSFunctionFunctionName)));
-        }
+    internal StatementSyntax AddFunction(ReactFunction function)
+    {
+      // generates:
+      //   moduleBuilder.AddInitializer((IReactContext reactContext) =>
+      //      module.MyEvent = (ArgType0 arg0, ArgType1 arg1, ...) => reactContext.EmitJsFunction("moduleName", "eventName", arg0, arg1, ...);
+      return InvocationStatement(
+        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+        ParenthesizedLambdaExpression(
+          parameterList: ParameterList(
+            Parameter(ReactNativeNames.ReactContextLocalName).WithType(ReactTypes.IReactContext.ToTypeSyntax())),
+          block: null,
+          expressionBody: GenerateCallback(function, ReactNativeNames.CallJSFunctionFunctionName)));
+    }
 
-        internal StatementSyntax AddInitializer(ReactInitializer initializer)
-        {
-            // generates:
-            //    moduleBuilder.AddInitializer((IReactContext reactContext) => module.initializerMethod(new ReactContext(reactContext)));
-            return InvocationStatement(
-              MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+    internal StatementSyntax AddInitializer(ReactInitializer initializer)
+    {
+      // generates:
+      //    moduleBuilder.AddInitializer((IReactContext reactContext) => module.initializerMethod(new ReactContext(reactContext)));
+      return InvocationStatement(
+        MemberAccessExpression(ReactNativeNames.ModuleBuilder, ReactNativeNames.AddInitializer),
+        ParenthesizedLambdaExpression(
+          parameterList: ParameterList(
+            Parameter(ReactNativeNames.ReactContextLocalName).WithType(ReactTypes.IReactContext.ToTypeSyntax())),
+          block: null,
+          expressionBody: InvocationExpression(
+            MemberAccessExpression(ReactNativeNames.Module, Identifier(initializer.Method.Name)),
+            ObjectCreationExpression(ReactTypes.ReactContext, IdentifierName((ReactNativeNames.ReactContextLocalName)))
+            )));
+    }
+
+    private ExpressionSyntax GenerateCallback(ReactCallback callback, SyntaxToken contextCallbackMethod)
+    {
+
+      var lambdaParams = new List<ParameterSyntax>(callback.CallbackParameters.Length);
+      var arguments = new List<ArgumentSyntax>(callback.CallbackParameters.Length);
+      arguments.Add(Argument(IdentifierName(ReactNativeNames.WriterLocalName)));
+
+      for (int i = 0; i < callback.CallbackParameters.Length; i++)
+      {
+        var paramType = callback.CallbackParameters[i].Type;
+        var identifierName = "arg" + i.ToString(CultureInfo.InvariantCulture);
+
+        lambdaParams.Add(Parameter(Identifier(identifierName)).WithType(paramType.ToTypeSyntax()));
+        arguments.Add(Argument(IdentifierName(identifierName)));
+      }
+
+      // generates:
+      //  module.<callackName> = (ArgType0 arg0, ArgType1 arg0, ...) =>
+      //    reactContext.<contextCallbackMethod>(
+      //      eventEmitterName,
+      //      eventName,
+      //      writer => writer.WriteArgs(arg0, arg1, ...)
+      //      )
+      return
+        AssignmentExpression(
+          SyntaxKind.SimpleAssignmentExpression,
+          MemberAccessExpression(ReactNativeNames.Module, Identifier(callback.Symbol.Name)),
+          ParenthesizedLambdaExpression(
+            parameterList: ParameterList(lambdaParams.ToArray()),
+            block: null,
+            expressionBody: InvocationExpression(
+              MemberAccessExpression(ReactNativeNames.ReactContextLocalName, contextCallbackMethod),
+              LiteralExpression(callback.CallbackContextName),
+              LiteralExpression(callback.Name),
               ParenthesizedLambdaExpression(
-                parameterList: ParameterList(
-                  Parameter(ReactNativeNames.ReactContextLocalName).WithType(m_reactTypes.IReactContext.ToTypeSyntax())),
+                parameterList: ParameterList(Parameter(ReactNativeNames.WriterLocalName)),
                 block: null,
                 expressionBody: InvocationExpression(
-                  MemberAccessExpression(ReactNativeNames.Module, Identifier(initializer.Method.Name)),
-                  ObjectCreationExpression(m_reactTypes.ReactContext, IdentifierName((ReactNativeNames.ReactContextLocalName)))
-                  )));
-        }
-
-        private ExpressionSyntax GenerateCallback(ReactCallback callback, SyntaxToken contextCallbackMethod)
-        {
-
-            var lambdaParams = new List<ParameterSyntax>(callback.CallbackParameters.Length);
-            var arguments = new List<ArgumentSyntax>(callback.CallbackParameters.Length);
-            arguments.Add(Argument(IdentifierName(ReactNativeNames.WriterLocalName)));
-
-            for (int i = 0; i < callback.CallbackParameters.Length; i++)
-            {
-                var paramType = callback.CallbackParameters[i].Type;
-                var identifierName = "arg" + i.ToString(CultureInfo.InvariantCulture);
-
-                lambdaParams.Add(Parameter(Identifier(identifierName)).WithType(paramType.ToTypeSyntax()));
-                arguments.Add(Argument(IdentifierName(identifierName)));
-            }
-
-            // generates:
-            //  module.<callackName> = (ArgType0 arg0, ArgType1 arg0, ...) =>
-            //    reactContext.<contextCallbackMethod>(
-            //      eventEmitterName,
-            //      eventName,
-            //      writer => writer.WriteArgs(arg0, arg1, ...)
-            //      )
-            return
-              AssignmentExpression(
-                SyntaxKind.SimpleAssignmentExpression,
-                MemberAccessExpression(ReactNativeNames.Module, Identifier(callback.Symbol.Name)),
-                ParenthesizedLambdaExpression(
-                  parameterList: ParameterList(lambdaParams.ToArray()),
-                  block: null,
-                  expressionBody: InvocationExpression(
-                    MemberAccessExpression(ReactNativeNames.ReactContextLocalName, contextCallbackMethod),
-                    LiteralExpression(callback.CallbackContextName),
-                    LiteralExpression(callback.Name),
-                    ParenthesizedLambdaExpression(
-                      parameterList: ParameterList(Parameter(ReactNativeNames.WriterLocalName)),
-                      block: null,
-                      expressionBody: InvocationExpression(
-                        MemberAccessExpression(m_reactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
-                        arguments
-                        )))));
-        }
-
-        private string GetMethodReturnTypeFromStyle(ReactMethod.MethodReturnStyle returnStyle)
-        {
-            switch (returnStyle)
-            {
-                case ReactMethod.MethodReturnStyle.Void:
-                    return "Void";
-                case ReactMethod.MethodReturnStyle.Task:
-                case ReactMethod.MethodReturnStyle.Promise:
-                    return "Promise";
-                case ReactMethod.MethodReturnStyle.Callback:
-                case ReactMethod.MethodReturnStyle.ReturnValue:
-                    return "Callback";
-                case ReactMethod.MethodReturnStyle.TwoCallbacks:
-                    return "TwoCallbacks";
-                default:
-                    throw new InvalidOperationException("Unexpected ReturnStyle");
-            }
-        }
+                  MemberAccessExpression(ReactTypes.JSValueWriter, ReactNativeNames.WriteArgsMethodName),
+                  arguments
+                  )))));
     }
+
+    private string GetMethodReturnTypeFromStyle(ReactMethod.MethodReturnStyle returnStyle)
+    {
+      switch (returnStyle)
+      {
+        case ReactMethod.MethodReturnStyle.Void:
+          return "Void";
+        case ReactMethod.MethodReturnStyle.Task:
+        case ReactMethod.MethodReturnStyle.Promise:
+          return "Promise";
+        case ReactMethod.MethodReturnStyle.Callback:
+        case ReactMethod.MethodReturnStyle.ReturnValue:
+          return "Callback";
+        case ReactMethod.MethodReturnStyle.TwoCallbacks:
+          return "TwoCallbacks";
+        default:
+          throw new InvalidOperationException("Unexpected ReturnStyle");
+      }
+    }
+  }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Serializers.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Serializers.cs
@@ -534,7 +534,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
           IdentifierName(ReactNativeNames.AssemblyLocalName)));
       separateRegistrationCalls.Add(
         InvocationStatement(
-          MemberAccessExpression(m_reactTypes.JSValueWriterGenerator, ReactNativeNames.RegisterAssemblyMethodName),
+          MemberAccessExpression(ReactTypes.JSValueWriterGenerator, ReactNativeNames.RegisterAssemblyMethodName),
           IdentifierName(ReactNativeNames.AssemblyLocalName)));
     }
   }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Serializers.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Serializers.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
               InvocationExpression(
                 MemberAccessExpression(
                   SyntaxKind.SimpleMemberAccessExpression,
-                  m_reactTypes.JSValueReader.ToTypeSyntax(),
+                  ReactTypes.JSValueReader.ToTypeSyntax(),
                   GenericName(ReactNativeNames.ReadValueMethodName, symbol.EnumUnderlyingType.ToTypeSyntax())
                 ),
                 new[]
@@ -99,7 +99,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             expression: InvocationExpression(
               MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
-                m_reactTypes.JSValueWriter.ToTypeSyntax(),
+                ReactTypes.JSValueWriter.ToTypeSyntax(),
                 GenericName(ReactNativeNames.WriteValueMethodName, symbol.EnumUnderlyingType.ToTypeSyntax())),
               IdentifierName(ReactNativeNames.WriterLocalName),
               CastExpression(
@@ -189,7 +189,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                   InvocationExpression(
                     MemberAccessExpression(
                       SyntaxKind.SimpleMemberAccessExpression,
-                      m_reactTypes.JSValueWriter.ToTypeSyntax(),
+                      ReactTypes.JSValueWriter.ToTypeSyntax(),
                       GenericName(ReactNativeNames.WriteObjectPropertyMethodName, type.ToTypeSyntax())),
                     IdentifierName(ReactNativeNames.WriterLocalName),
                     LiteralExpression(name),
@@ -236,7 +236,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                 BinaryExpression(
                   SyntaxKind.EqualsExpression,
                   MemberAccessExpression(ReactNativeNames.ReaderLocalName, ReactNativeNames.ValueTypePropertyName),
-                  MemberAccessExpression(m_reactTypes.JSValueType, ReactNativeNames.ObjectEnumMemberName)),
+                  MemberAccessExpression(ReactTypes.JSValueType, ReactNativeNames.ObjectEnumMemberName)),
                 Block(
                   WhileStatement(
                     InvocationExpression(
@@ -341,7 +341,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                 InvocationExpression(
                   MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    m_reactTypes.JSValueReader.ToTypeSyntax(),
+                    ReactTypes.JSValueReader.ToTypeSyntax(),
                     GenericName(ReactNativeNames.ReadValueMethodName, fieldType.ToTypeSyntax())
                   ),
                   new[]
@@ -366,12 +366,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen
           AssignmentExpression(
             SyntaxKind.SimpleAssignmentExpression,
             MemberAccessExpression(
-              m_reactTypes.JSValueReaderCodeGen.Construct(symbol),
+              ReactTypes.JSValueReaderCodeGen.Construct(symbol),
               ReactNativeNames.ReadValueMethodName),
             ParenthesizedLambdaExpression(
               parameterList: ParameterList(
                 Parameter(ReactNativeNames.ReaderLocalName)
-                  .WithType(m_reactTypes.IJSValueReader.ToTypeSyntax())
+                  .WithType(ReactTypes.IJSValueReader.ToTypeSyntax())
                 ,
                 Parameter(ReactNativeNames.ValueLocalName)
                   .WithModifiers(SyntaxTokenList.Create(Token(SyntaxKind.OutKeyword)))
@@ -405,7 +405,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
           AssignmentExpression(
             SyntaxKind.SimpleAssignmentExpression,
             MemberAccessExpression(
-              m_reactTypes.JSValueWriterCodeGen.Construct(symbol),
+              ReactTypes.JSValueWriterCodeGen.Construct(symbol),
               ReactNativeNames.WriteValueMethodName),
             ParenthesizedLambdaExpression(
               parameterList: ParameterList(
@@ -432,7 +432,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
         {
           generic.Add(InvocationStatement(
             MemberAccessExpression(
-              m_reactTypes.JSValueReaderGenerator,
+              ReactTypes.JSValueReaderGenerator,
               ReactNativeNames.RegisterCodeGeneratorGenericExtensionMethod),
             TypeOfExpression(type.ToTypeSyntax())
             ));
@@ -443,7 +443,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             AssignmentExpression(
               SyntaxKind.SimpleAssignmentExpression,
               MemberAccessExpression(
-                m_reactTypes.JSValueReaderCodeGen.Construct(type),
+                ReactTypes.JSValueReaderCodeGen.Construct(type),
                 ReactNativeNames.ReadValueMethodName),
               MemberAccessExpression(
                 method.ContainingType,
@@ -474,7 +474,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
         {
           generic.Add(InvocationStatement(
             MemberAccessExpression(
-              m_reactTypes.JSValueWriterGenerator,
+              ReactTypes.JSValueWriterGenerator,
               ReactNativeNames.RegisterCodeGeneratorGenericExtensionMethod),
             TypeOfExpression(type.ToTypeSyntax())
           ));
@@ -485,7 +485,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             AssignmentExpression(
               SyntaxKind.SimpleAssignmentExpression,
               MemberAccessExpression(
-                m_reactTypes.JSValueWriterCodeGen.Construct(type),
+                ReactTypes.JSValueWriterCodeGen.Construct(type),
                 ReactNativeNames.WriteValueMethodName),
               MemberAccessExpression(
                 method.ContainingType,
@@ -530,7 +530,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             IdentifierName(ReactNativeNames.AssemblyPropertyName))));
       separateRegistrationCalls.Add(
         InvocationStatement(
-          MemberAccessExpression(m_reactTypes.JSValueReaderGenerator, ReactNativeNames.RegisterAssemblyMethodName),
+          MemberAccessExpression(ReactTypes.JSValueReaderGenerator, ReactNativeNames.RegisterAssemblyMethodName),
           IdentifierName(ReactNativeNames.AssemblyLocalName)));
       separateRegistrationCalls.Add(
         InvocationStatement(

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.ViewManager.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.ViewManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
       // generates:
       //  IReactPackaBuilder ReactNativeNames.PackageBuilder
       return Parameter(ReactNativeNames.PackageBuilderId)
-        .WithType(m_reactTypes.IReactPackageBuilder.ToTypeSyntax());
+        .WithType(ReactTypes.IReactPackageBuilder.ToTypeSyntax());
     }
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
@@ -18,9 +18,11 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// </summary>
   public partial class CodeGenerator
   {
-    private readonly ReactTypes m_reactTypes;
+    public readonly ReactTypes m_reactTypes;
 
     private readonly string m_rootNamespace;
+
+    internal ReactTypes ReactTypes => m_reactTypes;
 
     public CodeGenerator(ReactTypes reactTypes, string rootNamespace)
     {

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
@@ -18,17 +18,15 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// </summary>
   public partial class CodeGenerator
   {
-    public readonly ReactTypes m_reactTypes;
+    internal readonly ReactTypes ReactTypes;
 
     private readonly string m_rootNamespace;
-
-    internal ReactTypes ReactTypes => m_reactTypes;
 
     public CodeGenerator(ReactTypes reactTypes, string rootNamespace)
     {
       Contract.Requires(!string.IsNullOrEmpty(rootNamespace));
 
-      m_reactTypes = reactTypes;
+      ReactTypes = reactTypes;
       m_rootNamespace = rootNamespace;
     }
 
@@ -105,7 +103,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                 Token(SyntaxKind.PartialKeyword))
               .AddBaseListTypes(
                 SimpleBaseType(
-                  m_reactTypes.IReactPackageProvider.ToTypeSyntax()))
+                  ReactTypes.IReactPackageProvider.ToTypeSyntax()))
               .WithMembers(
                 new SyntaxList<MemberDeclarationSyntax>(providerMembers))
           );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/DiagnosticDescriptors.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/DiagnosticDescriptors.cs
@@ -136,10 +136,18 @@ namespace Microsoft.ReactNative.Managed.CodeGen
       isEnabledByDefault: true);
 
     public static readonly DiagnosticDescriptor CallbackDelegateMustReturnVoid = new DiagnosticDescriptor(
-      id: Invariant($"{ReactNativeNames.ErrorCodePrefix}1008"),
+      id: Invariant($"{ReactNativeNames.ErrorCodePrefix}1014"),
       category: ReactNativeNames.ErrorCategory,
       title: "ReactModule Events and Functions must have a void delegate",
       messageFormat: "Events and Functions of ReactModules must be a delegate that returns void. Return type of delegate for callback '{0}' of module '{1}' is '{2}'.",
+      defaultSeverity: DiagnosticSeverity.Error,
+      isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor MethodShouldNotReturnTaskWhenSynchronous = new DiagnosticDescriptor(
+      id: Invariant($"{ReactNativeNames.ErrorCodePrefix}1015"),
+      category: ReactNativeNames.ErrorCategory,
+      title: "ReactModule Methods should not return ",
+      messageFormat: "Methods of ReactModules should not return a Task when they are synchronous. Change the attribute from '[ReactSyncMethod]' to '[ReactMethod]' for method '{0}' of module '{1}'.",
       defaultSeverity: DiagnosticSeverity.Error,
       isEnabledByDefault: true);
   };

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactMethod.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactMethod.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
 
     public ReactMethod(IMethodSymbol method, string name, MethodReturnStyle returnStyle, ITypeSymbol effectiveReturnType, IReadOnlyList<IParameterSymbol> effectiveParameters, bool isSynchronous)
     {
-      Contract.Requires(! (IsSynchronous && returnStyle == MethodReturnStyle.Task), "Task style methods are required to be asynchronous");
+      Contract.Requires(!(IsSynchronous && returnStyle == MethodReturnStyle.Task), "Task style methods are required to be asynchronous");
       Method = method;
       Name = name;
       ReturnStyle = returnStyle;
@@ -35,11 +35,11 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
     public enum MethodReturnStyle
     {
       Void = 0,
-      Callback = 1,
-      TwoCallbacks = 2,
-      Promise = 3,
-      ReturnValue = 4,
-      Task = 5,
+      Callback,
+      TwoCallbacks,
+      Promise,
+      ReturnValue,
+      Task,
     }
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactMethod.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactMethod.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Diagnostics.ContractsLight;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
@@ -13,21 +15,31 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
 
     public bool IsSynchronous { get; }
 
-    public MethodReturnType ReturnType { get; }
+    public MethodReturnStyle ReturnStyle { get; }
 
-    public ReactMethod(IMethodSymbol method, string name, bool isSynchronous = false)
+    public ITypeSymbol EffectiveReturnType { get; }
+
+    public IReadOnlyList<IParameterSymbol> EffectiveParameters { get; }
+
+    public ReactMethod(IMethodSymbol method, string name, MethodReturnStyle returnStyle, ITypeSymbol effectiveReturnType, IReadOnlyList<IParameterSymbol> effectiveParameters, bool isSynchronous)
     {
+      Contract.Requires(! (IsSynchronous && returnStyle == MethodReturnStyle.Task), "Task style methods are required to be asynchronous");
       Method = method;
       Name = name;
+      ReturnStyle = returnStyle;
+      EffectiveReturnType = effectiveReturnType;
+      EffectiveParameters = effectiveParameters;
       IsSynchronous = isSynchronous;
     }
 
-    public enum MethodReturnType
+    public enum MethodReturnStyle
     {
       Void = 0,
       Callback = 1,
       TwoCallbacks = 2,
-      Promise = 3
+      Promise = 3,
+      ReturnValue = 4,
+      Task = 5,
     }
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactTypes.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactTypes.cs
@@ -9,145 +9,158 @@ using System.Linq;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  /// <summary>
-  /// Helper class that stores all types needed for analysis and code generation
-  /// from Microsoft.ReactNative and Microsoft.ReactNative.Managed
-  /// </summary>
-  public class ReactTypes
-  {
-    private const string m_ReactNativeAssemblyName = "Microsoft.ReactNative";
-    private const string m_ReactNativeNamespace = "Microsoft.ReactNative";
-    private const string m_ReactNativeManagedAssemblyName = "Microsoft.ReactNative.Managed";
-    private const string m_ReactNativeManagedNamespace = "Microsoft.ReactNative.Managed";
-
-    public INamedTypeSymbol SystemVoid { get; }
-    public INamedTypeSymbol Task { get; set; }
-    public INamedTypeSymbol TaskOfT { get; set; }
-    
-    public INamedTypeSymbol IViewManagerType { get; }
-    public INamedTypeSymbol IReactPackageProvider { get; }
-    public INamedTypeSymbol IReactPackageBuilder { get; }
-    public INamedTypeSymbol IReactModuleBuilder { get; }
-    public INamedTypeSymbol IReactContext { get; }
-    public INamedTypeSymbol ReactContext { get; }
-    public INamedTypeSymbol IJSValueWriter { get; }
-    public INamedTypeSymbol IJSValueReader { get; }
-    public INamedTypeSymbol JSValueType { get; }
-    public INamedTypeSymbol JSValue { get; }
-    public INamedTypeSymbol JSValueWriter { get; }
-    public INamedTypeSymbol JSValueReader { get; }
-    public INamedTypeSymbol JSValueWriterGenerator { get; }
-    public INamedTypeSymbol JSValueReaderGenerator { get; }
-    public INamedTypeSymbol JSValueWriterCodeGen { get; }
-    public INamedTypeSymbol JSValueReaderCodeGen { get; }
-    public INamedTypeSymbol IReactPromise { get; }
-    public INamedTypeSymbol ReactPromise { get; }
-    public INamedTypeSymbol MethodReturnType { get; }
-    public INamedTypeSymbol MethodResultCallback { get; }
-    public INamedTypeSymbol ReactConstantProvider { get; }
-    public INamedTypeSymbol ReactModuleAttribute { get; }
-    public INamedTypeSymbol ReactInitializerAttribute { get; }
-    public INamedTypeSymbol ReactConstantAttribute { get; }
-    public INamedTypeSymbol ReactConstantProviderAttribute { get; }
-    public INamedTypeSymbol ReactMethodAttribute { get; }
-    public INamedTypeSymbol ReactSyncMethodAttribute { get; }
-    public INamedTypeSymbol ReactEventAttribute { get; }
-    public INamedTypeSymbol ReactFunctionAttribute { get; }
-    public INamedTypeSymbol ReactTaskExtensions { get; }
-
-    private readonly ICollection<Diagnostic> m_diagnostics = new List<Diagnostic>();
-
-    private ReactTypes(Compilation compilation)
+    /// <summary>
+    /// Helper class that stores all types needed for analysis and code generation
+    /// from Microsoft.ReactNative and Microsoft.ReactNative.Managed
+    /// </summary>
+    public class ReactTypes
     {
-      SystemVoid = compilation.GetSpecialType(SpecialType.System_Void);
-      Task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
-      TaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1")!.ConstructUnboundGenericType();
-      
-      IViewManagerType = FindReactNativeType(compilation, "IViewManager");
-      IReactPackageProvider = FindReactNativeType(compilation, "IReactPackageProvider");
-      IReactPackageBuilder = FindReactNativeType(compilation, "IReactPackageBuilder");
-      IReactModuleBuilder = FindReactNativeType(compilation, "IReactModuleBuilder");
-      IReactContext = FindReactNativeType(compilation, "IReactContext");
-      IJSValueWriter = FindReactNativeType(compilation, "IJSValueWriter");
-      IJSValueReader = FindReactNativeType(compilation, "IJSValueReader");
-      JSValueType = FindReactNativeType(compilation, "JSValueType");
-      MethodReturnType = FindReactNativeType(compilation, "MethodReturnType");
-      MethodResultCallback = FindReactNativeType(compilation, "MethodResultCallback");
+        private const string m_ReactNativeAssemblyName = "Microsoft.ReactNative";
+        private const string m_ReactNativeNamespace = "Microsoft.ReactNative";
+        private const string m_ReactNativeManagedAssemblyName = "Microsoft.ReactNative.Managed";
+        private const string m_ReactNativeManagedNamespace = "Microsoft.ReactNative.Managed";
 
-      ReactContext = FindReactNativeManagedType(compilation, "ReactContext");
-      ReactConstantProvider = FindReactNativeManagedType(compilation, "ReactConstantProvider");
-      IReactPromise = FindReactNativeManagedType(compilation, "IReactPromise`1");
-      ReactPromise = FindReactNativeManagedType(compilation, "ReactPromise`1");
-      JSValue = FindReactNativeManagedType(compilation, "JSValue");
-      JSValueWriter = FindReactNativeManagedType(compilation, "JSValueWriter");
-      JSValueReader = FindReactNativeManagedType(compilation, "JSValueReader");
-      JSValueWriterGenerator = FindReactNativeManagedType(compilation, "JSValueWriterGenerator");
-      JSValueReaderGenerator = FindReactNativeManagedType(compilation, "JSValueReaderGenerator");
-      JSValueWriterCodeGen = FindReactNativeManagedType(compilation, "JSValueWriterCodeGen`1");
-      JSValueReaderCodeGen = FindReactNativeManagedType(compilation, "JSValueReaderCodeGen`1");
+        public INamedTypeSymbol SystemVoid { get; }
+        public INamedTypeSymbol Task { get; }
+        public INamedTypeSymbol TaskOfT { get; }
 
-      ReactModuleAttribute = FindReactNativeManagedType(compilation, "ReactModuleAttribute");
-      ReactInitializerAttribute = FindReactNativeManagedType(compilation, "ReactInitializerAttribute");
-      ReactConstantAttribute = FindReactNativeManagedType(compilation, "ReactConstantAttribute");
-      ReactConstantProviderAttribute = FindReactNativeManagedType(compilation, "ReactConstantProviderAttribute");
-      ReactMethodAttribute = FindReactNativeManagedType(compilation, "ReactMethodAttribute");
-      ReactSyncMethodAttribute = FindReactNativeManagedType(compilation, "ReactSyncMethodAttribute");
-      ReactEventAttribute = FindReactNativeManagedType(compilation, "ReactEventAttribute");
-      ReactFunctionAttribute = FindReactNativeManagedType(compilation, "ReactFunctionAttribute");
-      ReactTaskExtensions = FindReactNativeManagedType(compilation, "ReactTaskExtensions");
-    }
+        public INamedTypeSymbol IViewManagerType { get; }
+        public INamedTypeSymbol IReactPackageProvider { get; }
+        public INamedTypeSymbol IReactPackageBuilder { get; }
+        public INamedTypeSymbol IReactModuleBuilder { get; }
+        public INamedTypeSymbol IReactContext { get; }
+        public INamedTypeSymbol ReactContext { get; }
+        public INamedTypeSymbol IJSValueWriter { get; }
+        public INamedTypeSymbol IJSValueReader { get; }
+        public INamedTypeSymbol JSValueType { get; }
+        public INamedTypeSymbol JSValue { get; }
+        public INamedTypeSymbol JSValueWriter { get; }
+        public INamedTypeSymbol JSValueReader { get; }
+        public INamedTypeSymbol JSValueWriterGenerator { get; }
+        public INamedTypeSymbol JSValueReaderGenerator { get; }
+        public INamedTypeSymbol JSValueWriterCodeGen { get; }
+        public INamedTypeSymbol JSValueReaderCodeGen { get; }
+        public INamedTypeSymbol IReactPromise { get; }
+        public INamedTypeSymbol ReactPromise { get; }
+        public INamedTypeSymbol MethodReturnType { get; }
+        public INamedTypeSymbol MethodResultCallback { get; }
+        public INamedTypeSymbol ReactConstantProvider { get; }
+        public INamedTypeSymbol ReactModuleAttribute { get; }
+        public INamedTypeSymbol ReactInitializerAttribute { get; }
+        public INamedTypeSymbol ReactConstantAttribute { get; }
+        public INamedTypeSymbol ReactConstantProviderAttribute { get; }
+        public INamedTypeSymbol ReactMethodAttribute { get; }
+        public INamedTypeSymbol ReactSyncMethodAttribute { get; }
+        public INamedTypeSymbol ReactEventAttribute { get; }
+        public INamedTypeSymbol ReactFunctionAttribute { get; }
+        public INamedTypeSymbol ReactTaskExtensions { get; }
 
-    public static bool TryLoad(Compilation compilation, ICollection<Diagnostic> diagnostics, [NotNullWhen(returnValue: true)] out ReactTypes types)
-    {
-      types = new ReactTypes(compilation);
-      if (types.m_diagnostics.Count > 0)
-      {
-        foreach (var diagnostic in types.m_diagnostics)
+        private readonly ICollection<Diagnostic> m_diagnostics = new List<Diagnostic>();
+
+        private ReactTypes(Compilation compilation)
         {
-          diagnostics.Add(diagnostic);
+            SystemVoid = compilation.GetSpecialType(SpecialType.System_Void);
+            Task = FindBclType(compilation, "System.Threading.Tasks.Task");
+            TaskOfT = FindBclType(compilation, "System.Threading.Tasks.Task`1")!.ConstructUnboundGenericType();
+
+            IViewManagerType = FindReactNativeType(compilation, "IViewManager");
+            IReactPackageProvider = FindReactNativeType(compilation, "IReactPackageProvider");
+            IReactPackageBuilder = FindReactNativeType(compilation, "IReactPackageBuilder");
+            IReactModuleBuilder = FindReactNativeType(compilation, "IReactModuleBuilder");
+            IReactContext = FindReactNativeType(compilation, "IReactContext");
+            IJSValueWriter = FindReactNativeType(compilation, "IJSValueWriter");
+            IJSValueReader = FindReactNativeType(compilation, "IJSValueReader");
+            JSValueType = FindReactNativeType(compilation, "JSValueType");
+            MethodReturnType = FindReactNativeType(compilation, "MethodReturnType");
+            MethodResultCallback = FindReactNativeType(compilation, "MethodResultCallback");
+
+            ReactContext = FindReactNativeManagedType(compilation, "ReactContext");
+            ReactConstantProvider = FindReactNativeManagedType(compilation, "ReactConstantProvider");
+            IReactPromise = FindReactNativeManagedType(compilation, "IReactPromise`1");
+            ReactPromise = FindReactNativeManagedType(compilation, "ReactPromise`1");
+            JSValue = FindReactNativeManagedType(compilation, "JSValue");
+            JSValueWriter = FindReactNativeManagedType(compilation, "JSValueWriter");
+            JSValueReader = FindReactNativeManagedType(compilation, "JSValueReader");
+            JSValueWriterGenerator = FindReactNativeManagedType(compilation, "JSValueWriterGenerator");
+            JSValueReaderGenerator = FindReactNativeManagedType(compilation, "JSValueReaderGenerator");
+            JSValueWriterCodeGen = FindReactNativeManagedType(compilation, "JSValueWriterCodeGen`1");
+            JSValueReaderCodeGen = FindReactNativeManagedType(compilation, "JSValueReaderCodeGen`1");
+
+            ReactModuleAttribute = FindReactNativeManagedType(compilation, "ReactModuleAttribute");
+            ReactInitializerAttribute = FindReactNativeManagedType(compilation, "ReactInitializerAttribute");
+            ReactConstantAttribute = FindReactNativeManagedType(compilation, "ReactConstantAttribute");
+            ReactConstantProviderAttribute = FindReactNativeManagedType(compilation, "ReactConstantProviderAttribute");
+            ReactMethodAttribute = FindReactNativeManagedType(compilation, "ReactMethodAttribute");
+            ReactSyncMethodAttribute = FindReactNativeManagedType(compilation, "ReactSyncMethodAttribute");
+            ReactEventAttribute = FindReactNativeManagedType(compilation, "ReactEventAttribute");
+            ReactFunctionAttribute = FindReactNativeManagedType(compilation, "ReactFunctionAttribute");
+            ReactTaskExtensions = FindReactNativeManagedType(compilation, "ReactTaskExtensions");
         }
 
-        return false;
-      }
+        public static bool TryLoad(Compilation compilation, ICollection<Diagnostic> diagnostics, [NotNullWhen(returnValue: true)] out ReactTypes types)
+        {
+            types = new ReactTypes(compilation);
+            if (types.m_diagnostics.Count > 0)
+            {
+                foreach (var diagnostic in types.m_diagnostics)
+                {
+                    diagnostics.Add(diagnostic);
+                }
 
-      return true;
+                return false;
+            }
+
+            return true;
+        }
+
+        private INamedTypeSymbol FindReactNativeType(Compilation compilation, string typeName)
+        {
+            return FindType(compilation, m_ReactNativeAssemblyName, m_ReactNativeNamespace + "." + typeName);
+        }
+
+        private INamedTypeSymbol FindReactNativeManagedType(Compilation compilation, string typeName)
+        {
+            return FindType(compilation, m_ReactNativeManagedAssemblyName, m_ReactNativeManagedNamespace + "." + typeName);
+        }
+
+        private INamedTypeSymbol FindBclType(Compilation compilation, string typeName)
+        {
+            var type = compilation.GetTypeByMetadataName(typeName);
+            if (type == null)
+            {
+                m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CantFindReferenceAssembly, Location.None, typeName, "BCL"));
+                // Return object to avoid null, the reported error tracks failure.
+                return compilation.ObjectType;
+            }
+
+            return type;
+        }
+
+        private INamedTypeSymbol FindType(Compilation compilation, string assemblyName, string typeName)
+        {
+            var assemblySymbol = compilation
+              .References
+              .Select(compilation.GetAssemblyOrModuleSymbol)
+              .OfType<IAssemblySymbol>()
+              .FirstOrDefault(asm =>
+                string.Equals(asm.Name, assemblyName, StringComparison.Ordinal));
+
+            if (assemblySymbol == null)
+            {
+                m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CantFindReferenceAssembly, Location.None, assemblyName));
+                // Return object to avoid null, the reported error tracks failure.
+                return compilation.ObjectType;
+            }
+
+            var type = assemblySymbol.GetTypeByMetadataName(typeName);
+            if (type == null)
+            {
+                m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CantFindReferenceAssembly, Location.None, typeName, assemblySymbol.Identity.GetDisplayName(true)));
+                // Return object to avoid null, the reported error tracks failure.
+                return compilation.ObjectType;
+            }
+
+            return type;
+        }
     }
-
-    private INamedTypeSymbol FindReactNativeType(Compilation compilation, string typeName)
-    {
-      return FindType(compilation, m_ReactNativeAssemblyName, m_ReactNativeNamespace + "." + typeName);
-    }
-
-    private INamedTypeSymbol FindReactNativeManagedType(Compilation compilation, string typeName)
-    {
-      return FindType(compilation, m_ReactNativeManagedAssemblyName, m_ReactNativeManagedNamespace + "." + typeName);
-    }
-
-    private INamedTypeSymbol FindType(Compilation compilation, string assemblyName, string typeName)
-    {
-      var assemblySymbol = compilation
-        .References
-        .Select(compilation.GetAssemblyOrModuleSymbol)
-        .OfType<IAssemblySymbol>()
-        .FirstOrDefault(asm =>
-          string.Equals(asm.Name, assemblyName, StringComparison.Ordinal));
-
-      if (assemblySymbol == null)
-      {
-        m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CantFindReferenceAssembly, Location.None, assemblyName));
-        // Return object to avoid null, the reported error tracks failure.
-        return compilation.ObjectType;
-      }
-
-      var type = assemblySymbol.GetTypeByMetadataName(typeName);
-      if (type == null)
-      {
-        m_diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.CantFindReferenceAssembly, Location.None, typeName, assemblySymbol.Identity.GetDisplayName(true)));
-        // Return object to avoid null, the reported error tracks failure.
-        return compilation.ObjectType;
-      }
-
-      return type;
-    }
-  }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactTypes.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactTypes.cs
@@ -20,6 +20,10 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
     private const string m_ReactNativeManagedAssemblyName = "Microsoft.ReactNative.Managed";
     private const string m_ReactNativeManagedNamespace = "Microsoft.ReactNative.Managed";
 
+    public INamedTypeSymbol SystemVoid { get; }
+    public INamedTypeSymbol Task { get; set; }
+    public INamedTypeSymbol TaskOfT { get; set; }
+    
     public INamedTypeSymbol IViewManagerType { get; }
     public INamedTypeSymbol IReactPackageProvider { get; }
     public INamedTypeSymbol IReactPackageBuilder { get; }
@@ -49,11 +53,16 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
     public INamedTypeSymbol ReactSyncMethodAttribute { get; }
     public INamedTypeSymbol ReactEventAttribute { get; }
     public INamedTypeSymbol ReactFunctionAttribute { get; }
+    public INamedTypeSymbol ReactTaskExtensions { get; }
 
     private readonly ICollection<Diagnostic> m_diagnostics = new List<Diagnostic>();
 
     private ReactTypes(Compilation compilation)
     {
+      SystemVoid = compilation.GetSpecialType(SpecialType.System_Void);
+      Task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+      TaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1")!.ConstructUnboundGenericType();
+      
       IViewManagerType = FindReactNativeType(compilation, "IViewManager");
       IReactPackageProvider = FindReactNativeType(compilation, "IReactPackageProvider");
       IReactPackageBuilder = FindReactNativeType(compilation, "IReactPackageBuilder");
@@ -85,6 +94,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
       ReactSyncMethodAttribute = FindReactNativeManagedType(compilation, "ReactSyncMethodAttribute");
       ReactEventAttribute = FindReactNativeManagedType(compilation, "ReactEventAttribute");
       ReactFunctionAttribute = FindReactNativeManagedType(compilation, "ReactFunctionAttribute");
+      ReactTaskExtensions = FindReactNativeManagedType(compilation, "ReactTaskExtensions");
     }
 
     public static bool TryLoad(Compilation compilation, ICollection<Diagnostic> diagnostics, [NotNullWhen(returnValue: true)] out ReactTypes types)

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/ReactNativeNames.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/ReactNativeNames.cs
@@ -72,6 +72,9 @@ namespace Microsoft.ReactNative.Managed.CodeGen
     public static readonly SyntaxToken ValueLocalName = Identifier("value");
     public static readonly SyntaxToken AssemblyLocalName = Identifier("assembly");
     public static readonly SyntaxToken AssemblyPropertyName = Identifier("Assembly");
+
+    public static readonly SyntaxToken ContinueWith = Identifier("ContinueWith");
+    public static readonly SyntaxToken TaskLocalName = Identifier("task");
   }
 
  

--- a/vnext/Microsoft.ReactNative.Managed/IReactPromise.cs
+++ b/vnext/Microsoft.ReactNative.Managed/IReactPromise.cs
@@ -38,4 +38,16 @@ namespace Microsoft.ReactNative.Managed
     public Exception Exception = null;
     public IReadOnlyDictionary<string, JSValue> UserInfo = null;
   }
+  
+  internal class ReactErrorConstants
+  {
+    internal const string DefaultCode = "EUNSPECIFIED";
+    internal const string DefaultMessage = "Error not specified.";
+    
+    // Keys for m_reject's Error object
+    internal const string Code = "code";
+    internal const string Message = "message";
+    internal const string UserInfo = "userInfo";
+    internal const string NativeStack = "nativeStackWindows";
+  }
 }

--- a/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
+++ b/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
@@ -20,7 +20,8 @@
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <NoWarn>;2008</NoWarn>
-    <NoWarn>$(NoWarn);1591</NoWarn> <!-- Missing XML comment for publicly visible type or member -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <!-- Missing XML comment for publicly visible type or member -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -118,6 +119,7 @@
     <Compile Include="ReactConstantProviderInfo.cs" />
     <Compile Include="ReactContext.cs" />
     <Compile Include="ReactContextGenerator.cs" />
+    <Compile Include="ReactTaskExtensions.cs" />
     <Compile Include="ReactEnumerableExtensions.cs" />
     <Compile Include="ReactEventInfo.cs" />
     <Compile Include="ReactException.cs" />
@@ -143,7 +145,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
     </PackageReference>
-    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(UseWinUI3)'=='true'"/>
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(UseWinUI3)'=='true'" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '16.0' ">
     <VisualStudioVersion>16.0</VisualStudioVersion>

--- a/vnext/Microsoft.ReactNative.Managed/ReactPromise.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactPromise.cs
@@ -16,102 +16,102 @@ using System.Collections.Generic;
 
 namespace Microsoft.ReactNative.Managed
 {
-  // Implementation of IReactPromise that represents a JavaScript Promise
-  // which can be passed to the native module as a method parameter.
-  //
-  // Methods with ReactMethodAttribute that use an IReactPromise as the last parameter
-  // will be marked as "promise" and will return a promise when invoked from JavaScript.
-  public class ReactPromise<T> : IReactPromise<T>
-  {
-    private IJSValueWriter m_writer;
-    private MethodResultCallback m_resolve;
-    private MethodResultCallback m_reject;
-
-    public ReactPromise(IJSValueWriter writer, MethodResultCallback resolve, MethodResultCallback reject)
+    // Implementation of IReactPromise that represents a JavaScript Promise
+    // which can be passed to the native module as a method parameter.
+    //
+    // Methods with ReactMethodAttribute that use an IReactPromise as the last parameter
+    // will be marked as "promise" and will return a promise when invoked from JavaScript.
+    public class ReactPromise<T> : IReactPromise<T>
     {
-      m_writer = writer;
-      m_resolve = resolve;
-      m_reject = reject;
-    }
+        private IJSValueWriter m_writer;
+        private MethodResultCallback m_resolve;
+        private MethodResultCallback m_reject;
 
-    //  Successfully resolve the ReactPromise with an optional value.
-    public void Resolve(T value)
-    {
-      if (m_resolve != null)
-      {
-        m_writer.WriteArgs(value);
-        m_resolve(m_writer);
-      }
-
-      Clear();
-    }
-
-    // Reject the ReactPromise and report an error.
-    public void Reject(ReactError error)
-    {
-      if (m_reject != null)
-      {
-        ReactPromiseWriter.WriteError(m_writer,
-          code: error?.Code,
-          message: error?.Message,
-          userInfo: error?.UserInfo,
-          stackTrace: error?.Exception?.StackTrace);
-        m_reject(m_writer);
-      }
-
-      Clear();
-    }
-
-    private void Clear()
-    {
-      m_resolve = null;
-      m_reject = null;
-      m_writer = null;
-    }
-  }
-
-  public class ReactPromiseWriter
-  {
-    public static void WriteError(
-      IJSValueWriter writer,
-      string code,
-      string message,
-      IReadOnlyDictionary<string, JSValue> userInfo,
-      string stackTrace)
-    {
-      writer.WriteArrayBegin();
-      {
-        writer.WriteObjectBegin();
+        public ReactPromise(IJSValueWriter writer, MethodResultCallback resolve, MethodResultCallback reject)
         {
-          writer.WritePropertyName(ReactErrorConstants.Code);
-          writer.WriteString(code ?? ReactErrorConstants.DefaultCode);
-
-          writer.WritePropertyName(ReactErrorConstants.Message);
-          writer.WriteString(message ?? ReactErrorConstants.DefaultMessage);
-
-          // For consistency with iOS ensure userInfo key exists, even if we null it.
-          // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-          writer.WritePropertyName(ReactErrorConstants.UserInfo);
-          if (userInfo == null)
-          {
-            writer.WriteNull();
-          }
-          else
-          {
-            writer.WriteValue(userInfo);
-          }
-
-          // Attach a nativeStackWindows string if an exception was passed.
-          // This matches iOS behavior - iOS adds a `nativeStackIOS` property
-          // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-          writer.WritePropertyName(ReactErrorConstants.NativeStack);
-          writer.WriteString(stackTrace ?? string.Empty);
+            m_writer = writer;
+            m_resolve = resolve;
+            m_reject = reject;
         }
-        writer.WriteObjectEnd();
 
-      }
-      writer.WriteArrayEnd();
+        //  Successfully resolve the ReactPromise with an optional value.
+        public void Resolve(T value)
+        {
+            if (m_resolve != null)
+            {
+                m_writer.WriteArgs(value);
+                m_resolve(m_writer);
+            }
+
+            Clear();
+        }
+
+        // Reject the ReactPromise and report an error.
+        public void Reject(ReactError error)
+        {
+            if (m_reject != null)
+            {
+                ReactPromiseWriter.WriteError(m_writer,
+                  code: error?.Code,
+                  message: error?.Message,
+                  userInfo: error?.UserInfo,
+                  stackTrace: error?.Exception?.StackTrace);
+                m_reject(m_writer);
+            }
+
+            Clear();
+        }
+
+        private void Clear()
+        {
+            m_resolve = null;
+            m_reject = null;
+            m_writer = null;
+        }
     }
 
-  }
+    public static class ReactPromiseWriter
+    {
+        public static void WriteError(
+          IJSValueWriter writer,
+          string code,
+          string message,
+          IReadOnlyDictionary<string, JSValue> userInfo,
+          string stackTrace)
+        {
+            writer.WriteArrayBegin();
+            {
+                writer.WriteObjectBegin();
+                {
+                    writer.WritePropertyName(ReactErrorConstants.Code);
+                    writer.WriteString(code ?? ReactErrorConstants.DefaultCode);
+
+                    writer.WritePropertyName(ReactErrorConstants.Message);
+                    writer.WriteString(message ?? ReactErrorConstants.DefaultMessage);
+
+                    // For consistency with iOS ensure userInfo key exists, even if we null it.
+                    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+                    writer.WritePropertyName(ReactErrorConstants.UserInfo);
+                    if (userInfo == null)
+                    {
+                        writer.WriteNull();
+                    }
+                    else
+                    {
+                        writer.WriteValue(userInfo);
+                    }
+
+                    // Attach a nativeStackWindows string if an exception was passed.
+                    // This matches iOS behavior - iOS adds a `nativeStackIOS` property
+                    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+                    writer.WritePropertyName(ReactErrorConstants.NativeStack);
+                    writer.WriteString(stackTrace ?? string.Empty);
+                }
+                writer.WriteObjectEnd();
+
+            }
+            writer.WriteArrayEnd();
+        }
+
+    }
 }

--- a/vnext/Microsoft.ReactNative.Managed/ReactPromise.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactPromise.cs
@@ -23,15 +23,6 @@ namespace Microsoft.ReactNative.Managed
   // will be marked as "promise" and will return a promise when invoked from JavaScript.
   public class ReactPromise<T> : IReactPromise<T>
   {
-    private static readonly string ErrorDefaultCode = "EUNSPECIFIED";
-    private static readonly string ErrorDefaultMessage = "Error not specified.";
-
-    // Keys for m_reject's Error object
-    private static readonly string ErrorMapKeyCode = "code";
-    private static readonly string ErrorMapKeyMessage = "message";
-    private static readonly string ErrorMapKeyUserInfo = "userInfo";
-    private static readonly string ErrorMapKeyNativeStack = "nativeStackWindows";
-
     private IJSValueWriter m_writer;
     private MethodResultCallback m_resolve;
     private MethodResultCallback m_reject;
@@ -60,22 +51,11 @@ namespace Microsoft.ReactNative.Managed
     {
       if (m_reject != null)
       {
-        var errorInfo = new Dictionary<string, JSValue>
-        {
-          [ErrorMapKeyCode] = new JSValue(error?.Code ?? ErrorDefaultCode),
-          [ErrorMapKeyMessage] = new JSValue(error?.Message ?? error?.Exception?.Message ?? ErrorDefaultMessage),
-
-          // For consistency with iOS ensure userInfo key exists, even if we null it.
-          // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-          [ErrorMapKeyUserInfo] = (error?.UserInfo != null) ? new JSValue(error.UserInfo) : new JSValue(),
-
-          // Attach a nativeStackWindows string if an exception was passed.
-          // This matches iOS behavior - iOS adds a `nativeStackIOS` property
-          // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-          [ErrorMapKeyNativeStack] = new JSValue(error?.Exception?.StackTrace ?? "")
-        };
-
-        m_writer.WriteArgs(errorInfo);
+        ReactPromiseWriter.WriteError(m_writer,
+          code: error?.Code,
+          message: error?.Message,
+          userInfo: error?.UserInfo,
+          stackTrace: error?.Exception?.StackTrace);
         m_reject(m_writer);
       }
 
@@ -88,5 +68,50 @@ namespace Microsoft.ReactNative.Managed
       m_reject = null;
       m_writer = null;
     }
+  }
+
+  public class ReactPromiseWriter
+  {
+    public static void WriteError(
+      IJSValueWriter writer,
+      string code,
+      string message,
+      IReadOnlyDictionary<string, JSValue> userInfo,
+      string stackTrace)
+    {
+      writer.WriteArrayBegin();
+      {
+        writer.WriteObjectBegin();
+        {
+          writer.WritePropertyName(ReactErrorConstants.Code);
+          writer.WriteString(code ?? ReactErrorConstants.DefaultCode);
+
+          writer.WritePropertyName(ReactErrorConstants.Message);
+          writer.WriteString(message ?? ReactErrorConstants.DefaultMessage);
+
+          // For consistency with iOS ensure userInfo key exists, even if we null it.
+          // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+          writer.WritePropertyName(ReactErrorConstants.UserInfo);
+          if (userInfo == null)
+          {
+            writer.WriteNull();
+          }
+          else
+          {
+            writer.WriteValue(userInfo);
+          }
+
+          // Attach a nativeStackWindows string if an exception was passed.
+          // This matches iOS behavior - iOS adds a `nativeStackIOS` property
+          // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+          writer.WritePropertyName(ReactErrorConstants.NativeStack);
+          writer.WriteString(stackTrace ?? string.Empty);
+        }
+        writer.WriteObjectEnd();
+
+      }
+      writer.WriteArrayEnd();
+    }
+
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed/ReactTaskExtensions.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactTaskExtensions.cs
@@ -2,13 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.ReactNative.Managed
 {
   public static class ReactTaskExtensions
   {
+    /// <summary>
+    /// Connects the given task to the React Native Module resolve and reject methods.
+    /// </summary>
+    /// <remarks>
+    /// The callback will be scheduled using the default task scheduling using the default continuation
+    /// options
+    /// </remarks>
     public static Task ContinueWith(this Task task, IJSValueWriter writer, MethodResultCallback resolve,
       MethodResultCallback reject)
     {
@@ -34,8 +40,15 @@ namespace Microsoft.ReactNative.Managed
       });
     }
 
+    /// <summary>
+    /// Connects the given task to the React Native Module resolve and reject methods.
+    /// </summary>
+    /// <remarks>
+    /// The callback will be scheduled using the default task scheduling using the default continuation
+    /// options
+    /// </remarks>
     public static Task ContinueWith<T>(this Task<T> task, IJSValueWriter writer, MethodResultCallback resolve,
-      MethodResultCallback reject)
+    MethodResultCallback reject)
     {
       return task.ContinueWith(t =>
       {

--- a/vnext/Microsoft.ReactNative.Managed/ReactTaskExtensions.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactTaskExtensions.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.ReactNative.Managed
+{
+  public static class ReactTaskExtensions
+  {
+    public static Task ContinueWith(this Task task, IJSValueWriter writer, MethodResultCallback resolve,
+      MethodResultCallback reject)
+    {
+      return task.ContinueWith(t =>
+      {
+        if (t.IsCompletedSuccessfully)
+        {
+          if (resolve != null)
+          {
+            writer.WriteArgs();
+            resolve(writer);
+          }
+        }
+        else
+        {
+          if (reject != null)
+          {
+            var exception = t.Exception.Flatten();
+            WriteReject(writer, exception);
+            reject(writer);
+          }
+        }
+      });
+    }
+
+    public static Task ContinueWith<T>(this Task<T> task, IJSValueWriter writer, MethodResultCallback resolve,
+      MethodResultCallback reject)
+    {
+      return task.ContinueWith(t =>
+      {
+        if (t.IsCompletedSuccessfully)
+        {
+          if (resolve != null)
+          {
+            writer.WriteArgs(t.Result);
+            resolve(writer);
+          }
+        }
+        else
+        {
+          if (reject != null)
+          {
+            var exception = t.Exception.Flatten();
+            WriteReject(writer, exception);
+            reject(writer);
+          }
+        }
+      });
+    }
+
+    private static void WriteReject(IJSValueWriter writer, Exception exception)
+    {
+      ReactPromiseWriter.WriteError(writer,
+        code: exception.HResult == 0 ? null : exception.HResult.ToString(),
+        message: exception.Message,
+        userInfo: null,
+        stackTrace: exception.StackTrace);
+    }
+  }
+}


### PR DESCRIPTION
This change allows C# native module authors to use `Task` and `Task<T>` based async methods like:

```cs
[ReactMethod]
public async Task<int> AddValuesVerySlow(int x, int y)
{
    await Task.Delay(TimeSpan.FromMilliseconds(250));
    return x + y;
}
```

For now if you want to use this you'll have to either:
 * Specialize your project for windows with nuget enabled: `--experimentalNuGetDependency true`
 * Enable the codegen feature by adding `<ReactNativeCodeGenEnabled>true</ReactNativeCodeGenEnabled>` to your msbuild file.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5523)