### PR TITLE
Default run-windows to disabling parallel MSBuild When Machine Has <=16GB of Memory

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -556,13 +556,13 @@ jobs:
           configuration: Debug
           platform: x86
           additionalInitArguments: --useWinUI3 true
-          additionalRunArguments: --singleproc
+          additionalRunArguments:
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
           platform: x86
           additionalInitArguments: --useWinUI3 true
-          additionalRunArguments: --singleproc
+          additionalRunArguments:
 
     timeoutInMinutes: 40 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/change/@react-native-windows-cli-2020-08-20-15-53-42-single-proc-mem.json
+++ b/change/@react-native-windows-cli-2020-08-20-15-53-42-single-proc-mem.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Default run-windows to disabling parallel MSBuild When Machine Has < 16GB of Memory",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T22:53:42.878Z"
+}


### PR DESCRIPTION
Building projects in parallel seems to increase the likeliehood of compiler OOM errors without dramatically impacting performace (See #4739). We're seeing OOM issues frequently with run-windows in CI. Change default behavior to build a single project at a time on machines that have <16 GB of memory. Not that this will still let individual CL processes use multiple cores, so we still do get some parallelism.

There doesn't seem to be an equivalent way to change the default for Visual Studio (from what I can tell default it to disable parallel project builds already).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5796)