### PR TITLE
Handle MessageWebSocket constructor exceptions

### DIFF
--- a/change/react-native-windows-2020-08-03-22-04-44-simplify-ws-factory.json
+++ b/change/react-native-windows-2020-08-03-22-04-44-simplify-ws-factory.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Handle MessageWebSocket constructor exceptions",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T05:04:44.587Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UEBA?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QEAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YA?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QEB_WI@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UEBA?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QEAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YA?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QEB_WI@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N1@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
@@ -54,7 +54,6 @@ EXPORTS
 ?GetFeatureGate@React@Microsoft@@YA?B_NABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z
 ?makeChakraRuntime@JSI@Microsoft@@YG?AV?$unique_ptr@VRuntime@jsi@facebook@@U?$default_delete@VRuntime@jsi@facebook@@@std@@@std@@$$QAUChakraRuntimeArgs@12@@Z
 ?CreateTimingModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z
-??0WebSocketModule@React@Microsoft@@QAE@XZ
 ??0WebSocketModule@React@Microsoft@@QAE@XZ
 ?CreateAsyncStorageModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@PB_W@Z
 ?Make@IHttpResource@React@Microsoft@@SG?AV?$unique_ptr@UIHttpResource@React@Microsoft@@U?$default_delete@UIHttpResource@React@Microsoft@@@std@@@std@@XZ

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -18,7 +18,7 @@ std::wstring ToString<TestStatus>(const TestStatus &status) {
 } // namespace Microsoft::VisualStudio::CppUnitTestFramework
 
 TEST_MODULE_INITIALIZE(InitModule) {
-  Microsoft::React::SetFeatureGate("UseWinRTWebSocket", true);
+  Microsoft::React::SetFeatureGate("WebSocket.AcceptSelfSigned", true);
 }
 
 // None of these tests are runnable

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -36,7 +36,7 @@ TEST_CLASS (WebSocketIntegrationTest)
     string scheme = "ws";
     if (isSecure)
       scheme += "s";
