### PR TITLE
Fix casing rules for new projects names for `react-native-windows-init`

### DIFF
--- a/change/@react-native-windows-cli-2020-09-22-11-08-10-pascalcasefix.json
+++ b/change/@react-native-windows-cli-2020-09-22-11-08-10-pascalcasefix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix casing rules for new projects names for `react-native-windows-init`",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T18:08:10.773Z"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -105,6 +105,11 @@ interface CppNugetPackage extends NugetPackage {
   hasTargets: boolean;
 }
 
+function pascalCase(str: string) {
+  const camelCase = _.camelCase(str);
+  return camelCase[0].toUpperCase() + camelCase.substr(1);
+}
+
 export async function copyProjectTemplateAndReplace(
   srcRootPath: string,
   destPath: string,
@@ -128,12 +133,12 @@ export async function copyProjectTemplateAndReplace(
 
   // React-native init only allows alphanumerics in project names, but other
   // new project tools (like create-react-native-module) are less strict.
-  newProjectName = _.camelCase(newProjectName);
+  newProjectName = pascalCase(newProjectName);
 
   // Similar to the above, but we want to retain namespace separators
   namespace = namespace
     .split(/[\.\:]+/)
-    .map(_.camelCase)
+    .map(pascalCase)
     .join('.');
 
   createDir(path.join(destPath, windowsDir));

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -133,13 +133,17 @@ export async function copyProjectTemplateAndReplace(
 
   // React-native init only allows alphanumerics in project names, but other
   // new project tools (like create-react-native-module) are less strict.
-  newProjectName = pascalCase(newProjectName);
+  if (projectType === 'lib') {
+    newProjectName = pascalCase(newProjectName);
+  }
 
   // Similar to the above, but we want to retain namespace separators
-  namespace = namespace
-    .split(/[\.\:]+/)
-    .map(pascalCase)
-    .join('.');
+  if (projectType === 'lib') {
+    namespace = namespace
+      .split(/[\.\:]+/)
+      .map(pascalCase)
+      .join('.');
+  }
 
   createDir(path.join(destPath, windowsDir));
   createDir(path.join(destPath, windowsDir, newProjectName));


### PR DESCRIPTION
When adding the `--projectType lib` to `react-native-windows-init`, I had to handle the case that the naming of new projects is looser for `create-react-native-module` than for `react-native init`.

I added logic to convert the incoming new project name and namespace to pascalCase for all new projects (app or lib). This will break some cases for each that I didn't test before.

I've reverted the logic for new apps (so no net behavior change) and changed the logic for new libs to match `create-react-native-module`, ie, using PascalCase, not camelCase.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6065)