### PR TITLE
Share packager connection between instances to same packager

### DIFF
--- a/change/react-native-windows-2020-07-29-13-39-44-packagecon.json
+++ b/change/react-native-windows-2020-07-29-13-39-44-packagecon.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Share packager connection between instances to same packager",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-07-29T20:39:44.819Z"
+}

--- a/vnext/Desktop/pch.h
+++ b/vnext/Desktop/pch.h
@@ -8,6 +8,7 @@
 #endif
 
 #include <windows.h>
+#include "unknwn.h"
 #include <winrt/base.h>
 #include <mutex>
 

--- a/vnext/Desktop/pch.h
+++ b/vnext/Desktop/pch.h
@@ -7,8 +7,9 @@
 #define NOGDI
 #endif
 
-#include <windows.h>
 #include "unknwn.h"
+
+#include <windows.h>
 #include <winrt/base.h>
 #include <mutex>
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -241,6 +241,13 @@ void ReactInstanceWin::Initialize() noexcept {
 
           devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
           devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
+          devSettings->showDevMenuCallback = [weakThis]() noexcept {
+            if (auto strongThis = weakThis.GetStrongPtr()) {
+              strongThis->m_uiQueue.Post([context = strongThis->m_reactContext]() {
+                Microsoft::ReactNative::DevMenuManager::Show(context->Properties());
+              });
+            }
+          };
 
           // Now that ReactNativeWindows is building outside devmain, it is missing
           // fix given by PR https://github.com/microsoft/react-native-windows/pull/2624 causing

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -104,6 +104,9 @@ struct DevSettings {
   /// Superseded by PreparedScriptStore on the JSI stack, and will be removed
   /// soon. (See #3603)
   ChakraBundleUrlMetadataMap chakraBundleUrlMetadataMap;
+
+  /// Callback to show the devmenu
+  std::function<void()> showDevMenuCallback;
 };
 
 } // namespace react

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -22,7 +22,6 @@ struct DevSettings;
 
 namespace Microsoft::ReactNative {
 
-
 std::pair<std::string, bool> GetJavaScriptFromServer(
     const std::string &sourceBundleHost,
     const uint16_t sourceBundlePort,

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -20,8 +20,14 @@ struct DevSettings;
 }
 } // namespace facebook
 