-    auto ws = IWebSocketResource::Make(scheme + "://localhost:5556/", false, true);
+    auto ws = IWebSocketResource::Make(scheme + "://localhost:5556/");
     promise<size_t> sentSizePromise;
     ws->SetOnSend([&sentSizePromise](size_t size)
     {

--- a/vnext/Desktop.UnitTests/UtilsTest.cpp
+++ b/vnext/Desktop.UnitTests/UtilsTest.cpp
@@ -4,7 +4,6 @@
 #include <CppUnitTest.h>
 #include <Utils.h>
 
-using namespace facebook::react;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using std::string;
@@ -25,7 +24,7 @@ TEST_CLASS(UtilsTest) {
       string path = "/",
       string query = "") {
 
-    Url url(urlString);
+    Url url(std::move(urlString));
 
     Assert::AreEqual(protocol, url.scheme);
     Assert::AreEqual(host, url.host);

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -60,7 +60,7 @@ TEST_CLASS (WebSocketModuleTest) {
     auto instance = CreateMockInstance(jsef);
     auto module = make_unique<WebSocketModule>();
     module->setInstance(instance);
-    module->SetResourceFactory([](const string &, bool, bool) {
+    module->SetResourceFactory([](const string &) {
       auto rc = make_shared<MockWebSocketResource>();
       rc->Mocks.Connect = [rc](const IWebSocketResource::Protocols &, const IWebSocketResource::Options &) {
         rc->OnConnect();

--- a/vnext/Desktop.UnitTests/WinRTNetworkingMocks.cpp
+++ b/vnext/Desktop.UnitTests/WinRTNetworkingMocks.cpp
@@ -3,6 +3,8 @@
 
 #include "WinRTNetworkingMocks.h"
 
+#include <Windows.h>
+
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Networking::Sockets;
 using namespace winrt::Windows::Storage::Streams;
@@ -15,6 +17,13 @@ using winrt::param::hstring;
 namespace Microsoft::React::Test {
 
 #pragma region MockMessageWebSocket
+
+MockMessageWebSocket::MockMessageWebSocket() {
+  Mocks.MessageReceivedToken =
+      [](TypedEventHandler<MessageWebSocket, MessageWebSocketMessageReceivedEventArgs> const &) -> event_token {
+    return event_token{};
+  };
+}
 
 // IWebSocket
 IOutputStream MockMessageWebSocket::OutputStream() const {
@@ -105,6 +114,14 @@ void MockMessageWebSocket::MessageReceived(event_token const &eventCookie) const
 }
 
 #pragma endregion MockMessageWebSocket
+
+#pragma region ThrowingMessageWebSocket
+
+ThrowingMessageWebSocket::ThrowingMessageWebSocket() : MockMessageWebSocket() {
+  throw winrt::hresult_error(winrt::hresult(E_FAIL), L"Failed to instantiate WinRT class.");
+}
+
+#pragma endregion ThrowingMessageWebSocket
 
 #pragma region MockDataWriter
 

--- a/vnext/Desktop.UnitTests/WinRTNetworkingMocks.h
+++ b/vnext/Desktop.UnitTests/WinRTNetworkingMocks.h
@@ -9,12 +9,15 @@
 namespace Microsoft::React::Test {
 
 /// <summary>
-//  Mocks winrt::Windows::Networking::Sockets::MessageWebSocket
+//  Mocks winrt::Windows::Networking::Sockets::MessageWebSocket.
+//  Behavior can be mocked per each interface mehtod.
 /// </summary>
 struct MockMessageWebSocket : public winrt::implements<
                                   MockMessageWebSocket,
                                   winrt::Windows::Networking::Sockets::IMessageWebSocket,
                                   winrt::Windows::Networking::Sockets::IWebSocket> {
+  MockMessageWebSocket();
+
   struct Mocks {
     // IWebSocket
     std::function<winrt::Windows::Foundation::IAsyncAction(winrt::Windows::Foundation::Uri const &) /*const*/>
@@ -116,6 +119,10 @@ struct MockMessageWebSocket : public winrt::implements<
 
 }; // MockMessageWebSocket
 
+struct ThrowingMessageWebSocket : public MockMessageWebSocket {
+  ThrowingMessageWebSocket();
+};
+
 struct MockDataWriter : public winrt::Windows::Storage::Streams::IDataWriter {
   struct Mocks {
     std::function<std::uint32_t() /*const*/> UnstoredBufferLength;
@@ -206,7 +213,7 @@ struct MockMessageWebSocketControl : winrt::implements<
 
 #pragma region IMessageWebSocketControl
 
-  uint32_t MaxMessageSize() const;
+  std::uint32_t MaxMessageSize() const;
   void MaxMessageSize(std::uint32_t value) const;
   winrt::Windows::Networking::Sockets::SocketMessageType MessageType() const;
   void MessageType(winrt::Windows::Networking::Sockets::SocketMessageType const &value) const;

--- a/vnext/Desktop.UnitTests/WinRTWebSocketResourceUnitTest.cpp
+++ b/vnext/Desktop.UnitTests/WinRTWebSocketResourceUnitTest.cpp
@@ -33,20 +33,7 @@ IAsyncAction ThrowAsync() {
 } // namespace
 
 namespace Microsoft::React::Test {
-
 TEST_CLASS (WinRTWebSocketResourceUnitTest) {
-  TEST_METHOD(InternalSocketThrowsHResult) {
-    shared_ptr<WinRTWebSocketResource> rc;
-
-    auto lambda = [&rc]() mutable {
-      rc = make_shared<WinRTWebSocketResource>(
-          winrt::make<ThrowingMessageWebSocket>(), MockDataWriter{}, Uri{L"ws://host:0"}, CertExceptions{});
-    };
-
-    Assert::ExpectException<winrt::hresult_error>(lambda);
-    Assert::IsTrue(nullptr == rc);
-  }
-
   TEST_METHOD(ConnectSucceeds) {
     bool connected = true;
     string errorMessage;
@@ -97,6 +84,18 @@ TEST_CLASS (WinRTWebSocketResourceUnitTest) {
 
     Assert::AreNotEqual({}, errorMessage);
     Assert::IsFalse(connected);
+  }
+
+  TEST_METHOD(InternalSocketThrowsHResult) {
+    shared_ptr<WinRTWebSocketResource> rc;
+
+    auto lambda = [&rc]() mutable {
+      rc = make_shared<WinRTWebSocketResource>(
+          winrt::make<ThrowingMessageWebSocket>(), MockDataWriter{}, Uri{L"ws://host:0"}, CertExceptions{});
+    };
+
+    Assert::ExpectException<winrt::hresult_error>(lambda);
+    Assert::IsTrue(nullptr == rc);
   }
 };
 

--- a/vnext/Desktop.UnitTests/WinRTWebSocketResourceUnitTest.cpp
+++ b/vnext/Desktop.UnitTests/WinRTWebSocketResourceUnitTest.cpp
@@ -11,6 +11,7 @@ using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Networking::Sockets;
 
 using std::make_shared;
+using std::shared_ptr;
 using std::string;
 using winrt::event_token;
 using winrt::param::hstring;
@@ -34,6 +35,18 @@ IAsyncAction ThrowAsync() {
 namespace Microsoft::React::Test {
 
 TEST_CLASS (WinRTWebSocketResourceUnitTest) {
+  TEST_METHOD(InternalSocketThrowsHResult) {
+    shared_ptr<WinRTWebSocketResource> rc;
+
+    auto lambda = [&rc]() mutable {
+      rc = make_shared<WinRTWebSocketResource>(
+          winrt::make<ThrowingMessageWebSocket>(), MockDataWriter{}, Uri{L"ws://host:0"}, CertExceptions{});
+    };
+
+    Assert::ExpectException<winrt::hresult_error>(lambda);
+    Assert::IsTrue(nullptr == rc);
+  }
+
   TEST_METHOD(ConnectSucceeds) {
     bool connected = true;
     string errorMessage;
@@ -43,10 +56,6 @@ TEST_CLASS (WinRTWebSocketResourceUnitTest) {
     auto mws{imws.as<MockMessageWebSocket>()};
     // TODO: Mock Control()
     mws->Mocks.ConnectAsync = [](const Uri &) -> IAsyncAction { return DoNothingAsync(); };
-    mws->Mocks.MessageReceivedToken =
-        [](TypedEventHandler<MessageWebSocket, MessageWebSocketMessageReceivedEventArgs> const &) -> event_token {
-      return event_token{};
-    };
     mws->Mocks.Close = [](uint16_t, const hstring &) {};
 
     // Test APIs
@@ -75,10 +84,6 @@ TEST_CLASS (WinRTWebSocketResourceUnitTest) {
     // Set up mocks
     auto mws{imws.as<MockMessageWebSocket>()};
     mws->Mocks.ConnectAsync = [](const Uri &) -> IAsyncAction { return ThrowAsync(); };
-    mws->Mocks.MessageReceivedToken =
-        [](TypedEventHandler<MessageWebSocket, MessageWebSocketMessageReceivedEventArgs> const &) -> event_token {
-      return event_token{};
-    };
     mws->Mocks.Close = [](uint16_t, const hstring &) {};
 
     // Test APIs

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -332,7 +332,7 @@ class TestWebSocketResource : public BaseWebSocketResource<
 #pragma endregion BaseWebSocketResource overrides
 
  public:
-  TestWebSocketResource(facebook::react::Url &&url);
+  TestWebSocketResource(Url &&url);
 
   void SetConnectResult(std::function<boost::system::error_code()> &&resultFunc);
   void SetHandshakeResult(std::function<boost::system::error_code(std::string, std::string)> &&resultFunc);

--- a/vnext/Desktop/HttpResource.cpp
+++ b/vnext/Desktop/HttpResource.cpp
@@ -43,7 +43,7 @@ void HttpResource::SendRequest(
   // Validate verb.
   unique_ptr<Url> url;
   try {
-    url = make_unique<Url>(urlString);
+    url = make_unique<Url>(string{urlString});
   } catch (...) {
     m_errorHandler("Malformed URL");
     return;

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -26,12 +26,12 @@ constexpr char moduleName[] = "WebSocketModule";
 namespace Microsoft::React {
 
 WebSocketModule::WebSocketModule()
-    : m_resourceFactory{[](const string &url, bool legacyImplementation, bool acceptSelfSigned) {
-        return IWebSocketResource::Make(url, legacyImplementation, acceptSelfSigned);
+    : m_resourceFactory{[](const string &url) {
+        return IWebSocketResource::Make(url);
       }} {}
 
 void WebSocketModule::SetResourceFactory(
-    std::function<shared_ptr<IWebSocketResource>(const string &, bool, bool)> &&resourceFactory) {
+    std::function<shared_ptr<IWebSocketResource>(const string &)> &&resourceFactory) {
   m_resourceFactory = std::move(resourceFactory);
 }
 
@@ -155,7 +155,7 @@ std::shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_
   auto itr = m_webSockets.find(id);
   if (itr == m_webSockets.end())
   {
-    auto ws = m_resourceFactory(std::move(url), /*legacyImplementation*/ false, /*acceptSelfSigned*/ false);
+    auto ws = m_resourceFactory(std::move(url));
     auto weakInstance = this->getInstance();
     ws->SetOnError([this, id, weakInstance](const IWebSocketResource::Error& err)
     {

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -27,7 +27,7 @@ constexpr char moduleName[] = "WebSocketModule";
 namespace Microsoft::React {
 
 WebSocketModule::WebSocketModule()
-    : m_resourceFactory{[](const string &url) { return IWebSocketResource::Make(url); }} {}
+    : m_resourceFactory{[](string &&url) { return IWebSocketResource::Make(std::move(url)); }} {}
 
 void WebSocketModule::SetResourceFactory(
     std::function<shared_ptr<IWebSocketResource>(const string &)> &&resourceFactory) {

--- a/vnext/Desktop/Modules/WebSocketModule.cpp
+++ b/vnext/Desktop/Modules/WebSocketModule.cpp
@@ -161,13 +161,20 @@ shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id,
     }
     catch (const winrt::hresult_error& e)
     {
-      SendEvent("webSocketFailed", dynamic::object("id", id)("message", Utf16ToUtf8(e.message())));
+      string message =  string{"[" + e.code()} + "] " + Utf16ToUtf8(e.message());
+      SendEvent("webSocketFailed", dynamic::object("id", id)("message", std::move(message)));
 
       return nullptr;
     }
     catch (const std::exception& e)
     {
       SendEvent("webSocketFailed", dynamic::object("id", id)("message", e.what()));
+
+      return nullptr;
+    }
+    catch (...)
+    {
+      SendEvent("webSocketFailed", dynamic::object("id", id)("message", "Unidentified error creating IWebSocketResource"));
 
       return nullptr;
     }

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -15,7 +15,7 @@ namespace Microsoft::React {
 #pragma region IWebSocketResource static members
 
 /*static*/
-shared_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString) {
+shared_ptr<IWebSocketResource> IWebSocketResource::Make(string &&urlString) {
   if (!GetFeatureGate("UseBeastWebSocket")) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (GetFeatureGate("WebSocket.AcceptSelfSigned")) {
@@ -24,9 +24,9 @@ shared_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString)
       certExceptions.emplace_back(
           winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
     }
-    return make_shared<WinRTWebSocketResource>(urlString, std::move(certExceptions));
+    return make_shared<WinRTWebSocketResource>(std::move(urlString), std::move(certExceptions));
   } else {
-    Url url(urlString);
+    Url url(std::move(urlString));
 
     if (url.scheme == "ws") {
       if (url.port.empty())

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -16,10 +16,10 @@ namespace Microsoft::React {
 
 /*static*/
 shared_ptr<IWebSocketResource>
-IWebSocketResource::Make(const string &urlString, bool legacyImplementation, bool acceptSelfSigned) {
-  if (GetFeatureGate("UseWinRTWebSocket")) {
+IWebSocketResource::Make(const string &urlString) {
+  if (!GetFeatureGate("UseBeastWebSocket")) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
-    if (acceptSelfSigned) {
+    if (GetFeatureGate("WebSocket.AcceptSelfSigned")) {
       certExceptions.emplace_back(
           winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::Untrusted);
       certExceptions.emplace_back(

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -15,8 +15,7 @@ namespace Microsoft::React {
 #pragma region IWebSocketResource static members
 
 /*static*/
-shared_ptr<IWebSocketResource>
-IWebSocketResource::Make(const string &urlString) {
+shared_ptr<IWebSocketResource> IWebSocketResource::Make(const string &urlString) {
   if (!GetFeatureGate("UseBeastWebSocket")) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (GetFeatureGate("WebSocket.AcceptSelfSigned")) {

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -84,7 +84,7 @@ struct IWebSocketResource {
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
   static std::shared_ptr<IWebSocketResource>
-  Make(const std::string &url, bool legacyImplementation = false, bool acceptSelfSigned = false);
+  Make(const std::string &url);
 
   virtual ~IWebSocketResource() noexcept {}
 

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -83,7 +83,7 @@ struct IWebSocketResource {
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::shared_ptr<IWebSocketResource> Make(const std::string &url);
+  static std::shared_ptr<IWebSocketResource> Make(std::string &&url);
 
   virtual ~IWebSocketResource() noexcept {}
 

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -83,8 +83,7 @@ struct IWebSocketResource {
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::shared_ptr<IWebSocketResource>
-  Make(const std::string &url);
+  static std::shared_ptr<IWebSocketResource> Make(const std::string &url);
 
   virtual ~IWebSocketResource() noexcept {}
 

--- a/vnext/Shared/Modules/WebSocketModule.h
+++ b/vnext/Shared/Modules/WebSocketModule.h
@@ -39,7 +39,7 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
 #pragma endregion CxxModule overrides
 
   void SetResourceFactory(
-      std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> &&resourceFactory = nullptr);
+      std::function<std::shared_ptr<IWebSocketResource>(const std::string &)> &&resourceFactory);
 
  private:
   /// <summary>
@@ -61,7 +61,7 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// <summary>
   /// Generates IWebSocketResource instances, defaulting to IWebSocketResource::Make.
   /// </summary>
-  std::function<std::shared_ptr<IWebSocketResource>(const std::string &, bool, bool)> m_resourceFactory;
+  std::function<std::shared_ptr<IWebSocketResource>(const std::string &)> m_resourceFactory;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/WebSocketModule.h
+++ b/vnext/Shared/Modules/WebSocketModule.h
@@ -38,8 +38,7 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
 
 #pragma endregion CxxModule overrides
 
-  void SetResourceFactory(
-      std::function<std::shared_ptr<IWebSocketResource>(const std::string &)> &&resourceFactory);
+  void SetResourceFactory(std::function<std::shared_ptr<IWebSocketResource>(const std::string &)> &&resourceFactory);
 
  private:
   /// <summary>

--- a/vnext/Shared/Modules/WebSocketModule.h
+++ b/vnext/Shared/Modules/WebSocketModule.h
@@ -60,7 +60,7 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
   /// <summary>
   /// Generates IWebSocketResource instances, defaulting to IWebSocketResource::Make.
   /// </summary>
-  std::function<std::shared_ptr<IWebSocketResource>(const std::string &)> m_resourceFactory;
+  std::function<std::shared_ptr<IWebSocketResource>(std::string &&)> m_resourceFactory;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -8,7 +8,7 @@ using std::string;
 
 namespace Microsoft::React {
 
-Url::Url(const string &source) {
+Url::Url(string &&source) {
   //                           ( 1 )              ( 2 )   ( 3 (4) )   ( 5 )    ( 6 (7) )
   std::regex expression("(http|https|ws|wss)://([^:/\\?]+)(:(\\d+))?(/[^\\?]*)?(\\?(.*))?$");
   //                          scheme              host       port      path      query

--- a/vnext/Shared/Utils.h
+++ b/vnext/Shared/Utils.h
@@ -14,16 +14,9 @@ struct Url {
   std::string path;
   std::string queryString;
 
-  Url(const std::string &urlString);
+  Url(std::string &&urlString);
 
   std::string Target();
 };
 
 } // namespace Microsoft::React
-
-// Deprecated. Keeping for compatibility.
-namespace facebook::react {
-
-using Url = Microsoft::React::Url;
-
-} // namespace facebook::react


### PR DESCRIPTION
The constructor of `Windows.Networking.Sockets.MessageWebSocket` may throw on abnormal but possible conditions (i.e. Windows.Networking.dll failing to load).

This change handles any construction-time exception and fails gracefully reporting the error to the JavaScript layer.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5629)