### PR TITLE
Fix 5870: In C# CodeGen, don't check for inheritance, but do explicit type checks

### DIFF
--- a/change/react-native-windows-2020-08-31-14-37-14-pr-FixBug.json
+++ b/change/react-native-windows-2020-08-31-14-37-14-pr-FixBug.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix 5870: Dont check for inheritance, but do explicit type check",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-31T21:37:14.617Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
@@ -28,6 +28,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests
         {
             var csCode = @"
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.ReactNative.Managed;
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenMethodTests.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/CodeGenMethodTests.cs
@@ -50,6 +50,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
     }
 
     [TestMethod]
+    public void ReadOnlyListOfStringParamReturnReadOnlyList()
+    {
+      TestMethod("public string Method(IReadOnlyList<string> values) { return string.Empty; }", ReactMethod.MethodReturnStyle.ReturnValue);
+    }
+
+    [TestMethod]
     public void PromiseParamReturnVoid()
     {
       TestMethod("public void Method(IReactPromise<int> promise) {}", ReactMethod.MethodReturnStyle.Promise);
@@ -74,6 +80,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
     }
 
     [TestMethod]
+    public void ReadOnlyListOfStringPromiseReturnVoid()
+    {
+      TestMethod("public void Method(string s, IReactPromise<IReadOnlyList<string>> p2) {}", ReactMethod.MethodReturnStyle.Promise);
+    }
+
+    [TestMethod]
     public void DoublePromiseParamReturnVoid()
     {
       TestMethod("public void Method(IReactPromise<string> p1, IReactPromise<int> p2) {}", ReactMethod.MethodReturnStyle.Promise);
@@ -89,6 +101,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
     public void SingleArgCallbackParamReturnVoid()
     {
       TestMethod("public void Method(Action<int> cb1) { }", ReactMethod.MethodReturnStyle.Callback);
+    }
+
+    [TestMethod]
+    public void SingleArgCallbackWithReadOnlyListParamReturnVoid()
+    {
+      TestMethod("public void Method(Action<IReadOnlyList<string>> cb1) { }", ReactMethod.MethodReturnStyle.Callback);
     }
 
     [TestMethod]
@@ -131,6 +149,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen
     public void TwoArgsTaskOfInt()
     {
       TestMethod("public Task<int> Method(int x, int y) { return Task.FromResult(42); }", ReactMethod.MethodReturnStyle.Task, isSynchronous: false);
+    }
+
+    [TestMethod]
+    public void ZeroArgTaskOfReadOnlyListOfString()
+    {
+      TestMethod("public Task<IReadOnlyList<string>> Method() { return Task.FromResult<IReadOnlyList<string>>(new string[] { \"s1\", \"s2\" }); }", ReactMethod.MethodReturnStyle.Task, isSynchronous: false);
     }
 
     private void TestMethod(string methodDecl, ReactMethod.MethodReturnStyle returnStyle)

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringParamReturnReadOnlyList--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringParamReturnReadOnlyList--Async.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Callback, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::System.Collections.Generic.IReadOnlyList<string> arg0);
+    string result = module.Method(arg0);
+    resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, result));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringParamReturnReadOnlyList--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringParamReturnReadOnlyList--Sync.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out global::System.Collections.Generic.IReadOnlyList<string> arg0);
+    string result = module.Method(arg0);
+    global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, result);
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringPromiseReturnVoid--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringPromiseReturnVoid--Async.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out string arg0);
+    module.Method(arg0, new global::Microsoft.ReactNative.Managed.ReactPromise<global::System.Collections.Generic.IReadOnlyList<string>>(writer, resolve, reject));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringPromiseReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ReadOnlyListOfStringPromiseReturnVoid--Sync.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader, out string arg0);
+    module.Method(arg0, new global::Microsoft.ReactNative.Managed.ReactPromise<global::System.Collections.Generic.IReadOnlyList<string>>(writer, resolve, reject));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--SingleArgCallbackWithReadOnlyListParamReturnVoid--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--SingleArgCallbackWithReadOnlyListParamReturnVoid--Async.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Callback, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method((value) => resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--SingleArgCallbackWithReadOnlyListParamReturnVoid--Sync.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--SingleArgCallbackWithReadOnlyListParamReturnVoid--Sync.lkg
@@ -1,0 +1,7 @@
+moduleBuilder.AddSyncMethod("MyMethod", (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    module.Method((value) => resolve(global::Microsoft.ReactNative.Managed.JSValueWriter.WriteArgs(writer, value)));
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ZeroArgTaskOfReadOnlyListOfString--Async.lkg
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/CodeGen/Lkg/Microsoft.ReactNative.Managed.CodeGen.UnitTests.CodeGen.CodeGenMethodTests--ZeroArgTaskOfReadOnlyListOfString--Async.lkg
@@ -1,0 +1,8 @@
+moduleBuilder.AddMethod("MyMethod", global::Microsoft.ReactNative.MethodReturnType.Promise, (global::Microsoft.ReactNative.IJSValueReader reader, global::Microsoft.ReactNative.IJSValueWriter writer, global::Microsoft.ReactNative.MethodResultCallback resolve, global::Microsoft.ReactNative.MethodResultCallback reject) =>
+{
+    global::Microsoft.ReactNative.Managed.JSValueReader.ReadArgs(reader);
+    global::System.Threading.Tasks.Task<global::System.Collections.Generic.IReadOnlyList<string>> result = module.Method();
+    global::Microsoft.ReactNative.Managed.ReactTaskExtensions.ContinueWith(result, writer, resolve, reject);
+}
+
+);

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
@@ -832,7 +832,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             if (type != null &&
                 type is INamedTypeSymbol namedType &&
                 namedType.IsGenericType &&
-                m_compilation.ClassifyConversion(namedType.ConstructUnboundGenericType(), m_reactTypes.IReactPromise.ConstructUnboundGenericType()).Exists)
+                (
+                   namedType.ConstructUnboundGenericType().Equals(
+                       m_reactTypes.IReactPromise.ConstructUnboundGenericType(), SymbolEqualityComparer.Default) ||
+                    namedType.ConstructUnboundGenericType().Equals(
+                       m_reactTypes.ReactPromise.ConstructUnboundGenericType(), SymbolEqualityComparer.Default)
+                ))
             {
                 typeParameter = namedType.TypeArguments[0];
                 return true;

--- a/vnext/Microsoft.ReactNative.sln
+++ b/vnext/Microsoft.ReactNative.sln
@@ -138,6 +138,7 @@ Global
 		Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
 		include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
 		Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4


### PR DESCRIPTION
The fix for #5617 introduced a regression. The fix for that issue updated the code
to allow for all derived types of `IReactPromise<T>`. In this exapmle the C# compiler
found an assignability conversion between `IReadOnlyList<string>` and `IReactPromise<T>`.
Which resulted in invalid generated code that doesn't compile.
This fix was in hindsight also not the correct fix since the codegen (jsut like the
reflection based code) passes ReactPromise<T> instance. So the only two valid types
should be `IReactPromise<T>` or `ReactPromise<T>`. Which is what this fix puts in.

Fixes #5870

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5874)