### PR TITLE
Fix crash due to missing Image brush compositor

### DIFF
--- a/change/react-native-windows-2020-08-11-23-19-31-imageBrushCompositor.json
+++ b/change/react-native-windows-2020-08-11-23-19-31-imageBrushCompositor.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use thread compositor in ReactImage",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-12T06:19:31.028Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -222,15 +222,6 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   if (auto strong_this{weak_this.get()}) {
     if (strong_this->m_useCompositionBrush) {
       const auto compositionBrush{ReactImageBrush::Create()};
-      // GetCompositor relies on the element's XamlRoot which is only set once the object enters the tree.
-      // This in turn happens before ReactImageBrush::GetOrCreateSurfaceBrush is called.
-      if (!strong_this->IsLoaded()) {
-        strong_this->Loaded([=](auto &&, auto &&) -> auto {
-          compositionBrush->Compositor(react::uwp::GetCompositor(*this));
-        });
-      } else {
-        compositionBrush->Compositor(react::uwp::GetCompositor(*this));
-      }
 
       compositionBrush->BlurRadius(strong_this->m_blurRadius);
       compositionBrush->TintColor(strong_this->m_tintColor);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
@@ -6,6 +6,7 @@
 #include <UI.Composition.Effects.h>
 #include "Effects.h"
 #include "ReactImageBrush.h"
+#include "XamlView.h"
 
 #include <winrt/Windows.Graphics.Display.h>
 #include <winrt/Windows.Graphics.Effects.h>
@@ -161,7 +162,7 @@ comp::CompositionStretch ReactImageBrush::ResizeModeToStretch() {
 comp::CompositionSurfaceBrush ReactImageBrush::GetOrCreateSurfaceBrush() {
   // If it doesn't exist, create it
   if (!CompositionBrush()) {
-    comp::CompositionSurfaceBrush surfaceBrush{m_compositor.CreateSurfaceBrush()};
+    comp::CompositionSurfaceBrush surfaceBrush{GetCompositor().CreateSurfaceBrush()};
     surfaceBrush.Surface(m_loadedImageSurface);
 
     return surfaceBrush;
@@ -231,7 +232,7 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
       effect = compositeEffect;
     }
 
-    comp::CompositionEffectFactory effectFactory{m_compositor.CreateEffectFactory(effect, animatedProperties)};
+    comp::CompositionEffectFactory effectFactory{GetCompositor().CreateEffectFactory(effect, animatedProperties)};
 
     m_effectBrush = effectFactory.CreateBrush();
     m_effectBrush.SetSourceParameter(L"source", surfaceBrush);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.h
@@ -46,10 +46,6 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
 
   void Source(xaml::Media::LoadedImageSurface const &value);
 
-  void Compositor(comp::Compositor const &compositor) {
-    m_compositor = compositor;
-  }
-
  private:
   static constexpr auto TintColorColor{L"TintColor.Color"};
   static constexpr auto BlurBlurAmount{L"Blur.BlurAmount"};
@@ -62,7 +58,6 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
       comp::CompositionSurfaceBrush const &surfaceBrush,
       bool forceEffectBrush = false);
 
-  comp::Compositor m_compositor;
   float m_blurRadius{0};
   react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
   winrt::Windows::UI::Color m_tintColor{winrt::Colors::Transparent()};


### PR DESCRIPTION
Fixed #5700 

It turns out the assumptions we had about ordering of when an image brush is created vs. when the image is added to layout (and therefore when the compositor is set) were wrong and things can happen out of order. Opting to use the thread compositor instead which is guaranteed to be set and valid as long as there is a `ReactRootView`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5701)