### PR TITLE
Don't Proxy NPM Registry for "react-native init"

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -49,10 +49,6 @@ steps:
         start-process npx -ArgumentList @('verdaccio', '--config', './.ado/verdaccio/config.yaml')
 
   - script: |
-      npm set registry http://localhost:4873
-    displayName: Modify default npm config to point to local verdaccio server
-
-  - script: |
       node .ado/waitForVerdaccio.js
     displayName: Wait for verdaccio server to boot
 
@@ -83,6 +79,10 @@ steps:
     inputs:
       script: npx react-native init testcli --npm --template react-native@$(reactNativeDevDependency)
       workingDirectory: $(Agent.BuildDirectory)
+
+  - script: |
+      npm set registry http://localhost:4873
+    displayName: Modify default npm config to point to local verdaccio server
 
   - task: CmdLine@2
     displayName: Apply windows template (with nuget)


### PR DESCRIPTION
We've seen sporadic reliability issues downloading upstream packages through Verdaccio, and haven't been able to determine the root cause. We currently proxy both "react-native init" and "react-native-windows-init" through Verdaccio, even though we only need to use it for the latter. This change sets our npm proxy only after "react-native init" is run to shift more of package installation off of the proxy, hopefully improving reliability.

This doesn't address the root cause at all, which is still unknown.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5795)