### PR TITLE
Enable using VS previews in run-windows

### DIFF
--- a/change/@react-native-windows-cli-2020-09-11-19-25-55-previewVS.json
+++ b/change/@react-native-windows-cli-2020-09-11-19-25-55-previewVS.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enable trying Previews of VS as a fallback",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-12T02:25:55.844Z"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -76,11 +76,15 @@ async function runWindows(
   try {
     buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose);
   } catch (error) {
-    newWarn("No public VS release found");
+    newWarn('No public VS release found');
     // Try prerelease
     try {
-      newInfo("Trying pre-release VS");
-      buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose, true);
+      newInfo('Trying pre-release VS');
+      buildTools = MSBuildTools.findAvailableVersion(
+        options.arch,
+        verbose,
+        true,
+      );
     } catch {
       throw error;
     }

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -83,7 +83,7 @@ async function runWindows(
       buildTools = MSBuildTools.findAvailableVersion(
         options.arch,
         verbose,
-        true,
+        true, // preRelease
       );
     } catch {
       throw error;

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -7,7 +7,7 @@
 import * as build from './utils/build';
 import * as chalk from 'chalk';
 import * as deploy from './utils/deploy';
-import {newError, newInfo} from './utils/commandWithProgress';
+import {newError, newInfo, newWarn} from './utils/commandWithProgress';
 import * as info from './utils/info';
 import MSBuildTools from './utils/msbuildtools';
 
@@ -72,7 +72,19 @@ async function runWindows(
     newInfo('Autolink step is skipped');
   }
 
-  const buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose);
+  let buildTools;
+  try {
+    buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose);
+  } catch (error) {
+    newWarn("No public VS release found");
+    // Try prerelease
+    try {
+      newInfo("Trying pre-release VS");
+      buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose, true);
+    } catch {
+      throw error;
+    }
+  }
 
   if (options.build) {
     if (!slnFile) {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -148,6 +148,7 @@ export default class MSBuildTools {
   static findAvailableVersion(
     buildArch: BuildArch,
     verbose: boolean,
+    prerelease?: boolean
   ): MSBuildTools {
     // https://aka.ms/vs/workloads
     const requires = [
@@ -155,7 +156,7 @@ export default class MSBuildTools {
       getVCToolsByArch(buildArch),
     ];
     const version = process.env.VisualStudioVersion || '16.0';
-    const vsInstallation = findLatestVsInstall({requires, version, verbose});
+    const vsInstallation = findLatestVsInstall({requires, version, verbose, prerelease});
 
     if (!vsInstallation) {
       if (process.env.VisualStudioVersion != null) {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -148,7 +148,7 @@ export default class MSBuildTools {
   static findAvailableVersion(
     buildArch: BuildArch,
     verbose: boolean,
-    prerelease?: boolean
+    prerelease?: boolean,
   ): MSBuildTools {
     // https://aka.ms/vs/workloads
     const requires = [
@@ -156,7 +156,12 @@ export default class MSBuildTools {
       getVCToolsByArch(buildArch),
     ];
     const version = process.env.VisualStudioVersion || '16.0';
-    const vsInstallation = findLatestVsInstall({requires, version, verbose, prerelease});
+    const vsInstallation = findLatestVsInstall({
+      requires,
+      version,
+      verbose,
+      prerelease,
+    });
 
     if (!vsInstallation) {
       if (process.env.VisualStudioVersion != null) {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -40,12 +40,8 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
   }
 
   const cmdline = `"${vsWherePath}" ${args.join(' ')} -format json -utf8`;
-  const json = JSON.parse(
-    execSync(cmdline).toString(
-      'utf8',
-    ),
-  );
-  
+  const json = JSON.parse(execSync(cmdline).toString('utf8'));
+
   for (const entry of json) {
     entry.prerelease = entry.catalog.productMilestoneIsPreRelease;
   }
@@ -96,7 +92,7 @@ export function findLatestVsInstall(opts: {
   let installs = enumerateVsInstalls({...opts, latest: true});
 
   if (opts.prerelease && installs.length > 0) {
-    installs = installs.filter((x) => x.prerelease === "True");
+    installs = installs.filter(x => x.prerelease === 'True');
   }
 
   if (installs.length > 0) {


### PR DESCRIPTION
Fixes #5900 
This adds a fallback to try VS Preview installs if we couldn't find any non-prerelease bits

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5971)