### PR TITLE
Integrate 5/28 Nightly RN Build 

### DIFF
--- a/change/@office-iss-react-native-win32-2020-08-20-13-20-19-integrate-5-28.json
+++ b/change/@office-iss-react-native-win32-2020-08-20-13-20-19-integrate-5-28.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 5/28 Nightly RN Build",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T20:20:17.930Z"
+}

--- a/change/react-native-windows-2020-08-20-13-20-19-integrate-5-28.json
+++ b/change/react-native-windows-2020-08-20-13-20-19-integrate-5-28.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 5/28 Nightly RN Build",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T20:20:19.958Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "prompt-sync": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65",
+    "react-native": "0.0.0-3b7679bd3",
     "react-native-windows": "0.0.0-canary.143"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65",
+    "react-native": "0.0.0-3b7679bd3",
     "react-native-windows": "0.0.0-canary.143"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65",
+    "react-native": "0.0.0-3b7679bd3",
     "react-native-windows": "0.0.0-canary.143"
   },
   "devDependencies": {

--- a/packages/react-native-win32/.flowconfig
+++ b/packages/react-native-win32/.flowconfig
@@ -94,12 +94,6 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FlowFixMeEmpty
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
-suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
-
 experimental.well_formed_exports=true
 experimental.types_first=true
 experimental.abstract_locations=true
@@ -127,4 +121,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.124.0
+^0.125.0

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -8,14 +8,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "494338afabeb89c26bf8f9e911b9167d6ec5741e"
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "a9a9d35f4e64c8d12f9ef604555270e46e05bf9e"
     },
     {
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -23,7 +23,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -31,7 +31,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "611e89285ac812456b381568052cf575c955575a",
       "issue": "LEGACY_FIXME"
     },
@@ -39,7 +39,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "b3e2c37d96de6f00066495267f7c32d6e9d3f840",
       "issue": "LEGACY_FIXME"
     },
@@ -55,7 +55,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.win32.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea",
       "issue": 4378
     },
@@ -63,7 +63,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.win32.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc",
       "issue": 4378
     },
@@ -71,7 +71,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -83,7 +83,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.win32.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b",
       "issue": 4378
     },
@@ -95,7 +95,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerAndroid.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -103,7 +103,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerIOS.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6",
       "issue": 4378
     },
@@ -111,7 +111,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -119,14 +119,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.win32.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
@@ -134,7 +134,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": 4378
     },
@@ -158,7 +158,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "2bfc1c66d26ce9a7af7ec30fdff3a99fd3073294",
       "issue": "LEGACY_FIXME"
     },
@@ -166,7 +166,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -174,7 +174,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.win32.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0",
       "issue": 4378
     },
@@ -206,7 +206,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
       "issue": "LEGACY_FIXME"
     },
@@ -214,7 +214,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -234,7 +234,7 @@
       "type": "patch",
       "file": "src/Libraries/core/ReactNativeVersionCheck.win32.js",
       "baseFile": "Libraries/core/ReactNativeVersionCheck.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "599ad6d6c8485cd453cd926cdf89f06640d439f6",
       "issue": 5170
     },
@@ -242,8 +242,8 @@
       "type": "derived",
       "file": "src/Libraries/Image/Image.win32.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "26acff268b815c7b3c5da0d6c9c009073b202ea8",
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4320
     },
     {
@@ -254,7 +254,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
       "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "6161ce89a0b45b24e8df69aa108af22a7b591483",
       "issue": 4320
     },
@@ -298,7 +298,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75",
       "issue": "LEGACY_FIXME"
     },
@@ -306,7 +306,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
       "baseFile": "Libraries/Inspector/InspectorOverlay.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "31687eefb91682d95abba47f8288f7c42158706e",
       "issue": "LEGACY_FIXME"
     },
@@ -314,7 +314,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworking.win32.js",
       "baseFile": "Libraries/Network/RCTNetworking.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "9ba4db01878648ef181dfd51debd821a837f56b3",
       "issue": 4318
     },
@@ -334,7 +334,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -354,7 +354,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheet.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84",
       "issue": "LEGACY_FIXME"
     },
@@ -362,7 +362,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheetValidation.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
@@ -370,7 +370,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/BackHandler.win32.ts",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": "LEGACY_FIXME"
     },
@@ -378,7 +378,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
       "issue": "LEGACY_FIXME"
     },
@@ -386,7 +386,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
       "issue": "LEGACY_FIXME"
     },
@@ -394,7 +394,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5",
       "issue": "LEGACY_FIXME"
     },
@@ -402,7 +402,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f",
       "issue": "LEGACY_FIXME"
     },
@@ -418,7 +418,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.win32.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -426,7 +426,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": "LEGACY_FIXME"
     },
@@ -438,7 +438,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.win32.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -446,7 +446,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.win32.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -62,17 +62,17 @@
     "@types/react-native": "^0.62.10",
     "babel-eslint": "10.0.1",
     "eslint": "6.7.0",
