### PR TITLE
Add API to enable non-3D controls

### DIFF
--- a/change/react-native-windows-2020-08-20-18-09-50-disable3D.json
+++ b/change/react-native-windows-2020-08-20-18-09-50-disable3D.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add API to turn off 3D perspective to enable controls that don't work in 3D",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-21T01:09:50.688Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -5,11 +5,13 @@
 #include "ReactRootView.g.cpp"
 #include "DynamicWriter.h"
 #include "ReactNativeHost.h"
+#include <UI.Xaml.Media.Media3D.h>
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactRootView::ReactRootView() noexcept {
   m_rootControl = std::make_shared<react::uwp::ReactRootControl>(*this);
+  UpdatePerspective();
   Loaded([this](auto &&, auto &&) { react::uwp::SetCompositor(react::uwp::GetCompositor(*this)); });
 }
 
@@ -65,4 +67,19 @@ void ReactRootView::ReloadView() noexcept {
   }
 }
 
+void ReactRootView::UpdatePerspective() {
+  // Xaml's default projection in 3D is orthographic (all lines are parallel)
+  // However React Native's default projection is a one-point perspective.
+  // Set a default perspective projection on the main control to mimic this.
+  auto grid = m_rootControl->GetXamlView().as<xaml::Controls::Grid>();
+
+  if (m_isPerspectiveEnabled) {
+    auto perspectiveTransform3D = xaml::Media::Media3D::PerspectiveTransform3D();
+    perspectiveTransform3D.Depth(850);
+    xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
+    grid.Transform3D(t3d);
+  } else {
+    grid.ClearValue(xaml::UIElement::Transform3DProperty());
+  }
+}
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -3,9 +3,9 @@
 #include "pch.h"
 #include "ReactRootView.h"
 #include "ReactRootView.g.cpp"
+#include <UI.Xaml.Media.Media3D.h>
 #include "DynamicWriter.h"
 #include "ReactNativeHost.h"
-#include <UI.Xaml.Media.Media3D.h>
 
 namespace winrt::Microsoft::ReactNative::implementation {
 

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -44,7 +44,7 @@ struct ReactRootView : ReactRootViewT<ReactRootView> {
   hstring m_componentName;
   ReactNative::JSValueArgWriter m_initialPropsWriter;
   folly::dynamic m_initialProps;
-  bool m_isPerspectiveEnabled;
+  bool m_isPerspectiveEnabled{true};
   std::shared_ptr<react::uwp::ReactRootControl> m_rootControl;
 
   void UpdatePerspective();

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -24,6 +24,15 @@ struct ReactRootView : ReactRootViewT<ReactRootView> {
   ReactNative::JSValueArgWriter InitialProps() noexcept;
   void InitialProps(ReactNative::JSValueArgWriter const &value) noexcept;
 
+  // property IsPerspectiveEnabled
+  bool IsPerspectiveEnabled() const noexcept {
+    return m_isPerspectiveEnabled;
+  }
+  void IsPerspectiveEnabled(bool value) noexcept {
+    m_isPerspectiveEnabled = value;
+    UpdatePerspective();
+  }
+
   void ReloadView() noexcept;
 
  private:
@@ -35,8 +44,10 @@ struct ReactRootView : ReactRootViewT<ReactRootView> {
   hstring m_componentName;
   ReactNative::JSValueArgWriter m_initialPropsWriter;
   folly::dynamic m_initialProps;
-
+  bool m_isPerspectiveEnabled;
   std::shared_ptr<react::uwp::ReactRootControl> m_rootControl;
+
+  void UpdatePerspective();
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -15,6 +15,7 @@ namespace Microsoft.ReactNative {
     ReactNativeHost ReactNativeHost { get; set; };
     String ComponentName { get; set; };
     JSValueArgWriter InitialProps { get; set; };
+    Boolean IsPerspectiveEnabled { get; set; };
 
     void ReloadView();
   }

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -33,7 +33,6 @@
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Markup.h>
-#include <UI.Xaml.Media.Media3D.h>
 
 #include "DevMenu.h"
 #include "Modules/DevSettingsModule.h"
@@ -341,13 +340,6 @@ void ReactRootControl::PrepareXamlRootView(XamlView const &rootView) noexcept {
     children.Clear();
 
     auto newRootView = winrt::Grid{};
-    // Xaml's default projection in 3D is orthographic (all lines are parallel)
-    // However React Native's default projection is a one-point perspective.
-    // Set a default perspective projection on the main control to mimic this.
-    auto perspectiveTransform3D = xaml::Media::Media3D::PerspectiveTransform3D();
-    perspectiveTransform3D.Depth(850);
-    xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
-    newRootView.Transform3D(t3d);
     children.Append(newRootView);
     m_weakXamlRootView = newRootView.try_as<XamlView>();
   } else {


### PR DESCRIPTION
Some controls like `InkCanvas` do not work in environments where a 3D transform is present. RNW adds a `PerspectiveTransform3D` at the root in order to achieve a projective perspective look during rotations (the default for XAML is orthographic). This PR adds an API to turn off the perspective transform which enables controls like `InkCanvas` to work and receive input.

Fixes #5773 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5798)