### PR TITLE
[0.62] Update V8 and Hermes package versions

### DIFF
--- a/change/react-native-windows-2020-09-08-15-06-41-0.62-stable.json
+++ b/change/react-native-windows-2020-09-08-15-06-41-0.62-stable.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update V8 and Hermes package versions",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-08T22:06:41.260Z"
+}

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -27,6 +27,13 @@ MainPage::MainPage() {
     x_rootComponentNameCombo().IsEditable(true);
     x_entryPointCombo().IsEditable(true);
   }
+
+  // TODO: a way to determine which engines are actually available
+  x_engineChakra().IsEnabled(true);
+  x_engineHermes().IsEnabled(true);
+  x_engineV8().IsEnabled(true);
+
+  x_JsEngine().SelectedIndex(0);
 }
 
 void MainPage::OnLoadClick(
@@ -42,6 +49,8 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().DebuggerBreakOnNextLine(x_BreakOnFirstLineCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().UseFastRefresh(x_UseFastRefreshCheckBox().IsChecked().GetBoolean());
   host.InstanceSettings().DebuggerPort(static_cast<uint16_t>(std::stoi(std::wstring(x_DebuggerPort().Text()))));
+  host.InstanceSettings().JSIEngineOverride(
+      static_cast<Microsoft::ReactNative::JSIEngine>(x_JsEngine().SelectedIndex()));
 
   // Nudge the ReactNativeHost to create the instance and wrapping context
   host.ReloadInstance();

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -132,6 +132,22 @@
                 VerticalAlignment="Center"
                 InputScope="Number"
                 MaxLength="5" />
+            <TextBlock
+                Margin="4"
+                VerticalAlignment="Center"
+                Text="JS Engine:"/>
+            <ComboBox
+                x:Name="x_JsEngine"
+                Margin="4"
+                MinWidth="150"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Center">
+                <ComboBox.Items>
+                    <ComboBoxItem Content="Chakra" x:Name="x_engineChakra" />
+                    <ComboBoxItem Content="Hermes" x:Name="x_engineHermes" />
+                    <ComboBoxItem Content="V8" x:Name="x_engineV8" />
+                </ComboBox.Items>
+            </ComboBox>
         </StackPanel>
 
         <Grid x:Name="x_rootElement"

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -32,6 +32,7 @@
     <ProjectName>React.Windows.Desktop.DLL</ProjectName>
     <TargetName>react-native-win32</TargetName>
     <USE_V8>true</USE_V8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -3,7 +3,7 @@
   <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.3.4" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->

--- a/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.h
+++ b/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.h
@@ -2,10 +2,8 @@
 
 #include <DevSettings.h>
 
-#include <JSI/Shared/RuntimeHolder.h>
-#include <ScriptStore.h>
-
 #include <JSI/Shared/ChakraRuntimeArgs.h>
+#include <JSI/Shared/RuntimeHolder.h>
 
 #include <Logging.h>
 

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -24,6 +24,7 @@
     <ProjectName>React.Windows.Desktop.IntegrationTests</ProjectName>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <USE_V8>true</USE_V8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />

--- a/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
+++ b/vnext/Desktop.Test.DLL/React.Windows.Desktop.Test.DLL.vcxproj
@@ -39,7 +39,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
     <!--
     Prevents Microsoft.Windows.CppWinRT.props from adding WindowsApp.lib reference, see

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -42,6 +42,7 @@
     <CppWinRTNamespaceMergeDepth>2</CppWinRTNamespaceMergeDepth>
     <CppWinRTUsePrefixes>true</CppWinRTUsePrefixes>
     <USE_V8>true</USE_V8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Permissive">
     <ENABLEPermissive>true</ENABLEPermissive>

--- a/vnext/Desktop/packages.config
+++ b/vnext/Desktop/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.72.0.0" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.3.4" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />

--- a/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
+++ b/vnext/JSI.Desktop.UnitTests/JSI.Desktop.UnitTests.vcxproj
@@ -17,6 +17,7 @@
     <ProjectGuid>{6f354505-fe3a-4bd2-a9a6-d12bbf37a85c}</ProjectGuid>
     <ProjectName>JSI.Desktop.UnitTests</ProjectName>
     <USE_V8>true</USE_V8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />

--- a/vnext/JSI.Desktop.UnitTests/packages.config
+++ b/vnext/JSI.Desktop.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.72.0.0" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.3.4" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{17DD1B17-3094-40DD-9373-AC2497932ECA}</ProjectGuid>
     <ProjectName>JSI.Desktop</ProjectName>
     <USE_V8>true</USE_V8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
@@ -52,7 +53,7 @@
   <PropertyGroup>
     <!-- We need $(ReactNativeWindowsDir)Chakra for ChakraCoreDebugger.h.
     We should remove it from IncludePath once we retire the ChakraExecutor stack. -->
-    <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/vnext/JSI/Shared/ChakraRuntime.cpp
+++ b/vnext/JSI/Shared/ChakraRuntime.cpp
@@ -7,7 +7,6 @@
 #include "Utilities.h"
 
 #include <MemoryTracker.h>
-#include <ScriptStore.h>
 #include <cxxreact/MessageQueueThread.h>
 
 #include <cstring>

--- a/vnext/JSI/Shared/ChakraRuntimeArgs.h
+++ b/vnext/JSI/Shared/ChakraRuntimeArgs.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <ScriptStore.h>
+#include <JSI/Shared/ScriptStore.h>
 #include <jsi/jsi.h>
 
 namespace facebook::react {

--- a/vnext/JSI/Shared/ScriptStore.h
+++ b/vnext/JSI/Shared/ScriptStore.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 #pragma once
 
 #include <jsi/jsi.h>
@@ -31,6 +33,8 @@ struct JSRuntimeSignature {
 // (through JSI::Runtime implementation's factory method), to enable persistance of the prepared script and retrieval on
 // subsequent evaluation of a script.
 struct PreparedScriptStore {
+  virtual ~PreparedScriptStore() = default;
+
   // Try to retrieve the prepared javascript for a given combination of script & runtime.
   // scriptSignature : Javascript url and version
   // RuntimeSignature : Javascript engine type and version
@@ -62,6 +66,8 @@ struct PreparedScriptStore {
 // such as usage of pre-prepared javascript script. Alternatively, this entity can be used to directly provide the
 // Javascript buffer and rich metadata to the JSI::Runtime instance.
 struct ScriptStore {
+  virtual ~ScriptStore() = default;
+
   // Return the Javascript buffer and version corresponding to a given url.
   virtual VersionedBuffer getVersionedScript(const std::string &url) noexcept = 0;
 

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj
@@ -65,7 +65,7 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludePath>$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeDir)\ReactCommon;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)ReactWindowsCore;$(IncludePath)</IncludePath>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -78,7 +78,7 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <Midl>
-      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)Microsoft.ReactNative;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Microsoft.ReactNative;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </Midl>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -77,7 +77,6 @@
   </ImportGroup>
   <ImportGroup Label="Shared" />
   <Import Project="..\Chakra\Chakra.vcxitems" Label="Shared" />
-  <Import Project="..\JSI\Shared\JSI.Shared.vcxitems" Label="Shared" />
   <Import Project="..\Shared\Shared.vcxitems" Label="Shared" />
   <Import Project="..\Mso\Mso.vcxitems" Label="Shared" />
   <Import Project="..\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
@@ -616,7 +615,8 @@
     <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
+    <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.UWP.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.UWP.targets') AND '$(USE_V8)' == 'true'" />
+    <Import Project="$(HERMES_Package)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(HERMES_Package)\build\native\ReactNative.Hermes.Windows.targets') AND '$(USE_HERMES)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -626,7 +626,8 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
+    <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.UWP.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.UWP.targets'))" />
+    <Error Condition="!Exists('$(HERMES_Package)\build\native\ReactNative.Hermes.Windows.targets') AND '$(USE_HERMES)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(HERMES_Package)\build\native\ReactNative.Hermes.Windows.targets'))" />
   </Target>
   <Target Name="AfterCppClean">
     <RemoveDir Directories="$(IdlHeaderDirectory)" ContinueOnError="true" />

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -214,6 +214,8 @@ struct ReactOptions {
   //! It is not safe to expose to Custom Function. Add this flag so we can turn it off for Custom Function.
   bool EnableNativePerformanceNow{true};
 
+  react::uwp::JSIEngine JsiEngine{react::uwp::JSIEngine::Chakra};
+
   ReactDevOptions DeveloperSettings = {};
 
   //! Adds registered JS bundle to JSBundles.

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -244,6 +244,7 @@ void ReactInstanceWin::Initialize() noexcept {
               case react::uwp::JSIEngine::Hermes:
 #if defined(USE_HERMES)
                 devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
+                devSettings->inlineSourceMap = false;
                 break;
 #endif
               case react::uwp::JSIEngine::V8:

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -88,6 +88,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
 
   JSIEngine JSIEngineOverride() noexcept;
   void JSIEngineOverride(JSIEngine value) noexcept;
+
  private:
   IReactPropertyBag m_properties{ReactPropertyBagHelper::CreatePropertyBag()};
   hstring m_mainComponentName{};

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -86,6 +86,8 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   IReactDispatcher UIDispatcher() noexcept;
   void UIDispatcher(IReactDispatcher const &value) noexcept;
 
+  JSIEngine JSIEngineOverride() noexcept;
+  void JSIEngineOverride(JSIEngine value) noexcept;
  private:
   IReactPropertyBag m_properties{ReactPropertyBagHelper::CreatePropertyBag()};
   hstring m_mainComponentName{};
@@ -107,6 +109,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   hstring m_bundleRootPath{};
   uint16_t m_debuggerPort{9229};
   IRedBoxHandler m_redBoxHandler{nullptr};
+  JSIEngine m_jSIEngineOverride{JSIEngine::Chakra};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation
@@ -277,6 +280,14 @@ inline IRedBoxHandler ReactInstanceSettings::RedBoxHandler() noexcept {
 
 inline void ReactInstanceSettings::RedBoxHandler(IRedBoxHandler const &value) noexcept {
   m_redBoxHandler = value;
+}
+
+inline JSIEngine ReactInstanceSettings::JSIEngineOverride() noexcept {
+  return m_jSIEngineOverride;
+}
+
+inline void ReactInstanceSettings::JSIEngineOverride(JSIEngine value) noexcept {
+  m_jSIEngineOverride = value;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -7,6 +7,13 @@ import "RedBoxHandler.idl";
 
 namespace Microsoft.ReactNative {
 
+  // Keep in sync with enum in IReactInstance.h
+  enum JSIEngine {
+    Chakra = 0,
+    Hermes = 1,
+    V8 = 2
+  };
+
   [webhosthidden]
   runtimeclass ReactInstanceSettings 
   {
@@ -33,5 +40,6 @@ namespace Microsoft.ReactNative {
     UInt16 DebuggerPort { get; set; };
     IRedBoxHandler RedBoxHandler { get; set; };
     IReactDispatcher UIDispatcher { get; set; };
+    JSIEngine JSIEngineOverride { get; set; };
   }
 }

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -103,6 +103,8 @@ void ReactNativeHost::ReloadInstance() noexcept {
   reactOptions.ModuleProvider = modulesProvider;
   reactOptions.ViewManagerProvider = viewManagersProvider;
 
+  reactOptions.JsiEngine = static_cast<react::uwp::JSIEngine>(m_instanceSettings.JSIEngineOverride());
+
   std::string jsBundleFile = to_string(m_instanceSettings.JavaScriptBundleFile());
   std::string jsMainModuleName = to_string(m_instanceSettings.JavaScriptMainModuleName());
   if (jsBundleFile.empty()) {

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -3,4 +3,6 @@
   <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
+  <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.1" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -24,12 +24,15 @@
 
   <PropertyGroup>
     <USE_HERMES Condition="'$(USE_HERMES)' == ''">false</USE_HERMES>
-    <HERMES_Version Condition="'$(HERMES_Version)' == ''">0.1.6</HERMES_Version>
+    <HERMES_Version Condition="'$(HERMES_Version)' == ''">0.5.0-f56606a8</HERMES_Version>
     <HERMES_Package Condition="'$(HERMES_Package)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HERMES_Version)</HERMES_Package>
+    <!-- TODO: Can we automatically distinguish between uwp and win32 here? -->
+    <HERMES_ARCH Condition="'$(HERMES_ARCH)' == ''">uwp</HERMES_ARCH>
 
-    <USE_V8 Condition="('$(USE_V8)' == '') Or ('$(Platform)' == 'ARM' OR '$(Platform)' == 'ARM64')">false</USE_V8>
-    <V8_Version Condition="'$(V8_Version)' == ''">0.3.4</V8_Version>
-    <V8_Package Condition="'$(V8_Package)' == ''">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
+    <USE_V8 Condition="('$(USE_V8)' == '') OR ('$(Platform)' == 'ARM')">false</USE_V8>
+    <V8_Version Condition="'$(V8_Version)' == ''">0.63.1</V8_Version>
+    <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' == 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
+    <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' != 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.$(V8_Version)</V8_Package>
 
     <!-- Enables React-Native-Windows ETW Provider : React-Native-Windows-Provider  -->
     <ENABLE_ETW_TRACING Condition="'$(ENABLE_ETW_TRACING)' == ''">true</ENABLE_ETW_TRACING>
@@ -54,11 +57,11 @@
   <PropertyGroup>
     <!-- This prop is used for shared JSI code and headers -->
     <JSI_Source Condition="'$(JSI_Source)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_Source>
-    <JSI_Source Condition="'$(USE_HERMES)' == 'true'">$(HERMES_Package)\installed\x64-windows\include\jsi_ref</JSI_Source>
 
     <!-- This prop is used for JSI code that may be overridden in external JSI implementations -->
     <JSI_SourcePath Condition="'$(JSI_SourcePath)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_SourcePath>
     <JSI_SourcePath Condition="'$(USE_V8)' == 'true'">$(V8_Package)\build\native\include</JSI_SourcePath>
+    <JSI_SourcePath Condition="'$(USE_HERMES)' == 'true'">$(HERMES_Package)\build\native\include</JSI_SourcePath>
 
     <!-- This disables copying the v8 DLL to outputs; it is re-enabled locally in win32 projects -->
     <V8JSI_NODLLCOPY>true</V8JSI_NODLLCOPY>

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -33,7 +33,7 @@ EXPORTS
 ?CreateMemoryTracker@react@facebook@@YA?AV?$shared_ptr@VMemoryTracker@react@facebook@@@std@@$$QEAV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z
 ?CreateTimingModule@react@facebook@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@AEBV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z
 ?CreateWorkerMessageQueue@uwp@react@@YA?AV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@XZ
-?GetJavaScriptFromServer@DevSupportManager@uwp@react@@UEAA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV45@00@Z
+?GetJavaScriptFromServer@DevSupportManager@uwp@react@@UEAA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV45@00_N@Z
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
 ?JsPointerToStringUtf8@react@facebook@@YA?AW4_JsErrorCode@@PEBD_KPEAPEAX@Z

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -33,7 +33,7 @@ EXPORTS
 ?CreateMemoryTracker@react@facebook@@YG?AV?$shared_ptr@VMemoryTracker@react@facebook@@@std@@$$QAV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z
 ?CreateTimingModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@ABV?$shared_ptr@VMessageQueueThread@react@facebook@@@4@@Z
 ?CreateWorkerMessageQueue@uwp@react@@YG?AV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@XZ
-?GetJavaScriptFromServer@DevSupportManager@uwp@react@@UAE?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV45@00@Z
+?GetJavaScriptFromServer@DevSupportManager@uwp@react@@UAE?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@ABV45@00_N@Z
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
 ?JsPointerToStringUtf8@react@facebook@@YG?AW4_JsErrorCode@@PBDIPAPAX@Z

--- a/vnext/ReactWindowsCore/BaseScriptStoreImpl.h
+++ b/vnext/ReactWindowsCore/BaseScriptStoreImpl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ScriptStore.h>
+#include <JSI/Shared/ScriptStore.h>
 #include <jsi/jsi.h>
 
 #include <algorithm>

--- a/vnext/ReactWindowsCore/DevServerHelper.h
+++ b/vnext/ReactWindowsCore/DevServerHelper.h
@@ -27,15 +27,17 @@ class DevServerHelper {
       const std::string &debugHost,
       const std::string &jsbundle,
       const std::string &platform,
-      const std::string &dev,
-      const std::string &hot) {
+      bool dev,
+      bool hot,
+      bool inlineSourceMap) {
     return string_format(
         BundleUrlFormat,
         GetDeviceLocalHost(debugHost).c_str(),
         jsbundle.c_str(),
         platform.c_str(),
-        dev.c_str(),
-        hot.c_str());
+        dev ? "true" : "false",
+        hot ? "true" : "false",
+        inlineSourceMap ? "true" : "false");
   }
 
   static std::string get_OnChangeEndpointUrl(const std::string &debugHost) {
@@ -48,7 +50,7 @@ class DevServerHelper {
   }
 
   static constexpr const char s_DeviceLocalhost[] = "localhost:8081";
-  static constexpr const char BundleUrlFormat[] = "http://%s/%s.bundle?platform=%s&dev=%s&hot=%s&inlineSourceMap=true";
+  static constexpr const char BundleUrlFormat[] = "http://%s/%s.bundle?platform=%s&dev=%s&hot=%s&inlineSourceMap=%s";
   static constexpr const char SourceMapUrlFormat[] = "http://%s/%s.map?platform=%s&dev=%s&hot=%s";
   static constexpr const char LaunchDevToolsCommandUrlFormat[] = "http://%s/launch-js-devtools";
   static constexpr const char OnChangeEndpointUrlFormat[] = "http://%s/onchange";

--- a/vnext/ReactWindowsCore/DevSettings.h
+++ b/vnext/ReactWindowsCore/DevSettings.h
@@ -103,6 +103,8 @@ struct DevSettings {
   /// Superseded by PreparedScriptStore on the JSI stack, and will be removed
   /// soon. (See #3603)
   ChakraBundleUrlMetadataMap chakraBundleUrlMetadataMap;
+
+  bool inlineSourceMap{true};
 };
 
 } // namespace react

--- a/vnext/ReactWindowsCore/DevSupportManager.cpp
+++ b/vnext/ReactWindowsCore/DevSupportManager.cpp
@@ -251,12 +251,13 @@ void DevSupportManager::StopPollingLiveReload() {
 std::string DevSupportManager::GetJavaScriptFromServer(
     const std::string &debugHost,
     const std::string &jsBundleName,
-    const std::string &platform) {
+    const std::string &platform,
+    bool inlineSourceMap) {
   // Reset exception state since client is requesting new service
   m_exceptionCaught = false;
 
   auto bundleUrl = facebook::react::DevServerHelper::get_BundleUrl(
-      debugHost, jsBundleName, platform, "true" /*dev*/, "false" /*hot*/);
+      debugHost, jsBundleName, platform, true /*dev*/, false /*hot*/, inlineSourceMap);
   try {
     std::string s;
     bool success;

--- a/vnext/ReactWindowsCore/DevSupportManager.h
+++ b/vnext/ReactWindowsCore/DevSupportManager.h
@@ -32,7 +32,8 @@ class DevSupportManager : public facebook::react::IDevSupportManager {
   virtual std::string GetJavaScriptFromServer(
       const std::string &debugHost,
       const std::string &jsBundleName,
-      const std::string &platform) override;
+      const std::string &platform,
+      bool inlineSourceMap) override;
   virtual void StartPollingLiveReload(const std::string &debugHost, std::function<void()> onChangeCallback) override;
   virtual void StopPollingLiveReload() override;
   virtual bool HasException() override {

--- a/vnext/ReactWindowsCore/IDevSupportManager.h
+++ b/vnext/ReactWindowsCore/IDevSupportManager.h
@@ -19,7 +19,8 @@ struct IDevSupportManager {
   virtual std::string GetJavaScriptFromServer(
       const std::string &debugHost,
       const std::string &jsBundleName,
-      const std::string &platform) = 0;
+      const std::string &platform,
+      bool inlineSourceMap) = 0;
   virtual void StartPollingLiveReload(const std::string &debugHost, std::function<void()> onChangeCallback) = 0;
   virtual void StopPollingLiveReload() = 0;
   virtual bool HasException() = 0;

--- a/vnext/ReactWindowsCore/ReactWindowsCore-Desktop.vcxproj
+++ b/vnext/ReactWindowsCore/ReactWindowsCore-Desktop.vcxproj
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <USE_V8>true</USE_V8>
     <USE_HERMES>false</USE_HERMES>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="ReactWindowsCore.vcxitems" Label="Shared" />
 </Project>

--- a/vnext/ReactWindowsCore/ReactWindowsCore.vcxitems
+++ b/vnext/ReactWindowsCore/ReactWindowsCore.vcxitems
@@ -69,13 +69,6 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros">
-    <!-- TODO: Figure out the right long-term way to integrate the Hermes and V8 dependencies -->
-    <VcpkgTriplet Condition="('$(Platform)'=='Win32' OR '$(Platform)'=='x86')">x86-windows</VcpkgTriplet>
-    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgTriplet>
-    <VcpkgTriplet Condition="'$(Platform)'=='ARM'">arm-windows</VcpkgTriplet>
-    <VcpkgTriplet Condition="'$(Platform)'=='ARM64'">arm64-windows</VcpkgTriplet>
-  </PropertyGroup>
   <PropertyGroup>
     <GenerateManifest>false</GenerateManifest>
     <ItemsProjectGuid>{11C084A3-A57C-4296-A679-CAC17B603145}</ItemsProjectGuid>
@@ -114,7 +107,6 @@
         $(ReactNativeWindowsDir)\Mso;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <PreprocessToFile>false</PreprocessToFile>
     </ClCompile>
@@ -123,7 +115,6 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
     <Lib>
-      <AdditionalLibraryDirectories Condition="'$(USE_HERMES)'=='true'">$(HERMES_Package)\installed\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="'$(USE_HERMES)'=='true'">hermes.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
@@ -3,7 +3,7 @@
 #include <DevSettings.h>
 
 #include <JSI/Shared/RuntimeHolder.h>
-#include <ScriptStore.h>
+#include <JSI/Shared/ScriptStore.h>
 
 #include <Logging.h>
 

--- a/vnext/ReactWindowsCore/packages.ReactWindowsCore-Desktop.config
+++ b/vnext/ReactWindowsCore/packages.ReactWindowsCore-Desktop.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.68.0.0" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.1.6" targetFramework="native" Condition="$(USE_HERMES)' == 'true'" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.3.4" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
+  <package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" Condition="$(USE_HERMES)' == 'true'" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
 </packages>

--- a/vnext/include/ReactUWP/Utils/UwpPreparedScriptStore.h
+++ b/vnext/include/ReactUWP/Utils/UwpPreparedScriptStore.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ScriptStore.h>
+#include <JSI/Shared/ScriptStore.h>
 #include <cxxreact/JSBigString.h>
 #include <jsi/jsi.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/include/ReactUWP/Utils/UwpScriptStore.h
+++ b/vnext/include/ReactUWP/Utils/UwpScriptStore.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ScriptStore.h>
+#include <JSI/Shared/ScriptStore.h>
 #include <future>
 
 namespace react {


### PR DESCRIPTION
Backporting same change from master and 0.63 related to the JSI header divergence in <=0.63 vs. RN master (0.64+).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5944)