### PR TITLE
[0.62] Fix deploy bug when framework packages are installed but not for all archs

### DIFF
--- a/change/react-native-windows-2020-08-25-14-42-13-archDeploy-0.62.json
+++ b/change/react-native-windows-2020-08-25-14-42-13-archDeploy-0.62.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[0.62] Fix deploy bug when framework packages are installed but not for all archs",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T21:42:13.886Z"
+}

--- a/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/vnext/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -242,7 +242,7 @@ function Install-AppDependencies {
     $xml=[xml] (gc $AppxManifestPath);
     $packageNamesToInstall = $xml.Package.Dependencies.PackageDependency | 
         Where-Object { 
-            $installed = Get-AppxPackage $_.Name;
+            $installed = Get-AppxPackage $_.Name  | Where-Object -Property Architecture -EQ -Value $Architecture;
             $installed -eq $null -or $installed.Version -lt $_.MinVersion 
         } | 
         % { $_.Name };


### PR DESCRIPTION
Port #5838 to 0.62

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5840)