### PR TITLE
Add --singleproc option to run-windows

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -556,13 +556,13 @@ jobs:
           configuration: Debug
           platform: x86
           additionalInitArguments: --useWinUI3 true
-          additionalRunArguments:
+          additionalRunArguments: --singleproc
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
           additionalInitArguments: --useWinUI3 true
-          additionalRunArguments:
+          additionalRunArguments: --singleproc
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/change/@react-native-windows-cli-2020-08-19-14-49-47-mp.json
+++ b/change/@react-native-windows-cli-2020-08-19-14-49-47-mp.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add --singleproc to run-windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:49:47.080Z"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -106,6 +106,7 @@ async function runWindows(
         verbose,
         undefined, // build the default target
         options.buildLogDirectory,
+        options.singleproc,
       );
     } catch (e) {
       newError(

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -14,6 +14,7 @@ export type BuildConfig = 'Debug' | 'DebugBundle' | 'Release' | 'ReleaseBundle';
  *    release: Boolean - Specifies release build
  *    root: String - The root of the application
  *    arch: String - The build architecture (x86, x64, ARM, Any CPU)
+ *    singleproc: Boolean - opt out of multi-proc builds
  *    emulator: Boolean - Deploy to the emulator
  *    device: Boolean - Deploy to a device
  *    target: String - Device GUID to deploy to
@@ -32,6 +33,7 @@ export interface RunWindowsOptions {
   release?: boolean;
   root: string;
   arch: BuildArch;
+  singleproc?: boolean;
   emulator?: boolean;
   device?: boolean;
   target?: string;
@@ -67,6 +69,10 @@ export const runWindowsOptions: CommandOption[] = [
     description: 'The build architecture (ARM, ARM64, x86, x64)',
     default: 'x86',
     parse: parseBuildArch,
+  },
+  {
+    name: '--singleproc',
+    description: 'Disables multi-proc build',
   },
   {
     name: '--emulator',

--- a/packages/@react-native-windows/cli/src/runWindows/utils/build.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/build.ts
@@ -21,6 +21,7 @@ export async function buildSolution(
   verbose: boolean,
   target?: string,
   buildLogDirectory?: string,
+  singleproc?: boolean,
 ) {
   const minVersion = new Version(10, 0, 18362, 0);
   const allVersions = MSBuildTools.getAllAvailableUAPVersions();
@@ -38,6 +39,7 @@ export async function buildSolution(
     verbose,
     target,
     buildLogDirectory,
+    singleproc,
   );
 }
 

--- a/packages/@react-native-windows/cli/src/runWindows/utils/checkRequirements.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/checkRequirements.ts
@@ -32,7 +32,7 @@ function shortenVersion(version: Version): string {
 
 function getMinimalRequiredVersionFor(
   requirement: Requirement,
-  windowsTargetVersion: keyof (typeof REQUIRED_VERSIONS),
+  windowsTargetVersion: keyof typeof REQUIRED_VERSIONS,
 ): Version {
   return REQUIRED_VERSIONS[windowsTargetVersion][requirement];
 }

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -56,6 +56,7 @@ export default class MSBuildTools {
     verbose: boolean,
     target: string | undefined,
     buildLogDirectory: string | undefined,
+    singleproc?: boolean,
   ) {
     newSuccess(`Found Solution: ${slnFile}`);
     newInfo(`Build configuration: ${buildType}`);
@@ -78,7 +79,6 @@ export default class MSBuildTools {
     const args = [
       `/clp:NoSummary;NoItemAndPropertyList;Verbosity=${verbosityOption}`,
       '/nologo',
-      '/maxCpuCount',
       `/p:Configuration=${buildType}`,
       `/p:Platform=${buildArch}`,
       '/p:AppxBundle=Never',
@@ -86,6 +86,10 @@ export default class MSBuildTools {
       `/flp1:errorsonly;logfile=${errorLog}`,
       `/flp2:warningsonly;logfile=${warnLog}`,
     ];
+
+    if (!singleproc) {
+      args.push('/maxCpuCount');
+    }
 
     if (target) {
       args.push(`/t:${target}`);


### PR DESCRIPTION
This would be used by winui3 builds to hopefully reduce the occurrence of compiler out of heap space problems

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5784)