### PR TITLE
Issue Template: Should be --version, not -v

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ Your issue will be triaged by the RNW team according to this process: https://gi
 -->
 ## Environment
 Run the following in your terminal and copy the results here.
-1. `npx react-native -v`:
+1. `npx react-native --version`:
 2. `npx react-native run-windows --info`:
 3. `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"`
 


### PR DESCRIPTION
```
> npx react-native -v
error: unknown option `-v'
> npx react-native --version
4.10.1
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5657)