### PR TITLE
Fix C# interop serialization for JsValueObject

### DIFF
--- a/change/react-native-windows-2020-08-24-18-13-47-master.json
+++ b/change/react-native-windows-2020-08-24-18-13-47-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix C# interop serialization for JsValueObject",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T01:13:46.898Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenMethodTests.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenMethodTests.cs
@@ -56,6 +56,18 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
     }
 
     [TestMethod]
+    public void PromiseStructParamReturnVoid()
+    {
+      TestMethod("public void Method(ReactPromise<int> promise) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
+    public void PromiseStructOneArgParamReturnVoid()
+    {
+      TestMethod("public void Method(string s, ReactPromise<int> promise) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
     public void IntParamAndPromiseParamReturnVoid()
     {
       TestMethod("public void Method(int x, IReactPromise<int> promise) {}", ReactMethod.MethodReturnStyle.Promise);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructOneArgParamReturnVoid--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructOneArgParamReturnVoid--Async.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out string arg0);
+    module.Method(arg0, new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructOneArgParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructOneArgParamReturnVoid--Sync.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out string arg0);
+    module.Method(arg0, new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructParamReturnVoid--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructParamReturnVoid--Async.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method(new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--PromiseStructParamReturnVoid--Sync.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method(new global::Microsoft.ReactNative.Managed.ReactPromise<int>(writer, resolve, reject));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGenTestBase.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGenTestBase.cs
@@ -11,89 +11,89 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests
 {
-  public abstract class CodeGenTestBase : AnalysisTestBase
-  {
-    /// <summary>
-    /// This property when set to true will update all LKG files automatically.
-    /// </summary>
-    protected const bool AutoFixLkgs = false;
-
-    protected void TestCodeGen<TSymbol>(string csSnippet, Func<CodeGenerator, TSymbol, SyntaxNode> generateCode, string lkgName = null)
+    public abstract class CodeGenTestBase : AnalysisTestBase
     {
-      TestMultipleCodeGen<TSymbol>(csSnippet, (codeGen, symbols) => generateCode(codeGen, symbols.FirstOrDefault()), lkgName);
-    }
+        /// <summary>
+        /// This property when set to true will update all LKG files automatically.
+        /// </summary>
+        protected const bool AutoFixLkgs = false;
 
-    protected void TestMultipleCodeGen<TSymbol>(string csSnippet, Func<CodeGenerator, IEnumerable<TSymbol>, SyntaxNode> generateCode, string lkgName = null)
-    {
-      var (analyzer, type) = AnalyzeModuleFile(csSnippet);
-      IEnumerable<TSymbol> symbols = type.GetMembers().OfType<TSymbol>();
-      Assert.IsTrue(symbols.Any());
+        protected void TestCodeGen<TSymbol>(string csSnippet, Func<CodeGenerator, TSymbol, SyntaxNode> generateCode, string lkgName = null)
+        {
+            TestMultipleCodeGen<TSymbol>(csSnippet, (codeGen, symbols) => generateCode(codeGen, symbols.FirstOrDefault()), lkgName);
+        }
 
-      var codeGen = new CodeGenerator(analyzer.ReactTypes, "Test.TestNS");
-      var syntax = generateCode(codeGen, symbols);
+        protected void TestMultipleCodeGen<TSymbol>(string csSnippet, Func<CodeGenerator, IEnumerable<TSymbol>, SyntaxNode> generateCode, string lkgName = null)
+        {
+            var (analyzer, type) = AnalyzeModuleFile(csSnippet);
+            IEnumerable<TSymbol> symbols = type.GetMembers().OfType<TSymbol>();
+            Assert.IsTrue(symbols.Any());
 
-      var codeToCompare = syntax.NormalizeWhitespace().ToFullString();
+            var codeGen = new CodeGenerator(analyzer.ReactTypes, "Test.TestNS");
+            var syntax = generateCode(codeGen, symbols);
+
+            var codeToCompare = syntax.NormalizeWhitespace().ToFullString();
 #pragma warning disable CS0162 // This is here to help update all the LKG's in one go and allow for easy diffing in case a codegen change is made that affects many changes
-      if (AutoFixLkgs)
-      {
-        var lkgSourceFile = GetLkgSourceFile(lkgName);
-        File.WriteAllText(lkgSourceFile, codeToCompare);
-      }
-      else
-      {
-        var lkgFile = GetLkgPath(lkgName);
-        if (!File.Exists(lkgFile))
-        {
-          TraceEncountered(codeToCompare, "Encountered");
-          Assert.Fail(
-            $"Could not find expected LKG file: '{lkgFile}'. To generate the file, set CodeGenTestBase.AutoFixLkgs temporarily to true.");
-        }
+            if (AutoFixLkgs)
+            {
+                var lkgSourceFile = GetLkgSourceFile(lkgName);
+                File.WriteAllText(lkgSourceFile, codeToCompare);
+            }
+            else
+            {
+                var lkgFile = GetLkgPath(lkgName);
+                if (!File.Exists(lkgFile))
+                {
+                    TraceEncountered(codeToCompare, "Encountered");
+                    Assert.Fail(
+                      $"Could not find expected LKG file: '{lkgFile}'. To generate the file, set CodeGenTestBase.AutoFixLkgs temporarily to true.");
+                }
 
-        var lkgContents = File.ReadAllText(lkgFile);
-        if (!String.Equals(lkgContents, codeToCompare, StringComparison.Ordinal))
-        {
-          TraceEncountered(lkgContents, "Expected");
-          TraceEncountered(codeToCompare, "Encountered");
-          Assert.AreEqual(lkgContents, codeToCompare, "Lkg does not match. To generate the file, set CodeGenTestBase.AutoFixLkgs temporarily to true.");
-        }
+                var lkgContents = File.ReadAllText(lkgFile);
+                if (!String.Equals(lkgContents, codeToCompare, StringComparison.Ordinal))
+                {
+                    TraceEncountered(lkgContents, "Expected");
+                    TraceEncountered(codeToCompare, "Encountered");
+                    Assert.AreEqual(lkgContents, codeToCompare, "Lkg does not match. To generate the file, set CodeGenTestBase.AutoFixLkgs temporarily to true.");
+                }
 #pragma warning restore CS0162
-      }
+            }
+        }
+
+        private void TraceEncountered(string contents, string title)
+        {
+            TestContext.WriteLine("*********************");
+            TestContext.WriteLine("* " + title);
+            TestContext.WriteLine("*********************");
+            TestContext.WriteLine(contents);
+
+            TestContext.WriteLine("*********************");
+        }
+
+        private string GetLkgPath(string lkgName)
+        {
+            return Path.Combine(TestContext.TestDeploymentDir, GetRelativeLkgPath(lkgName));
+        }
+
+        private string GetLkgSourceFile(string lkgName, [CallerFilePath] string file = "")
+        {
+            var sourceRoot = Path.GetDirectoryName(file);
+            return Path.Combine(sourceRoot, "CodeGen", GetRelativeLkgPath(lkgName));
+        }
+
+        private string GetRelativeLkgPath(string lkgName)
+        {
+            var suffix = string.IsNullOrEmpty(lkgName) ? lkgName : "--" + lkgName;
+            return Path.Combine("Lkg", TestContext.FullyQualifiedTestClassName + "--" + TestContext.TestName + suffix + ".lkg");
+        }
+
+        protected IPropertySymbol ParseProp(string csSnippet) => ParseMemberSymbol<IPropertySymbol>(csSnippet);
+
+        protected TSymbol ParseMemberSymbol<TSymbol>(string csSnippet)
+          where TSymbol : ISymbol
+        {
+            var (_, type) = AnalyzeModuleFile(csSnippet);
+            return type.GetMembers().OfType<TSymbol>().First();
+        }
     }
-
-    private void TraceEncountered(string contents, string title)
-    {
-      TestContext.WriteLine("*********************");
-      TestContext.WriteLine("* " + title);
-      TestContext.WriteLine("*********************");
-      TestContext.WriteLine(contents);
-
-      TestContext.WriteLine("*********************");
-    }
-
-    private string GetLkgPath(string lkgName)
-    {
-      return Path.Combine(TestContext.TestDeploymentDir, GetRelativeLkgPath(lkgName));
-    }
-
-    private string GetLkgSourceFile(string lkgName, [CallerFilePath] string file = "")
-    {
-      var sourceRoot = Path.GetDirectoryName(file);
-      return Path.Combine(sourceRoot, "CodeGen", GetRelativeLkgPath(lkgName));
-    }
-
-    private string GetRelativeLkgPath(string lkgName)
-    {
-      var suffix = string.IsNullOrEmpty(lkgName) ? lkgName : "--" + lkgName;
-      return Path.Combine("Lkg", TestContext.FullyQualifiedTestClassName + "--" + TestContext.TestName + suffix + ".lkg");
-    }
-
-    protected IPropertySymbol ParseProp(string csSnippet) => ParseMemberSymbol<IPropertySymbol>(csSnippet);
-
-    protected TSymbol ParseMemberSymbol<TSymbol>(string csSnippet)
-      where TSymbol : ISymbol
-    {
-      var (_, type) = AnalyzeModuleFile(csSnippet);
-      return type.GetMembers().OfType<TSymbol>().First();
-    }
-  }
 }

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
@@ -832,8 +832,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             if (type != null &&
                 type is INamedTypeSymbol namedType &&
                 namedType.IsGenericType &&
-                namedType.ConstructUnboundGenericType()
-                  .Equals(m_reactTypes.IReactPromise.ConstructUnboundGenericType(), SymbolEqualityComparer.Default))
+                m_compilation.ClassifyConversion(namedType.ConstructUnboundGenericType(), m_reactTypes.IReactPromise.ConstructUnboundGenericType()).Exists)
             {
                 typeParameter = namedType.TypeArguments[0];
                 return true;

--- a/vnext/Microsoft.ReactNative.Managed/JSValueWriter.cs
+++ b/vnext/Microsoft.ReactNative.Managed/JSValueWriter.cs
@@ -79,6 +79,11 @@ namespace Microsoft.ReactNative.Managed
       value.WriteTo(writer);
     }
 
+    public static void WriteValue(this IJSValueWriter writer, JSValueObject value)
+    {
+      JSValue.WriteObject(writer, value);
+    }
+
     public static void WriteValue(this IJSValueWriter writer, JSValue.Void _)
     {
       writer.WriteNull();

--- a/vnext/Microsoft.ReactNative.sln
+++ b/vnext/Microsoft.ReactNative.sln
@@ -138,20 +138,19 @@ Global
 		Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
 		include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Debug|ARM = Debug|ARM
 		Debug|ARM64 = Debug|ARM64
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|ARM = Release|ARM
 		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|ARM.ActiveCfg = Debug|ARM


### PR DESCRIPTION
Fixes #5617 

This PR addresses 2 issues dicovered through the associated bug.
* There was no direct serialization for JsValueObject
* The C# codegen assumed people used the interface IReactPromise and not the instance struct.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5826)