### PR TITLE
[0.63] Fix TouchableWin32 Infinite Recursion on Click (#5846)

### DIFF
--- a/change/@office-iss-react-native-win32-2020-08-26-03-46-19-fix-touchablewin32-recurse.json
+++ b/change/@office-iss-react-native-win32-2020-08-26-03-46-19-fix-touchablewin32-recurse.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix TouchableWin32 Infinite Recursion on Click",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T10:46:19.635Z"
+}

--- a/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableWin32.tsx
@@ -31,6 +31,8 @@ import { IKeyboardEvent } from '../View/ViewWin32.Props';
 const BoundingDimensions = require('./BoundingDimensions');
 const Position = require('./Position');
 
+const {findNodeHandle} = require('../../Renderer/shims/ReactNative');
+
 /**
  * Extracts a single touch, generally this is the active touch or touch that
  * has just ended
@@ -290,7 +292,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
    * On responder being granted, state and local data need to be set
    */
   private _touchableHandleResponderGrant = (e: IPressEvent): void => {
-    const dispatchID = e.currentTarget;
+    const dispatchID = findNodeHandle(e.currentTarget);
     e.persist();
 
     this._pressOutDelayTimeout && clearTimeout(this._pressOutDelayTimeout);


### PR DESCRIPTION
* Fix TouchableWin32 Infinite Recursion on Click

Seems this made it into 0.63. onResponderGrant's currentTarget type changed from a react tag to host component. The target is untyped, but we were assuming it was a react tag and calling UIManager.measure on it. Call findNodeHandle when we get the event to convert to react tag.

* Change files

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5853)