### PR TITLE
Run Non-UI-Thread Core Modules on the JS Thread 

### DIFF
--- a/change/react-native-windows-2020-09-20-06-37-45-core-js-modules.json
+++ b/change/react-native-windows-2020-09-20-06-37-45-core-js-modules.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Run Non-UI-Thread Core Modules on the JS Thread",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-20T13:37:45.211Z"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -46,12 +46,14 @@ bool HasPackageIdentity() noexcept {
 
 std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     const std::shared_ptr<facebook::react::IUIManager> &uiManager,
-    const std::shared_ptr<facebook::react::MessageQueueThread> &messageQueue,
-    const std::shared_ptr<facebook::react::MessageQueueThread> &uiMessageQueue,
+    const std::shared_ptr<facebook::react::MessageQueueThread> &batchingUIMessageQueue,
+    const std::shared_ptr<facebook::react::MessageQueueThread>
+        &uiMessageQueue, // UI queue without batching or affinity limitations
+    const std::shared_ptr<facebook::react::MessageQueueThread>
+        &jsMessageQueue, // JS engine thread (what we use for external modules)
     std::shared_ptr<react::uwp::AppTheme> &&appTheme,
     Mso::CntPtr<AppearanceChangeListener> &&appearanceListener,
     const std::shared_ptr<IReactInstance> &uwpInstance) noexcept {
-  // Modules
   std::vector<facebook::react::NativeModuleDescription> modules;
 
   modules.emplace_back(
@@ -59,52 +61,53 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
       [uiManager, uiMessageQueue]() {
         return facebook::react::createUIManagerModule(std::shared_ptr(uiManager), std::shared_ptr(uiMessageQueue));
       },
-      messageQueue);
+      batchingUIMessageQueue);
 
   modules.emplace_back(
       react::uwp::WebSocketModule::Name,
       []() { return std::make_unique<react::uwp::WebSocketModule>(); },
-      MakeSerialQueueThread());
+      jsMessageQueue);
+
+  modules.emplace_back(NetworkingModule::Name, []() { return std::make_unique<NetworkingModule>(); }, jsMessageQueue);
 
   modules.emplace_back(
-      NetworkingModule::Name, []() { return std::make_unique<NetworkingModule>(); }, MakeSerialQueueThread());
+      "Timing",
+      [batchingUIMessageQueue]() { return facebook::react::CreateTimingModule(batchingUIMessageQueue); },
+      batchingUIMessageQueue);
 
   modules.emplace_back(
-      "Timing", [messageQueue]() { return facebook::react::CreateTimingModule(messageQueue); }, messageQueue);
-
-  modules.emplace_back(
-      LinkingManagerModule::name, []() { return std::make_unique<LinkingManagerModule>(); }, messageQueue);
+      LinkingManagerModule::name, []() { return std::make_unique<LinkingManagerModule>(); }, batchingUIMessageQueue);
 
   modules.emplace_back(
       ImageViewManagerModule::name,
-      [messageQueue]() { return std::make_unique<ImageViewManagerModule>(); },
-      messageQueue);
+      []() { return std::make_unique<ImageViewManagerModule>(); },
+      batchingUIMessageQueue);
 
   modules.emplace_back(
       LocationObserverModule::name,
-      [messageQueue]() { return std::make_unique<LocationObserverModule>(messageQueue); },
-      MakeSerialQueueThread()); // TODO: figure out threading
+      [batchingUIMessageQueue]() { return std::make_unique<LocationObserverModule>(batchingUIMessageQueue); },
+      jsMessageQueue); // TODO: figure out threading
 
   modules.emplace_back(
       react::uwp::AppThemeModule::Name,
       [appTheme = std::move(appTheme)]() mutable {
         return std::make_unique<react::uwp::AppThemeModule>(std::move(appTheme));
       },
-      messageQueue);
+      batchingUIMessageQueue);
 
   modules.emplace_back(
       NativeAnimatedModule::name,
       [wpUwpInstance = std::weak_ptr(uwpInstance)]() mutable {
         return std::make_unique<NativeAnimatedModule>(std::move(wpUwpInstance));
       },
-      messageQueue);
+      batchingUIMessageQueue);
 
   modules.emplace_back(
       AppearanceModule::Name,
       [appearanceListener = std::move(appearanceListener)]() mutable {
         return std::make_unique<AppearanceModule>(std::move(appearanceListener));
       },
-      messageQueue);
+      jsMessageQueue);
 
   // AsyncStorageModule doesn't work without package identity (it indirectly depends on
   // Windows.Storage.StorageFile), so check for package identity before adding it.
