### PR TITLE
[0.63] Update nuspec copyright header to use xml entity

### DIFF
--- a/change/react-native-windows-2020-08-18-12-19-10-0.63-stable.json
+++ b/change/react-native-windows-2020-08-18-12-19-10-0.63-stable.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update nuspec copyright header to use xml entity as some of the powershell processing we do messed up the encoding",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-18T19:19:10.241Z"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.Cxx.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Cxx.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>https://github.com/microsoft/react-native-windows</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>https://github.com/microsoft/react-native-windows</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>https://github.com/microsoft/react-native-windows</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>https://github.com/microsoft/react-native-windows</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>https://github.com/microsoft/react-native-windows</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <repository type="git"
       url="https://github.com/microsoft/react-native-windows.git"
       commit="$CommitId$" />


### PR DESCRIPTION
Update nuspec copyright header to use xml entity as some of the powerhell processing we do messed up the encoding

This is the backport of change: #5765

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5764)