### PR TITLE
Ensure PR Nuget and NPM Test Versions Match

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,12 +70,12 @@ steps:
     inputs:
       versionSpec: ">=4.6.0"
 
-- ${{ if eq(parameters.useNuGet, true) }}:
-  - template: templates/prep-and-pack-nuget.yml
-    parameters:
-      npmVersion: $(npmVersion)
-      packDesktop: false
-      slices: '("${{ parameters.platform }}.${{ parameters.configuration }}")'
+  - ${{ if eq(parameters.useNuGet, true) }}:
+    - template: templates/prep-and-pack-nuget.yml
+      parameters:
+        npmVersion: $(npmVersion)
+        packDesktop: false
+        slices: '("${{ parameters.platform }}.${{ parameters.configuration }}")'
 
   # We force the usage of npm instead of yarn becuase yarn has fragility issues when redirected to a different server (such as verdaccio)
   - task: CmdLine@2

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
     inputs:
       versionSpec: ">=4.6.0"
 
-- ${{ if eq(parameters.useNuGet, true) }}
+- ${{ if eq(parameters.useNuGet, true) }}:
   - template: templates/prep-and-pack-nuget.yml
     parameters:
       npmVersion: $(npmVersion)

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -71,7 +71,7 @@ steps:
       versionSpec: ">=4.6.0"
 
   - ${{ if eq(parameters.useNuGet, true) }}:
-    - template: templates/prep-and-pack-nuget.yml
+    - template: prep-and-pack-nuget.yml
       parameters:
         npmVersion: $(npmVersion)
         packDesktop: false

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,6 +70,13 @@ steps:
     inputs:
       versionSpec: ">=4.6.0"
 
+- ${{ if parameters.useNuGet }}
+  - template: templates/prep-and-pack-nuget.yml
+    parameters:
+      npmVersion: $(npmVersion)
+      packDesktop: false
+      slices: '("${{ parameters.platform }}.${{ parameters.configuration }}")'
+
   # We force the usage of npm instead of yarn becuase yarn has fragility issues when redirected to a different server (such as verdaccio)
   - task: CmdLine@2
     displayName: Init new project
@@ -77,13 +84,6 @@ steps:
       script: npx react-native init testcli --npm --template react-native@$(reactNativeDevDependency)
       workingDirectory: $(Agent.BuildDirectory)
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Nuget Test Feed'
-    inputs:
-      artifactName: NuGetTestFeed
-      downloadPath: $(System.DefaultWorkingDirectory)
-    condition: and(succeeded(), ${{ parameters.useNuGet }})
-    
   - task: CmdLine@2
     displayName: Apply windows template (with nuget)
     inputs:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
     inputs:
       versionSpec: ">=4.6.0"
 
-- ${{ if parameters.useNuGet }}
+- ${{ if eq(parameters.useNuGet, true) }}
   - template: templates/prep-and-pack-nuget.yml
     parameters:
       npmVersion: $(npmVersion)

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -699,8 +699,6 @@ jobs:
     steps:
       - checkout: none
 
-      - template: templates/apply-published-version-vars.yml
-
       # The commit tag in the nuspec requires that we use at least NuGet 4.6
       - task: NuGetToolInstaller@0
         inputs:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -586,7 +586,7 @@ jobs:
       and
       (
         ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' ),
-        in(dependencies.RNWUniversalPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
+        in(dependencies.RNWUniversalPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
       )
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -678,33 +678,3 @@ jobs:
     parameters:
       name: E2ETest
       BuildPlatform: x64
-
-  - job: RNWNugetPR
-    displayName: Build and Pack NuGet
-    dependsOn:
-      - Setup
-      - RNWUniversalPR
-      - RNWDesktopPR
-    condition: |
-      and
-      (
-        ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' ),
-        in(dependencies.RNWUniversalPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-        in(dependencies.RNWDesktopPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-      )
-    pool:
-      vmImage: $(VmImage)
-    timeoutInMinutes: 30
-    cancelTimeoutInMinutes: 5
-    steps:
-      - checkout: none
-
-      # The commit tag in the nuspec requires that we use at least NuGet 4.6
-      - task: NuGetToolInstaller@0
-        inputs:
-          versionSpec: ">=4.6.0"
-
-      - template: templates/prep-and-pack-nuget.yml
-        parameters:
-          slices: '("x64.Release", "x86.Debug", "ARM.Release")'
-

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -581,14 +581,12 @@ jobs:
     displayName: Verify react-native init experimental
     dependsOn:
      - Setup
-     - RNWNugetPR
+     - RNWUniversalPR
     condition: |
       and
       (
         ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' ),
-        in(dependencies.RNWNugetPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
         in(dependencies.RNWUniversalPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-        in(dependencies.RNWDesktopPR.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
       )
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
@@ -608,8 +606,8 @@ jobs:
           platform: x86
           useNuGet: true
 
-  - job: JSTasks
-    displayName: JavaScript Tasks
+  - job: JSChecks
+    displayName: JavaScript Checks
     dependsOn: Setup
     condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
     pool:
@@ -676,14 +674,6 @@ jobs:
         inputs:
           script: yarn api
 
-      - script: |
-          npx --no-install beachball bump --branch origin/$(System.PullRequest.TargetBranch)
-        displayName: Bump packages
-
-      - template: templates/set-version-vars.yml
-
-      - template: templates/publish-version-vars.yml
-
   - template: templates/e2e-test-job.yml # Template reference
     parameters:
       name: E2ETest
@@ -695,7 +685,6 @@ jobs:
       - Setup
       - RNWUniversalPR
       - RNWDesktopPR
-      - JSTasks
     condition: |
       and
       (
@@ -720,10 +709,4 @@ jobs:
       - template: templates/prep-and-pack-nuget.yml
         parameters:
           slices: '("x64.Release", "x86.Debug", "ARM.Release")'
-          npmVersion: $(npmVersion)
 
-      - task: PublishBuildArtifacts@1
-        displayName: Upload PR NuGet Test feed
-        inputs:
-          pathtoPublish: $(System.DefaultWorkingDirectory)/NuGetTestFeed
-          artifactName: NuGetTestFeed


### PR DESCRIPTION
Right now we publish NuGet packages to a test feed in RNWNugetPR using the current NPM version, then download that in react-native-init tests. NPM versions might have changed since the initial NuGet package creation if a new NPM version has been published since then.

This change makes it so that NuGet packages are packed to the local test feed after JS publish in react-native-init tests. This should ensure NPM versions match, and lets us avoid trying to match NPM versions in the earlier NuGet PR.

This shouldn't extend the critical path, and actually now lets us start init tests before the desktop PR has finished and also to download/pack a bit less in react-native-init PRs.  Note that we keep the existing NuGet packing step in PR, since it will have desktop coverage that init tests won't.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5753)