### PR TITLE
Drop PPL concurrent_queue usage in WinRTWebSocketResource

### DIFF
--- a/change/react-native-windows-2020-09-11-16-19-12-ws-noconcqueue.json
+++ b/change/react-native-windows-2020-09-11-16-19-12-ws-noconcqueue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "WinRTWebSocket: Drop concurrent_queue.",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-11T23:19:12.796Z"
+}

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -19,6 +19,7 @@ std::wstring ToString<TestStatus>(const TestStatus &status) {
 
 TEST_MODULE_INITIALIZE(InitModule) {
   Microsoft::React::SetRuntimeOptionBool("WebSocket.AcceptSelfSigned", true);
+  Microsoft::React::SetRuntimeOptionBool("UseBeastWebSocket", false);
 }
 
 // None of these tests are runnable

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -56,7 +56,7 @@ TEST_CLASS (WebSocketIntegrationTest)
     server->Start();
     string sent = "prefix";
     ws->Connect();
-    ws->Send(sent);
+    ws->Send(string{sent});
 
     // Block until response is received. Fail in case of a remote endpoint failure.
     auto sentSizeFuture = sentSizePromise.get_future();
@@ -197,8 +197,7 @@ TEST_CLASS (WebSocketIntegrationTest)
       chars[i] = digits[i % 16];
     }
     chars[LEN] = '\0';
-    string large(chars);
-    ws->Send(large);
+    ws->Send(string{chars});
 
     // Block until response is received. Fail in case of a remote endpoint failure.
     auto future = response.get_future();
