### PR TITLE
Integrate 6/18 Nightly RN Build

### DIFF
--- a/change/@office-iss-react-native-win32-2020-09-01-06-04-23-integrate-6-18.json
+++ b/change/@office-iss-react-native-win32-2020-09-01-06-04-23-integrate-6-18.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 6-18 Nightly RN Build",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T13:04:22.230Z"
+}

--- a/change/react-native-windows-2020-09-01-06-04-23-integrate-6-18.json
+++ b/change/react-native-windows-2020-09-01-06-04-23-integrate-6-18.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 6-18 Nightly RN Build",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T13:04:23.464Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "prompt-sync": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9",
+    "react-native": "0.0.0-b095432e6",
     "react-native-windows": "0.0.0-canary.153"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9",
+    "react-native": "0.0.0-b095432e6",
     "react-native-windows": "0.0.0-canary.153"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9",
+    "react-native": "0.0.0-b095432e6",
     "react-native-windows": "0.0.0-canary.153"
   },
   "devDependencies": {

--- a/packages/react-native-win32/.flowconfig
+++ b/packages/react-native-win32/.flowconfig
@@ -122,4 +122,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.126.1
+^0.127.0

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -8,14 +8,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-3346ac7f9",
-      "baseHash": "e377e2dacacf415baa21050dd389cac9873c9f4d"
+      "baseVersion": "0.0.0-b095432e6",
+      "baseHash": "bbadb1b26ce42ed9cc3f7d950c8c2a3f9d1086d9"
     },
     {
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -23,7 +23,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -31,7 +31,7 @@
       "type": "patch",
       "file": "src/Libraries/BatchedBridge/MessageQueue.win32.js",
       "baseFile": "Libraries/BatchedBridge/MessageQueue.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "2971684d702beed9825dca81523731c1852ba388",
       "issue": 5807
     },
@@ -39,7 +39,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "611e89285ac812456b381568052cf575c955575a",
       "issue": "LEGACY_FIXME"
     },
@@ -47,7 +47,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "b3e2c37d96de6f00066495267f7c32d6e9d3f840",
       "issue": "LEGACY_FIXME"
     },
@@ -63,7 +63,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.win32.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea",
       "issue": 4378
     },
@@ -71,7 +71,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.win32.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc",
       "issue": 4378
     },
@@ -79,7 +79,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -91,7 +91,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.win32.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b",
       "issue": 4378
     },
@@ -103,7 +103,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerAndroid.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -111,7 +111,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerIOS.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6",
       "issue": 4378
     },
@@ -119,7 +119,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -127,22 +127,22 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.win32.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-3346ac7f9",
-      "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
+      "baseVersion": "0.0.0-b095432e6",
+      "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "copy",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": 4378
     },
@@ -166,7 +166,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "4508091254e184ee4dfc383c091186ba6ed60f01",
       "issue": "LEGACY_FIXME"
     },
@@ -174,7 +174,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -182,7 +182,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.win32.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0",
       "issue": 4378
     },
@@ -214,7 +214,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
       "issue": "LEGACY_FIXME"
     },
@@ -222,7 +222,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -234,7 +234,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.win32.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseVersion": "0.63.2",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "147459dc889f04f2405db051445833f791726895",
       "issue": 5843
     },
@@ -250,7 +250,7 @@
       "type": "patch",
       "file": "src/Libraries/core/ReactNativeVersionCheck.win32.js",
       "baseFile": "Libraries/core/ReactNativeVersionCheck.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "599ad6d6c8485cd453cd926cdf89f06640d439f6",
       "issue": 5170
     },
@@ -258,7 +258,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/Image.win32.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4320
     },
@@ -270,7 +270,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
       "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "6161ce89a0b45b24e8df69aa108af22a7b591483",
       "issue": 4320
     },
@@ -314,7 +314,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75",
       "issue": "LEGACY_FIXME"
     },
@@ -322,7 +322,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
       "baseFile": "Libraries/Inspector/InspectorOverlay.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "a1d045fb2d0fb751d8f0518fd40af63454b88b04",
       "issue": "LEGACY_FIXME"
     },
