### PR TITLE
Fix fast refresh

### DIFF
--- a/change/react-native-windows-2020-08-27-14-35-27-fixrefresh.json
+++ b/change/react-native-windows-2020-08-27-14-35-27-fixrefresh.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix fast refresh",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T21:35:27.726Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -224,9 +224,15 @@ void ReactInstanceWin::Initialize() noexcept {
 
           auto devSettings = std::make_shared<facebook::react::DevSettings>();
           devSettings->useJITCompilation = m_options.EnableJITCompilation;
-          devSettings->sourceBundleHost = m_options.DeveloperSettings.SourceBundleHost;
-          devSettings->sourceBundlePort = m_options.DeveloperSettings.SourceBundlePort;
-          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName;
+          devSettings->sourceBundleHost = m_options.DeveloperSettings.SourceBundleHost.empty()
+              ? facebook::react::DevServerHelper::DefaultPackagerHost
+              : m_options.DeveloperSettings.SourceBundleHost;
+          devSettings->sourceBundlePort = m_options.DeveloperSettings.SourceBundlePort
+              ? m_options.DeveloperSettings.SourceBundlePort
+              : facebook::react::DevServerHelper::DefaultPackagerPort;
+          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName.empty()
+              ? m_options.Identity
+              : m_options.DeveloperSettings.SourceBundleName;
           devSettings->liveReloadCallback = GetLiveReloadCallback();
           devSettings->errorCallback = GetErrorCallback();
           devSettings->loggingCallback = GetLoggingCallback();
@@ -735,8 +741,8 @@ void ReactInstanceWin::DispatchEvent(int64_t viewTag, std::string &&eventName, f
 }
 
 facebook::react::INativeUIManager *ReactInstanceWin::NativeUIManager() noexcept {
-  if (auto uimanger = m_uiManager.LoadWithLock()) {
-    return uimanger->getNativeUIManager();
+  if (auto uimanager = m_uiManager.LoadWithLock()) {
+    return uimanager->getNativeUIManager();
   }
   return nullptr;
 }


### PR DESCRIPTION
The bundle path for non- index bundles wasn't getting passed through correctly.  This was causing fast refresh to not work in the platground app.

I'm going to do some testing on 0.63 to see if this needs backporting.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5860)