### PR TITLE
Fix crash in ViewViewManager

### DIFF
--- a/change/react-native-windows-2020-08-13-11-26-05-crashViewViewManager.json
+++ b/change/react-native-windows-2020-08-13-11-26-05-crashViewViewManager.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in ViewViewManager",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T18:26:05.458Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-
 #include "ViewViewManager.h"
+#include <cdebug.h>
 
 #include "ViewControl.h"
 
@@ -16,9 +16,11 @@
 #include <INativeUIManager.h>
 #include <IReactInstance.h>
 
+#include <inspectable.h>
 #include <unicode.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Xaml.Interop.h>
+#include <winstring.h>
 
 #if defined(_DEBUG)
 // Currently only used for tagging controls in debug
@@ -136,9 +138,13 @@ class ViewShadowNode : public ShadowNodeBase {
     // TODO NOW: Why do we do this? Removal of children doesn't seem to imply we
     // tear down the infrastr
     if (IsControl()) {
-      auto control = m_view.as<xaml::Controls::ContentControl>();
-      current = control.Content().as<XamlView>();
-      control.Content(nullptr);
+      if (auto control = m_view.try_as<xaml::Controls::ContentControl>()) {
+        current = control.Content().as<XamlView>();
+        control.Content(nullptr);
+      } else {
+        std::string name = Microsoft::Common::Unicode::Utf16ToUtf8(winrt::get_class_name(current).c_str());
+        cdebug << "Tearing down, IsControl=true but the control is not a ContentControl, it's a " << name << std::endl;
+      }
     }
 
     if (HasOuterBorder()) {


### PR DESCRIPTION
Fixes #5721
There are cases (read: race conditions) in which the m_view will not be a `ContentControl` but a `Microsoft.ReactNative.ViewPanel`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5722)