@@ -330,7 +330,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworking.win32.js",
       "baseFile": "Libraries/Network/RCTNetworking.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "9ba4db01878648ef181dfd51debd821a837f56b3",
       "issue": 4318
     },
@@ -350,7 +350,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -370,7 +370,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheet.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84",
       "issue": "LEGACY_FIXME"
     },
@@ -378,7 +378,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheetValidation.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
@@ -386,7 +386,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/BackHandler.win32.ts",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": "LEGACY_FIXME"
     },
@@ -394,7 +394,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
       "issue": "LEGACY_FIXME"
     },
@@ -402,7 +402,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
       "issue": "LEGACY_FIXME"
     },
@@ -410,7 +410,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5",
       "issue": "LEGACY_FIXME"
     },
@@ -418,7 +418,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f",
       "issue": "LEGACY_FIXME"
     },
@@ -434,7 +434,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.win32.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -442,7 +442,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": "LEGACY_FIXME"
     },
@@ -454,7 +454,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.win32.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -462,7 +462,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.win32.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -52,7 +52,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "@office-iss/rex-win32": "0.62.0-preview.17-tenantreactnativewin-13114",
+    "@office-iss/rex-win32": "0.62.7-tenantreactnativewin-13222",
     "@rnw-scripts/eslint-config": "0.1.0",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-promise": "0.0.32",
@@ -62,17 +62,17 @@
     "@types/react-native": "^0.62.10",
     "babel-eslint": "10.0.1",
     "eslint": "6.8.0",
-    "flow-bin": "^0.126.1",
+    "flow-bin": "^0.127.0",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9",
+    "react-native": "0.0.0-b095432e6",
     "react-native-platform-override": "^0.2.2",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9"
+    "react-native": "0.0.0-b095432e6"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/packages/react-native-win32/src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js
@@ -8,9 +8,9 @@
  * @format
  */
 
-const Platform = require('../../Utilities/Platform');
-const React = require('react');
-const View = require('../View/View');
+import Platform from '../../Utilities/Platform';
+import * as React from 'react';
+import View from '../View/View';
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -133,4 +133,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.126.1
+^0.127.0

