### PR TITLE
[0.63] Fix word-wrapping behavior of tooltips

### DIFF
--- a/change/react-native-windows-2020-08-04-10-25-43-tooltip-0.63.json
+++ b/change/react-native-windows-2020-08-04-10-25-43-tooltip-0.63.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "[0.63] Fix word-wrapping behavior of tooltips",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T17:25:43.448Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -484,9 +484,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (propertyName == "tooltip") {
       if (propertyValue.isString()) {
-        winrt::TextBlock tooltip = winrt::TextBlock();
-        tooltip.Text(asHstring(propertyValue));
-        winrt::ToolTipService::SetToolTip(element, tooltip);
+        winrt::ToolTipService::SetToolTip(element, winrt::box_value(asHstring(propertyValue)));
       }
     } else if (propertyName == "zIndex") {
       if (propertyValue.isNumber()) {


### PR DESCRIPTION
Related: #5625 
Ports #5626 to 0.63-stable

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5627)