### PR TITLE
Update artifact publish and download to the newer versions.

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -61,11 +61,11 @@ jobs:
         env:
           RUNNER_TEMP: $(Build.StagingDirectory)
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: Publish VersionEnvVars
         inputs:
-          PathtoPublish: $(Build.StagingDirectory)/versionEnvVars
-          ArtifactName: VersionEnvVars
+          targetPath: $(Build.StagingDirectory)/versionEnvVars
+          artifactName: VersionEnvVars
 
   - job: RnwNativeBuildDesktop
     displayName: Build Desktop
@@ -88,11 +88,11 @@ jobs:
       vmImage: $(VmImage)
 
     steps:
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         displayName: Download VersionEnvVars
         inputs:
-          artifactName: VersionEnvVars
-          downloadPath: $(Build.StagingDirectory)
+          artifact: VersionEnvVars
+          path: $(Build.StagingDirectory)
 
       - task: CmdLine@2
         inputs:
@@ -148,11 +148,11 @@ jobs:
       vmImage: $(VmImage)
 
     steps:
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         displayName: Download VersionEnvVars
         inputs:
-          artifactName: VersionEnvVars
-          downloadPath: $(Build.StagingDirectory)
+          artifact: VersionEnvVars
+          path: $(Build.StagingDirectory)
 
       - task: CmdLine@2
         inputs:
@@ -189,11 +189,11 @@ jobs:
     steps:
       - checkout: none
 
-      - task: DownloadBuildArtifacts@0
+      - task: DownloadPipelineArtifact@2
         displayName: Download VersionEnvVars
         inputs:
-          artifactName: VersionEnvVars
-          downloadPath: $(Build.StagingDirectory)
+          artifact: VersionEnvVars
+          path: $(Build.StagingDirectory)
 
       - task: CmdLine@2
         inputs:
@@ -209,8 +209,8 @@ jobs:
           publishCommitId: $(publishCommitId)
           npmVersion: $(npmVersion)
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: "Publish final nuget artifacts"
         inputs:
-          PathtoPublish: $(System.DefaultWorkingDirectory)\NugetRootFinal
-          ArtifactName: "ReactWindows-final-nuget"
+          targetPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
+          artifactName: "ReactWindows-final-nuget"

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -92,7 +92,7 @@ jobs:
         displayName: Download VersionEnvVars
         inputs:
           artifact: VersionEnvVars
-          path: $(Build.StagingDirectory)
+          path: $(Build.StagingDirectory)/VersionEnvVars
 
       - task: CmdLine@2
         inputs:
@@ -152,7 +152,7 @@ jobs:
         displayName: Download VersionEnvVars
         inputs:
           artifact: VersionEnvVars
-          path: $(Build.StagingDirectory)
+          path: $(Build.StagingDirectory)/VersionEnvVars
 
       - task: CmdLine@2
         inputs:
@@ -193,7 +193,7 @@ jobs:
         displayName: Download VersionEnvVars
         inputs:
           artifact: VersionEnvVars
-          path: $(Build.StagingDirectory)
+          path: $(Build.StagingDirectory)/VersionEnvVars
 
       - task: CmdLine@2
         inputs:

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -46,11 +46,11 @@ jobs:
           script: yarn windows --no-packager --arch ${{ parameters.BuildPlatform }} --release --logging --buildLogDirectory $(BuildLogDirectory) --msbuildprops BaseIntDir=$(BaseIntDir)
           workingDirectory: packages/E2ETest
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: Upload build logs
-        condition:  succeededOrFailed()
+        condition: succeededOrFailed()
         inputs:    
-          pathtoPublish: '$(BuildLogDirectory)'
+          targetPath: '$(BuildLogDirectory)'
           artifactName: 'Build logs - $(Agent.JobName)' 
 
       - task: CopyFiles@2
@@ -61,11 +61,11 @@ jobs:
           contents: AppPackages\**
         condition: succeededOrFailed()
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: "Publish Artifact:ReactUWPTestApp"
         inputs:
           artifactName: ReactUWPTestApp
