### PR TITLE
Fix rnw-dependencies to work in cases where the VS installer is present but no VS 2019 installation is

### DIFF
--- a/change/react-native-windows-2020-09-16-22-48-43-codespacesDeps.json
+++ b/change/react-native-windows-2020-09-16-22-48-43-codespacesDeps.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix rnw-dependencies for cases where the installer is installed but not VS itself",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-17T05:48:42.949Z"
+}


### PR DESCRIPTION
Fixes #5913 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6026)