### PR TITLE
Integrate 6/4 Nightly RN Build

### DIFF
--- a/change/@office-iss-react-native-win32-2020-08-20-19-56-45-integrate-6-4.json
+++ b/change/@office-iss-react-native-win32-2020-08-20-19-56-45-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 6/4 Nightly RN Build",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-21T02:56:43.950Z"
+}

--- a/change/@react-native-windows-cli-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@react-native-windows-cli-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:13.971Z"
+}

--- a/change/@rnw-scripts-create-github-releases-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-create-github-releases-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:19.021Z"
+}

--- a/change/@rnw-scripts-eslint-config-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-eslint-config-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/eslint-config",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:23.538Z"
+}

--- a/change/@rnw-scripts-find-repo-root-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-find-repo-root-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/find-repo-root",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:28.675Z"
+}

--- a/change/@rnw-scripts-format-files-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-format-files-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/format-files",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:31.782Z"
+}

--- a/change/@rnw-scripts-integrate-rn-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-integrate-rn-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:35.985Z"
+}

--- a/change/@rnw-scripts-package-utils-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-package-utils-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/package-utils",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:40.863Z"
+}

--- a/change/@rnw-scripts-promote-release-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/@rnw-scripts-promote-release-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:43.445Z"
+}

--- a/change/react-native-platform-override-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/react-native-platform-override-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:48.853Z"
+}

--- a/change/react-native-windows-2020-08-20-19-56-45-integrate-6-4.json
+++ b/change/react-native-windows-2020-08-20-19-56-45-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 6/4 Nightly RN Build",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-21T02:56:45.883Z"
+}

--- a/change/react-native-windows-codegen-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/react-native-windows-codegen-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "react-native-windows-codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:52.116Z"
+}

--- a/change/react-native-windows-init-2020-08-20-20-21-56-integrate-6-4.json
+++ b/change/react-native-windows-init-2020-08-20-20-21-56-integrate-6-4.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Upgrade to eslint 6.8.0",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-21T03:21:56.331Z"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -46,7 +46,7 @@
     "@types/uuid": "^8.0.0",
     "@types/xmldom": "^0.1.29",
     "@types/xml-parser": "^1.2.29",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -32,7 +32,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/semver": "^7.3.1",
     "@types/yargs": "^15.0.5",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/eslint-config/package.json
+++ b/packages/@rnw-scripts/eslint-config/package.json
@@ -7,7 +7,7 @@
     "@react-native-community/eslint-config": "^1.1.0"
   },
   "devDependencies": {
-    "eslint": "6.7.0"
+    "eslint": "6.8.0"
   },
   "peerDependencies": {
     "eslint": ">=6.7.0"

--- a/packages/@rnw-scripts/find-repo-root/package.json
+++ b/packages/@rnw-scripts/find-repo-root/package.json
@@ -18,7 +18,7 @@
     "@rnw-scripts/just-task": "0.0.2",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/find-up": "^4.0.0",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -21,7 +21,7 @@
     "@rnw-scripts/just-task": "0.0.2",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/async": "^3.2.3",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -31,7 +31,7 @@
     "@types/ora": "^3.2.0",
     "@types/semver": "^7.3.1",
     "@types/yargs": "^15.0.5",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/package-utils/package.json
+++ b/packages/@rnw-scripts/package-utils/package.json
@@ -20,7 +20,7 @@
     "@rnw-scripts/just-task": "0.0.2",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/lodash": "^4.14.157",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -25,7 +25,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/chalk": "^2.2.0",
     "@types/yargs": "^15.0.5",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -44,7 +44,7 @@
     "@wdio/local-runner": "5.12.1",
     "@wdio/sync": "5.12.1",
     "appium": "1.14.1",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "metro-react-native-babel-preset": "^0.56.0",
     "prettier": "^1.18.2",

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "prompt-sync": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3",
+    "react-native": "0.0.0-851d01b0a",
     "react-native-windows": "0.0.0-canary.144"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3",
+    "react-native": "0.0.0-851d01b0a",
     "react-native-windows": "0.0.0-canary.144"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -21,7 +21,7 @@
     "@rnw-scripts/eslint-config": "0.0.2",
     "@types/react": "16.9.0",
     "@types/react-native": "^0.62.10",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "metro-react-native-babel-preset": "^0.56.0",
     "react-native-windows-codegen": "0.1.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3",
+    "react-native": "0.0.0-851d01b0a",
     "react-native-windows": "0.0.0-canary.144"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -21,7 +21,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/react": "16.9.0",
     "@types/react-native": "^0.62.10",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "metro-react-native-babel-preset": "^0.56.0",
     "react-test-renderer": "16.9.0"

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -57,7 +57,7 @@
     "@types/yargs": "^15.0.3",
     "babel-jest": "^24.9.0",
     "diff-match-patch": "^1.0.4",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "fp-ts": "^2.5.0",
     "jest": "^24.9.0",
     "just-scripts": "^0.36.1",

--- a/packages/react-native-win32/.flowconfig
+++ b/packages/react-native-win32/.flowconfig
@@ -121,4 +121,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.0
+^0.126.1

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -8,14 +8,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "a9a9d35f4e64c8d12f9ef604555270e46e05bf9e"
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "e377e2dacacf415baa21050dd389cac9873c9f4d"
     },
     {
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -23,7 +23,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -31,7 +31,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "611e89285ac812456b381568052cf575c955575a",
       "issue": "LEGACY_FIXME"
     },