-          pathtoPublish: $(Build.StagingDirectory)/ReactUWPTestApp
+          targetPath: $(Build.StagingDirectory)/ReactUWPTestApp
         condition: succeededOrFailed()
 
       # Wait for app to launch. A workaround to avoid WinAppDriver error: Failed to locate opened application window with appId
@@ -124,11 +124,11 @@ jobs:
           script: ". $(Build.SourcesDirectory)\\.ado\\Get-ShellScaling.ps1 > $(Build.StagingDirectory)\\ReactUWPTestAppTreeDump\\scaleFactor.txt"
         condition: failed()
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: "Publish Artifact:ReactUWPTestAppTreeDump"
         inputs:
           artifactName: ReactUWPTestAppTreeDump
-          pathtoPublish: $(Build.StagingDirectory)/ReactUWPTestAppTreeDump
+          targetPath: $(Build.StagingDirectory)/ReactUWPTestAppTreeDump
         condition: succeededOrFailed()
 
       - task: PublishTestResults@2

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -13,11 +13,11 @@ parameters:
   packMicrosoftReactNativeManagedCodeGen: true
 
 steps:
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     displayName: 'Download ReactWindows Artifact'
     inputs:
-      artifactName: ReactWindows
-      downloadPath: $(System.DefaultWorkingDirectory)
+      artifact: ReactWindows
+      path: $(System.DefaultWorkingDirectory)
 
   - ${{ if eq(parameters.packDesktop, true) }}:
     - template: prep-and-pack-single.yml

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -17,7 +17,7 @@ steps:
     displayName: 'Download ReactWindows Artifact'
     inputs:
       artifact: ReactWindows
-      path: $(System.DefaultWorkingDirectory)
+      path: $(System.DefaultWorkingDirectory)/ReactWindows
 
   - ${{ if eq(parameters.packDesktop, true) }}:
     - template: prep-and-pack-single.yml

--- a/.ado/templates/publish-build-artifacts-for-nuget.yml
+++ b/.ado/templates/publish-build-artifacts-for-nuget.yml
@@ -19,8 +19,9 @@ steps:
       targetFolder: $(Build.StagingDirectory)/$(BuildPlatform)/$(BuildConfiguration)
       contents: ${{parameters.contents}}
 
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: "Publish Artifact: ${{parameters.artifactName}}"
     inputs:
       artifactName: ${{parameters.artifactName}}
-      targetPath: $(Build.StagingDirectory)
+      pathToPublish: $(Build.StagingDirectory)
+      parralel: true

--- a/.ado/templates/publish-build-artifacts-for-nuget.yml
+++ b/.ado/templates/publish-build-artifacts-for-nuget.yml
@@ -19,8 +19,8 @@ steps:
       targetFolder: $(Build.StagingDirectory)/$(BuildPlatform)/$(BuildConfiguration)
       contents: ${{parameters.contents}}
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: ${{parameters.artifactName}}"
     inputs:
       artifactName: ${{parameters.artifactName}}
-      pathtoPublish: $(Build.StagingDirectory)
+      targetPath: $(Build.StagingDirectory)

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -108,11 +108,11 @@ steps:
       script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --no-deploy --logging --buildLogDirectory $(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs $(releaseBuildArgs)
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Upload build logs
     condition:  succeededOrFailed()
     inputs:
-      pathtoPublish: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
+      targetPath: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
       artifactName: 'Build logs - $(Agent.JobName)' 
 
   - task: CmdLine@2
@@ -137,6 +137,5 @@ steps:
     inputs:
       targetPath: 'verdaccio.log'
       artifact: '$(Agent.JobName).Verdaccio.log'
-      publishLocation: 'pipeline'
     condition: failed()
 


### PR DESCRIPTION
This shaves about ~7 minutes of the download in the publish nuget phase.
I unfortunatley wasn't able to use the new one in the upload as it complains about the artifact already existing. The old one seems to support merging. I tried looking at the code for the upload, but there are too many wrappers and too much difference in the code to quickly determine this. I'll keep this on the backlog to investigate or when I get a chance to chat with someone from the devops team.

See https://github.com/MicrosoftDocs/azure-devops-docs/issues/2341 for details on difference between the old and new.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5526)