--- a/vnext/ReactCopies/RNTester/js/examples/Image/ImageExample.js
+++ b/vnext/ReactCopies/RNTester/js/examples/Image/ImageExample.js
@@ -36,7 +36,7 @@ type ImageSource = $ReadOnly<{|
 type NetworkImageCallbackExampleState = {|
   events: Array<string>,
   startLoadPrefetched: boolean,
-  mountTime: Date,
+  mountTime: number,
 |};
 
 type NetworkImageCallbackExampleProps = $ReadOnly<{|
@@ -51,11 +51,11 @@ class NetworkImageCallbackExample extends React.Component<
   state = {
     events: [],
     startLoadPrefetched: false,
-    mountTime: new Date(),
+    mountTime: Date.now(),
   };
 
   UNSAFE_componentWillMount() {
-    this.setState({mountTime: new Date()});
+    this.setState({mountTime: Date.now()});
   }
 
   _loadEventFired = (event: string) => {
@@ -72,43 +72,50 @@ class NetworkImageCallbackExample extends React.Component<
           source={this.props.source}
           style={[styles.base, {overflow: 'visible'}]}
           onLoadStart={() =>
-            this._loadEventFired(`✔ onLoadStart (+${new Date() - mountTime}ms)`)
+            this._loadEventFired(`✔ onLoadStart (+${Date.now() - mountTime}ms)`)
           }
+          onProgress={event => {
+            const {loaded, total} = event.nativeEvent;
+            const percent = Math.round((loaded / total) * 100);
+            this._loadEventFired(
+              `✔ onProgress ${percent}% (+${Date.now() - mountTime}ms)`,
+            );
+          }}
           onLoad={event => {
             if (event.nativeEvent.source) {
-              const url = event.nativeEvent.source.url;
+              const url = event.nativeEvent.source.uri;
               this._loadEventFired(
-                `✔ onLoad (+${new Date() - mountTime}ms) for URL ${url}`,
+                `✔ onLoad (+${Date.now() - mountTime}ms) for URL ${url}`,
               );
             } else {
-              this._loadEventFired(`✔ onLoad (+${new Date() - mountTime}ms)`);
+              this._loadEventFired(`✔ onLoad (+${Date.now() - mountTime}ms)`);
             }
           }}
           onLoadEnd={() => {
-            this._loadEventFired(`✔ onLoadEnd (+${new Date() - mountTime}ms)`);
+            this._loadEventFired(`✔ onLoadEnd (+${Date.now() - mountTime}ms)`);
             this.setState({startLoadPrefetched: true}, () => {
               prefetchTask.then(
                 () => {
                   this._loadEventFired(
-                    `✔ Prefetch OK (+${new Date() - mountTime}ms)`,
+                    `✔ Prefetch OK (+${Date.now() - mountTime}ms)`,
                   );
                   Image.queryCache([IMAGE_PREFETCH_URL]).then(map => {
                     const result = map[IMAGE_PREFETCH_URL];
                     if (result) {
                       this._loadEventFired(
-                        `✔ queryCache "${result}" (+${new Date() -
+                        `✔ queryCache "${result}" (+${Date.now() -
                           mountTime}ms)`,
                       );
                     } else {
                       this._loadEventFired(
-                        `✘ queryCache (+${new Date() - mountTime}ms)`,
+                        `✘ queryCache (+${Date.now() - mountTime}ms)`,
                       );
                     }
                   });
                 },
                 error => {
                   this._loadEventFired(
-                    `✘ Prefetch failed (+${new Date() - mountTime}ms)`,
+                    `✘ Prefetch failed (+${Date.now() - mountTime}ms)`,
                   );
                 },
               );
@@ -121,26 +128,26 @@ class NetworkImageCallbackExample extends React.Component<
             style={[styles.base, {overflow: 'visible'}]}
             onLoadStart={() =>
               this._loadEventFired(
-                `✔ (prefetched) onLoadStart (+${new Date() - mountTime}ms)`,
+                `✔ (prefetched) onLoadStart (+${Date.now() - mountTime}ms)`,
               )
             }
             onLoad={event => {
               // Currently this image source feature is only available on iOS.
               if (event.nativeEvent.source) {
-                const url = event.nativeEvent.source.url;
+                const url = event.nativeEvent.source.uri;
                 this._loadEventFired(
-                  `✔ (prefetched) onLoad (+${new Date() -
+                  `✔ (prefetched) onLoad (+${Date.now() -
                     mountTime}ms) for URL ${url}`,
                 );
               } else {
                 this._loadEventFired(
-                  `✔ (prefetched) onLoad (+${new Date() - mountTime}ms)`,
+                  `✔ (prefetched) onLoad (+${Date.now() - mountTime}ms)`,
                 );
               }
             }}
             onLoadEnd={() =>
               this._loadEventFired(
-                `✔ (prefetched) onLoadEnd (+${new Date() - mountTime}ms)`,
+                `✔ (prefetched) onLoadEnd (+${Date.now() - mountTime}ms)`,
               )
             }
           />
@@ -152,9 +159,9 @@ class NetworkImageCallbackExample extends React.Component<
 }
 
 type NetworkImageExampleState = {|
-  error: boolean,
+  error: ?string,
   loading: boolean,
-  progress: number,
+  progress: $ReadOnlyArray<number>,
 |};
 
 type NetworkImageExampleProps = $ReadOnly<{|
@@ -166,38 +173,38 @@ class NetworkImageExample extends React.Component<
   NetworkImageExampleState,
 > {
   state = {
-    error: false,
+    error: null,
     loading: false,
-    progress: 0,
+    progress: [],
   };
 
   render() {
-    const loader = this.state.loading ? (
-      <View style={styles.progress}>
-        <Text>{this.state.progress}%</Text>
-        <ActivityIndicator style={{marginLeft: 5}} />
-      </View>
-    ) : null;
-    return this.state.error ? (
+    return this.state.error != null ? (
       <Text>{this.state.error}</Text>
     ) : (
-      <ImageBackground
-        source={this.props.source}
-        style={[styles.base, {overflow: 'visible'}]}
-        onLoadStart={e => this.setState({loading: true})}
-        onError={e =>
-          this.setState({error: e.nativeEvent.error, loading: false})
-        }
-        onProgress={e =>
-          this.setState({
-            progress: Math.round(
-              (100 * e.nativeEvent.loaded) / e.nativeEvent.total,
-            ),
-          })
-        }
-        onLoad={() => this.setState({loading: false, error: false})}>
-        {loader}
-      </ImageBackground>
+      <>
+        <Image
+          source={this.props.source}
+          style={[styles.base, {overflow: 'visible'}]}
+          onLoadStart={e => this.setState({loading: true})}
+          onError={e =>
+            this.setState({error: e.nativeEvent.error, loading: false})
+          }
+          onProgress={e => {
+            const {loaded, total} = e.nativeEvent;
+            this.setState(prevState => ({
+              progress: [
+                ...prevState.progress,
+                Math.round((100 * loaded) / total),
+              ],
+            }));
+          }}
+          onLoad={() => this.setState({loading: false, error: null})}
+        />
+        <Text>
+          {this.state.progress.map(progress => `${progress}%`).join('\n')}
+        </Text>
+      </>
     );
   }
 }
@@ -346,12 +353,6 @@ const styles = StyleSheet.create({
     width: 38,
     height: 38,
   },
-  progress: {
-    flex: 1,
-    alignItems: 'center',
-    flexDirection: 'row',
-    width: 100,
-  },
   leftMargin: {
     marginLeft: 10,
   },
@@ -465,7 +466,6 @@ exports.examples = [
         />
       );
     },
-    platform: 'ios',
   },
   {
     title: 'Image Download Progress',
@@ -478,7 +478,6 @@ exports.examples = [
         />
       );
     },
-    platform: 'ios',
   },
   {
     title: 'defaultSource',

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -17,14 +17,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-3346ac7f9",
-      "baseHash": "e377e2dacacf415baa21050dd389cac9873c9f4d"
+      "baseVersion": "0.0.0-b095432e6",
+      "baseHash": "bbadb1b26ce42ed9cc3f7d950c8c2a3f9d1086d9"
     },
     {
       "type": "patch",
       "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "fc9f1020bf6ea3ab580171bdb19e0b82df4f8d00",
       "issue": 3994
     },
@@ -32,7 +32,7 @@
       "type": "copy",
       "directory": "ReactCopies/IntegrationTests",
       "baseDirectory": "IntegrationTests",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "b189414bfc74b1a14e0181a79b92a18e67253491",
       "issue": 4054
     },
@@ -40,15 +40,15 @@
       "type": "copy",
       "directory": "ReactCopies/RNTester/js",
       "baseDirectory": "RNTester/js",
-      "baseVersion": "0.0.0-3346ac7f9",
-      "baseHash": "537220cadacbcc5269320a16127f62e3ab58e754",
+      "baseVersion": "0.0.0-b095432e6",
+      "baseHash": "ee28c50fbc73374281e415252e2cc6fcf93a356a",
       "issue": 4054
     },
     {
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/GenerateViewConfigJs.js",
       "baseFile": "packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "80aa1fe96412a5f027dbf5e3df3feddab91c3ccb",
       "issue": 5430
     },
@@ -56,7 +56,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/index.js",
       "baseFile": "packages/babel-plugin-inline-view-configs/index.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "02590f3430fb57fcd954357c9dbeeaa8bdc01d06",
       "issue": 5430
     },
@@ -64,7 +64,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/package.json",
       "baseFile": "packages/babel-plugin-inline-view-configs/package.json",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "8d37fac510a533c0badffacd9c3aa9c392fd58c6",
       "issue": 5430
     },
@@ -72,7 +72,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -92,7 +92,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -108,7 +108,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "611e89285ac812456b381568052cf575c955575a",
       "issue": 4578
     },
@@ -116,7 +116,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Button.windows.js",
       "baseFile": "Libraries/Components/Button.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "3c1baecf9171422511a08436edd423c5da9cf5c2",
       "issue": "LEGACY_FIXME"
     },
@@ -128,7 +128,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windows.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
@@ -139,14 +139,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windows.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
@@ -177,14 +177,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windows.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Picker/Picker.windows.js",
       "baseFile": "Libraries/Components/Picker/Picker.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "ebfef6691cf4634daa34c025327f837d292ef44f",
       "issue": 4611
     },
@@ -192,14 +192,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerAndroid.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerIOS.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
@@ -210,7 +210,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
       "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "1a94e2e99474b15141d1c67c1211ac1dc2c2a62d",
       "issue": 4611
     },
@@ -226,21 +226,21 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windows.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45",
       "issue": "LEGACY_FIXME"
     },
@@ -248,15 +248,15 @@
       "type": "derived",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-3346ac7f9",
-      "baseHash": "59dabb86baedb0088e110f8cdeb914fa3271dfd9",
+      "baseVersion": "0.0.0-b095432e6",
+      "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
@@ -264,7 +264,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "4508091254e184ee4dfc383c091186ba6ed60f01",
       "issue": "LEGACY_FIXME"
     },
