### PR TITLE
Ignore filemode for react-native-platform-override Scratch Repository

### DIFF
--- a/change/react-native-platform-override-2020-09-23-03-59-58-less-diff.json
+++ b/change/react-native-platform-override-2020-09-23-03-59-58-less-diff.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ignore filemode for Scratch Repository",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T10:59:58.784Z"
+}

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -55,6 +55,7 @@ export default class GitReactFileRepository
       await gitClient.init();
     }
 
+    await gitClient.addConfig('core.filemode', 'false');
     return new GitReactFileRepository(dir, gitClient);
   }
 
@@ -101,6 +102,8 @@ export default class GitReactFileRepository
           '--patch',
           '--ignore-space-at-eol',
           '--binary',
+          '--',
+          filename,
         ]);
 
         if (patch.length === 0) {


### PR DESCRIPTION
Fixes #5898

Was lucky enough to get into a state where running react-native-platform-overrides would reproduce the issue end-to-end. Git fails to apply a patch stating "error: xxxx: does not match index", referring to files outside of the target file. Files outside of the target show as changed due to Unix file permissions we don't really care about.

This change:

1. Disables core.filemode for the scratch repo since it shouldn't matter
2. Makes it so that we only generate a patch against the target file instead of the whole working tree

Validated we pass end-to-end tests evaluating override validation + upgrading. In my current machine state, we deterministically pass with either change, and deterministically fail without.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6069)