### PR TITLE
Revert "Use explicit calling convention for IWebSocketResource::Make"

### DIFF
--- a/change/react-native-windows-2020-08-18-21-02-07-iwscallconv.json
+++ b/change/react-native-windows-2020-08-18-21-02-07-iwscallconv.json
@@ -1,8 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Export IWebSocketResource::Make as __cdecl",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-08-19T04:02:07.302Z"
-}

--- a/change/react-native-windows-2020-08-19-23-34-08-revert-5778-iwscallconv.json
+++ b/change/react-native-windows-2020-08-19-23-34-08-revert-5778-iwscallconv.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Revert \"Use explicit calling convention for IWebSocketResource::Make (#5778)\"",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T06:34:08.180Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -24,7 +24,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -15,7 +15,7 @@ namespace Microsoft::React {
 #pragma region IWebSocketResource static members
 
 /*static*/
-shared_ptr<IWebSocketResource> __cdecl IWebSocketResource::Make(string &&urlString) {
+shared_ptr<IWebSocketResource> IWebSocketResource::Make(string &&urlString) {
   if (!GetRuntimeOptionBool("UseBeastWebSocket")) {
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
     if (GetRuntimeOptionBool("WebSocket.AcceptSelfSigned")) {

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -83,7 +83,7 @@ struct IWebSocketResource {
   /// WebSocket URL address the instance will connect to.
   /// The address's scheme can be either ws:// or wss://.
   /// </param>
-  static std::shared_ptr<IWebSocketResource> __cdecl Make(std::string &&url);
+  static std::shared_ptr<IWebSocketResource> Make(std::string &&url);
 
   virtual ~IWebSocketResource() noexcept {}
 


### PR DESCRIPTION
Reverts microsoft/react-native-windows#5778

The reason Office is hitting the calling convention problem seems to stem from the fact that they are building a native ARM64 DLL and using an x86 react native DLL, which is not supported. After consulting with the CHPE team, it turns out you have to match the architecture of all binaries running on ARM64: either they're all ARM64-native or they're all CHPE (x86-on-arm64), you can't mix and match.
In the original PR I had asked why was IWebSocketResource special that it was triggering this. It turns out that it isn't :) and after speaking with Julio it looks like the fix just kicks the ball forward and you get a different linker error.

So long story short, the previous fix is not needed/correct, and there's an action item on Office/Julio to figure how to ship arm64 that's independent of anything RNW related. Office could, for example, ship a pure arm64 react-windows-win32.dll instead of the x86 one on arm64.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5786)