### PR TITLE
Fix deploy bug when framework packages are installed but not for all archs 

### DIFF
--- a/change/@react-native-windows-cli-2020-08-25-14-33-38-archDeploy.json
+++ b/change/@react-native-windows-cli-2020-08-25-14-33-38-archDeploy.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix deploy bug where a framework package is installed for one arch but not the one that we are building for",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T21:33:38.306Z"
+}

--- a/packages/@react-native-windows/cli/powershell/WindowsStoreAppUtils.ps1
+++ b/packages/@react-native-windows/cli/powershell/WindowsStoreAppUtils.ps1
@@ -254,7 +254,7 @@ function Install-AppDependencies {
     $xml=[xml] (gc $AppxManifestPath);
     $packageNamesToInstall = $xml.Package.Dependencies.PackageDependency | 
         Where-Object { 
-            $installed = Get-AppxPackage $_.Name;
+            $installed = Get-AppxPackage $_.Name | Where-Object -Property Architecture -EQ -Value $Architecture;
             $installed -eq $null -or $installed.Version -lt $_.MinVersion 
         } | 
         % { $_.Name };


### PR DESCRIPTION
Fixes #5793 

When determining which dependent framework packages to install we weren't filtering the list based on architecture, so if we were trying to install an x86 app and depend on a package that we only have the x64 version installed, we would report the package as installed and the app deploy would then fail since it depends on the x86 package.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5838)