### PR TITLE
[0.62] Restore Previous Behavior Allowing onMouseEnter and onMouseLeave on Touchables (#5736)

### DIFF
--- a/change/react-native-windows-2020-08-14-09-57-33-fix-touchable-mouse.json
+++ b/change/react-native-windows-2020-08-14-09-57-33-fix-touchable-mouse.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Restore Previous Behavior Allowing onMouseEnter and onMouseLeave on Touchables",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T16:57:33.938Z"
+}

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -68,7 +68,6 @@
                     <ComboBoxItem Content="Samples\image" />
                     <ComboBoxItem Content="Samples\index" />
                     <ComboBoxItem Content="Samples\messages" />
-                    <ComboBoxItem Content="Samples\mouse" />
                     <ComboBoxItem Content="Samples\scrollViewSnapSample" />
                     <ComboBoxItem Content="Samples\simple" />
                     <ComboBoxItem Content="Samples\text" />

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -43,6 +43,8 @@
 <PROJECT_ROOT>/Libraries/StyleSheet/processColor.js
 <PROJECT_ROOT>/Libraries/StyleSheet/processColorArray.js
 <PROJECT_ROOT>/Libraries/StyleSheet/StyleSheetTypes.js
+<PROJECT_ROOT>/Libraries/Pressability/Pressability.js
+<PROJECT_ROOT>/Libraries/Types/CoreEventTypes.js
 <PROJECT_ROOT>/RNTester/js/components/ListExampleShared.js
 <PROJECT_ROOT>/RNTester/js/components/RNTesterExampleList.js
 <PROJECT_ROOT>/RNTester/js/examples/ScrollView/ScrollViewExample.js

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -176,6 +176,8 @@ class TouchableHighlight extends React.Component<Props, State> {
       getPressOutDelayMS: () => this.props.delayPressOut,
       getPressRectOffset: () => this.props.pressRetentionOffset,
       getTouchSoundDisabled: () => this.props.touchSoundDisabled,
+      onMouseEnter: this.props.onMouseEnter, // [Windows]
+      onMouseLeave: this.props.onMouseLeave, // [Windows]
       onBlur: event => {
         if (Platform.isTV) {
           this._hideUnderlay();

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
@@ -150,6 +150,8 @@ class TouchableOpacity extends React.Component<Props, State> {
       getPressDelayMS: () => this.props.delayPressIn,
       getPressOutDelayMS: () => this.props.delayPressOut,
       getPressRectOffset: () => this.props.pressRetentionOffset,
+      onMouseEnter: this.props.onMouseEnter, // [Windows]
+      onMouseLeave: this.props.onMouseLeave, // [Windows]
       onBlur: event => {
         if (Platform.isTV) {
           this._opacityInactive(250);

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -27,6 +27,7 @@ import type {
   BlurEvent,
   FocusEvent,
   LayoutEvent,
+  MouseEvent, // [Windows]
   PressEvent,
 } from '../../Types/CoreEventTypes';
 import Platform from '../../Utilities/Platform';
@@ -70,8 +71,8 @@ type Props = $ReadOnly<{|
   accessibilityPosInSet?: ?number, // [Windows]
   accessibilitySetSize?: ?number, // [Windows]
   onAccessibilityTap?: ?() => void, // [Windows]
-  onMouseEnter?: ?(event: SyntheticEvent<{}>) => void, // [Windows]
-  onMouseLeave?: ?(event: SyntheticEvent<{}>) => void, // [Windows]
+  onMouseEnter?: ?(event: MouseEvent) => void, // [Windows]
+  onMouseLeave?: ?(event: MouseEvent) => void, // [Windows]
   tabIndex?: ?number, // [Windows]
   tooltip?: ?Stringish, // [Windows]
 |}>;
@@ -127,6 +128,8 @@ class TouchableWithoutFeedback extends React.Component<Props, State> {
       getPressOutDelayMS: () => this.props.delayPressOut,
       getPressRectOffset: () => this.props.pressRetentionOffset,
       getTouchSoundDisabled: () => this.props.touchSoundDisabled,
+      onMouseEnter: this.props.onMouseEnter, // [Windows]
+      onMouseLeave: this.props.onMouseLeave, // [Windows]
       onBlur: event => {
         if (this.props.onBlur != null) {
           this.props.onBlur(event);

--- a/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
@@ -434,8 +434,8 @@ type WindowsViewProps = $ReadOnly<{|
 
   onFocus?: ?(event: FocusEvent) => mixed,
   onBlur?: ?(event: FocusEvent) => mixed,
-  onMouseLeave?: ?(event: SyntheticEvent<{}>) => mixed,
-  onMouseEnter?: ?(event: SyntheticEvent<{}>) => mixed,
+  onMouseLeave?: ?(event: MouseEvent) => mixed,
+  onMouseEnter?: ?(event: MouseEvent) => mixed,
 |}>;
 // Windows]
 

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -20,7 +20,7 @@ import type {
   PressEvent,
   MouseEvent,
   KeyEvent, // [Windows]
-} from '../Types/CoreEventTypes.js';
+} from '../Types/CoreEventTypes'; // [Windows] remove explicit .js
 import Platform from '../Utilities/Platform';
 import UIManager from '../ReactNative/UIManager';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
@@ -129,6 +129,22 @@ export type PressabilityConfig = $ReadOnly<{|
    * Returns whether to start a press gesture.
    */
   onStartShouldSetResponder?: ?() => boolean,
+
+  // [Windows
+  /**
+   * Raw handler for onMouseEnter that will be preferred if set over hover
+   * events. This is to preserve compatibility with pre-0.62 behavior which
+   * allowed attaching mouse event handlers to Touchables
+   */
+  onMouseEnter?: ?(event: MouseEvent) => mixed,
+
+  /**
+   * Raw handler for onMouseLeave that will be preferred if set over hover
+   * events. This is to preserve compatibility with pre-0.62 behavior which
+   * allowed attaching mouse event handlers to Touchables
+   */
+  onMouseLeave?: ?(event: MouseEvent) => mixed,
+  // Windows]
 |}>;
 
 type EventHandlers = $ReadOnly<{|
@@ -528,6 +544,12 @@ export default class Pressability {
         ? null
         : {
             onMouseEnter: (event: MouseEvent): void => {
+              // [Windows Add attached raw mouse event handler for compat
+              if (this._config.onMouseEnter) {
+                this._config.onMouseEnter(event);
+              }
+              // Windows]
+
               if (isHoverEnabled()) {
                 this._isHovered = true;
                 this._cancelHoverOutDelayTimeout();
@@ -546,6 +568,12 @@ export default class Pressability {
             },
 
             onMouseLeave: (event: MouseEvent): void => {
+              // [Windows Add attached raw mouse event handler for compat
+              if (this._config.onMouseLeave) {
+                this._config.onMouseLeave(event);
+              }
+              // Windows]
+
               if (this._isHovered) {
                 this._isHovered = false;
                 this._cancelHoverInDelayTimeout();

--- a/vnext/src/Libraries/Types/CoreEventTypes.windows.js
+++ b/vnext/src/Libraries/Types/CoreEventTypes.windows.js
@@ -151,15 +151,32 @@ export type FocusEvent = SyntheticEvent<
   |}>,
 >;
 
+// [Windows Mouse events on Windows don't match up with the version in core
+// introduced for react-native-web. Replace typings with our values to catch
+// anything dependent on react-native-web specific values
 export type MouseEvent = SyntheticEvent<
   $ReadOnly<{|
-    clientX: number,
-    clientY: number,
+    target: number,
+    identifier: number,
     pageX: number,
     pageY: number,
+    locationX: number,
+    locationY: number,
     timestamp: number,
+    pointerType: string,
+    force: number,
+    isLeftButton: boolean,
+    isRightButton: boolean,
+    isMiddleButton: boolean,
+    isBarrelButtonPressed: boolean,
+    isHorizontalScrollWheel: boolean,
+    isEraser: boolean,
+    shiftKey: boolean,
+    ctrlKey: boolean,
+    altKey: boolean,
   |}>,
 >;
+// Windows]
 
 // [Windows
 export type KeyEvent = SyntheticEvent<

--- a/vnext/src/RNTester/js/examples-win/Mouse/MouseExample.windows.js
+++ b/vnext/src/RNTester/js/examples-win/Mouse/MouseExample.windows.js
@@ -3,16 +3,31 @@
  * Licensed under the MIT License.
  * @format
  */
-import * as React from 'react';
-import {
-  AppRegistry,
+
+'use strict';
+
+const React = require('react');
+
+const {
   StyleSheet,
   View,
   Text,
   GestureResponderEvent,
   TouchableHighlight,
   BackHandler,
-} from 'react-native';
+} = require('react-native');
+
+exports.displayName = 'MouseExample';
+exports.title = 'Mouse Events';
+exports.description = 'Tests that mouse events can be observed';
+exports.examples = [
+  {
+    title: 'onMouseEnter and onMouseLeave affect style\n',
+    render: function(): React.Node {
+      return <ExampleComponent />;
+    },
+  },
+];
 
 const styles = StyleSheet.create({
   page: {
@@ -68,16 +83,16 @@ const styles = StyleSheet.create({
   },
 });
 
-export default class Bootstrap extends React.Component<
+export default class ExampleComponent extends React.Component<
   {},
   {
-    clicked: number;
-    pageHover: boolean;
-    contentHover: boolean;
-    contentChildHover: boolean;
-    overlayHover: boolean;
-    overlayChildHover: boolean;
-  }
+    clicked: number,
+    pageHover: boolean,
+    contentHover: boolean,
+    contentChildHover: boolean,
+    overlayHover: boolean,
+    overlayChildHover: boolean,
+  },
 > {
   constructor(props: {}) {
     super(props);
@@ -225,5 +240,3 @@ export default class Bootstrap extends React.Component<
     return true;
   };
 }
-
-AppRegistry.registerComponent('Bootstrap', () => Bootstrap);

--- a/vnext/src/RNTester/js/utils/RNTesterList.windows.ts
+++ b/vnext/src/RNTester/js/utils/RNTesterList.windows.ts
@@ -204,6 +204,10 @@ const APIExamples: Array<IRNTesterExample> = [
     module: require('react-native/RNTester/js/examples/Layout/LayoutExample'),
   },
   {
+    key: 'MouseExample',
+    module: require('./../examples-win/Mouse/MouseExample'),
+  },
+  {
     key: 'NativeAnimationsExample',
     module: require('react-native/RNTester/js/examples/NativeAnimation/NativeAnimationsExample'),
   },

--- a/vnext/src/overrides.json
+++ b/vnext/src/overrides.json
@@ -674,7 +674,7 @@
     },
     {
       "type": "patch",
-      "file": "Libraries\\Types\\CoreEventTypes.js",
+      "file": "Libraries\\Types\\CoreEventTypes.windows.js",
       "baseFile": "Libraries\\Types\\CoreEventTypes.js",
       "baseVersion": "0.62.0-rc.3",
       "baseHash": "83b203d547d9bdc57a8f3346ecee6f6e34b25f5d",


### PR DESCRIPTION
* Restore Previous Behavior Allowing onMouseEnter and onMouseLeave on Touchables

Fixes #5715

See issue for some discussion. Pointer handling in RNW is something of a mess right now, but we need to preserve existing compatibility after conflicting Pressability changes were introuced. Fixup MouseEvent typings, add raw MouseEvent handlers to Pressability, and hook those to Touchables to allow previous behavior. We will need to reconcile this with other platforms eventually.

I don't hook this up to Pressable. This leaves it impossible to add hover styling to Pressable, but I would rather we wait until we have a more generalized solution for MouseEvents before forking more component APIs we will need to worry about breaking later.

Moved a mouse sample that existed in Playground to RNTester to try to catch mouse regressions in the future. Discovered our forked CoreEventTypes wasn't using the ".windows.js" platform suffix and fixed that.

* Change files

* Fix overrides and feedback

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5738)