### PR TITLE
Hyperlink tooltips

### DIFF
--- a/change/react-native-windows-2020-08-13-21-08-10-hyperlinkTooltip.json
+++ b/change/react-native-windows-2020-08-13-21-08-10-hyperlinkTooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "remove textbox for tooltips in hyperlinks as that can mess up word-wrapping",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T04:08:10.715Z"
+}

--- a/vnext/Microsoft.ReactNative/Polyester/HyperlinkViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Polyester/HyperlinkViewManager.cpp
@@ -71,9 +71,7 @@ bool HyperlinkViewManager::UpdateProperty(
       button.IsEnabled(!propertyValue.asBool());
   } else if (propertyName == "tooltip") {
     if (propertyValue.isString()) {
-      winrt::TextBlock tooltip = winrt::TextBlock();
-      tooltip.Text(asHstring(propertyValue));
-      winrt::ToolTipService::SetToolTip(button, tooltip);
+      winrt::ToolTipService::SetToolTip(button, winrt::box_value(asHstring(propertyValue));
     }
   } else if (propertyName == "url") {
     winrt::Uri myUri(asHstring(propertyValue));

--- a/vnext/Microsoft.ReactNative/Polyester/HyperlinkViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Polyester/HyperlinkViewManager.cpp
@@ -71,7 +71,7 @@ bool HyperlinkViewManager::UpdateProperty(
       button.IsEnabled(!propertyValue.asBool());
   } else if (propertyName == "tooltip") {
     if (propertyValue.isString()) {
-      winrt::ToolTipService::SetToolTip(button, winrt::box_value(asHstring(propertyValue));
+      winrt::ToolTipService::SetToolTip(button, winrt::box_value(asHstring(propertyValue)));
     }
   } else if (propertyName == "url") {
     winrt::Uri myUri(asHstring(propertyValue));


### PR DESCRIPTION
Followup to #5626 - make sure hyperlinks use string tooltips instead of a textbox so that word-wrapping works as expected

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5734)