### PR TITLE
Remove compiler flags disabling FH4

### DIFF
--- a/change/react-native-windows-2020-08-11-06-11-05-remove-fh4.json
+++ b/change/react-native-windows-2020-08-11-06-11-05-remove-fh4.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove compiler flags disabling FH4",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T13:11:05.384Z"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -113,19 +113,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
-  <!--
-    #4804: CxxFrameHandler4 leads to generated code that incompatible with VS
-    2015 and 2017. Disable it until consumers are updated or on an ABI-safe API
-  -->
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalOptions>/d2FH4- %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
-    <Link>
-      <AdditionalOptions>/d2:-FH4- %(AdditionalOptions)</AdditionalOptions>
-    </Link>
-  </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(ConfigurationType)' == 'Application' OR '$(ConfigurationType)' == 'DynamicLibrary'">
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Fixes #4804

This hasn't worked since VS 16.6 and all consumers should now be on V142. Remove flags to disable FH4.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5691)