### PR TITLE
[0.62] Update react-native config to handle (userConfig === null)

### DIFF
--- a/change/react-native-windows-2020-08-17-10-34-34-removeconfig62.json
+++ b/change/react-native-windows-2020-08-17-10-34-34-removeconfig62.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[0.62] Update react-native config to handle ( userConfig === null)",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T17:34:34.863Z"
+}

--- a/vnext/local-cli/config/dependencyConfig.js
+++ b/vnext/local-cli/config/dependencyConfig.js
@@ -4,6 +4,10 @@ const glob = require('glob');
 const xmldoc = require('xmldoc');
 
 function dependencyConfigWindows(folder, userConfig = {}) {
+  if (userConfig === null) {
+    return null;
+  }
+  
   const sourceDir = userConfig.sourceDir || findWindowsAppFolder(folder);
 
   if (!sourceDir) {

--- a/vnext/local-cli/config/projectConfig.js
+++ b/vnext/local-cli/config/projectConfig.js
@@ -3,6 +3,10 @@ const path = require('path');
 const glob = require('glob');
 
 function projectConfigWindows(folder, userConfig = {}) {
+  if (userConfig === null) {
+    return null;
+  }
+  
   const sourceDir = userConfig.sourceDir || findWindowsAppFolder(folder);
 
   if (!sourceDir) {


### PR DESCRIPTION
The react-native config implementation introduced in RNW 0.61 does not
properly handle when userConfig is explicitly null. This can cause
errors when projects use null (correctly) to prevent the config from
running.

Closes #5752

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5754)