@@ -117,7 +120,7 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
           return std::make_unique<facebook::react::AsyncStorageModuleWin32>();
         }
       },
-      MakeSerialQueueThread());
+      jsMessageQueue);
 
   return modules;
 }

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.h
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.h
@@ -25,8 +25,9 @@ struct ViewManagerProvider;
 
 std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     const std::shared_ptr<facebook::react::IUIManager> &uiManager,
-    const std::shared_ptr<facebook::react::MessageQueueThread> &messageQueue,
+    const std::shared_ptr<facebook::react::MessageQueueThread> &batchingUIMessageQueue,
     const std::shared_ptr<facebook::react::MessageQueueThread> &uiMessageQueue,
+    const std::shared_ptr<facebook::react::MessageQueueThread> &jsMessageQueue,
     std::shared_ptr<react::uwp::AppTheme> &&appTheme,
     Mso::CntPtr<AppearanceChangeListener> &&appearanceListener,
     const std::shared_ptr<IReactInstance> &uwpInstance) noexcept;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -273,11 +273,13 @@ void ReactInstanceWin::Initialize() noexcept {
           devSettings->debuggerConsoleRedirection =
               false; // JSHost::ChangeGate::ChakraCoreDebuggerConsoleRedirection();
 
-          // Acquire default modules and then populate with custom modules
+          // Acquire default modules and then populate with custom modules.
+          // Note that some of these have custom thread affinity.
           std::vector<facebook::react::NativeModuleDescription> cxxModules = react::uwp::GetCoreModules(
               m_uiManager.Load(),
               m_batchingUIThread,
               m_uiMessageThread.Load(),
+              m_jsMessageThread.Load(),
               std::move(m_appTheme),
               std::move(m_appearanceListener),
               m_legacyReactInstance);

--- a/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.cpp
+++ b/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.cpp
@@ -18,10 +18,6 @@ std::shared_ptr<facebook::react::MessageQueueThread> MakeUIQueueThread() noexcep
   return messageThread;
 }
 
-std::shared_ptr<facebook::react::MessageQueueThread> MakeSerialQueueThread() noexcept {
-  return std::make_shared<Mso::React::MessageDispatchQueue>(Mso::DispatchQueue{}, nullptr, nullptr);
-}
-
 std::shared_ptr<facebook::react::BatchingMessageQueueThread> MakeBatchingQueueThread(
     std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept {
   return std::make_shared<BatchingQueueThread>(queueThread);

--- a/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.h
+++ b/vnext/Microsoft.ReactNative/Threading/MessageQueueThreadFactory.h
@@ -12,8 +12,6 @@ std::shared_ptr<facebook::react::MessageQueueThread> MakeJSQueueThread() noexcep
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeUIQueueThread() noexcept;
 
-std::shared_ptr<facebook::react::MessageQueueThread> MakeSerialQueueThread() noexcept;
-
 std::shared_ptr<facebook::react::BatchingMessageQueueThread> MakeBatchingQueueThread(
     std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept;
 


### PR DESCRIPTION
We invoke modules provided by the NativeModulesProvider on the JS thread as of RNW 0.63. We still invoke core modules on either the UI thread (ReactUwp style) or an arbitrary background thread via `MakeSerialQueueThread()`. Invoke non-UI thread modules on the JS thread to align behavior with non-core modules.

There's also a bit of renaming here, since the previous differentiation of `messageQueue` and `uiMessageQueue` made it unclear that both point towards the UI thread, and that `messageQueue` wasn't the usual native module queue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6039)