### PR TITLE
[0.63] Fix fast refresh

### DIFF
--- a/change/react-native-windows-2020-08-27-15-10-24-fixrefresh63.json
+++ b/change/react-native-windows-2020-08-27-15-10-24-fixrefresh63.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix fast refresh",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T22:10:24.789Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -221,9 +221,15 @@ void ReactInstanceWin::Initialize() noexcept {
 
           auto devSettings = std::make_shared<facebook::react::DevSettings>();
           devSettings->useJITCompilation = m_options.EnableJITCompilation;
-          devSettings->sourceBundleHost = m_options.DeveloperSettings.SourceBundleHost;
-          devSettings->sourceBundlePort = m_options.DeveloperSettings.SourceBundlePort;
-          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName;
+          devSettings->sourceBundleHost = m_options.DeveloperSettings.SourceBundleHost.empty()
+              ? facebook::react::DevServerHelper::DefaultPackagerHost
+              : m_options.DeveloperSettings.SourceBundleHost;
+          devSettings->sourceBundlePort = m_options.DeveloperSettings.SourceBundlePort
+              ? m_options.DeveloperSettings.SourceBundlePort
+              : facebook::react::DevServerHelper::DefaultPackagerPort;
+          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName.empty()
+              ? m_options.Identity
+              : m_options.DeveloperSettings.SourceBundleName;
           devSettings->liveReloadCallback = GetLiveReloadCallback();
           devSettings->errorCallback = GetErrorCallback();
           devSettings->loggingCallback = GetLoggingCallback();


### PR DESCRIPTION
Porting #5860 to 0.63

This fixes fast refresh. -- The source URL wasn't getting past correctly to the instance when the entry file wasn't "index".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5861)