### PR TITLE
Restore Previous Behavior Allowing onMouseEnter and onMouseLeave on Touchables

### DIFF
--- a/change/react-native-windows-2020-08-14-09-57-33-fix-touchable-mouse.json
+++ b/change/react-native-windows-2020-08-14-09-57-33-fix-touchable-mouse.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Restore Previous Behavior Allowing onMouseEnter and onMouseLeave on Touchables",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T16:57:33.938Z"
+}

--- a/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
+++ b/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
@@ -52,6 +52,7 @@ let pages = [
   'Layout Events',
   'Linking',
   'Layout - Flexbox',
+  'Mouse Events',
   'Native Animated Example',
   'PanResponder Sample',
   'PlatformColor',

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -69,7 +69,6 @@
                     <ComboBoxItem Content="Samples\image" />
                     <ComboBoxItem Content="Samples\index" />
                     <ComboBoxItem Content="Samples\messages" />
-                    <ComboBoxItem Content="Samples\mouse" />
                     <ComboBoxItem Content="Samples\scrollViewSnapSample" />
                     <ComboBoxItem Content="Samples\simple" />
                     <ComboBoxItem Content="Samples\text" />

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -29,6 +29,8 @@
 <PROJECT_ROOT>/Libraries/Network/RCTNetworking.js
 <PROJECT_ROOT>/Libraries/NewAppScreen/components/DebugInstructions.js
 <PROJECT_ROOT>/Libraries/NewAppScreen/components/ReloadInstructions.js
+<PROJECT_ROOT>/Libraries/Pressability/Pressability.js
+<PROJECT_ROOT>/Libraries/Types/CoreEventTypes.js
 <PROJECT_ROOT>/RNTester/js/components/ListExampleShared.js
 <PROJECT_ROOT>/RNTester/js/components/RNTesterExampleList.js
 <PROJECT_ROOT>/RNTester/js/examples/ScrollView/ScrollViewExample.js

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -437,7 +437,7 @@
     },
     {
       "type": "patch",
-      "file": "src/Libraries/Types/CoreEventTypes.js",
+      "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
       "baseVersion": "0.0.0-d8e6c4578",
       "baseHash": "83b203d547d9bdc57a8f3346ecee6f6e34b25f5d",

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -176,6 +176,8 @@ class TouchableHighlight extends React.Component<Props, State> {
       delayPressOut: this.props.delayPressOut,
       pressRectOffset: this.props.pressRetentionOffset,
       android_disableSound: this.props.touchSoundDisabled,
+      onMouseEnter: this.props.onMouseEnter, // [Windows]
+      onMouseLeave: this.props.onMouseLeave, // [Windows]
       onBlur: event => {
         if (Platform.isTV) {
           this._hideUnderlay();

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
@@ -148,6 +148,8 @@ class TouchableOpacity extends React.Component<Props, State> {
       delayPressIn: this.props.delayPressIn,
       delayPressOut: this.props.delayPressOut,
       pressRectOffset: this.props.pressRetentionOffset,
+      onMouseEnter: this.props.onMouseEnter, // [Windows]
+      onMouseLeave: this.props.onMouseLeave, // [Windows]
       onBlur: event => {
         if (Platform.isTV) {
           this._opacityInactive(250);

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -27,6 +27,7 @@ import type {
   BlurEvent,
   FocusEvent,
   LayoutEvent,
+  MouseEvent, // [Windows]
   PressEvent,
 } from '../../Types/CoreEventTypes';
 import Platform from '../../Utilities/Platform';
@@ -70,8 +71,8 @@ type Props = $ReadOnly<{|
   accessibilityPosInSet?: ?number, // [Windows]
   accessibilitySetSize?: ?number, // [Windows]
   onAccessibilityTap?: ?() => void, // [Windows]
-  onMouseEnter?: ?(event: SyntheticEvent<{}>) => void, // [Windows]
-  onMouseLeave?: ?(event: SyntheticEvent<{}>) => void, // [Windows]
+  onMouseEnter?: ?(event: MouseEvent) => void, // [Windows]
+  onMouseLeave?: ?(event: MouseEvent) => void, // [Windows]
   tabIndex?: ?number, // [Windows]
   tooltip?: ?Stringish, // [Windows]
 |}>;
@@ -206,6 +207,8 @@ function createPressabilityConfig(props: Props): PressabilityConfig {
     onPress: props.onPress,
     onPressIn: props.onPressIn,
     onPressOut: props.onPressOut,
+    onMouseEnter: props.onMouseEnter, // [Windows]
+    onMouseLeave: props.onMouseLeave, // [Windows]
   };
 }
 

--- a/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
@@ -435,8 +435,8 @@ type WindowsViewProps = $ReadOnly<{|
 
   onFocus?: ?(event: FocusEvent) => mixed,
   onBlur?: ?(event: FocusEvent) => mixed,
-  onMouseLeave?: ?(event: SyntheticEvent<{}>) => mixed,
-  onMouseEnter?: ?(event: SyntheticEvent<{}>) => mixed,
+  onMouseLeave?: ?(event: MouseEvent) => mixed,
+  onMouseEnter?: ?(event: MouseEvent) => mixed,
 |}>;
 // Windows]
 

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -146,6 +146,22 @@ export type PressabilityConfig = $ReadOnly<{|
    * @deprecated
    */
   onStartShouldSetResponder_DEPRECATED?: ?() => boolean,
+
+  // [Windows
+  /**
+   * Raw handler for onMouseEnter that will be preferred if set over hover
+   * events. This is to preserve compatibility with pre-0.62 behavior which
+   * allowed attaching mouse event handlers to Touchables
+   */
+  onMouseEnter?: ?(event: MouseEvent) => mixed,
+
+  /**
+   * Raw handler for onMouseLeave that will be preferred if set over hover
+   * events. This is to preserve compatibility with pre-0.62 behavior which
+   * allowed attaching mouse event handlers to Touchables
+   */
+  onMouseLeave?: ?(event: MouseEvent) => mixed,
+  // Windows]
 |}>;
 
 export type EventHandlers = $ReadOnly<{|
@@ -562,6 +578,13 @@ export default class Pressability {
         ? null
         : {
             onMouseEnter: (event: MouseEvent): void => {
+              // [Windows Prefer attached raw mouse event handler for compat
+              if (this._config.onMouseEnter) {
+                this._config.onMouseEnter(event);
+                return;
+              }
+              // Windows]
+
               if (isHoverEnabled()) {
                 this._isHovered = true;
                 this._cancelHoverOutDelayTimeout();
@@ -582,6 +605,13 @@ export default class Pressability {
             },
 
             onMouseLeave: (event: MouseEvent): void => {
+              // [Windows Prefer attached raw mouse event handler for compat
+              if (this._config.onMouseLeave) {
+                this._config.onMouseLeave(event);
+                return;
+              }
+              // Windows]
+
               if (this._isHovered) {
                 this._isHovered = false;
                 this._cancelHoverInDelayTimeout();

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -578,10 +578,9 @@ export default class Pressability {
         ? null
         : {
             onMouseEnter: (event: MouseEvent): void => {
-              // [Windows Prefer attached raw mouse event handler for compat
+              // [Windows Add attached raw mouse event handler for compat
               if (this._config.onMouseEnter) {
                 this._config.onMouseEnter(event);
-                return;
               }
               // Windows]
 
@@ -605,10 +604,9 @@ export default class Pressability {
             },
 
             onMouseLeave: (event: MouseEvent): void => {
-              // [Windows Prefer attached raw mouse event handler for compat
+              // [Windows Add attached raw mouse event handler for compat
               if (this._config.onMouseLeave) {
                 this._config.onMouseLeave(event);
-                return;
               }
               // Windows]
 

--- a/vnext/src/Libraries/Types/CoreEventTypes.windows.js
+++ b/vnext/src/Libraries/Types/CoreEventTypes.windows.js
@@ -151,15 +151,32 @@ export type FocusEvent = SyntheticEvent<
   |}>,
 >;
 
+// [Windows Mouse events on Windows don't match up with the version in core
+// introduced for react-native-web. Replace typings with our values to catch
+// anything dependent on react-native-web specific values
 export type MouseEvent = SyntheticEvent<
   $ReadOnly<{|
-    clientX: number,
-    clientY: number,
+    target: number,
+    identifier: number,
     pageX: number,
     pageY: number,
+    locationX: number,
+    locationY: number,
     timestamp: number,
+    pointerType: string,
+    force: number,
+    isLeftButton: boolean,
+    isRightButton: boolean,
+    isMiddleButton: boolean,
+    isBarrelButtonPressed: boolean,
+    isHorizontalScrollWheel: boolean,
+    isEraser: boolean,
+    shiftKey: boolean,
+    ctrlKey: boolean,
+    altKey: boolean,
   |}>,
 >;
+// Windows]
 
 // [Windows
 export type KeyEvent = SyntheticEvent<

--- a/vnext/src/RNTester/js/examples-win/Mouse/MouseExample.windows.js
+++ b/vnext/src/RNTester/js/examples-win/Mouse/MouseExample.windows.js
@@ -3,16 +3,31 @@
  * Licensed under the MIT License.
  * @format
  */
-import * as React from 'react';
-import {
-  AppRegistry,
+
+'use strict';
+
+const React = require('react');
+
+const {
   StyleSheet,
   View,
   Text,
   GestureResponderEvent,
   TouchableHighlight,
   BackHandler,
-} from 'react-native';
+} = require('react-native');
+
+exports.displayName = 'MouseExample';
+exports.title = 'Mouse Events';
+exports.description = 'Tests that mouse events can be observed';
+exports.examples = [
+  {
+    title: 'onMouseEnter and onMouseLeave affect style\n',
+    render: function(): React.Node {
+      return <ExampleComponent />;
+    },
+  },
+];
 
 const styles = StyleSheet.create({
   page: {
@@ -68,16 +83,16 @@ const styles = StyleSheet.create({
   },
 });
 
-export default class Bootstrap extends React.Component<
+export default class ExampleComponent extends React.Component<
   {},
   {
-    clicked: number;
-    pageHover: boolean;
-    contentHover: boolean;
-    contentChildHover: boolean;
-    overlayHover: boolean;
-    overlayChildHover: boolean;
-  }
+    clicked: number,
+    pageHover: boolean,
+    contentHover: boolean,
+    contentChildHover: boolean,
+    overlayHover: boolean,
+    overlayChildHover: boolean,
+  },
 > {
   constructor(props: {}) {
     super(props);
@@ -225,5 +240,3 @@ export default class Bootstrap extends React.Component<
     return true;
   };
 }
-
-AppRegistry.registerComponent('Bootstrap', () => Bootstrap);

--- a/vnext/src/RNTester/js/utils/RNTesterList.windows.ts
+++ b/vnext/src/RNTester/js/utils/RNTesterList.windows.ts
@@ -222,6 +222,10 @@ const APIExamples: Array<IRNTesterExample> = [
     module: require('react-native/RNTester/js/examples/Layout/LayoutExample'),
   },
   {
+    key: 'MouseExample',
+    module: require('./../examples-win/Mouse/MouseExample'),
+  },
+  {
     key: 'NativeAnimationsExample',
     module: require('react-native/RNTester/js/examples/NativeAnimation/NativeAnimationsExample'),
   },


### PR DESCRIPTION
Fixes #5715

See issue for some discussion. Pointer handling in RNW is something of a mess right now, but we need to preserve existing compatibility after conflicting mouse handling changes for Pressability changes were introduced. Fixup MouseEvent typings, add raw MouseEvent handlers to Pressability, and hook those to Touchables to allow previous behavior. We will need to reconcile this with other platforms eventually.

I don't hook this up to Pressable. This leaves it impossible to add hover styling to Pressable, but I would rather we wait until we have a more generalized solution for MouseEvents before forking more component APIs we will need to worry about breaking later.

Moved a mouse sample that existed in Playground to RNTester to try to catch mouse regressions in the future. Discovered our forked CoreEventTypes wasn't using the ".windows.js" platform suffix and fixed that.

Validated in the mouse example that the TouchableHighlight with mouse event handlers now see styling changes when hovered over.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5736)