@@ -39,7 +39,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "b3e2c37d96de6f00066495267f7c32d6e9d3f840",
       "issue": "LEGACY_FIXME"
     },
@@ -55,7 +55,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.win32.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea",
       "issue": 4378
     },
@@ -63,7 +63,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.win32.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc",
       "issue": 4378
     },
@@ -71,7 +71,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -83,7 +83,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.win32.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b",
       "issue": 4378
     },
@@ -95,7 +95,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerAndroid.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -103,7 +103,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerIOS.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6",
       "issue": 4378
     },
@@ -111,7 +111,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -119,14 +119,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.win32.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
@@ -134,7 +134,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": 4378
     },
@@ -158,15 +158,15 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "2bfc1c66d26ce9a7af7ec30fdff3a99fd3073294",
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "4508091254e184ee4dfc383c091186ba6ed60f01",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -174,7 +174,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.win32.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0",
       "issue": 4378
     },
@@ -206,7 +206,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
       "issue": "LEGACY_FIXME"
     },
@@ -214,7 +214,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -234,7 +234,7 @@
       "type": "patch",
       "file": "src/Libraries/core/ReactNativeVersionCheck.win32.js",
       "baseFile": "Libraries/core/ReactNativeVersionCheck.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "599ad6d6c8485cd453cd926cdf89f06640d439f6",
       "issue": 5170
     },
@@ -242,7 +242,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/Image.win32.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4320
     },
@@ -254,7 +254,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
       "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "6161ce89a0b45b24e8df69aa108af22a7b591483",
       "issue": 4320
     },
@@ -298,7 +298,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75",
       "issue": "LEGACY_FIXME"
     },
@@ -306,15 +306,15 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
       "baseFile": "Libraries/Inspector/InspectorOverlay.js",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "31687eefb91682d95abba47f8288f7c42158706e",
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "a1d045fb2d0fb751d8f0518fd40af63454b88b04",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworking.win32.js",
       "baseFile": "Libraries/Network/RCTNetworking.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "9ba4db01878648ef181dfd51debd821a837f56b3",
       "issue": 4318
     },
@@ -334,7 +334,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -354,7 +354,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheet.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84",
       "issue": "LEGACY_FIXME"
     },
@@ -362,7 +362,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheetValidation.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
@@ -370,7 +370,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/BackHandler.win32.ts",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": "LEGACY_FIXME"
     },
@@ -378,7 +378,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
       "issue": "LEGACY_FIXME"
     },
@@ -386,7 +386,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
       "issue": "LEGACY_FIXME"
     },
@@ -394,7 +394,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5",
       "issue": "LEGACY_FIXME"
     },
@@ -402,7 +402,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f",
       "issue": "LEGACY_FIXME"
     },
@@ -418,7 +418,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.win32.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -426,7 +426,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": "LEGACY_FIXME"
     },
@@ -438,7 +438,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.win32.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -446,7 +446,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.win32.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -61,7 +61,7 @@
     "@types/react": "16.9.0",
     "@types/react-native": "^0.62.10",
     "babel-eslint": "10.0.1",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "flow-bin": "^0.126.1",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -62,17 +62,17 @@
     "@types/react-native": "^0.62.10",
     "babel-eslint": "10.0.1",
     "eslint": "6.7.0",
