### PR TITLE
Add option to devmenu to configure bundler

### DIFF
--- a/change/react-native-windows-2020-08-03-08-49-30-configbundler.json
+++ b/change/react-native-windows-2020-08-03-08-49-30-configbundler.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add option to devmenu to configure bundler",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T15:49:30.262Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -503,6 +503,7 @@
     <ClCompile Include="Utils\ValueUtils.cpp" />
     <ClCompile Include="Views\ActivityIndicatorViewManager.cpp" />
     <ClCompile Include="Views\CheckboxViewManager.cpp" />
+    <ClCompile Include="Views\ConfigureBundlerDlg.cpp" />
     <ClCompile Include="Views\ControlViewManager.cpp" />
     <ClCompile Include="Views\DatePickerViewManager.cpp" />
     <ClCompile Include="Views\DevMenu.cpp" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -212,6 +212,9 @@
     <ClCompile Include="Views\CheckboxViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
+    <ClCompile Include="Views\ConfigureBundlerDlg.cpp">
+      <Filter>Views</Filter>
+    </ClCompile>
     <ClCompile Include="Views\ControlViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -199,7 +199,7 @@ void ReactInstanceWin::Initialize() noexcept {
   InitUIManager();
 
   Microsoft::ReactNative::DevMenuManager::InitDevMenu(m_reactContext, [weakReactHost = m_weakReactHost]() noexcept {
-    winrt::make<Microsoft::ReactNative::ConfigureBundlerDlg>(weakReactHost);
+    Microsoft::ReactNative::ShowConfigureBundlerDialog(weakReactHost);
   });
 
   Mso::PostFuture(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -27,6 +27,7 @@
 #include <Shared/DevServerHelper.h>
 #include <Shared/ViewManager.h>
 #include <dispatchQueue/dispatchQueue.h>
+#include "ConfigureBundlerDlg.h"
 #include "DevMenu.h"
 #include "IReactContext.h"
 #include "IReactDispatcher.h"
@@ -197,7 +198,9 @@ void ReactInstanceWin::Initialize() noexcept {
   // InitUIManager uses m_legacyReactInstance
   InitUIManager();
 
-  Microsoft::ReactNative::DevMenuManager::InitDevMenu(m_reactContext);
+  Microsoft::ReactNative::DevMenuManager::InitDevMenu(m_reactContext, [weakReactHost = m_weakReactHost]() noexcept {
+    winrt::make<Microsoft::ReactNative::ConfigureBundlerDlg>(weakReactHost);
+  });
 
   Mso::PostFuture(
       m_uiQueue,

--- a/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
@@ -15,19 +15,20 @@
 
 namespace Microsoft::ReactNative {
 
-ConfigureBundlerDlg::ConfigureBundlerDlg(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost)
-    : m_weakReactHost(std::move(weakReactHost)) {
-  if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
-    auto uiDispatcher = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatcher(
-        reactHost->Options().Properties);
-    uiDispatcher.Post([pThis = get_strong()]() { pThis->CreateAndShowUI(); });
+struct ConfigureBundlerDlg : winrt::implements<ConfigureBundlerDlg, winrt::IInspectable> {
+  ConfigureBundlerDlg(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost) : m_weakReactHost(std::move(weakReactHost)) {
+    if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+      auto uiDispatcher = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatcher(
+          reactHost->Options().Properties);
+      uiDispatcher.Post([pThis = get_strong()]() { pThis->CreateAndShowUI(); });
+    }
   }
-}
 
-void ConfigureBundlerDlg::CreateAndShowUI() noexcept {
-  if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
-    const winrt::hstring xamlString =
-        LR"(
+ private:
+  void CreateAndShowUI() noexcept {
+    if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+      const winrt::hstring xamlString =
+          LR"(
   <StackPanel
     xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
@@ -46,135 +47,141 @@ void ConfigureBundlerDlg::CreateAndShowUI() noexcept {
       </TransitionCollection>
     </StackPanel.Transitions>
     <TextBlock FontSize="20" Margin="{ThemeResource ContentDialogTitleMargin}">Configure Bundler</TextBlock>
+    <TextBlock Opacity='0.5' TextWrapping="Wrap" Margin="{ThemeResource ContentDialogTitleMargin}">Provide a custom bundler address, port and entrypoint.<LineBreak/>Applying these settings will cause the instance to be reloaded.</TextBlock>
     <TextBox x:Name="Host" Header="Bundler host:" PlaceholderText="localhost"/>
     <TextBox x:Name="Port" Header="Bundler port:" PlaceholderText="8081" Margin="0,4,0,0"/>
-    <TextBox x:Name="EntryPoint" Header="entrypoint:" PlaceholderText="index.windows" Margin="0,4,0,0"/>
+    <TextBox x:Name="EntryPoint" Header="Entrypoint:" PlaceholderText="index.windows" Margin="0,4,0,0"/>
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="{ThemeResource ContentDialogCommandSpaceMargin}">
       <Button x:Name="Apply" Style="{StaticResource AccentButtonStyle}" Content="Apply Changes" />
       <Button x:Name="Reset" Content="Reset to Default" Margin="4,0,0,0"/>
       <Button x:Name="Cancel" Content="Cancel" Margin="4,0,0,0"/>
     </StackPanel>
   </StackPanel>)";
-    auto configureUI = winrt::unbox_value<xaml::Controls::StackPanel>(xaml::Markup::XamlReader::Load(xamlString));
+      auto configureUI = winrt::unbox_value<xaml::Controls::StackPanel>(xaml::Markup::XamlReader::Load(xamlString));
 
-    auto options = reactHost->Options();
+      auto options = reactHost->Options();
 
-    configureUI.FindName(L"Host").as<xaml::Controls::TextBox>().Text(Microsoft::Common::Unicode::Utf8ToUtf16(
-        options.DeveloperSettings.SourceBundleHost.empty() ? facebook::react::DevServerHelper::DefaultPackagerHost
-                                                           : options.DeveloperSettings.SourceBundleHost));
+      auto host = configureUI.FindName(L"Host").as<xaml::Controls::TextBox>();
 
-    configureUI.FindName(L"Port").as<xaml::Controls::TextBox>().Text(std::to_wstring(
-        options.DeveloperSettings.SourceBundlePort ? options.DeveloperSettings.SourceBundlePort
-                                                   : facebook::react::DevServerHelper::DefaultPackagerPort));
+      host.PlaceholderText(
+          Microsoft::Common::Unicode::Utf8ToUtf16(facebook::react::DevServerHelper::DefaultPackagerHost));
+      host.Text(Microsoft::Common::Unicode::Utf8ToUtf16(options.DeveloperSettings.SourceBundleHost));
 
-    configureUI.FindName(L"EntryPoint")
-        .as<xaml::Controls::TextBox>()
-        .Text(Microsoft::Common::Unicode::Utf8ToUtf16(
-            options.DeveloperSettings.SourceBundleName.empty() ? "index.windows"
-                                                               : options.DeveloperSettings.SourceBundleName));
+      auto port = configureUI.FindName(L"Port").as<xaml::Controls::TextBox>();
+      port.PlaceholderText(std::to_wstring(facebook::react::DevServerHelper::DefaultPackagerPort));
+      if (options.DeveloperSettings.SourceBundlePort)
+        port.Text(std::to_wstring(options.DeveloperSettings.SourceBundlePort));
 
-    auto applyButton = configureUI.FindName(L"Apply").as<xaml::Controls::Button>();
-    m_applyRevoker = applyButton.Click(
-        winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-          if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
-            auto options = reactHost->Options();
-            options.DeveloperSettings.SourceBundleHost =
-                Microsoft::Common::Unicode::Utf16ToUtf8(m_flyout.Content()
-                                                            .as<xaml::FrameworkElement>()
-                                                            .FindName(L"Host")
-                                                            .as<xaml::Controls::TextBox>()
-                                                            .Text()
-                                                            .c_str());
-            options.DeveloperSettings.SourceBundlePort =
-                static_cast<uint16_t>(std::stoi(std::wstring(m_flyout.Content()
-                                                                 .as<xaml::FrameworkElement>()
-                                                                 .FindName(L"Port")
-                                                                 .as<xaml::Controls::TextBox>()
-                                                                 .Text())));
-            options.DeveloperSettings.SourceBundleName =
-                Microsoft::Common::Unicode::Utf16ToUtf8(m_flyout.Content()
-                                                            .as<xaml::FrameworkElement>()
-                                                            .FindName(L"EntryPoint")
-                                                            .as<xaml::Controls::TextBox>()
-                                                            .Text()
-                                                            .c_str());
-            Hide();
-            reactHost->ReloadInstanceWithOptions(std::move(options));
-          }
-        });
+      auto entry = configureUI.FindName(L"EntryPoint").as<xaml::Controls::TextBox>();
+      entry.PlaceholderText(L"index.windows");
+      entry.Text(Microsoft::Common::Unicode::Utf8ToUtf16(options.DeveloperSettings.SourceBundleName));
 
-    auto resetButton = configureUI.FindName(L"Reset").as<xaml::Controls::Button>();
-    m_resetRevoker = resetButton.Click(
-        winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-          if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
-            auto options = reactHost->Options();
-            options.DeveloperSettings.SourceBundleHost = facebook::react::DevServerHelper::DefaultPackagerHost;
-            options.DeveloperSettings.SourceBundlePort = facebook::react::DevServerHelper::DefaultPackagerPort;
-            options.DeveloperSettings.SourceBundleName = nullptr;
-            Hide();
-            reactHost->ReloadInstanceWithOptions(std::move(options));
-          }
-        });
+      auto applyButton = configureUI.FindName(L"Apply").as<xaml::Controls::Button>();
+      applyButton.Click([this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+          auto options = reactHost->Options();
+          options.DeveloperSettings.SourceBundleHost =
+              Microsoft::Common::Unicode::Utf16ToUtf8(m_flyout.Content()
+                                                          .as<xaml::FrameworkElement>()
+                                                          .FindName(L"Host")
+                                                          .as<xaml::Controls::TextBox>()
+                                                          .Text()
+                                                          .c_str());
 
-    auto cancelButton = configureUI.FindName(L"Cancel").as<xaml::Controls::Button>();
-    m_cancelRevoker = cancelButton.Click(
-        winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          auto portText =
+              m_flyout.Content().as<xaml::FrameworkElement>().FindName(L"Port").as<xaml::Controls::TextBox>().Text();
+          options.DeveloperSettings.SourceBundlePort = portText.empty()
+              ? facebook::react::DevServerHelper::DefaultPackagerPort
+              : static_cast<uint16_t>(std::stoi(std::wstring(portText)));
+          options.DeveloperSettings.SourceBundleName =
+              Microsoft::Common::Unicode::Utf16ToUtf8(m_flyout.Content()
+                                                          .as<xaml::FrameworkElement>()
+                                                          .FindName(L"EntryPoint")
+                                                          .as<xaml::Controls::TextBox>()
+                                                          .Text()
+                                                          .c_str());
           Hide();
-        });
+          reactHost->ReloadInstanceWithOptions(std::move(options));
+        }
+      });
 
