### PR TITLE
Enable reload while editing of files in vnext/src

### DIFF
--- a/change/react-native-windows-2020-09-14-14-45-14-fastrefreshplayground.json
+++ b/change/react-native-windows-2020-09-14-14-45-14-fastrefreshplayground.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enable reload while editing of files in vnext/src",
+  "packageName": "react-native-windows",
+  "email": "acoates-ms@noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-14T21:45:14.669Z"
+}

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -7,10 +7,105 @@
 const fs = require('fs');
 const path = require('path');
 const blacklist = require('metro-config/src/defaults/blacklist');
+const {resolve} = require('metro-resolver');
 
 const rnwPath = fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),
 );
+
+const rnwPathNormalized = path.normalize(rnwPath);
+const rnwSrcPathNormalized = path.normalize(rnwPath + '/src');
+
+function isRelativeImport(filePath) {
+  return /^[.][.]?(?:[/]|$)/.test(filePath);
+}
+
+// Example: vnextResolve('C:/Repos/react-native-windows/vnext/', './Libraries/Text/Text');
+// Returns a full path to the resolved location which would be in vnext/src if the file exists there
+// or just in vnext otherwise
+function vnextResolve(originDir, moduleName) {
+  const originDirSrc = originDir.replace(
+    rnwPathNormalized,
+    rnwSrcPathNormalized,
+  );
+
+  // redirect the resolution to src if an appropriate file exists there
+  const extensions = [
+    '.windows.tsx',
+    '.windows.ts',
+    '.windows.jsx',
+    '.windows.js',
+    '.tsx',
+    '.ts',
+    '.jsx',
+    '.js',
+  ];
+
+  // For each potential extension we need to check for the file in either vnext/src, or in vnext
+  for (let extension of extensions) {
+    const potentialSrcModuleName =
+      path.resolve(originDirSrc, moduleName) + extension;
+    if (fs.existsSync(potentialSrcModuleName)) {
+      return potentialSrcModuleName;
+    }
+
+    const potentialModuleName = path.resolve(originDir, moduleName) + extension;
+    if (fs.existsSync(potentialModuleName)) {
+      return potentialModuleName;
+    }
+  }
+}
+
+// This teaches metro how we merge vnext/src and files from core to vnext...
+// Basically any resolves within vnext we look to see if the file exists in vnext/src,
+// and use that one if it exists.  That way fast refresh will work on files within vnext/src
+function vnextDevResolveRequest(
+  context,
+  _realModuleName /* string */,
+  platform /* string */,
+  moduleName /* string */,
+) {
+  let backupResolveRequest = context.resolveRequest;
+  delete context.resolveRequest;
+
+  try {
+    let modifiedModuleName = moduleName;
+    if (platform === 'windows') {
+      if (moduleName === 'react-native') {
+        // redirect react-native -> vnext/src/index.windows.js
+        modifiedModuleName = path.resolve(rnwPath, 'src/index.windows.js');
+      } else if (moduleName.startsWith('react-native/')) {
+        // redirect react-native/foo -> vnext/src/foo or vnext/foo
+        modifiedModuleName = vnextResolve(
+          rnwPath,
+          (moduleName = `./${moduleName.slice('react-native/'.length)}`),
+        );
+      } else if (
+        context.originModulePath.startsWith(rnwPath) &&
+        isRelativeImport(moduleName)
+      ) {
+        // We need to handle relative paths from within react-native-windows
+        let originPathWithoutSrc = context.originModulePath;
+        if (originPathWithoutSrc.startsWith(rnwSrcPathNormalized))
+          originPathWithoutSrc = `${rnwPath}/${originPathWithoutSrc.slice(
+            rnwSrcPathNormalized.length,
+          )}`;
+
+        const resolvedLocation = vnextResolve(
+          path.dirname(originPathWithoutSrc),
+          moduleName,
+        );
+        if (resolvedLocation) modifiedModuleName = resolvedLocation;
+      }
+    }
+    let result = resolve(context, modifiedModuleName, platform);
+    return result;
+  } catch (e) {
+    throw e;
+  } finally {
+    context.resolveRequest = backupResolveRequest;
+  }
+}
 
 module.exports = {
   // WatchFolders is only needed due to the yarn workspace layout of node_modules, we need to watch the symlinked locations separately
@@ -35,6 +130,7 @@ module.exports = {
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
       ),
     ]),
+    resolveRequest: vnextDevResolveRequest,
   },
 
   // Metro doesn't currently handle assets from other packages within a monorepo.  This is the current workaround people use

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -40,6 +40,7 @@
 
 ; Ignore react-native-windows' target folder. Flow is not compiled with long path support and after running unittests these folders have long paths
 .*/node_modules/react-native-windows/target/.*
