### PR TITLE
[0.62] Fixed external targets for apps and libs

### DIFF
--- a/change/react-native-windows-2020-07-23-13-43-02-fix62targets.json
+++ b/change/react-native-windows-2020-07-23-13-43-02-fix62targets.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed external targets for apps and libs",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-23T20:43:02.786Z"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -16,4 +16,20 @@
   </ItemGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.targets" />
   <Import Project="$(ProjectDir)\AutolinkedNativeModules.g.targets" Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.targets')" />
+
+  <Import Project="$(OutputPath)$(AssemblyName).Build.appxrecipe"
+          Condition="Exists('$(OutputPath)$(AssemblyName).Build.appxrecipe') And '$(DeployLayout)'=='true'" />
+
+  <Target Name="Deploy" Condition="'$(DeployLayout)'=='true'">
+    <Error Condition="!Exists('$(OutputPath)$(AssemblyName).Build.appxrecipe')"
+           Text="You must first build the project before deploying it" />
+    <Copy SourceFiles="%(AppxPackagedFile.Identity)"
+          DestinationFiles="$(OutputPath)Appx\%(AppxPackagedFile.PackagePath)" />
+    <Copy SourceFiles="%(AppXManifest.Identity)"
+          DestinationFiles="$(OutputPath)Appx\%(AppxManifest.PackagePath)"
+          Condition="'%(AppxManifest.SubType)'!='Designer'"/>
+    <Exec Command="powershell -NonInteractive -NoProfile -Command Add-AppxPackage -Register $(OutputPath)Appx\AppxManifest.xml"
+          ContinueOnError="false" />
+  </Target>
+
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
@@ -9,6 +9,7 @@
     <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
       <Name>Microsoft.ReactNative</Name>
+      <Private>true</Private>
     </ProjectReference>
   </ItemGroup>
   <Target Name="Deploy" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
@@ -9,7 +9,7 @@
     <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
       <Name>Microsoft.ReactNative</Name>
-      <Private>true</Private>
+      <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
   <Target Name="Deploy" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -14,4 +14,20 @@
   </ItemGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.Cpp.targets"/>
   <Import Project="$(ProjectDir)\AutolinkedNativeModules.g.targets" Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.targets')" />
+
+  <Import Project="$(OutputPath)$(AssemblyName).Build.appxrecipe"
+          Condition="Exists('$(OutputPath)$(AssemblyName).Build.appxrecipe') And '$(DeployLayout)'=='true'" />
+
+  <Target Name="Deploy" Condition="'$(DeployLayout)'=='true'">
+    <Error Condition="!Exists('$(OutputPath)$(AssemblyName).Build.appxrecipe')"
+           Text="You must first build the project before deploying it" />
+    <Copy SourceFiles="%(AppxPackagedFile.Identity)"
+          DestinationFiles="$(OutputPath)Appx\%(AppxPackagedFile.PackagePath)" />
+    <Copy SourceFiles="%(AppXManifest.Identity)"
+          DestinationFiles="$(OutputPath)Appx\%(AppxManifest.PackagePath)"
+          Condition="'%(AppxManifest.SubType)'!='Designer'"/>
+    <Exec Command="powershell -NonInteractive -NoProfile -Command Add-AppxPackage -Register $(OutputPath)Appx\AppxManifest.xml"
+          ContinueOnError="false" />
+  </Target>
+
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
@@ -10,7 +10,7 @@
   <ItemGroup Condition="'$(UseExperimentalNuget)' == 'false'">
     <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
-      <Private>true</Private>
+      <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
   <Target Name="Deploy" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
@@ -10,6 +10,7 @@
   <ItemGroup Condition="'$(UseExperimentalNuget)' == 'false'">
     <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
+      <Private>true</Private>
     </ProjectReference>
   </ItemGroup>
   <Target Name="Deploy" />


### PR DESCRIPTION
This change adds the "Deploy" target to Microsoft.ReactNative.Uwp.CppApp.targets  and Microsoft.ReactNative.Uwp.CSharpApp.targets .

This change also adds the "Private" flag to the M.RN project reference for libs, which was missing and causes problems when trying to consume the modules in your app.

Closes #5581

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5582)