-    "flow-bin": "^0.124.0",
+    "flow-bin": "^0.125.1",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65",
+    "react-native": "0.0.0-3b7679bd3",
     "react-native-platform-override": "^0.2.1",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65"
+    "react-native": "0.0.0-3b7679bd3"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/packages/react-native-win32/src/Libraries/Image/Image.win32.js
+++ b/packages/react-native-win32/src/Libraries/Image/Image.win32.js
@@ -15,6 +15,7 @@ const React = require('react');
 const ReactNative = require('../Renderer/shims/ReactNative'); // eslint-disable-line no-unused-vars
 const StyleSheet = require('../StyleSheet/StyleSheet');
 
+const ImageAnalyticsTagContext = require('./ImageAnalyticsTagContext').default;
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const resolveAssetSource = require('./resolveAssetSource');
 
@@ -143,14 +144,21 @@ let Image = (props: ImagePropsType, forwardedRef) => {
   }
 
   return (
-    <ImageViewNativeComponent
-      {...props}
-      ref={forwardedRef}
-      style={style}
-      resizeMode={resizeMode}
-      tintColor={tintColor}
-      source={sources}
-    />
+    <ImageAnalyticsTagContext.Consumer>
+      {analyticTag => {
+        return (
+          <ImageViewNativeComponent
+            {...props}
+            ref={forwardedRef}
+            style={style}
+            resizeMode={resizeMode}
+            tintColor={tintColor}
+            source={sources}
+            internal_analyticTag={analyticTag}
+          />
+        );
+      }}
+    </ImageAnalyticsTagContext.Consumer>
   );
 };
 

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -106,12 +106,6 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FlowFixMeEmpty
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
-suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
-
 experimental.well_formed_exports=true
 experimental.types_first=true
 experimental.abstract_locations=true
@@ -139,4 +133,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.124.0
+^0.125.0

--- a/vnext/JSI/Shared/ChakraRuntime.cpp
+++ b/vnext/JSI/Shared/ChakraRuntime.cpp
@@ -440,7 +440,7 @@ facebook::jsi::WeakObject ChakraRuntime::createWeakObject(const facebook::jsi::O
   return make<facebook::jsi::WeakObject>(CloneChakraPointerValue(getPointerValue(object)));
 }
 
-facebook::jsi::Value ChakraRuntime::lockWeakObject(const facebook::jsi::WeakObject &weakObject) {
+facebook::jsi::Value ChakraRuntime::lockWeakObject(facebook::jsi::WeakObject &weakObject) {
   // We need to make a copy of the ChakraObjectRef held within weakObj's
   // member PointerValue for the returned jsi::Value here.
   ChakraObjectRef ref = GetChakraObjectRef(weakObject);

--- a/vnext/JSI/Shared/ChakraRuntime.h
+++ b/vnext/JSI/Shared/ChakraRuntime.h
@@ -111,7 +111,7 @@ class ChakraRuntime : public facebook::jsi::Runtime {
   facebook::jsi::Array getPropertyNames(const facebook::jsi::Object &obj) override;
 
   facebook::jsi::WeakObject createWeakObject(const facebook::jsi::Object &obj) override;
-  facebook::jsi::Value lockWeakObject(const facebook::jsi::WeakObject &weakObj) override;
+  facebook::jsi::Value lockWeakObject(facebook::jsi::WeakObject &weakObj) override;
 
   facebook::jsi::Array createArray(size_t length) override;
   size_t size(const facebook::jsi::Array &arr) override;

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -144,7 +144,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\privatedata\PrivateDataBase.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <CLCompile Include="$(ReactNativeDir)\ReactCommon\reactperflogger\reactperflogger\NativeModulePerfLogger.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\reactperflogger\reactperflogger\BridgeNativeModulePerfLogger.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\log.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
     <!-- We should ideally upstream a fix for missing stdexcept, but Yoga hasn't been accepting PRs as of May 2020 -->
     <ClCompile Include="$(YogaDir)\yoga\Utils.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" ForcedIncludeFiles="stdexcept" />

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -17,14 +17,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "494338afabeb89c26bf8f9e911b9167d6ec5741e"
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "a9a9d35f4e64c8d12f9ef604555270e46e05bf9e"
     },
     {
       "type": "patch",
       "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "07249701aad4220602e97b3a14f74a90666c56c4",
       "issue": 3994
     },
@@ -32,7 +32,7 @@
       "type": "copy",
       "directory": "ReactCopies/IntegrationTests",
       "baseDirectory": "IntegrationTests",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "b189414bfc74b1a14e0181a79b92a18e67253491",
       "issue": 4054
     },
@@ -40,7 +40,7 @@
       "type": "copy",
       "directory": "ReactCopies/RNTester/js",
       "baseDirectory": "RNTester/js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "75092965cbaa16d425f0495ef57400f1fd9fa1cb",
       "issue": 4054
     },