@@ -303,7 +302,7 @@ TEST_CLASS (WebSocketIntegrationTest)
     ws->Connect();
 
     for (size_t i = 0; i < messages.size(); i++) {
-      ws->SendBinary(messages[i]);
+      ws->SendBinary(string{messages[i]});
       auto future = responsePromise.get_future();
       future.wait();
       string response = future.get();

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -331,7 +331,7 @@ TEST_CLASS (WebSocketIntegrationTest)
 
     string expected = "ABCDEFGHIJ";
     string result(expected.size(), '0');
-    int index = 0;
+    size_t index = 0;
     promise<void> responsesReceived;
     ws->SetOnMessage([&result, &index, &responsesReceived, count=expected.size()](size_t size, const string& message)
     {

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -352,7 +352,7 @@ TEST_CLASS (WebSocketIntegrationTest)
     // Consecutive immediate writes should be enqueued.
     // The WebSocket library (WinRT or Beast) can't handle multiple write operations
     // concurrently.
-    for (int i = 0; i < expected.size(); i++)
+    for (size_t i = 0; i < expected.size(); i++)
     {
       ws->Send(string{expected[i]});
     }

--- a/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketIntegrationTest.cpp
@@ -57,8 +57,9 @@ TEST_CLASS (WebSocketIntegrationTest)
 
     server->Start();
     string sent = "prefix";
+    auto expectedSize = sent.size();
     ws->Connect();
-    ws->Send(string{sent});
+    ws->Send(std::move(sent));
 
     // Block until response is received. Fail in case of a remote endpoint failure.
     auto sentSizeFuture = sentSizePromise.get_future();
@@ -74,7 +75,7 @@ TEST_CLASS (WebSocketIntegrationTest)
 
     Assert::AreEqual({}, serverError);
     Assert::AreEqual({}, clientError);
-    Assert::AreEqual(sent.length(), sentSize);
+    Assert::AreEqual(expectedSize, sentSize);
     Assert::AreEqual({"prefix_response"}, received);
   }
 
@@ -324,18 +325,20 @@ TEST_CLASS (WebSocketIntegrationTest)
     auto server = make_shared<Test::WebSocketServer>(5556);
     server->SetMessageFactory([](string&& message)
     {
-      return message + "_response";
+      return message;
     });
     auto ws = IWebSocketResource::Make("ws://localhost:5556/");
-    promise<string> response;
-    const int writes = 10;
-    int count = 0;
-    ws->SetOnMessage([&response, &count, writes](size_t size, const string& message)
-    {
-      if (++count < writes)
-        return;
 
-      response.set_value(message);
+    string expected = "ABCDEFGHIJ";
+    string result(expected.size(), '0');
+    int index = 0;
+    promise<void> responsesReceived;
+    ws->SetOnMessage([&result, &index, &responsesReceived, count=expected.size()](size_t size, const string& message)
+    {
+      result[index++] = message[0];
+
+      if (index == count)
+        responsesReceived.set_value();
     });
     string errorMessage;
     ws->SetOnError([&errorMessage](Error err)
@@ -347,23 +350,20 @@ TEST_CLASS (WebSocketIntegrationTest)
     ws->Connect();
 
     // Consecutive immediate writes should be enqueued.
-    // The WebSocket implementation can't handle multiple write operations
+    // The WebSocket library (WinRT or Beast) can't handle multiple write operations
     // concurrently.
-    for (int i = 0; i < writes; i++)
+    for (int i = 0; i < expected.size(); i++)
     {
-      ws->Send("suffixme");
+      ws->Send(string{expected[i]});
     }
 
     // Block until response is received. Fail in case of a remote endpoint failure.
-    auto future = response.get_future();
-    future.wait();
-    string result = future.get();
+    responsesReceived.get_future().wait();
 
     ws->Close(CloseCode::Normal, "Closing");
     server->Stop();
 
     Assert::AreEqual({}, errorMessage);
-    Assert::AreEqual(writes, count);
-    Assert::AreEqual({"suffixme_response"}, result);
+    Assert::AreEqual(expected, result);
   }
 };

--- a/vnext/Desktop.UnitTests/WebSocketMocks.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.cpp
@@ -22,16 +22,16 @@ void MockWebSocketResource::Ping() noexcept /*override*/
     return Mocks.Ping();
 }
 
-void MockWebSocketResource::Send(const string &message) noexcept /*override*/
+void MockWebSocketResource::Send(string &&message) noexcept /*override*/
 {
   if (Mocks.Send)
-    return Mocks.Send(message);
+    return Mocks.Send(std::move(message));
 }
 
-void MockWebSocketResource::SendBinary(const string &message) noexcept /*override*/
+void MockWebSocketResource::SendBinary(string &&message) noexcept /*override*/
 {
   if (Mocks.SendBinary)
-    return Mocks.SendBinary(message);
+    return Mocks.SendBinary(std::move(message));
 }
 
 void MockWebSocketResource::Close(CloseCode code, const string &reason) noexcept /*override*/

--- a/vnext/Desktop.UnitTests/WebSocketMocks.h
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.h
@@ -29,9 +29,9 @@ struct MockWebSocketResource : public IWebSocketResource {
 
   void Ping() noexcept override;
 
-  void Send(const std::string &) noexcept override;
+  void Send(std::string &&) noexcept override;
 
-  void SendBinary(const std::string &) noexcept override;
+  void SendBinary(std::string &&) noexcept override;
 
   void Close(CloseCode, const std::string &) noexcept override;
 

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -391,12 +391,12 @@ void BaseWebSocketResource<SocketLayer, Stream>::Close(CloseCode code, const str
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::Send(const string &message) noexcept {
+void BaseWebSocketResource<SocketLayer, Stream>::Send(string &&message) noexcept {
   EnqueueWrite(std::move(message), false);
 }
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::SendBinary(const string &base64String) noexcept {
+void BaseWebSocketResource<SocketLayer, Stream>::SendBinary(string &&base64String) noexcept {
   m_stream->binary(true);
 
   string message;

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -166,12 +166,12 @@ class BaseWebSocketResource : public IWebSocketResource {
   /// <summary>
   /// <see cref="IWebSocketResource::Send" />
   /// </summary>
-  void Send(const std::string &message) noexcept override;
+  void Send(std::string &&message) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SendBinary" />
   /// </summary>
-  void SendBinary(const std::string &base64String) noexcept override;
+  void SendBinary(std::string &&base64String) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Close" />

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -110,7 +110,7 @@ struct IWebSocketResource {
   /// <param name="message">
   /// UTF8-encoded string of arbitrary length.
   /// </param>
-  virtual void Send(const std::string &message) noexcept = 0;
+  virtual void Send(std::string &&message) noexcept = 0;
 
   /// <summary>
   /// Sends a non-plain-text message to the remote endpoint.
@@ -118,7 +118,7 @@ struct IWebSocketResource {
   /// <param name="base64String">
   /// Binary message encoded in Base64 format.
   /// </param>
-  virtual void SendBinary(const std::string &base64String) noexcept = 0;
+  virtual void SendBinary(std::string &&base64String) noexcept = 0;
 
   /// <summary>
   /// Terminates this resource's connection to the remote endpoint.

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -12,14 +12,13 @@
 #include <winrt/Windows.Security.Cryptography.h>
 #include <RestrictedErrorInfo.h>
 
-// Standard Library
-#include <future>
-
 using Microsoft::Common::Unicode::Utf8ToUtf16;
 using Microsoft::Common::Unicode::Utf16ToUtf8;
 using Microsoft::Common::Utilities::CheckedReinterpretCast;
 
 using std::function;
+using std::lock_guard;
+using std::mutex;
 using std::size_t;
 using std::string;
 using std::vector;
@@ -189,7 +188,7 @@ fire_and_forget WinRTWebSocketResource::PerformWrite(string&& message, bool isBi
 {
   auto self = shared_from_this();
   {
-    auto guard = std::lock_guard<std::mutex>{m_writeQueueMutex};
+    auto guard = lock_guard<mutex>{m_writeQueueMutex};
     m_writeQueue.emplace(std::move(message), false);
   }
 
@@ -211,7 +210,7 @@ fire_and_forget WinRTWebSocketResource::PerformWrite(string&& message, bool isBi
     string messageLocal;
     bool isBinaryLocal;
     {
-      auto guard = std::lock_guard<std::mutex>{m_writeQueueMutex};
+      auto guard = lock_guard<mutex>{m_writeQueueMutex};
       std::tie(messageLocal, isBinaryLocal) = m_writeQueue.front();
       m_writeQueue.pop();
     }

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -383,16 +383,16 @@ void WinRTWebSocketResource::Ping() noexcept
   PerformPing();
 }
 
-void WinRTWebSocketResource::Send(const string& message) noexcept
+void WinRTWebSocketResource::Send(string&& message) noexcept
 {
-  m_writeQueue.push({ message, false });
+  m_writeQueue.push({ std::move(message), false });
 
   PerformWrite();
 }
 
-void WinRTWebSocketResource::SendBinary(const string& base64String) noexcept
+void WinRTWebSocketResource::SendBinary(string&& base64String) noexcept
 {
-  m_writeQueue.push({ base64String, true });
+  m_writeQueue.push({ std::move(base64String), true });
 
   PerformWrite();
 }

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -11,6 +11,7 @@
 
 // Standard Library
 #include <future>
+#include <mutex>
 #include <queue>
 
 namespace Microsoft::React {
@@ -32,6 +33,8 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
 
   CloseCode m_closeCode{CloseCode::Normal};
   std::string m_closeReason;
+  std::queue<std::pair<std::string, bool>> m_writeQueue;
+  std::mutex m_writeQueueMutex;
 
   std::function<void()> m_connectHandler;
   std::function<void()> m_pingHandler;

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -89,12 +89,12 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   /// <summary>
   /// <see cref="IWebSocketResource::Send" />
   /// </summary>
-  void Send(const std::string &message) noexcept override;
+  void Send(std::string &&message) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::SendBinary" />
   /// </summary>
-  void SendBinary(const std::string &base64String) noexcept override;
+  void SendBinary(std::string &&base64String) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Close" />

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -9,9 +9,6 @@
 #include <winrt/Windows.Networking.Sockets.h>
 #include <winrt/Windows.Storage.Streams.h>
 
-// PPL
-#include <concurrent_queue.h>
-
 // Standard Library
 #include <future>
 #include <queue>
@@ -35,7 +32,6 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
 
   CloseCode m_closeCode{CloseCode::Normal};
   std::string m_closeReason;
-  concurrency::concurrent_queue<std::pair<std::string, bool>> m_writeQueue;
 
   std::function<void()> m_connectHandler;
   std::function<void()> m_pingHandler;
@@ -51,7 +47,7 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
 
   winrt::Windows::Foundation::IAsyncAction PerformConnect() noexcept;
   winrt::fire_and_forget PerformPing() noexcept;
-  winrt::fire_and_forget PerformWrite() noexcept;
+  winrt::fire_and_forget PerformWrite(std::string &&message, bool isBinary) noexcept;
   winrt::fire_and_forget PerformClose() noexcept;
 
   void OnMessageReceived(


### PR DESCRIPTION
`WinRTWebSocketResource` already uses an write-enqueuing mechanism via `Mso::DispatchQueue`.
This allows enqueuing the message payload as an argument of the `PerformWrite` coroutine.
The thread-safe container `concurrency::concurrent_queue` `m_writeQueue` is redundant and should be dropped.

- Updates `IWebSocketResource::Send` to use r-value args instead of `const &`.
- Relevant test: `WebSocketIntegrationTest::SendConsecutive`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5969)