### PR TITLE
 Fix Closing a UWP WebSocket

### DIFF
--- a/change/react-native-windows-2020-09-08-23-00-18-fix-uwp-websocket-close.json
+++ b/change/react-native-windows-2020-09-08-23-00-18-fix-uwp-websocket-close.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Closing a UWP Websocket",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T06:00:18.192Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
@@ -54,7 +54,7 @@ class WebSocketModule::WebSocket {
       folly::dynamic /* @Nullable final ReadableArray */ protocols,
       folly::dynamic /* @Nullable final ReadableArray */ headers,
       int64_t id);
-  void close(int64_t id);
+  void close(int64_t code, std::string &&reason, int64_t id);
   void send(const std::string &message, int64_t id);
   void sendBinary(const std::string &base64String, int64_t id);
   void ping(int64_t id);
@@ -188,9 +188,10 @@ void WebSocketModule::WebSocket::connect(
   }
 }
 
-void WebSocketModule::WebSocket::close(int64_t id) {
+void WebSocketModule::WebSocket::close(int64_t code, std::string &&reason, int64_t id) {
   auto socket = m_ws_clients[id];
   socket.Close();
+  sendEvent("websocketClosed", folly::dynamic::object("id", id)("code", code)("reason", std::move(reason)));
 }
 
 void WebSocketModule::WebSocket::send(const std::string &message, int64_t id) {
@@ -295,8 +296,8 @@ auto WebSocketModule::getMethods() -> std::vector<Method> {
           }),
       Method(
           "close",
-          [webSocket](folly::dynamic args) // int64_t id
-          { webSocket->close(facebook::xplat::jsArgAsInt(args, 0)); }),
+          [webSocket](folly::dynamic args) // iint64_t code, std::string_view reason, int64_t id
+          { webSocket->close(facebook::xplat::jsArgAsInt(args, 0), facebook::xplat::jsArgAsString(args, 1), facebook::xplat::jsArgAsInt(args, 2)); }),
       Method(
           "send",
           [webSocket](folly::dynamic args) // const std::string& message, int64_t id

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
@@ -297,7 +297,12 @@ auto WebSocketModule::getMethods() -> std::vector<Method> {
       Method(
           "close",
           [webSocket](folly::dynamic args) // iint64_t code, std::string_view reason, int64_t id
-          { webSocket->close(facebook::xplat::jsArgAsInt(args, 0), facebook::xplat::jsArgAsString(args, 1), facebook::xplat::jsArgAsInt(args, 2)); }),
+          {
+            webSocket->close(
+                facebook::xplat::jsArgAsInt(args, 0),
+                facebook::xplat::jsArgAsString(args, 1),
+                facebook::xplat::jsArgAsInt(args, 2));
+          }),
       Method(
           "send",
           [webSocket](folly::dynamic args) // const std::string& message, int64_t id


### PR DESCRIPTION
The arguments for WebsocketModule were wrong on UWP. Fix that, and start firing closed events like we should. This is enough to get websocket integration tests passing.

This should all eventually be replaced by the new WebSocketResource code once we don't need to touch it as much.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5953)