### PR TITLE
Start application when activated by ToastActivation

### DIFF
--- a/change/react-native-windows-2020-08-27-07-37-21-fix-toast-activation.json
+++ b/change/react-native-windows-2020-08-27-07-37-21-fix-toast-activation.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Launch application for all ActivationKinds",
+  "packageName": "react-native-windows",
+  "email": "ryan.fowler@singlewire.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T13:37:21.576Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -104,6 +104,8 @@ void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActiv
     auto protocolActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
     react::uwp::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
     this->OnCreate(e);
+  } else if (e.Kind() == ActivationKind::ToastNotification) {
+    this->OnCreate(e);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -103,10 +103,8 @@ void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActiv
   if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
     auto protocolActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
     react::uwp::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
-    this->OnCreate(e);
-  } else if (e.Kind() == ActivationKind::ToastNotification) {
-    this->OnCreate(e);
   }
+  this->OnCreate(e);
 }
 
 void ReactApplication::OnLaunched(activation::LaunchActivatedEventArgs const &e_) {


### PR DESCRIPTION
Clicking on a Toast notification should start the application. This change does that, but I'm not sure if other `ActivationKind`s need the same treatment or if/how to write a test for this change.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5850)