### PR TITLE
Ingest a new version of Folly, add folly changes to prevent VS 16.8 from breaking the build

### DIFF
--- a/change/react-native-windows-2020-09-14-12-27-48-follyUpdate.json
+++ b/change/react-native-windows-2020-09-14-12-27-48-follyUpdate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update folly",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-14T19:27:48.743Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -7,7 +7,6 @@
 EXPORTS
 ??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
-??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0LayoutAnimation@react@facebook@@QEAA@Udynamic@folly@@@Z
 ??0TypeError@folly@@QEAA@$$QEAU01@@Z
 ??0TypeError@folly@@QEAA@AEBU01@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -7,7 +7,6 @@
 EXPORTS
 ??$str_to_floating@N@detail@folly@@YG?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
-??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0LayoutAnimation@react@facebook@@QAE@Udynamic@folly@@@Z
 ??0TypeError@folly@@QAE@$$QAU01@@Z
 ??0TypeError@folly@@QAE@ABU01@@Z

--- a/vnext/Desktop.UnitTests/EmptyUIManagerModule.cpp
+++ b/vnext/Desktop.UnitTests/EmptyUIManagerModule.cpp
@@ -5,7 +5,6 @@
 #include <cxxreact/JsArgumentHelpers.h>
 
 using namespace std;
-using namespace folly;
 using namespace facebook::react;
 using namespace facebook::xplat;
 
@@ -36,7 +35,7 @@ EmptyUIManager::EmptyUIManager(
     std::shared_ptr<NodeRegistry> nodeRegistry)
     : m_viewManagers(std::move(viewManagers)), m_nodeRegistry(nodeRegistry) {}
 
-void EmptyUIManager::PopulateViewManagerConstants(std::map<std::string, dynamic> &constants) {
+void EmptyUIManager::PopulateViewManagerConstants(std::map<std::string, folly::dynamic> &constants) {
   for (auto &&vm : *m_viewManagers)
     constants.emplace(std::make_pair(std::string(vm->GetName()), vm->GetConstants()));
 }
@@ -97,15 +96,15 @@ std::map<std::string, folly::dynamic> EmptyUIManagerModule::getConstants() {
 
 auto EmptyUIManagerModule::getMethods() -> std::vector<Method> {
   return {
-      Method("removeRootView", [this](dynamic args) { m_manager->removeRootView(jsArgAsInt(args, 0)); }),
+      Method("removeRootView", [this](folly::dynamic args) { m_manager->removeRootView(jsArgAsInt(args, 0)); }),
       Method(
           "createView",
-          [this](dynamic args) {
+          [this](folly::dynamic args) {
             m_manager->createView(
                 jsArgAsInt(args, 0), jsArgAsString(args, 1), jsArgAsInt(args, 2), jsArgAsDynamic(args, 3));
           }),
       Method(
-          "setChildren", [this](dynamic args) { m_manager->setChildren(jsArgAsInt(args, 0), jsArgAsArray(args, 1)); }),
+          "setChildren", [this](folly::dynamic args) { m_manager->setChildren(jsArgAsInt(args, 0), jsArgAsArray(args, 1)); }),
   };
 }
 

--- a/vnext/Desktop.UnitTests/EmptyUIManagerModule.cpp
+++ b/vnext/Desktop.UnitTests/EmptyUIManagerModule.cpp
@@ -104,7 +104,8 @@ auto EmptyUIManagerModule::getMethods() -> std::vector<Method> {
                 jsArgAsInt(args, 0), jsArgAsString(args, 1), jsArgAsInt(args, 2), jsArgAsDynamic(args, 3));
           }),
       Method(
-          "setChildren", [this](folly::dynamic args) { m_manager->setChildren(jsArgAsInt(args, 0), jsArgAsArray(args, 1)); }),
+          "setChildren",
+          [this](folly::dynamic args) { m_manager->setChildren(jsArgAsInt(args, 0), jsArgAsArray(args, 1)); }),
   };
 }
 

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -17,6 +17,7 @@
       The PR (windows-vs-pr.yml) and CI (publish.yml() turn it back on.
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
+    <FollyVersion>2020.09.14.00</FollyVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">
@@ -49,7 +50,7 @@
 
     <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)ReactCommon\yoga</YogaDir>
 
