### PR TITLE
Fix react-native-platform-override CLI Locking Issues

### DIFF
--- a/change/react-native-platform-override-2020-09-21-14-32-23-override-locks.json
+++ b/change/react-native-platform-override-2020-09-21-14-32-23-override-locks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix react-native-platform-override CLI",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-21T21:32:23.569Z"
+}

--- a/packages/react-native-platform-override/src/Cli.ts
+++ b/packages/react-native-platform-override/src/Cli.ts
@@ -40,8 +40,9 @@ void doMain(async () => {
               describe: 'Optional React Native version to check against',
             },
           }),
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         cmdArgv =>
-          void validateManifest({
+          validateManifest({
             manifestPath: cmdArgv.manifest,
             reactNativeVersion: cmdArgv.version,
           }),
@@ -53,7 +54,8 @@ void doMain(async () => {
           cmdYargs.options({
             override: {type: 'string', describe: 'The override to add'},
           }),
-        cmdArgv => void addOverride(cmdArgv.override!),
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        cmdArgv => addOverride(cmdArgv.override!),
       )
       .command(
         'remove <override>',
@@ -62,7 +64,8 @@ void doMain(async () => {
           cmdYargs.options({
             override: {type: 'string', describe: 'The override to remove'},
           }),
-        cmdArgv => void removeOverride(cmdArgv.override!),
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        cmdArgv => removeOverride(cmdArgv.override!),
       )
       .command(
         'upgrade',
@@ -83,8 +86,9 @@ void doMain(async () => {
               describe: 'Optional React Native version to check against',
             },
           }),
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         cmdArgv =>
-          void upgrade({
+          upgrade({
             manifestPath: cmdArgv.manifest,
             reactNativeVersion: cmdArgv.version,
             allowConflicts: cmdArgv.conflicts,


### PR DESCRIPTION
Fixes #6055 

Fallout from #5980. `yargs` accepts promise-returning async command handlers, and we were relying on that previously. Revert the addition of the void operator and suppress warnings stemming from incorrect typings.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6056)