### PR TITLE
Update to standard github label: "enhancement"

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-module-support-request.md
+++ b/.github/ISSUE_TEMPLATE/community-module-support-request.md
@@ -2,7 +2,7 @@
 name: Community Module support request
 about: Suggest that Windows support be added to a community module
 title: Support react-native-foo
-labels: Extensions, Proposal
+labels: Extensions, enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a new feature or idea
 title: Your feature request
-labels: Proposal
+labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
New github repos are populated with a defualt "enhancement" label.
We have used "Proposal" in our repo.
Aligning to the standard label  will help our unified SLA toolchain.

When this change is in I'll rename the label on the repo and update the bot to match.
The samples repo already uses the standard "bug"/"enhacement"/"question" labels, so no update needed there.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/5997)