-    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-2019.09.30.00</FollyDir>
+    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-$(FollyVersion)</FollyDir>
     <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
   </PropertyGroup>
 

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -51,6 +51,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="$(FollyDir)\folly\lang\Assume.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\lang\SafeAssert.cpp" />
     <ClCompile Include="$(FollyDir)\folly\json_pointer.cpp" />
     <ClCompile Include="$(FollyDir)\folly\Format.cpp" />
     <ClCompile Include="$(FollyDir)\folly\String.cpp" />
@@ -59,6 +60,8 @@
     <ClCompile Include="$(FollyDir)\folly\portability\string.cpp">
       <ObjectFileName>$(IntDir)\potabilityString.obj</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\portability\unistd.cpp" />
+    
     <ClCompile Include="$(FollyDir)\folly\Demangle.cpp" />
     <ClCompile Include="$(FollyDir)\folly\dynamic.cpp" />
     <ClCompile Include="$(FollyDir)\folly\json.cpp" />
@@ -248,7 +251,7 @@
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
       <DisableSpecificWarnings>4018;4146;4244;4251;4267;4293;4305;4800;4804;4310;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -9,7 +9,6 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <FollyVersion>2020.09.14.00</FollyVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -51,7 +51,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="$(FollyDir)\folly\lang\Assume.cpp" />
-    <ClCompile Include="$(FollyDir)\folly\lang\SafeAssert.cpp" />
     <ClCompile Include="$(FollyDir)\folly\json_pointer.cpp" />
     <ClCompile Include="$(FollyDir)\folly\Format.cpp" />
     <ClCompile Include="$(FollyDir)\folly\String.cpp" />

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -58,10 +58,8 @@
     <ClCompile Include="$(FollyDir)\folly\container\detail\F14Table.cpp" />
     <ClCompile Include="$(FollyDir)\folly\Conv.cpp" />
     <ClCompile Include="$(FollyDir)\folly\portability\string.cpp">
-      <ObjectFileName>$(IntDir)\potabilityString.obj</ObjectFileName>
+      <ObjectFileName>$(IntDir)\portabilityString.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="$(FollyDir)\folly\portability\unistd.cpp" />
-    
     <ClCompile Include="$(FollyDir)\folly\Demangle.cpp" />
     <ClCompile Include="$(FollyDir)\folly\dynamic.cpp" />
     <ClCompile Include="$(FollyDir)\folly\json.cpp" />
@@ -251,7 +249,7 @@
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;_CRT_SECURE_NO_WARNINGS;WINAPI_PARTITION_APP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
       <DisableSpecificWarnings>4018;4146;4244;4251;4267;4293;4305;4800;4804;4310;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
@@ -282,10 +280,10 @@
     <TemporaryFollyPatchFiles Include="$(MSBuildThisFileDirectory)\TEMP_UntilFollyUpdate\**\*.*" />
   </ItemGroup>
   <Target Name="Deploy" />
+
   <!-- Reenable this task if we need to temporarily replace any folly files for fixes, while we wait for PRs to land in folly -->
-  <!--
   <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
     <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
   </Target>
-  -->
+ 
 </Project>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -66,7 +66,6 @@
     <ClCompile Include="$(FollyDir)\folly\ScopeGuard.cpp" />
     <ClCompile Include="$(FollyDir)\folly\Unicode.cpp" />
     <ClCompile Include="$(FollyDir)\folly\memory\detail\MallocImpl.cpp" />
-    <ClCompile Include="$(FollyDir)\folly\lang\ColdClass.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(FollyDir)\folly\AtomicBitSet.h" />
@@ -251,7 +250,7 @@
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4018;4146;4244;4251;4267;4293;4305;4800;4804;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4146;4244;4251;4267;4293;4305;4800;4804;4310;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -9,6 +9,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <FollyVersion>2020.09.14.00</FollyVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
@@ -267,14 +268,14 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
-  </Target>
+  </Target>  
   <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
