### PR TITLE
[0.63] Fix Crash Using accessibilityValue Outside of Web Debugging (#5619)

### DIFF
--- a/change/react-native-windows-2020-08-01-16-32-46-accvalue-crash.json
+++ b/change/react-native-windows-2020-08-01-16-32-46-accvalue-crash.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Crash Using accessibilityValue Without Web Debugging",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-01T23:32:46.665Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -462,11 +462,11 @@ bool FrameworkElementViewManager::UpdateProperty(
           const folly::dynamic &innerValue = pair.second;
 
           if (innerName == "min" && innerValue.isNumber()) {
-            DynamicAutomationProperties::SetAccessibilityValueMin(element, static_cast<double>(innerValue.getInt()));
+            DynamicAutomationProperties::SetAccessibilityValueMin(element, innerValue.asDouble());
           } else if (innerName == "max" && innerValue.isNumber()) {
-            DynamicAutomationProperties::SetAccessibilityValueMax(element, static_cast<double>(innerValue.getInt()));
+            DynamicAutomationProperties::SetAccessibilityValueMax(element, innerValue.asDouble());
           } else if (innerName == "now" && innerValue.isNumber()) {
-            DynamicAutomationProperties::SetAccessibilityValueNow(element, static_cast<double>(innerValue.getInt()));
+            DynamicAutomationProperties::SetAccessibilityValueNow(element, innerValue.asDouble());
           } else if (innerName == "text" && innerValue.isString()) {
             auto value = react::uwp::asHstring(innerValue);
             DynamicAutomationProperties::SetAccessibilityValueText(element, value);


### PR DESCRIPTION
* Fix Crash Using accessibilityValue Without Web Debugging

Existing code will crash with a folly TypeError since we enforce the folly::dynamic value is an integer. Using Chakra, in AccessibilityExample we see the dynamic for min represented as a double (0.00000) and crash.

We're converting to a double anyway, so we instead rely on builtin folly type converstion instead of trying to coerce the value to an int to convert into a double again.

Note that we still see issues with the AccessibilityExample page.

* Change files

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5624)