### PR TITLE
[0.62] Revert folly back to 2019.09.30.00 with patch file for compiler fix

### DIFF
--- a/change/react-native-windows-2020-09-23-11-08-48-0.62minorfolly.json
+++ b/change/react-native-windows-2020-09-23-11-08-48-0.62minorfolly.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Revert folly back to 2019.09.30.00 with patch file for compiler fix",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T18:08:48.067Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -7,6 +7,7 @@
 EXPORTS
 ??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
+??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0LayoutAnimation@react@facebook@@QEAA@Udynamic@folly@@@Z
 ??0TypeError@folly@@QEAA@$$QEAU01@@Z
 ??0TypeError@folly@@QEAA@AEBU01@@Z
@@ -41,7 +42,6 @@ EXPORTS
 ?loadScriptFromString@Instance@react@facebook@@QEAAXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PEBD@1@@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QEAA?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QEBDEB
 ?parseJson@folly@@YA?AUdynamic@1@V?$Range@PEBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QEAAXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z
 ?size@dynamic@folly@@QEBA_KXZ

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -7,6 +7,7 @@
 EXPORTS
 ??$str_to_floating@N@detail@folly@@YG?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
+??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0LayoutAnimation@react@facebook@@QAE@Udynamic@folly@@@Z
 ??0TypeError@folly@@QAE@$$QAU01@@Z
 ??0TypeError@folly@@QAE@ABU01@@Z
@@ -41,7 +42,6 @@ EXPORTS
 ?hash@dynamic@folly@@QBEIXZ
 ?loadScriptFromString@Instance@react@facebook@@QAEXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YG?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QBDB
 ?parseJson@folly@@YG?AUdynamic@1@V?$Range@PBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QAEXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z
 ?size@dynamic@folly@@QBEIXZ

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -66,6 +66,7 @@
     <ClCompile Include="$(FollyDir)\folly\ScopeGuard.cpp" />
     <ClCompile Include="$(FollyDir)\folly\Unicode.cpp" />
     <ClCompile Include="$(FollyDir)\folly\memory\detail\MallocImpl.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\lang\ColdClass.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(FollyDir)\folly\AtomicBitSet.h" />

--- a/vnext/Folly/Folly.vcxproj.filters
+++ b/vnext/Folly/Folly.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="$(FollyDir)\folly\lang\Assume.cpp">
       <Filter>Source Files\lang</Filter>
     </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\lang\ColdClass.cpp">
+      <Filter>Source Files\lang</Filter>
+    </ClCompile>
     <ClCompile Include="$(FollyDir)\folly\Conv.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/vnext/PropertySheets/ReactDirectories.props
+++ b/vnext/PropertySheets/ReactDirectories.props
@@ -28,7 +28,7 @@
     <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$(IntDir)\react-native-patched\</ReactNativeDir>
 
     <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)\ReactCommon\yoga</YogaDir>
-    <FollyVersion>2020.09.14.00</FollyVersion>
+    <FollyVersion>2019.09.30.00</FollyVersion>
     <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativePackageDir)..\..\node_modules))')">$(ReactNativePackageDir)..\..\node_modules\.folly\folly-$(FollyVersion)</FollyDir>
     <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
   </PropertyGroup>

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.arm.def
@@ -6,6 +6,7 @@ EXPORTS
 ??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_K@detail@folly@@YA?AV?$Expected@_KW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
+??0ColdClass@cold_detail@folly@@QAA@XZ
 ??0ReactRootView@uwp@react@@QAA@UDependencyObject@Xaml@UI@Windows@winrt@@@Z
 ??0TypeError@folly@@QAA@$$QAU01@@Z
 ??0TypeError@folly@@QAA@ABU01@@Z
@@ -26,6 +27,7 @@ EXPORTS
 ?atImpl@dynamic@folly@@AGBAABU12@ABU12@@Z
 ?callJSFunction@Instance@react@facebook@@QAAX$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QAUdynamic@folly@@@Z
 ?checkedMalloc@folly@@YAPAXI@Z
+?demangle@folly@@YA?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PBD@Z
 ?destroy@dynamic@folly@@AAAXXZ
 ?get_ptr@dynamic@folly@@QGBAPBU12@V?$Range@PBD@2@@Z
 ?hash@dynamic@folly@@QBAIXZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x64.def
@@ -7,6 +7,7 @@ EXPORTS
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??0AppState@react@facebook@@QEAA@XZ
 ??0AppStateModule@react@facebook@@QEAA@$$QEAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
+??0ColdClass@cold_detail@folly@@QEAA@XZ
 ??0DeviceInfoModule@uwp@react@@QEAA@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
 ??0DeviceInfo@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QEAA@AEBV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
@@ -42,17 +43,18 @@ EXPORTS
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YA?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QEB_WI@Z
 ?StartPollingLiveReload@DevSupportManager@uwp@react@@UEAAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$function@$$A6AXXZ@5@@Z
 ?StopPollingLiveReload@DevSupportManager@uwp@react@@UEAAXXZ
