### PR TITLE
Update bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -14,8 +14,6 @@ Your issue will be triaged by the RNW team according to this process: https://gi
 Run the following in your terminal and copy the results here.
 1. `npx react-native --version`:
 2. `npx react-native info`:
-3. `npx react-native run-windows --info`:
-4. `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"`
 
 <!-- Consider including this information as well:
 What SDK version are you building for? Choose from 10.0.15063, 10.0.16299, 10.0.18362, etc.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -13,8 +13,9 @@ Your issue will be triaged by the RNW team according to this process: https://gi
 ## Environment
 Run the following in your terminal and copy the results here.
 1. `npx react-native --version`:
-2. `npx react-native run-windows --info`:
-3. `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"`
+2. `npx react-native info`:
+3. `npx react-native run-windows --info`:
+4. `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"`
 
 <!-- Consider including this information as well:
 What SDK version are you building for? Choose from 10.0.15063, 10.0.16299, 10.0.18362, etc.


### PR DESCRIPTION
now that envinfo changes have flowed into RN cli we can benefit from them. We'll remove the run-windows --info step once my PR to cli to include rnw version in win32 goes through https://github.com/react-native-community/cli/pull/1264

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5929)