### PR TITLE
Workaround for metro monorepo asset issues

### DIFF
--- a/packages/E2ETest/metro.config.js
+++ b/packages/E2ETest/metro.config.js
@@ -32,6 +32,19 @@ module.exports = {
       ),
     ]),
   },
+
+  // Metro doesn't currently handle assets from other packages within a monorepo.  This is the current workaround people use
+  server: {
+    enhanceMiddleware: middleware => {
+      return (req, res, next) => {
+        if (req.url.startsWith('/vnext')) {
+          req.url = req.url.replace('/vnext', '/assets/../../vnext');
+        }
+        return middleware(req, res, next);
+      };
+    },
+  },
+
   transformer: {
     getTransformOptions: async () => ({
       transform: {

--- a/packages/microsoft-reactnative-sampleapps/metro.config.js
+++ b/packages/microsoft-reactnative-sampleapps/metro.config.js
@@ -31,6 +31,19 @@ module.exports = {
       ),
     ]),
   },
+
+  // Metro doesn't currently handle assets from other packages within a monorepo.  This is the current workaround people use
+  server: {
+    enhanceMiddleware: middleware => {
+      return (req, res, next) => {
+        if (req.url.startsWith('/vnext')) {
+          req.url = req.url.replace('/vnext', '/assets/../../vnext');
+        }
+        return middleware(req, res, next);
+      };
+    },
+  },
+
   transformer: {
     getTransformOptions: async () => ({
       transform: {

--- a/packages/playground/just-task.js
+++ b/packages/playground/just-task.js
@@ -19,7 +19,7 @@ task('lint', series('eslint'));
 task('lint:fix', series('eslint:fix'));
 
 task('prepareBundleWin32', () => {
-  const file = 'windows/playground-win32/Bundle';
+  const file = 'windows/playground-win32/Bundle/Samples';
   if (!fs.existsSync(file)) {
     fs.mkdirSync(file);
   }

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -36,6 +36,19 @@ module.exports = {
       ),
     ]),
   },
+
+  // Metro doesn't currently handle assets from other packages within a monorepo.  This is the current workaround people use
+  server: {
+    enhanceMiddleware: middleware => {
+      return (req, res, next) => {
+        if (req.url.startsWith('/vnext')) {
+          req.url = req.url.replace('/vnext', '/assets/../../vnext');
+        }
+        return middleware(req, res, next);
+      };
+    },
+  },
+
   transformer: {
     getTransformOptions: async () => ({
       transform: {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.54",
   "private": true,
   "scripts": {
-    "bundle-win32": "just-scripts prepareBundleWin32 && npx react-native bundle --entry-file Samples\\rntester.tsx --bundle-output windows\\playground-win32\\Bundle\\Samples\\rntester.bundle --platform windows",
+    "bundle-win32": "just-scripts prepareBundleWin32 && npx react-native bundle --entry-file Samples\\rntester.tsx --bundle-output windows\\playground-win32\\Bundle\\Samples\\rntester.bundle --platform windows --assets-dest windows\\playground-win32\\Bundle",
     "start": "react-native start",
     "lint:fix": "just-scripts lint:fix",
     "lint": "just-scripts lint",


### PR DESCRIPTION
Currently in the playground/E2E app some of the images on the RNTester image page, and within the logbox experience do not show up when debugging.   This is due to an issue with metro not able to handle assets that are located outside of the app's package folder, which is often the case in monorepos.

This change applies a workaround that the community uses for this case, which fixes this images within our repo.  Hopefully this is something we can look into fixing in metro in the future.

See  https://github.com/facebook/metro/issues/290#issuecomment-526774959

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5551)