### PR TITLE
Move WinUI 3 to Preview 2

### DIFF
--- a/change/react-native-windows-2020-07-21-00-03-28-preview2.json
+++ b/change/react-native-windows-2020-07-21-00-03-28-preview2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "move to winui3 preview 2",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-21T07:03:28.086Z"
+}

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -79,7 +79,7 @@
   <ImportGroup Label="ReactNativeWindowsPropertySheets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props"/>
   </ImportGroup>
-  <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('$(WinUIPackageProps)')" />
+  <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('..\packages\$(WinUIPackageProps)')" />
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -79,7 +79,7 @@
   <ImportGroup Label="ReactNativeWindowsPropertySheets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.props"/>
   </ImportGroup>
-  <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!=''" />
+  <Import Project="..\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('$(WinUIPackageProps)')" />
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
-  <package id="Microsoft.WinUI" version="3.0.0-preview1.200515.3" targetFramework="native"/>
+  <package id="Microsoft.WinUI" version="3.0.0-preview2.200713.0" targetFramework="native"/>
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx/UI.Text.h
+++ b/vnext/Microsoft.ReactNative.Cxx/UI.Text.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <winrt/Windows.UI.Text.h>
+
 #ifdef USE_WINUI3
 #include <winrt/Microsoft.UI.Text.h>
+namespace text = winrt::Microsoft::UI::Text;
 #else
-#include <winrt/Windows.UI.Text.h>
+namespace text = winrt::Windows::UI::Text;
 #endif //  USE_WINUI3

--- a/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
@@ -6,11 +6,11 @@
 #include <Utils/ResourceBrushUtils.h>
 #include <Utils/ValueUtils.h>
 
+#include <UI.Text.h>
 #include <folly/dynamic.h>
 #include <stdint.h>
 #include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Text.h>
 
 #include <Views/ShadowNodeBase.h>
 
@@ -282,9 +282,9 @@ bool TryUpdateFontProperties(const T &element, const std::string &propertyName, 
       const std::string &value = propertyValue.getString();
       winrt::Windows::UI::Text::FontWeight fontWeight;
       if (value == "normal")
-        fontWeight = winrt::Windows::UI::Text::FontWeights::Normal();
+        fontWeight = text::FontWeights::Normal();
       else if (value == "bold")
-        fontWeight = winrt::Windows::UI::Text::FontWeights::Bold();
+        fontWeight = text::FontWeights::Bold();
       else if (value == "100")
         fontWeight.Weight = 100;
       else if (value == "200")
@@ -304,7 +304,7 @@ bool TryUpdateFontProperties(const T &element, const std::string &propertyName, 
       else if (value == "900")
         fontWeight.Weight = 900;
       else
-        fontWeight = winrt::Windows::UI::Text::FontWeights::Normal();
+        fontWeight = text::FontWeights::Normal();
 
       element.FontWeight(fontWeight);
     } else if (propertyValue.isNull()) {
@@ -407,14 +407,15 @@ bool TryUpdateTextDecorationLine(
 
       const std::string &value = propertyValue.getString();
       TextDecorations decorations = TextDecorations::None;
-      if (value == "none")
+      if (value == "none") {
         decorations = TextDecorations::None;
-      else if (value == "underline")
+      } else if (value == "underline") {
         decorations = TextDecorations::Underline;
-      else if (value == "line-through")
+      } else if (value == "line-through") {
         decorations = TextDecorations::Strikethrough;
-      else if (value == "underline line-through")
+      } else if (value == "underline line-through") {
         decorations = TextDecorations::Underline | TextDecorations::Strikethrough;
+      }
 
       element.TextDecorations(decorations);
     } else if (propertyValue.isNull()) {

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
-  <package id="Microsoft.WinUI" version="3.0.0-preview1.200515.3" targetFramework="native" />
+  <package id="Microsoft.WinUI" version="3.0.0-preview2.200713.0" targetFramework="native" />
 </packages>

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -5,20 +5,26 @@
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI3 versioning">
-    <!-- This value is also used by the CLI, see \vnext\local-cli\generator-windows\index.js -->
-    <WinUI3Version>3.0.0-preview1.200515.3</WinUI3Version>
-
-    <WinUIPackageName Condition="'$(UseWinUI3)'=='true'">Microsoft.WinUI</WinUIPackageName>
-    <WinUIPackageVersion Condition="'$(UseWinUI3)'=='true'">$(WinUI3Version)</WinUIPackageVersion>
-    <WinUIPackageProps Condition="'$(UseWinUI3)'=='true'">$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).props</WinUIPackageProps>
-
-    <WinUIPackageName Condition="'$(UseWinUI3)'!='true'">Microsoft.UI.Xaml</WinUIPackageName>
-    <WinUIPackageVersion Condition="'$(UseWinUI3)'!='true'">2.3.191129002</WinUIPackageVersion>
-    <!-- In WinUI 2.x, the props file is imported for us by the targets file -->
-    <WinUIPackageProps Condition="'$(UseWinUI3)'!='true'" />
+    <!-- This value is also used by the CLI, see \vnext\local-cli\src\generator-windows\index.ts -->
+    <WinUI3Version>3.0.0-preview2.200713.0</WinUI3Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseWinUI3)'=='true'">
+    <WinUIPackageName>Microsoft.WinUI</WinUIPackageName>
+    <WinUIPackageVersion>$(WinUI3Version)</WinUIPackageVersion>
+    <WinUIPackageProps>$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).props</WinUIPackageProps>
 
     <!-- Enlighten C# code about WinUI3 -->
     <DefineConstants Condition="'$(UseWinUI3)'=='true'">USE_WINUI3;$(DefineConstants)</DefineConstants>
+
+    <IsWinUIAlpha Condition="'$(IsWinUIAlpha)' == ''">true</IsWinUIAlpha>
+    <WindowsKitsPath Condition="'$(IsWinUIAlpha)' == 'true'">WinUI-Alpha-Projects-Don-t-Use-SDK-Xaml-Tools</WindowsKitsPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseWinUI3)'!='true'">
+    <WinUIPackageName>Microsoft.UI.Xaml</WinUIPackageName>
+    <WinUIPackageVersion>2.3.191129002</WinUIPackageVersion>
+    <!-- In WinUI 2.x, the props file is imported for us by the targets file -->
+    <WinUIPackageProps />
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition="'$(UseWinUI3)'=='true'">


### PR DESCRIPTION
Moving nuget packages to preview 2 and adding a couple of properties that the VSIXs added in preview 2.

Turns out my xaml load guard caught a bug :)  we were using `Windows::UI::Text::FontWeights` instead of `Microsoft::UI::Text::FontWeights` which resulted in loading WUX.dll just to get a struct, so I fixed that.

![image](https://user-images.githubusercontent.com/22989529/88023668-4ceb4f80-cae6-11ea-92a9-16a463fbf331.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5561)
