### PR TITLE
Stop placing Microsoft.ReactNative.Cxx in the Microsoft.ReactNative nuget package

### DIFF
--- a/change/react-native-windows-2020-07-21-19-54-05-master.json
+++ b/change/react-native-windows-2020-07-21-19-54-05-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Stop placing Microsoft.ReactNative.Cxx in the Microsoft.ReactNative nuget package",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-22T02:54:05.829Z"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -22,8 +22,6 @@
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml"   target="lib\uap10.0"/> 
     -->
 
-    <file src="$nugetroot$\Microsoft.ReactNative.Cxx\**" target ="Microsoft.ReactNative.Cxx"/>
-
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\release" />
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\release" />
     <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\release" />


### PR DESCRIPTION
PR #5184 Added the Microsoft.ReactNative.Cxx code to unblock an internal
Microsoft team. PR #5483 introduced a proper nuget package for this. 
Therefore this PR is removing the temporary workaround. 

If you depended on this, please update your project to take a dependency 
on the Microsoft.Reactnative.Cxx nuget package.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5569)