### PR TITLE
[Win32] Bump rex-win32 version

### DIFF
--- a/change/@office-iss-react-native-win32-2020-08-13-15-17-52-bumprex.json
+++ b/change/@office-iss-react-native-win32-2020-08-13-15-17-52-bumprex.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "[Win32] Bump rex-win32 version",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-13T22:17:52.113Z"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -42,7 +42,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "@office-iss/rex-win32": "0.0.33",
+    "@office-iss/rex-win32": "0.62.0-preview.17-tenantreactnativewin-13114",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
     "@types/node": "^12.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,10 +2529,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@office-iss/rex-win32@0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.0.33.tgz#960ed52275c827df58aede4819d39927bdf2ae70"
-  integrity sha512-Eh4orZ3F4P03IJAn509H7rXPcA8/6iXIEJbBTrNdO0RK6gVIRQ/5GVVPg3BA3QrFN7GDJeXOqjN1/9daV4O8ag==
+"@office-iss/rex-win32@0.62.0-preview.17-tenantreactnativewin-13114":
+  version "0.62.0-preview.17-tenantreactnativewin-13114"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.62.0-preview.17-tenantreactnativewin-13114.tgz#e5c5ad0acbb4ec126307baa9fd5be171b41a2500"
+  integrity sha512-DQx7VS49T9I3Qh7EoA4VSe6cDzKWo2gZH4VXNzZwVu444pg+4nLP3/xTBcCltedXqmoH821YEdpXzHdgsKj4ww==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"


### PR DESCRIPTION
Port of #5535 to 0.62 branch

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5728)