### PR TITLE
Use per-thread compositor

### DIFF
--- a/change/react-native-windows-2020-07-21-01-18-27-perThreadCompositor.json
+++ b/change/react-native-windows-2020-07-21-01-18-27-perThreadCompositor.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use compositor in TLS",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-21T08:18:27.548Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
@@ -19,7 +19,7 @@ AdditionAnimatedNode::AdditionAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
-    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = react::uwp::GetCompositor().CreateExpressionAnimation();
 
     anim.Expression([nodes, manager, anim]() {
       winrt::hstring expr = L"0";

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -12,7 +12,7 @@ namespace uwp {
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedAnimationDriver::MakeAnimation(
     const folly::dynamic & /*config*/) {
   const auto [scopedBatch, animation, easingFunction] = []() {
-    const auto compositor = xaml::Window::Current().Compositor();
+    const auto compositor = react::uwp::GetCompositor();
     return std::make_tuple(
         compositor.CreateScopedBatch(comp::CompositionBatchTypes::AllAnimations),
         compositor.CreateScalarKeyFrameAnimation(),

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
@@ -18,7 +18,7 @@ DiffClampAnimatedNode::DiffClampAnimatedNode(
   m_max = config.find(s_maxName).dereference().second.asDouble();
 
   m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, min = m_min, max = m_max, manager]() {
-    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = react::uwp::GetCompositor().CreateExpressionAnimation();
     anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
     anim.SetScalarParameter(s_minParameterName, static_cast<float>(min));
     anim.SetScalarParameter(s_maxParameterName, static_cast<float>(max));

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
@@ -22,7 +22,7 @@ DivisionAnimatedNode::DivisionAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
-    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = react::uwp::GetCompositor().CreateExpressionAnimation();
 
     anim.Expression([firstNode, nodes, manager, anim]() {
       anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
@@ -23,7 +23,7 @@ FrameAnimationDriver::FrameAnimationDriver(
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimationDriver::MakeAnimation(
     const folly::dynamic & /*config*/) {
   const auto [scopedBatch, animation] = []() {
-    const auto compositor = xaml::Window::Current().Compositor();
+    const auto compositor = react::uwp::GetCompositor();
     return std::make_tuple(
         compositor.CreateScopedBatch(comp::CompositionBatchTypes::AllAnimations),
         compositor.CreateScalarKeyFrameAnimation());

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -43,7 +43,7 @@ void InterpolationAnimatedNode::OnAttachToNode(int64_t animatedNodeTag) {
   const auto [rawValueAnimation, offsetAnimation] = [this]() {
     if (const auto manager = m_manager.lock()) {
       if (const auto parent = manager->GetValueAnimatedNode(m_parentTag)) {
-        const auto compositor = xaml::Window::Current().Compositor();
+        const auto compositor = react::uwp::GetCompositor();
 
         const auto rawValueAnimation = CreateExpressionAnimation(compositor, *parent);
         rawValueAnimation.Expression(

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
@@ -17,7 +17,7 @@ ModulusAnimatedNode::ModulusAnimatedNode(
   m_modulus = static_cast<int64_t>(config.find(s_modulusName).dereference().second.asDouble());
 
   m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, mod = m_modulus, manager]() {
-    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = react::uwp::GetCompositor().CreateExpressionAnimation();
     anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
     anim.SetScalarParameter(s_modName, static_cast<float>(mod));
     anim.Expression(

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
@@ -18,7 +18,7 @@ MultiplicationAnimatedNode::MultiplicationAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
-    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = react::uwp::GetCompositor().CreateExpressionAnimation();
 
     anim.Expression([nodes, manager, anim]() {
       winrt::hstring expr = L"1";

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -22,19 +22,19 @@ PropsAnimatedNode::PropsAnimatedNode(
   for (const auto &entry : config.find("props").dereference().second.items()) {
     m_propMapping.insert({entry.first.getString(), static_cast<int64_t>(entry.second.asDouble())});
   }
-
-  m_subchannelPropertySet = xaml::Window::Current().Compositor().CreatePropertySet();
+  auto compositor = react::uwp::GetCompositor();
+  m_subchannelPropertySet = compositor .CreatePropertySet();
   m_subchannelPropertySet.InsertScalar(L"TranslationX", 0.0f);
   m_subchannelPropertySet.InsertScalar(L"TranslationY", 0.0f);
   m_subchannelPropertySet.InsertScalar(L"ScaleX", 1.0f);
   m_subchannelPropertySet.InsertScalar(L"ScaleY", 1.0f);
 
-  m_translationCombined = xaml::Window::Current().Compositor().CreateExpressionAnimation(
+  m_translationCombined = compositor .CreateExpressionAnimation(
       L"Vector3(subchannels.TranslationX, subchannels.TranslationY, 0.0)");
   m_translationCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
   m_translationCombined.Target(L"Translation");
 
-  m_scaleCombined = xaml::Window::Current().Compositor().CreateExpressionAnimation(
+  m_scaleCombined = compositor.CreateExpressionAnimation(
       L"Vector3(subchannels.ScaleX, subchannels.ScaleY, 1.0)");
   m_scaleCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
   m_scaleCombined.Target(L"Scale");
@@ -137,7 +137,7 @@ void PropsAnimatedNode::StartAnimations() {
       }
       if (m_needsCenterPointAnimation) {
         if (!m_centerPointAnimation) {
-          m_centerPointAnimation = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+          m_centerPointAnimation = react::uwp::GetCompositor().CreateExpressionAnimation();
           m_centerPointAnimation.Target(L"CenterPoint");
           m_centerPointAnimation.SetReferenceParameter(
               L"centerPointPropertySet", GetShadowNodeBase()->EnsureTransformPS());
@@ -188,7 +188,7 @@ void PropsAnimatedNode::ResumeSuspendedAnimations(int64_t valueTag) {
 void PropsAnimatedNode::MakeAnimation(int64_t valueNodeTag, FacadeType facadeType) {
   if (const auto manager = m_manager.lock()) {
     if (const auto valueNode = manager->GetValueAnimatedNode(valueNodeTag)) {
-      const auto animation = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+      const auto animation = react::uwp::GetCompositor().CreateExpressionAnimation();
       animation.SetReferenceParameter(L"ValuePropSet", valueNode->PropertySet());
       animation.Expression(
           static_cast<winrt::hstring>(L"ValuePropSet.") + ValueAnimatedNode::s_valueName + L" + ValuePropSet." +

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -23,19 +23,18 @@ PropsAnimatedNode::PropsAnimatedNode(
     m_propMapping.insert({entry.first.getString(), static_cast<int64_t>(entry.second.asDouble())});
   }
   auto compositor = react::uwp::GetCompositor();
-  m_subchannelPropertySet = compositor .CreatePropertySet();
+  m_subchannelPropertySet = compositor.CreatePropertySet();
   m_subchannelPropertySet.InsertScalar(L"TranslationX", 0.0f);
   m_subchannelPropertySet.InsertScalar(L"TranslationY", 0.0f);
   m_subchannelPropertySet.InsertScalar(L"ScaleX", 1.0f);
   m_subchannelPropertySet.InsertScalar(L"ScaleY", 1.0f);
 
-  m_translationCombined = compositor .CreateExpressionAnimation(
-      L"Vector3(subchannels.TranslationX, subchannels.TranslationY, 0.0)");
+  m_translationCombined =
+      compositor.CreateExpressionAnimation(L"Vector3(subchannels.TranslationX, subchannels.TranslationY, 0.0)");
   m_translationCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
   m_translationCombined.Target(L"Translation");
 
-  m_scaleCombined = compositor.CreateExpressionAnimation(
-      L"Vector3(subchannels.ScaleX, subchannels.ScaleY, 1.0)");
+  m_scaleCombined = compositor.CreateExpressionAnimation(L"Vector3(subchannels.ScaleX, subchannels.ScaleY, 1.0)");
   m_scaleCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
   m_scaleCombined.Target(L"Scale");
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
@@ -22,7 +22,7 @@ SubtractionAnimatedNode::SubtractionAnimatedNode(
   }
 
   m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
-    const auto anim = xaml::Window::Current().Compositor().CreateExpressionAnimation();
+    const auto anim = react::uwp::GetCompositor().CreateExpressionAnimation();
 
     anim.Expression([firstNode, nodes, manager, anim]() {
       anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
@@ -15,7 +15,7 @@ ValueAnimatedNode::ValueAnimatedNode(
     : AnimatedNode(tag, manager) {
   // TODO: Islands - need to get the XamlView associated with this animation in order to
   // use the compositor react::uwp::GetCompositor(xamlView)
-  m_propertySet = xaml::Window::Current().Compositor().CreatePropertySet();
+  m_propertySet = react::uwp::GetCompositor().CreatePropertySet();
   m_propertySet.InsertScalar(
       s_valueName, static_cast<float>(config.find(s_jsValueName).dereference().second.asDouble()));
   m_propertySet.InsertScalar(
@@ -26,7 +26,7 @@ ValueAnimatedNode::ValueAnimatedNode(int64_t tag, const std::shared_ptr<NativeAn
     : AnimatedNode(tag, manager) {
   // TODO: Islands - need to get the XamlView associated with this animation in order to
   // use the compositor react::uwp::GetCompositor(xamlView)
-  m_propertySet = xaml::Window::Current().Compositor().CreatePropertySet();
+  m_propertySet = react::uwp::GetCompositor().CreatePropertySet();
   m_propertySet.InsertScalar(s_valueName, 0.0);
   m_propertySet.InsertScalar(s_offsetName, 0.0);
 }

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -10,9 +10,7 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactRootView::ReactRootView() noexcept {
   m_rootControl = std::make_shared<react::uwp::ReactRootControl>(*this);
-  Loaded([this](auto &&, auto &&) {
-    react::uwp::SetCompositor(react::uwp::GetCompositor(*this));
-  });
+  Loaded([this](auto &&, auto &&) { react::uwp::SetCompositor(react::uwp::GetCompositor(*this)); });
 }
 
 ReactNative::ReactNativeHost ReactRootView::ReactNativeHost() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -10,6 +10,9 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactRootView::ReactRootView() noexcept {
   m_rootControl = std::make_shared<react::uwp::ReactRootControl>(*this);
+  Loaded([this](auto &&, auto &&) {
+    react::uwp::SetCompositor(react::uwp::GetCompositor(*this));
+  });
 }
 
 ReactNative::ReactNativeHost ReactRootView::ReactNativeHost() noexcept {

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -3,8 +3,10 @@
 
 #include "pch.h"
 #include "XamlView.h"
+#include <UI.Composition.h>
 #include <UI.Xaml.Controls.Primitives.h>
 #include <UI.Xaml.Documents.h>
+#include "Utils/Helpers.h"
 
 namespace react::uwp {
 
@@ -25,12 +27,39 @@ comp::Compositor GetCompositor(const XamlView &view) {
     return window.Compositor();
   }
 #ifdef USE_WINUI3
-  else {
-    return TryGetXamlRoot(view).Compositor();
+  else if (auto root = TryGetXamlRoot(view)) {
+    return root.Compositor();
   }
 #endif
+  return GetCompositor();
+}
 
-  throw std::exception("Could not get a compositor instance");
+static DWORD tlsCompositor = 0;
+void SetCompositor(const comp::Compositor &compositor) {
+  if (tlsCompositor == 0) {
+    tlsCompositor = TlsAlloc();
+  }
+  winrt::com_ptr<IUnknown> rawCompositor(winrt::get_abi(compositor), winrt::take_ownership_from_abi);
+  auto oldCompositor = TlsGetValue(tlsCompositor);
+  if (oldCompositor != nullptr) {
+    assert(oldCompositor == rawCompositor.get());
+  } else {
+    rawCompositor->AddRef();
+    TlsSetValue(tlsCompositor, rawCompositor.get());
+  }
+}
+
+comp::Compositor GetCompositor() {
+
+  if (!react::uwp::IsXamlIsland()) {
+    return xaml::Window::Current().Compositor();
+  }
+  comp::Compositor compositor;
+  if (tlsCompositor != 0) {
+    winrt::copy_from_abi(compositor, TlsGetValue(tlsCompositor));
+  }
+  assert(compositor != nullptr);
+  return compositor;
 }
 
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -50,7 +50,6 @@ void SetCompositor(const comp::Compositor &compositor) {
 }
 
 comp::Compositor GetCompositor() {
-
   if (!react::uwp::IsXamlIsland()) {
     return xaml::Window::Current().Compositor();
   }

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -39,6 +39,8 @@ inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);
 comp::Compositor GetCompositor(const XamlView &view);
+void SetCompositor(const comp::Compositor &compositor);
+comp::Compositor GetCompositor();
 
 } // namespace uwp
 } // namespace react


### PR DESCRIPTION
This is in advance of WinUI 3 / islands work, basically keep a reference to the per-thread compositor and use it instead of the current Window compositor (since that won't exist in WinUI 3).

Fixes #5498 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5562)