@@ -48,7 +48,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/GenerateViewConfigJs.js",
       "baseFile": "packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "80aa1fe96412a5f027dbf5e3df3feddab91c3ccb",
       "issue": 5430
     },
@@ -56,7 +56,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/index.js",
       "baseFile": "packages/babel-plugin-inline-view-configs/index.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "02590f3430fb57fcd954357c9dbeeaa8bdc01d06",
       "issue": 5430
     },
@@ -64,7 +64,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/package.json",
       "baseFile": "packages/babel-plugin-inline-view-configs/package.json",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "8d37fac510a533c0badffacd9c3aa9c392fd58c6",
       "issue": 5430
     },
@@ -72,7 +72,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -92,7 +92,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -108,7 +108,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "611e89285ac812456b381568052cf575c955575a",
       "issue": 4578
     },
@@ -116,7 +116,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Button.windows.js",
       "baseFile": "Libraries/Components/Button.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "3c1baecf9171422511a08436edd423c5da9cf5c2",
       "issue": "LEGACY_FIXME"
     },
@@ -128,7 +128,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windows.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
@@ -139,14 +139,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windows.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
@@ -177,14 +177,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windows.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Picker/Picker.windows.js",
       "baseFile": "Libraries/Components/Picker/Picker.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "ebfef6691cf4634daa34c025327f837d292ef44f",
       "issue": 4611
     },
@@ -192,14 +192,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerAndroid.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerIOS.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
@@ -210,7 +210,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
       "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "1a94e2e99474b15141d1c67c1211ac1dc2c2a62d",
       "issue": 4611
     },
@@ -226,21 +226,21 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windows.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45",
       "issue": "LEGACY_FIXME"
     },
@@ -248,7 +248,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
@@ -256,7 +256,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
@@ -264,7 +264,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "2bfc1c66d26ce9a7af7ec30fdff3a99fd3073294",
       "issue": "LEGACY_FIXME"
     },
@@ -272,7 +272,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -280,38 +280,38 @@
       "type": "derived",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "f64ec6932d14bff2716953facba5b27b2b1e73d1",
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "cff05f21476e8b5048cc353ffad59f9ef93c9894",
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "8fef33cd9edce5725695ca1e7fd9705916578799",
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "58698d349b3327660c71708f7128c2247caaef3f",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -319,7 +319,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
       "baseFile": "Libraries/Components/View/ViewAccessibility.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
       "issue": "LEGACY_FIXME"
     },
@@ -327,7 +327,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
       "baseFile": "Libraries/Components/View/ViewPropTypes.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "f768a7dd320d434d9bc9dacef3ee2ca9776e2197",
       "issue": "LEGACY_FIXME"
     },
@@ -343,7 +343,7 @@
       "type": "patch",
       "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
       "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
       "issue": "LEGACY_FIXME"
     },
@@ -351,8 +351,8 @@
       "type": "copy",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "26acff268b815c7b3c5da0d6c9c009073b202ea8",
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4590
     },
     {
@@ -363,7 +363,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "fa5d7d307e25d22d699a1d2d1eec9c0ac79ba928",
       "issue": "LEGACY_FIXME"
     },
@@ -371,7 +371,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
       "issue": "LEGACY_FIXME"
     },
@@ -379,7 +379,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
       "issue": "LEGACY_FIXME"
     },
@@ -387,15 +387,15 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseVersion": "0.0.0-6a96a9f65",
-      "baseHash": "34d1e6b2d7c9e30b625ade06f129ad65dcff5163",
+      "baseVersion": "0.0.0-3b7679bd3",
+      "baseHash": "b7ab4262be21b1c2db00dd52e345529181c45aa8",
       "issue": 4379
     },
     {
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.windows.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -407,7 +407,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheetValidation.windows.js",
       "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
@@ -415,7 +415,7 @@
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "83b203d547d9bdc57a8f3346ecee6f6e34b25f5d",
       "issue": "LEGACY_FIXME"
     },
@@ -423,7 +423,7 @@
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.windows.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": 4629
     },
@@ -431,14 +431,14 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.windows.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f"
     },
     {
@@ -449,7 +449,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.windows.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -457,7 +457,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleList.windows.js",
       "baseFile": "RNTester/js/components/RNTesterExampleList.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "fc507321dc5cb53be93df517ba5c4b1acd0074f4",
       "issue": "LEGACY_FIXME"
     },
@@ -465,7 +465,7 @@
       "type": "derived",
       "file": "src/RNTester/js/examples/PlatformColor/PlatformColorExample.windows.js",
       "baseFile": "RNTester/js/examples/PlatformColor/PlatformColorExample.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "a63038b104bcf3caa0984d994bf3916ef1aa38ee",
       "issue": 4055
     },
