### PR TITLE
[Win32] Enable logbox support on 0.62 with experimental flag

### DIFF
--- a/change/react-native-windows-2020-08-24-13-14-55-logbox.json
+++ b/change/react-native-windows-2020-08-24-13-14-55-logbox.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[Internal] Changes to ExceptionManager to allow experimental logbox",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-24T20:14:55.887Z"
+}

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -385,16 +385,6 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
   }
 
   virtual void showNewError(ErrorInfo &&info, ErrorType /*exceptionType*/) override {
-    // Check if the rebox has been suppressed
-    if (!info.ExtraData.isNull()) {
-      auto iterator = info.ExtraData.find("suppressRedBox");
-      if (iterator != info.ExtraData.items().end()) {
-        if (iterator->second.asBool()) {
-          return;
-        }
-      }
-    }
-
     std::shared_ptr<RedBox> redbox(std::make_shared<RedBox>(
         m_weakReactHost,
         [wkthis = std::weak_ptr(shared_from_this())](uint32_t id) {

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -385,6 +385,16 @@ struct DefaultRedBoxHandler : public std::enable_shared_from_this<DefaultRedBoxH
   }
 
   virtual void showNewError(ErrorInfo &&info, ErrorType /*exceptionType*/) override {
+    // Check if the rebox has been suppressed
+    if (!info.ExtraData.isNull()) {
+      auto iterator = info.ExtraData.find("suppressRedBox");
+      if (iterator != info.ExtraData.items().end()) {
+        if (iterator->second.asBool()) {
+          return;
+        }
+      }
+    }
+
     std::shared_ptr<RedBox> redbox(std::make_shared<RedBox>(
         m_weakReactHost,
         [wkthis = std::weak_ptr(shared_from_this())](uint32_t id) {

--- a/vnext/ReactWindowsCore/IRedBoxHandler.h
+++ b/vnext/ReactWindowsCore/IRedBoxHandler.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
+#include <folly/dynamic.h>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,7 @@ struct ErrorInfo {
   std::string Message;
   uint32_t Id;
   std::vector<ErrorFrameInfo> Callstack;
+  folly::dynamic ExtraData;
 };
 
 struct IRedBoxHandler {


### PR DESCRIPTION
Partial cherry pick internals of support for ExceptionsManager.reportException.  This is used for logbox support which is off by default in 0.62.  This doesn't change the external interface of 0.62, or add support for LogBox externally.

It does enable win32 to provide a implementation of the LogBox native module and allow users turn on logbox using unstable_enableLogBox which will improve the experience for win32, which didn't have a good Redbox implementation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5808)