### PR TITLE
 Fix issue loading offline bundle after failing to load from packager

### DIFF
--- a/change/react-native-windows-2020-09-11-16-46-06-loadofflineafterfailure.json
+++ b/change/react-native-windows-2020-09-11-16-46-06-loadofflineafterfailure.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Fix issue loading offline bundle after failing to load from pacakger",
+  "comment": "Fix issue loading offline bundle after failing to load from packager",
   "packageName": "react-native-windows",
   "email": "acoates-ms@noreply.github.com",
   "dependentChangeType": "patch",

--- a/change/react-native-windows-2020-09-11-16-46-06-loadofflineafterfailure.json
+++ b/change/react-native-windows-2020-09-11-16-46-06-loadofflineafterfailure.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix issue loading offline bundle after failing to load from pacakger",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-11T23:46:06.899Z"
+}

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -34,18 +34,16 @@ class DevSupportManager final : public facebook::react::IDevSupportManager {
   DevSupportManager() = default;
   ~DevSupportManager();
 
-  virtual facebook::react::JSECreator LoadJavaScriptInProxyMode(const facebook::react::DevSettings &settings) override;
+  virtual facebook::react::JSECreator LoadJavaScriptInProxyMode(
+      const facebook::react::DevSettings &settings,
+      std::function<void()> &&errorCallback) override;
   virtual void StartPollingLiveReload(
       const std::string &sourceBundleHost,
       const uint16_t sourceBundlePort,
       std::function<void()> onChangeCallback) override;
   virtual void StopPollingLiveReload() override;
-  virtual bool HasException() override {
-    return m_exceptionCaught;
-  }
 
  private:
-  bool m_exceptionCaught = false;
   std::atomic_bool m_cancellation_token;
 };
 

--- a/vnext/Shared/IDevSupportManager.h
+++ b/vnext/Shared/IDevSupportManager.h
@@ -15,13 +15,12 @@ namespace react {
 struct DevSettings;
 
 struct IDevSupportManager {
-  virtual JSECreator LoadJavaScriptInProxyMode(const DevSettings &settings) = 0;
+  virtual JSECreator LoadJavaScriptInProxyMode(const DevSettings &settings, std::function<void()> &&errorCallback) = 0;
   virtual void StartPollingLiveReload(
       const std::string &sourceBundleHost,
       const uint16_t sourceBundlePort,
       std::function<void()> onChangeCallback) = 0;
   virtual void StopPollingLiveReload() = 0;
-  virtual bool HasException() = 0;
 };
 
 std::shared_ptr<IDevSupportManager> CreateDevSupportManager();

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -312,6 +312,10 @@ struct BridgeTestInstanceCallback : public InstanceCallback {
   return instance;
 }
 
+void InstanceImpl::SetInError() noexcept {
+  m_isInError = true;
+}
+
 InstanceImpl::InstanceImpl(
     std::string &&jsBundleBasePath,
     std::vector<
@@ -353,9 +357,13 @@ InstanceImpl::InstanceImpl(
   std::shared_ptr<JSExecutorFactory> jsef;
   if (m_devSettings->useWebDebugger) {
     try {
-      auto jseFunc = m_devManager->LoadJavaScriptInProxyMode(*m_devSettings);
+      auto jseFunc = m_devManager->LoadJavaScriptInProxyMode(*m_devSettings, [weakthis = weak_from_this()]() {
+        if (auto strongThis = weakthis.lock()) {
+          strongThis->SetInError();
+        }
+      });
 
-      if ((jseFunc == nullptr) || m_devManager->HasException()) {
+      if ((jseFunc == nullptr) || m_isInError) {
         m_devSettings->errorCallback("Failed to create JavaScript Executor.");
         return;
       }
@@ -562,7 +570,7 @@ InstanceImpl::~InstanceImpl() {
 }
 
 void InstanceImpl::AttachMeasuredRootView(IReactRootView *rootView, folly::dynamic &&initProps) noexcept {
-  if (m_devManager->HasException()) {
+  if (m_isInError) {
     return;
   }
 
@@ -578,7 +586,7 @@ void InstanceImpl::AttachMeasuredRootView(IReactRootView *rootView, folly::dynam
 }
 
 void InstanceImpl::DetachRootView(IReactRootView *rootView) noexcept {
-  if (m_devManager->HasException()) {
+  if (m_isInError) {
     return;
   }
 
@@ -660,14 +668,14 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
 
 void InstanceImpl::RegisterForReloadIfNecessary() noexcept {
   // setup polling for live reload
-  if (!m_devManager->HasException() && !m_devSettings->useFastRefresh && m_devSettings->liveReloadCallback != nullptr) {
+  if (!m_isInError && !m_devSettings->useFastRefresh && m_devSettings->liveReloadCallback != nullptr) {
     m_devManager->StartPollingLiveReload(
         m_devSettings->sourceBundleHost, m_devSettings->sourceBundlePort, m_devSettings->liveReloadCallback);
   }
 }
 
 void InstanceImpl::DispatchEvent(int64_t viewTag, std::string eventName, folly::dynamic &&eventData) {
-  if (m_devManager->HasException()) {
+  if (m_isInError) {
     return;
   }
 
@@ -676,7 +684,7 @@ void InstanceImpl::DispatchEvent(int64_t viewTag, std::string eventName, folly::
 }
 
 void InstanceImpl::invokeCallback(const int64_t callbackId, folly::dynamic &&params) {
-  if (m_devManager->HasException()) {
+  if (m_isInError) {
     return;
   }
 

--- a/vnext/Shared/OInstance.h
+++ b/vnext/Shared/OInstance.h
@@ -89,6 +89,7 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
   std::vector<std::unique_ptr<NativeModule>> GetDefaultNativeModules(std::shared_ptr<MessageQueueThread> nativeQueue);
   void RegisterForReloadIfNecessary() noexcept;
   void loadBundleInternal(std::string &&jsBundleRelativePath, bool synchronously);
+  void SetInError() noexcept;
 
  private:
   std::shared_ptr<Instance> m_innerInstance;
@@ -102,6 +103,7 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
 
   std::shared_ptr<IDevSupportManager> m_devManager;
   std::shared_ptr<DevSettings> m_devSettings;
+  bool m_isInError{false};
 };
 
 } // namespace react


### PR DESCRIPTION
Load a RN app with settings that will attempt to get the bundle from a bundle server.  (Ex FastRefresh on), without a bundle server running.  Then open the debug menu and turn off fast refresh, which will cause RN to try to load a local bundle.  Even if the local bundle exists, the rootview will fail to attach to the instance.

This is due to an error state maintained in DevSupportManager.  This error state is set when we fail to load a bundle from a bundle server, but it only reset when we make another attempt to the bundle server.  If we instead use a local bundle, the error state was never reset, and root views would fail to attach.  The change is to move the error state to the instance.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5970)