### PR TITLE
Disable autolinking check in msbuild when using `react-native run-windows`

### DIFF
--- a/change/@react-native-windows-cli-2020-08-13-11-25-40-lessautolinkchecks.json
+++ b/change/@react-native-windows-cli-2020-08-13-11-25-40-lessautolinkchecks.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Disable autolinking check in msbuild when using `react-native run-windows`",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T18:25:40.171Z"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -93,10 +93,8 @@ async function runWindows(
     const buildType = deploy.getBuildConfiguration(options);
     var msBuildProps = build.parseMsBuildProps(options);
 
-    if (!options.autolink) {
-      // Disable the autolink check if --no-autolink was passed
-      msBuildProps.RunAutolinkCheck = 'false';
-    }
+    // Disable the autolink check since we just ran it
+    msBuildProps.RunAutolinkCheck = 'false';
 
     try {
       await build.buildSolution(


### PR DESCRIPTION
Since we run auto-linking at the start of `run-windows` there's no reason to run the check during the build.

Closes #5304

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5719)