@@ -272,7 +272,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -280,14 +280,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912",
       "issue": "LEGACY_FIXME"
     },
@@ -295,7 +295,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95",
       "issue": "LEGACY_FIXME"
     },
@@ -303,7 +303,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "58698d349b3327660c71708f7128c2247caaef3f",
       "issue": "LEGACY_FIXME"
     },
@@ -311,7 +311,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -319,7 +319,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.windows.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseVersion": "0.63.2",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "147459dc889f04f2405db051445833f791726895",
       "issue": 5843
     },
@@ -327,7 +327,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
       "baseFile": "Libraries/Components/View/ViewAccessibility.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
       "issue": "LEGACY_FIXME"
     },
@@ -335,7 +335,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
       "baseFile": "Libraries/Components/View/ViewPropTypes.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "2b12228aa1ab0e12844996a99ff5d38fbff689a1",
       "issue": "LEGACY_FIXME"
     },
@@ -351,7 +351,7 @@
       "type": "patch",
       "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
       "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
       "issue": "LEGACY_FIXME"
     },
@@ -359,7 +359,7 @@
       "type": "copy",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4590
     },
@@ -371,7 +371,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "fa5d7d307e25d22d699a1d2d1eec9c0ac79ba928",
       "issue": "LEGACY_FIXME"
     },