-    m_flyout = xaml::Controls::Flyout{};
-    m_flyout.Content(configureUI);
-    if (react::uwp::Is19H1OrHigher()) {
-      // ShouldConstrainToRootBounds added in 19H1
-      m_flyout.ShouldConstrainToRootBounds(false);
+      auto resetButton = configureUI.FindName(L"Reset").as<xaml::Controls::Button>();
+      resetButton.Click([this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+          m_flyout.Content().as<xaml::FrameworkElement>().FindName(L"Host").as<xaml::Controls::TextBox>().Text(L"");
+          m_flyout.Content().as<xaml::FrameworkElement>().FindName(L"Port").as<xaml::Controls::TextBox>().Text(L"");
+          m_flyout.Content()
+              .as<xaml::FrameworkElement>()
+              .FindName(L"EntryPoint")
+              .as<xaml::Controls::TextBox>()
+              .Text(L"");
+        }
+      });
+
+      auto cancelButton = configureUI.FindName(L"Cancel").as<xaml::Controls::Button>();
+      cancelButton.Click([this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept { Hide(); });
+
+      m_flyout = xaml::Controls::Flyout{};
+      m_flyout.Content(configureUI);
+      if (react::uwp::Is19H1OrHigher()) {
+        // ShouldConstrainToRootBounds added in 19H1
+        m_flyout.ShouldConstrainToRootBounds(false);
+      }
+
+      configureUI.Tag(*this);
+      m_flyout.Closing(
+          [](xaml::Controls::Primitives::FlyoutBase const &sender,
+             xaml::Controls::Primitives::FlyoutBaseClosingEventArgs const & /*args*/) noexcept {
+            // Remove the tag to disconnect the ref cycle
+            sender.as<xaml::Controls::Flyout>().Content().as<xaml::FrameworkElement>().Tag(nullptr);
+          });
+
+      xaml::UIElement root{nullptr};
+      auto xamlRoot = winrt::Microsoft::ReactNative::XamlUIService::GetXamlRoot(reactHost->Options().Properties);
+      if (xamlRoot) {
+        m_flyout.XamlRoot(xamlRoot);
+        root = xamlRoot.Content();
+      } else {
+        auto window = xaml::Window::Current();
+        root = window.Content();
+      }
+
+      m_flyout.LightDismissOverlayMode(xaml::Controls::LightDismissOverlayMode::On);
+      configureUI.XYFocusKeyboardNavigation(xaml::Input::XYFocusKeyboardNavigationMode::Enabled);
+
+      auto style = xaml::Style(winrt::xaml_typename<xaml::Controls::FlyoutPresenter>());
+      style.Setters().Append(xaml::Setter(
+          xaml::Controls::ScrollViewer::HorizontalScrollBarVisibilityProperty(),
+          winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
+      style.Setters().Append(xaml::Setter(
+          xaml::Controls::ScrollViewer::VerticalScrollBarVisibilityProperty(),
+          winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
+      style.Setters().Append(xaml::Setter(
+          xaml::Controls::ScrollViewer::HorizontalScrollModeProperty(),
+          winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
+      style.Setters().Append(xaml::Setter(
+          xaml::Controls::ScrollViewer::VerticalScrollModeProperty(),
+          winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
+
+      m_flyout.FlyoutPresenterStyle(style);
+      m_flyout.ShowAt(root.as<xaml::FrameworkElement>());
     }
-
-    configureUI.Tag(*this);
-    m_flyout.Closing(
-        [](xaml::Controls::Primitives::FlyoutBase const &sender,
-           xaml::Controls::Primitives::FlyoutBaseClosingEventArgs const & /*args*/) noexcept {
-          // Remove the tag to disconnect the ref cycle
-          sender.as<xaml::Controls::Flyout>().Content().as<xaml::FrameworkElement>().Tag(nullptr);
-        });
-
-    xaml::UIElement root{nullptr};
-    auto xamlRoot = winrt::Microsoft::ReactNative::XamlUIService::GetXamlRoot(reactHost->Options().Properties);
-    if (xamlRoot) {
-      m_flyout.XamlRoot(xamlRoot);
-      root = xamlRoot.Content();
-    } else {
-      auto window = xaml::Window::Current();
-      root = window.Content();
-    }
-
-    m_flyout.LightDismissOverlayMode(xaml::Controls::LightDismissOverlayMode::On);
-    configureUI.XYFocusKeyboardNavigation(xaml::Input::XYFocusKeyboardNavigationMode::Enabled);
-
-    auto style = xaml::Style(winrt::xaml_typename<xaml::Controls::FlyoutPresenter>());
-    style.Setters().Append(xaml::Setter(
-        xaml::Controls::ScrollViewer::HorizontalScrollBarVisibilityProperty(),
-        winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
-    style.Setters().Append(xaml::Setter(
-        xaml::Controls::ScrollViewer::VerticalScrollBarVisibilityProperty(),
-        winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
-    style.Setters().Append(xaml::Setter(
-        xaml::Controls::ScrollViewer::HorizontalScrollModeProperty(),
-        winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
-    style.Setters().Append(xaml::Setter(
-        xaml::Controls::ScrollViewer::VerticalScrollModeProperty(),
-        winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
-
-    m_flyout.FlyoutPresenterStyle(style);
-    m_flyout.ShowAt(root.as<xaml::FrameworkElement>());
   }
-} // namespace Microsoft::ReactNative
+  void Hide() noexcept {
+    if (!m_flyout)
+      return;
+    auto localFlyout = m_flyout;
+    m_flyout = nullptr;
+    localFlyout.Hide();
+  }
 
-void ConfigureBundlerDlg::Hide() noexcept {
-  if (!m_flyout)
-    return;
-  auto localFlyout = m_flyout;
-  m_flyout = nullptr;
-  localFlyout.Hide();
+  const Mso::WeakPtr<Mso::React::IReactHost> m_weakReactHost;
+
+  xaml::Controls::Flyout m_flyout{nullptr};
+};
+
+void ShowConfigureBundlerDialog(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost) {
+  winrt::make<ConfigureBundlerDlg>(weakReactHost);
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
@@ -118,8 +118,9 @@ void ConfigureBundlerDlg::CreateAndShowUI() noexcept {
 
     auto cancelButton = configureUI.FindName(L"Cancel").as<xaml::Controls::Button>();
     m_cancelRevoker = cancelButton.Click(
-        winrt::auto_revoke,
-        [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept { Hide(); });
+        winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          Hide();
+        });
 
     m_flyout = xaml::Controls::Flyout{};
     m_flyout.Content(configureUI);
@@ -129,11 +130,12 @@ void ConfigureBundlerDlg::CreateAndShowUI() noexcept {
     }
 
     configureUI.Tag(*this);
-    m_flyout.Closing([](xaml::Controls::Primitives::FlyoutBase const &sender,
-                        xaml::Controls::Primitives::FlyoutBaseClosingEventArgs const & /*args*/) noexcept {
-      // Remove the tag to disconnect the ref cycle
-      sender.as<xaml::Controls::Flyout>().Content().as<xaml::FrameworkElement>().Tag(nullptr);
-    });
+    m_flyout.Closing(
+        [](xaml::Controls::Primitives::FlyoutBase const &sender,
+           xaml::Controls::Primitives::FlyoutBaseClosingEventArgs const & /*args*/) noexcept {
+          // Remove the tag to disconnect the ref cycle
+          sender.as<xaml::Controls::Flyout>().Content().as<xaml::FrameworkElement>().Tag(nullptr);
+        });
 
     xaml::UIElement root{nullptr};
     auto xamlRoot = winrt::Microsoft::ReactNative::XamlUIService::GetXamlRoot(reactHost->Options().Properties);

--- a/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "ConfigureBundlerDlg.h"
+#include "DevServerHelper.h"
+#include "IReactDispatcher.h"
+#include "UI.Xaml.Controls.Primitives.h"
+#include "UI.Xaml.Controls.h"
+#include "UI.Xaml.Input.h"
+#include "UI.Xaml.Markup.h"
+#include "Unicode.h"
+#include "Utils/Helpers.h"
+#include "winrt/Windows.UI.Xaml.Interop.h"
+
+namespace Microsoft::ReactNative {
+
+ConfigureBundlerDlg::ConfigureBundlerDlg(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost)
+    : m_weakReactHost(std::move(weakReactHost)) {
+  if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+    auto uiDispatcher = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatcher(
+        reactHost->Options().Properties);
+    uiDispatcher.Post([pThis = get_strong()]() { pThis->CreateAndShowUI(); });
+  }
+}
+
+void ConfigureBundlerDlg::CreateAndShowUI() noexcept {
+  if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+    const winrt::hstring xamlString =
+        LR"(
+  <StackPanel
+    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    Background='{ThemeResource ContentDialogBackground}'
+    HorizontalAlignment='Center'
+    MinWidth="{ThemeResource ContentDialogMinWidth}"
+    MaxWidth="{ThemeResource ContentDialogMaxWidth}"
+    MinHeight="{ThemeResource ContentDialogMinHeight}"
+    MaxHeight="{ThemeResource ContentDialogMaxHeight}"
+    Margin='-10'
+    Padding="{ThemeResource ContentDialogPadding}"
+  >
+    <StackPanel.Transitions>
+      <TransitionCollection>
+        <EntranceThemeTransition />
+      </TransitionCollection>
+    </StackPanel.Transitions>
+    <TextBlock FontSize="20" Margin="{ThemeResource ContentDialogTitleMargin}">Configure Bundler</TextBlock>
+    <TextBox x:Name="Host" Header="Bundler host:" PlaceholderText="localhost"/>
+    <TextBox x:Name="Port" Header="Bundler port:" PlaceholderText="8081" Margin="0,4,0,0"/>
+    <TextBox x:Name="EntryPoint" Header="entrypoint:" PlaceholderText="index.windows" Margin="0,4,0,0"/>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="{ThemeResource ContentDialogCommandSpaceMargin}">
+      <Button x:Name="Apply" Style="{StaticResource AccentButtonStyle}" Content="Apply Changes" />
+      <Button x:Name="Reset" Content="Reset to Default" Margin="4,0,0,0"/>
+      <Button x:Name="Cancel" Content="Cancel" Margin="4,0,0,0"/>
+    </StackPanel>
+  </StackPanel>)";
+    auto configureUI = winrt::unbox_value<xaml::Controls::StackPanel>(xaml::Markup::XamlReader::Load(xamlString));
+
+    auto options = reactHost->Options();
+
+    configureUI.FindName(L"Host").as<xaml::Controls::TextBox>().Text(Microsoft::Common::Unicode::Utf8ToUtf16(
+        options.DeveloperSettings.SourceBundleHost.empty() ? facebook::react::DevServerHelper::DefaultPackagerHost
+                                                           : options.DeveloperSettings.SourceBundleHost));
+
+    configureUI.FindName(L"Port").as<xaml::Controls::TextBox>().Text(std::to_wstring(
+        options.DeveloperSettings.SourceBundlePort ? options.DeveloperSettings.SourceBundlePort
+                                                   : facebook::react::DevServerHelper::DefaultPackagerPort));
+
+    configureUI.FindName(L"EntryPoint")
+        .as<xaml::Controls::TextBox>()
+        .Text(Microsoft::Common::Unicode::Utf8ToUtf16(
+            options.DeveloperSettings.SourceBundleName.empty() ? "index.windows"
+                                                               : options.DeveloperSettings.SourceBundleName));
+
+    auto applyButton = configureUI.FindName(L"Apply").as<xaml::Controls::Button>();
+    m_applyRevoker = applyButton.Click(
+        winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+            auto options = reactHost->Options();
+            options.DeveloperSettings.SourceBundleHost =
+                Microsoft::Common::Unicode::Utf16ToUtf8(m_flyout.Content()
+                                                            .as<xaml::FrameworkElement>()
+                                                            .FindName(L"Host")
+                                                            .as<xaml::Controls::TextBox>()
+                                                            .Text()
+                                                            .c_str());
+            options.DeveloperSettings.SourceBundlePort =
+                static_cast<uint16_t>(std::stoi(std::wstring(m_flyout.Content()
+                                                                 .as<xaml::FrameworkElement>()
+                                                                 .FindName(L"Port")
+                                                                 .as<xaml::Controls::TextBox>()
+                                                                 .Text())));
+            options.DeveloperSettings.SourceBundleName =
+                Microsoft::Common::Unicode::Utf16ToUtf8(m_flyout.Content()
+                                                            .as<xaml::FrameworkElement>()
+                                                            .FindName(L"EntryPoint")
+                                                            .as<xaml::Controls::TextBox>()
+                                                            .Text()
+                                                            .c_str());
+            Hide();
+            reactHost->ReloadInstanceWithOptions(std::move(options));
+          }
+        });
+
+    auto resetButton = configureUI.FindName(L"Reset").as<xaml::Controls::Button>();
+    m_resetRevoker = resetButton.Click(
+        winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
+            auto options = reactHost->Options();
+            options.DeveloperSettings.SourceBundleHost = facebook::react::DevServerHelper::DefaultPackagerHost;
+            options.DeveloperSettings.SourceBundlePort = facebook::react::DevServerHelper::DefaultPackagerPort;
+            options.DeveloperSettings.SourceBundleName = nullptr;
+            Hide();
+            reactHost->ReloadInstanceWithOptions(std::move(options));
+          }
+        });
+
+    auto cancelButton = configureUI.FindName(L"Cancel").as<xaml::Controls::Button>();
+    m_cancelRevoker = cancelButton.Click(
+        winrt::auto_revoke,
+        [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept { Hide(); });
+
+    m_flyout = xaml::Controls::Flyout{};
+    m_flyout.Content(configureUI);
+    if (react::uwp::Is19H1OrHigher()) {
+      // ShouldConstrainToRootBounds added in 19H1
+      m_flyout.ShouldConstrainToRootBounds(false);
+    }
+
+    configureUI.Tag(*this);
+    m_flyout.Closing([](xaml::Controls::Primitives::FlyoutBase const &sender,
+                        xaml::Controls::Primitives::FlyoutBaseClosingEventArgs const & /*args*/) noexcept {
+      // Remove the tag to disconnect the ref cycle
+      sender.as<xaml::Controls::Flyout>().Content().as<xaml::FrameworkElement>().Tag(nullptr);
+    });
+
+    xaml::UIElement root{nullptr};
+    auto xamlRoot = winrt::Microsoft::ReactNative::XamlUIService::GetXamlRoot(reactHost->Options().Properties);
+    if (xamlRoot) {
+      m_flyout.XamlRoot(xamlRoot);
+      root = xamlRoot.Content();
+    } else {
+      auto window = xaml::Window::Current();
+      root = window.Content();
+    }
+
+    m_flyout.LightDismissOverlayMode(xaml::Controls::LightDismissOverlayMode::On);
+    configureUI.XYFocusKeyboardNavigation(xaml::Input::XYFocusKeyboardNavigationMode::Enabled);
+
+    auto style = xaml::Style(winrt::xaml_typename<xaml::Controls::FlyoutPresenter>());
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::HorizontalScrollBarVisibilityProperty(),
+        winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::VerticalScrollBarVisibilityProperty(),
+        winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::HorizontalScrollModeProperty(),
+        winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::VerticalScrollModeProperty(),
+        winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
+
+    m_flyout.FlyoutPresenterStyle(style);
+    m_flyout.ShowAt(root.as<xaml::FrameworkElement>());
+  }
+} // namespace Microsoft::ReactNative
+
+void ConfigureBundlerDlg::Hide() noexcept {
+  if (!m_flyout)
+    return;
+  auto localFlyout = m_flyout;
+  m_flyout = nullptr;
+  localFlyout.Hide();
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.h
+++ b/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <ReactHost/React.h>
+
+namespace Microsoft::ReactNative {
+
+struct ConfigureBundlerDlg : winrt::implements<ConfigureBundlerDlg, winrt::IInspectable> {
+  ConfigureBundlerDlg(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost);
+
+ private:
+  void CreateAndShowUI() noexcept;
+  void Hide() noexcept;
+
+  const Mso::WeakPtr<Mso::React::IReactHost> m_weakReactHost;
+
+  xaml::Controls::Flyout m_flyout{nullptr};
+  xaml::Controls::Button::Click_revoker m_applyRevoker{};
+  xaml::Controls::Button::Click_revoker m_cancelRevoker{};
+  xaml::Controls::Button::Click_revoker m_resetRevoker{};
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.h
+++ b/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.h
@@ -6,19 +6,6 @@
 
 namespace Microsoft::ReactNative {
 
-struct ConfigureBundlerDlg : winrt::implements<ConfigureBundlerDlg, winrt::IInspectable> {
-  ConfigureBundlerDlg(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost);
-
- private:
-  void CreateAndShowUI() noexcept;
-  void Hide() noexcept;
-
-  const Mso::WeakPtr<Mso::React::IReactHost> m_weakReactHost;
-
-  xaml::Controls::Flyout m_flyout{nullptr};
-  xaml::Controls::Button::Click_revoker m_applyRevoker{};
-  xaml::Controls::Button::Click_revoker m_cancelRevoker{};
-  xaml::Controls::Button::Click_revoker m_resetRevoker{};
-};
+void ShowConfigureBundlerDialog(Mso::WeakPtr<Mso::React::IReactHost> weakReactHost);
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.h
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.h
@@ -13,7 +13,9 @@ namespace Microsoft::ReactNative {
 struct DevMenuManager : public std::enable_shared_from_this<DevMenuManager> {
   DevMenuManager(Mso::CntPtr<Mso::React::IReactContext> const &reactContext);
 
-  static void InitDevMenu(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept;
+  static void InitDevMenu(
+      Mso::CntPtr<Mso::React::IReactContext> const &reactContext,
+      Mso::VoidFunctor &&configureBundler) noexcept;
   static void Show(React::IReactPropertyBag const &properties) noexcept;
   static void Hide(React::IReactPropertyBag const &properties) noexcept;
 
@@ -23,11 +25,11 @@ struct DevMenuManager : public std::enable_shared_from_this<DevMenuManager> {
   void Init() noexcept;
 
   const Mso::CntPtr<Mso::React::IReactContext> m_context;
-  xaml::Controls::Primitives::Popup m_popup{nullptr};
   xaml::Controls::Flyout m_flyout{nullptr};
   xaml::Controls::Button::Click_revoker m_remoteDebugJSRevoker{};
   xaml::Controls::Button::Click_revoker m_cancelRevoker{};
   xaml::Controls::Button::Click_revoker m_toggleInspectorRevoker{};
+  xaml::Controls::Button::Click_revoker m_configBundlerRevoker{};
   xaml::Controls::Button::Click_revoker m_reloadJSRevoker{};
   xaml::Controls::Button::Click_revoker m_fastRefreshRevoker{};
   xaml::Controls::Button::Click_revoker m_directDebuggingRevoker{};


### PR DESCRIPTION
This aligns with the option provided in the iOS devmenu which allows developers to modify the remote host/port of the packager that the app should talk to at runtime.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5621)