### PR TITLE
Make C# CodeGen the default

### DIFF
--- a/change/@react-native-windows-cli-2020-08-04-13-53-11-master.json
+++ b/change/@react-native-windows-cli-2020-08-04-13-53-11-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make C# CodeGen the default",
+  "packageName": "@react-native-windows/cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T20:53:08.556Z"
+}

--- a/change/react-native-windows-2020-08-04-13-53-11-master.json
+++ b/change/react-native-windows-2020-08-04-13-53-11-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make C# CodeGen the default",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T20:53:11.347Z"
+}

--- a/packages/@react-native-windows/cli/templates/cs/proj/MyApp.csproj
+++ b/packages/@react-native-windows/cli/templates/cs/proj/MyApp.csproj
@@ -135,6 +135,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AutolinkedNativeModules.g.cs" />
+    <Compile Include="ReactPackageProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/packages/@react-native-windows/cli/templates/cs/proj/MyApp.sln
+++ b/packages/@react-native-windows/cli/templates/cs/proj/MyApp.sln
@@ -35,6 +35,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Share
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ReactNative.Managed", "..\node_modules\react-native-windows\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.csproj", "{F2824844-CE15-4242-9420-308923CD76C3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ReactNative.Managed.CodeGen", "..\node_modules\react-native-windows\Microsoft.ReactNative.Managed.CodeGen\Microsoft.ReactNative.Managed.CodeGen.csproj", "{ADED4FBE-887D-4271-AF24-F0823BCE7961}"
+EndProject
 {{/useExperimentalNuget}}
 Global
 	{{^useExperimentalNuget}}
@@ -183,6 +185,22 @@ Global
 		{F2824844-CE15-4242-9420-308923CD76C3}.Release|x64.Build.0 = Release|x64
 		{F2824844-CE15-4242-9420-308923CD76C3}.Release|x86.ActiveCfg = Release|x86
 		{F2824844-CE15-4242-9420-308923CD76C3}.Release|x86.Build.0 = Release|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM.ActiveCfg = Debug|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM.Build.0 = Debug|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM64.Build.0 = Debug|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x64.ActiveCfg = Debug|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x64.Build.0 = Debug|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x86.ActiveCfg = Debug|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x86.Build.0 = Debug|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM.ActiveCfg = Release|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM.Build.0 = Release|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM64.ActiveCfg = Release|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM64.Build.0 = Release|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x64.ActiveCfg = Release|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x64.Build.0 = Release|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x86.ActiveCfg = Release|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x86.Build.0 = Release|x86
 		{{/useExperimentalNuget}}
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
@@ -200,6 +218,7 @@ Global
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{F2824844-CE15-4242-9420-308923CD76C3} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 	EndGlobalSection
 	{{/useExperimentalNuget}}
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/packages/@react-native-windows/cli/templates/cs/src/App.xaml.cs
+++ b/packages/@react-native-windows/cli/templates/cs/src/App.xaml.cs
@@ -30,12 +30,7 @@ namespace {{ namespace }}
             Microsoft.ReactNative.Managed.AutolinkedNativeModules.RegisterAutolinkedNativeModulePackages(PackageProviders); // Includes any autolinked modules
 
             PackageProviders.Add(new Microsoft.ReactNative.Managed.ReactPackageProvider());
-{{^useExperimentalNuget}}
-            PackageProviders.Add(new Microsoft.ReactNative.Managed.ReflectionReactPackageProvider<App>());
-{{/useExperimentalNuget}}
-{{#useExperimentalNuget}}
             PackageProviders.Add(new ReactPackageProvider());
-{{/useExperimentalNuget}}
 
             InitializeComponent();
         }

--- a/packages/@react-native-windows/cli/templates/cs/src/ReactPackageProvider.cs
+++ b/packages/@react-native-windows/cli/templates/cs/src/ReactPackageProvider.cs
@@ -1,9 +1,6 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 using Microsoft.ReactNative;
 
-namespace ReactUWPTestApp
+namespace {{ namespace }}
 {
     public partial class ReactPackageProvider : IReactPackageProvider
     {

--- a/packages/E2ETest/windows/ReactUWPTestApp.sln
+++ b/packages/E2ETest/windows/ReactUWPTestApp.sln
@@ -34,6 +34,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative", "..
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ReactNative.Managed", "..\..\..\vnext\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.csproj", "{F2824844-CE15-4242-9420-308923CD76C3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ReactNative.Managed.CodeGen", "..\..\..\vnext\Microsoft.ReactNative.Managed.CodeGen\Microsoft.ReactNative.Managed.CodeGen.csproj", "{ADED4FBE-887D-4271-AF24-F0823BCE7961}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
@@ -174,6 +176,22 @@ Global
 		{F2824844-CE15-4242-9420-308923CD76C3}.Release|x64.Build.0 = Release|x64
 		{F2824844-CE15-4242-9420-308923CD76C3}.Release|x86.ActiveCfg = Release|x86
 		{F2824844-CE15-4242-9420-308923CD76C3}.Release|x86.Build.0 = Release|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM.ActiveCfg = Debug|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM.Build.0 = Debug|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|ARM64.Build.0 = Debug|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x64.ActiveCfg = Debug|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x64.Build.0 = Debug|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x86.ActiveCfg = Debug|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Debug|x86.Build.0 = Debug|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM.ActiveCfg = Release|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM.Build.0 = Release|ARM
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM64.ActiveCfg = Release|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|ARM64.Build.0 = Release|ARM64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x64.ActiveCfg = Release|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x64.Build.0 = Release|x64
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x86.ActiveCfg = Release|x86
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -185,6 +203,7 @@ Global
 		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D} = {AB7DB37D-898C-4BBC-9F2A-E043EC90C8F3}
 		{F7D32BD0-2749-483E-9A0D-1635EF7E3136} = {AB7DB37D-898C-4BBC-9F2A-E043EC90C8F3}
 		{F2824844-CE15-4242-9420-308923CD76C3} = {AB7DB37D-898C-4BBC-9F2A-E043EC90C8F3}
+		{ADED4FBE-887D-4271-AF24-F0823BCE7961} = {AB7DB37D-898C-4BBC-9F2A-E043EC90C8F3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F5EAF3BA-6B6F-4E81-B5C6-49B30EC0A32E}

--- a/packages/E2ETest/windows/ReactUWPTestApp/App.xaml.cs
+++ b/packages/E2ETest/windows/ReactUWPTestApp/App.xaml.cs
@@ -44,8 +44,7 @@ namespace ReactUWPTestApp
             Microsoft.ReactNative.Managed.AutolinkedNativeModules.RegisterAutolinkedNativeModulePackages(PackageProviders); // Includes any autolinked modules
 
             PackageProviders.Add(new Microsoft.ReactNative.Managed.ReactPackageProvider());
-            PackageProviders.Add(new ReflectionReactPackageProvider<App>());
-            PackageProviders.Add(new TreeDumpLibrary.ReactPackageProvider());
+            PackageProviders.Add(new ReactUWPTestApp.ReactPackageProvider());
 
             this.InitializeComponent();
         }

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/App.xaml.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/App.xaml.cs
@@ -45,7 +45,7 @@ namespace SampleAppCS
             Microsoft.ReactNative.Managed.AutolinkedNativeModules.RegisterAutolinkedNativeModulePackages(PackageProviders); // Includes any autolinked modules
 
             PackageProviders.Add(new Microsoft.ReactNative.Managed.ReactPackageProvider());
-            PackageProviders.Add(new ReflectionReactPackageProvider<App>());
+            PackageProviders.Add(new SampleAppCS.ReactPackageProvider());
             PackageProviders.Add(new SampleLibraryCS.ReactPackageProvider());
             PackageProviders.Add(new SampleLibraryCpp.ReactPackageProvider());
 

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/ReactPackageProvider.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/ReactPackageProvider.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.ReactNative;
 
-namespace ReactUWPTestApp
+namespace SampleAppCS
 {
     public partial class ReactPackageProvider : IReactPackageProvider
     {

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/SampleAppCS.csproj
@@ -130,6 +130,7 @@
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReactPackageProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/ReactPackageProvider.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/ReactPackageProvider.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.ReactNative;
 
-namespace ReactUWPTestApp
+namespace SampleLibraryCS
 {
     public partial class ReactPackageProvider : IReactPackageProvider
     {

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleLibraryCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleLibraryCS.csproj
@@ -113,6 +113,7 @@
     <Compile Include="CustomUserControlViewManagerCS.cs" />
     <Compile Include="CircleViewManagerCS.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReactPackageProvider.cs" />
     <Compile Include="SampleModuleCS.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleLibraryCS.csproj
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleLibraryCS.csproj
@@ -22,7 +22,6 @@
     <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
     <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
     <LangVersion>7.3</LangVersion>
-    <ReactNativeCodeGenEnabled>true</ReactNativeCodeGenEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
@@ -72,9 +72,9 @@ namespace Microsoft.ReactNative.Managed.CodeGen
       //  }
       var createPackageMethod = MethodDeclaration(
           PredefinedType(Token(SyntaxKind.VoidKeyword)),
-          ReactNativeNames.CreatePackage)
+          ReactNativeNames.CreatePackageImplementation)
         .AddModifiers(
-          Token(SyntaxKind.PublicKeyword))
+          Token(SyntaxKind.PartialKeyword))
         .AddParameterListParameters(
           GetPackageBuilderArgument())
         .WithBody(
@@ -88,7 +88,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
       // Generates:
       //    namespace "MyNS"
       //    {
-      //      public sealed partial ReactPackageProvider : IReactPackageProvider
+      //      public sealed partial ReactPackageProvider
       //      {
       //        ... providerMembers
       //      }
@@ -101,9 +101,6 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                 Token(SyntaxKind.PublicKeyword),
                 Token(SyntaxKind.SealedKeyword),
                 Token(SyntaxKind.PartialKeyword))
-              .AddBaseListTypes(
-                SimpleBaseType(
-                  ReactTypes.IReactPackageProvider.ToTypeSyntax()))
               .WithMembers(
                 new SyntaxList<MemberDeclarationSyntax>(providerMembers))
           );

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/ReactNativeNames.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/ReactNativeNames.cs
@@ -28,6 +28,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
     public static readonly SyntaxToken ModuleBuilder = Identifier("moduleBuilder");
     public static readonly SyntaxToken Module = Identifier("module");
     public static readonly SyntaxToken CreatePackage = Identifier("CreatePackage");
+    public static readonly SyntaxToken CreatePackageImplementation = Identifier("CreatePackageImplementation");
     public static readonly SyntaxToken AddViewManager = Identifier("AddViewManager");
     public static readonly SyntaxToken AddModule = Identifier("AddModule");
 

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
@@ -8,6 +8,10 @@
   Do not make any changes here unless it applies to ALL such projects.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ReactNativeCodeGenEnabled Condition="'$(ReactNativeCodeGenEnabled)' == ''">true</ReactNativeCodeGenEnabled>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Autolink.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
@@ -9,7 +9,7 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ReactNativeCodeGenEnabled>true</ReactNativeCodeGenEnabled>
+    <ReactNativeCodeGenEnabled Condition="'$(ReactNativeCodeGenEnabled)' == ''">true</ReactNativeCodeGenEnabled>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
@@ -8,5 +8,9 @@
   Do not make any changes here unless it applies to ALL such projects.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ReactNativeCodeGenEnabled>true</ReactNativeCodeGenEnabled>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
 </Project>

--- a/vnext/PropertySheets/ManagedCodeGen/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/PropertySheets/ManagedCodeGen/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -72,7 +72,7 @@
     <MakeDir Directories="$(XamlGeneratedOutputPath)intermediatexaml\" />
 
     <!-- Write the response file -->
-    <WriteLinesToFile File="$(_ReactNativeCodeGenResponseFile)" Lines="@(_ReactNativeCodeGenResponseFileLines)" WriteOnlyWhenDifferent="true" Encoding="Unicode"/>
+    <WriteLinesToFile File="$(_ReactNativeCodeGenResponseFile)" Lines="@(_ReactNativeCodeGenResponseFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" Encoding="Unicode"/>
 
     <!-- Execute teh code generation /> -->
     <Exec Command="$(_ReactNativeCodeGenToolExecutable) @$(_ReactNativeCodeGenResponseFile)" />

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -48,6 +48,7 @@
     <WriteLinesToFile
         File="$(ReactNativeCodeGenDummyFile)"
         Lines="@(_DesignTimeCodeGenFile)"
+        Overwrite="true"
         WriteOnlyWhenDifferent="true" />
   </Target>
 

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -14,7 +14,6 @@
     <_ReactNativeCodeGenOutFolder>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', '$(_ReactNativeName)'))</_ReactNativeCodeGenOutFolder>
 
     <ReactNativeCodeGenFile>$(_ReactNativeCodeGenOutFolder)$(_ReactNativeName).g.cs</ReactNativeCodeGenFile>
-    <ReactNativeCodeGenDummyFile>$(_ReactNativeCodeGenOutFolder)$(_ReactNativeName).tmp.g.cs</ReactNativeCodeGenDummyFile>
     <_ReactNativeCodeGenResponseFile>$(_ReactNativeCodeGenOutFolder)$(_ReactNativeName).rsp</_ReactNativeCodeGenResponseFile>
     <_ReactNativeCodeGenToolFolder>$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory)\..\tools))</_ReactNativeCodeGenToolFolder>
     <_ReactNativeCodeGenToolExecutable>$(_ReactNativeCodeGenToolFolder)Microsoft.ReactNative.Managed.CodeGen.exe</_ReactNativeCodeGenToolExecutable>
@@ -27,30 +26,7 @@
 
   <ItemGroup>
     <_ReactNativeCodeGenToolFiles Include="$(_ReactNativeCodeGenToolFolder)**" />
-    <Compile Include="$(ReactNativeCodeGenDummyFile)"/>
   </ItemGroup>
-
-  <Target
-    Name="CreateDesignTimeCodeGenFile"
-    BeforeTargets="BeforeBuild"
-  >
-    <ItemGroup>
-      <_DesignTimeCodeGenFile Include="namespace $(RootNamespace)" />
-      <_DesignTimeCodeGenFile Include="{" />
-      <_DesignTimeCodeGenFile Include="    public class ReactPackageProvider : global::Microsoft.ReactNative.IReactPackageProvider" />
-      <_DesignTimeCodeGenFile Include="    {" />
-      <_DesignTimeCodeGenFile Include="        public void CreatePackage(global::Microsoft.ReactNative.IReactPackageBuilder packageBuilder)" />
-      <_DesignTimeCodeGenFile Include="        {" />
-      <_DesignTimeCodeGenFile Include="        }" />
-      <_DesignTimeCodeGenFile Include="    }" />
-      <_DesignTimeCodeGenFile Include="}" />
-    </ItemGroup>
-    <WriteLinesToFile
-        File="$(ReactNativeCodeGenDummyFile)"
-        Lines="@(_DesignTimeCodeGenFile)"
-        Overwrite="true"
-        WriteOnlyWhenDifferent="true" />
-  </Target>
 
   <Target 
     Name="ReactNativeManagedCodeGen"
@@ -85,7 +61,6 @@
     <Exec Command="$(_ReactNativeCodeGenToolExecutable) @$(_ReactNativeCodeGenResponseFile)" />
 
     <ItemGroup>
-      <Compile Remove="$(ReactNativeCodeGenDummyFile)"/>
       <Compile Include="$(ReactNativeCodeGenFile)"/>
       <FileWrites Include="$(ReactNativeCodeGenFile)" />
       <FileWrites Include="$(_ReactNativeCodeGenResponseFile)" />

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -87,6 +87,7 @@
     "/Microsoft.ReactNative",
     "/Microsoft.ReactNative.Cxx",
     "/Microsoft.ReactNative.Managed",
+    "/Microsoft.ReactNative.Managed.CodeGen",
     "/Microsoft.ReactNative.SharedManaged",
     "/Mso",
     "/PropertySheets",


### PR DESCRIPTION
This change contains the following:
* It makes C# compile time CodeGen the default. Initial assumption was to ship the binary distribution where it is default, but that has been postponed to 0.64
* This fixes a problem with the Xaml designer where it sometimes gave compile errors because it didn't like the generated C# file being added dynamically by MsBuild during the build. To make this more robust I changed the strategy to have a partial class that is part of the repo and the other partial part is generated. This will also make the documentation easier to write for people that want to go back to the previous style of analysis.
* Update the samples with C# in our repo to use the same pattern as the init template.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5630)