@@ -379,7 +379,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
       "issue": "LEGACY_FIXME"
     },
@@ -387,7 +387,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
       "issue": "LEGACY_FIXME"
     },
@@ -395,7 +395,7 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "b7ab4262be21b1c2db00dd52e345529181c45aa8",
       "issue": 4379
     },
@@ -403,7 +403,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.windows.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -415,7 +415,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheetValidation.windows.js",
       "baseFile": "Libraries/StyleSheet/StyleSheetValidation.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "5fe7febd1eb5374745fe612030806512e9161796",
       "issue": 5269
     },
@@ -423,7 +423,7 @@
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e8f8ce02645228b423fdda317e5d1d9e69b54e6d",
       "issue": "LEGACY_FIXME"
     },
@@ -431,7 +431,7 @@
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.windows.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": 4629
     },
@@ -439,14 +439,14 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.windows.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f"
     },
     {
@@ -457,7 +457,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleList.windows.js",
       "baseFile": "RNTester/js/components/RNTesterExampleList.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "fc507321dc5cb53be93df517ba5c4b1acd0074f4",
       "issue": 5834
     },
@@ -465,7 +465,7 @@
       "type": "derived",
       "file": "src/RNTester/js/examples/PlatformColor/PlatformColorExample.windows.js",
       "baseFile": "RNTester/js/examples/PlatformColor/PlatformColorExample.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "a63038b104bcf3caa0984d994bf3916ef1aa38ee",
       "issue": 4055
     },
