### PR TITLE
Fix label of RedBox reload button

### DIFF
--- a/change/react-native-windows-2020-08-07-09-24-14-reloadtext.json
+++ b/change/react-native-windows-2020-08-07-09-24-14-reloadtext.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix label of RedBox reload button",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T16:24:14.476Z"
+}

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -91,7 +91,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
             </StackPanel>
           </ScrollViewer>
           <Button x:Name='DismissButton' Grid.Row='1' Grid.Column='0' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Dismiss</Button>
-          <Button x:Name='ReloadButton' Grid.Row='1' Grid.Column='2' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Reload (NYI)</Button>
+          <Button x:Name='ReloadButton' Grid.Row='1' Grid.Column='2' HorizontalAlignment='Stretch' Margin='15' Style='{StaticResource ButtonRevealStyle}'>Reload</Button>
         </Grid>)";
 
     m_redboxContent = winrt::unbox_value<xaml::Controls::Grid>(xaml::Markup::XamlReader::Load(xamlString));


### PR DESCRIPTION
Fixes #5655 

The reload button on RedBox currently says "Reload (NYI)".  The button has since been implemented.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5664)