### PR TITLE
Add verification to ensure nuget and npm version match.

### DIFF
--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -20,6 +20,10 @@ steps:
       artifact: ReactWindows
       path: $(System.DefaultWorkingDirectory)/ReactWindows
 
+  - powershell: |
+      (Get-Content -Path $(System.DefaultWorkingDirectory)\ReactWindows\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '${{parameters.npmVersion}}' | Set-Content -Path  $(System.DefaultWorkingDirectory)\ReactWindows\Microsoft.ReactNative.VersionCheck.targets
+    displayName: Patch version check file with version ${{parameters.npmVersion}}
+
   - ${{ if eq(parameters.packDesktop, true) }}:
     - template: prep-and-pack-single.yml
       parameters:

--- a/change/react-native-windows-2020-08-26-14-38-45-master.json
+++ b/change/react-native-windows-2020-08-26-14-38-45-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add verification to ensure nuget and npm version match.",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T21:38:45.526Z"
+}

--- a/docs/testing-nuget-packages.md
+++ b/docs/testing-nuget-packages.md
@@ -50,7 +50,7 @@ Today we support the following projects as a NuGet package:
       error : Mismatch detected between npm package versions and nuget package version.
       error :     Npm:   '0.0.0-canary.148' - Z:\Temp\tst2\node_modules\react-native-windows\package.json
       error :     NuGet: '0.0.1-MyTest010' - Z:\Temp\tst2\windows\tst2\tsts2.csproj
