### PR TITLE
Zero-Config Tests for CLI, react-native-windows-init, react-native-windows-codegen

### DIFF
--- a/change/@react-native-windows-cli-2020-09-23-04-17-20-more-jest.json
+++ b/change/@react-native-windows-cli-2020-09-23-04-17-20-more-jest.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Zero-Config Tests for CLI, react-native-windows-init, react-native-windows-codegen",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T11:16:43.656Z"
+}

--- a/change/@rnw-scripts-just-task-2020-09-23-04-17-20-more-jest.json
+++ b/change/@rnw-scripts-just-task-2020-09-23-04-17-20-more-jest.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix test task when no tests present",
+  "packageName": "@rnw-scripts/just-task",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T11:17:16.539Z"
+}

--- a/change/react-native-windows-codegen-2020-09-23-04-17-20-more-jest.json
+++ b/change/react-native-windows-codegen-2020-09-23-04-17-20-more-jest.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Zero-Config Tests for CLI, react-native-windows-init, react-native-windows-codegen",
+  "packageName": "react-native-windows-codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T11:17:19.465Z"
+}

--- a/change/react-native-windows-init-2020-09-23-04-17-20-more-jest.json
+++ b/change/react-native-windows-init-2020-09-23-04-17-20-more-jest.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Zero-Config Tests for CLI, react-native-windows-init, react-native-windows-codegen",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T11:17:20.801Z"
+}

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "private": true,
   "scripts": {
     "build": "lerna run build --stream -- --color",
-    "lint": "lerna run lint --stream -- --color",
-    "lint:fix": "lerna run lint:fix --stream -- --color",
-    "api": "lerna run api --stream -- --color",
+    "lint": "lerna run lint --parallel -- --color",
+    "lint:fix": "lerna run lint:fix --parallel -- --color",
+    "api": "lerna run api --parallel -- --color",
     "buildci": "lerna run build --stream -- --ci",
     "change": "beachball change",
-    "clean": "lerna run clean --stream -- --color",
+    "clean": "lerna run clean --parallel -- --color",
     "format": "format-files -i -style=file -assume-filename=../.clang-format",
     "format:verify": "format-files -i -style=file -assume-filename=../.clang-format -verify",
-    "test": "lerna run test --stream -- --color",
-    "validate-overrides": "lerna run validate-overrides --stream -- --color"
+    "test": "lerna run test --parallel -- --color",
+    "validate-overrides": "lerna run validate-overrides --parallel -- --color"
   },
   "repository": {
     "type": "git",

--- a/packages/@react-native-windows/cli/.vscode/launch.json
+++ b/packages/@react-native-windows/cli/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "vscode-jest-tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "../../../node_modules/jest/bin/jest.js",
+        "--runInBand",
+        "--config",
+        "../../@rnw-scripts/jest-debug-config/jest.debug.config.js",
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229,
+    },
+  ]
+}

--- a/packages/@react-native-windows/cli/jest.config.js
+++ b/packages/@react-native-windows/cli/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@rnw-scripts/jest-unittest-config');

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -13,6 +13,7 @@
     "clean": "just-scripts clean",
     "lint": "just-scripts lint",
     "lint:fix": "just-scripts lint:fix",