@@ -473,7 +473,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/ScrollView/ScrollViewExample.windows.js",
       "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "e622893fe0a5ce9d48b10644cd29a38de72b6a26",
       "issue": "LEGACY_FIXME"
     },
@@ -481,7 +481,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/TextInput/TextInputExample.windows.js",
       "baseFile": "RNTester/js/examples/TextInput/TextInputExample.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "1755bffd6ae353838f1779007dc4a512b8dddcdc",
       "issue": 5688
     },
@@ -489,7 +489,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/View/ViewExample.windows.js",
       "baseFile": "RNTester/js/examples/View/ViewExample.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "76d4a9914e731bffefefd3b0de90c97a1726e2a9",
       "issue": "LEGACY_FIXME"
     },
@@ -497,7 +497,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.windows.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -505,7 +505,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.windows.ts",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-b095432e6",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,12 +59,12 @@
     "@types/react-native": "^0.62.10",
     "eslint": "6.8.0",
     "eslint-plugin-prettier": "2.6.2",
-    "flow-bin": "^0.126.1",
+    "flow-bin": "^0.127.0",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "prettier": "1.17.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9",
+    "react-native": "0.0.0-b095432e6",
     "react-native-platform-override": "^0.2.2",
     "react-native-windows-codegen": "0.1.1",
     "react-refresh": "^0.4.0",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-3346ac7f9"
+    "react-native": "0.0.0-b095432e6"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js
+++ b/vnext/src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js
@@ -8,9 +8,9 @@
  * @format
  */
 
-const Platform = require('../../Utilities/Platform');
-const React = require('react');
-const View = require('../View/View');
+import Platform from '../../Utilities/Platform';
+import * as React from 'react';
+import View from '../View/View';
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,10 +2604,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@office-iss/rex-win32@0.62.0-preview.17-tenantreactnativewin-13114":
-  version "0.62.0-preview.17-tenantreactnativewin-13114"
-  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.62.0-preview.17-tenantreactnativewin-13114.tgz#e5c5ad0acbb4ec126307baa9fd5be171b41a2500"
-  integrity sha512-DQx7VS49T9I3Qh7EoA4VSe6cDzKWo2gZH4VXNzZwVu444pg+4nLP3/xTBcCltedXqmoH821YEdpXzHdgsKj4ww==
+"@office-iss/rex-win32@0.62.7-tenantreactnativewin-13222":
+  version "0.62.7-tenantreactnativewin-13222"
+  resolved "https://registry.yarnpkg.com/@office-iss/rex-win32/-/rex-win32-0.62.7-tenantreactnativewin-13222.tgz#32bf141552588e7e71d87a8276aa67f4ebdb0017"
+  integrity sha512-D15B9H9e96C9aovfuC3V9A4Wy1fwLf8R5nEDcpn3nObdePT1Zwm02/yvrND6Jpmf3bcxHPikKcCwF6d1TQI31A==
   dependencies:
     command-line-args "^5.0.2"
     command-line-usage "^5.0.5"
@@ -7074,10 +7074,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.126.1:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.126.1.tgz#2726595e1891dc35b379b5994627432df4ead52c"
-  integrity sha512-RI05x7rVzruRVJQN3M4vLEjZMwUHJKhGz9FmL8HN7WiSo66/131EyJS6Vo8PkKyM2pgT9GRWfGP/tXlqS54XUg==
+flow-bin@^0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.127.0.tgz#0614cff4c1b783beef1feeb7108d536e09d77632"
+  integrity sha512-ywvCCdV4NJWzrqjFrMU5tAiVGyBiXjsJQ1+/kj8thXyX15V17x8BFvNwoAH97NrUU8T1HzmFBjLzWc0l2319qg==
 
 flow-parser@0.*:
   version "0.113.0"
