### PR TITLE
Add fix for msbuild long paths in machine setup script

### DIFF
--- a/change/react-native-windows-2020-07-16-16-31-04-master.json
+++ b/change/react-native-windows-2020-07-16-16-31-04-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add fix for msbuild long paths in fixup script",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T23:31:03.942Z"
+}


### PR DESCRIPTION
To support the new agents, this has to be patched since our CI is configured to use 64bit msbuild.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5542)