### PR TITLE
Supply UniversalApiContract for Platform.Version

### DIFF
--- a/change/@office-iss-react-native-win32-2020-09-23-07-23-03-platform-version.json
+++ b/change/@office-iss-react-native-win32-2020-09-23-07-23-03-platform-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Supply UniversalApiContract for Platform.Version",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T14:23:01.779Z"
+}

--- a/change/react-native-windows-2020-09-23-07-23-03-platform-version.json
+++ b/change/react-native-windows-2020-09-23-07-23-03-platform-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Supply UniversalApiContract for Platform.Version",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T14:23:03.309Z"
+}

--- a/packages/IntegrationTest/tests/PlatformTests.ts
+++ b/packages/IntegrationTest/tests/PlatformTests.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import {assert} from 'chai';
+import {Platform} from 'react-native';
+import {functionTest} from './lib/TestDefinition';
+
+functionTest('Platform.OS', () => {
+  assert.equal(Platform.OS, 'windows', 'Platform.OS should be windows');
+});
+
+functionTest('Platform.Version', () => {
+  assert.isNumber(Platform.Version, 'Platform.Version should be a number');
+  assert.isAtLeast(
+    Platform.Version as number,
+    1,
+    'Universal API contract should be at least 1',
+  );
+});
+
+functionTest('PlatformConstants.reactNativeVersion', () => {
+  // @ts-ignore constants not exposed in public typings
+  const constants = Platform.constants;
+
+  assert.isObject(
+    constants.reactNativeVersion,
+    'Platform.constants.reactNativeVersion should be an object',
+  );
+  assert.isNumber(
+    constants.reactNativeVersion.major,
+    'reactNativeVersion.major should be a number',
+  );
+  assert.isNumber(
+    constants.reactNativeVersion.minor,
+    'reactNativeVersion.minor should be a number',
+  );
+  assert.isNumber(
+    constants.reactNativeVersion.patch,
+    'reactNativeVersion.patch should be a number',
+  );
+});

--- a/packages/IntegrationTest/tests/index.ts
+++ b/packages/IntegrationTest/tests/index.ts
@@ -8,4 +8,5 @@
 require('./lib/SetupGlobals');
 
 require('./MountComponentTests');
+require('./PlatformTests');
 require('./SampleTests');

--- a/packages/react-native-win32/src/Libraries/Utilities/NativePlatformConstantsWin.js
+++ b/packages/react-native-win32/src/Libraries/Utilities/NativePlatformConstantsWin.js
@@ -20,6 +20,7 @@ export interface Spec extends TurboModule {
       patch: number,
       prerelease: ?number,
     |},
+    osVersion: number,
   |};
 }
 

--- a/packages/react-native-win32/src/Libraries/Utilities/Platform.win32.js
+++ b/packages/react-native-win32/src/Libraries/Utilities/Platform.win32.js
@@ -20,6 +20,9 @@ export type PlatformSelectSpec<A, N, D> = {
 const Platform = {
   __constants: null,
   OS: 'win32',
+  get Version(): number {
+    return this.constants.osVersion;
+  },
   get constants(): {|
     isTesting: boolean,
     reactNativeVersion: {|
@@ -28,6 +31,7 @@ const Platform = {
       patch: number,
       prerelease: ?number,
     |},
+    osVersion: number,
   |} {
     if (this.__constants == null) {
       this.__constants = NativePlatformConstantsWin.getConstants();

--- a/vnext/Shared/Modules/PlatformConstantsModule.cpp
+++ b/vnext/Shared/Modules/PlatformConstantsModule.cpp
@@ -4,6 +4,9 @@
 #include "PlatformConstantsModule.h"
 #include <VersionHelpers.h>
 #include <cxxreact/ReactNativeVersion.h>
+#include <winrt/Windows.Foundation.Metadata.h>
+
+using namespace winrt::Windows::Foundation::Metadata;
 
 using Method = facebook::xplat::module::CxxModule::Method;
 
@@ -45,17 +48,23 @@ std::map<std::string, folly::dynamic> PlatformConstantsModule::getConstants() {
       // the version of react-native we are built from
       {"reactNativeWindowsVersion",
        folly::dynamic::object("major", RNW_PKG_VERSION_MAJOR)("minor", RNW_PKG_VERSION_MINOR)(
-           "patch", RNW_PKG_VERSION_PATCH)}
+           "patch", RNW_PKG_VERSION_PATCH)},
 
-      // We don't provide the typical OS version here. Windows make it hard to
-      // get an exact version by-design. In the future we should consider
-      // exposing something here like a facility to check Universal API
-      // Contract.
+      // Provide the universal API contract as an OS version
+      {"osVersion", OsVersion()},
   };
 }
 
-folly::dynamic PlatformConstantsModule::StringOrNull(std::string_view str) noexcept {
+/*static*/ folly::dynamic PlatformConstantsModule::StringOrNull(std::string_view str) noexcept {
   return str.empty() ? folly::dynamic(nullptr) : folly::dynamic(str);
+}
+
+/*static*/ int32_t PlatformConstantsModule::OsVersion() noexcept {
+  for (uint16_t i = 1;; ++i) {
+    if (!ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", i)) {
+      return i - 1;
+    }
+  }
 }
 
 } // namespace facebook::react

--- a/vnext/Shared/Modules/PlatformConstantsModule.h
+++ b/vnext/Shared/Modules/PlatformConstantsModule.h
@@ -16,7 +16,8 @@ class PlatformConstantsModule : public facebook::xplat::module::CxxModule {
   std::vector<Method> getMethods() override;
 
  private:
-  folly::dynamic StringOrNull(std::string_view str) noexcept;
+  static folly::dynamic StringOrNull(std::string_view str) noexcept;
+  static int32_t OsVersion() noexcept;
 };
 
 } // namespace facebook::react

--- a/vnext/src/Libraries/Utilities/NativePlatformConstantsWin.js
+++ b/vnext/src/Libraries/Utilities/NativePlatformConstantsWin.js
@@ -20,6 +20,7 @@ export interface Spec extends TurboModule {
       patch: number,
       prerelease: ?number,
     |},
+    osVersion: number,
   |};
 }
 

--- a/vnext/src/Libraries/Utilities/Platform.windows.js
+++ b/vnext/src/Libraries/Utilities/Platform.windows.js
@@ -20,6 +20,9 @@ export type PlatformSelectSpec<A, N, D> = {
 const Platform = {
   __constants: null,
   OS: 'windows',
+  get Version(): number {
+    return this.constants.osVersion;
+  },
   get constants(): {|
     isTesting: boolean,
     reactNativeVersion: {|
@@ -28,6 +31,7 @@ const Platform = {
       patch: number,
       prerelease: ?number,
     |},
+    osVersion: number,
   |} {
     if (this.__constants == null) {
       this.__constants = NativePlatformConstantsWin.getConstants();


### PR DESCRIPTION
Fixes #4176

When implementing PlatformConstants I originally took the route of not providing a version, since Windows likes to hide it. Version is officially part of typings though, and it seems some code will be unhappy if its undefined. With this change, we provide UniversalApiContract as a proxy of "what native functionality is available", similar to how Android Platform versions work.

This module is shared between desktop/XAML, which has some special considerations. Namely when running on Windows < 10, we should just return 0 for API contract.

Added integration tests to validate this is working correctly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6074)