### PR TITLE
Add `-NoProfile` option to powershell invocations

### DIFF
--- a/change/@react-native-windows-cli-2020-09-23-19-35-29-master.json
+++ b/change/@react-native-windows-cli-2020-09-23-19-35-29-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add -NoProfile to powershell invocations to ensure deterministic script execution where user profiles do not have the ability to break or change the build outputs",
+  "packageName": "@react-native-windows/cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T02:35:26.069Z"
+}

--- a/change/react-native-windows-2020-09-23-19-35-29-master.json
+++ b/change/react-native-windows-2020-09-23-19-35-29-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add -NoProfile to powershell invocations to ensure deterministic script execution where user profiles do not have the ability to break or change the build outputs",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T02:35:29.097Z"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -38,7 +38,7 @@ async function generateCertificate(
       const timeout = 10000; // 10 seconds;
       const thumbprint = childProcess
         .execSync(
-          `powershell -command "Write-Output (New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject 'CN=${currentUser}' -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}Subject Type:End Entity') -CertStoreLocation 'Cert:\\CurrentUser\\My').Thumbprint"`,
+          `powershell -NoProfile -Command "Write-Output (New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject 'CN=${currentUser}' -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}Subject Type:End Entity') -CertStoreLocation 'Cert:\\CurrentUser\\My').Thumbprint"`,
           {timeout},
         )
         .toString()
@@ -47,7 +47,7 @@ async function generateCertificate(
         fs.mkdirSync(path.join(windowsDir, newProjectName));
       }
       childProcess.execSync(
-        `powershell -command "$pwd = (ConvertTo-SecureString -String password -Force -AsPlainText); Export-PfxCertificate -Cert 'cert:\\CurrentUser\\My\\${thumbprint}' -FilePath ${path.join(
+        `powershell -NoProfile -Command "$pwd = (ConvertTo-SecureString -String password -Force -AsPlainText); Export-PfxCertificate -Cert 'cert:\\CurrentUser\\My\\${thumbprint}' -FilePath ${path.join(
           windowsDir,
           newProjectName,
           newProjectName,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -114,7 +114,7 @@ function getWindowsStoreAppUtils(options: RunWindowsOptions) {
     'powershell',
     'WindowsStoreAppUtils.ps1',
   );
-  execSync(`powershell Unblock-File "${windowsStoreAppUtilsPath}"`);
+  execSync(`powershell -NoProfile Unblock-File "${windowsStoreAppUtilsPath}"`);
   popd();
   return windowsStoreAppUtilsPath;
 }
@@ -328,7 +328,7 @@ export async function deployToDesktop(
   }
 
   const appFamilyName = execSync(
-    `powershell -c $(Get-AppxPackage -Name ${appName}).PackageFamilyName`,
+    `powershell -NoProfile -c $(Get-AppxPackage -Name ${appName}).PackageFamilyName`,
   )
     .toString()
     .trim();

--- a/packages/E2ETest/run_wdio.js
+++ b/packages/E2ETest/run_wdio.js
@@ -56,7 +56,7 @@ console.log(`Selected tests: ${opts}`);
 
 function ensureRunningInHyperV() {
   const baseboardMfr = child_process
-    .execSync('powershell.exe (gwmi Win32_BaseBoard).Manufacturer')
+    .execSync('powershell.exe -NoProfile (gwmi Win32_BaseBoard).Manufacturer')
     .toString()
     .replace(/[\r\n]/, '');
   if (!baseboardMfr.startsWith('Microsoft Corporation')) {

--- a/vnext/Scripts/PublishNugetPackagesLocally.cmd
+++ b/vnext/Scripts/PublishNugetPackagesLocally.cmd
@@ -57,13 +57,13 @@ echo Invoking publish nuget packages with: %0 %*
     )
 
 :PrepFiles
-    powershell %ScriptFolder%tfs\Layout-Headers.ps1 -NuGetPackageVersion %version%
+    powershell -NoProfile %ScriptFolder%tfs\Layout-Headers.ps1 -NuGetPackageVersion %version%
     if ERRORLEVEL 1 (
         echo Failed to layout files for nuget packing
         exit /b 1
     )
 
-    powershell -Command "(Get-Content -Path %ScriptFolder%..\target\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '%version%' | Set-Content -Path  %ScriptFolder%..\target\Microsoft.ReactNative.VersionCheck.targets"
+    powershell -NoProfile -Command "(Get-Content -Path %ScriptFolder%..\target\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '%version%' | Set-Content -Path  %ScriptFolder%..\target\Microsoft.ReactNative.VersionCheck.targets"
     if ERRORLEVEL 1 (
         echo Failed to path version check file for nuget packing
         exit /b 1
@@ -89,7 +89,7 @@ exit /b 0
     echo Processing %packageId%
     echo --------------------------------
     if '%strip%' == 'strip' (
-        powershell %ScriptFolder%StripAdditionalPlatformsFromNuspec.ps1 -nuspec %scriptFolder%%nuspecFile% -outFile %targetNuspec% -slices %slices% %3 %4 %5 %6
+        powershell -NoProfile %ScriptFolder%StripAdditionalPlatformsFromNuspec.ps1 -nuspec %scriptFolder%%nuspecFile% -outFile %targetNuspec% -slices %slices% %3 %4 %5 %6
     ) else (
         copy %scriptFolder%%nuspecFile% %targetNuspec% /y
     )


### PR DESCRIPTION
This change adds the -NoProfile option to powershell invocations from build scripts. 
This makes these build scripts more robust as user install extensions will not be loaded automatically giving a minor perf improvement but more importnatly promotes reliable reproducable builds as user installed extensions can't cause the scripts to fail or worse alter the output unexpectedly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6078)