### PR TITLE
E2ETest small tweak

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -65,14 +65,6 @@ jobs:
           targetPath: $(Build.StagingDirectory)/ReactUWPTestApp
         condition: succeededOrFailed()
 
-      # Wait for app to launch. A workaround to avoid WinAppDriver error: Failed to locate opened application window with appId
-      - task: PowerShell@2
-        displayName: Pre-warm test app
-        inputs:
-          targetType: inline # filePath | inline
-          script: |
-            Start-Sleep -Seconds 30
-
       - task: CmdLine@2
         displayName: run e2etest
         inputs:

--- a/change/react-native-windows-2020-07-21-19-02-11-rntester-fix1.json
+++ b/change/react-native-windows-2020-07-21-19-02-11-rntester-fix1.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "move legacy tests to end of list",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-22T02:02:11.154Z"
+}

--- a/packages/E2ETest/wdio/test/AAA_SmokeTest.spec.ts
+++ b/packages/E2ETest/wdio/test/AAA_SmokeTest.spec.ts
@@ -2,11 +2,10 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  */
-import { By } from '../pages/BasePage';
-import { LOGIN_TESTPAGE } from 'react-native-windows/RNTester/js/examples-win/LegacyTests/Consts';
+import HomePage from '../pages/HomePage';
 
 describe('SmokeTest', () => {
   it('SmokeTest', () => {
-    By(LOGIN_TESTPAGE);
+    HomePage.clickAndGotoControlStylePage();
   });
 });

--- a/packages/E2ETest/wdio/test/AAA_SmokeTest.spec.ts
+++ b/packages/E2ETest/wdio/test/AAA_SmokeTest.spec.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+describe('SmokeTest', () => {
+  it('SmokeTest', () => {});
+});

--- a/packages/E2ETest/wdio/test/AAA_SmokeTest.spec.ts
+++ b/packages/E2ETest/wdio/test/AAA_SmokeTest.spec.ts
@@ -2,7 +2,11 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  */
+import { By } from '../pages/BasePage';
+import { LOGIN_TESTPAGE } from 'react-native-windows/RNTester/js/examples-win/LegacyTests/Consts';
 
 describe('SmokeTest', () => {
-  it('SmokeTest', () => {});
+  it('SmokeTest', () => {
+    By(LOGIN_TESTPAGE);
+  });
 });

--- a/vnext/src/RNTester/js/utils/RNTesterList.windows.ts
+++ b/vnext/src/RNTester/js/utils/RNTesterList.windows.ts
@@ -28,34 +28,6 @@ interface IRNTesterModuleExample {
 
 const ComponentExamples: Array<IRNTesterExample> = [
   {
-    key: 'LegacyControlStyleTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/ControlStyleTestPage'),
-  },
-  {
-    key: 'LegacyTransformTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/TransformTestPage'),
-  },
-  {
-    key: 'LegacyTextInputTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/TextInputTestPage'),
-  },
-  {
-    key: 'LegacyLoginTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/LoginTestPage'),
-  },
-  {
-    key: 'LegacyDirectManipulationTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/DirectManipulationTestPage'),
-  },
-  {
-    key: 'LegacyImageTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/ImageTestPage'),
-  },
-  {
-    key: 'LegacyAccessibilityTest',
-    module: require('react-native/RNTester/js/examples-win/LegacyTests/AccessibilityTestPage'),
-  },
-  {
     key: 'ActivityIndicatorExample',
     module: require('react-native/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample'),
   },
@@ -288,6 +260,34 @@ const APIExamples: Array<IRNTesterExample> = [
   {
     key: 'WebSocketExample',
     module: require('react-native/RNTester/js/examples/WebSocket/WebSocketExample'),
+  },
+  {
+    key: 'LegacyControlStyleTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/ControlStyleTestPage'),
+  },
+  {
+    key: 'LegacyTransformTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/TransformTestPage'),
+  },
+  {
+    key: 'LegacyTextInputTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/TextInputTestPage'),
+  },
+  {
+    key: 'LegacyLoginTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/LoginTestPage'),
+  },
+  {
+    key: 'LegacyDirectManipulationTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/DirectManipulationTestPage'),
+  },
+  {
+    key: 'LegacyImageTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/ImageTestPage'),
+  },
+  {
+    key: 'LegacyAccessibilityTest',
+    module: require('react-native/RNTester/js/examples-win/LegacyTests/AccessibilityTestPage'),
   },
   // TODO:  TurboModuleExample crashes the app if web debugging is turned on
   //  {


### PR DESCRIPTION
This change moves the E2E test pages to the bottom of the RNTester list, to be less disruptive to folks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5568)