-    <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" />
-    <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip')" SourceUrl="https://github.com/facebook/folly/archive/v2019.09.30.00.zip" DestinationFileName="folly-2019.09.30.00.zip" DestinationFolder="$(FollyDir)..\.follyzip" />
+    <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')" />
+    <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')" SourceUrl="https://github.com/facebook/folly/archive/v$(FollyVersion).zip" DestinationFileName="folly-$(FollyVersion).zip" DestinationFolder="$(FollyDir)..\.follyzip" />
   </Target>
   <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
     <Message Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
-    <Unzip Condition="!Exists('$(FollyDir)')" SourceFiles="$(FollyDir)..\.follyzip\folly-2019.09.30.00.zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
+    <Unzip Condition="!Exists('$(FollyDir)')" SourceFiles="$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
   </Target>
   <ItemGroup>
     <TemporaryFollyPatchFiles Include="$(MSBuildThisFileDirectory)\TEMP_UntilFollyUpdate\**\*.*" />

--- a/vnext/Folly/Folly.vcxproj.filters
+++ b/vnext/Folly/Folly.vcxproj.filters
@@ -72,9 +72,6 @@
     <ClCompile Include="$(FollyDir)\folly\Unicode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(FollyDir)\folly\lang\SafeAssert.cpp">
-      <Filter>Source Files\lang</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(FollyDir)\folly\portability\Asm.h">

--- a/vnext/Folly/Folly.vcxproj.filters
+++ b/vnext/Folly/Folly.vcxproj.filters
@@ -33,9 +33,6 @@
     <ClCompile Include="$(FollyDir)\folly\lang\Assume.cpp">
       <Filter>Source Files\lang</Filter>
     </ClCompile>
-    <ClCompile Include="$(FollyDir)\folly\lang\ColdClass.cpp">
-      <Filter>Source Files\lang</Filter>
-    </ClCompile>
     <ClCompile Include="$(FollyDir)\folly\Conv.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -74,6 +71,12 @@
     </ClCompile>
     <ClCompile Include="$(FollyDir)\folly\Unicode.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\lang\SafeAssert.cpp">
+      <Filter>Source Files\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\portability\unistd.cpp">
+      <Filter>Source Files\portability</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Folly/Folly.vcxproj.filters
+++ b/vnext/Folly/Folly.vcxproj.filters
@@ -75,9 +75,6 @@
     <ClCompile Include="$(FollyDir)\folly\lang\SafeAssert.cpp">
       <Filter>Source Files\lang</Filter>
     </ClCompile>
-    <ClCompile Include="$(FollyDir)\folly\portability\unistd.cpp">
-      <Filter>Source Files\portability</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(FollyDir)\folly\portability\Asm.h">

--- a/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
@@ -30,19 +30,19 @@
 namespace folly {
 namespace portability {
 namespace detail {
-void call_flush_instruction_cache_self_pid(void* begin, size_t size);
+void call_flush_instruction_cache_self_pid(void *begin, size_t size);
 }
 } // namespace portability
 } // namespace folly
 
-FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char* begin, char* end) {
+FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char *begin, char *end) {
   if (folly::kIsArchAmd64) {
     // x86_64 doesn't require the instruction cache to be flushed after
     // modification.
   } else {
     // Default to flushing it for everything else, such as ARM.
     folly::portability::detail::call_flush_instruction_cache_self_pid(
-        static_cast<void*>(begin), static_cast<size_t>(end - begin));
+        static_cast<void *>(begin), static_cast<size_t>(end - begin));
   }
 }
 
@@ -135,8 +135,7 @@ FOLLY_ALWAYS_INLINE int __builtin_popcountl(unsigned long x) {
 #if !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
 #if defined(_M_IX86)
 FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
-  return int(__popcnt((unsigned int)(x >> 32))) +
-      int(__popcnt((unsigned int)x));
+  return int(__popcnt((unsigned int)(x >> 32))) + int(__popcnt((unsigned int)x));
 }
 #elif defined(_M_X64)
 FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
@@ -145,7 +144,7 @@ FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
 #endif
 #endif // !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
 
