### PR TITLE
Alert should track its xamlroot's size

### DIFF
--- a/change/react-native-windows-2020-09-18-22-49-20-alertTracking.json
+++ b/change/react-native-windows-2020-09-18-22-49-20-alertTracking.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make Alert track its xamlroot's size changes",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-19T05:49:20.007Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -5,11 +5,13 @@
 #include "AlertModule.h"
 #include "Unicode.h"
 
+#include <UI.Xaml.Controls.Primitives.h>
+#include <UI.Xaml.Controls.h>
+#include <UI.Xaml.Media.h>
+#include <UI.Xaml.Shapes.h>
 #include <Utils/ValueUtils.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 #include "Utils/Helpers.h"
-
-#include <UI.Xaml.Controls.h>
 
 namespace Microsoft::ReactNative {
 
@@ -26,8 +28,29 @@ void Alert::showAlert(ShowAlertArgs const &args, std::function<void(std::string)
 
       if (react::uwp::Is19H1OrHigher()) {
         // XamlRoot added in 19H1
-        if (auto xamlRoot = React::XamlUIService::GetXamlRoot(strongThis->m_context.Properties().Handle())) {
+        if (const auto xamlRoot = React::XamlUIService::GetXamlRoot(strongThis->m_context.Properties().Handle())) {
           dialog.XamlRoot(xamlRoot);
+          auto rootChangedToken = xamlRoot.Changed([=](auto &&, auto &&) {
+            const auto rootSize = xamlRoot.Size();
+            const auto popupRoot = xaml::Media::VisualTreeHelper::GetParent(dialog);
+            const auto nChildren = xaml::Media::VisualTreeHelper::GetChildrenCount(popupRoot);
+            if (nChildren == 2) {
+              // The first is supposed to be the smoke screen (Rectangle), and the second the content dialog
+              if (const auto smoke =
+                      xaml::Media::VisualTreeHelper::GetChild(popupRoot, 0).try_as<xaml::Shapes::Rectangle>()) {
+                const auto assertDialog =
+                    xaml::Media::VisualTreeHelper::GetChild(popupRoot, 1).try_as<xaml::Controls::ContentDialog>();
+                if (assertDialog == dialog) {
+                  smoke.Width(rootSize.Width);
+                  smoke.Height(rootSize.Height);
+                  dialog.Width(rootSize.Width);
+                  dialog.Height(rootSize.Height);
+                }
+              }
+            }
+          });
+
+          dialog.Closed([=](auto &&, auto &&) { xamlRoot.Changed(rootChangedToken); });
         }
       }
 


### PR DESCRIPTION
Fixes #6017 

![alert](https://user-images.githubusercontent.com/22989529/93660227-608d3680-fa01-11ea-9d74-f2a0270c79ba.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6034)