-      error : Update either to match the version.
+      error : To update the nuget version, please see https://microsoft.github.io/react-native-windows/docs/nuget-update for instructions
       ```
       
       You can disable the check by setting the environment variable:

--- a/docs/testing-nuget-packages.md
+++ b/docs/testing-nuget-packages.md
@@ -43,6 +43,19 @@ Today we support the following projects as a NuGet package:
    1. Apply the react-native-windows template:
       1. `node z:\src\r3\packages\react-native-windows-init\lib-commonjs\Cli.js --useDevMode --overwrite  --language cs --experimentalNuGetDependency --nuGetTestFeed c:\temp\RnWNuGetTesting\feed --nuGetTestVersion 0.0.1-MyTest001 `
          > See below for a breakdown of the arguments:
+1. Deal with npm / nuget version mismatch
+   1. The nuget package checks to see if there is a version match between the nuget package and the npm package.
+      In testing these likely don't line up. You'll get the following error:
+      ```
+      error : Mismatch detected between npm package versions and nuget package version.
+      error :     Npm:   '0.0.0-canary.148' - Z:\Temp\tst2\node_modules\react-native-windows\package.json
+      error :     NuGet: '0.0.1-MyTest010' - Z:\Temp\tst2\windows\tst2\tsts2.csproj
+      error : Update either to match the version.
+      ```
+      
+      You can disable the check by setting the environment variable:
+
+      `set ReactNativeWindowsAllowNugetNpmMismatch=true`
 1. Do your testing
 
 ## Changes:

--- a/vnext/Scripts/Microsoft.ReactNative.Cxx.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Cxx.nuspec
@@ -21,6 +21,8 @@
   </metadata>
   <files>
     <file src="$nugetroot$\Microsoft.ReactNative.Cxx.targets" target="build\native"/>
+    <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build\native"/>
+    
     <file src="$nugetroot$\Microsoft.ReactNative.Cxx\**" target ="tools\Microsoft.ReactNative.Cxx"/>
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.nuspec
@@ -16,6 +16,8 @@
   </metadata>
   <files>
     <file src="$nugetroot$\Microsoft.ReactNative.Managed.CodeGen.targets" target="build"/>
+    <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build"/>
+
     <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed.CodeGen\Publish\**" target="tools"/>
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -4,6 +4,7 @@
  Licensed under the MIT License.. 
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.VersionCheck.targets" />
 
   <PropertyGroup>
     <ReactNativeCodeGenEnabled Condition="'$(ReactNativeCodeGenEnabled)' == ''">false</ReactNativeCodeGenEnabled>

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
@@ -23,6 +23,9 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="$nugetroot$\Microsoft.ReactNative.Managed.targets" target="build"/>
+    <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build"/>
+
     <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed\ref\Microsoft.ReactNative.Managed.dll" target="ref\uap10.0"/>
     <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.xml" target="ref\uap10.0"/> 
 

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.targets
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.VersionCheck.targets" />
-  <Import Project="$(MSBuildThisFileDirectory)..\..\tools\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
 </Project>

--- a/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
@@ -95,6 +95,6 @@
       Text="Expected to find npm package 'react-native-windows' in '$(_ReactNativeWindowsVersionCheckPackageJsonPath)', encountered '$(_ReactNativeWindowsVersionCheckNpmName)'" />
     <Error 
       Condition="'$(_ReactNativeWindowsVersionCheckNpmVersion)' != '$(_ReactNativeWindowsVersionCheckNugetVersion)'"
-      Text="Mismatch detected between npm package versions and nuget package version.%0a    Npm:   '$(_ReactNativeWindowsVersionCheckNpmVersion)' - $(_ReactNativeWindowsVersionCheckPackageJsonPath)%0a    NuGet: '$(_ReactNativeWindowsVersionCheckNugetVersion)' - $(MSBuildProjectFile)%0aUpdate either to match the version." />
+      Text="Mismatch detected between npm package versions and nuget package version.%0a    Npm:   '$(_ReactNativeWindowsVersionCheckNpmVersion)' - $(_ReactNativeWindowsVersionCheckPackageJsonPath)%0a    NuGet: '$(_ReactNativeWindowsVersionCheckNugetVersion)' - $(MSBuildProjectFile)%0aTo update the nuget version, please see https://microsoft.github.io/react-native-windows/docs/nuget-update for instructions." />
   </Target>
 </Project>

--- a/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <UsingTask
+    TaskName="ExtractNpmVersion"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+
+    <ParameterGroup>
+      <PackageJsonPath ParameterType="System.String" Required="true" />
+      <NpmName ParameterType="System.String" Output="true" />
+      <NpmVersion ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    
+    <Task>
+      <!-- <Reference Include="System.Runtime.Serialization.dll" /> -->
+
+      <Code Type="Class" Language="cs">
+<![CDATA[
+  using System;
+  using System.Data;
+  using System.IO;
+  using System.Runtime.Serialization;
+  using System.Runtime.Serialization.Json;
+
+    public class ExtractNpmVersion : Microsoft.Build.Utilities.Task {
+        [DataContract]
+        private class PackageJson {
+
+          [DataMember]
+          public string name { get; set; }
+
+          [DataMember]
+          public string version { get; set; }
+        }
+
+        public virtual string PackageJsonPath { get; set; }
+        public virtual string NpmName { get; set; }
+        public virtual string NpmVersion { get; set; }
+        
+        public override bool Execute() {
+          // This code uses DataContractJsonSerializer because that ships with all frameworks
+          // System.Text.Json or NewtonSoft would require a package depednency, which is pretty cumbersome today.
+          var jsonSerializer = new DataContractJsonSerializer(typeof(PackageJson));
+          using (var fileStream = new FileStream(PackageJsonPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+          {
+            var pkgJson = (PackageJson)jsonSerializer.ReadObject(fileStream);
+            NpmName = pkgJson.name;
+            NpmVersion = pkgJson.version;
+          }
+
+          return true;
+        }
+    }
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  
+  <!-- This target checks if the npm package version matches the nuget package -->
+  <Target 
+    Name="ReactNativeWindowsVersionCheck" 
+    BeforeTargets="PrepareForBuild"
+    Condition="'$(ReactNativeWindowsAllowNugetNpmMismatch)' != 'true'"
+    >
+
+    <PropertyGroup>
+      <_ReactNativeWindowsVersionCheckNugetVersion>$$nuGetPackageVersion$$</_ReactNativeWindowsVersionCheckNugetVersion>
+    </PropertyGroup>
+   
+    <!-- Validate package.json file -->
+    <Error
+      Condition="'$(ReactNativeWindowsDir)' == ''"
+      Text="The project does not defined property 'ReactNativeWindowsDir'. This is required to be configured for any react-native-windows project."
+    />
+    
+    <PropertyGroup>
+      <_ReactNativeWindowsVersionCheckPackageJsonPath>$([System.IO.Path]::Combine($(ReactNativeWindowsDir), 'package.json'))</_ReactNativeWindowsVersionCheckPackageJsonPath>
+    </PropertyGroup>
+    
+    <Error
+      Condition="!Exists($(_ReactNativeWindowsVersionCheckPackageJsonPath))"
+      Text="The package.json file for react-native-windows could not be found at: '$(_ReactNativeWindowsVersionCheckPackageJsonPath)'"
+    />
+
+    <ExtractNpmVersion PackageJsonPath="$(_ReactNativeWindowsVersionCheckPackageJsonPath)">
+      <Output PropertyName="_ReactNativeWindowsVersionCheckNpmVersion" TaskParameter="NpmVersion" />
+      <Output PropertyName="_ReactNativeWindowsVersionCheckNpmName" TaskParameter="NpmName" />
+    </ExtractNpmVersion>
+  
+    <Message Text="Discovered package '$(_ReactNativeWindowsVersionCheckNpmName)' with version '$(_ReactNativeWindowsVersionCheckNpmVersion)'" Importance="High" />
+
+    <Error 
+      Condition="'$(_ReactNativeWindowsVersionCheckNpmName)' != 'react-native-windows'"
+      Text="Expected to find npm package 'react-native-windows' in '$(_ReactNativeWindowsVersionCheckPackageJsonPath)', encountered '$(_ReactNativeWindowsVersionCheckNpmName)'" />
+    <Error 
+      Condition="'$(_ReactNativeWindowsVersionCheckNpmVersion)' != '$(_ReactNativeWindowsVersionCheckNugetVersion)'"
+      Text="Mismatch detected between npm package versions and nuget package version.%0a    Npm:   '$(_ReactNativeWindowsVersionCheckNpmVersion)' - $(_ReactNativeWindowsVersionCheckPackageJsonPath)%0a    NuGet: '$(_ReactNativeWindowsVersionCheckNugetVersion)' - $(MSBuildProjectFile)%0aUpdate either to match the version." />
+  </Target>
+</Project>

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -17,6 +17,7 @@
   <files>
 
     <file src="$nugetroot$\Microsoft.ReactNative.targets" target="build\native"/>
+    <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build\native"/>
 
     <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative\Microsoft.ReactNative.winmd"   target="lib\uap10.0"/>
     <!-- 

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.VersionCheck.targets" />
+
   <PropertyGroup>
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -103,11 +103,17 @@ Copy-Item -Force -Path $ReactWindowsRoot\Scripts\*.nuspec -Destination $TargetRo
 #Copy StripAdditionalPlatformsFromNuspec.ps1 for use by publish task
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\StripAdditionalPlatformsFromNuspec.ps1 -Destination $TargetRoot
 
+# Microsoft.ReactNative.VersionCheck.targets
+Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.VersionCheck.targets -Destination $TargetRoot
+
 # Microsoft.ReactNative.targets
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.targets -Destination $TargetRoot
 
 # Microsoft.ReactNative.Cxx.targets
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.Cxx.targets -Destination $TargetRoot
+
+# Microsoft.ReactNative.Managed.targets
+Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.Managed.targets -Destination $TargetRoot
 
 # Microsoft.ReactNative.Managed.CodeGen.targets
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.Managed.CodeGen.targets -Destination $TargetRoot


### PR DESCRIPTION
This will add a targets file: Microsoft.ReactNative.VersionCheck.targets
to all nuget packages. When evaluated in msbuild it will perform a check
to see if the specified version of the react-native-windows package matches
the current nuget package.

It is challenging with a mix of `PackageReference` and `packages.json` (UWP doesn't support the former yet)
to consistenly figure out the version number from within the nuget package itself.
It would involve walking the parent folder looking for nuspec or npkg files and reverse engineering
the version number from the nupkg filename. In the nuspec case (PackageReference) it is simple as you just need to
parse the nusepc file. In the UWP case, it is complicated since there is no nuspec file by default, on a nupkg file.
The issue with that is that the filename is <id>.<version> and the dot separator is valid in both the id and the version
so there is no clear way to know which is which. The only approach would have
been to extract the zip file (with nuget semantics, it's not a straight unzip as filenames are url-encoded in the zip) and
then parse the nuspect inside...

To simplify this change takes a short-cut of baking the nuget version into the targets file during the build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5836)