-FOLLY_ALWAYS_INLINE void* __builtin_return_address(unsigned int frame) {
+FOLLY_ALWAYS_INLINE void *__builtin_return_address(unsigned int frame) {
   // I really hope frame is zero...
   (void)frame;
   assert(frame == 0);

--- a/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/portability/Builtins.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if defined(_WIN32) && !defined(__clang__)
+#include <assert.h>
+#include <folly/Portability.h>
+#include <intrin.h>
+#include <stdint.h>
+
+// MSVC had added support for __builtin_clz etc. in 16.3 (1923) but it will be removed in 16.8 (1928).
+#if (_MSC_VER >= 1923) && (_MSC_VER < 1928)
+#define _MSC_BUILTIN_SUPPORT
+#endif
+
+namespace folly {
+namespace portability {
+namespace detail {
+void call_flush_instruction_cache_self_pid(void* begin, size_t size);
+}
+} // namespace portability
+} // namespace folly
+
+FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char* begin, char* end) {
+  if (folly::kIsArchAmd64) {
+    // x86_64 doesn't require the instruction cache to be flushed after
+    // modification.
+  } else {
+    // Default to flushing it for everything else, such as ARM.
+    folly::portability::detail::call_flush_instruction_cache_self_pid(
+        static_cast<void*>(begin), static_cast<size_t>(end - begin));
+  }
+}
+
+#if !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
+FOLLY_ALWAYS_INLINE int __builtin_clz(unsigned int x) {
+  unsigned long index;
+  return int(_BitScanReverse(&index, (unsigned long)x) ? 31 - index : 32);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_clzl(unsigned long x) {
+  return __builtin_clz((unsigned int)x);
+}
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
+  if (x == 0) {
+    return 64;
+  }
+  unsigned int msb = (unsigned int)(x >> 32);
+  unsigned int lsb = (unsigned int)x;
+  return (msb != 0) ? __builtin_clz(msb) : 32 + __builtin_clz(lsb);
+}
+#else
+FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
+  unsigned long index;
+  return int(_BitScanReverse64(&index, x) ? 63 - index : 64);
+}
+#endif
+
+FOLLY_ALWAYS_INLINE int __builtin_ctz(unsigned int x) {
+  unsigned long index;
+  return int(_BitScanForward(&index, (unsigned long)x) ? index : 32);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_ctzl(unsigned long x) {
+  return __builtin_ctz((unsigned int)x);
+}
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
+  unsigned long index;
+  unsigned int msb = (unsigned int)(x >> 32);
+  unsigned int lsb = (unsigned int)x;
+  if (lsb != 0) {
+    return (int)(_BitScanForward(&index, lsb) ? index : 64);
+  } else {
+    return (int)(_BitScanForward(&index, msb) ? index + 32 : 64);
+  }
+}
+#else
+FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
+  unsigned long index;
+  return int(_BitScanForward64(&index, x) ? index : 64);
+}
+#endif
+#endif // !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
+
+FOLLY_ALWAYS_INLINE int __builtin_ffs(int x) {
+  unsigned long index;
+  return int(_BitScanForward(&index, (unsigned long)x) ? index + 1 : 0);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_ffsl(long x) {
+  return __builtin_ffs(int(x));
+}
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
+  int ctzll = __builtin_ctzll((unsigned long long)x);
+  return ctzll != 64 ? ctzll + 1 : 0;
+}
+#else
+FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
+  unsigned long index;
+  return int(_BitScanForward64(&index, (unsigned long long)x) ? index + 1 : 0);
+}
+
+FOLLY_ALWAYS_INLINE int __builtin_popcount(unsigned int x) {
+  return int(__popcnt(x));
+}
+
+#if !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
+FOLLY_ALWAYS_INLINE int __builtin_popcountl(unsigned long x) {
+  static_assert(sizeof(x) == 4, "");
+  return int(__popcnt(x));
+}
+#endif // !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
+#endif
+
+#if !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
+#if defined(_M_IX86)
+FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
+  return int(__popcnt((unsigned int)(x >> 32))) +
+      int(__popcnt((unsigned int)x));
+}
+#elif defined(_M_X64)
+FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
+  return int(__popcnt64(x));
+}
+#endif
+#endif // !defined(_MSC_VER) || !defined(_MSC_BUILTIN_SUPPORT)
+
+FOLLY_ALWAYS_INLINE void* __builtin_return_address(unsigned int frame) {
+  // I really hope frame is zero...
+  (void)frame;
+  assert(frame == 0);
+  return _ReturnAddress();
+}
+#endif