@@ -11838,10 +11838,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-3346ac7f9:
-  version "0.0.0-3346ac7f9"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-3346ac7f9.tgz#7c82ec49e21ccedc812cc5bc9b949df84aa93683"
-  integrity sha512-LcGBiI5H0mB2h6XYo1lOG7AwxNRKzWzQbJSmreYIDupi/gTRejGWNZY6ysMzrM55QBp5LaTLAzK1dBvbhFj6uw==
+react-native@0.0.0-b095432e6:
+  version "0.0.0-b095432e6"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-b095432e6.tgz#d318f6746244bbdbaabd1af6b8eca61374995dda"
+  integrity sha512-Ss4UfZf9+rHV8L40R11DMXGh4XXwKXGOiJN38sGD6Gn3BvPEaQd2tbprTc6IONEUgNubM+TCrN36GqPaE18i5w==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^4.10.0"


### PR DESCRIPTION
Commits: https://github.com/facebook/react-native/compare/3346ac7f9...b095432e6

This week brings in a change to imageLoad event structure, that we previously brought into our own native code prematurely (whoops). Tracked with #5896

Some stuff that doesn't affect us includes Fabric VM changes, some shared instance refactoring, changes around legacy bytecode bundles we never tried to support, and work to load split bundles for development that we're not trying to follow yet.

facebook/react-native@76fe94e fixes codegen support for $ReadOnly and will likely need to be picked up soon in react-native-tscodegen for flow-types of internal interfaces.

Validated we can launch XAML + NetUI Testsers, that ImageLoad event in RNTester show URLs correctly.

----

### Breaking

#### Android specific

- On `Image`, `onLoad` event objects' `source.url` is now renamed to `source.uri`. ([74ab8f6e5a](facebook/react-native@74ab8f6) by [@yungsters](https://github.com/yungsters))

#### iOS specific

### Added

