### PR TITLE
View manager core

### DIFF
--- a/change/react-native-windows-2020-08-05-12-35-53-viewManagerCore.json
+++ b/change/react-native-windows-2020-08-05-12-35-53-viewManagerCore.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Split IViewManager into core and ui-dependent parts to remove dependency on XAML from Core projects",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-05T19:35:53.142Z"
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -139,7 +139,7 @@
     <Midl Include="..\Microsoft.ReactNative\IJSValueWriter.idl" />
     <Midl Include="..\Microsoft.ReactNative\IReactContext.idl" />
     <Midl Include="..\Microsoft.ReactNative\IJSValueReader.idl" />
-    <Midl Include="..\Microsoft.ReactNative\IViewManager.idl" />
+    <Midl Include="..\Microsoft.ReactNative\IViewManagerCore.idl" />
     <Midl Include="..\Microsoft.ReactNative\IReactDispatcher.idl" />
     <Midl Include="..\Microsoft.ReactNative\IReactNotificationService.idl" />
     <Midl Include="..\Microsoft.ReactNative\IReactNonAbiValue.idl" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj.filters
@@ -57,9 +57,6 @@
     <Midl Include="..\Microsoft.ReactNative\IReactPropertyBag.idl">
       <Filter>ABI</Filter>
     </Midl>
-    <Midl Include="..\Microsoft.ReactNative\IViewManager.idl">
-      <Filter>ABI</Filter>
-    </Midl>
     <Midl Include="..\Microsoft.ReactNative\ReactInstanceSettings.idl">
       <Filter>ABI</Filter>
     </Midl>
@@ -85,6 +82,9 @@
       <Filter>ABI</Filter>
     </Midl>
     <Midl Include="..\Microsoft.ReactNative\IReactNonAbiValue.idl">
+      <Filter>ABI</Filter>
+    </Midl>
+    <Midl Include="..\Microsoft.ReactNative\IViewManagerCore.idl">
       <Filter>ABI</Filter>
     </Midl>
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -146,6 +146,7 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilder.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPropertyBag.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IViewManager.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IViewManagerCore.idl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "winrt/Microsoft.ReactNative.h"
-
+#include <winrt/Windows.Foundation.h>
 #include "JSValueReader.h"
 #include "JSValueWriter.h"
 #include "ModuleRegistration.h"
 #include "ReactContext.h"
 #include "ReactNonAbiValue.h"
 #include "ReactPromise.h"
+#include "winrt/Microsoft.ReactNative.h"
 
 #include <functional>
 #include <type_traits>