+.*/node_modules/react-native-windows/Microsoft.ReactNative.Managed.CodeGen.UnitTests/.*
 .target/.*
 
 ; These files dont need to be checked and just increase the build time

--- a/vnext/etc/react-native-windows.api.md
+++ b/vnext/etc/react-native-windows.api.md
@@ -32,7 +32,7 @@ export class DatePicker extends React_2.Component<IDatePickerProps> {
     }
 
 // @public (undocumented)
-export const enum DayOfWeek {
+export enum DayOfWeek {
     // (undocumented)
     Friday = 5,
     // (undocumented)

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -498,7 +498,7 @@
     },
     {
       "type": "derived",
-      "file": "src/RNTester/js/utils/RNTesterList.windows.ts",
+      "file": "src/RNTester/js/utils/RNTesterList.windows.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
       "baseVersion": "0.0.0-a36d9cd7e",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",

--- a/vnext/src/Libraries/Components/DatePicker/DatePickerProps.ts
+++ b/vnext/src/Libraries/Components/DatePicker/DatePickerProps.ts
@@ -31,7 +31,7 @@ export interface IDatePickerChangeEvent {
   };
 }
 
-export const enum DayOfWeek {
+export enum DayOfWeek {
   Sunday = 0,
   Monday = 1,
   Tuesday = 2,

--- a/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {
   FlatList,
   Text,

--- a/vnext/src/RNTester/js/examples-win/AsyncStorage/AsyncStorageExampleWindows.tsx
+++ b/vnext/src/RNTester/js/examples-win/AsyncStorage/AsyncStorageExampleWindows.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {
   AsyncStorage,
   Button,

--- a/vnext/src/RNTester/js/examples-win/CustomView/CustomViewExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/CustomView/CustomViewExample.windows.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {
   Button,
   NativeModules,

--- a/vnext/src/RNTester/js/examples-win/DatePicker/DatePickerExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/DatePicker/DatePickerExample.windows.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {Text, View} from 'react-native';
 import {DatePicker} from '../../../../Libraries/Components/DatePicker/DatePicker';
 import {DayOfWeek} from '../../../../Libraries/Components/DatePicker/DatePickerProps';

--- a/vnext/src/RNTester/js/examples-win/FastText/FastTextExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/FastText/FastTextExample.windows.tsx
@@ -6,7 +6,7 @@
 
 import {Text, View, Button} from 'react-native';
 
-import React = require('react');
+import * as React from 'react';
 
 class WithoutCurlyBracketsExample extends React.Component<{}, any> {
   constructor(props: {}) {

--- a/vnext/src/RNTester/js/examples-win/Flyout/FlyoutExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Flyout/FlyoutExample.windows.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {Button, Switch, Text, TextInput, View} from 'react-native';
 import {Flyout} from '../../../../Libraries/Components/Flyout/Flyout';
 import {Picker} from '../../../../Libraries/Components/Picker/PickerWindows';

--- a/vnext/src/RNTester/js/examples-win/Glyph/GlyphExample.tsx
+++ b/vnext/src/RNTester/js/examples-win/Glyph/GlyphExample.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {Text, View} from 'react-native';
 import {Glyph} from '../../../../Libraries/Components/Glyph/Glyph';
 

--- a/vnext/src/RNTester/js/examples-win/Keyboard/KeyboardExample.tsx
+++ b/vnext/src/RNTester/js/examples-win/Keyboard/KeyboardExample.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {Text, TouchableHighlight, View, ViewStyle} from 'react-native';
 import {Picker} from '../../../../Libraries/Components/Picker/PickerWindows';
 

--- a/vnext/src/RNTester/js/examples-win/Picker/PickerWindowsExample.tsx
+++ b/vnext/src/RNTester/js/examples-win/Picker/PickerWindowsExample.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {Button, Text, View} from 'react-native';
 import {Picker} from '../../../../Libraries/Components/Picker/PickerWindows';
 

--- a/vnext/src/RNTester/js/examples-win/Popup/PopupExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Popup/PopupExample.windows.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {Button, Text, TextInput, View} from 'react-native';
 import {Popup} from '../../../../Libraries/Components/Popup/Popup';
 

--- a/vnext/src/RNTester/js/examples-win/Text/TextExample.windows.tsx
+++ b/vnext/src/RNTester/js/examples-win/Text/TextExample.windows.tsx
@@ -7,7 +7,7 @@
 // This is a port of TextExample.android.js
 // Image inline in Text removed
 
-import React = require('react');
+import * as React from 'react';
 import {/*Image,*/ StyleSheet, Text, View, TextStyle} from 'react-native';
 const RNTesterBlock = require('../../components/RNTesterBlock');
 const RNTesterPage = require('../../components/RNTesterPage');

--- a/vnext/src/RNTester/js/examples-win/TransferProperties/TransferPropertiesExample.tsx
+++ b/vnext/src/RNTester/js/examples-win/TransferProperties/TransferPropertiesExample.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 
-import React = require('react');
+import * as React from 'react';
 import {StyleSheet, Button, Text, View} from 'react-native';
 
 const styles = StyleSheet.create({

--- a/vnext/src/RNTester/js/examples/TextInput/TextInputExample.windows.js
+++ b/vnext/src/RNTester/js/examples/TextInput/TextInputExample.windows.js
@@ -21,7 +21,7 @@ const {
   Switch,
 } = require('react-native');
 
-const TextInputSharedExamples = require('./TextInputSharedExamples.js');
+const TextInputSharedExamples = require('./TextInputSharedExamples');
 
 import type {RNTesterExampleModuleItem} from '../../types/RNTesterTypes';
 

--- a/vnext/src/RNTester/js/utils/RNTesterList.windows.js
+++ b/vnext/src/RNTester/js/utils/RNTesterList.windows.js
@@ -143,6 +143,8 @@ const APIExamples: Array<RNTesterExample> = [
         .AlertExample.description,
       examples: [
         {
+          title: require('react-native/RNTester/js/examples/Alert/AlertExample')
+            .AlertExample.title,
           render: () => {
             return React.createElement(
               require('react-native/RNTester/js/examples/Alert/AlertExample')

--- a/vnext/src/RNTester/js/utils/RNTesterList.windows.js
+++ b/vnext/src/RNTester/js/utils/RNTesterList.windows.js
@@ -2,31 +2,15 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  * @format
+ * @flow
  */
 
 'use strict';
-import React = require('react');
+import * as React from 'react';
 
-interface IRNTesterExample {
-  key: string;
-  // tslint:disable-next-line no-reserved-keywords
-  module: IRNTesterModule;
-}
+import type {RNTesterExample} from '../types/RNTesterTypes';
 
-interface IRNTesterModule {
-  title: string;
-  description: string;
-  external: boolean;
-  examples: [IRNTesterModuleExample];
-}
-
-interface IRNTesterModuleExample {
-  title: string;
-  description: string;
-  render(): React.Component;
-}
-
-const ComponentExamples: Array<IRNTesterExample> = [
+const ComponentExamples: Array<RNTesterExample> = [
   {
     key: 'ActivityIndicatorExample',
     module: require('react-native/RNTester/js/examples/ActivityIndicator/ActivityIndicatorExample'),
@@ -129,7 +113,7 @@ const ComponentExamples: Array<IRNTesterExample> = [
   },
 ];
 
-const APIExamples: Array<IRNTesterExample> = [
+const APIExamples: Array<RNTesterExample> = [
   {
     key: 'KeyboardFocusExample',
     module: require('./../examples-win/Keyboard/KeyboardFocusExample'),
@@ -305,9 +289,9 @@ const APIExamples: Array<IRNTesterExample> = [
   },*/
 ];
 
-const Modules: {[key: string]: IRNTesterModule} = {};
+const Modules: any = {};
 
-APIExamples.concat(ComponentExamples).forEach((Example: IRNTesterExample) => {
+APIExamples.concat(ComponentExamples).forEach(Example => {
   Modules[Example.key] = Example.module;
 });
 
@@ -317,4 +301,4 @@ const RNTesterList = {
   Modules,
 };
 
-export = RNTesterList;
+module.exports = RNTesterList;


### PR DESCRIPTION
Fixes #5968

The current workflow for testing changes internal to react-native-windows is annoying since you can't edit the files in vnext/src directly and have the instance reload.  Instead you must run `yarn build`, and then likely restart metro / the app since one of the other stops working during the churn of `yarn build`.

This fix adds a custom resolver to the playground app's `metro.config.js`, which will resolve files from `vnext/src` if they exist.  Thus allowing full fast refresh and reload scenarios to work within RNTester for the playground apps.

I didn't do this for E2E tests or Integrations tests, since I feel like those are less likely to be used in this way, but it wouldn't be hard to extract this logic to a new shared package if we want to have it in more places.  (Its only useful within the RNW repo).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5993)