### PR TITLE
[0.62] Internal nuget is missing slices

### DIFF
--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,17 +1,17 @@
 parameters:
-  publishCommitId: "0"
-  npmVersion: "0.0.1-pr"
+  publishCommitId: '0'
+  npmVersion: '0.0.1-pr'
   # Note: Nuget pack expects platform-specific file spearators ('\' on Windows).
   nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
-  desktopId: "OfficeReact.Win32"
-  microsoftRNId: "Microsoft.ReactNative"
+  desktopId: 'OfficeReact.Win32'
+  microsoftRNId: 'Microsoft.ReactNative'
   slices: '("x64.Release", "x64.Debug", "x86.Release", "x86.Debug", "ARM.Release", "ARM.Debug", "ARM64.Release", "ARM64.Debug")'
   packDesktop: true
   packMicrosoft: true
 
 steps:
   - task: DownloadBuildArtifacts@0
-    displayName: "Download ReactWindows Artifact"
+    displayName: 'Download ReactWindows Artifact'
     inputs:
       artifactName: ReactWindows
       downloadPath: $(System.DefaultWorkingDirectory)
@@ -22,24 +22,24 @@ steps:
     inputs:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1
-      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -slices ${{ parameters.packMicrosoft }}
+      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -slices ${{ parameters.slices }}
     condition: and(succeeded(), ${{ parameters.packMicrosoft }})
 
   - task: NuGetCommand@2
-    displayName: "NuGet pack Desktop"
+    displayName: 'NuGet pack Desktop'
     inputs:
       command: pack
-      verbosityPack: "Detailed"
+      verbosityPack: 'Detailed'
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/ReactWin32.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
       buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.desktopId}};nugetroot=${{parameters.nugetroot}}
     condition: and(succeeded(), ${{ parameters.packDesktop }})
 
   - task: NuGetCommand@2
-    displayName: "NuGet pack Microsoft.ReactNative"
+    displayName: 'NuGet pack Microsoft.ReactNative'
     inputs:
       command: pack
-      verbosityPack: "Detailed"
+      verbosityPack: 'Detailed'
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
       buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.microsoftRNId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,17 +1,17 @@
 parameters:
-  publishCommitId: '0'
-  npmVersion: '0.0.1-pr'
+  publishCommitId: "0"
+  npmVersion: "0.0.1-pr"
   # Note: Nuget pack expects platform-specific file spearators ('\' on Windows).
   nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
-  desktopId: 'OfficeReact.Win32'
-  microsoftRNId: 'Microsoft.ReactNative'
+  desktopId: "OfficeReact.Win32"
+  microsoftRNId: "Microsoft.ReactNative"
   slices: '("x64.Release", "x64.Debug", "x86.Release", "x86.Debug", "ARM.Release", "ARM.Debug", "ARM64.Release", "ARM64.Debug")'
   packDesktop: true
   packMicrosoft: true
 
 steps:
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download ReactWindows Artifact'
+    displayName: "Download ReactWindows Artifact"
     inputs:
       artifactName: ReactWindows
       downloadPath: $(System.DefaultWorkingDirectory)
@@ -22,24 +22,24 @@ steps:
     inputs:
       targetType: filePath
       filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1
-      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -slices ("x64.Release", "x86.Debug", "ARM.Release")
+      arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec -slices ${{ parameters.packMicrosoft }}
     condition: and(succeeded(), ${{ parameters.packMicrosoft }})
 
   - task: NuGetCommand@2
-    displayName: 'NuGet pack Desktop'
+    displayName: "NuGet pack Desktop"
     inputs:
       command: pack
-      verbosityPack: 'Detailed'
+      verbosityPack: "Detailed"
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/ReactWin32.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
       buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.desktopId}};nugetroot=${{parameters.nugetroot}}
     condition: and(succeeded(), ${{ parameters.packDesktop }})
 
   - task: NuGetCommand@2
-    displayName: 'NuGet pack Microsoft.ReactNative'
+    displayName: "NuGet pack Microsoft.ReactNative"
     inputs:
       command: pack
-      verbosityPack: 'Detailed'
+      verbosityPack: "Detailed"
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/Microsoft.ReactNative.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
       buildProperties: CommitId=${{parameters.publishCommitId}};version=${{parameters.npmVersion}};id=${{parameters.microsoftRNId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -613,5 +613,5 @@ jobs:
 
       - template: templates/prep-and-pack-nuget.yml
         parameters:
-          slices: '("x64.Release", "x86.Debug", "ARM.Debug")'
+          slices: '("x64.Release", "x86.Debug", "ARM.Release")'
           packUniversal: false


### PR DESCRIPTION
The nuget being published for internal use only includes some of the platform/release/debug combinations.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5904)