### PR TITLE
Fix activation startup issue

### DIFF
--- a/change/react-native-windows-2020-09-24-08-50-17-fix-activation-startup-issue.json
+++ b/change/react-native-windows-2020-09-24-08-50-17-fix-activation-startup-issue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Activation startup for new processes",
+  "packageName": "react-native-windows",
+  "email": "ryan.fowler@singlewire.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T14:50:17.401Z"
+}

--- a/vnext/template/cs-app/src/App.xaml.cs
+++ b/vnext/template/cs-app/src/App.xaml.cs
@@ -47,5 +47,24 @@ namespace {{ namespace }}
             frame.Navigate(typeof(MainPage));
             Window.Current.Activate();
         }
+
+        /// <summary>
+        /// Invoked when the application is launched by something other than normally by the
+        /// end user. The list of activation types is specified in the
+        ///  Windows.ApplicationModel.Activation.ActivationKind enum.
+        ///  </summary> 
+        ///  <param name="e">Details about the activation event.</param>
+        protected override void OnActivated(IActivatedEventArgs e)
+        {
+            base.OnActivated(e);
+            var frame = Window.Current.Content as Frame;
+            // If the application is activating from a not running state,
+            // we want to navigate to the main page and activate the window.
+            if (frame.GetNavigationState().Equals("1,0"))
+            {
+                frame.Navigate(typeof(MainPage));
+                Window.Current.Activate();
+            }
+        }
     }
 }


### PR DESCRIPTION
This is missing a cpp version but I'd like to make sure you think I'm on the right track before spending more time on that template.

Without this change, the executable just exits if activation happens to a not-running application.

I pushed a sample app that lets you send a toast and mess with launching from that toast here: https://github.com/ryfow/rnwtoastactivation

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6086)