### PR TITLE
Create release notes for first preview + stable release as a draft

### DIFF
--- a/change/@rnw-scripts-create-github-releases-2020-07-28-07-39-21-draft-notes.json
+++ b/change/@rnw-scripts-create-github-releases-2020-07-28-07-39-21-draft-notes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Create release notes for first preview + stable release as a draft",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-28T14:39:21.798Z"
+}


### PR DESCRIPTION
We want to add manually curated notes before notifications with release notes are sent out. Tell the robots to create these as draft releases to give an opportunity for us to add our own notes first.

Manually tested the change locally. Need to spend some time making this more testable once we have UTs hooked up everywhere.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5600)