### PR TITLE
Ensure Integration Tests Show Exceptions When Source Resolution Fails

### DIFF
--- a/packages/IntegrationTest/windows/integrationtest/ExceptionInfo.h
+++ b/packages/IntegrationTest/windows/integrationtest/ExceptionInfo.h
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <winrt/Microsoft.ReactNative.h>
+#include <winrt/Windows.Foundation.h>
+
+namespace IntegrationTest {
+
+struct CallStackFrame {
+  winrt::hstring File;
+  winrt::hstring Method;
+  uint32_t Line{};
+  uint32_t Column{};
+};
+
+//! Mutable representation of an exception from a RedBoxHandler
+struct ExceptionInfo {
+  ExceptionInfo() noexcept = default;
+  ExceptionInfo(const winrt::Microsoft::ReactNative::IRedBoxErrorInfo &errorInfo) noexcept {
+    Id = errorInfo.Id();
+    UpdateInfo(errorInfo);
+  }
+
+  void UpdateInfo(const winrt::Microsoft::ReactNative::IRedBoxErrorInfo &errorInfo) noexcept {
+    assert(errorInfo.Id() == Id);
+
+    if (!errorInfo.Message().empty()) {
+      Message = errorInfo.Message();
+    }
+    if (!errorInfo.OriginalMessage().empty()) {
+      OriginalMessage = errorInfo.OriginalMessage();
+    }
+    if (!errorInfo.Name().empty()) {
+      Name = errorInfo.Name();
+    }
+    if (errorInfo.Callstack().Size() > 0) {
+      Callstack.clear();
+      for (const auto &frame : errorInfo.Callstack()) {
+        Callstack.push_back({frame.File(), frame.Method(), frame.Line(), frame.Column()});
+      }
+    }
+  }
+
+  winrt::hstring Message;
+  winrt::hstring OriginalMessage;
+  winrt::hstring Name;
+  std::vector<CallStackFrame> Callstack;
+  uint32_t Id{};
+};
+
+} // namespace IntegrationTest

--- a/packages/IntegrationTest/windows/integrationtest/TestCommandListener.h
+++ b/packages/IntegrationTest/windows/integrationtest/TestCommandListener.h
@@ -8,6 +8,8 @@
 #include <winrt/Windows.Networking.Sockets.h>
 #include "winrt/integrationtest.h"
 
