### PR TITLE
Port REACT_MODULE() from react-native-windows to react-native-macos (2/4)

### DIFF
--- a/change/react-native-windows-2020-09-16-10-05-25-tm-files.json
+++ b/change/react-native-windows-2020-09-16-10-05-25-tm-files.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Port REACT_MODULE() from react-native-windows to react-native-macos (2/4)",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-16T17:05:25.492Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -214,7 +214,7 @@ struct CallbackCreator<TCallback<void(TArgs...)>> {
   static TCallback<void(TArgs...)> Create(
       IJSValueWriter const &argWriter,
       MethodResultCallback const &callback) noexcept {
-    return TCallback([ callback, argWriter ](TArgs... args) noexcept {
+    return TCallback<void(TArgs...)>([ callback, argWriter ](TArgs... args) noexcept {
       WriteArgs(argWriter, std::move(args)...);
       callback(argWriter);
     });
@@ -227,7 +227,7 @@ struct CallbackCreator<TCallback<void(TArgs...) noexcept>> {
   static TCallback<void(TArgs...)> Create(
       IJSValueWriter const &argWriter,
       MethodResultCallback const &callback) noexcept {
-    return TCallback([ callback, argWriter ](TArgs... args) noexcept {
+    return TCallback<void(TArgs...)>([ callback, argWriter ](TArgs... args) noexcept {
       WriteArgs(argWriter, std::move(args)...);
       callback(argWriter);
     });

--- a/vnext/Microsoft.ReactNative.Cxx/README.md
+++ b/vnext/Microsoft.ReactNative.Cxx/README.md
@@ -44,3 +44,12 @@ and manual sync will be no longer needed.
   - ReactPromise.h
   - ReactPromise.cpp
   - NativeModules.h
+- vnext\Microsoft.ReactNative
+  - JsiReader.h
+  - JsiReader.cpp
+  - JsiWriter.h
+  - JsiWriter.cpp
+  - TurboModulesProvider.h
+  - TurboModulesProvider.cpp
+- vnext\Shared
+  - TurboModuleRegistry

--- a/vnext/Microsoft.ReactNative/JsiReader.cpp
+++ b/vnext/Microsoft.ReactNative/JsiReader.cpp
@@ -1,9 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
 
 #include "pch.h"
 #include "JsiReader.h"
+#ifdef __APPLE__
+#include "Crash.h"
+#else
 #include <crash/verifyElseCrash.h>
+#endif
 
 namespace winrt::Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative/JsiReader.cpp
+++ b/vnext/Microsoft.ReactNative/JsiReader.cpp
@@ -29,12 +29,12 @@ JsiReader::JsiReader(facebook::jsi::Runtime &runtime, const facebook::jsi::Value
 
 JSValueType JsiReader::ValueType() noexcept {
   if (m_currentPrimitiveValue) {
-    if (m_currentPrimitiveValue.value().isString()) {
+    if (ReadOptional(m_currentPrimitiveValue).isString()) {
       return JSValueType::String;
-    } else if (m_currentPrimitiveValue.value().isBool()) {
+    } else if (ReadOptional(m_currentPrimitiveValue).isBool()) {
       return JSValueType::Boolean;
-    } else if (m_currentPrimitiveValue.value().isNumber()) {
-      double number = m_currentPrimitiveValue.value().getNumber();
+    } else if (ReadOptional(m_currentPrimitiveValue).isNumber()) {
+      double number = ReadOptional(m_currentPrimitiveValue).getNumber();
 
       // unfortunately JSI doesn't differentiate int and double
       // here we test if the double value can be converted to int without data loss
@@ -64,11 +64,11 @@ bool JsiReader::GetNextObjectProperty(hstring &propertyName) noexcept {
   }
 
   top.Index++;
-  if (top.Index < static_cast<int>(top.PropertyNames.value().size(m_runtime))) {
+  if (top.Index < static_cast<int>(ReadOptional(top.PropertyNames).size(m_runtime))) {
     auto propertyId =
-        top.PropertyNames.value().getValueAtIndex(m_runtime, static_cast<size_t>(top.Index)).getString(m_runtime);
+        ReadOptional(top.PropertyNames).getValueAtIndex(m_runtime, static_cast<size_t>(top.Index)).getString(m_runtime);
     propertyName = winrt::to_hstring(propertyId.utf8(m_runtime));
-    SetValue(top.CurrentObject.value().getProperty(m_runtime, propertyId));
+    SetValue(ReadOptional(top.CurrentObject).getProperty(m_runtime, propertyId));
     return true;
   } else {
     m_containers.pop_back();
@@ -91,8 +91,8 @@ bool JsiReader::GetNextArrayItem() noexcept {
 
   switch (top.Type) {
     case ContainerType::Array: {
-      if (top.Index < static_cast<int>(top.CurrentArray.value().size(m_runtime))) {
-        SetValue(top.CurrentArray.value().getValueAtIndex(m_runtime, static_cast<size_t>(top.Index)));
+      if (top.Index < static_cast<int>(ReadOptional(top.CurrentArray).size(m_runtime))) {
+        SetValue(ReadOptional(top.CurrentArray).getValueAtIndex(m_runtime, static_cast<size_t>(top.Index)));
         return true;
       }
       break;
@@ -118,21 +118,21 @@ hstring JsiReader::GetString() noexcept {
   if (ValueType() != JSValueType::String) {
     return {};
   }
-  return winrt::to_hstring(m_currentPrimitiveValue.value().getString(m_runtime).utf8(m_runtime));
+  return winrt::to_hstring(ReadOptional(m_currentPrimitiveValue).getString(m_runtime).utf8(m_runtime));
 }
 
 bool JsiReader::GetBoolean() noexcept {
   if (ValueType() != JSValueType::Boolean) {
     return false;
   }
-  return m_currentPrimitiveValue.value().getBool();
+  return ReadOptional(m_currentPrimitiveValue).getBool();
 }
 
 int64_t JsiReader::GetInt64() noexcept {
   if (ValueType() != JSValueType::Int64) {
     return 0;
   }
-  return static_cast<int64_t>(m_currentPrimitiveValue.value().getNumber());
+  return static_cast<int64_t>(ReadOptional(m_currentPrimitiveValue).getNumber());
 }
 
 double JsiReader::GetDouble() noexcept {
@@ -140,7 +140,7 @@ double JsiReader::GetDouble() noexcept {
   if (valueType != JSValueType::Int64 && valueType != JSValueType::Double) {
     return 0;
   }
-  return m_currentPrimitiveValue.value().getNumber();
+  return ReadOptional(m_currentPrimitiveValue).getNumber();
 }
 
 void JsiReader::SetValue(const facebook::jsi::Value &value) noexcept {

--- a/vnext/Microsoft.ReactNative/JsiReader.h
+++ b/vnext/Microsoft.ReactNative/JsiReader.h
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
 
 #pragma once
 

--- a/vnext/Microsoft.ReactNative/JsiReader.h
+++ b/vnext/Microsoft.ReactNative/JsiReader.h
@@ -11,6 +11,16 @@
 
 namespace winrt::Microsoft::ReactNative {
 
+// workaround: in macOS 10.13, optional<T>::value is not available
+
+#ifndef __APPLE__
+template<typename T>
+decltype(auto) ReadOptional(std::optional<T>& opt)
+{
+  return opt.value();
+}
+#endif
+
 struct JsiReader : implements<JsiReader, IJSValueReader> {
   JsiReader(facebook::jsi::Runtime &runtime, const facebook::jsi::Value &root) noexcept;
   JsiReader(facebook::jsi::Runtime &runtime, const facebook::jsi::Value *args, size_t count) noexcept;
@@ -42,7 +52,7 @@ struct JsiReader : implements<JsiReader, IJSValueReader> {
 
     Container(facebook::jsi::Runtime &runtime, facebook::jsi::Object &&value) noexcept
         : Type(ContainerType::Object), CurrentObject(std::make_optional<facebook::jsi::Object>(std::move(value))) {
-      PropertyNames = CurrentObject.value().getPropertyNames(runtime);
+      PropertyNames = ReadOptional(CurrentObject).getPropertyNames(runtime);
     }
 
     Container(facebook::jsi::Array &&value) noexcept

--- a/vnext/Microsoft.ReactNative/JsiReader.h
+++ b/vnext/Microsoft.ReactNative/JsiReader.h
@@ -14,9 +14,8 @@ namespace winrt::Microsoft::ReactNative {
 // workaround: in macOS 10.13, optional<T>::value is not available
 
 #ifndef __APPLE__
-template<typename T>
-decltype(auto) ReadOptional(std::optional<T>& opt)
-{
+template <typename T>
+decltype(auto) ReadOptional(std::optional<T> &opt) {
   return opt.value();
 }
 #endif

--- a/vnext/Microsoft.ReactNative/JsiWriter.cpp
+++ b/vnext/Microsoft.ReactNative/JsiWriter.cpp
@@ -1,9 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
 
 #include "pch.h"
 #include "JsiWriter.h"
+#ifdef __APPLE__
+#include "Crash.h"
+#else
 #include <crash/verifyElseCrash.h>
+#endif
 
 namespace winrt::Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative/JsiWriter.cpp
+++ b/vnext/Microsoft.ReactNative/JsiWriter.cpp
@@ -10,6 +10,7 @@
 #include "Crash.h"
 #else
 #include <crash/verifyElseCrash.h>
+#include "JsiReader.h"
 #endif
 
 namespace winrt::Microsoft::ReactNative {
@@ -25,15 +26,15 @@ JsiWriter::JsiWriter(facebook::jsi::Runtime &runtime) noexcept : m_runtime(runti
 facebook::jsi::Value JsiWriter::MoveResult() noexcept {
   VerifyElseCrash(m_containers.size() == 0);
   if (m_resultAsContainer.has_value()) {
-    m_resultAsValue = ContainerToValue(std::move(m_resultAsContainer.value()));
+    m_resultAsValue = ContainerToValue(std::move(ReadOptional(m_resultAsContainer)));
     m_resultAsContainer.reset();
   }
-  return std::move(m_resultAsValue.value());
+  return std::move(ReadOptional(m_resultAsValue));
 }
 
 void JsiWriter::AccessResultAsArgs(const facebook::jsi::Value *&args, size_t &count) noexcept {
   VerifyElseCrash(m_resultAsContainer.has_value());
-  auto &container = m_resultAsContainer.value();
+  auto &container = ReadOptional(m_resultAsContainer);
   if (container.CurrentArrayElements.size() == 0) {
     args = nullptr;
     count = 0;
@@ -98,7 +99,7 @@ void JsiWriter::WriteArrayEnd() noexcept {
 facebook::jsi::Value JsiWriter::ContainerToValue(Container &&container) noexcept {
   switch (container.State) {
     case ContainerState::AcceptPropertyName: {
-      return std::move(container.CurrentObject.value());
+      return std::move(ReadOptional(container.CurrentObject));
     }
     case ContainerState::AcceptArrayElement: {
       facebook::jsi::Array createdArray(m_runtime, container.CurrentArrayElements.size());
@@ -136,7 +137,7 @@ void JsiWriter::WriteValue(facebook::jsi::Value &&value) noexcept {
       break;
     }
     case ContainerState::AcceptPropertyValue: {
-      auto &createdObject = top.CurrentObject.value();
+      auto &createdObject = ReadOptional(top.CurrentObject);
       createdObject.setProperty(m_runtime, top.PropertyName.c_str(), std::move(value));
       top.State = ContainerState::AcceptPropertyName;
       top.PropertyName = {};

--- a/vnext/Microsoft.ReactNative/JsiWriter.h
+++ b/vnext/Microsoft.ReactNative/JsiWriter.h
@@ -1,6 +1,10 @@
-#pragma once
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
+
+#pragma once
 
 #include "jsi/jsi.h"
 #include "winrt/Microsoft.ReactNative.h"

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
+
 #pragma once
 
 #include <TurboModuleRegistry.h>

--- a/vnext/Shared/TurboModuleRegistry.h
+++ b/vnext/Shared/TurboModuleRegistry.h
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
 
 #pragma once
 


### PR DESCRIPTION
# Summary
- Make `REACT_MODULE` usable for macOS (co-op with https://github.com/microsoft/react-native-macos/pull/599 ).
- In this change, comments are added to involved files to tell developers that, they need to take care about macOS from now on.
- In order to do this, react-native-macos needs to use some files from react-native-windows.
- For development convenience, these files are duplicated in react-native-macos.
- After the porting is done, I will make another change to eliminate the duplication. Files will be shared from one single source.

# Notice
This change also fixes a few issues:
- Workaround XCode compiler issue
  - optional<T>::value() is missing (it is added in macOS 10.14, but it is required to support 10.13)
  - hash<pair<T, U>> is missing (same reason)
  - lambda cannot capture objects that only have rvalue copy ctor (this should be xcode's bug)
- Function returning `ReactPromise` is not currectly handled when `Reject` is called.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6023)