### PR TITLE
Print out debug Wininet errors

### DIFF
--- a/change/react-native-windows-2020-08-13-11-05-38-wininetErrors.json
+++ b/change/react-native-windows-2020-08-13-11-05-38-wininetErrors.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Print out Wininet error strings",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T18:05:37.959Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
@@ -2,17 +2,17 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-#include <cdebug.h>
-#include <WinInet.h>
+#include "WebSocketModuleUwp.h"
 #include <Utils/CppWinrtLessExceptions.h>
+#include <WinInet.h>
 #include <Windows.Storage.Streams.h>
+#include <cdebug.h>
 #include <winrt/Windows.Networking.Sockets.h>
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <future>
 #include "Unicode.h"
 #include "Utilities.h"
-#include "WebSocketModuleUwp.h"
 
 #pragma warning(push)
 #pragma warning(disable : 4146)
@@ -182,7 +182,8 @@ void WebSocketModule::WebSocket::connect(
     } else {
       error = e.message().c_str();
     }
-    cwdebug << L"WebSocket.connect failed (0x" << std::hex << e.code() << ") " << error << " at " << uri.DisplayUri().c_str() << std::endl;
+    cwdebug << L"WebSocket.connect failed (0x" << std::hex << e.code() << ") " << error << " at "
+            << uri.DisplayUri().c_str() << std::endl;
     onError(id, e.code());
   }
 }

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-
+#include <cdebug.h>
+#include <WinInet.h>
 #include <Utils/CppWinrtLessExceptions.h>
 #include <Windows.Storage.Streams.h>
 #include <winrt/Windows.Networking.Sockets.h>
@@ -164,7 +165,24 @@ void WebSocketModule::WebSocket::connect(
 
   if (!SUCCEEDED(hr)) {
     winrt::hresult_error e{hr};
-    OutputDebugString("WebSocket.connect failed (0x%8X) %ls\n", e);
+    std::wstring error;
+#define INET_ERR_OUT_FORMAT_BUFFER_SIZE 256
+    const DWORD err = hr & 0xffff;
+    if (err >= INTERNET_ERROR_BASE && err <= INTERNET_ERROR_LAST) {
+      wchar_t errorStr[INET_ERR_OUT_FORMAT_BUFFER_SIZE] = {};
+      FormatMessageW(
+          FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_HMODULE,
+          GetModuleHandle(L"wininet.dll"),
+          err,
+          0,
+          errorStr,
+          INET_ERR_OUT_FORMAT_BUFFER_SIZE,
+          nullptr);
+      error = errorStr;
+    } else {
+      error = e.message().c_str();
+    }
+    cwdebug << L"WebSocket.connect failed (0x" << std::hex << e.code() << ") " << error << " at " << uri.DisplayUri().c_str() << std::endl;
     onError(id, e.code());
   }
 }


### PR DESCRIPTION
I commented about this in PR #5610 and followed up offline. Wininet errors strings are not normally resolved by cppwinrt since they require knowing they are wininet errors and cppwinrt doesn't do that: https://github.com/microsoft/cppwinrt/issues/710

This change adds the code to the web socket module to print out the right string, instead of "The text associated with this error code could not be found".

Fixes #5720

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5717)