### PR TITLE
Make Chrome install optional in rnw-dependencies.ps1

### DIFF
--- a/change/react-native-windows-2020-09-08-18-00-31-rnwdeps-nochrome.json
+++ b/change/react-native-windows-2020-09-08-18-00-31-rnwdeps-nochrome.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make Chrome optional in rnw-deps",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T01:00:31.847Z"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -314,9 +314,6 @@ if ($Installed -ne 0) {
 
 if ($NeedsRerun -ne 0) {
     Write-Error "Some dependencies are not met. Re-run with -Install to install them.";
-    if (!$NoPrompt) {
-        [System.Console]::ReadKey();
-    }
     throw;
 } else {
     Write-Output "All mandatory requirements met";

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -320,6 +320,6 @@ if ($NeedsRerun -ne 0) {
     throw;
 } else {
     Write-Output "All mandatory requirements met";
-    exit 0;
+    return;
 }
 

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -182,6 +182,7 @@ $requirements = @(
         Valid = try { ((Get-Item (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe' -ErrorAction Stop).'(Default)').VersionInfo).ProductMajorPart
         } catch { $false } ;
         Install = { choco install -y GoogleChrome };
+        Optional = $true;
     },
     @{
         Name = 'Yarn';


### PR DESCRIPTION
Now Chrome is optional (we'll use Edge if that's the default) so don't require it in rnw-dependencies.ps1
Also don't exit the PS session upon success, let the user do that so that it doesn't close the window out from under them

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5947)