### PR TITLE
[Playground] Allow entering freeform app name

### DIFF
--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -51,7 +51,13 @@ void MainPage::OnLoadClick(
   }
   host.InstanceSettings().JavaScriptBundleFile(bundleFile);
 
-  auto mainComponentName = unbox_value<hstring>(x_rootComponentNameCombo().SelectedItem().as<ComboBoxItem>().Content());
+  auto item = x_rootComponentNameCombo().SelectedItem();
+  winrt::hstring mainComponentName;
+  if (auto selected = item.try_as<ComboBoxItem>()) {
+    mainComponentName = unbox_value<hstring>(selected.Content());
+  } else {
+    mainComponentName = unbox_value<hstring>(item);
+  }
   ReactRootView().ComponentName(mainComponentName);
   ReactRootView().ReactNativeHost(host);
 


### PR DESCRIPTION
The playground app allows manually entering an app name in the combobox but it doesn't handle it correctly (the app crashes when trying to cast the hstring to a combobox item).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5746)