### PR TITLE
Fix CI for 0.62-stable

### DIFF
--- a/change/react-native-windows-2020-08-17-13-49-27-fix-62-ci.json
+++ b/change/react-native-windows-2020-08-17-13-49-27-fix-62-ci.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix CI for 0.62-stable",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-17T20:49:27.634Z"
+}

--- a/vnext/src/overrides.json
+++ b/vnext/src/overrides.json
@@ -800,6 +800,10 @@
     },
     {
       "type": "platform",
+      "file": "RNTester\\js\\examples-win\\Mouse\\MouseExample.windows.js"
+    },
+    {
+      "type": "platform",
       "file": "RNTester\\js\\examples-win\\Picker\\PickerWindowsExample.tsx"
     },
     {


### PR DESCRIPTION
Fallout from my last change. Extra Checks was seeing repeated timeouts due to Network Issues, so I pushed the PR in without it passing after locally validating. Looks like I missed something, since 0.62 didn't exempt examples-win from override validation and I didn't add it to the 0.62 manifest.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5755)