### PR TITLE
Harden ReactInstanceWin::NativeUIManager to return null when instance is being torn down

### DIFF
--- a/change/react-native-windows-2020-08-26-09-05-25-hardengetnui.json
+++ b/change/react-native-windows-2020-08-26-09-05-25-hardengetnui.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Harden ReactInstanceWin::NativeUIManager to return null when instance is being torn down",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T16:05:25.107Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -735,7 +735,10 @@ void ReactInstanceWin::DispatchEvent(int64_t viewTag, std::string &&eventName, f
 }
 
 facebook::react::INativeUIManager *ReactInstanceWin::NativeUIManager() noexcept {
-  return m_uiManager.LoadWithLock()->getNativeUIManager();
+  if (auto uimanger = m_uiManager.LoadWithLock()) {
+    return uimanger->getNativeUIManager();
+  }
+  return nullptr;
 }
 
 std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() noexcept {


### PR DESCRIPTION
I hit a crash on reload.  Couldn't hit it again, but the crash was caused by this function as called from PreviewKeyboardEventHandlerOnRoot.  PreviewKeyboardEventHandlerOnRoot correctly handles the null return, so this should prevent this crash.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5848)