### PR TITLE
Add dotnet core runtime and sdk to setup scripts

### DIFF
--- a/change/react-native-windows-2020-07-17-09-11-26-master.json
+++ b/change/react-native-windows-2020-07-17-09-11-26-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add dotnet core runtime and sdk to setup scripts",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T16:11:26.823Z"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -127,6 +127,16 @@ $requirements = @(
         Install = { InstallVS };
     },
     @{
+        Name = 'DotNet Core';
+        Valid = (Test-Path "${env:ProgramFiles}\dotnet\shared\Microsoft.NETCore.App\3.1.6");
+        Install = { choco install -y dotnetcore --version=3.1.6 };
+    },
+    @{
+        Name = 'DotNet Core Sdk';
+        Valid = (Test-Path "${env:ProgramFiles}\dotnet\sdk\3.1.302");
+        Install = { choco install -y dotnetcore-sdk --version=3.1.302 };
+    },
+   @{
         Name = 'NodeJS 12 or 13 installed';
         Valid = CheckNode;
         Install = { choco install -y nodejs.install --version=12.9.1 };


### PR DESCRIPTION
This is to ensure the dotnet sdks are availalbe on the build agents.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5549)