### PR TITLE
Reenable RNTesterIntegrationTests::Logging

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -394,7 +394,6 @@ jobs:
         (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
         (FullyQualifiedName!=RNTesterIntegrationTests::Dummy)&
         (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
-        (FullyQualifiedName!=RNTesterIntegrationTests::Logging)&
         (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
         (FullyQualifiedName!=RNTesterIntegrationTests::XHRSample)&
         (FullyQualifiedName!~WebSocketModule_)&

--- a/change/react-native-windows-2020-09-16-16-20-52-deskit-reenablelogging.json
+++ b/change/react-native-windows-2020-09-16-16-20-52-deskit-reenablelogging.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Re-enable RNTesterIntegrationTests::Logging",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-16T23:20:52.292Z"
+}

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -8,6 +8,9 @@
 using namespace Microsoft::React::Test;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
+using facebook::react::RCTLogLevel;
+using std::string;
+
 namespace Microsoft::VisualStudio::CppUnitTestFramework {
 
 template <>
@@ -35,39 +38,40 @@ TEST_CLASS (RNTesterIntegrationTests) {
 #pragma region Prototype tests
 
   BEGIN_TEST_METHOD_ATTRIBUTE(Logging)
-  // TEST_IGNORE()
   END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(Logging) {
     int logCalls{0};
     auto result = m_runner.RunTest(
         "IntegrationTests/LoggingTest",
         "LoggingTest",
-        [&logCalls](facebook::react::RCTLogLevel logLevel, const char *message) {
-          if ((strcmp(message, "This is from console.trace") == 0) &&
-              (logLevel == facebook::react::RCTLogLevel::Trace)) {
+        [&logCalls](RCTLogLevel logLevel, const char *message) {
+          // trace, warn and error print stack traces rather than a single-line message.
+          // https://developer.mozilla.org/en-US/docs/Web/API/Console/trace
+          if (string{message}.find("This is from console.trace") != string::npos &&
+              (logLevel == RCTLogLevel::Trace)) {
             logCalls++;
           }
 
           if ((strcmp(message, "This is from console.debug") == 0) &&
-              (logLevel == facebook::react::RCTLogLevel::Trace)) {
+              (logLevel == RCTLogLevel::Trace)) {
             logCalls++;
           }
 
-          if ((strcmp(message, "This is from console.info") == 0) && (logLevel == facebook::react::RCTLogLevel::Info)) {
+          if ((strcmp(message, "This is from console.info") == 0) && (logLevel == RCTLogLevel::Info)) {
             logCalls++;
           }
 
-          if ((strcmp(message, "This is from console.log") == 0) && (logLevel == facebook::react::RCTLogLevel::Info)) {
+          if ((strcmp(message, "This is from console.log") == 0) && (logLevel == RCTLogLevel::Info)) {
             logCalls++;
           }
 
-          if ((strcmp(message, "This is from console.warn") == 0) &&
-              (logLevel == facebook::react::RCTLogLevel::Warning)) {
+          if (string{message}.find("This is from console.warn") != string::npos &&
+              (logLevel == RCTLogLevel::Warning)) {
             logCalls++;
           }
 
-          if ((strcmp(message, "This is from console.error") == 0) &&
-              (logLevel == facebook::react::RCTLogLevel::Error)) {
+          if (string{message}.find("This is from console.error") != string::npos &&
+              (logLevel == RCTLogLevel::Error)) {
             logCalls++;
           }
         });

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -42,18 +42,14 @@ TEST_CLASS (RNTesterIntegrationTests) {
   TEST_METHOD(Logging) {
     int logCalls{0};
     auto result = m_runner.RunTest(
-        "IntegrationTests/LoggingTest",
-        "LoggingTest",
-        [&logCalls](RCTLogLevel logLevel, const char *message) {
+        "IntegrationTests/LoggingTest", "LoggingTest", [&logCalls](RCTLogLevel logLevel, const char *message) {
           // trace, warn and error print stack traces rather than a single-line message.
           // https://developer.mozilla.org/en-US/docs/Web/API/Console/trace
-          if (string{message}.find("This is from console.trace") != string::npos &&
-              (logLevel == RCTLogLevel::Trace)) {
+          if (string{message}.find("This is from console.trace") != string::npos && (logLevel == RCTLogLevel::Trace)) {
             logCalls++;
           }
 
-          if ((strcmp(message, "This is from console.debug") == 0) &&
-              (logLevel == RCTLogLevel::Trace)) {
+          if ((strcmp(message, "This is from console.debug") == 0) && (logLevel == RCTLogLevel::Trace)) {
             logCalls++;
           }
 
@@ -65,13 +61,11 @@ TEST_CLASS (RNTesterIntegrationTests) {
             logCalls++;
           }
 
-          if (string{message}.find("This is from console.warn") != string::npos &&
-              (logLevel == RCTLogLevel::Warning)) {
+          if (string{message}.find("This is from console.warn") != string::npos && (logLevel == RCTLogLevel::Warning)) {
             logCalls++;
           }
 
-          if (string{message}.find("This is from console.error") != string::npos &&
-              (logLevel == RCTLogLevel::Error)) {
+          if (string{message}.find("This is from console.error") != string::npos && (logLevel == RCTLogLevel::Error)) {
             logCalls++;
           }
         });


### PR DESCRIPTION
This test was failing consistently and got disabled because the messages coming from the JS runtime for WARN, ERROR and TRACE changed their format from plain string to stack trace:
https://developer.mozilla.org/en-US/docs/Web/API/Console/trace

This change uses string matching for those three log types to remove the false negatives from the affected test.
![image](https://user-images.githubusercontent.com/4507319/93402739-684eae80-f83a-11ea-8562-7ddde2348b73.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6025)