### PR TITLE
Increase WebSocketJSExecutor Retry Count

### DIFF
--- a/change/react-native-windows-2020-09-10-23-42-42-wsexecutor-retry.json
+++ b/change/react-native-windows-2020-09-10-23-42-42-wsexecutor-retry.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Increase WebSocketJSExecutor Retry Count",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-11T06:42:42.678Z"
+}

--- a/vnext/Shared/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.cpp
@@ -228,9 +228,7 @@ bool WebSocketJSExecutor::PrepareJavaScriptRuntime(int milliseconds) {
 
 void WebSocketJSExecutor::PollPrepareJavaScriptRuntime() {
   m_messageQueueThread->runOnQueue([this]() {
-    auto timeout = std::chrono::milliseconds(750);
-
-    for (uint32_t retries = 20; retries > 0; --retries) {
+    for (uint32_t retries = 50; retries > 0; --retries) {
       if (PrepareJavaScriptRuntime(750)) {
         OnDebuggerAttach();
         return;


### PR DESCRIPTION
We will often see "Prepare JS runtime timed out, Executor instance is not connected to a WebSocket endpoint." in cases where we start an app directly after starting Metro, and the bundler is still taking time to initialize.

Increase the retry count.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5962)