-    "flow-bin": "^0.125.1",
+    "flow-bin": "^0.126.1",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3",
+    "react-native": "0.0.0-851d01b0a",
     "react-native-platform-override": "^0.2.1",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3"
+    "react-native": "0.0.0-851d01b0a"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/packages/react-native-win32/src/Libraries/Inspector/InspectorOverlay.win32.js
+++ b/packages/react-native-win32/src/Libraries/Inspector/InspectorOverlay.win32.js
@@ -57,6 +57,7 @@ class InspectorOverlay extends React.Component<Props> {
       <View
         onStartShouldSetResponder={this.shouldSetResponser}
         onResponderMove={this.findViewForTouchEvent}
+        nativeID="inspectorOverlay"
         style={[styles.inspector, {height: '100%'}]}>
         {content}
       </View>

--- a/packages/react-native-windows-codegen/package.json
+++ b/packages/react-native-windows-codegen/package.json
@@ -30,7 +30,7 @@
     "@types/chalk": "^2.2.0",
     "@types/globby": "^9.1.0",
     "@types/yargs": "^15.0.3",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1"
   }
 }

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -35,7 +35,7 @@
     "@types/semver": "^7.1.0",
     "@types/valid-url": "^1.0.2",
     "@types/yargs": "^15.0.3",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -133,4 +133,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.0
+^0.126.1

--- a/vnext/ReactCopies/RNTester/js/examples/Pressable/PressableExample.js
+++ b/vnext/ReactCopies/RNTester/js/examples/Pressable/PressableExample.js
@@ -167,7 +167,7 @@ function ForceTouchExample() {
           style={styles.wrapper}
           testID="pressable_3dtouch_button"
           onStartShouldSetResponder={() => true}
-          onResponderMove={event => setForce(event.nativeEvent.force)}
+          onResponderMove={event => setForce(event.nativeEvent?.force || 1)}
           onResponderRelease={event => setForce(0)}>
           <Text style={styles.button}>Press Me</Text>
         </View>

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -17,14 +17,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "a9a9d35f4e64c8d12f9ef604555270e46e05bf9e"
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "e377e2dacacf415baa21050dd389cac9873c9f4d"
     },
     {
       "type": "patch",
       "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "07249701aad4220602e97b3a14f74a90666c56c4",
       "issue": 3994
     },
@@ -32,7 +32,7 @@
       "type": "copy",
       "directory": "ReactCopies/IntegrationTests",
       "baseDirectory": "IntegrationTests",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "b189414bfc74b1a14e0181a79b92a18e67253491",
       "issue": 4054
     },
@@ -40,15 +40,15 @@
       "type": "copy",
       "directory": "ReactCopies/RNTester/js",
       "baseDirectory": "RNTester/js",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "75092965cbaa16d425f0495ef57400f1fd9fa1cb",
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "537220cadacbcc5269320a16127f62e3ab58e754",
       "issue": 4054
     },
     {
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/GenerateViewConfigJs.js",
       "baseFile": "packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "80aa1fe96412a5f027dbf5e3df3feddab91c3ccb",
       "issue": 5430
     },
@@ -56,7 +56,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/index.js",
       "baseFile": "packages/babel-plugin-inline-view-configs/index.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "02590f3430fb57fcd954357c9dbeeaa8bdc01d06",
       "issue": 5430
     },
@@ -64,7 +64,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/package.json",
       "baseFile": "packages/babel-plugin-inline-view-configs/package.json",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "8d37fac510a533c0badffacd9c3aa9c392fd58c6",
       "issue": 5430
     },
@@ -72,7 +72,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -92,7 +92,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -108,7 +108,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "611e89285ac812456b381568052cf575c955575a",
       "issue": 4578
     },
@@ -116,7 +116,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Button.windows.js",
       "baseFile": "Libraries/Components/Button.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "3c1baecf9171422511a08436edd423c5da9cf5c2",
       "issue": "LEGACY_FIXME"
     },
@@ -128,7 +128,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windows.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
@@ -139,14 +139,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windows.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
@@ -177,14 +177,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windows.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Picker/Picker.windows.js",
       "baseFile": "Libraries/Components/Picker/Picker.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "ebfef6691cf4634daa34c025327f837d292ef44f",
       "issue": 4611
     },