@@ -473,7 +473,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/ScrollView/ScrollViewExample.windows.js",
       "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "e622893fe0a5ce9d48b10644cd29a38de72b6a26",
       "issue": "LEGACY_FIXME"
     },
@@ -481,7 +481,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/TextInput/TextInputExample.windows.js",
       "baseFile": "RNTester/js/examples/TextInput/TextInputExample.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "1755bffd6ae353838f1779007dc4a512b8dddcdc",
       "issue": 5688
     },
@@ -489,7 +489,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/View/ViewExample.windows.js",
       "baseFile": "RNTester/js/examples/View/ViewExample.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "76d4a9914e731bffefefd3b0de90c97a1726e2a9",
       "issue": "LEGACY_FIXME"
     },
@@ -497,7 +497,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.windows.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -505,7 +505,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.windows.ts",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-6a96a9f65",
+      "baseVersion": "0.0.0-3b7679bd3",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,12 +59,12 @@
     "@types/react-native": "^0.62.10",
     "eslint": "6.7.0",
     "eslint-plugin-prettier": "2.6.2",
-    "flow-bin": "^0.124.0",
+    "flow-bin": "^0.125.1",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "prettier": "1.17.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65",
+    "react-native": "0.0.0-3b7679bd3",
     "react-native-platform-override": "^0.2.1",
     "react-native-windows-codegen": "0.1.0",
     "react-refresh": "^0.4.0",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-6a96a9f65"
