### PR TITLE
Clang tidy, wave 2

### DIFF
--- a/change/react-native-windows-2020-07-25-18-52-13-clangtidy2.json
+++ b/change/react-native-windows-2020-07-25-18-52-13-clangtidy2.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Clang tidy, wave 2",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-26T01:52:13.216Z"
+}

--- a/vnext/Chakra/ChakraExecutor.h
+++ b/vnext/Chakra/ChakraExecutor.h
@@ -56,7 +56,7 @@ class WorkerRegistration {
   ChakraObject jsObj;
 };
 
-class ChakraExecutor : public JSExecutor {
+class ChakraExecutor final : public JSExecutor {
  public:
   /**
    * Must be invoked from thread this Executor will run on.

--- a/vnext/Chakra/ChakraValue.cpp
+++ b/vnext/Chakra/ChakraValue.cpp
@@ -20,7 +20,7 @@ namespace react {
 
 ChakraValue::ChakraValue(JsValueRef value) : m_value(value) {}
 
-ChakraValue::ChakraValue(ChakraValue &&other) : m_value(other.m_value) {
+ChakraValue::ChakraValue(ChakraValue &&other) noexcept : m_value(other.m_value) {
   other.m_value = nullptr;
 }
 
@@ -207,7 +207,7 @@ ChakraValue ChakraObject::getProperty(const char *propName) const {
 
 void ChakraObject::setProperty(const ChakraString &propName, const ChakraValue &value) const {
   JsValueRef exn = NULL;
-  JSObjectSetProperty(m_obj, propName, value, kJSPropertyAttributeNone, &exn);
+  JSObjectSetProperty(m_obj, propName, value, JSPropertyAttributes::kJSPropertyAttributeNone, &exn);
   if (exn) {
     std::string exceptionText = ChakraValue(exn).toString().str();
     throwJSExecutionException("Failed to set property: %s", exceptionText.c_str());

--- a/vnext/Chakra/ChakraValue.h
+++ b/vnext/Chakra/ChakraValue.h
@@ -24,7 +24,7 @@ namespace react {
 class ChakraValue;
 class ChakraObject;
 
-enum JSPropertyAttributes { kJSPropertyAttributeNone };
+enum class JSPropertyAttributes { kJSPropertyAttributeNone };
 
 class ChakraString {
  public:
@@ -39,7 +39,7 @@ class ChakraString {
     m_string = value;
   }
 
-  ChakraString(ChakraString &&other) : m_string(other.m_string) {
+  ChakraString(ChakraString &&other) noexcept : m_string(other.m_string) {
     other.m_string = nullptr;
   }
 
@@ -131,7 +131,7 @@ class ChakraObject {
     // TODO :: VEC is value is not object.
   }
 
-  ChakraObject(ChakraObject &&other) : m_obj(other.m_obj), m_isProtected(other.m_isProtected) {
+  ChakraObject(ChakraObject &&other) noexcept : m_obj(other.m_obj), m_isProtected(other.m_isProtected) {
     other.m_obj = nullptr;
     other.m_isProtected = false;
   }
@@ -142,7 +142,7 @@ class ChakraObject {
     }
   }
 
-  ChakraObject &operator=(ChakraObject &&other) {
+  ChakraObject &operator=(ChakraObject &&other) noexcept {
     std::swap(m_obj, other.m_obj);
     std::swap(m_isProtected, other.m_isProtected);
     return *this;
@@ -205,7 +205,7 @@ class ChakraValue {
   ChakraValue &operator=(const ChakraValue &) = delete;
   ChakraValue() = default;
   ChakraValue(JsValueRef value);
-  ChakraValue(ChakraValue &&);
+  ChakraValue(ChakraValue &&) noexcept;
 
   operator JsValueRef() const {
     return m_value;

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
@@ -169,7 +169,11 @@ struct JSValueLogWriter {
   }
 
   JSValueLogWriter &WriteSeparator(bool &start) noexcept {
-    m_stream << start ? (start = false, "") : ",";
+    if (start) {
+      start = false;
+    } else {
+      m_stream << ",";
+    }
     return *this;
   }
 
@@ -466,6 +470,11 @@ JSValue::~JSValue() noexcept {
       break;
     case JSValueType::String:
       m_string.~basic_string();
+      break;
+    case JSValueType::Boolean:
+    case JSValueType::Int64:
+    case JSValueType::Double:
+    case JSValueType::Null:
       break;
   }
 

--- a/vnext/Microsoft.ReactNative/CxxReactUWP/JSBigString.cpp
+++ b/vnext/Microsoft.ReactNative/CxxReactUWP/JSBigString.cpp
@@ -14,7 +14,7 @@ namespace facebook {
 namespace react {
 
 JSBigFileString::JSBigFileString(int fd, size_t size, off_t /*offset*/ /*= 0*/)
-    : m_fd(fd), m_size(size), m_data(new char[size + 1]) {
+    : m_fd(fd), m_size(size), m_pageOff(0), m_mapOff(0), m_data(new char[size + 1]) {
   *(const_cast<char *>(&m_data[m_size])) = '\0';
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -3,7 +3,6 @@
 
 #include "pch.h"
 #include "AlertModule.h"
-// #include <XamlUtils.h>
 #include "Unicode.h"
 
 #include <Utils/ValueUtils.h>

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNodeType.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNodeType.h
@@ -5,7 +5,7 @@
 #include <cassert>
 #include <string>
 
-enum AnimatedNodeType {
+enum class AnimatedNodeType {
   Style,
   Value,
   Props,

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
@@ -51,6 +51,13 @@ class AnimationDriver {
     return std::vector<double>();
   }
 
+ private:
+  Callback m_endCallback{};
+  void DoCallback(bool value);
+#ifdef DEBUG
+  int m_debug_callbackAttempts{0};
+#endif // DEBUG
+
  protected:
   ValueAnimatedNode *GetAnimatedValue();
 
@@ -65,12 +72,5 @@ class AnimationDriver {
   // auto revoker for scopedBatch.Completed is broken, tracked by internal bug
   // #22399779
   winrt::event_token m_scopedBatchCompletedToken{};
-
- private:
-  Callback m_endCallback{};
-  void DoCallback(bool value);
-#ifdef DEBUG
-  int m_debug_callbackAttempts{0};
-#endif // DEBUG
 };
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ExtrapolationType.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ExtrapolationType.h
@@ -2,7 +2,7 @@
 #include <cassert>
 #include <string>
 
-enum ExtrapolationType {
+enum class ExtrapolationType {
   Identity,
   Clamp,
   Extend,

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
@@ -31,7 +31,7 @@ class AppTheme {
   std::weak_ptr<IReactInstance> m_wkReactInstance;
   std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
   xaml::ApplicationTheme m_currentTheme{xaml::ApplicationTheme::Light};
-  bool m_isHighContrast;
+  bool m_isHighContrast{false};
   folly::dynamic m_highContrastColors;
 
   winrt::Windows::UI::ViewManagement::AccessibilitySettings m_accessibilitySettings{};

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -27,7 +27,7 @@ struct YogaNodeDeleter {
 
 typedef std::unique_ptr<YGNode, YogaNodeDeleter> YogaNodePtr;
 
-class NativeUIManager : public facebook::react::INativeUIManager {
+class NativeUIManager final : public facebook::react::INativeUIManager {
  public:
   NativeUIManager(Mso::React::IReactContext *reactContext);
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -86,7 +86,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
       const std::shared_ptr<winrt::Microsoft::ReactNative::NativeModulesProvider> &nativeModulesProvider,
       const std::shared_ptr<winrt::Microsoft::ReactNative::TurboModulesProvider> &turboModulesProvider) noexcept;
   void Initialize() noexcept override;
-  ~ReactInstanceWin() noexcept;
+  ~ReactInstanceWin() noexcept override;
 
  private:
   void LoadJSBundles() noexcept;

--- a/vnext/Microsoft.ReactNative/ReactSupport.cpp
+++ b/vnext/Microsoft.ReactNative/ReactSupport.cpp
@@ -177,7 +177,7 @@ folly::dynamic ConvertToDynamic(IInspectable const &object) {
     }
     default:
       wchar_t buf[512];
-      swprintf(buf, sizeof(buf), L"Unrecognized argument value type: %d\n", propType);
+      swprintf(buf, ARRAYSIZE(buf), L"Unrecognized argument value type: %d\n", propType);
       throw hresult_invalid_argument(buf);
   }
 

--- a/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
@@ -32,41 +32,43 @@ static const std::unordered_map<std::string, ShadowEdges> edgeTypeMap = {
     {"borderWidth", ShadowEdges::AllEdges},
 };
 
-inline xaml::Thickness GetThickness(double thicknesses[ShadowEdges::CountEdges]) {
-  const double defaultWidth = std::max<double>(0, thicknesses[ShadowEdges::AllEdges]);
-  double startWidth = DefaultOrOverride(thicknesses[ShadowEdges::Left], thicknesses[ShadowEdges::Start]);
-  double endWidth = DefaultOrOverride(thicknesses[ShadowEdges::Right], thicknesses[ShadowEdges::End]);
+inline xaml::Thickness GetThickness(double thicknesses[(int)ShadowEdges::CountEdges]) {
+  const double defaultWidth = std::max<double>(0, thicknesses[(int)ShadowEdges::AllEdges]);
+  double startWidth = DefaultOrOverride(thicknesses[(int)ShadowEdges::Left], thicknesses[(int)ShadowEdges::Start]);
+  double endWidth = DefaultOrOverride(thicknesses[(int)ShadowEdges::Right], thicknesses[(int)ShadowEdges::End]);
 
   // Compute each edge.  Most specific setting wins, so fill from broad to
   // narrow: all, horiz/vert, start/end, left/right
   xaml::Thickness thickness = {defaultWidth, defaultWidth, defaultWidth, defaultWidth};
 
-  if (thicknesses[ShadowEdges::Horizontal] != c_UndefinedEdge)
-    thickness.Left = thickness.Right = thicknesses[ShadowEdges::Horizontal];
-  if (thicknesses[ShadowEdges::Vertical] != c_UndefinedEdge)
-    thickness.Top = thickness.Bottom = thicknesses[ShadowEdges::Vertical];
+  if (thicknesses[(int)ShadowEdges::Horizontal] != c_UndefinedEdge)
+    thickness.Left = thickness.Right = thicknesses[(int)ShadowEdges::Horizontal];
+  if (thicknesses[(int)ShadowEdges::Vertical] != c_UndefinedEdge)
+    thickness.Top = thickness.Bottom = thicknesses[(int)ShadowEdges::Vertical];
 
   if (startWidth != c_UndefinedEdge)
     thickness.Left = startWidth;
   if (endWidth != c_UndefinedEdge)
     thickness.Right = endWidth;
-  if (thicknesses[ShadowEdges::Top] != c_UndefinedEdge)
-    thickness.Top = thicknesses[ShadowEdges::Top];
-  if (thicknesses[ShadowEdges::Bottom] != c_UndefinedEdge)
-    thickness.Bottom = thicknesses[ShadowEdges::Bottom];
+  if (thicknesses[(int)ShadowEdges::Top] != c_UndefinedEdge)
+    thickness.Top = thicknesses[(int)ShadowEdges::Top];
+  if (thicknesses[(int)ShadowEdges::Bottom] != c_UndefinedEdge)
+    thickness.Bottom = thicknesses[(int)ShadowEdges::Bottom];
 
   return thickness;
 }
 
-inline xaml::CornerRadius GetCornerRadius(double cornerRadii[ShadowCorners::CountCorners]) {
+inline xaml::CornerRadius GetCornerRadius(double cornerRadii[(int)ShadowCorners::CountCorners]) {
   xaml::CornerRadius cornerRadius;
-  const double defaultRadius = std::max<double>(0, cornerRadii[ShadowCorners::AllCorners]);
-  double topStartRadius = DefaultOrOverride(cornerRadii[ShadowCorners::TopLeft], cornerRadii[ShadowCorners::TopStart]);
-  double topEndRadius = DefaultOrOverride(cornerRadii[ShadowCorners::TopRight], cornerRadii[ShadowCorners::TopEnd]);
+  const double defaultRadius = std::max<double>(0, cornerRadii[(int)ShadowCorners::AllCorners]);
+  double topStartRadius =
+      DefaultOrOverride(cornerRadii[(int)ShadowCorners::TopLeft], cornerRadii[(int)ShadowCorners::TopStart]);
+  double topEndRadius =
+      DefaultOrOverride(cornerRadii[(int)ShadowCorners::TopRight], cornerRadii[(int)ShadowCorners::TopEnd]);
   double bottomStartRadius =
-      DefaultOrOverride(cornerRadii[ShadowCorners::BottomLeft], cornerRadii[ShadowCorners::BottomStart]);
+      DefaultOrOverride(cornerRadii[(int)ShadowCorners::BottomLeft], cornerRadii[(int)ShadowCorners::BottomStart]);
   double bottomEndRadius =
-      DefaultOrOverride(cornerRadii[ShadowCorners::BottomRight], cornerRadii[ShadowCorners::BottomEnd]);
+      DefaultOrOverride(cornerRadii[(int)ShadowCorners::BottomRight], cornerRadii[(int)ShadowCorners::BottomEnd]);
 
   cornerRadius.TopLeft = DefaultOrOverride(defaultRadius, topStartRadius);
   cornerRadius.TopRight = DefaultOrOverride(defaultRadius, topEndRadius);
@@ -78,14 +80,14 @@ inline xaml::CornerRadius GetCornerRadius(double cornerRadii[ShadowCorners::Coun
 
 template <class T>
 void UpdatePadding(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
-  node->m_padding[edge] = margin;
+  node->m_padding[(int)edge] = margin;
   xaml::Thickness thickness = GetThickness(node->m_padding);
   element.Padding(thickness);
 }
 
 template <class T>
 void SetBorderThickness(ShadowNodeBase *node, const T &element, ShadowEdges edge, double margin) {
-  node->m_border[edge] = margin;
+  node->m_border[(int)edge] = margin;
   xaml::Thickness thickness = GetThickness(node->m_border);
   element.BorderThickness(thickness);
 }
@@ -116,9 +118,9 @@ bool TryUpdateBackgroundBrush(const T &element, const std::string &propertyName,
 inline void
 UpdateCornerRadiusValueOnNode(ShadowNodeBase *node, ShadowCorners corner, const folly::dynamic &propertyValue) {
   if (propertyValue.isNumber())
-    node->m_cornerRadius[corner] = propertyValue.asDouble();
+    node->m_cornerRadius[(int)corner] = propertyValue.asDouble();
   else
-    node->m_cornerRadius[corner] = c_UndefinedEdge;
+    node->m_cornerRadius[(int)corner] = c_UndefinedEdge;
 }
 
 template <class T>

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
@@ -28,8 +28,7 @@ class DatePickerShadowNode : public ShadowNodeBase {
  private:
   void OnDateChanged(IReactInstance &instance, int64_t tag, winrt::DateTime const &newDate);
 
-  int64_t m_selectedTime, m_maxTime,
-      m_minTime; // These values are expected to be in milliseconds
+  int64_t m_selectedTime{0}, m_maxTime{0}, m_minTime{0}; // These values are expected to be in milliseconds
   int64_t m_timeZoneOffsetInSeconds = 0; // Timezone offset is expected to be in seconds
 
   xaml::Controls::CalendarDatePicker::DateChanged_revoker m_dataPickerDateChangedRevoker{};

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -117,7 +117,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
 
   winrt::Flyout::Closing_revoker m_flyoutClosingRevoker{};
   winrt::Flyout::Closed_revoker m_flyoutClosedRevoker{};
-  int64_t m_tokenContentPropertyChangeCallback;
+  int64_t m_tokenContentPropertyChangeCallback{0};
   winrt::Flyout::Opened_revoker m_flyoutOpenedRevoker{};
 };
 

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -53,7 +53,7 @@ class PopupShadowNode : public ShadowNodeBase {
   std::unique_ptr<TouchEventHandler> m_touchEventHandler;
   std::unique_ptr<PreviewKeyboardEventHandlerOnRoot> m_previewKeyboardEventHandlerOnRoot;
 
-  int64_t m_targetTag;
+  int64_t m_targetTag{0};
   winrt::Popup::Closed_revoker m_popupClosedRevoker{};
   winrt::Popup::Opened_revoker m_popupOpenedRevoker{};
   xaml::FrameworkElement::SizeChanged_revoker m_popupSizeChangedRevoker{};

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -16,9 +16,20 @@ namespace react::uwp {
 
 class ViewManagerBase;
 
-enum ShadowEdges : uint8_t { Left = 0, Top, Right, Bottom, Start, End, Horizontal, Vertical, AllEdges, CountEdges };
+enum class ShadowEdges : uint8_t {
+  Left = 0,
+  Top,
+  Right,
+  Bottom,
+  Start,
+  End,
+  Horizontal,
+  Vertical,
+  AllEdges,
+  CountEdges
+};
 
-enum ShadowCorners : uint8_t {
+enum class ShadowCorners : uint8_t {
   TopLeft = 0,
   TopRight,
   BottomRight,
@@ -102,9 +113,9 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
   comp::CompositionPropertySet m_transformPS{nullptr};
 
  public:
-  double m_padding[ShadowEdges::CountEdges] = INIT_UNDEFINED_EDGES;
-  double m_border[ShadowEdges::CountEdges] = INIT_UNDEFINED_EDGES;
-  double m_cornerRadius[ShadowCorners::CountCorners] = INIT_UNDEFINED_CORNERS;
+  double m_padding[(int)ShadowEdges::CountEdges] = INIT_UNDEFINED_EDGES;
+  double m_border[(int)ShadowEdges::CountEdges] = INIT_UNDEFINED_EDGES;
+  double m_cornerRadius[(int)ShadowCorners::CountCorners] = INIT_UNDEFINED_CORNERS;
 
   // Bound event types
   bool m_onLayout = false;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -5,6 +5,7 @@
 #include <IReactInstance.h>
 #include <UI.Xaml.Documents.h>
 #include <folly/dynamic.h>
+#include <winrt/Windows.Devices.Input.h>
 #include <optional>
 #include <set>
 #include "XamlView.h"
@@ -50,7 +51,8 @@ class TouchEventHandler {
     uint64_t timestamp = 0;
     winrt::Point positionRoot = {0, 0};
     winrt::Point positionView = {0, 0};
-    winrt::Windows::Devices::Input::PointerDeviceType deviceType;
+    winrt::Windows::Devices::Input::PointerDeviceType deviceType{
+        winrt::Windows::Devices::Input::PointerDeviceType::Mouse};
     float pressure = 0;
     bool isLeftButton = false;
     bool isRightButton = false;

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -96,7 +96,7 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
 
   // Child Elements
   xaml::Controls::Border m_border{nullptr};
-  bool m_hasOuterBorder;
+  bool m_hasOuterBorder{false};
 
  private:
   static void VisualPropertyChanged(xaml::DependencyObject sender, xaml::DependencyPropertyChangedEventArgs e);

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -144,14 +144,14 @@ XamlLoadState::XamlLoadState() {
   }
 
   auto ntdll = GetModuleHandle(L"ntdll.dll");
-  __analysis_assume(ntdll != nullptr);
+  _Analysis_assume(ntdll != nullptr);
   auto pfn = NTDLL_FUNCTION(LdrRegisterDllNotification);
   (*pfn)(0, XamlLoadNotification, nullptr, &m_cookie);
 }
 
 XamlLoadState::~XamlLoadState() {
   auto ntdll = GetModuleHandle(L"ntdll.dll");
-  __analysis_assume(ntdll != nullptr);
+  _Analysis_assume(ntdll != nullptr);
   auto pfn = NTDLL_FUNCTION(LdrUnregisterDllNotification);
   (*pfn)(m_cookie);
 }

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -144,12 +144,14 @@ XamlLoadState::XamlLoadState() {
   }
 
   auto ntdll = GetModuleHandle(L"ntdll.dll");
+  __analysis_assume(ntdll != nullptr);
   auto pfn = NTDLL_FUNCTION(LdrRegisterDllNotification);
   (*pfn)(0, XamlLoadNotification, nullptr, &m_cookie);
 }
 
 XamlLoadState::~XamlLoadState() {
   auto ntdll = GetModuleHandle(L"ntdll.dll");
+  __analysis_assume(ntdll != nullptr);
   auto pfn = NTDLL_FUNCTION(LdrUnregisterDllNotification);
   (*pfn)(m_cookie);
 }

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -144,14 +144,14 @@ XamlLoadState::XamlLoadState() {
   }
 
   auto ntdll = GetModuleHandle(L"ntdll.dll");
-  _Analysis_assume(ntdll != nullptr);
+  _Analysis_assume_(ntdll != nullptr);
   auto pfn = NTDLL_FUNCTION(LdrRegisterDllNotification);
   (*pfn)(0, XamlLoadNotification, nullptr, &m_cookie);
 }
 
 XamlLoadState::~XamlLoadState() {
   auto ntdll = GetModuleHandle(L"ntdll.dll");
-  _Analysis_assume(ntdll != nullptr);
+  _Analysis_assume_(ntdll != nullptr);
   auto pfn = NTDLL_FUNCTION(LdrUnregisterDllNotification);
   (*pfn)(m_cookie);
 }

--- a/vnext/Shared/AsyncStorage/AsyncStorageManager.cpp
+++ b/vnext/Shared/AsyncStorage/AsyncStorageManager.cpp
@@ -104,7 +104,7 @@ void AsyncStorageManager::executeAsyncKVOperation(
         break;
 
       default:
-        [this, jsCallback] { jsCallback({makeError("Invalid AsyncStorage operation")}); }();
+        jsCallback({makeError("Invalid AsyncStorage operation")});
         break;
     }
   } catch (std::exception &e) {

--- a/vnext/Shared/AsyncStorage/AsyncStorageManager.cpp
+++ b/vnext/Shared/AsyncStorage/AsyncStorageManager.cpp
@@ -104,7 +104,7 @@ void AsyncStorageManager::executeAsyncKVOperation(
         break;
 
       default:
-        [this, jsCallback] { jsCallback({makeError("Invalid AsyncStorage operation")}); };
+        [this, jsCallback] { jsCallback({makeError("Invalid AsyncStorage operation")}); }();
         break;
     }
   } catch (std::exception &e) {

--- a/vnext/Shared/BaseScriptStoreImpl.cpp
+++ b/vnext/Shared/BaseScriptStoreImpl.cpp
@@ -45,7 +45,7 @@ class BufferViewBuffer : public facebook::jsi::Buffer {
     return size_;
   }
 
-  const uint8_t *data() const {
+  const uint8_t *data() const override {
     return buffer_->data() + offset_;
   }
 

--- a/vnext/Shared/BaseScriptStoreImpl.h
+++ b/vnext/Shared/BaseScriptStoreImpl.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <ScriptStore.h>

--- a/vnext/Shared/ChakraRuntimeHolder.h
+++ b/vnext/Shared/ChakraRuntimeHolder.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <DevSettings.h>

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#pragma once
-
 #include "pch.h"
 
 #include "DevSupportManager.h"

--- a/vnext/Shared/FeatureGate.h
+++ b/vnext/Shared/FeatureGate.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <string>

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "pch.h"
 
 #include <hermes/hermes.h>

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 #include <JSI/Shared/RuntimeHolder.h>
 

--- a/vnext/Shared/IRedBoxHandler.h
+++ b/vnext/Shared/IRedBoxHandler.h
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 #pragma once
 #include <folly/dynamic.h>
 #include <string>

--- a/vnext/Shared/LayoutAnimation.cpp
+++ b/vnext/Shared/LayoutAnimation.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "LayoutAnimation.h"
 
 #include <folly/dynamic.h>

--- a/vnext/Shared/LayoutAnimation.h
+++ b/vnext/Shared/LayoutAnimation.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 namespace folly {

--- a/vnext/Shared/MemoryMappedBuffer.cpp
+++ b/vnext/Shared/MemoryMappedBuffer.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "pch.h"
 #include "MemoryMappedBuffer.h"
 

--- a/vnext/Shared/MemoryMappedBuffer.h
+++ b/vnext/Shared/MemoryMappedBuffer.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <jsi/jsi.h>

--- a/vnext/Shared/Modules/AsyncStorageModuleWin32.cpp
+++ b/vnext/Shared/Modules/AsyncStorageModuleWin32.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "pch.h"
 
 #include "AsyncStorageModuleWin32.h"

--- a/vnext/Shared/Modules/AsyncStorageModuleWin32.cpp
+++ b/vnext/Shared/Modules/AsyncStorageModuleWin32.cpp
@@ -103,7 +103,7 @@ bool CheckArgs(sqlite3 *db, folly::dynamic &args, const CxxModule::Callback &cal
 // Commit() has not been called, rolls back the transactions
 // The provided sqlite connection handle & Callback must outlive
 // the Sqlite3Transaction object
-class Sqlite3Transaction {
+class Sqlite3Transaction final {
   sqlite3 *m_db{nullptr};
   const CxxModule::Callback *m_callback{nullptr};
 
@@ -116,12 +116,12 @@ class Sqlite3Transaction {
     }
   }
   Sqlite3Transaction(const Sqlite3Transaction &) = delete;
-  Sqlite3Transaction(Sqlite3Transaction &&other) : m_db(other.m_db), m_callback(other.m_callback) {
+  Sqlite3Transaction(Sqlite3Transaction &&other) noexcept : m_db(other.m_db), m_callback(other.m_callback) {
     other.m_db = nullptr;
     other.m_callback = nullptr;
   }
   Sqlite3Transaction &operator=(const Sqlite3Transaction &) = delete;
-  Sqlite3Transaction &operator=(Sqlite3Transaction &&rhs) {
+  Sqlite3Transaction &operator=(Sqlite3Transaction &&rhs) noexcept {
     if (this != &rhs) {
       Commit();
       std::swap(m_db, rhs.m_db);

--- a/vnext/Shared/Modules/ExceptionsManagerModule.cpp
+++ b/vnext/Shared/Modules/ExceptionsManagerModule.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#pragma once
-
 #include "ExceptionsManagerModule.h"
 #include <assert.h>
 #include <cxxreact/JsArgumentHelpers.h>

--- a/vnext/Shared/Modules/PlatformConstantsModule.h
+++ b/vnext/Shared/Modules/PlatformConstantsModule.h
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 #pragma once
 
 #include <cxxreact/CxxModule.h>

--- a/vnext/Shared/Modules/StatusBarManagerModule.h
+++ b/vnext/Shared/Modules/StatusBarManagerModule.h
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 #pragma once
 
 #include <cxxreact/CxxModule.h>

--- a/vnext/Shared/Modules/UIManagerModule.cpp
+++ b/vnext/Shared/Modules/UIManagerModule.cpp
@@ -28,7 +28,7 @@ UIManager::UIManager(std::vector<std::unique_ptr<IViewManager>> &&viewManagers, 
   m_nativeUIManager->setHost(this);
 }
 
-UIManager::~UIManager() {
+UIManager::~UIManager() noexcept {
   m_nodeRegistry.removeAllRootViews([this](int64_t rootViewTag) { removeRootView(rootViewTag); });
 
   m_nativeUIManager->setHost(nullptr);

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -381,6 +381,7 @@ InstanceImpl::InstanceImpl(
           break;
 #else
           assert(false); // Hermes is not available in this build, fallthrough
+          [[fallthrough]];
 #endif
         case JSIEngineOverride::V8: {
 #if defined(USE_V8)
@@ -397,6 +398,7 @@ InstanceImpl::InstanceImpl(
           break;
 #else
           assert(false); // V8 is not available in this build, fallthrough
+          [[fallthrough]];
 #endif
         }
         case JSIEngineOverride::Chakra:

--- a/vnext/Shared/TurboModuleManager.cpp
+++ b/vnext/Shared/TurboModuleManager.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "TurboModuleManager.h"
 #include "turbomodule/samples/SampleTurboCxxModule.h"
 

--- a/vnext/Shared/TurboModuleManager.cpp
+++ b/vnext/Shared/TurboModuleManager.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "TurboModuleManager.h"
 #include "turbomodule/samples/SampleTurboCxxModule.h"
 

--- a/vnext/Shared/TurboModuleManager.h
+++ b/vnext/Shared/TurboModuleManager.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>

--- a/vnext/Shared/TurboModuleRegistry.h
+++ b/vnext/Shared/TurboModuleRegistry.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>

--- a/vnext/Shared/V8JSIRuntimeHolder.cpp
+++ b/vnext/Shared/V8JSIRuntimeHolder.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "pch.h"
 
 #include <V8JsiRuntime.h>

--- a/vnext/Shared/V8JSIRuntimeHolder.h
+++ b/vnext/Shared/V8JSIRuntimeHolder.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <DevSettings.h>

--- a/vnext/Shared/cdebug.cpp
+++ b/vnext/Shared/cdebug.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "cdebug.h"
 
 basic_dostream<char> cdebug;


### PR DESCRIPTION
Cleans up some more clang tidy issues, and fixes two bugs that I found:
- ReactSupport.cpp had a buffer overflow via using sizeof instead of ARRAYSIZE
- AsyncStorageManager.cpp declared an anonymous lambda but never used/called it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5591)