### PR TITLE
Implement textTransform

### DIFF
--- a/change/react-native-windows-2020-08-09-05-01-47-textTransform.json
+++ b/change/react-native-windows-2020-08-09-05-01-47-textTransform.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implement textTransform",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-09T12:01:47.038Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -299,6 +299,7 @@
     <ClInclude Include="Utils\PropertyUtils.h" />
     <ClInclude Include="Utils\ResourceBrushUtils.h" />
     <ClInclude Include="Utils\StandardControlResourceKeyNames.h" />
+    <ClInclude Include="Utils\TransformableText.h" />
     <ClInclude Include="Utils\UwpPreparedScriptStore.h" />
     <ClInclude Include="Utils\UwpScriptStore.h" />
     <ClInclude Include="Utils\ValueUtils.h" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -711,6 +711,9 @@
     <ClInclude Include="Views\Image\Effects.h">
       <Filter>Views\Image</Filter>
     </ClInclude>
+    <ClInclude Include="Utils\TransformableText.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -25,7 +25,7 @@ struct TransformableText final {
             LOCALE_NAME_USER_DEFAULT,
             LCMAP_TITLECASE,
             m_originalText.c_str(),
-            m_originalText.length(),
+            static_cast<int>(m_originalText.length()),
             str,
             static_cast<int>(m_originalText.length() + 1));
 

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -27,7 +27,7 @@ struct TransformableText final {
             m_originalText.c_str(),
             m_originalText.length(),
             str,
-            m_originalText.length() + 1);
+            static_cast<int>(m_originalText.length() + 1));
 
         std::wstring result(str, nChars);
         delete[] str;

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+
+namespace react::uwp {
+struct TransformableText final {
+  enum class TextTransform { Undefined, None, Uppercase, Lowercase, Capitalize };
+
+  TextTransform m_textTransform{TextTransform::Undefined};
+  std::wstring m_originalText{};
+
+  std::wstring TransformText() {
+    switch (m_textTransform) {
+      case TextTransform::Undefined:
+      case TextTransform::None:
+        return m_originalText;
+      case TextTransform::Uppercase:
+        return boost::to_upper_copy(m_originalText);
+      case TextTransform::Lowercase:
+        return boost::to_lower_copy(m_originalText);
+      case TextTransform::Capitalize: {
+        PWSTR str = new wchar_t[m_originalText.length() + 1];
+        const int nChars = LCMapStringW(
+            LOCALE_NAME_USER_DEFAULT,
+            LCMAP_TITLECASE,
+            m_originalText.c_str(),
+            m_originalText.length(),
+            str,
+            m_originalText.length() + 1);
+
+        std::wstring result(str, nChars);
+        delete[] str;
+        return result;
+      }
+    }
+    nyi();
+    return m_originalText;
+  }
+
+  static TextTransform GetTextTransform(const folly::dynamic &propertyValue) {
+    if (propertyValue.isString()) {
+      auto value = propertyValue.asString();
+      if (value == "none") {
+      } else if (value == "lowercase") {
+        return TextTransform::Lowercase;
+      } else if (value == "uppercase") {
+        return TextTransform ::Uppercase;
+      } else if (value == "capitalize") {
+        return TextTransform::Capitalize;
+      }
+    }
+    return TextTransform::None;
+  }
+};
+
+} // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -20,18 +20,16 @@ struct TransformableText final {
       case TextTransform::Lowercase:
         return boost::to_lower_copy(m_originalText);
       case TextTransform::Capitalize: {
-        PWSTR str = new wchar_t[m_originalText.length() + 1];
+        auto str = std::make_unique<wchar_t[]>(m_originalText.length() + 1);
         const int nChars = LCMapStringW(
             LOCALE_NAME_USER_DEFAULT,
             LCMAP_TITLECASE,
             m_originalText.c_str(),
             static_cast<int>(m_originalText.length()),
-            str,
+            str.get(),
             static_cast<int>(m_originalText.length() + 1));
 
-        std::wstring result(str, nChars);
-        delete[] str;
-        return result;
+        return std::move(str.get());
       }
     }
     nyi();

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -12,6 +12,7 @@ struct TransformableText final {
   std::wstring TransformText() {
     switch (m_textTransform) {
       case TextTransform::Undefined:
+        [[fallthrough]];
       case TextTransform::None:
         return m_originalText;
       case TextTransform::Uppercase:

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -44,8 +44,8 @@ class TextShadowNode final : public ShadowNodeBase {
         m_firstChildNode = &child;
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
         std::wstring text(run.Text().c_str());
-        m_transformableText.m_originalText = text;
-        text = m_transformableText.TransformText();
+        transformableText.originalText = text;
+        text = transformableText.TransformText();
         textBlock.Text(winrt::hstring(text));
         return;
       }
@@ -70,7 +70,7 @@ class TextShadowNode final : public ShadowNodeBase {
     Super::RemoveChildAt(indexToRemove);
   }
 
-  TransformableText m_transformableText{};
+  TransformableText transformableText{};
 };
 
 TextViewManager::TextViewManager(const std::shared_ptr<IReactInstance> &reactInstance) : Super(reactInstance) {}
@@ -102,7 +102,7 @@ bool TextViewManager::UpdateProperty(
   } else if (propertyName == "textTransform") {
     auto textNode = static_cast<TextShadowNode *>(nodeToUpdate);
     auto textTransform = TransformableText::GetTextTransform(propertyValue);
-    textNode->m_transformableText.m_textTransform = textTransform;
+    textNode->transformableText.textTransform = textTransform;
   } else if (TryUpdatePadding(nodeToUpdate, textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextAlignment(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextTrimming(textBlock, propertyName, propertyValue)) {

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -12,6 +12,7 @@
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
 #include <Utils/PropertyUtils.h>
+#include <Utils/TransformableText.h>
 #include <Utils/ValueUtils.h>
 
 namespace winrt {
@@ -22,7 +23,7 @@ using namespace xaml::Automation::Peers;
 
 namespace react::uwp {
 
-class TextShadowNode : public ShadowNodeBase {
+class TextShadowNode final : public ShadowNodeBase {
   using Super = ShadowNodeBase;
 
  private:
@@ -42,7 +43,10 @@ class TextShadowNode : public ShadowNodeBase {
       if (run != nullptr) {
         m_firstChildNode = &child;
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
-        textBlock.Text(run.Text());
+        std::wstring text(run.Text().c_str());
+        m_transformableText.m_originalText = text;
+        text = m_transformableText.TransformText();
+        textBlock.Text(winrt::hstring(text));
         return;
       }
     } else if (index == 1 && m_firstChildNode != nullptr) {
@@ -65,6 +69,8 @@ class TextShadowNode : public ShadowNodeBase {
     }
     Super::RemoveChildAt(indexToRemove);
   }
+
+  TransformableText m_transformableText{};
 };
 
 TextViewManager::TextViewManager(const std::shared_ptr<IReactInstance> &reactInstance) : Super(reactInstance) {}
@@ -93,6 +99,10 @@ bool TextViewManager::UpdateProperty(
 
   if (TryUpdateForeground(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateFontProperties(textBlock, propertyName, propertyValue)) {
+  } else if (propertyName == "textTransform") {
+    auto textNode = static_cast<TextShadowNode *>(nodeToUpdate);
+    auto textTransform = TransformableText::GetTextTransform(propertyValue);
+    textNode->m_transformableText.m_textTransform = textTransform;
   } else if (TryUpdatePadding(nodeToUpdate, textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextAlignment(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextTrimming(textBlock, propertyName, propertyValue)) {

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -44,6 +44,9 @@ bool VirtualTextViewManager::UpdateProperty(
   } else if (TryUpdateFontProperties<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine<winrt::TextElement>(span, propertyName, propertyValue)) {
+  } else if (propertyName == "textTransform") {
+    auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
+    node->m_transformableText.m_textTransform = TransformableText::GetTextTransform(propertyValue);
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -19,6 +19,29 @@ using namespace xaml::Documents;
 
 namespace react::uwp {
 
+void VirtualTextShadowNode::AddView(ShadowNode &child, int64_t index) {
+  auto view = static_cast<ShadowNodeBase &>(child).GetView();
+
+  if (auto run = view.try_as<xaml::Documents::Run>()) {
+    transformableText.originalText = run.Text().c_str();
+    run.Text(transformableText.TransformText());
+  } else if (auto span = view.try_as<xaml::Documents::Span>()) {
+    auto &childVTSN = static_cast<VirtualTextShadowNode &>(child);
+    auto transform = childVTSN.transformableText.textTransform;
+
+    for (const auto &i : span.Inlines()) {
+      if (auto run = i.try_as<xaml::Documents::Run>()) {
+        if (transform == TransformableText::TextTransform::Undefined) {
+          // project the parent transform onto the child
+          childVTSN.transformableText.textTransform = transformableText.textTransform;
+          run.Text(childVTSN.transformableText.TransformText());
+        }
+      }
+    }
+  }
+  Super::AddView(child, index);
+}
+
 VirtualTextViewManager::VirtualTextViewManager(const std::shared_ptr<IReactInstance> &reactInstance)
     : Super(reactInstance) {}
 
@@ -46,7 +69,7 @@ bool VirtualTextViewManager::UpdateProperty(
   } else if (TryUpdateTextDecorationLine<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (propertyName == "textTransform") {
     auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
-    node->m_transformableText.m_textTransform = TransformableText::GetTextTransform(propertyValue);
+    node->transformableText.textTransform = TransformableText::GetTextTransform(propertyValue);
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -13,28 +13,9 @@ namespace react::uwp {
 
 struct VirtualTextShadowNode final : public ShadowNodeBase {
   using Super = ShadowNodeBase;
-  TransformableText m_transformableText{};
-  void AddView(ShadowNode &child, int64_t index) override {
-    auto &childSNB = static_cast<ShadowNodeBase &>(child);
-    if (auto run = childSNB.GetView().try_as<xaml::Documents::Run>()) {
-      m_transformableText.m_originalText = run.Text().c_str();
-      run.Text(m_transformableText.TransformText());
-    } else if (auto span = childSNB.GetView().try_as<xaml::Documents::Span>()) {
-      auto &childVTSN = static_cast<VirtualTextShadowNode &>(child);
-      auto transform = childVTSN.m_transformableText.m_textTransform;
+  TransformableText transformableText{};
 
-      for (const auto &i : span.Inlines()) {
-        if (auto run = i.try_as<xaml::Documents::Run>()) {
-          if (transform == TransformableText::TextTransform::Undefined) {
-            // project the parent transform onto the child
-            childVTSN.m_transformableText.m_textTransform = m_transformableText.m_textTransform;
-            run.Text(childVTSN.m_transformableText.TransformText());
-          }
-        }
-      }
-    }
-    Super::AddView(child, index);
-  }
+  void AddView(ShadowNode &child, int64_t index) override;
 };
 
 class VirtualTextViewManager : public ViewManagerBase {

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -17,8 +17,7 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   void AddView(ShadowNode &child, int64_t index) override {
     auto &childSNB = static_cast<ShadowNodeBase &>(child);
     if (auto run = childSNB.GetView().try_as<xaml::Documents::Run>()) {
-      std::wstring text(run.Text().c_str());
-      m_transformableText.m_originalText = text;
+      m_transformableText.m_originalText = run.Text().c_str();
       run.Text(m_transformableText.TransformText());
     } else if (auto span = childSNB.GetView().try_as<xaml::Documents::Span>()) {
       auto &childVTSN = static_cast<VirtualTextShadowNode &>(child);
@@ -26,7 +25,6 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
       for (const auto &i : span.Inlines()) {
         if (auto run = i.try_as<xaml::Documents::Run>()) {
-          std::wstring text(run.Text().c_str());
           if (transform == TransformableText::TextTransform::Undefined) {
             // project the parent transform onto the child
             childVTSN.m_transformableText.m_textTransform = m_transformableText.m_textTransform;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -3,9 +3,41 @@
 
 #pragma once
 
+#include <INativeUIManager.h>
+#include <ShadowNodeBase.h>
+#include <UI.Xaml.Documents.h>
+#include <Utils/TransformableText.h>
 #include <Views/FrameworkElementViewManager.h>
 
 namespace react::uwp {
+
+struct VirtualTextShadowNode final : public ShadowNodeBase {
+  using Super = ShadowNodeBase;
+  TransformableText m_transformableText{};
+  void AddView(ShadowNode &child, int64_t index) override {
+    auto &childSNB = static_cast<ShadowNodeBase &>(child);
+    if (auto run = childSNB.GetView().try_as<xaml::Documents::Run>()) {
+      std::wstring text(run.Text().c_str());
+      m_transformableText.m_originalText = text;
+      run.Text(m_transformableText.TransformText());
+    } else if (auto span = childSNB.GetView().try_as<xaml::Documents::Span>()) {
+      auto &childVTSN = static_cast<VirtualTextShadowNode &>(child);
+      auto transform = childVTSN.m_transformableText.m_textTransform;
+
+      for (const auto &i : span.Inlines()) {
+        if (auto run = i.try_as<xaml::Documents::Run>()) {
+          std::wstring text(run.Text().c_str());
+          if (transform == TransformableText::TextTransform::Undefined) {
+            // project the parent transform onto the child
+            childVTSN.m_transformableText.m_textTransform = m_transformableText.m_textTransform;
+            run.Text(childVTSN.m_transformableText.TransformText());
+          }
+        }
+      }
+    }
+    Super::AddView(child, index);
+  }
+};
 
 class VirtualTextViewManager : public ViewManagerBase {
   using Super = ViewManagerBase;
@@ -14,6 +46,9 @@ class VirtualTextViewManager : public ViewManagerBase {
   VirtualTextViewManager(const std::shared_ptr<IReactInstance> &reactInstance);
 
   const char *GetName() const override;
+  facebook::react::ShadowNode *createShadow() const override {
+    return new VirtualTextShadowNode();
+  }
 
   void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
   void RemoveAllChildren(const XamlView &parent) override;

--- a/vnext/src/RNTester/js/examples-win/Text/TextExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Text/TextExample.windows.tsx
@@ -79,6 +79,39 @@ export class TextExample extends React.Component<{}> {
 
     return (
       <RNTesterPage>
+        <RNTesterBlock title="textTransform">
+          <View>
+            <Text style={{textTransform: 'uppercase'}}>
+              This text should be uppercased.
+            </Text>
+            <Text style={{textTransform: 'lowercase'}}>
+              This TEXT SHOULD be lowercased.
+            </Text>
+            <Text style={{textTransform: 'capitalize'}}>
+              This text should be CAPITALIZED.
+            </Text>
+            <Text style={{textTransform: 'capitalize'}}>
+              Mixed:{' '}
+              <Text style={{textTransform: 'uppercase'}}>uppercase </Text>
+              <Text style={{textTransform: 'lowercase'}}>LoWeRcAsE </Text>
+              <Text style={{textTransform: 'capitalize'}}>
+                capitalize each word
+              </Text>
+            </Text>
+            <Text>
+              Should be "ABC":
+              <Text style={{textTransform: 'uppercase'}}>
+                a<Text>b</Text>c
+              </Text>
+            </Text>
+            <Text>
+              Should be "XyZ":
+              <Text style={{textTransform: 'uppercase'}}>
+                x<Text style={{textTransform: 'none'}}>y</Text>z
+              </Text>
+            </Text>
+          </View>
+        </RNTesterBlock>
         <RNTesterBlock title="Wrap">
           <Text>
             The text should wrap if it goes on multiple lines. See, this is


### PR DESCRIPTION
Implement the `textTransform` prop: none/lowercase/uppercase/capitalize
The prop has some interesting behavior that requires us to differentiate between `none` and `undefined` namely that nested `<Text>` elements will inherit their parent `textTransform` if they don't have one defined themselves.

This is clunkier than I'd like it to be because of the ordering of operations between:
- Creating a view
- Setting its `text` property
- Setting its or its parent `textTransform` property
- Adding the view to its parent's tree

The ordering makes it necessary for us to keep state and calculate things instead of doing the transform in-place when setting the text or transform.

Added an RNTester section in the `<Text>` page which I copied from the iOS/Android examples.

![image](https://user-images.githubusercontent.com/22989529/89758717-4b85c500-da9d-11ea-849c-5a7ca534fd0e.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5672)