+    "react-native": "0.0.0-3b7679bd3"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -174,6 +174,7 @@ class TouchableHighlight extends React.Component<Props, State> {
       delayLongPress: this.props.delayLongPress,
       delayPressIn: this.props.delayPressIn,
       delayPressOut: this.props.delayPressOut,
+      minPressDuration: 0,
       pressRectOffset: this.props.pressRetentionOffset,
       android_disableSound: this.props.touchSoundDisabled,
       onMouseEnter: this.props.onMouseEnter, // [Windows]

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
@@ -147,6 +147,7 @@ class TouchableOpacity extends React.Component<Props, State> {
       delayLongPress: this.props.delayLongPress,
       delayPressIn: this.props.delayPressIn,
       delayPressOut: this.props.delayPressOut,
+      minPressDuration: 0,
       pressRectOffset: this.props.pressRetentionOffset,
       onMouseEnter: this.props.onMouseEnter, // [Windows]
       onMouseLeave: this.props.onMouseLeave, // [Windows]

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -199,6 +199,7 @@ function createPressabilityConfig(props: Props): PressabilityConfig {
     delayLongPress: props.delayLongPress,
     delayPressIn: props.delayPressIn,
     delayPressOut: props.delayPressOut,
+    minPressDuration: 0,
     pressRectOffset: props.pressRetentionOffset,
     android_disableSound: props.touchSoundDisabled,
     onBlur: props.onBlur,

--- a/vnext/src/Libraries/Image/Image.windows.js
+++ b/vnext/src/Libraries/Image/Image.windows.js
@@ -15,6 +15,7 @@ const React = require('react');
 const ReactNative = require('../Renderer/shims/ReactNative'); // eslint-disable-line no-unused-vars
 const StyleSheet = require('../StyleSheet/StyleSheet');
 
+const ImageAnalyticsTagContext = require('./ImageAnalyticsTagContext').default;
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const resolveAssetSource = require('./resolveAssetSource');
 
@@ -124,14 +125,21 @@ let Image = (props: ImagePropsType, forwardedRef) => {
   }
 
   return (
-    <ImageViewNativeComponent
-      {...props}
-      ref={forwardedRef}
-      style={style}
-      resizeMode={resizeMode}
-      tintColor={tintColor}
-      source={sources}
-    />
+    <ImageAnalyticsTagContext.Consumer>
+      {analyticTag => {
+        return (
+          <ImageViewNativeComponent
+            {...props}
+            ref={forwardedRef}
+            style={style}
+            resizeMode={resizeMode}
+            tintColor={tintColor}
+            source={sources}
+            internal_analyticTag={analyticTag}
+          />
+        );
+      }}
+    </ImageAnalyticsTagContext.Consumer>
   );
 };
 

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -80,6 +80,11 @@ export type PressabilityConfig = $ReadOnly<{|
   delayPressOut?: ?number,
 
   /**
+   * Minimum duration to wait between calling `onPressIn` and `onPressOut`.
+   */
+  minPressDuration?: ?number,
+
+  /**
    * Called after the element loses focus.
    */
   onBlur?: ?(event: BlurEvent) => mixed,
@@ -300,6 +305,7 @@ const DEFAULT_PRESS_RECT_OFFSETS = {
   right: 20,
   top: 20,
 };
+const DEFAULT_MIN_PRESS_DURATION = 130;
 
 /**
  * Pressability implements press handling capabilities.
@@ -414,6 +420,7 @@ export default class Pressability {
     pageX: number,
     pageY: number,
   |}>;
+  _touchActivateTime: ?number;
   _touchState: TouchState = 'NOT_RESPONDER';
 
   constructor(config: PressabilityConfig) {
@@ -593,6 +600,7 @@ export default class Pressability {
                     this._config.delayHoverIn,
                   );
                   if (delayHoverIn > 0) {
+                    event.persist();
                     this._hoverInDelayTimeout = setTimeout(() => {
                       onHoverIn(event);
                     }, delayHoverIn);
@@ -619,6 +627,7 @@ export default class Pressability {
                     this._config.delayHoverOut,
                   );
                   if (delayHoverOut > 0) {
+                    event.persist();
                     this._hoverInDelayTimeout = setTimeout(() => {
                       onHoverOut(event);
                     }, delayHoverOut);
@@ -767,6 +776,7 @@ export default class Pressability {
       pageX: touch.pageX,
       pageY: touch.pageY,
     };
+    this._touchActivateTime = Date.now();
     if (onPressIn != null) {
       onPressIn(event);
     }
@@ -775,8 +785,18 @@ export default class Pressability {
   _deactivate(event: PressEvent): void {
     const {onPressOut} = this._config;
     if (onPressOut != null) {
-      const delayPressOut = normalizeDelay(this._config.delayPressOut);
+      const minPressDuration = normalizeDelay(
+        this._config.minPressDuration,
+        0,
+        DEFAULT_MIN_PRESS_DURATION,
+      );
+      const pressDuration = Date.now() - (this._touchActivateTime ?? 0);
+      const delayPressOut = Math.max(
+        minPressDuration - pressDuration,
+        normalizeDelay(this._config.delayPressOut),
+      );
       if (delayPressOut > 0) {
+        event.persist();
         this._pressOutDelayTimeout = setTimeout(() => {
           onPressOut(event);
         }, delayPressOut);
@@ -784,6 +804,7 @@ export default class Pressability {
         onPressOut(event);
       }
     }
+    this._touchActivateTime = null;
   }
 
   _measureResponderRegion(): void {
@@ -799,16 +820,7 @@ export default class Pressability {
   }
 
   _measureCallback = (left, top, width, height, pageX, pageY) => {
-    if (
-      !(
-        left > 0 ||
-        top > 0 ||
-        width > 0 ||
-        height > 0 ||
-        pageX > 0 ||
-        pageY > 0
-      )
-    ) {
+    if (!left && !top && !width && !height && !pageX && !pageY) {
       return;
     }
     this._responderRegion = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7053,10 +7053,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.124.0:
-  version "0.124.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.124.0.tgz#24b2e55874e1e2041f9247f42473b3db2ef32758"
-  integrity sha512-KEtDJ7CFUjcuhw6N52FTZshDd1krf1fxpp4APSIrwhVm+IrlcKJ+EMXpeXKM1kKNSZ347dYGh8wEvXQl4pHZEA==
+flow-bin@^0.125.1:
+  version "0.125.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.125.1.tgz#7edbc71e7dc39ddef18086ef75c714bbf1c5917f"
+  integrity sha512-jEury9NTXylxQEOAXLWEE945BjBwYcMwwKVnb+5XORNwMQE7i5hQYF0ysYfsaaYOa7rW/U16rHBfwLuaZfWV7A==
 
 flow-parser@0.*:
   version "0.113.0"
@@ -11812,10 +11812,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-6a96a9f65:
-  version "0.0.0-6a96a9f65"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-6a96a9f65.tgz#df7bc33d9582e48d6ceb33744ef4913379fdb9f2"
-  integrity sha512-weJbjzqnIzMBpWi/0fZOvo425zfhWiNTOrc0mRY11CTFl17uYmQUFm1BuM8vxdo7tus3bwZg/fIHdJvizTcH5A==
+react-native@0.0.0-3b7679bd3:
+  version "0.0.0-3b7679bd3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-3b7679bd3.tgz#557981e56c8ab24aff9b1c5d11f3f54c02720e22"
+  integrity sha512-xtMS2S/mrG8ouA0G92npKnCh1WjXzNIHC5LVbhSdXISffQsHBze8/89LOJfzUSNxNbaig7iGn2f2kouUztxoCw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^4.7.0"


### PR DESCRIPTION
This is the next available build, as it looks like upstream nightly publish was temporarily broken. Nothing too interesting here from scanning through commits.

A new native component prop was aded to RCTImage on iOS (and was present before on Android) for passing tag information from Image components in a React context to the native image loader, but the JS APIs aren't exposed publicly, so this is seemingly Facebook internal and not worth implementing.

NativeModulePerfLogger was renamed to BridgeNativeModulePerfLogger. We don't set a sink for this logging yet (nor does public RN seemingly), and most events are logged by shared C++ code we're using already, so there isn't much to do here either apart from changing the file we compile.

A mechanical interface change was made to jsi::runtime that we replicate.

Platform-specific flow-check suprressions were removed upstream so we do the same here.

-----

Commits: https://github.com/facebook/react-native/compare/6a96a9f65...3b7679bd3

### Added

- Added Inspector overlay support for Pressable ([8ac467c51b](facebook/react-native@8ac467c) by [@yungsters](https://github.com/yungsters))

#### iOS specific

- Allow hotkeys to be used without command key ([f2b9ec7981](facebook/react-native@f2b9ec7) by [@rickhanlonii](https://github.com/rickhanlonii))
- Add disableButtonsIndices option to ActionSheetIOS component ([f0bf4b0986](facebook/react-native@f0bf4b0) by [@lukewalczak](https://github.com/lukewalczak))

### Changed

- Docs: mention prettier in eslint-config README ([0a2bb714ae](facebook/react-native@0a2bb71) by [@exKAZUu](https://github.com/exKAZUu))

#### Android specific

- Moved TimePickerAndroid to FB internal. ([c8fed9e385](facebook/react-native@c8fed9e))
- Test Modernization ([6a78b32878](facebook/react-native@6a78b32))
- Renamed EventDispatcher to EventDispatcherImpl and created EventDispatcher interface; calls to EventDispatcher contstructor need to be updated ([68c0eddb71](facebook/react-native@68c0edd) by [@ejanzer](https://github.com/ejanzer))
- Get ripple drawables by id ([c8ed2dbbb2](facebook/react-native@c8ed2db) by [@vonovak](https://github.com/vonovak))

### Fixed

- Fix invalid `event` objects from `onPressOut` in certain cases ([2c600b7c5a](facebook/react-native@2c600b7) by [@yungsters](https://github.com/yungsters))

#### Android specific

- Use actual constructor when throwing GradleScriptException ([8ef0f1d90b](facebook/react-native@8ef0f1d))

#### iOS specific

- Fix imports in `RCTUtilsUIOverride.h` ([b7e8f66795](facebook/react-native@b7e8f66) by [@Fanghao](https://github.com/Fanghao))

### Unknown

- Always return an EventDispatcher in bridgeless mode ([0a12f3ea77](facebook/react-native@0a12f3e) by [@ejanzer](https://github.com/ejanzer))
- Annotate <Image> components in QPL logging using ImageAnalyticsTagContext ([60b7a3085c](facebook/react-native@60b7a30) by [@p-sun](https://github.com/p-sun))
- Daily `arc lint --take CLANGFORMAT` ([7e343c8d3a](facebook/react-native@7e343c8))
- Daily `arc lint --take GOOGLEJAVAFORMAT` ([6b64810f33](facebook/react-native@6b64810))

#### iOS Unknown

- Add new bundle loading strategy in FBiOS behind GK ([34b23c1220](facebook/react-native@34b23c1) by [@rickhanlonii](https://github.com/rickhanlonii))
- IOS: Fix logging lifecycle when image is scrolled out and immediately back in ([1f95c9b62e](facebook/react-native@1f95c9b) by [@p-sun](https://github.com/p-sun))

#### Failed to parse

- Clean up Flow & lint errors ([3b7679bd35](facebook/react-native@3b7679b) by [@cpojer](https://github.com/cpojer))
- Extend Text to support measurement of empty Texts ([4b596fd5b3](facebook/react-native@4b596fd) by [@mdvacca](https://github.com/mdvacca))
- Internal changes to extend logging ([6f8fc40195](facebook/react-native@6f8fc40) by [@mdvacca](https://github.com/mdvacca))
- Remove calls to AllocationLocationTracker for native memory ([9bb7e06747](facebook/react-native@9bb7e06) by [@dulinriley](https://github.com/dulinriley))
- Fix crash in removeViewAt by fixing incorrect error-detection ([8da92d746b](facebook/react-native@8da92d7) by [@JoshuaGross](https://github.com/JoshuaGross))
- Fix crash introduced by D21735940 in T67525923 ([7e559465bd](facebook/react-native@7e55946) by [@JoshuaGross](https://github.com/JoshuaGross))
- Do not use variable types for array elements ([97d3abf982](facebook/react-native@97d3abf) by [@hramos](https://github.com/hramos))
- Reset RootView ID when root view is detached from view hierarchy ([bd314168dd](facebook/react-native@bd31416) by [@JoshuaGross](https://github.com/JoshuaGross))
- Upgrade to Babel 7.10 ([fd97e955f8](facebook/react-native@fd97e95) by [@cpojer](https://github.com/cpojer))
- Better error message when crashing because of an invalid Remove operation ([1a77943e8b](facebook/react-native@1a77943) by [@JoshuaGross](https://github.com/JoshuaGross))
- Remove unused double key press code ([6f75065d82](facebook/react-native@6f75065) by [@rickhanlonii](https://github.com/rickhanlonii))
- Add new swizzle method RCTSwapInstanceMethodWithBlock ([6ff6a79dd9](facebook/react-native@6ff6a79) by [@rickhanlonii](https://github.com/rickhanlonii))
- C++ LayoutAnimations: solve crash when "animating" virtual views ([8b2eb3766b](facebook/react-native@8b2eb37) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutAnimations: fail silently instead of redboxing if there's a misconfigured LayoutAnimation ([ae7df2df22](facebook/react-native@ae7df2d) by [@JoshuaGross](https://github.com/JoshuaGross))
- Fix NativeAnimatedModule timing for Fabric/Venice(?) ([8e1348046a](facebook/react-native@8e13480) by [@JoshuaGross](https://github.com/JoshuaGross))
- Android Animated timing: interface-only ([0b00d92514](facebook/react-native@0b00d92) by [@JoshuaGross](https://github.com/JoshuaGross))
- Change jsi::Runtime::lockWeakObject to take a mutable ref ([8d6cc50d77](facebook/react-native@8d6cc50) by [@christophpurrer](https://github.com/christophpurrer))
- Cleanup of RCTTExtInputComponentView.mm ([18b3680761](facebook/react-native@18b3680) by [@sammy-SC](https://github.com/sammy-SC))
- Delete copy constructor and copy assignment operator in ShadowNode ([1b1ebaf2bd](facebook/react-native@1b1ebaf) by [@sammy-SC](https://github.com/sammy-SC))
- Add ART components into Catalyst app Android ([95546d932f](facebook/react-native@95546d9) by [@mdvacca](https://github.com/mdvacca))
- Delete unused class ([19e0b133f8](facebook/react-native@19e0b13) by [@mdvacca](https://github.com/mdvacca))
- Implement equality of ARTElements and use it in ARTState ([58a7ddd55d](facebook/react-native@58a7ddd) by [@mdvacca](https://github.com/mdvacca))
- Rename Element -> ARTElement ([55c36661d9](facebook/react-native@55c3666) by [@mdvacca](https://github.com/mdvacca))
- Add support for Text in ART Fabric Android ([cfd2e7d88d](facebook/react-native@cfd2e7d) by [@mdvacca](https://github.com/mdvacca))
- Serialize ART text components and send data to Android ([b8b683dc46](facebook/react-native@b8b683d) by [@mdvacca](https://github.com/mdvacca))
- Refactor types of ART Text class ([888866461b](facebook/react-native@8888664) by [@mdvacca](https://github.com/mdvacca))
- Update internal code attribution ([e85118cc43](facebook/react-native@e85118c) by [@fkgozali](https://github.com/fkgozali))
- Introduce BatchedEventQueue::enqueueUniqueEvent ([b31149cf90](facebook/react-native@b31149c) by [@sammy-SC](https://github.com/sammy-SC))
- Separate event dispatchers to ivars instead of array ([43d65ed66c](facebook/react-native@43d65ed) by [@sammy-SC](https://github.com/sammy-SC))
- Fix order in which views are mounted in RCTLegacyViewManagerInteropComponentView ([6626b84f89](facebook/react-native@6626b84) by [@sammy-SC](https://github.com/sammy-SC))
- Prevent ABA problem during YogaLayoutableShadowNode cloning ([745ff1086a](facebook/react-native@745ff10) by [@sammy-SC](https://github.com/sammy-SC))
- Serialize ART state into folly::dynamic ([21afa62517](facebook/react-native@21afa62) by [@mdvacca](https://github.com/mdvacca))
- Integrate ElementType Enum into state ([0305ff8ee0](facebook/react-native@0305ff8) by [@mdvacca](https://github.com/mdvacca))
- Integrate State into ARTSurfaceViewShadowNode ([b7ab3aaf61](facebook/react-native@b7ab3aa) by [@mdvacca](https://github.com/mdvacca))
- Create internal State of ART based on Shadow Nodes ([493d616521](facebook/react-native@493d616) by [@mdvacca](https://github.com/mdvacca))
- Internal change to support ART in Fabric ([192bea1613](facebook/react-native@192bea1) by [@mdvacca](https://github.com/mdvacca))
- Guard all NativeModulePerfLogger calls with a null check ([4830085f40](facebook/react-native@4830085) by [@RSNara](https://github.com/RSNara))
- LayoutAnimations: allow Paragraph props to be interpolated ([c75e8ae4ff](facebook/react-native@c75e8ae) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutAnimations: Use Quaternions to interpolate rotation transforms ([3f9fad1052](facebook/react-native@3f9fad1) by [@JoshuaGross](https://github.com/JoshuaGross))
- IOS-specific LayoutAnimation integration ([73995cf7e2](facebook/react-native@73995cf) by [@JoshuaGross](https://github.com/JoshuaGross))
- Android-specific LayoutAnimation integration ([483f84e881](facebook/react-native@483f84e) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutAnimations: implement LayoutAnimationStatusDelegate for platform-specific integrations ([eb9b2cedb8](facebook/react-native@eb9b2ce) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutImplementations: implement all existing animation curves besides Keyboard ([8d2c1f6e7e](facebook/react-native@8d2c1f6) by [@JoshuaGross](https://github.com/JoshuaGross))
- C++ Fabric Core LayoutAnimations ([3331962279](facebook/react-native@3331962) by [@JoshuaGross](https://github.com/JoshuaGross))
- Remove flow-node requirement from native modules codegen script ([2e756e024f](facebook/react-native@2e756e0) by [@hramos](https://github.com/hramos))
- LayoutAnimations: allow Paragraph props to be interpolated ([a799367baf](facebook/react-native@a799367) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutAnimations: Use Quaternions to interpolate rotation transforms ([3cbafcccba](facebook/react-native@3cbafcc) by [@JoshuaGross](https://github.com/JoshuaGross))
- IOS-specific LayoutAnimation integration ([e781b31489](facebook/react-native@e781b31) by [@JoshuaGross](https://github.com/JoshuaGross))
- Android-specific LayoutAnimation integration ([076ba4c920](facebook/react-native@076ba4c) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutAnimations: implement LayoutAnimationStatusDelegate for platform-specific integrations ([f0c595b57c](facebook/react-native@f0c595b) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutImplementations: implement all existing animation curves besides Keyboard ([46310c1976](facebook/react-native@46310c1) by [@JoshuaGross](https://github.com/JoshuaGross))
- C++ Fabric Core LayoutAnimations ([e9d6fb2ec6](facebook/react-native@e9d6fb2) by [@JoshuaGross](https://github.com/JoshuaGross))
- Fix assignment of hitTestEdgeInsets in RCTViewComponentView ([3265519920](facebook/react-native@3265519) by [@sammy-SC](https://github.com/sammy-SC))
- Add FBRotatablePhotoPlayerView to LegacyInterop whitelist ([6acccae980](facebook/react-native@6acccae) by [@jimmy623](https://github.com/jimmy623))
- Remove suppress_comments from xplat flowconfigs ([afad239d72](facebook/react-native@afad239) by [@dsainati1](https://github.com/dsainati1))
- Copy alreadyAppliedPadding when cloning SafeAreaViewShadowNode ([351a9f1047](facebook/react-native@351a9f1) by [@sammy-SC](https://github.com/sammy-SC))
- Prevent SafeAreaView from reporting same size twice ([f9e4e246ff](facebook/react-native@f9e4e24) by [@sammy-SC](https://github.com/sammy-SC))
- Deploy Flow 0.125.1 to xplat ([37e7b41419](facebook/react-native@37e7b41) by [@mvitousek](https://github.com/mvitousek))
- Delete local data from Fabric android ([04b8c9c925](facebook/react-native@04b8c9c) by [@mdvacca](https://github.com/mdvacca))
- Basic implementation of ARTText ([7929f674cc](facebook/react-native@7929f67) by [@mdvacca](https://github.com/mdvacca))
- Basic implementation of ARTGroupProps ([54adda64ec](facebook/react-native@54adda6) by [@mdvacca](https://github.com/mdvacca))
- Create basic implementation of Shape ([12fee9af62](facebook/react-native@12fee9a) by [@mdvacca](https://github.com/mdvacca))
- Basic implementation of ARTSurfaceView ([a011eaf7e5](facebook/react-native@a011eaf) by [@mdvacca](https://github.com/mdvacca))
- Fabric: Simplification of `UIManager::getRelativeLayoutMetrics` ([dafa975352](facebook/react-native@dafa975) by [@shergin](https://github.com/shergin))
- Fabric: Refinement of `LayoutableShadowNode::getRelativeLayoutMetrics` ([caab26e0c3](facebook/react-native@caab26e) by [@shergin](https://github.com/shergin))
- Fabric: Changes in LayoutableShadowNodeTest ([656db7823c](facebook/react-native@656db78) by [@shergin](https://github.com/shergin))
- Update Hermes attribution labels ([b4f4f2d33e](facebook/react-native@b4f4f2d) by [@zlern2k](https://github.com/zlern2k))
- Extends view flattening algorithm to support flattening of absolute positioned views ([a2e46e43fb](facebook/react-native@a2e46e4) by [@mdvacca](https://github.com/mdvacca))
- Set `NSAllowsArbitraryLoads` to `false` by default in template ([7b61a968fd](facebook/react-native@7b61a96) by [@wddwycc](https://github.com/wddwycc))
- Fabric: Automatic removing outstanding Surface on Scheduler destruction; gated. ([b72d6768e0](facebook/react-native@b72d676) by [@shergin](https://github.com/shergin))


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5794)