### PR TITLE
set up collecting crash dumps for cl.exe in CI

### DIFF
--- a/.ado/SetupLocalDumps.cmd
+++ b/.ado/SetupLocalDumps.cmd
@@ -1,12 +1,13 @@
 setlocal
-set CRASHDUMPS_FOLDER=%BUILD_ARTIFACTSTAGINGDIRECTORY%\ReactUWPTestAppTreeDump\CrashDumps
+if "%1"=="" (echo Must provide an executable name to set up local crash dumps for && exit /b 1)
+if "%BUILD_ARTIFACTSTAGINGDIRECTORY%"=="" (echo BUILD_ARTIFACTSTAGINGDIRECTORY must be set to the artifact staging directory && exit /b 2)
+
+set CRASHDUMPS_FOLDER=%BUILD_ARTIFACTSTAGINGDIRECTORY%\CrashDumps
 reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" /s
-reg add  "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ReactUWPTestApp.exe" /v DumpFolder /t REG_SZ /d %CRASHDUMPS_FOLDER%
-reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\ReactUWPTestApp.exe" /v DumpType /t REG_DWORD /d 2
+reg add  "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /v DumpFolder /t REG_SZ /d %CRASHDUMPS_FOLDER%
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /v DumpType /t REG_DWORD /d 2
 if not exist %CRASHDUMPS_FOLDER% ( 
     md %CRASHDUMPS_FOLDER%
-) else (
-    del %CRASHDUMPS_FOLDER%\* /s /q
 )
 
 regedit /S %~dp0%\ReactUWPTestApp.reg

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -29,7 +29,7 @@ jobs:
       - task: CmdLine@2
         displayName: Set LocalDumps
         inputs:
-          script: $(Build.SourcesDirectory)\.ado\SetupLocalDumps.cmd
+          script: $(Build.SourcesDirectory)\.ado\SetupLocalDumps.cmd ReactUWPTestApp
           workingDirectory: $(Build.SourcesDirectory)
 
       - task: NuGetCommand@2

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -58,3 +58,9 @@ steps:
       targetType: inline # filePath | inline
       script: |
         Get-WmiObject Win32_LogicalDisk
+
+  - task: CmdLine@2
+    displayName: Set LocalDumps for cl.exe
+    inputs:
+      script: $(Build.SourcesDirectory)\.ado\SetupLocalDumps.cmd cl
+      workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
we are seeing some builds fail with no error message which hints at cl.exe crashing so I'm setting up collecting cl.exe crash dumps

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5791)