### PR TITLE
Use npx to run react-native

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,8 +12,8 @@ Your issue will be triaged by the RNW team according to this process: https://gi
 -->
 ## Environment
 Run the following in your terminal and copy the results here.
-1. `react-native -v`:
-2. `react-native run-windows --info`:
+1. `npx react-native -v`:
+2. `npx react-native run-windows --info`:
 3. `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"`
 
 <!-- Consider including this information as well:


### PR DESCRIPTION
We don't use the globally installed CLI anymore so we should use npx to run react-native

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5651)