+#include "ExceptionInfo.h"
+
 namespace IntegrationTest {
 //! Command id from the test runner
 enum class TestCommandId {
@@ -18,20 +20,6 @@ enum class TestCommandId {
 struct TestCommand {
   TestCommandId Id{};
   winrt::Windows::Data::Json::JsonValue payload;
-};
-
-struct CallStackFrame {
-  winrt::hstring File;
-  winrt::hstring Method;
-  uint32_t Line{};
-  uint32_t Column{};
-};
-
-struct ExceptionInfo {
-  winrt::hstring Message;
-  winrt::hstring OriginalMessage;
-  winrt::hstring Name;
-  std::vector<CallStackFrame> Callstack;
 };
 
 class TestCommandResponse {

--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
@@ -7,8 +7,10 @@
 #include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Networking.Sockets.h>
+#include <functional>
 
 #include "TestCommandListener.h"
+#include "TestTransaction.h"
 
 namespace IntegrationTest {
 
@@ -26,20 +28,19 @@ class TestHostHarness : public winrt::implements<TestHostHarness, winrt::Windows
   void ShowJSError(std::string_view err) noexcept;
   winrt::fire_and_forget StartListening() noexcept;
   winrt::fire_and_forget OnTestCommand(TestCommand command, TestCommandResponse response) noexcept;
-  void OnTestCompleted() noexcept;
-  void OnTestPassed(bool passed) noexcept;
-  winrt::Windows::Foundation::IAsyncAction TimeoutOnInactivty() noexcept;
+  winrt::fire_and_forget TimeoutOnInactivty(winrt::weak_ref<TestTransaction> transaction) noexcept;
+  winrt::fire_and_forget HandleHostAction(HostAction action) noexcept;
+
   winrt::Windows::Foundation::IAsyncAction FlushJSQueue() noexcept;
-  void CompletePendingResponse() noexcept;
 
   winrt::Microsoft::ReactNative::ReactRootView m_rootView;
   winrt::Microsoft::ReactNative::ReactContext m_context;
   winrt::Microsoft::ReactNative::IReactInstanceSettings::InstanceLoaded_revoker m_instanceLoadedRevoker;
 
   winrt::com_ptr<TestCommandListener> m_commandListener;
+  winrt::com_ptr<TestTransaction> m_currentTransaction;
   winrt::Microsoft::ReactNative::IRedBoxHandler m_redboxHandler;
   std::optional<TestCommandResponse> m_pendingResponse;
-  winrt::Windows::Foundation::IAsyncAction m_timeoutAction;
 };
 
 //! Redbox handler which feeds into the TestHostHarness to communicate exceptions to the test runner
@@ -57,9 +58,9 @@ class TestHostHarnessRedboxHandler
   void DismissRedBox() noexcept;
 
  private:
-  void HandleException() noexcept;
+  template <typename TFunc>
+  void QueueToUI(TFunc &&func) noexcept;
 
   winrt::weak_ref<TestHostHarness> m_weakHarness;
-  std::unique_ptr<ExceptionInfo> m_pendingException;
 };
 } // namespace IntegrationTest

--- a/packages/IntegrationTest/windows/integrationtest/TestTransaction.cpp
+++ b/packages/IntegrationTest/windows/integrationtest/TestTransaction.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "TestTransaction.h"
+
+#include <Crash.h>;
+
+using namespace winrt::Microsoft::ReactNative;
+
+namespace IntegrationTest {
+
+HostAction TestTransaction::OnNewError(const IRedBoxErrorInfo &errorInfo) noexcept {
+  VerifyElseCrash(m_state == TestState::Started || m_state == TestState::WaitingForCompletion);
+
+  // Ignore this exception if we've already seen one
+  if (m_result == TestResult::Exception) {
+    return HostAction::Continue;
+  }
+
+  m_result = TestResult::Exception;
+  m_exception = std::make_unique<ExceptionInfo>(errorInfo);
+
+  // When __DEV__ is set, ExceptionsManager will always try to prettify the
+  // stack trace, and will usually succeed. Wait for either a prettified
+  // strack trace or timeout.
+#if BUNDLE
+  m_state = TestState::WaitingForCompletion;
+  return HostAction::FlushEvents;
+#else
+  return HostAction::Continue;
+#endif
+}
+
+HostAction TestTransaction::OnUpdateError(const IRedBoxErrorInfo &errorInfo) noexcept {
+  // Note that we can get updates asynchronously some time after test
+  // completion. Make sure the update correlates to the transactions exception.
+  if (m_result != TestResult::Exception || m_exception->Id != errorInfo.Id()) {
+    return HostAction::Continue;
+  }
+
+  VerifyElseCrash(m_state == TestState::Started || m_state == TestState::WaitingForCompletion);
+
+  m_exception->UpdateInfo(errorInfo);
+
+  if (m_state == TestState::Started) {
+    m_state = TestState::WaitingForCompletion;
+    return HostAction::FlushEvents;
+  } else {
+    return HostAction::Continue;
+  }
+}
+
+HostAction TestTransaction::OnTestModuleTestCompleted() noexcept {
+  return OnTestModuleTestPassed(true);
+}
+
+HostAction TestTransaction::OnTestModuleTestPassed(bool passed) noexcept {
+  VerifyElseCrash(m_state == TestState::Started || m_state == TestState::WaitingForCompletion);
+
+  switch (m_result) {
+    case TestResult::None:
+    case TestResult::Pass:
+    case TestResult::Timeout:
+      // Prefer the new result
+      m_result = passed ? TestResult::Pass : TestResult::FailNoMessage;
+      break;
+
+    case TestResult::FailNoMessage:
+    case TestResult::Exception:
+      // Prefer the old result
+      break;
+
+    default:
+      VerifyElseCrash(false);
+  }
+
+  if (m_state == TestState::Started) {
+    m_state = TestState::WaitingForCompletion;
+    return HostAction::FlushEvents;
+  } else {
+    return HostAction::Continue;
+  }
+}
+
+HostAction TestTransaction::OnTimeout() noexcept {
+  // Don't do anything if we already have a pending response
+  if (m_state == TestState::WaitingForCompletion || m_state == TestState::Complete) {
+    return HostAction::Continue;
+  }
+
+  if (m_result == TestResult::None) {
+    m_result = TestResult::Timeout;
+  }
+
+  m_state = TestState::WaitingForCompletion;
+  return HostAction::FlushEvents;
+}
+
+HostAction TestTransaction::OnEventsFlushed() noexcept {
+  VerifyElseCrash(m_state == TestState::WaitingForCompletion);
+  VerifyElseCrash(m_result != TestResult::None);
+
+  m_state = TestState::Complete;
+  return HostAction::SubmitResult;
+}
+
+void TestTransaction::SubmitResult(TestCommandResponse &response) noexcept {
+  VerifyElseCrash(m_state == TestState::Complete);
+
+  switch (m_result) {
+    case TestResult::Pass:
+      response.TestPassed();
+      break;
+
+    case TestResult::Timeout:
+      response.Timeout();
+      break;
+
+    case TestResult::FailNoMessage:
+      response.TestFailed();
+      break;
+
+    case TestResult::Exception:
+      response.Exception(*m_exception);
+      break;
+
+    case TestResult::None:
+    default:
+      VerifyElseCrash(false);
+  }
+}
+
+} // namespace IntegrationTest

--- a/packages/IntegrationTest/windows/integrationtest/TestTransaction.h
+++ b/packages/IntegrationTest/windows/integrationtest/TestTransaction.h
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <winrt/Microsoft.ReactNative.h>
+#include "TestCommandListener.h"
+
+namespace IntegrationTest {
+
+//! Describes the phase of running a test
+enum class TestState {
+  // The test has been started
+  Started,
+
+  // The test has a preliminary result, such as seeing that a test has passed
+  // or seen an exception. This may not be the final result, such as if
+  // exceptions get updated, or if exceptions happen after we pass.
+  WaitingForCompletion,
+
+  // The test is complete
+  Complete,
+};
+
+//! An action the test host must take in response to an event
+enum class HostAction {
+  // No actions needed
+  Continue,
+
+  // Ensure that all pending events from the test are fired. The transaction
+  // should be notifed after by calling OnEventsFlushed.
+  FlushEvents,
+
+  // A test result is ready to be submitted
+  SubmitResult,
+};
+
+//! Describes the peding transaction result
+enum class TestResult {
+  None,
+  FailNoMessage,
+  Exception,
+  Timeout,
+  Pass,
+};
+
+//! Defines the state machine of interactions between an individual test and
+//! external events
+class TestTransaction final : public winrt::implements<TestTransaction, winrt::Windows::Foundation::IInspectable> {
+  using IRedBoxErrorInfo = winrt::Microsoft::ReactNative::IRedBoxErrorInfo;
+
+ public:
+  //! The RedboxHandler has observed an error
+  [[nodiscard]] HostAction OnNewError(const IRedBoxErrorInfo &errorInfo) noexcept;
+
+  //! The RedboxHandler has updates to an existing error
+  [[nodiscard]] HostAction OnUpdateError(const IRedBoxErrorInfo &errorInfo) noexcept;
+
+  //! TestModule.testCompleted has been called
+  [[nodiscard]] HostAction OnTestModuleTestCompleted() noexcept;
+
+  //! TestModule.testPassed has been called
+  [[nodiscard]] HostAction OnTestModuleTestPassed(bool passed) noexcept;
+
+  //! A test has timed out without giving a response
+  [[nodiscard]] HostAction OnTimeout() noexcept;
+
+  //! All test events have been flushed
+  [[nodiscard]] HostAction OnEventsFlushed() noexcept;
+
+  //! Submits a result based on the completed transaction. Must only be
+  //! called once the test is complete.
+  void SubmitResult(TestCommandResponse &response) noexcept;
+
+ private:
+  TestState m_state{TestState::Started};
+  TestResult m_result{TestResult::None};
+  std::unique_ptr<ExceptionInfo> m_exception;
+};
+} // namespace IntegrationTest

--- a/packages/IntegrationTest/windows/integrationtest/integrationtest.vcxproj
+++ b/packages/IntegrationTest/windows/integrationtest/integrationtest.vcxproj
@@ -105,6 +105,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ExceptionInfo.h" />
     <ClInclude Include="MainPage.h">
       <DependentUpon>MainPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -118,6 +119,7 @@
     <ClInclude Include="TestCommandListener.h" />
     <ClInclude Include="TestHostHarness.h" />
     <ClInclude Include="TestModule.h" />
+    <ClInclude Include="TestTransaction.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -155,6 +157,7 @@
     <ClCompile Include="TestCommandListener.cpp" />
     <ClCompile Include="TestHostHarness.cpp" />
     <ClCompile Include="TestModule.cpp" />
+    <ClCompile Include="TestTransaction.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl">

--- a/packages/IntegrationTest/windows/integrationtest/integrationtest.vcxproj.filters
+++ b/packages/IntegrationTest/windows/integrationtest/integrationtest.vcxproj.filters
@@ -16,6 +16,7 @@
     <ClCompile Include="TestModule.cpp" />
     <ClCompile Include="TestHostHarness.cpp" />
     <ClCompile Include="TestCommandListener.cpp" />
+    <ClCompile Include="TestTransaction.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -25,6 +26,8 @@
     <ClInclude Include="TestModule.h" />
     <ClInclude Include="TestHostHarness.h" />
     <ClInclude Include="TestCommandListener.h" />
+    <ClInclude Include="TestTransaction.h" />
+    <ClInclude Include="ExceptionInfo.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Wide310x150Logo.scale-200.png">


### PR DESCRIPTION
RN will sometimes fail to prettify stack information with source map information. In this case, the RedboxHandler never sees a call to update error information. We don't have a great signal of when this fails, so this change alters logic so that a timeout will show exception information if we have an unresolved exception pending.

Validated cases around:
- Tests passing
- Badly behaved tests calling testPassed multiple times not leaking
- Live reload editing tests
- Exceptions where resolution succeeds
- Exceptions where resolution fails

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6047)