### PR TITLE
[0.60] DropViews still in ShadowNode registry during UIManager dtor

### DIFF
--- a/change/react-native-windows-2020-08-26-19-52-57-dropview.json
+++ b/change/react-native-windows-2020-08-26-19-52-57-dropview.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "DropViews still in the Registry in UIManager dtor",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T02:52:57.094Z"
+}

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -26,7 +26,7 @@ UIManager::UIManager(std::vector<std::unique_ptr<IViewManager>> &&viewManagers, 
 
 UIManager::~UIManager() {
   m_nodeRegistry.removeAllRootViews([this](int64_t rootViewTag) { removeRootView(rootViewTag); });
-  m_nodeRegistry.ForAllNodes([this](int64_t tag, shadow_ptr const &shadowNode) noexcept {
+  m_nodeRegistry.ForAllNodes([this](int64_t tag, shadow_ptr const &shadowNode) {
     DropView(tag, false, true);
   });
   m_nativeUIManager->setHost(nullptr);

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -26,9 +26,7 @@ UIManager::UIManager(std::vector<std::unique_ptr<IViewManager>> &&viewManagers, 
 
 UIManager::~UIManager() {
   m_nodeRegistry.removeAllRootViews([this](int64_t rootViewTag) { removeRootView(rootViewTag); });
-  m_nodeRegistry.ForAllNodes([this](int64_t tag, shadow_ptr const &shadowNode) {
-    DropView(tag, false, true);
-  });
+  m_nodeRegistry.ForAllNodes([this](int64_t tag, shadow_ptr const &shadowNode) { DropView(tag, false, true); });
   m_nativeUIManager->setHost(nullptr);
   m_nativeUIManager->destroy();
 }

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -26,7 +26,9 @@ UIManager::UIManager(std::vector<std::unique_ptr<IViewManager>> &&viewManagers, 
 
 UIManager::~UIManager() {
   m_nodeRegistry.removeAllRootViews([this](int64_t rootViewTag) { removeRootView(rootViewTag); });
-
+  for (auto it = m_nodeRegistry.getAllNodes().begin(); it != m_nodeRegistry.getAllNodes().end(); it++) {
+    DropView(it->first, false, true);
+  }
   m_nativeUIManager->setHost(nullptr);
   m_nativeUIManager->destroy();
 }

--- a/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
+++ b/vnext/ReactWindowsCore/Modules/UIManagerModule.cpp
@@ -26,9 +26,9 @@ UIManager::UIManager(std::vector<std::unique_ptr<IViewManager>> &&viewManagers, 
 
 UIManager::~UIManager() {
   m_nodeRegistry.removeAllRootViews([this](int64_t rootViewTag) { removeRootView(rootViewTag); });
-  for (auto it = m_nodeRegistry.getAllNodes().begin(); it != m_nodeRegistry.getAllNodes().end(); it++) {
-    DropView(it->first, false, true);
-  }
+  m_nodeRegistry.ForAllNodes([this](int64_t tag, shadow_ptr const &shadowNode) noexcept {
+    DropView(tag, false, true);
+  });
   m_nativeUIManager->setHost(nullptr);
   m_nativeUIManager->destroy();
 }

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -78,7 +78,7 @@
       -->
       <PreprocessorDefinitions>REACTWINDOWS_BUILD;NOMINMAX;FOLLY_NO_CONFIG;WIN32=0;RN_EXPORT=;CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(USE_HERMES)'=='true'">USE_HERMES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)Mso;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)Mso;$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <PreprocessToFile>false</PreprocessToFile>

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxproj
@@ -78,7 +78,7 @@
       -->
       <PreprocessorDefinitions>REACTWINDOWS_BUILD;NOMINMAX;FOLLY_NO_CONFIG;WIN32=0;RN_EXPORT=;CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(USE_HERMES)'=='true'">USE_HERMES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)Mso;$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(ReactNativeWindowsDir)include;$(ReactNativeWindowsDir)include\ReactWindowsCore;$(ReactNativeDir)\ReactCommon;$(JSI_Source);$(ReactNativeWindowsDir)stubs;$(FollyDir);$(ReactNativeWindowsDir)\ReactWindowsCore\tracing;$(ReactNativeWindowsDir)Mso;$(ReactNativeWindowsDir)\JSI\Shared;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <PreprocessToFile>false</PreprocessToFile>

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -66,7 +66,7 @@ ShadowNode *ShadowNodeRegistry::getParentRootShadowNode(int64_t nodeTag) {
   return nullptr;
 }
 
-void ShadowNodeRegistry::ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &) noexcept> &fnDo) noexcept {
+void ShadowNodeRegistry::ForAllNodes(const std::function<void(int64_t, shadow_ptr const &)> &fnDo) noexcept {
   for (auto &kvp : m_allNodes) {
     fnDo(kvp.first, kvp.second);
   }

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -66,7 +66,7 @@ ShadowNode *ShadowNodeRegistry::getParentRootShadowNode(int64_t nodeTag) {
   return nullptr;
 }
 
-void ShadowNodeRegistry::ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &)> &fnDo) noexcept {
+void ShadowNodeRegistry::ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &) noexcept> &fnDo) noexcept {
   for (auto &kvp : m_allNodes) {
     fnDo(kvp.first, kvp.second);
   }

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -54,10 +54,6 @@ std::unordered_set<int64_t> &ShadowNodeRegistry::getAllRoots() {
   return m_roots;
 }
 
-std::map<int64_t, shadow_ptr> &ShadowNodeRegistry::getAllNodes() {
-  return m_allNodes;
-}
-
 // iterate its parent to get the root shadow node
 ShadowNode *ShadowNodeRegistry::getParentRootShadowNode(int64_t nodeTag) {
   auto node = findNode(nodeTag);

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -54,6 +54,10 @@ std::unordered_set<int64_t> &ShadowNodeRegistry::getAllRoots() {
   return m_roots;
 }
 
+std::map<int64_t, shadow_ptr>& ShadowNodeRegistry::getAllNodes() {
+  return m_allNodes;
+}
+
 // iterate its parent to get the root shadow node
 ShadowNode *ShadowNodeRegistry::getParentRootShadowNode(int64_t nodeTag) {
   auto node = findNode(nodeTag);

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -54,7 +54,7 @@ std::unordered_set<int64_t> &ShadowNodeRegistry::getAllRoots() {
   return m_roots;
 }
 
-std::map<int64_t, shadow_ptr>& ShadowNodeRegistry::getAllNodes() {
+std::map<int64_t, shadow_ptr> &ShadowNodeRegistry::getAllNodes() {
   return m_allNodes;
 }
 

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.cpp
@@ -70,5 +70,11 @@ ShadowNode *ShadowNodeRegistry::getParentRootShadowNode(int64_t nodeTag) {
   return nullptr;
 }
 
+void ShadowNodeRegistry::ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &)> &fnDo) noexcept {
+  for (auto &kvp : m_allNodes) {
+    fnDo(kvp.first, kvp.second);
+  }
+}
+
 } // namespace react
 } // namespace facebook

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.h
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include <ShadowNode.h>
-#include <functional/functorref.h>
 #include <map>
 
 namespace facebook {
@@ -33,7 +32,7 @@ struct ShadowNodeRegistry {
 
   ShadowNode *getParentRootShadowNode(int64_t nodeTag);
 
-  void ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &) noexcept> &fnDo) noexcept;
+  void ForAllNodes(const std::function<void(int64_t, shadow_ptr const &)> &fnDo) noexcept;
 
  private:
   std::unordered_set<int64_t> m_roots;

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.h
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <ShadowNode.h>
+#include <functional/functorref.h>
 #include <map>
 
 namespace facebook {
@@ -32,6 +33,8 @@ struct ShadowNodeRegistry {
   std::map<int64_t, shadow_ptr> &getAllNodes();
 
   ShadowNode *getParentRootShadowNode(int64_t nodeTag);
+
+  void ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &)> &fnDo) noexcept;
 
  private:
   std::unordered_set<int64_t> m_roots;

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.h
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.h
@@ -33,7 +33,7 @@ struct ShadowNodeRegistry {
 
   ShadowNode *getParentRootShadowNode(int64_t nodeTag);
 
-  void ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &)> &fnDo) noexcept;
+  void ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &) noexcept> &fnDo) noexcept;
 
  private:
   std::unordered_set<int64_t> m_roots;

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.h
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.h
@@ -30,7 +30,6 @@ struct ShadowNodeRegistry {
   void removeAllRootViews(const std::function<void(int64_t rootViewTag)> &);
 
   std::unordered_set<int64_t> &getAllRoots();
-  std::map<int64_t, shadow_ptr> &getAllNodes();
 
   ShadowNode *getParentRootShadowNode(int64_t nodeTag);
 

--- a/vnext/ReactWindowsCore/ShadowNodeRegistry.h
+++ b/vnext/ReactWindowsCore/ShadowNodeRegistry.h
@@ -29,6 +29,7 @@ struct ShadowNodeRegistry {
   void removeAllRootViews(const std::function<void(int64_t rootViewTag)> &);
 
   std::unordered_set<int64_t> &getAllRoots();
+  std::map<int64_t, shadow_ptr> &getAllNodes();
 
   ShadowNode *getParentRootShadowNode(int64_t nodeTag);
 


### PR DESCRIPTION
Office E2E Automation is running into a failure during shutdown caused by rapidly spinning up & shutting down some react-native UI.  What's happening is some Views get created, but the batch to add them to the ui tree never completes.  Usually the removeAllRootView call is sufficient to tear down the UI, but since the shadow nodes finished their batch, they're not parented to the root view.  This iterates through all shadow node left in the registry after removing the root view and explictly calls DropView on them so they can clean up their resources.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5854)