### PR TITLE
Handle ReactPromise return value correctly

### DIFF
--- a/change/react-native-windows-2020-09-21-12-28-47-tm-files.json
+++ b/change/react-native-windows-2020-09-21-12-28-47-tm-files.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Handle ReactPromise correctly",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-21T19:28:47.449Z"
+}

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -166,7 +166,16 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                             argWriter,
                             [promise, &runtime](const IJSValueWriter &writer) {
                               auto result = writer.as<JsiWriter>()->MoveResult();
-                              promise->resolve(result);
+                              if (result.isObject()) {
+                                auto resultArrayObject = result.getObject(runtime);
+                                VerifyElseCrash(resultArrayObject.isArray(runtime));
+                                auto resultArray = resultArrayObject.getArray(runtime);
+                                VerifyElseCrash(resultArray.length(runtime) == 1);
+                                auto resultItem = resultArray.getValueAtIndex(runtime, 0);
+                                promise->resolve(resultItem);
+                              } else {
+                                VerifyElseCrash(false);
+                              }
                             },
                             [promise, &runtime](const IJSValueWriter &writer) {
                               auto result = writer.as<JsiWriter>()->MoveResult();


### PR DESCRIPTION
In the current implementation, when ReactPromise::Resolve is called, the created array is passed to JSI instead of the only element in that array, causing type mismatch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6052)