### PR TITLE
Fix layout deploy

### DIFF
--- a/change/react-native-windows-2020-07-16-17-09-31-deployPS.json
+++ b/change/react-native-windows-2020-07-16-17-09-31-deployPS.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix layout deploy",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T00:09:31.852Z"
+}

--- a/vnext/local-cli/src/runWindows/utils/deploy.ts
+++ b/vnext/local-cli/src/runWindows/utils/deploy.ts
@@ -263,7 +263,9 @@ export async function deployToDesktop(
     await runPowerShellScriptFunction(
       'Installing dependent framework packages',
       windowsStoreAppUtils,
-      `Install-AppDependencies ${script} ${appPackageFolder} ${options.arch}`,
+      `Install-AppDependencies ${appxManifestPath} ${appPackageFolder} ${
+        options.arch
+      }`,
       verbose,
     );
     await build.buildSolution(


### PR DESCRIPTION
Fixing a few issues with the deploy from layout codepath
- we were using the script path instead of the manifest path (i.e. add-appxpackage.ps1 instead of appxmanifest.xml) to parse XML
- PWSH 7 has added some types to its baseline like the system.io.compression namespace but those need to be explicitly imported in windows powershell

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5543)