@@ -1111,19 +1111,20 @@ struct TurboModuleSpec {
 // The default factory for the TModule.
 // It wraps up the TModule into a ReactNonAbiValue to be passed through the ABI boundary.
 template <class TModule>
-inline std::tuple<IInspectable, TModule *> MakeDefaultReactModuleWrapper() noexcept {
+inline std::tuple<winrt::Windows::Foundation::IInspectable, TModule *> MakeDefaultReactModuleWrapper() noexcept {
   ReactNonAbiValue<TModule> moduleWrapper{std::in_place};
   TModule *module = moduleWrapper.GetPtr();
-  return std::tuple<IInspectable, TModule *>{std::move(moduleWrapper), module};
+  return std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>{std::move(moduleWrapper), module};
 }
 
 // The default factory for TModule inherited from enable_shared_from_this<T>.
 // It wraps up the TModule into an  std::shared_ptr before giving it to ReactNonAbiValue.
 template <class TModule>
-inline std::tuple<IInspectable, TModule *> MakeDefaultSharedPtrReactModuleWrapper() noexcept {
+inline std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>
+MakeDefaultSharedPtrReactModuleWrapper() noexcept {
   ReactNonAbiValue<std::shared_ptr<TModule>> moduleWrapper{std::in_place, std::make_shared<TModule>()};
   TModule *module = moduleWrapper.GetPtr()->get();
-  return std::tuple<IInspectable, TModule *>{std::move(moduleWrapper), module};
+  return std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>{std::move(moduleWrapper), module};
 }
 
 namespace Internal {
@@ -1157,7 +1158,7 @@ inline constexpr auto GetReactModuleFactory(TModule * /*moduleNullPtr*/, int * /
 // Type traits for TModule. It defines a factory to create the module and its ABI-safe wrapper.
 template <class TModule>
 struct ReactModuleTraits {
-  using FactoryType = std::tuple<IInspectable, TModule *>() noexcept;
+  using FactoryType = std::tuple<winrt::Windows::Foundation::IInspectable, TModule *>() noexcept;
   static constexpr FactoryType *Factory = GetReactModuleFactory((TModule *)nullptr, 0);
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -5,7 +5,9 @@
 #ifndef MICROSOFT_REACTNATIVE_REACTCONTEXT
 #define MICROSOFT_REACTNATIVE_REACTCONTEXT
 
+#ifndef CORE_ABI
 #include <CppWinRTIncludes.h>
+#endif
 #include <string_view>
 #include "JSValueWriter.h"
 #include "ReactNotificationService.h"

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -3,8 +3,8 @@
 
 #include "pch.h"
 #include <NativeModules.h>
+#include <winrt/Windows.System.h>
 #include "MockReactPackageProvider.h"
-
 using namespace React;
 
 namespace ReactNativeIntegrationTests {

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -5,7 +5,9 @@ import "IJSValueWriter.idl";
 import "IReactNotificationService.idl";
 import "IReactPropertyBag.idl";
 
+#ifndef CORE_ABI
 #include "NamespaceRedirect.h"
+#endif
 
 namespace Microsoft.ReactNative {
 

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -1,23 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import "IReactModuleBuilder.idl";
-import "IReactContext.idl";
+import "IViewManagerCore.idl";
 
 #include "NamespaceRedirect.h"
 
 namespace Microsoft.ReactNative
 {
-  [webhosthidden]
-  enum ViewManagerPropertyType
-  {
-    Boolean,
-    Number,
-    String,
-    Array,
-    Map,
-    Color,
-  };
 
   [webhosthidden]
   interface IViewManager
@@ -25,18 +14,6 @@ namespace Microsoft.ReactNative
     String Name { get; };
 
     XAML_NAMESPACE.FrameworkElement CreateView();
-  }
-
-  [webhosthidden]
-  interface IViewManagerWithReactContext
-  {
-    IReactContext ReactContext { get; set; };
-  }
-
-  [webhosthidden]
-  interface IViewManagerWithExportedViewConstants
-  {
-    ConstantProviderDelegate ExportedViewConstants { get; };
   }
 
   [webhosthidden]
@@ -53,14 +30,6 @@ namespace Microsoft.ReactNative
     IVectorView<String> Commands { get; };
 
     void DispatchCommand(XAML_NAMESPACE.FrameworkElement view, String commandId, IJSValueReader commandArgsReader);
-  }
-
-  [webhosthidden]
-  interface IViewManagerWithExportedEventTypeConstants
-  {
-    ConstantProviderDelegate ExportedCustomBubblingEventTypeConstants { get; };
-
-    ConstantProviderDelegate ExportedCustomDirectEventTypeConstants { get; };
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/IViewManagerCore.idl
+++ b/vnext/Microsoft.ReactNative/IViewManagerCore.idl
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "IReactModuleBuilder.idl";
+import "IReactContext.idl";
+
+// Do not add any XAML/UI framework-specific pieces here - use IViewManager.idl instead
+
+namespace Microsoft.ReactNative
+{
+
+  [webhosthidden]
+  enum ViewManagerPropertyType
+  {
+    Boolean,
+    Number,
+    String,
+    Array,
+    Map,
+    Color,
+  };
+
+  [webhosthidden]
+  interface IViewManagerWithReactContext
+  {
+    IReactContext ReactContext { get; set; };
+  }
+
+  [webhosthidden]
+  interface IViewManagerWithExportedViewConstants
+  {
+    ConstantProviderDelegate ExportedViewConstants { get; };
+  }
+
+  [webhosthidden]
+  interface IViewManagerWithExportedEventTypeConstants
+  {
+    ConstantProviderDelegate ExportedCustomBubblingEventTypeConstants { get; };
+
+    ConstantProviderDelegate ExportedCustomDirectEventTypeConstants { get; };
+  }
+
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -584,6 +584,7 @@
     <Midl Include="IReactPackageBuilder.idl" />
     <Midl Include="IReactPackageProvider.idl" />
     <Midl Include="IViewManager.idl" />
+    <Midl Include="IViewManagerCore.idl" />
     <Midl Include="ReactApplication.idl" />
     <Midl Include="IReactContext.idl">
       <SubType>Designer</SubType>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -744,6 +744,7 @@
     <Midl Include="Views\cppwinrt\Effects.idl">
       <Filter>Views\cppwinrt</Filter>
     </Midl>
+    <Midl Include="IViewManagerCore.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="microsoft.reactnative.def" />


### PR DESCRIPTION
Split IViewManager into core and ui-dependent parts to remove dependency on XAML from Core projects

Fixes #5640 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5642)