- Add non-fatal error handling ([568d2206f7](facebook/react-native@568d220) by [@lunaleaps](https://github.com/lunaleaps))
- Support `$ReadOnly` in object properties when defining native event types ([76fe94e8b0](facebook/react-native@76fe94e) by [@yungsters](https://github.com/yungsters))

#### Android specific

- Adds support for the `onProgress` event on `Image` ([fa0e6f8051](facebook/react-native@fa0e6f8) by [@yungsters](https://github.com/yungsters))

#### iOS specific

### Changed

- Catch getRouteEntry errors ([b095432e6d](facebook/react-native@b095432) by [@lunaleaps](https://github.com/lunaleaps))
- Switched to es6 import for SafeAreaView ([a69bd9dadf](facebook/react-native@a69bd9d) by [@Naturalclar](https://github.com/Naturalclar))

#### Android specific

- Effect of `blurRadius` now more closely matches other platforms. ([64860972be](facebook/react-native@6486097) by [@yungsters](https://github.com/yungsters))

#### iOS specific

### Deprecated

#### Android specific

#### iOS specific

### Removed

#### Android specific

#### iOS specific

### Fixed

- Update podspecs for latest Fabric changes ([fb2a7765ac](facebook/react-native@fb2a776) by [@empyrical](https://github.com/empyrical))

#### Android specific

- Picker - fix usage of setNativeSelectedPosition in onSelect ([078e386024](facebook/react-native@078e386))

#### iOS specific

- Better error message when missing entry file ([e73208e2ca](facebook/react-native@e73208e) by [@petrbela](https://github.com/petrbela))
- RNTester app builds in a path that contains a space ([3e5a7b2939](facebook/react-native@3e5a7b2) by [@richardgroves](https://github.com/richardgroves))

### Security

#### Android specific

#### iOS specific

### Unknown

- Add native module for loading split JS bundles in development ([fca3a39da5](facebook/react-native@fca3a39) by [@makovkastar](https://github.com/makovkastar))

#### Android Unknown

- Update loading banner text and colors ([6afc984e81](facebook/react-native@6afc984) by [@makovkastar](https://github.com/makovkastar))

#### iOS Unknown

#### Failed to parse

- Upgrade to flow v0.127.0 ([9a532edaaf](facebook/react-native@9a532ed) by [@vrama628](https://github.com/vrama628))
- Keyframes is not implemented in Fabric Android ([e6fc20ee68](facebook/react-native@e6fc20e))
- An attempt at resolving crash in RCTStringFromNSString ([93f9d8dd6b](facebook/react-native@93f9d8d) by [@sammy-SC](https://github.com/sammy-SC))
- Add FDSTooltipView to LegacyViewManagerInterop for Fabric ([8e1b812779](facebook/react-native@8e1b812) by [@kacieb](https://github.com/kacieb))
- Font size in Text now respects preferredContentSizeCategory ([36b586ada1](facebook/react-native@36b586a) by [@sammy-SC](https://github.com/sammy-SC))
- Rename LayoutableShadowNode::measure to LayoutableShadowNode::measureContent ([ec9da43de5](facebook/react-native@ec9da43) by [@sammy-SC](https://github.com/sammy-SC))
- NativeAnimatedModule should not crash if UIManager disappears ([2e2c881147](facebook/react-native@2e2c881) by [@JoshuaGross](https://github.com/JoshuaGross))
- RN: Cleanup `ImageLoadEvent` Logic (Android) ([90997c26e3](facebook/react-native@90997c2) by [@yungsters](https://github.com/yungsters))
- Deprecate calculateChildFrames from RCTScrollView ([62aa84a325](facebook/react-native@62aa84a) by [@PeteTheHeat](https://github.com/PeteTheHeat))
- Do not retain paper view inside legacy interop after it has been recycled ([3ff671c704](facebook/react-native@3ff671c) by [@sammy-SC](https://github.com/sammy-SC))
- Remove legacy bytecode handling ([56689e9e28](facebook/react-native@56689e9) by [@cpojer](https://github.com/cpojer))
- Feature-flag gate stopSurface on root view unmount ([b69041f086](facebook/react-native@b69041f) by [@JoshuaGross](https://github.com/JoshuaGross))
- Bust `surfaceActiveForExecution` cache after executing a batch of items ([33ed358330](facebook/react-native@33ed358) by [@JoshuaGross](https://github.com/JoshuaGross))
- LayoutAnimations: fix crashes ([e0294aff68](facebook/react-native@e0294af) by [@JoshuaGross](https://github.com/JoshuaGross))
- Bytecode client for iOS ([382f0898cf](facebook/react-native@382f089) by [@cpojer](https://github.com/cpojer))
- Fix padding flickering visible during initial render of text input ([6d6268e903](facebook/react-native@6d6268e) by [@mdvacca](https://github.com/mdvacca))
- Ensure that layout events contain the correct padding information ([1e453860d0](facebook/react-native@1e45386) by [@mdvacca](https://github.com/mdvacca))
- Avoid using ViewManager childCount to detect errors, since it's not reliable ([86c38739a7](facebook/react-native@86c3873) by [@JoshuaGross](https://github.com/JoshuaGross))
- Implement autoFocus in TextInput ([ccf5c86bd7](facebook/react-native@ccf5c86) by [@sammy-SC](https://github.com/sammy-SC))
- Add incomplete support for accessibility state prop ([8dce59cee8](facebook/react-native@8dce59c) by [@sammy-SC](https://github.com/sammy-SC))
- For lifecycle correctness, call scheduleMountItems even with empty BatchMountItem ([40b36a040f](facebook/react-native@40b36a0) by [@JoshuaGross](https://github.com/JoshuaGross))
- Fix typos in Native Animated error messages ([0d073013a5](facebook/react-native@0d07301) by [@JoshuaGross](https://github.com/JoshuaGross))
- AnimatedDivision: pass zero instead of Inf/NaN in case of division by zero ([23f2ec7e8c](facebook/react-native@23f2ec7) by [@JoshuaGross](https://github.com/JoshuaGross))
- NativeAnimatedDriver: synchronize animation lifecycle closer to Fabric or Paper lifecycle ([472cf3f4ad](facebook/react-native@472cf3f) by [@JoshuaGross](https://github.com/JoshuaGross))

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5897)