+    "test": "just-scripts test",
     "watch": "just-scripts watch"
   },
   "dependencies": {
@@ -35,10 +36,12 @@
   "devDependencies": {
     "@react-native-community/cli-types": "^4.10.1",
     "@rnw-scripts/eslint-config": "0.1.3",
+    "@rnw-scripts/jest-unittest-config": "0.1.0",
     "@rnw-scripts/just-task": "0.0.4",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/chalk": "^2.2.0",
     "@types/inquirer": "^6.5.0",
+    "@types/jest": "^26.0.13",
     "@types/mustache": "^4.0.1",
     "@types/ora": "^3.2.0",
     "@types/semver": "^7.3.3",
@@ -46,7 +49,9 @@
     "@types/uuid": "^8.0.0",
     "@types/xml-parser": "^1.2.29",
     "@types/xmldom": "^0.1.29",
+    "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
+    "jest": "^26.4.2",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/just-task/just-task.js
+++ b/packages/@rnw-scripts/just-task/just-task.js
@@ -65,5 +65,5 @@ if (hasE2eTests && hasUnitTests) {
 } else if (hasUnitTests) {
   task('test', 'unitTest');
 } else {
-  logger.info('No tests found');
+  task('test', () => logger.info('No tests found'));
 }

--- a/packages/react-native-windows-codegen/.vscode/launch.json
+++ b/packages/react-native-windows-codegen/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "vscode-jest-tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "../../node_modules/jest/bin/jest.js",
+        "--runInBand",
+        "--config",
+        "../@rnw-scripts/jest-debug-config/jest.debug.config.js",
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229,
+    },
+  ]
+}

--- a/packages/react-native-windows-codegen/jest.config.js
+++ b/packages/react-native-windows-codegen/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@rnw-scripts/jest-unittest-config');

--- a/packages/react-native-windows-codegen/package.json
+++ b/packages/react-native-windows-codegen/package.json
@@ -11,6 +11,7 @@
     "clean": "just-scripts clean",
     "lint": "just-scripts lint",
     "lint:fix": "just-scripts lint:fix",
+    "test": "just-scripts test",
     "watch": "just-scripts watch"
   },
   "bin": {
@@ -25,12 +26,17 @@
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.3",
+    "@rnw-scripts/jest-unittest-config": "0.1.0",
     "@rnw-scripts/just-task": "0.0.4",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/chalk": "^2.2.0",
     "@types/globby": "^9.1.0",
+    "@types/jest": "^26.0.13",
     "@types/yargs": "15.0.5",
+    "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1"
+    "jest": "^26.4.2",
+    "just-scripts": "^0.36.1",
+    "typescript": "^3.8.3"
   }
 }

--- a/packages/react-native-windows-init/.vscode/launch.json
+++ b/packages/react-native-windows-init/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "vscode-jest-tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "../../node_modules/jest/bin/jest.js",
+        "--runInBand",
+        "--config",
+        "../@rnw-scripts/jest-debug-config/jest.debug.config.js",
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229,
+    },
+  ]
+}

--- a/packages/react-native-windows-init/jest.config.js
+++ b/packages/react-native-windows-init/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@rnw-scripts/jest-unittest-config');

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -11,6 +11,7 @@
     "clean": "just-scripts clean",
     "lint": "just-scripts lint",
     "lint:fix": "just-scripts lint:fix",
+    "test": "just-scripts test",
     "watch": "just-scripts watch"
   },
   "bin": {
@@ -28,14 +29,18 @@
   "devDependencies": {
     "@react-native-windows/cli": "0.0.0-canary.17",
     "@rnw-scripts/eslint-config": "0.1.3",
+    "@rnw-scripts/jest-unittest-config": "0.1.0",
     "@rnw-scripts/just-task": "0.0.4",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/chalk": "^2.2.0",
+    "@types/jest": "^26.0.13",
     "@types/prompts": "^2.0.3",
     "@types/semver": "7.3.3",
     "@types/valid-url": "^1.0.2",
     "@types/yargs": "15.0.5",
+    "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
+    "jest": "^26.4.2",
     "just-scripts": "^0.36.1",
     "typescript": "^3.8.3"
   },


### PR DESCRIPTION
This change configures the above packages so that unit tests and end to ends tests can be run and debugged by placing jest tests in either `src/test` or `src/e2etest`. Docs coming soon on the differences between these.

Validated tests are picked up by yarn test, unit tests are automatically run by VS Code, e2etests aren't automatically run but can be debugged in-UI.

This also changes some top-level lerna scripts to allow scripts to be run in non-topological order since they have already been built.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6070)