### PR TITLE
 Don't Elongate Frame-Based Timers

### DIFF
--- a/change/react-native-windows-2020-09-20-07-06-28-too-long-timer.json
+++ b/change/react-native-windows-2020-09-20-07-06-28-too-long-timer.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't Elongate Frame-Based Timers",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-20T14:06:28.261Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -143,8 +143,7 @@ void Timing::createTimer(int64_t id, double duration, double jsSchedulingTime, b
   }
 
   // Convert double duration in ms to TimeSpan
-  // Make sure duration is always larger than 16ms to avoid unnecessary wakeups.
-  auto period = TimeSpanFromMs(std::max(duration, 16.0));
+  auto period = TimeSpanFromMs(duration);
   const int64_t msFrom1601to1970 = 11644473600000;
   winrt::DateTime scheduledTime(TimeSpanFromMs(jsSchedulingTime + msFrom1601to1970));
   auto initialTargetTime = scheduledTime + period;


### PR DESCRIPTION
Fixes #6031

The UWP implementation of TimingModule took quite a bit from the Desktop TimingModule. One bit is ensuring that timers fire at least 16ms apart to prevent frequent wakeups. This has an impact on desktop, which uses kernel timers, but doesn't do anything useful on UWP, since we wake every frame to evaluate timers.

Remove the logic, since it has the potential to add delay and doesn't seem to serve its intended purpose.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6040)