### PR TITLE
Fix Building Playground in 0.61 

### DIFF
--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -115,8 +115,7 @@ class SampleNativeModuleProvider final : public facebook::react::NativeModulePro
     std::vector<facebook::react::NativeModuleDescription> modules;
     std::shared_ptr<facebook::react::MessageQueueThread> queue = defaultQueueThread;
 
-    modules.emplace_back(
-        SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
+    modules.emplace_back(SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
 
     return modules;
   }

--- a/packages/playground/windows/playground/HostingPane.xaml.cpp
+++ b/packages/playground/windows/playground/HostingPane.xaml.cpp
@@ -12,6 +12,8 @@
 #include <ReactUWP/ReactUwp.h>
 #include <ViewManager.h>
 
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <wrl.h>
@@ -113,7 +115,8 @@ class SampleNativeModuleProvider final : public facebook::react::NativeModulePro
     std::vector<facebook::react::NativeModuleDescription> modules;
     std::shared_ptr<facebook::react::MessageQueueThread> queue = defaultQueueThread;
 
-    modules.emplace_back(SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
+    modules.emplace_back(
+        SampleCxxModule::Name, []() { return std::make_unique<SampleCxxModule>(); }, queue);
 
     return modules;
   }


### PR DESCRIPTION
Even with VS 2017, we can't seem to build Playground in 0.61 due to missing headers. Not sure if we built playground in CI at the time, or had a different environment.

Fix the build, so we can use 0.61 to test reproing issues.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5866)