### PR TITLE
 Remove dead mousemove code

### DIFF
--- a/change/react-native-windows-2020-08-21-00-49-50-no-mouse-move.json
+++ b/change/react-native-windows-2020-08-21-00-49-50-no-mouse-move.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove dead mousemove code",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-21T07:49:50.359Z"
+}

--- a/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
@@ -491,8 +491,6 @@ TryUpdateMouseEvents(ShadowNodeBase *node, const std::string &propertyName, cons
     node->m_onMouseEnterRegistered = !propertyValue.isNull() && propertyValue.asBool();
   else if (propertyName == "onMouseLeave")
     node->m_onMouseLeaveRegistered = !propertyValue.isNull() && propertyValue.asBool();
-  else if (propertyName == "onMouseMove")
-    node->m_onMouseMoveRegistered = !propertyValue.isNull() && propertyValue.asBool();
   else
     return false;
 

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -108,7 +108,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
   void UpdateTransformPS();
 
   bool IsRegisteredForMouseEvents() const {
-    return m_onMouseEnterRegistered || m_onMouseLeaveRegistered || m_onMouseMoveRegistered;
+    return m_onMouseEnterRegistered || m_onMouseLeaveRegistered;
   }
 
  protected:
@@ -125,7 +125,6 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public facebook::react::ShadowNode {
   bool m_onLayoutRegistered = false;
   bool m_onMouseEnterRegistered = false;
   bool m_onMouseLeaveRegistered = false;
-  bool m_onMouseMoveRegistered = false;
 
   // Support Keyboard
  public:

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -154,8 +154,6 @@ void TouchEventHandler::OnPointerMoved(
   } else {
     // Move with no buttons pressed
     UpdatePointersInViews(instance, args, tag, sourceElement);
-    // MouseMove support: (Not yet enabled, requires adding to ViewPropTypes.js)
-    // SendPointerMove(args, tag, sourceElement);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -165,11 +165,7 @@ dynamic ViewManagerBase::GetExportedCustomDirectEventTypeConstants() const {
   eventTypes.update(folly::dynamic::object("topLayout", folly::dynamic::object("registrationName", "onLayout"))(
       "topMouseEnter", folly::dynamic::object("registrationName", "onMouseEnter"))(
       "topMouseLeave", folly::dynamic::object("registrationName", "onMouseLeave"))(
-      "topAccessibilityAction", folly::dynamic::object("registrationName", "onAccessibilityAction"))
-                    //    ("topMouseMove",
-                    //    folly::dynamic::object("registrationName",
-                    //    "onMouseMove"))
-  );
+      "topAccessibilityAction", folly::dynamic::object("registrationName", "onAccessibilityAction")));
   return eventTypes;
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -345,9 +345,7 @@ folly::dynamic ViewViewManager::GetNativeProps() const {
   auto props = Super::GetNativeProps();
 
   props.update(folly::dynamic::object("pointerEvents", "string")("onClick", "function")("onMouseEnter", "function")(
-      "onMouseLeave", "function")
-               //("onMouseMove", "function")
-               ("acceptsKeyboardFocus", "boolean") // deprecated in 63, remove in 64.
+      "onMouseLeave", "function")("acceptsKeyboardFocus", "boolean") // deprecated in 63, remove in 64.
                ("focusable", "boolean")("enableFocusRing", "boolean")("tabIndex", "number"));
 
   return props;


### PR DESCRIPTION
RNW has native code in support of mousemove events that were never implemented. The code has been commented out for multiple years, not exposed to JS, and we want to be intentional about adding new APIs not yet in core. Remove the dead code.