### PR TITLE
[0.63] Harden ReactInstanceWin::NativeUIManager to return null when instance is being torn down

### DIFF
--- a/change/react-native-windows-2020-08-27-15-14-10-hardengetui63.json
+++ b/change/react-native-windows-2020-08-27-15-14-10-hardengetui63.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Harden ReactInstanceWin::NativeUIManager to return null when instance is being torn down",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T22:14:10.532Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -734,6 +734,7 @@ facebook::react::INativeUIManager *ReactInstanceWin::NativeUIManager() noexcept 
   if (auto uimanager = m_uiManager.LoadWithLock()) {
     return uimanager->getNativeUIManager();
   }
+  return nullptr;
 }
 
 std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -731,7 +731,9 @@ void ReactInstanceWin::DispatchEvent(int64_t viewTag, std::string &&eventName, f
 }
 
 facebook::react::INativeUIManager *ReactInstanceWin::NativeUIManager() noexcept {
-  return m_uiManager.LoadWithLock()->getNativeUIManager();
+  if (auto uimanager = m_uiManager.LoadWithLock()) {
+    return uimanager->getNativeUIManager();
+  }
 }
 
 std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() noexcept {


### PR DESCRIPTION
Port #5848 to 0.63

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5862)