+?assertionFailure@detail@folly@@YAXPEBD00I0@Z
 ?assume_check@detail@folly@@YAX_N@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z
 ?atImpl@dynamic@folly@@AEGBAAEBU12@AEBU12@@Z
 ?callJSFunction@Instance@react@facebook@@QEAAX$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QEAUdynamic@folly@@@Z
 ?createUIManagerModule@react@facebook@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$shared_ptr@VIUIManager@react@facebook@@@4@@Z
+?demangle@folly@@YA?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PEBD@Z
 ?destroy@dynamic@folly@@AEAAXXZ
 ?get_ptr@dynamic@folly@@QEGBAPEBU12@V?$Range@PEBD@2@@Z
 ?hash@dynamic@folly@@QEBA_KXZ
 ?logTaggedMarker@ReactMarker@react@facebook@@3P6AXW4ReactMarkerId@123@PEBD@ZEA
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PEBD@1@@Z
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QEBDEB
 ?parseJson@folly@@YA?AUdynamic@1@V?$Range@PEBD@1@@Z
 ?print_as_pseudo_json@dynamic@folly@@AEBAXAEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z
 ?size@dynamic@folly@@QEBA_KXZ

--- a/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
+++ b/vnext/ReactUWP/EndPoints/dll/react-native-uwp.x86.def
@@ -7,6 +7,7 @@ EXPORTS
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??0AppState@react@facebook@@QAE@XZ
 ??0AppStateModule@react@facebook@@QAE@$$QAV?$shared_ptr@VAppState@react@facebook@@@std@@@Z
+??0ColdClass@cold_detail@folly@@QAE@XZ
 ??0DeviceInfoModule@uwp@react@@QAE@V?$shared_ptr@VDeviceInfo@uwp@react@@@std@@@Z
 ??0DeviceInfo@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
 ??0ImageViewManager@uwp@react@@QAE@ABV?$shared_ptr@UIReactInstance@uwp@react@@@std@@@Z
@@ -42,17 +43,18 @@ EXPORTS
 ?MakeMemoryMappedBuffer@JSI@Microsoft@@YG?AV?$shared_ptr@VBuffer@jsi@facebook@@@std@@QB_WI@Z
 ?StartPollingLiveReload@DevSupportManager@uwp@react@@UAEXABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$function@$$A6GXXZ@5@@Z
 ?StopPollingLiveReload@DevSupportManager@uwp@react@@UAEXXZ
+?assertionFailure@detail@folly@@YGXPBD00I0@Z
 ?assume_check@detail@folly@@YGX_N@Z
 ?at@dynamic@folly@@QGBEABU12@V?$Range@PBD@2@@Z
 ?atImpl@dynamic@folly@@AGBEABU12@ABU12@@Z
 ?callJSFunction@Instance@react@facebook@@QAEX$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QAUdynamic@folly@@@Z
 ?createUIManagerModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$shared_ptr@VIUIManager@react@facebook@@@4@@Z
+?demangle@folly@@YG?AV?$basic_fbstring@DU?$char_traits@D@std@@V?$allocator@D@2@V?$fbstring_core@D@folly@@@1@PBD@Z
 ?destroy@dynamic@folly@@AAEXXZ
 ?get_ptr@dynamic@folly@@QGBEPBU12@V?$Range@PBD@2@@Z
 ?hash@dynamic@folly@@QBEIXZ
 ?logTaggedMarker@ReactMarker@react@facebook@@3P6GXW4ReactMarkerId@123@PBD@ZA
 ?makeConversionError@folly@@YG?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QBDB
 ?parseJson@folly@@YG?AUdynamic@1@V?$Range@PBD@1@@Z
 ?print_as_pseudo_json@dynamic@folly@@ABEXAAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z
 ?size@dynamic@folly@@QBEIXZ

--- a/vnext/ReactWindowsCore/Utils.cpp
+++ b/vnext/ReactWindowsCore/Utils.cpp
@@ -65,8 +65,7 @@ void assertionFailure(
     const char *msg,
     const char *file,
     unsigned int line,
-    const char *function,
-    int error) {
+    const char *function) {
   // nyi
   std::terminate();
 }

--- a/vnext/ReactWindowsCore/Utils.cpp
+++ b/vnext/ReactWindowsCore/Utils.cpp
@@ -60,12 +60,7 @@ void writeStderr(const char *s) {
 } // namespace
 
 // \node_modules\.folly\folly-2020.09.14.00\folly\lang\SafeAssert.h
-void assertionFailure(
-    const char *expr,
-    const char *msg,
-    const char *file,
-    unsigned int line,
-    const char *function) {
+void assertionFailure(const char *expr, const char *msg, const char *file, unsigned int line, const char *function) {
   // nyi
   std::terminate();
 }


### PR DESCRIPTION
Updating folly for a patch release was more than we should have been changing.  -- And it broke some internal consumption.

This puts folly back to the version it was before, but still adds the one patch file on top which will allow folly to continue to build when VS 16.8 is released.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6075)