### PR TITLE
Fix word-wrapping behavior of tooltips

### DIFF
--- a/change/react-native-windows-2020-08-03-16-13-47-tooltip.json
+++ b/change/react-native-windows-2020-08-03-16-13-47-tooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use string object for tooltips instead of textblocks since that breaks wordwrap etc",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T23:13:47.059Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -484,9 +484,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (propertyName == "tooltip") {
       if (propertyValue.isString()) {
-        winrt::TextBlock tooltip = winrt::TextBlock();
-        tooltip.Text(asHstring(propertyValue));
-        winrt::ToolTipService::SetToolTip(element, tooltip);
+        winrt::ToolTipService::SetToolTip(element, asHstring(propertyValue));
       }
     } else if (propertyName == "zIndex") {
       if (propertyValue.isNumber()) {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -484,7 +484,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (propertyName == "tooltip") {
       if (propertyValue.isString()) {
-        winrt::ToolTipService::SetToolTip(element, asHstring(propertyValue));
+        winrt::ToolTipService::SetToolTip(element, winrt::box_value(asHstring(propertyValue)));
       }
     } else if (propertyName == "zIndex") {
       if (propertyValue.isNumber()) {


### PR DESCRIPTION
We currently put all tooltips in a textblock which is unnecessary and moreover breaks word wrapping logic

Fixes #5625 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5626)