@@ -192,14 +192,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerAndroid.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerIOS.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
@@ -210,7 +210,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
       "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "1a94e2e99474b15141d1c67c1211ac1dc2c2a62d",
       "issue": 4611
     },
@@ -226,21 +226,21 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windows.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45",
       "issue": "LEGACY_FIXME"
     },
@@ -248,7 +248,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
       "issue": "LEGACY_FIXME"
     },
@@ -256,7 +256,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
@@ -264,15 +264,15 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "2bfc1c66d26ce9a7af7ec30fdff3a99fd3073294",
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "4508091254e184ee4dfc383c091186ba6ed60f01",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -280,14 +280,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912",
       "issue": "LEGACY_FIXME"
     },
@@ -295,7 +295,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95",
       "issue": "LEGACY_FIXME"
     },
@@ -303,7 +303,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "58698d349b3327660c71708f7128c2247caaef3f",
       "issue": "LEGACY_FIXME"
     },
@@ -311,7 +311,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -319,7 +319,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
       "baseFile": "Libraries/Components/View/ViewAccessibility.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
       "issue": "LEGACY_FIXME"
     },
@@ -327,8 +327,8 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
       "baseFile": "Libraries/Components/View/ViewPropTypes.js",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "f768a7dd320d434d9bc9dacef3ee2ca9776e2197",
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "2b12228aa1ab0e12844996a99ff5d38fbff689a1",
       "issue": "LEGACY_FIXME"
     },
     {
@@ -343,7 +343,7 @@
       "type": "patch",
       "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
       "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
       "issue": "LEGACY_FIXME"
     },
@@ -351,7 +351,7 @@
       "type": "copy",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4590
     },
@@ -363,7 +363,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "fa5d7d307e25d22d699a1d2d1eec9c0ac79ba928",
       "issue": "LEGACY_FIXME"
     },
@@ -371,7 +371,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
       "issue": "LEGACY_FIXME"
     },
@@ -379,7 +379,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
       "issue": "LEGACY_FIXME"
     },
@@ -387,7 +387,7 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "b7ab4262be21b1c2db00dd52e345529181c45aa8",
       "issue": 4379
     },
@@ -395,7 +395,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.windows.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -407,7 +407,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheetValidation.windows.js",
       "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
@@ -415,15 +415,15 @@
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseVersion": "0.0.0-3b7679bd3",
-      "baseHash": "83b203d547d9bdc57a8f3346ecee6f6e34b25f5d",
+      "baseVersion": "0.0.0-851d01b0a",
+      "baseHash": "e8f8ce02645228b423fdda317e5d1d9e69b54e6d",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.windows.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": 4629
     },
@@ -431,14 +431,14 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.windows.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f"
     },
     {
@@ -449,7 +449,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.windows.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -457,7 +457,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleList.windows.js",
       "baseFile": "RNTester/js/components/RNTesterExampleList.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "fc507321dc5cb53be93df517ba5c4b1acd0074f4",
       "issue": "LEGACY_FIXME"
     },
@@ -465,7 +465,7 @@
       "type": "derived",
       "file": "src/RNTester/js/examples/PlatformColor/PlatformColorExample.windows.js",
       "baseFile": "RNTester/js/examples/PlatformColor/PlatformColorExample.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "a63038b104bcf3caa0984d994bf3916ef1aa38ee",
       "issue": 4055
     },
@@ -473,7 +473,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/ScrollView/ScrollViewExample.windows.js",
       "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "e622893fe0a5ce9d48b10644cd29a38de72b6a26",
       "issue": "LEGACY_FIXME"
     },
@@ -481,7 +481,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/TextInput/TextInputExample.windows.js",
       "baseFile": "RNTester/js/examples/TextInput/TextInputExample.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "1755bffd6ae353838f1779007dc4a512b8dddcdc",
       "issue": 5688
     },
@@ -489,7 +489,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/View/ViewExample.windows.js",
       "baseFile": "RNTester/js/examples/View/ViewExample.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "76d4a9914e731bffefefd3b0de90c97a1726e2a9",
       "issue": "LEGACY_FIXME"
     },
