### PR TITLE
Fix Errant "Nested elements in TextInput are currently unsupported on Windows" Yellowbox Warnings

### DIFF
--- a/change/react-native-windows-2020-08-12-04-26-05-fix-yellowbox.json
+++ b/change/react-native-windows-2020-08-12-04-26-05-fix-yellowbox.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Errant \"Nested elements in TextInput are currently unsupported on Windows\" Yellowbox Warnings",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-12T11:26:05.719Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -95,10 +95,6 @@ class TextInputShadowNode : public ShadowNodeBase {
 
   void dispatchCommand(const std::string &commandId, const folly::dynamic &commandArgs) override;
 
-  void removeAllChildren() override {
-    // NYI #5689
-    YellowBox("Nested elements in TextInput are currently unsupported on Windows");
-  }
   void AddView(ShadowNode & /*child*/, int64_t /*index*/) override {
     // NYI #5689
     YellowBox("Nested elements in TextInput are currently unsupported on Windows");


### PR DESCRIPTION
When standing up the TextInput RNTester page I ran into ViewManagerBase assertions related to trying to embed Text elements inside of TextInput. To avoid debug assertions which may break tests, I implemented child manipulation functions in TextInputShadowNode to Yellowbox instead. One of the functions implemented was removeAllChildren, which seems to be called in cases where there were no children to begin with. This leads to seeing "Nested elements in TextInput are currently unsupported on Windows" in some cases where we shouldn't.

ViewManagerBase doesn't assert when the default removeAllChildren is called, and we shouldn't either.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5703)