### PR TITLE
[Win32] Publish TS files in src as they are references in sourcemaps

### DIFF
--- a/change/@office-iss-react-native-win32-2020-08-18-16-33-02-sourcemap.json
+++ b/change/@office-iss-react-native-win32-2020-08-18-16-33-02-sourcemap.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Publish TS files in src as they are references in sourcemaps",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-18T23:33:02.199Z"
+}

--- a/packages/react-native-win32/.npmignore
+++ b/packages/react-native-win32/.npmignore
@@ -6,7 +6,7 @@
 /lib/tester/index.win32.bundle*
 /lib/tester/index.win32.dev.bundle*
 /scripts
-/src
+/src/**/*.js
 /temp
 /ts-api.json
 /tsconfig.json


### PR DESCRIPTION
The sourcemap files currently point to files in src, which are not part of the published package, which makes for a poor debugging experience.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5774)