-namespace react {
-namespace uwp {
+namespace Microsoft::ReactNative {
+
+
+std::pair<std::string, bool> GetJavaScriptFromServer(
+    const std::string &sourceBundleHost,
+    const uint16_t sourceBundlePort,
+    const std::string &jsBundleName,
+    const std::string &platform);
 
 class DevSupportManager final : public facebook::react::IDevSupportManager {
  public:
@@ -29,11 +35,6 @@ class DevSupportManager final : public facebook::react::IDevSupportManager {
   ~DevSupportManager();
 
   virtual facebook::react::JSECreator LoadJavaScriptInProxyMode(const facebook::react::DevSettings &settings) override;
-  virtual std::string GetJavaScriptFromServer(
-      const std::string &sourceBundleHost,
-      const uint16_t sourceBundlePort,
-      const std::string &jsBundleName,
-      const std::string &platform) override;
   virtual void StartPollingLiveReload(
       const std::string &sourceBundleHost,
       const uint16_t sourceBundlePort,
@@ -44,15 +45,8 @@ class DevSupportManager final : public facebook::react::IDevSupportManager {
   }
 
  private:
-  void LaunchDevTools(const facebook::react::DevSettings &settings);
-  std::future<void> CreatePackagerConnection(const facebook::react::DevSettings &settings);
-
- private:
-  winrt::Windows::Networking::Sockets::MessageWebSocket m_ws{nullptr};
-  winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_wsMessageRevoker;
   bool m_exceptionCaught = false;
   std::atomic_bool m_cancellation_token;
 };
 
-} // namespace uwp
-} // namespace react
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/IDevSupportManager.h
+++ b/vnext/Shared/IDevSupportManager.h
@@ -16,11 +16,6 @@ struct DevSettings;
 
 struct IDevSupportManager {
   virtual JSECreator LoadJavaScriptInProxyMode(const DevSettings &settings) = 0;
-  virtual std::string GetJavaScriptFromServer(
-      const std::string &sourceBundleHost,
-      const uint16_t sourceBundlePort,
-      const std::string &jsBundleName,
-      const std::string &platform) = 0;
   virtual void StartPollingLiveReload(
       const std::string &sourceBundleHost,
       const uint16_t sourceBundlePort,

--- a/vnext/Shared/Modules/ExceptionsManagerModule.cpp
+++ b/vnext/Shared/Modules/ExceptionsManagerModule.cpp
@@ -156,11 +156,12 @@ std::map<std::string, folly::dynamic> ExceptionsManagerModule::getConstants() {
 }
 
 std::vector<facebook::xplat::module::CxxModule::Method> ExceptionsManagerModule::getMethods() {
+  auto redboxHandler = m_redboxHandler;
   return {Method(
               "reportFatalException",
-              [this](folly::dynamic args) noexcept {
-                if (m_redboxHandler && m_redboxHandler->isDevSupportEnabled()) {
-                  m_redboxHandler->showNewError(std::move(CreateErrorInfo(args)), Mso::React::ErrorType::JSFatal);
+              [redboxHandler](folly::dynamic args) noexcept {
+                if (redboxHandler && redboxHandler->isDevSupportEnabled()) {
+                  redboxHandler->showNewError(std::move(CreateErrorInfo(args)), Mso::React::ErrorType::JSFatal);
                 }
                 /*
                 // TODO - fatal errors should throw if there is no redbox handler
@@ -171,18 +172,18 @@ std::vector<facebook::xplat::module::CxxModule::Method> ExceptionsManagerModule:
 
           Method(
               "reportSoftException",
-              [this](folly::dynamic args) noexcept {
-                if (m_redboxHandler && m_redboxHandler->isDevSupportEnabled()) {
-                  m_redboxHandler->showNewError(std::move(CreateErrorInfo(args)), Mso::React::ErrorType::JSSoft);
+              [redboxHandler](folly::dynamic args) noexcept {
+                if (redboxHandler && redboxHandler->isDevSupportEnabled()) {
+                  redboxHandler->showNewError(std::move(CreateErrorInfo(args)), Mso::React::ErrorType::JSSoft);
                 }
               }),
 
           Method(
               "reportException",
-              [this](folly::dynamic args) noexcept {
-                if (m_redboxHandler && m_redboxHandler->isDevSupportEnabled()) {
+              [redboxHandler](folly::dynamic args) noexcept {
+                if (redboxHandler && redboxHandler->isDevSupportEnabled()) {
                   auto isFatal = RetrieveOptionalBoolFromMap(args[0], "isFatal");
-                  m_redboxHandler->showNewError(
+                  redboxHandler->showNewError(
                       std::move(CreateErrorInfo2(args[0])),
                       isFatal ? Mso::React::ErrorType::JSFatal : Mso::React::ErrorType::JSSoft);
                 }
@@ -190,15 +191,15 @@ std::vector<facebook::xplat::module::CxxModule::Method> ExceptionsManagerModule:
 
           Method(
               "updateExceptionMessage",
-              [this](folly::dynamic args) noexcept {
-                if (m_redboxHandler && m_redboxHandler->isDevSupportEnabled()) {
-                  m_redboxHandler->updateError(std::move(CreateErrorInfo(args)));
+              [redboxHandler](folly::dynamic args) noexcept {
+                if (redboxHandler && redboxHandler->isDevSupportEnabled()) {
+                  redboxHandler->updateError(std::move(CreateErrorInfo(args)));
                 }
               }),
 
-          Method("dismissRedbox", [this](folly::dynamic /*args*/) noexcept {
-            if (m_redboxHandler)
-              m_redboxHandler->dismissRedbox();
+          Method("dismissRedbox", [redboxHandler](folly::dynamic /*args*/) noexcept {
+            if (redboxHandler)
+              redboxHandler->dismissRedbox();
           })};
 }
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -366,7 +366,6 @@ InstanceImpl::InstanceImpl(
       return;
     }
   } else {
-    
     if (m_devSettings->useFastRefresh || m_devSettings->liveReloadCallback) {
       Microsoft::ReactNative::PackagerConnection::CreateOrReusePackagerConnection(*m_devSettings);
     }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -497,9 +497,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       // First attempt to get download the Js locally, to catch any bundling
       // errors before attempting to load the actual script.
 
-      std::string jsBundleString;
-      bool success;
-      std::tie(jsBundleString, success) = Microsoft::ReactNative::GetJavaScriptFromServer(
+      auto [jsBundleString, success] = Microsoft::ReactNative::GetJavaScriptFromServer(
           m_devSettings->sourceBundleHost,
           m_devSettings->sourceBundlePort,
           m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -38,11 +38,12 @@
 #include <BatchingMessageQueueThread.h>
 #include <CreateModules.h>
 #include <DevSettings.h>
-#include <IDevSupportManager.h>
+#include <DevSupportManager.h>
 #include <IReactRootView.h>
 #include <IUIManager.h>
 #include <Shlwapi.h>
 #include <WebSocketJSExecutorFactory.h>
+#include "PackagerConnection.h"
 
 #if defined(USE_HERMES)
 #include "HermesRuntimeHolder.h"
@@ -365,6 +366,11 @@ InstanceImpl::InstanceImpl(
       return;
     }
   } else {
+    
+    if (m_devSettings->useFastRefresh || m_devSettings->liveReloadCallback) {
+      Microsoft::ReactNative::PackagerConnection::CreateOrReusePackagerConnection(*m_devSettings);
+    }
+
     // If the consumer gives us a JSI runtime, then  use it.
     if (m_devSettings->jsiRuntimeHolder) {
       assert(m_devSettings->jsiEngineOverride == JSIEngineOverride::Default);
@@ -491,13 +497,16 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
         m_devSettings->useFastRefresh) {
       // First attempt to get download the Js locally, to catch any bundling
       // errors before attempting to load the actual script.
-      auto jsBundleString = m_devManager->GetJavaScriptFromServer(
+
+      std::string jsBundleString;
+      bool success;
+      std::tie(jsBundleString, success) = Microsoft::ReactNative::GetJavaScriptFromServer(
           m_devSettings->sourceBundleHost,
           m_devSettings->sourceBundlePort,
           m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,
           m_devSettings->platformName);
 
-      if (m_devManager->HasException()) {
+      if (!success) {
         m_devSettings->errorCallback(jsBundleString);
         return;
       }

--- a/vnext/Shared/PackagerConnection.cpp
+++ b/vnext/Shared/PackagerConnection.cpp
@@ -5,10 +5,10 @@
 
 #include <Shared/DevServerHelper.h>
 #include <Utils/CppWinrtLessExceptions.h>
+#include <Windows.Storage.Streams.h>
+#include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
-#include <winrt/Windows.Data.Json.h>
-#include <Windows.Storage.Streams.h>
 #include "Unicode.h"
 #include "Utilities.h"
 
@@ -32,35 +32,35 @@ winrt::Microsoft::ReactNative::IReactPropertyName ReloadEventName() {
 
 winrt::Microsoft::ReactNative::IReactPropertyName DevMenuEventName() {
   static const winrt::Microsoft::ReactNative::IReactPropertyName propName =
-      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetName(PackagerNamespace(),
-          L"DevMenu");
+      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetName(PackagerNamespace(), L"DevMenu");
   return propName;
 }
 
-/* static */ std::shared_ptr<PackagerConnection> PackagerConnection::GetOrCreate(const std::string& sourceBundleHost, uint16_t sourceBundlePort) 
-{
-    std::shared_ptr<PackagerConnection> packager;
-    {
-        std::lock_guard<std::mutex> guard(m_mutexPackagers);
-        auto key = std::pair<std::string, uint16_t>(sourceBundleHost, sourceBundlePort);
-        auto it = m_connections.find(key);
+/* static */ std::shared_ptr<PackagerConnection> PackagerConnection::GetOrCreate(
+    const std::string &sourceBundleHost,
+    uint16_t sourceBundlePort) {
+  std::shared_ptr<PackagerConnection> packager;
+  {
+    std::lock_guard<std::mutex> guard(m_mutexPackagers);
+    auto key = std::pair<std::string, uint16_t>(sourceBundleHost, sourceBundlePort);
+    auto it = m_connections.find(key);
 
-        if (it != m_connections.end()) {
-            return it->second;
-        }
-
-        packager = std::make_shared<PackagerConnection>(sourceBundleHost, sourceBundlePort);
-        m_connections.emplace(key, packager);
+    if (it != m_connections.end()) {
+      return it->second;
     }
 
-    packager->Connect();
-    return packager;
-}
+    packager = std::make_shared<PackagerConnection>(sourceBundleHost, sourceBundlePort);
+    m_connections.emplace(key, packager);
+  }
 
+  packager->Connect();
+  return packager;
+}
 
 void PackagerConnection::CreateOrReusePackagerConnection(const facebook::react::DevSettings &settings) {
   auto packager = GetOrCreate(settings.sourceBundleHost, settings.sourceBundlePort);
-  packager->SubscribeReloadEvent([callback = settings.liveReloadCallback](
+  packager->SubscribeReloadEvent(
+      [callback = settings.liveReloadCallback](
           winrt::IInspectable const & /*sender*/,
           winrt::Microsoft::ReactNative::IReactNotificationArgs const & /*args*/) { callback(); });
   packager->SubscribeDevMenuEvent(
@@ -69,18 +69,18 @@ void PackagerConnection::CreateOrReusePackagerConnection(const facebook::react::
           winrt::Microsoft::ReactNative::IReactNotificationArgs const & /*args*/) { callback(); });
 }
 
+PackagerConnection::PackagerConnection(const std::string &sourceBundleHost, uint16_t sourceBundlePort)
+    : m_sourceBundleHost(sourceBundleHost),
+      m_sourceBundlePort(sourceBundlePort),
+      m_notificationService(
+          winrt::Microsoft::ReactNative::ReactNotificationServiceHelper::CreateNotificationService()) {}
 
-PackagerConnection::PackagerConnection(const std::string& sourceBundleHost, uint16_t sourceBundlePort) 
-: m_sourceBundleHost(sourceBundleHost) , m_sourceBundlePort(sourceBundlePort), m_notificationService(winrt::Microsoft::ReactNative::ReactNotificationServiceHelper::CreateNotificationService()) {}
-
-
-void PackagerConnection::SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler)
-{
-    m_notificationService.Subscribe(ReloadEventName(), nullptr, handler);
+void PackagerConnection::SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler) {
+  m_notificationService.Subscribe(ReloadEventName(), nullptr, handler);
 }
 
 void PackagerConnection::SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler) {
-    m_notificationService.Subscribe(DevMenuEventName(), nullptr, handler);
+  m_notificationService.Subscribe(DevMenuEventName(), nullptr, handler);
 }
 
 std::future<void> PackagerConnection::Connect() {
@@ -135,9 +135,8 @@ std::future<void> PackagerConnection::Connect() {
         }
       });
 
-  winrt::Windows::Foundation::Uri uri(
-      Microsoft::Common::Unicode::Utf8ToUtf16(facebook::react::DevServerHelper::get_PackagerConnectionUrl(
-          m_sourceBundleHost, m_sourceBundlePort)));
+  winrt::Windows::Foundation::Uri uri(Microsoft::Common::Unicode::Utf8ToUtf16(
+      facebook::react::DevServerHelper::get_PackagerConnectionUrl(m_sourceBundleHost, m_sourceBundlePort)));
   auto async = m_ws.ConnectAsync(uri);
 
 #ifdef DEFAULT_CPPWINRT_EXCEPTIONS
@@ -147,5 +146,4 @@ std::future<void> PackagerConnection::Connect() {
 #endif
 }
 
-
-}
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/PackagerConnection.cpp
+++ b/vnext/Shared/PackagerConnection.cpp
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "pch.h"
+
 #include "PackagerConnection.h"
 
 #include <Shared/DevServerHelper.h>
 #include <Utils/CppWinrtLessExceptions.h>
 #include <Windows.Storage.Streams.h>
+#include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.Streams.h>
@@ -61,11 +64,11 @@ void PackagerConnection::CreateOrReusePackagerConnection(const facebook::react::
   auto packager = GetOrCreate(settings.sourceBundleHost, settings.sourceBundlePort);
   packager->SubscribeReloadEvent(
       [callback = settings.liveReloadCallback](
-          winrt::IInspectable const & /*sender*/,
+          winrt::Windows::Foundation::IInspectable const & /*sender*/,
           winrt::Microsoft::ReactNative::IReactNotificationArgs const & /*args*/) { callback(); });
   packager->SubscribeDevMenuEvent(
       [callback = settings.showDevMenuCallback](
-          winrt::IInspectable const & /*sender*/,
+          winrt::Windows::Foundation::IInspectable const & /*sender*/,
           winrt::Microsoft::ReactNative::IReactNotificationArgs const & /*args*/) { callback(); });
 }
 
@@ -83,7 +86,7 @@ void PackagerConnection::SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::Re
   m_notificationService.Subscribe(DevMenuEventName(), nullptr, handler);
 }
 
-std::future<void> PackagerConnection::Connect() {
+winrt::fire_and_forget PackagerConnection::Connect() {
   m_ws = winrt::Windows::Networking::Sockets::MessageWebSocket();
 
   m_wsMessageRevoker = m_ws.MessageReceived(

--- a/vnext/Shared/PackagerConnection.cpp
+++ b/vnext/Shared/PackagerConnection.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "PackagerConnection.h"
+
+#include <Shared/DevServerHelper.h>
+#include <Utils/CppWinrtLessExceptions.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Data.Json.h>
+#include <Windows.Storage.Streams.h>
+#include "Unicode.h"
+#include "Utilities.h"
+
+namespace Microsoft::ReactNative {
+
+/*static*/ std::mutex PackagerConnection::m_mutexPackagers;
+/*static*/ std::unordered_map<std::pair<std::string, uint16_t>, std::shared_ptr<PackagerConnection>>
+    PackagerConnection::m_connections;
+
+winrt::Microsoft::ReactNative::IReactPropertyNamespace PackagerNamespace() {
+  static const winrt::Microsoft::ReactNative::IReactPropertyNamespace ns =
+      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetNamespace(L"ReactNative.PackagerConnection");
+  return ns;
+}
+
+winrt::Microsoft::ReactNative::IReactPropertyName ReloadEventName() {
+  static const winrt::Microsoft::ReactNative::IReactPropertyName propName =
+      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetName(PackagerNamespace(), L"Reload");
+  return propName;
+}
+
+winrt::Microsoft::ReactNative::IReactPropertyName DevMenuEventName() {
+  static const winrt::Microsoft::ReactNative::IReactPropertyName propName =
+      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetName(PackagerNamespace(),
+          L"DevMenu");
+  return propName;
+}
+
+/* static */ std::shared_ptr<PackagerConnection> PackagerConnection::GetOrCreate(const std::string& sourceBundleHost, uint16_t sourceBundlePort) 
+{
+    std::shared_ptr<PackagerConnection> packager;
+    {
+        std::lock_guard<std::mutex> guard(m_mutexPackagers);
+        auto key = std::pair<std::string, uint16_t>(sourceBundleHost, sourceBundlePort);
+        auto it = m_connections.find(key);
+
+        if (it != m_connections.end()) {
+            return it->second;
+        }
+
+        packager = std::make_shared<PackagerConnection>(sourceBundleHost, sourceBundlePort);
+        m_connections.emplace(key, packager);
+    }
+
+    packager->Connect();
+    return packager;
+}
+
+
+void PackagerConnection::CreateOrReusePackagerConnection(const facebook::react::DevSettings &settings) {
+  auto packager = GetOrCreate(settings.sourceBundleHost, settings.sourceBundlePort);
+  packager->SubscribeReloadEvent([callback = settings.liveReloadCallback](
+          winrt::IInspectable const & /*sender*/,
+          winrt::Microsoft::ReactNative::IReactNotificationArgs const & /*args*/) { callback(); });
+  packager->SubscribeDevMenuEvent(
+      [callback = settings.showDevMenuCallback](
+          winrt::IInspectable const & /*sender*/,
+          winrt::Microsoft::ReactNative::IReactNotificationArgs const & /*args*/) { callback(); });
+}
+
+
+PackagerConnection::PackagerConnection(const std::string& sourceBundleHost, uint16_t sourceBundlePort) 
+: m_sourceBundleHost(sourceBundleHost) , m_sourceBundlePort(sourceBundlePort), m_notificationService(winrt::Microsoft::ReactNative::ReactNotificationServiceHelper::CreateNotificationService()) {}
+
+
+void PackagerConnection::SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler)
+{
+    m_notificationService.Subscribe(ReloadEventName(), nullptr, handler);
+}
+
+void PackagerConnection::SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler) {
+    m_notificationService.Subscribe(DevMenuEventName(), nullptr, handler);
+}
+
+std::future<void> PackagerConnection::Connect() {
+  m_ws = winrt::Windows::Networking::Sockets::MessageWebSocket();
+
+  m_wsMessageRevoker = m_ws.MessageReceived(
+      winrt::auto_revoke, [weakThis = this->weak_from_this()](auto && /*sender*/, auto &&args) noexcept {
+        try {
+          if (auto strongThis = weakThis.lock()) {
+            // Use ABI to avoid throwing exceptions on standard errors
+            winrt::com_ptr<ABI::Windows::Networking::Sockets::IMessageWebSocketMessageReceivedEventArgs> abiArgs{
+                args.as<ABI::Windows::Networking::Sockets::IMessageWebSocketMessageReceivedEventArgs>()};
+            winrt::com_ptr<ABI::Windows::Storage::Streams::IDataReader> abiReader;
+            auto hr = abiArgs->GetDataReader(abiReader.put());
+            if (FAILED(hr)) {
+              return;
+            }
+
+            winrt::Windows::Storage::Streams::DataReader reader{
+                abiReader.as<winrt::Windows::Storage::Streams::DataReader>()};
+
+            uint32_t len = reader.UnconsumedBufferLength();
+            if (args.MessageType() == winrt::Windows::Networking::Sockets::SocketMessageType::Utf8) {
+              reader.UnicodeEncoding(winrt::Windows::Storage::Streams::UnicodeEncoding::Utf8);
+              std::vector<uint8_t> data(len);
+              reader.ReadBytes(data);
+
+              auto response =
+                  std::string(Microsoft::Common::Utilities::CheckedReinterpretCast<char *>(data.data()), data.size());
+              auto json =
+                  winrt::Windows::Data::Json::JsonObject::Parse(Microsoft::Common::Unicode::Utf8ToUtf16(response));
+
+              auto version = (int)json.GetNamedNumber(L"version", 0.0);
+              if (version != 2) {
+                return;
+              }
+              auto method = std::wstring(json.GetNamedString(L"method", L""));
+              if (method.empty()) {
+                return;
+              }
+
+              if (!method.compare(L"reload")) {
+                strongThis->m_notificationService.SendNotification(ReloadEventName(), nullptr, nullptr);
+              } else if (!method.compare(L"devMenu")) {
+                strongThis->m_notificationService.SendNotification(DevMenuEventName(), nullptr, nullptr);
+              } else if (!method.compare(L"captureHeap")) {
+                // TODO captureHeap
+              }
+            }
+          }
+        } catch (winrt::hresult_error const &e) {
+        }
+      });
+
+  winrt::Windows::Foundation::Uri uri(
+      Microsoft::Common::Unicode::Utf8ToUtf16(facebook::react::DevServerHelper::get_PackagerConnectionUrl(
+          m_sourceBundleHost, m_sourceBundlePort)));
+  auto async = m_ws.ConnectAsync(uri);
+
+#ifdef DEFAULT_CPPWINRT_EXCEPTIONS
+  co_await async;
+#else
+  co_await lessthrow_await_adapter<winrt::Windows::Foundation::IAsyncAction>{async};
+#endif
+}
+
+
+}

--- a/vnext/Shared/PackagerConnection.h
+++ b/vnext/Shared/PackagerConnection.h
@@ -1,34 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <winrt/Windows.Networking.Sockets.h>
 #include "DevSettings.h"
 #include "ReactNotificationService.h"
-#include <winrt/Windows.Networking.Sockets.h>
 
 namespace Microsoft::ReactNative {
 
 /*
  * Maintains a list of connections to packaging servers which can notify the instance to reload, or show the dev menu
- * Generally an app will only ever talk to one server, so if there are mutliple instances running in an app this allows them to share a connection to that pacakger.
-*/
+ * Generally an app will only ever talk to one server, so if there are mutliple instances running in an app this allows
+ * them to share a connection to that pacakger.
+ */
 struct PackagerConnection : std::enable_shared_from_this<PackagerConnection> {
   PackagerConnection(const std::string &sourceBundleHost, uint16_t sourceBundlePort);
   static void CreateOrReusePackagerConnection(const facebook::react::DevSettings &settings);
 
-private:
-    std::future<void> Connect();
-    void SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
-    void SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
+ private:
+  std::future<void> Connect();
+  void SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
+  void SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
 
-    static std::shared_ptr<PackagerConnection> GetOrCreate(const std::string& sourceBundleHost, uint16_t sourceBundlePort);
+  static std::shared_ptr<PackagerConnection> GetOrCreate(
+      const std::string &sourceBundleHost,
+      uint16_t sourceBundlePort);
 
-    std::string m_sourceBundleHost;
-    uint16_t m_sourceBundlePort;
-    winrt::Microsoft::ReactNative::IReactNotificationService m_notificationService;
-    winrt::Windows::Networking::Sockets::MessageWebSocket m_ws;
-    winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_wsMessageRevoker;
-    static std::mutex m_mutexPackagers;
-    static std::unordered_map<std::pair<std::string, uint16_t>, std::shared_ptr<PackagerConnection>> m_connections;
+  std::string m_sourceBundleHost;
+  uint16_t m_sourceBundlePort;
+  winrt::Microsoft::ReactNative::IReactNotificationService m_notificationService;
+  winrt::Windows::Networking::Sockets::MessageWebSocket m_ws;
+  winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_wsMessageRevoker;
+  static std::mutex m_mutexPackagers;
+  static std::unordered_map<std::pair<std::string, uint16_t>, std::shared_ptr<PackagerConnection>> m_connections;
 };
-    
-}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/PackagerConnection.h
+++ b/vnext/Shared/PackagerConnection.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "DevSettings.h"
+#include "ReactNotificationService.h"
+#include <winrt/Windows.Networking.Sockets.h>
+
+namespace Microsoft::ReactNative {
+
+/*
+ * Maintains a list of connections to packaging servers which can notify the instance to reload, or show the dev menu
+ * Generally an app will only ever talk to one server, so if there are mutliple instances running in an app this allows them to share a connection to that pacakger.
+*/
+struct PackagerConnection : std::enable_shared_from_this<PackagerConnection> {
+  PackagerConnection(const std::string &sourceBundleHost, uint16_t sourceBundlePort);
+  static void CreateOrReusePackagerConnection(const facebook::react::DevSettings &settings);
+
+private:
+    std::future<void> Connect();
+    void SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
+    void SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
+
+    static std::shared_ptr<PackagerConnection> GetOrCreate(const std::string& sourceBundleHost, uint16_t sourceBundlePort);
+
+    std::string m_sourceBundleHost;
+    uint16_t m_sourceBundlePort;
+    winrt::Microsoft::ReactNative::IReactNotificationService m_notificationService;
+    winrt::Windows::Networking::Sockets::MessageWebSocket m_ws;
+    winrt::Windows::Networking::Sockets::MessageWebSocket::MessageReceived_revoker m_wsMessageRevoker;
+    static std::mutex m_mutexPackagers;
+    static std::unordered_map<std::pair<std::string, uint16_t>, std::shared_ptr<PackagerConnection>> m_connections;
+};
+    
+}

--- a/vnext/Shared/PackagerConnection.h
+++ b/vnext/Shared/PackagerConnection.h
@@ -17,7 +17,7 @@ struct PackagerConnection : std::enable_shared_from_this<PackagerConnection> {
   static void CreateOrReusePackagerConnection(const facebook::react::DevSettings &settings);
 
  private:
-  std::future<void> Connect();
+  winrt::fire_and_forget Connect();
   void SubscribeReloadEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
   void SubscribeDevMenuEvent(winrt::Microsoft::ReactNative::ReactNotificationHandler const &handler);
 

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -46,6 +46,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\StatusBarManagerModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\UIManagerModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)OInstance.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)PackagerConnection.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ShadowNode.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ShadowNodeRegistry.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)tracing\tracing.cpp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -106,6 +106,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Executors\WebSocketJSExecutorFactory.cpp">
       <Filter>Source Files\Executors</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)PackagerConnection.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
Before this, if two instances were run against the same package server then the first one would be able to connect to the packager and receive reload commands.  But the second one would not be able to connect since the socket would already be in use.

You can hit this today in the playground-win32 app by opening a 2nd window running an instance in both windows.  When you hit 'R' in metro to reload the instances, only one of them will reload.

This PR changes it so that we can share a connection to the packager when multiple instances are run in the same app.  Which means in the above scenario both instances will reload.

This change also hooks up support for handling the DevMenu command from the packager, which will now correctly show the DevMenu when you hit 'D' in metro.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5610)