@@ -497,7 +497,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.windows.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -505,7 +505,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.windows.ts",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-3b7679bd3",
+      "baseVersion": "0.0.0-851d01b0a",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,7 +57,7 @@
     "@react-native-community/eslint-config": "^1.1.0",
     "@types/react": "16.9.0",
     "@types/react-native": "^0.62.10",
-    "eslint": "6.7.0",
+    "eslint": "6.8.0",
     "eslint-plugin-prettier": "2.6.2",
     "flow-bin": "^0.126.1",
     "jscodeshift": "^0.9.0",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,12 +59,12 @@
     "@types/react-native": "^0.62.10",
     "eslint": "6.7.0",
     "eslint-plugin-prettier": "2.6.2",
-    "flow-bin": "^0.125.1",
+    "flow-bin": "^0.126.1",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "prettier": "1.17.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3",
+    "react-native": "0.0.0-851d01b0a",
     "react-native-platform-override": "^0.2.1",
     "react-native-windows-codegen": "0.1.0",
     "react-refresh": "^0.4.0",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3b7679bd3"
+    "react-native": "0.0.0-851d01b0a"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -1117,8 +1117,7 @@ function InternalTextInput(props: Props): React.Node {
     const style = [props.style];
     const autoCapitalize = props.autoCapitalize || 'sentences';
     let children = props.children;
-    let childCount = 0;
-    React.Children.forEach(children, () => ++childCount);
+    const childCount = React.Children.count(children);
     invariant(
       !(props.value && childCount),
       'Cannot specify both value and children.',

--- a/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
@@ -251,18 +251,6 @@ type AndroidViewProps = $ReadOnly<{|
   renderToHardwareTextureAndroid?: ?boolean,
 
   /**
-   * Views that are only used to layout their children or otherwise don't draw
-   * anything may be automatically removed from the native hierarchy as an
-   * optimization. Set this property to `false` to disable this optimization and
-   * ensure that this `View` exists in the native view hierarchy.
-   *
-   * @platform android
-   *
-   * See https://reactnative.dev/docs/view.html#collapsable
-   */
-  collapsable?: ?boolean,
-
-  /**
    * Whether this `View` needs to rendered offscreen and composited with an
    * alpha in order to preserve 100% correct colors and blending behavior.
    *
@@ -496,6 +484,19 @@ export type ViewProps = $ReadOnly<{|
    *
    */
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+
+  /**
+   * Views that are only used to layout their children or otherwise don't draw
+   * anything may be automatically removed from the native hierarchy as an
+   * optimization. Set this property to `false` to disable this optimization and
+   * ensure that this `View` exists in the native view hierarchy.
+   *
+   * @platform android
+   * In Fabric, this prop is used in ios as well.
+   *
+   * See https://reactnative.dev/docs/view.html#collapsable
+   */
+  collapsable?: ?boolean,
 
   /**
    * Used to locate this view in end-to-end tests.

--- a/vnext/src/Libraries/Types/CoreEventTypes.windows.js
+++ b/vnext/src/Libraries/Types/CoreEventTypes.windows.js
@@ -91,7 +91,7 @@ export type PressEvent = ResponderSyntheticEvent<
     button: ?number, // TODO(macOS)
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
     ctrlKey: ?boolean, // TODO(macOS)
-    force: number,
+    force?: number,
     identifier: number,
     locationX: number,
     locationY: number,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,14 +2481,6 @@
     js-yaml "~3.13.1"
     resolve "~1.17.0"
 
-"@microsoft/api-extractor-model@7.8.15":
-  version "7.8.15"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.8.15.tgz#a9ade86180157aead2e63e5edb439c4d8f158049"
-  integrity sha512-z81RLrvZdCxPMDBH6JVtZAMMrxDsDGz4mW7GM6OGxPlooTtSVtPH9RNhZFbA6zp7/4ANgBlqURl8zIsxvFeppA==
-  dependencies:
-    "@microsoft/tsdoc" "0.12.19"
-    "@rushstack/node-core-library" "3.27.0"
-
 "@microsoft/api-extractor-model@7.8.16":
   version "7.8.16"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.8.16.tgz#0d4eb2ca65a62db2c2e0db3ee1ba04af74afef55"
@@ -2751,19 +2743,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz#e42b1bef12d2415411519fd528e64b593b1363dc"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
 
-"@rushstack/node-core-library@3.27.0":
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.27.0.tgz#474446d29dcb5166946af2cd9ec86d58e1444b58"
-  integrity sha512-6fS7wqcxL4XGVFkhECMCqsqXouPRDWKMgNpyrmXJRS0PPumRMW+9m2knVK/kgTrMwcnbGysqxX/77PiFErw8wg==
-  dependencies:
-    "@types/node" "10.17.13"
-    colors "~1.2.1"
-    fs-extra "~7.0.1"
-    jju "~1.4.0"
-    semver "~7.3.0"
-    timsort "~0.3.0"
-    z-schema "~3.18.3"
-
 "@rushstack/node-core-library@3.28.0":
   version "3.28.0"
   resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.28.0.tgz#e52b4171cb2a62fc347b3ca18a408f53281f6ae0"
@@ -2777,15 +2756,6 @@
     semver "~7.3.0"
     timsort "~0.3.0"
     z-schema "~3.18.3"
-
-"@rushstack/ts-command-line@4.4.8":
-  version "4.4.8"
-  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.4.8.tgz#46559932c7e9a70ea071c3ce376a2e7ad0d2e9b1"
-  integrity sha512-giyVXuyI2BAID0BINp8TbxcTf5MEao+UPadAMfCuuS64mSE1E76S8wzhjqEy3WaTSpgyRDi7dMlEegNnD/97Gw==
-  dependencies:
-    "@types/argparse" "1.0.38"
-    argparse "~1.0.9"
-    colors "~1.2.1"
 
 "@rushstack/ts-command-line@4.5.0":
   version "4.5.0"
@@ -7085,10 +7055,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.125.1:
-  version "0.125.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.125.1.tgz#7edbc71e7dc39ddef18086ef75c714bbf1c5917f"
-  integrity sha512-jEury9NTXylxQEOAXLWEE945BjBwYcMwwKVnb+5XORNwMQE7i5hQYF0ysYfsaaYOa7rW/U16rHBfwLuaZfWV7A==
+flow-bin@^0.126.1:
+  version "0.126.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.126.1.tgz#2726595e1891dc35b379b5994627432df4ead52c"
+  integrity sha512-RI05x7rVzruRVJQN3M4vLEjZMwUHJKhGz9FmL8HN7WiSo66/131EyJS6Vo8PkKyM2pgT9GRWfGP/tXlqS54XUg==
 
 flow-parser@0.*:
   version "0.113.0"
@@ -11849,10 +11819,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-3b7679bd3:
-  version "0.0.0-3b7679bd3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-3b7679bd3.tgz#557981e56c8ab24aff9b1c5d11f3f54c02720e22"
-  integrity sha512-xtMS2S/mrG8ouA0G92npKnCh1WjXzNIHC5LVbhSdXISffQsHBze8/89LOJfzUSNxNbaig7iGn2f2kouUztxoCw==
+react-native@0.0.0-851d01b0a:
+  version "0.0.0-851d01b0a"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-851d01b0a.tgz#19df5150980f5f120f136c3b8f7478673730d90c"
+  integrity sha512-JhwM4ysn4eVbwA/jayeGNPpXUZgDdCpzTacioePLweTR/PAxeKTwt002NyhQ+CVhWPowJDubWtSrxWfJjHksPg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6466,10 +6466,10 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.0.tgz#766162e383b236e61d873697f82c3a3e41392020"
-  integrity sha512-dQpj+PaHKHfXHQ2Imcw5d853PTvkUGbHk/MR68KQUl98EgKDCdh4vLRH1ZxhqeQjQFJeg8fgN0UwmNhN3l8dDQ==
+eslint@6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"


### PR DESCRIPTION
A very gentle 1 week of changes. Notable bits are marking the collapsable prop as available on both Android + iOS, added caching code for NM constants, some internal JSI changes around error handling.

----
Commits: https://github.com/facebook/react-native/compare/3b7679bd3...851d01b0a

### Removed

#### Android specific

- Delete ReactViewPager ([f438a6e8f6](facebook/react-native@f438a6e) by [@JoshuaGross](https://github.com/JoshuaGross))

#### iOS specific

- Main queue execution of constantsToExport in NativeModules requiring main queue setup ([d7ac21cec5](facebook/react-native@d7ac21c) by [@RSNara](https://github.com/RSNara))

### Fixed

- Make sure LogBox is not included in production bundles ([d3b937f990](facebook/react-native@d3b937f) by [@janicduplessis](https://github.com/janicduplessis))
- Fix assertions ([ceb6c3de54](facebook/react-native@ceb6c3d) by [@lunaleaps](https://github.com/lunaleaps))
- Mark `force` as an optional property of the PressEvent object ([ad2f98df8f](facebook/react-native@ad2f98d) by [@Simek](https://github.com/Simek))

#### iOS specific

- Execute ObjC TurboModule async method calls on JS thread for sync modules ([976f51abd9](facebook/react-native@976f51a) by [@RSNara](https://github.com/RSNara))

### Unknown

- Cache constants for MP Search NativeModules ([96fdaa541e](facebook/react-native@96fdaa5) by [@RSNara](https://github.com/RSNara))
- Cache constants for MP Home NativeModules ([4e9c428328](facebook/react-native@4e9c428) by [@RSNara](https://github.com/RSNara))
- Remove usage of legacy context API in modal ([29f0cedc0a](facebook/react-native@29f0ced) by [@satya164](https://github.com/satya164))
- Update to eslint 6.8 ([a4757d2823](facebook/react-native@a4757d2) by [@cpojer](https://github.com/cpojer))

#### iOS Unknown

- Convert JSEngineInstance into a runtime factory, move runtime ownership to ReactInstance ([5c474ac24c](facebook/react-native@5c474ac) by [@ejanzer](https://github.com/ejanzer))

#### Failed to parse

- Move Collapsable into shared props ([851d01b0aa](facebook/react-native@851d01b) by [@sammy-SC](https://github.com/sammy-SC))
- RM stub function from MessageQueue.js ([fdadff92ab](facebook/react-native@fdadff9) by [@PeteTheHeat](https://github.com/PeteTheHeat))
- Handle stack overflow in JSError construction gracefully ([9baf6f2140](facebook/react-native@9baf6f2) by [@mhorowitz](https://github.com/mhorowitz))
- Deploy Flow 0.126.1 ([3b96b39ab3](facebook/react-native@3b96b39) by [@samwgoldman](https://github.com/samwgoldman))
- Run getConstants method statements on main queue ([39d67737c0](facebook/react-native@39d6773) by [@RSNara](https://github.com/RSNara))
- Remove TurboModule debug logs ([e5bef7338f](facebook/react-native@e5bef73) by [@RSNara](https://github.com/RSNara))
- Remove docblock util from `@fb-tools/transformer` ([150d7f61c6](facebook/react-native@150d7f6) by [@cpojer](https://github.com/cpojer))
- Force JS inspector to form stacking context ([ee3994530d](facebook/react-native@ee39945) by [@sammy-SC](https://github.com/sammy-SC))
- A corner case check in `Instance::handleMemoryPressure` ([9d6d39de86](facebook/react-native@9d6d39d) by [@shergin](https://github.com/shergin))
- Fabric: Calling JSVM GC on memory pressure event on iOS (second attempt) ([b99bdaa218](facebook/react-native@b99bdaa) by [@shergin](https://github.com/shergin))
- Fix using deprecated constants in Android API Level 29 ([f29238cc0c](facebook/react-native@f29238c) by [@d22yan](https://github.com/d22yan))
- Fix crash in NativeAnimatedModule due to inlining and race between animation/teardown ([5d39bfa501](facebook/react-native@5d39bfa) by [@JoshuaGross](https://github.com/JoshuaGross))
- Stop all surfaces when tearing down FabricUIManager ([8a02450fbb](facebook/react-native@8a02450) by [@JoshuaGross](https://github.com/JoshuaGross))
- Remove logs related to T62192299 ([983b0a0903](facebook/react-native@983b0a0) by [@JoshuaGross](https://github.com/JoshuaGross))
- Use React.Children.count for counting children ([92160f3144](facebook/react-native@92160f3) by [@vonovak](https://github.com/vonovak))
- Disable restoreDefaultValues in Native Animated in Fabric ([163ec924fb](facebook/react-native@163ec92) by [@sammy-SC](https://github.com/sammy-SC))
- Delete ViewPagerAndroid JS and BUCK targets ([3148d1746e](facebook/react-native@3148d17) by [@JoshuaGross](https://github.com/JoshuaGross))

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5801)