### PR TITLE
Deprecate AppTheme by adding yellowbox warning (#5889)

### DIFF
--- a/change/react-native-windows-2020-08-31-17-06-38-apptheme-warnonce.json
+++ b/change/react-native-windows-2020-08-31-17-06-38-apptheme-warnonce.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "yellowbox AppTheme",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T00:06:38.767Z"
+}

--- a/change/react-native-windows-2020-08-31-17-06-38-apptheme-warnonce.json
+++ b/change/react-native-windows-2020-08-31-17-06-38-apptheme-warnonce.json
@@ -1,8 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "yellowbox AppTheme",
-  "packageName": "react-native-windows",
-  "email": "email not defined",
-  "dependentChangeType": "patch",
-  "date": "2020-09-01T00:06:38.767Z"
-}

--- a/change/react-native-windows-2020-09-08-15-37-07-apptheme.json
+++ b/change/react-native-windows-2020-09-08-15-37-07-apptheme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Deprecate AppTheme by adding yellowbox warning (#5889)",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-09-08T22:37:07.426Z"
+}

--- a/vnext/etc/react-native-windows.api.md
+++ b/vnext/etc/react-native-windows.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { EmitterSubscription } from 'react-native';
 import { NativeEventEmitter } from 'react-native';
 import * as React_2 from 'react';
 import * as RN from 'react-native';

--- a/vnext/src/Libraries/AppTheme/AppTheme.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.ts
@@ -5,7 +5,11 @@
  */
 'use strict';
 
-import {NativeEventEmitter, NativeModules} from 'react-native';
+import {
+  NativeEventEmitter,
+  EmitterSubscription,
+  NativeModules,
+} from 'react-native';
 import {
   AppThemeTypes,
   IAppThemeChangedEvent,
@@ -13,7 +17,7 @@ import {
   IHighContrastChangedEvent,
 } from './AppThemeTypes';
 const invariant = require('invariant');
-
+const warnOnce = require('../Utilities/warnOnce');
 const NativeAppTheme = NativeModules.RTCAppTheme;
 
 class AppThemeModule extends NativeEventEmitter {
@@ -37,7 +41,7 @@ class AppThemeModule extends NativeEventEmitter {
     );
 
     this._currentTheme = NativeAppTheme.initialAppTheme;
-    this.addListener(
+    super.addListener(
       'appThemeChanged',
       ({currentTheme}: {currentTheme: AppThemeTypes}) => {
         this._currentTheme = currentTheme;
@@ -45,7 +49,29 @@ class AppThemeModule extends NativeEventEmitter {
     );
   }
 
+  addListener(
+    eventType: string,
+    listener: (...args: any[]) => any,
+    context?: any,
+  ): EmitterSubscription {
+    if (eventType === 'appThemeChanged') {
+      warnOnce(
+        'appThemeChanged-deprecated',
+        'AppTheme.appThemeChanged() has been deprecated and will be removed in a future release. ' +
+          'Please use Appearance instead ' +
+          'See https://microsoft.github.io/react-native-windows/docs/windowsbrush-and-theme',
+      );
+    }
+    return super.addListener(eventType, listener, context);
+  }
+
   get currentTheme(): AppThemeTypes {
+    warnOnce(
+      'currentTheme-deprecated',
+      'AppTheme.currentTheme() has been deprecated and will be removed in a future release. ' +
+        'Please use Appearance instead ' +
+        'See https://microsoft.github.io/react-native-windows/docs/windowsbrush-and-theme',
+    );
     return this._currentTheme;
   }
 


### PR DESCRIPTION
* yellowbox AppTheme

* Change files

* move warnOnce to currentTheme usage

* only show yellowbow if we have a subscriber

* ran yarn api

* Revert "Bump beachball from 1.35.3 to 1.35.4 (#5876)"

This reverts commit 95935e008621778dbcec01363602c19abc060632.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5945)