### PR TITLE
Update codegen targets for source mode to use property instead of items

### DIFF
--- a/change/react-native-windows-2020-07-27-11-50-28-master.json
+++ b/change/react-native-windows-2020-07-27-11-50-28-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update codegen targets for source mode to use property instead of items",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-27T18:50:28.262Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -46,10 +46,10 @@
   <!-- 
     This target returns the location of the deployed executable.
   -->
-  <Target Name="GetPublishedToolPath" DependsOnTargets="PublishTool" Returns="$(_PublishedToolExecutable)">
-    <PropertyGroup>
-      <_PublishedToolExecutable>$([System.IO.Path]::GetFullPath('$(PublishDir)'))$(_DeploymentApplicationManifestIdentity)</_PublishedToolExecutable>
-    </PropertyGroup>
+  <Target Name="GetPublishedToolPath" DependsOnTargets="PublishTool" Returns="@(_PublishedToolExecutable)">
+    <ItemGroup>
+      <_PublishedToolExecutable Include="$([System.IO.Path]::GetFullPath('$(PublishDir)'))$(_DeploymentApplicationManifestIdentity)" />
+    </ItemGroup>
   </Target>
 
   <!-- 

--- a/vnext/PropertySheets/ManagedCodeGen/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/PropertySheets/ManagedCodeGen/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -35,31 +35,17 @@
     <Error Condition="'$(ReactNativeWindowsDir)' == ''" Text="CodeGen is only supported when property ReactNativeWindowsDir is set." />
 
     <MSBuild Projects="$(_ReactNativeCodeGenProjectPath)" Targets="PublishTool" BuildInParallel="$(BuildInParallel)" Properties="$(_ReactNativeCodeGenProjectProperties)" ContinueOnError="!$(BuildingProject)" RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-
       <!-- This target will return all the files of the tool so we can track these for incrementality-->
-      <Output TaskParameter="TargetOutputs" ItemName="_ReactNativeCodeGenToolFilesTemp" />
+      <Output TaskParameter="TargetOutputs" ItemName="_ReactNativeCodeGenToolFiles" />
     </MSBuild>
 
     <MSBuild Projects="$(_ReactNativeCodeGenProjectPath)" Targets="GetPublishedToolPath" BuildInParallel="$(BuildInParallel)" Properties="$(_ReactNativeCodeGenProjectProperties)" ContinueOnError="!$(BuildingProject)" RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-
       <!-- This target will return the tools executable. We unfortunately have ot use a separate target invocation
          - because msbuid does not allow returning multiple pieces of data from a single invocation nor is it easy
          - to setup a convention where the first element would be the executable
          -->
-      <Output TaskParameter="TargetOutputs" ItemName="_ReactNativeCodeGenToolExecutableTemp" />
-
+      <Output TaskParameter="TargetOutputs" PropertyName="_ReactNativeCodeGenToolExecutable" />
     </MSBuild>
-
-    <ItemGroup>
-      <!-- MSBuild does not allow targets to return properties, so map it to a property from an itemgroup -->
-      <_ReactNativeCodeGenToolFiles Include="@(_ReactNativeCodeGenToolFilesTemp)" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <!-- MSBuild does not allow targets to return properties, so map it to a property from an itemgroup -->
-      <_ReactNativeCodeGenToolExecutable>@(_ReactNativeCodeGenToolExecutableTemp)</_ReactNativeCodeGenToolExecutable>
-    </PropertyGroup>
-
   </Target>
 
   <Target Name="ReactNativeManagedCodeGen" DependsOnTargets="_ReactNativeManagedCodeGenPublishTool" Inputs="$(MSBuildProjectFullPath);@(Compile);@(_ReactNativeCodeGenToolFiles)" Outputs="$(ReactNativeCodeGenFile);$(_ReactNativeCodeGenResponseFile)" Condition="'$(DesignTimeBuild)' != 'true'">


### PR DESCRIPTION
This updates the targets for C# codegen to use the proper item vs property settings for msbuild task outputs.

Note: this does not affect the nuget version since that is a separate targets file.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5599)