### PR TITLE
Small tweak to #5659

### DIFF
--- a/change/react-native-windows-2020-08-07-02-41-33-transparent-tweak.json
+++ b/change/react-native-windows-2020-08-07-02-41-33-transparent-tweak.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "change to member as static DOs aren't safe in multi window apps",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T09:41:33.882Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -309,8 +309,6 @@ bool TryUpdateBorderProperties(
 
 // ViewViewManager
 
-xaml::Media::SolidColorBrush ViewViewManager::s_transparentBrush{nullptr};
-
 ViewViewManager::ViewViewManager(const std::shared_ptr<IReactInstance> &reactInstance) : Super(reactInstance) {}
 
 const char *ViewViewManager::GetName() const {
@@ -564,10 +562,10 @@ void ViewViewManager::SetLayoutProps(
 }
 
 xaml::Media::SolidColorBrush ViewViewManager::EnsureTransparentBrush() {
-  if (!s_transparentBrush) {
-    s_transparentBrush = xaml::Media::SolidColorBrush(winrt::Colors::Transparent());
+  if (!m_transparentBrush) {
+    m_transparentBrush = xaml::Media::SolidColorBrush(winrt::Colors::Transparent());
   }
-  return s_transparentBrush;
+  return m_transparentBrush;
 }
 
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
@@ -41,10 +41,10 @@ class ViewViewManager : public FrameworkElementViewManager {
   XamlView CreateViewCore(int64_t tag) override;
   void TryUpdateView(ViewShadowNode *viewShadowNode, winrt::react::uwp::ViewPanel &pPanel, bool useControl);
 
-  static xaml::Media::SolidColorBrush EnsureTransparentBrush();
+  xaml::Media::SolidColorBrush EnsureTransparentBrush();
 
  private:
-  static xaml::Media::SolidColorBrush s_transparentBrush;
+  xaml::Media::SolidColorBrush m_transparentBrush{nullptr};
 };
 
 } // namespace react::uwp


### PR DESCRIPTION
This is a small tweak to PR #5659 which added a static SolidColorBrush.  Static DO's aren't safe in general because they can't be shared across XAML instances, which can happen in a multi Core-Window application.  

The change is very straightforward - just changes to a member variable.  The object is still shared across all views in a single instance.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5662)