--- a/vnext/IntegrationTests/TestInstance.cpp
+++ b/vnext/IntegrationTests/TestInstance.cpp
@@ -4,7 +4,6 @@
 #include "TestInstance.h"
 
 using namespace facebook::react;
-using namespace folly;
 
 using std::make_unique;
 using std::map;
@@ -22,15 +21,15 @@ const char *TestViewManager::GetName() const {
   return m_name.c_str();
 }
 
-dynamic TestViewManager::GetExportedViewConstants() const {
-  return dynamic();
+folly::dynamic TestViewManager::GetExportedViewConstants() const {
+  return folly::dynamic();
 }
 
-dynamic TestViewManager::GetCommands() const {
-  return dynamic();
+folly::dynamic TestViewManager::GetCommands() const {
+  return folly::dynamic();
 }
 
-dynamic TestViewManager::GetNativeProps() const {
+folly::dynamic TestViewManager::GetNativeProps() const {
   return folly::dynamic::object("dummyprop", "string");
 }
 
@@ -40,7 +39,7 @@ ShadowNode *TestViewManager::createShadow() const {
 
 void TestViewManager::destroyShadow(ShadowNode *) const {}
 
-dynamic TestViewManager::GetConstants() const {
+folly::dynamic TestViewManager::GetConstants() const {
   folly::dynamic constants = folly::dynamic::object("Constants", GetExportedViewConstants())("Commands", GetCommands())(
       "NativeProps", GetNativeProps());
 
@@ -54,12 +53,12 @@ dynamic TestViewManager::GetConstants() const {
   return constants;
 }
 
-dynamic TestViewManager::GetExportedCustomBubblingEventTypeConstants() const {
-  return dynamic::object();
+folly::dynamic TestViewManager::GetExportedCustomBubblingEventTypeConstants() const {
+  return folly::dynamic::object();
 }
 
-dynamic TestViewManager::GetExportedCustomDirectEventTypeConstants() const {
-  return dynamic::object();
+folly::dynamic TestViewManager::GetExportedCustomDirectEventTypeConstants() const {
+  return folly::dynamic::object();
 }
 
 #pragma endregion TestViewManager members
@@ -148,3 +147,7 @@ void TestShadowNode::createView() {}
 #pragma endregion
 
 } // namespace Microsoft::React::Test
+
+namespace folly {
+char const *const dynamic::TypeInfo<dynamic::ObjectImpl>::name = "object";
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -16,8 +16,6 @@
 #include <TestHook.h>
 #include <Views/ShadowNodeBase.h>
 
-using namespace folly;
-
 namespace winrt {
 using namespace xaml;
 }
@@ -81,21 +79,21 @@ YGSize DefaultYogaSelfMeasureFunc(
 ViewManagerBase::ViewManagerBase(const std::shared_ptr<IReactInstance> &reactInstance)
     : m_wkReactInstance(reactInstance) {}
 
-dynamic ViewManagerBase::GetExportedViewConstants() const {
-  return dynamic::object();
+folly::dynamic ViewManagerBase::GetExportedViewConstants() const {
+  return folly::dynamic::object();
 }
 
-dynamic ViewManagerBase::GetCommands() const {
-  return dynamic::object();
+folly::dynamic ViewManagerBase::GetCommands() const {
+  return folly::dynamic::object();
 }
 
-dynamic ViewManagerBase::GetNativeProps() const {
+folly::dynamic ViewManagerBase::GetNativeProps() const {
   folly::dynamic props = folly::dynamic::object();
   props.update(folly::dynamic::object("onLayout", "function")("keyDownEvents", "array")("keyUpEvents", "array"));
   return props;
 }
 
-dynamic ViewManagerBase::GetConstants() const {
+folly::dynamic ViewManagerBase::GetConstants() const {
   folly::dynamic constants = folly::dynamic::object("Constants", GetExportedViewConstants())("Commands", GetCommands())(
       "NativeProps", GetNativeProps());
 
@@ -121,7 +119,7 @@ void ViewManagerBase::destroyShadow(facebook::react::ShadowNode *node) const {
   delete node;
 }
 
-dynamic ViewManagerBase::GetExportedCustomBubblingEventTypeConstants() const {
+folly::dynamic ViewManagerBase::GetExportedCustomBubblingEventTypeConstants() const {
   const PCSTR standardEventBaseNames[] = {
       // Generic events
       "Press",
@@ -160,7 +158,7 @@ dynamic ViewManagerBase::GetExportedCustomBubblingEventTypeConstants() const {
   return bubblingEvents;
 }
 
-dynamic ViewManagerBase::GetExportedCustomDirectEventTypeConstants() const {
+folly::dynamic ViewManagerBase::GetExportedCustomDirectEventTypeConstants() const {
   folly::dynamic eventTypes = folly::dynamic::object();
   eventTypes.update(folly::dynamic::object("topLayout", folly::dynamic::object("registrationName", "onLayout"))(
       "topMouseEnter", folly::dynamic::object("registrationName", "onMouseEnter"))(
@@ -209,7 +207,7 @@ void ViewManagerBase::ReplaceChild(const XamlView &parent, const XamlView &oldCh
   assert(false);
 }
 
-void ViewManagerBase::UpdateProperties(ShadowNodeBase *nodeToUpdate, const dynamic &reactDiffMap) {
+void ViewManagerBase::UpdateProperties(ShadowNodeBase *nodeToUpdate, const folly::dynamic &reactDiffMap) {
   // Directly dirty this node since non-layout changes like the text property do
   // not trigger relayout
   //  There isn't actually a yoga node for RawText views, but it will invalidate

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -6,10 +6,12 @@ param(
 	[string] $TargetRoot = "$SourceRoot\vnext\target",
 	[System.IO.DirectoryInfo] $ReactWindowsRoot = "$SourceRoot\vnext",
 	[System.IO.DirectoryInfo] $ReactNativeRoot,
-	[string] $FollyVersion = '2019.09.30.00',
-	[System.IO.DirectoryInfo] $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}",
 	[string[]] $Extensions = ('h', 'hpp', 'def')
 )
+
+[xml]$props = gc $PSScriptRoot\..\..\Directory.Build.props
+[string] $FollyVersion = $props.Project.PropertyGroup.FollyVersion;
+[System.IO.DirectoryInfo] $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}";
 
 if (!$ReactNativeRoot) {
     $intermediateBuildDir = if ($env:BaseIntDir) { $env:BaseIntDir } else { "$SourceRoot\vnext\build" }

--- a/vnext/Shared/Modules/UIManagerModule.cpp
+++ b/vnext/Shared/Modules/UIManagerModule.cpp
@@ -18,7 +18,6 @@ using namespace std;
 #include <cdebug.h>
 #include <winrt/base.h>
 
-using namespace folly;
 using namespace facebook::xplat;
 
 namespace facebook {
@@ -45,7 +44,7 @@ folly::dynamic UIManager::getConstantsForViewManager(const std::string &classNam
   return nullptr;
 }
 
-void UIManager::populateViewManagerConstants(std::map<std::string, dynamic> &constants) {
+void UIManager::populateViewManagerConstants(std::map<std::string, folly::dynamic> &constants) {
   for (auto &&vm : m_viewManagers)
     constants.emplace(vm->GetName(), vm->GetConstants());
 }
@@ -480,8 +479,8 @@ std::vector<facebook::xplat::module::CxxModule::Method> UIManagerModule::getMeth
   return {
       Method(
           "getConstantsForViewManager",
-          [manager](dynamic argsJson) -> dynamic {
-            dynamic args;
+          [manager](folly::dynamic argsJson) -> folly::dynamic {
+            folly::dynamic args;
             if (argsJson.isString()) {
               args = folly::parseJson(argsJson.asString());
             } else {
@@ -492,33 +491,33 @@ std::vector<facebook::xplat::module::CxxModule::Method> UIManagerModule::getMeth
             return manager->getConstantsForViewManager(jsArgAsString(args, 0));
           },
           SyncTag),
-      Method("removeRootView", [manager](dynamic args) { manager->removeRootView(jsArgAsInt(args, 0)); }),
+      Method("removeRootView", [manager](folly::dynamic args) { manager->removeRootView(jsArgAsInt(args, 0)); }),
       Method(
           "createView",
-          [manager](dynamic args) {
+          [manager](folly::dynamic args) {
             manager->createView(
                 jsArgAsInt(args, 0), jsArgAsString(args, 1), jsArgAsInt(args, 2), std::move(jsArgAsDynamic(args, 3)));
           }),
       Method(
           "configureNextLayoutAnimation",
-          [manager](dynamic args, Callback cbSuccess, Callback cbError) {
+          [manager](folly::dynamic args, Callback cbSuccess, Callback cbError) {
             manager->configureNextLayoutAnimation(std::move(jsArgAsDynamic(args, 0)), cbSuccess, cbError);
           },
           AsyncTag),
       Method(
           "setChildren",
-          [manager](dynamic args) { manager->setChildren(jsArgAsInt(args, 0), std::move(jsArgAsArray(args, 1))); }),
+          [manager](folly::dynamic args) { manager->setChildren(jsArgAsInt(args, 0), std::move(jsArgAsArray(args, 1))); }),
       Method(
           "updateView",
-          [manager](dynamic args) {
+          [manager](folly::dynamic args) {
             manager->updateView(jsArgAsInt(args, 0), jsArgAsString(args, 1), std::move(jsArgAsDynamic(args, 2)));
           }),
       Method(
           "removeSubviewsFromContainerWithID",
-          [manager](dynamic args) { manager->removeSubviewsFromContainerWithID(jsArgAsInt(args, 0)); }),
+          [manager](folly::dynamic args) { manager->removeSubviewsFromContainerWithID(jsArgAsInt(args, 0)); }),
       Method(
           "manageChildren",
-          [manager](dynamic args) {
+          [manager](folly::dynamic args) {
             manager->manageChildren(
                 jsArgAsInt(args, 0),
                 jsArgAsDynamic(args, 1),
@@ -529,36 +528,36 @@ std::vector<facebook::xplat::module::CxxModule::Method> UIManagerModule::getMeth
           }),
       Method(
           "replaceExistingNonRootView",
-          [manager](dynamic args) { manager->replaceExistingNonRootView(jsArgAsInt(args, 0), jsArgAsInt(args, 1)); }),
+          [manager](folly::dynamic args) { manager->replaceExistingNonRootView(jsArgAsInt(args, 0), jsArgAsInt(args, 1)); }),
       Method(
           "dispatchViewManagerCommand",
-          [manager](dynamic args) {
+          [manager](folly::dynamic args) {
             // 0.61 allows directly dispatching command names instead of querying the ViewManager for the command ID.
             // In stock React Native, integer commands are deprecated but not yet removed. RNW APIs only allow strings,
             // and provide command constants as their literal string.
             manager->dispatchViewManagerCommand(
                 jsArgAsInt(args, 0), jsArgAsString(args, 1), std::move(jsArgAsDynamic(args, 2)));
           }),
-      Method("measure", [manager](dynamic args, Callback cb) { manager->measure(jsArgAsInt(args, 0), cb); }),
+      Method("measure", [manager](folly::dynamic args, Callback cb) { manager->measure(jsArgAsInt(args, 0), cb); }),
       Method(
           "measureInWindow",
-          [manager](dynamic args, Callback cb) { manager->measureInWindow(jsArgAsInt(args, 0), cb); }),
+          [manager](folly::dynamic args, Callback cb) { manager->measureInWindow(jsArgAsInt(args, 0), cb); }),
       Method(
           "measureLayout",
-          [manager](dynamic args, Callback cbError, Callback cbSuccess) {
+          [manager](folly::dynamic args, Callback cbError, Callback cbSuccess) {
             manager->measureLayout(jsArgAsInt(args, 0), jsArgAsInt(args, 1), cbError, cbSuccess);
           },
           AsyncTag),
       Method(
           "findSubviewIn",
-          [manager](dynamic args, Callback cb) {
+          [manager](folly::dynamic args, Callback cb) {
             manager->findSubviewIn(jsArgAsInt(args, 0), std::move(jsArgAsDynamic(args, 1)), cb);
           }),
-      Method("focus", [manager](dynamic args) { manager->focus(jsArgAsInt(args, 0)); }),
-      Method("blur", [manager](dynamic args) { manager->blur(jsArgAsInt(args, 0)); }),
+      Method("focus", [manager](folly::dynamic args) { manager->focus(jsArgAsInt(args, 0)); }),
+      Method("blur", [manager](folly::dynamic args) { manager->blur(jsArgAsInt(args, 0)); }),
       Method(
           "setJSResponder",
-          [manager](dynamic args) {
+          [manager](folly::dynamic args) {
             // TODO: Implement?
             // manager->setJSResponder(jsArgAsInt(args, 0), jsArgAsBool(args,
             // 1));

--- a/vnext/Shared/Modules/UIManagerModule.cpp
+++ b/vnext/Shared/Modules/UIManagerModule.cpp
@@ -506,7 +506,9 @@ std::vector<facebook::xplat::module::CxxModule::Method> UIManagerModule::getMeth
           AsyncTag),
       Method(
           "setChildren",
-          [manager](folly::dynamic args) { manager->setChildren(jsArgAsInt(args, 0), std::move(jsArgAsArray(args, 1))); }),
+          [manager](folly::dynamic args) {
+            manager->setChildren(jsArgAsInt(args, 0), std::move(jsArgAsArray(args, 1)));
+          }),
       Method(
           "updateView",
           [manager](folly::dynamic args) {
@@ -528,7 +530,9 @@ std::vector<facebook::xplat::module::CxxModule::Method> UIManagerModule::getMeth
           }),
       Method(
           "replaceExistingNonRootView",
-          [manager](folly::dynamic args) { manager->replaceExistingNonRootView(jsArgAsInt(args, 0), jsArgAsInt(args, 1)); }),
+          [manager](folly::dynamic args) {
+            manager->replaceExistingNonRootView(jsArgAsInt(args, 0), jsArgAsInt(args, 1));
+          }),
       Method(
           "dispatchViewManagerCommand",
           [manager](folly::dynamic args) {

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -60,7 +60,13 @@ void writeStderr(const char *s) {
 } // namespace
 
 // \node_modules\.folly\folly-2020.09.14.00\folly\lang\SafeAssert.h
-void assertionFailure(const char *expr, const char *msg, const char *file, unsigned int line, const char *function, int error) {
+void assertionFailure(
+    const char *expr,
+    const char *msg,
+    const char *file,
+    unsigned int line,
+    const char *function,
+    int error) {
   // nyi
   std::terminate();
 }

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -59,7 +59,8 @@ void writeStderr(const char *s) {
 }
 } // namespace
 
-void assertionFailure(const char *expr, const char *msg, const char *file, unsigned int line, const char *function) {
+// \node_modules\.folly\folly-2020.09.14.00\folly\lang\SafeAssert.h
+void assertionFailure(const char *expr, const char *msg, const char *file, unsigned int line, const char *function, int error) {
   // nyi
   std::terminate();
 }


### PR DESCRIPTION
Update to 2020.09.14.00
Fixes #5987 

Includes fixes for a number of issues:
- Parametrized folly version across the repo
- Folly removed `ColdClass`
- Folly changed the signature of the `assertionFailure` function
- Folly added a type `tag` which creates duplicate definitions in files that have a variable with that name and use `using namespace folly`
- VS 16.8 removed intrinsics that were added in 16.3, but the new folly version check only works for 16.8+ which is not out yet. I am fixing that in the folly repo as https://github.com/facebook/folly/pull/1450
- For the time being until we take a new folly drop, I'm resuscitating a Target that will override the file we need in order to fix the intrinsics issue.
- Updated `Layout-Headers.ps1` to use the version from Directory.Build.props instead of a hardcoded one. Removed these as options since we always have only one version of folly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5992)