### PR TITLE
Fix devmode for react-native-windows-init to add the package to packages.config as well

### DIFF
--- a/change/react-native-windows-init-2020-07-28-10-12-52-master.json
+++ b/change/react-native-windows-init-2020-07-28-10-12-52-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix devmode for react-native-windows-init to add the package to packages.config as well",
+  "packageName": "react-native-windows-init",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-28T17:12:52.650Z"
+}


### PR DESCRIPTION
Fixes bug where the -usedevMode for react-native-init did not include adding the dependency to package.json.
This at the same time adds support for not passing a version and inferring it from the linked pacakge.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5603)