### PR TITLE
Use explicit calling convention for IWebSocketResource::Make

### DIFF
--- a/change/react-native-windows-2020-08-18-21-02-07-iwscallconv.json
+++ b/change/react-native-windows-2020-08-18-21-02-07-iwscallconv.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Export IWebSocketResource::Make as __cdecl",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T04:02:07.302Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -15,7 +15,7 @@ namespace Microsoft::React {
 #pragma region IWebSocketResource static members
 
 /*static*/
-shared_ptr<IWebSocketResource> IWebSocketResource::Make(string &&urlString) {
+shared_ptr<IWebSocketResource> __cdecl IWebSocketResource::Make(string &&urlString) {
   if (!GetRuntimeOptionBool("UseBeastWebSocket")) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (GetRuntimeOptionBool("WebSocket.AcceptSelfSigned")) {

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -83,7 +83,7 @@ struct IWebSocketResource {
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::shared_ptr<IWebSocketResource> Make(std::string &&url);
+  static std::shared_ptr<IWebSocketResource> __cdecl Make(std::string &&url);
 
   virtual ~IWebSocketResource() noexcept {}
 


### PR DESCRIPTION
On x86, the default/implicit calling convention is `__stdcall`.

An ARM64 application consuming `react-native-win32.dll` may face linking errors when invoking `IWebSocketResource::Make` (ARM64 seems to expect `__cdecl` by default).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5778)