### PR TITLE
[0.62] Install framework package dependencies 

### DIFF
--- a/change/react-native-windows-2020-07-31-21-11-13-deployDeps-62.json
+++ b/change/react-native-windows-2020-07-31-21-11-13-deployDeps-62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-01T04:11:13.262Z"
+}

--- a/vnext/local-cli/runWindows/utils/deploy.js
+++ b/vnext/local-cli/runWindows/utils/deploy.js
@@ -261,6 +261,15 @@ async function deployToDesktop(options, verbose, slnFile) {
     );
   } else {
     const realAppxManifestPath = fs.realpathSync(appxManifestPath);
+    // Install the app package's dependencies before attempting to deploy.
+    await runPowerShellScriptFunction(
+      'Installing dependent framework packages',
+      windowsStoreAppUtils,
+      `Install-AppDependencies ${realAppxManifestPath} ${appPackageFolder} ${
+        options.arch
+      }`,
+      verbose,
+    );
     await runPowerShellScriptFunction(
       'Installing new version of the app from layout',
       windowsStoreAppUtils,


### PR DESCRIPTION
Backporting the fix to #5500 to 0.62 as there have been a number of folks who hit this problem (we've been telling them to F5 in VS once to get bootstrapped, but this should work out of the box)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5618)