### PR TITLE
Enable new Integration Test Framework in CI

### DIFF
--- a/.ado/templates/integration-test-job.yml
+++ b/.ado/templates/integration-test-job.yml
@@ -1,0 +1,113 @@
+parameters:
+  name: ''
+  BuildPlatform: x64
+
+jobs:
+  - job: ${{ parameters.name }}
+    displayName: Integration Test
+    dependsOn: Setup
+    condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
+
+    pool:
+      vmImage: $(VmImage)
+
+    variables:
+      BuildLogDirectory:  $(Build.BinariesDirectory)\$(BuildPlatform)\BuildLogs
+
+    timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 1 # the depth of commits to ask Git to fetch
+        submodules: false
+            
+      - template: prepare-env.yml
+
+      - script: .ado\SetupLocalDumps.cmd integrationtest
+        displayName: Set LocalDumps
+
+      # The build is more likely to crash after we've started other bits that
+      # take up memory. Do the expensive parts of the build first.
+      - script: yarn windows --no-launch --no-packager --no-deploy --no-autolink --arch ${{ parameters.BuildPlatform }} --logging --buildLogDirectory $(BuildLogDirectory)
+        displayName: yarn windows --no-launch
+        workingDirectory: packages/IntegrationTest
+
+      # This will normally be run during tests if it isn't already, but running
+      # it before helps avoid our window from being obscured.
+      - powershell: Start-Process CheckNetIsolation.exe -ArgumentList "LoopbackExempt","-is" -Verb runAs
+        displayName: Exempt loopback server
+
+      - powershell: Start-Process npm -ArgumentList "run","start"
+        displayName: Start packager
+        workingDirectory: packages/IntegrationTest
+
+      # Instance load may time out if the packager takes too long to return a
+      # bundle. Request the bundle ahead of time so that the instance will get
+      # it back quickly.
+      - powershell: |
+          while ($true) {
+            try {
+              Invoke-WebRequest -Uri "http://localhost:8081/index.bundle?platform=windows&dev=true"
+              break
+            } catch [Exception] {
+              echo $_.Exception
+              Start-Sleep -s 1
+            }
+          }
+        displayName: Warm packager
+
+      # If a debugger isn't connected to the packager, the CLI will launch the
+      # default browser to go there. On Windows Server that means launching IE
+      # with a bunch of restrictions. Explicitly launch Chrome to the debugger
+      # UI instead.
+      - powershell: Start-Process chrome http://localhost:8081/debugger-ui/
+        displayName: Launch debugger-ui
+
+      # There's a slight race condition here, where we assume Chrome will open
+      # before this launches the app. This step takes ~1m on CI machines so it
+      # shouldn't be a practical concern.
+      - script: yarn windows --no-build --no-packager --no-autolink --arch ${{ parameters.BuildPlatform }} --logging
+        displayName: yarn windows --no-build
+        workingDirectory: packages/IntegrationTest
+
+      - powershell: |
+          $wshell = New-Object -ComObject wscript.shell
+          $wshell.AppActivate('integrationtest')
+        displayName: Activate test window
+
+      # Wait a brief moment before taking a screenshot to give the bundle a chance to load
+      - powershell: Start-Sleep -s 5
+        displayName: Pause before screenshot
+
+      - script: yarn take-screenshot --filename $(Build.StagingDirectory)/Screenshots/before-test.png
+        displayName: Screenshot desktop before tests
+        condition: succeededOrFailed()
+
+      - script: yarn integration-test
+        displayName: yarn integration-test
+        workingDirectory: packages/IntegrationTest
+
+      - script: yarn take-screenshot --filename $(Build.StagingDirectory)/Screenshots/after-test.png
+        displayName: Screenshot desktop after tests
+        condition: succeededOrFailed()
+
+      - task: PublishPipelineArtifact@1
+        displayName: Upload targets
+        inputs:
+          artifactName: Targets - IntegrationTest-$(System.JobAttempt)
+          targetPath: packages/IntegrationTest/windows/${{ parameters.BuildPlatform }}/Debug/integrationtest
+        condition: failed()
+
+      - task: PublishPipelineArtifact@1
+        displayName: Upload screenshots
+        inputs:
+          artifactName: Screenshots - IntegrationTest-$(System.JobAttempt)
+          targetPath: $(Build.StagingDirectory)/Screenshots
+        condition: succeededOrFailed()
+
+      - template: upload-build-logs.yml
+        parameters:
+          buildLogDirectory: '$(BuildLogDirectory)'
+          condition: succeededOrFailed()

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -79,3 +79,4 @@ steps:
 
   - powershell: |
         Write-Host "##vso[task.setvariable variable=MSBUILDDEBUGPATH]$(Build.StagingDirectory)\CrashDumps"
+    displayName: Set MSBUILDDEBUGPATH

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -719,7 +719,12 @@ jobs:
         inputs:
           script: yarn api
 
-  - template: templates/e2e-test-job.yml # Template reference
+  - template: templates/e2e-test-job.yml
     parameters:
       name: E2ETest
+      BuildPlatform: x64
+
+  - template: templates/integration-test-job.yml
+    parameters:
+      name: IntegrationTest
       BuildPlatform: x64

--- a/change/@rnw-scripts-take-screenshot-2020-09-24-01-00-03-integration-test-ci.json
+++ b/change/@rnw-scripts-take-screenshot-2020-09-24-01-00-03-integration-test-ci.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add Script to Screenshot Desktop",
+  "packageName": "@rnw-scripts/take-screenshot",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T08:00:03.515Z"
+}

--- a/packages/@rnw-scripts/take-screenshot/.eslintrc.js
+++ b/packages/@rnw-scripts/take-screenshot/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['@rnw-scripts'],
+  parserOptions: {tsconfigRootDir : __dirname},
+};

--- a/packages/@rnw-scripts/take-screenshot/.gitignore
+++ b/packages/@rnw-scripts/take-screenshot/.gitignore
@@ -1,0 +1,2 @@
+lib/
+lib-commonjs/

--- a/packages/@rnw-scripts/take-screenshot/bin.js
+++ b/packages/@rnw-scripts/take-screenshot/bin.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+// Yarn will fail to link workspace binaries if they haven't been built yet. Add
+// a simple JS file to forward to the CLI which is built after install.
+require('./lib-commonjs/takeScreenshot');

--- a/packages/@rnw-scripts/take-screenshot/just-task.js
+++ b/packages/@rnw-scripts/take-screenshot/just-task.js
@@ -1,0 +1,1 @@
+require('@rnw-scripts/just-task');

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@rnw-scripts/take-screenshot",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "lint": "just-scripts lint",
+    "lint:fix": "just-scripts lint:fix",
+    "watch": "just-scripts watch"
+  },
+  "bin": {
+    "take-screenshot": "./bin.js"
+  },
+  "dependencies": {
+    "screenshot-desktop": "^1.12.2",
+    "yargs": "^15.3.1"
+  },
+  "devDependencies": {
+    "@rnw-scripts/eslint-config": "0.1.3",
+    "@rnw-scripts/just-task": "0.0.4",
+    "@rnw-scripts/ts-config": "0.1.0",
+    "@types/yargs": "^15.0.5",
+    "eslint": "6.8.0",
+    "just-scripts": "^0.36.1",
+    "typescript": "^3.8.3"
+  },
+  "beachball": {
+    "disallowedChangeTypes": [
+      "major"
+    ]
+  },
+  "files": [
+    "bin.js",
+    "lib-commonjs"
+  ]
+}

--- a/packages/@rnw-scripts/take-screenshot/src/takeScreenshot.ts
+++ b/packages/@rnw-scripts/take-screenshot/src/takeScreenshot.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yargs from 'yargs';
+
+const screenshot = require('screenshot-desktop');
+
+const {filename} = yargs.options({
+  filename: {
+    describe: 'Where to place the screenshot',
+    type: 'string',
+    demandOption: true,
+  },
+}).argv;
+
+fs.mkdirSync(path.dirname(filename), {recursive: true});
+screenshot({filename});

--- a/packages/@rnw-scripts/take-screenshot/tsconfig.json
+++ b/packages/@rnw-scripts/take-screenshot/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@rnw-scripts/ts-config",
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/IntegrationTest/runner/lib/IntegrationTestRunner.ts
+++ b/packages/IntegrationTest/runner/lib/IntegrationTestRunner.ts
@@ -6,7 +6,6 @@
  */
 
 import * as ora from 'ora';
-import * as prettyFormat from 'pretty-format';
 import * as psList from 'ps-list';
 
 import {execSync} from 'child_process';
@@ -29,12 +28,15 @@ export default class IntegrationTestRunner {
       component: startingComponent,
     });
 
-    if (res.status !== 'okay') {
-      throw new Error(
-        `Unexpected response going to initial test page: ${prettyFormat(res)}`,
+    if (res.status === 'error') {
+      failWithoutContext(`Error going to initial component: "${res.message}"`);
+    } else if (res.status !== 'okay') {
+      failWithoutContext(
+        `Unexpected response going to initial component: ${JSON.stringify(
+          res,
+        )}`,
       );
     }
-
     return new IntegrationTestRunner(testClient);
   }
 
@@ -60,7 +62,7 @@ export default class IntegrationTestRunner {
 
     switch (res.status) {
       case 'error':
-        failWithoutContext(`Error from test host: ${res.message}`);
+        failWithoutContext(`Error from test host: "${res.message}"`);
         break;
 
       case 'exception':
@@ -92,7 +94,9 @@ export default class IntegrationTestRunner {
         break;
 
       case 'timeout':
-        failWithoutContext('The test timed out without providing a result');
+        failWithoutContext(
+          'The test timed out without seeing an exception or TestModule result',
+        );
         break;
 
       case 'passed':
@@ -100,7 +104,9 @@ export default class IntegrationTestRunner {
         break;
 
       default:
-        throw new Error(`Unexpected response to test command: ${res}`);
+        throw new Error(
+          `Unexpected response to test command: ${JSON.stringify(res)}`,
+        );
     }
   }
 

--- a/packages/IntegrationTest/tests/MountComponentTests.tsx
+++ b/packages/IntegrationTest/tests/MountComponentTests.tsx
@@ -94,16 +94,22 @@ componentTest(
 // Need a real implementaion here once we supoprt Modal
 componentTest.skip('Modal', mountAndMeasure(RN.Modal));
 
-componentTest(
-  'Picker',
-  mountAndMeasure(
+componentTest('Picker', props => {
+  if ((RN.Platform.Version as number) < 8) {
+    props.pass();
+    return <RN.View />;
+  }
+
+  const PickerTestComponent = mountAndMeasure(
     React.forwardRef<RN.Image>((_, ref) => (
       <RN.Picker ref={ref}>
         <RN.Picker.Item label="foo" value="bar" />
       </RN.Picker>
     )),
-  ),
-);
+  );
+
+  return <PickerTestComponent {...props} />;
+});
 
 componentTest(
   'Pressable',

--- a/packages/IntegrationTest/tests/MountComponentTests.tsx
+++ b/packages/IntegrationTest/tests/MountComponentTests.tsx
@@ -95,6 +95,8 @@ componentTest(
 componentTest.skip('Modal', mountAndMeasure(RN.Modal));
 
 componentTest('Picker', props => {
+  // Using AsyncStorage will YellowBox, which crashes on pre-1903 (including
+  // CI) trying to load an image (#6085)
   if ((RN.Platform.Version as number) < 8) {
     props.pass();
     return <RN.View />;

--- a/packages/IntegrationTest/tests/SampleTests.tsx
+++ b/packages/IntegrationTest/tests/SampleTests.tsx
@@ -28,6 +28,12 @@ functionTest.skip('FailingExample', () => {
  * Test methods can also be async
  */
 functionTest('AsyncNativeModuleExample', async () => {
+  // Using AsyncStorage will YellowBox, which crashes on pre-1903 (including
+  // CI) trying to load an image (#6085)
+  if (Platform.Version < 8) {
+    return;
+  }
+
   await AsyncStorage.clear();
   await AsyncStorage.setItem('foo', 'bar');
 
@@ -41,10 +47,8 @@ functionTest('AsyncNativeModuleExample', async () => {
 
 /**
  * Tests can be written as React Components which call callbacks
- *
- * Disabled due to pre-1903 image load crashes hitting CI (#6085)
  */
-componentTest.skip('ComponentExample', ({pass, fail}) => {
+componentTest('ComponentExample', ({pass, fail}) => {
   return (
     <Image
       source={require('react-native-windows/IntegrationTests/blue_square.png')}

--- a/packages/IntegrationTest/tests/SampleTests.tsx
+++ b/packages/IntegrationTest/tests/SampleTests.tsx
@@ -41,8 +41,10 @@ functionTest('AsyncNativeModuleExample', async () => {
 
 /**
  * Tests can be written as React Components which call callbacks
+ *
+ * Disabled due to pre-1903 image load crashes hitting CI (#6085)
  */
-componentTest('ComponentExample', ({pass, fail}) => {
+componentTest.skip('ComponentExample', ({pass, fail}) => {
   return (
     <Image
       source={require('react-native-windows/IntegrationTests/blue_square.png')}

--- a/packages/IntegrationTest/windows/integrationtest/App.cpp
+++ b/packages/IntegrationTest/windows/integrationtest/App.cpp
@@ -39,8 +39,7 @@ App::App() noexcept {
 
   PackageProviders().Append(make<ReactPackageProvider>()); // Includes all modules in this project
 
-  m_harness = winrt::make_self<IntegrationTest::TestHostHarness>();
-  m_harness->SetReactHost(Host());
+  m_harness = winrt::make_self<IntegrationTest::TestHostHarness>(Host());
 
   InitializeComponent();
 }

--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.cpp
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.cpp
@@ -14,66 +14,80 @@ using namespace winrt::integrationtest;
 using namespace winrt::Microsoft::ReactNative;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Data::Json;
+using namespace winrt::Windows::System;
 
 namespace IntegrationTest {
 
-TestHostHarness::TestHostHarness() noexcept {
+TestHostHarness::TestHostHarness(const ReactNativeHost &reactHost) noexcept
+    : m_dispatcher{ReactDispatcherHelper::UIThreadDispatcher()} {
+  VerifyElseCrash(m_dispatcher);
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   m_redboxHandler = winrt::make<TestHostHarnessRedboxHandler>(get_weak());
   m_commandListener = winrt::make_self<TestCommandListener>();
 
   m_commandListener->OnTestCommand([weakThis{get_weak()}](
       const TestCommand &command, TestCommandResponse response) noexcept {
     if (auto strongThis = weakThis.get()) {
-      strongThis->OnTestCommand(command, std::move(response));
+      strongThis->m_dispatcher.Post([ strongThis, command, response{std::move(response)} ]() mutable noexcept {
+        strongThis->OnTestCommand(command, std::move(response));
+      });
     }
   });
+
+  reactHost.InstanceSettings().RedBoxHandler(m_redboxHandler);
+  m_instanceLoadedRevoker = reactHost.InstanceSettings().InstanceLoaded(
+      winrt::auto_revoke, [weakThis{get_weak()}](const auto & /*sender*/, auto &&args) noexcept {
+        if (auto strongThis = weakThis.get()) {
+          strongThis->m_dispatcher.Post(
+              [ strongThis, args{std::move(args)} ]() noexcept { strongThis->OnInstanceLoaded(args); });
+        }
+      });
 }
 
 void TestHostHarness::SetRootView(ReactRootView &&rootView) noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   m_rootView = std::move(rootView);
 }
 
-void TestHostHarness::SetReactHost(ReactNativeHost &&reactHost) noexcept {
-  reactHost.InstanceSettings().RedBoxHandler(m_redboxHandler);
-  m_instanceLoadedRevoker = reactHost.InstanceSettings().InstanceLoaded(
-      winrt::auto_revoke, [weakThis{get_weak()}](const auto & /*sender*/, const auto &args) noexcept {
-        auto strongThis = weakThis.get();
-        if (!strongThis) {
-          return;
+void TestHostHarness::OnInstanceLoaded(const InstanceLoadedEventArgs &args) noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
+  if (!m_commandListener->IsListening()) {
+    StartListening();
+  }
+
+  ReactContext context(args.Context());
+  m_context = context;
+  m_instanceFailedToLoad = args.Failed();
+
+  context.Notifications().Subscribe(
+      TestModule::TestCompletedEvent(),
+      m_dispatcher,
+      [weakThis{get_weak()}](const auto & /*sender*/, ReactNotificationArgs<void> /*args*/) noexcept {
+        if (auto strongThis = weakThis.get()) {
+          if (strongThis->m_currentTransaction) {
+            strongThis->HandleHostAction(strongThis->m_currentTransaction->OnTestModuleTestCompleted());
+          }
         }
+      });
 
-        if (!strongThis->m_commandListener->IsListening()) {
-          strongThis->StartListening();
+  context.Notifications().Subscribe(
+      TestModule::TestPassedEvent(),
+      m_dispatcher,
+      [weakThis{get_weak()}](const auto & /*sender*/, ReactNotificationArgs<bool> args) noexcept {
+        if (auto strongThis = weakThis.get()) {
+          if (strongThis->m_currentTransaction) {
+            strongThis->HandleHostAction(strongThis->m_currentTransaction->OnTestModuleTestPassed(*args.Data()));
+          }
         }
-
-        ReactContext context(args.Context());
-        strongThis->m_context = context;
-
-        context.Notifications().Subscribe(
-            TestModule::TestCompletedEvent(),
-            context.UIDispatcher(),
-            [weakThis](const auto & /*sender*/, ReactNotificationArgs<void> /*args*/) noexcept {
-              if (auto strongThis = weakThis.get()) {
-                if (strongThis->m_currentTransaction) {
-                  strongThis->HandleHostAction(strongThis->m_currentTransaction->OnTestModuleTestCompleted());
-                }
-              }
-            });
-
-        context.Notifications().Subscribe(
-            TestModule::TestPassedEvent(),
-            context.UIDispatcher(),
-            [weakThis](const auto & /*sender*/, ReactNotificationArgs<bool> args) noexcept {
-              if (auto strongThis = weakThis.get()) {
-                if (strongThis->m_currentTransaction) {
-                  strongThis->HandleHostAction(strongThis->m_currentTransaction->OnTestModuleTestPassed(*args.Data()));
-                }
-              }
-            });
       });
 }
 
 winrt::fire_and_forget TestHostHarness::StartListening() noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   auto listenResult = co_await m_commandListener->StartListening();
 
   switch (listenResult) {
@@ -95,11 +109,18 @@ winrt::fire_and_forget TestHostHarness::StartListening() noexcept {
 }
 
 winrt::fire_and_forget TestHostHarness::OnTestCommand(TestCommand command, TestCommandResponse response) noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   // Keep ourselves alive while we have a test command
   auto strongThis = get_strong();
 
   if (m_pendingResponse) {
     response.Error("Received a test command while still processing the previous");
+    co_return;
+  }
+
+  if (m_instanceFailedToLoad) {
+    response.Error("The instance failed to load");
     co_return;
   }
 
@@ -134,6 +155,8 @@ winrt::fire_and_forget TestHostHarness::OnTestCommand(TestCommand command, TestC
 }
 
 winrt::fire_and_forget TestHostHarness::TimeoutOnInactivty(winrt::weak_ref<TestTransaction> transaction) noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   constexpr auto CommandTimeout = 20s;
 
   auto weakThis = get_weak();
@@ -149,6 +172,8 @@ winrt::fire_and_forget TestHostHarness::TimeoutOnInactivty(winrt::weak_ref<TestT
 }
 
 winrt::fire_and_forget TestHostHarness::HandleHostAction(HostAction action) noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   switch (action) {
     case HostAction::Continue:
       break;
@@ -173,9 +198,11 @@ winrt::fire_and_forget TestHostHarness::HandleHostAction(HostAction action) noex
 }
 
 IAsyncAction TestHostHarness::FlushJSQueue() noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   winrt::handle signal(CreateEvent(nullptr, false, false, nullptr));
 
-  m_context.JSDispatcher().Post([&signal, uiDispatcher{m_context.UIDispatcher()} ]() noexcept {
+  m_context.JSDispatcher().Post([&signal, uiDispatcher{m_dispatcher} ]() noexcept {
     uiDispatcher.Post([&signal]() noexcept { SetEvent(signal.get()); });
   });
 
@@ -183,6 +210,8 @@ IAsyncAction TestHostHarness::FlushJSQueue() noexcept {
 }
 
 void TestHostHarness::ShowJSError(std::string_view err) noexcept {
+  VerifyElseCrash(m_dispatcher.HasThreadAccess());
+
   m_context.CallJSFunction(L"RCTLog", L"logToConsole", "error", err);
 }
 
@@ -214,10 +243,7 @@ void TestHostHarnessRedboxHandler::DismissRedBox() noexcept {
 template <typename TFunc>
 void TestHostHarnessRedboxHandler::QueueToUI(TFunc &&func) noexcept {
   if (auto strongHarness = m_weakHarness.get()) {
-    if (strongHarness->m_context) {
-      strongHarness->m_context.UIDispatcher().Post(
-          [ strongHarness, func{std::move(func)} ]() noexcept { func(*strongHarness); });
-    }
+    strongHarness->m_dispatcher.Post([ strongHarness, func{std::move(func)} ]() noexcept { func(*strongHarness); });
   }
 }
 

--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
@@ -19,13 +19,13 @@ class TestHostHarness : public winrt::implements<TestHostHarness, winrt::Windows
   friend class TestHostHarnessRedboxHandler;
 
  public:
-  TestHostHarness() noexcept;
+  TestHostHarness(const winrt::Microsoft::ReactNative::ReactNativeHost &reactHost) noexcept;
 
   void SetRootView(winrt::Microsoft::ReactNative::ReactRootView &&rootView) noexcept;
-  void SetReactHost(winrt::Microsoft::ReactNative::ReactNativeHost &&reactHost) noexcept;
 
  private:
   void ShowJSError(std::string_view err) noexcept;
+  void OnInstanceLoaded(const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) noexcept;
   winrt::fire_and_forget StartListening() noexcept;
   winrt::fire_and_forget OnTestCommand(TestCommand command, TestCommandResponse response) noexcept;
   winrt::fire_and_forget TimeoutOnInactivty(winrt::weak_ref<TestTransaction> transaction) noexcept;
@@ -41,6 +41,11 @@ class TestHostHarness : public winrt::implements<TestHostHarness, winrt::Windows
   winrt::com_ptr<TestTransaction> m_currentTransaction;
   winrt::Microsoft::ReactNative::IRedBoxHandler m_redboxHandler;
   std::optional<TestCommandResponse> m_pendingResponse;
+
+  bool m_instanceFailedToLoad{false};
+
+  // Note: this may be accessed by other threads
+  const winrt::Microsoft::ReactNative::ReactDispatcher m_dispatcher;
 };
 
 //! Redbox handler which feeds into the TestHostHarness to communicate exceptions to the test runner

--- a/packages/IntegrationTest/windows/integrationtest/integrationtest.vcxproj
+++ b/packages/IntegrationTest/windows/integrationtest/integrationtest.vcxproj
@@ -15,9 +15,7 @@
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
-    <PackageCertificateKeyFile>integrationtest_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <PackageCertificateThumbprint>006EBE45F57E03EABB522A925433187D31F21373</PackageCertificateThumbprint>
-    <PackageCertificatePassword>password</PackageCertificatePassword>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">

--- a/yarn.lock
+++ b/yarn.lock
@@ -11785,7 +11785,7 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pinkie-promise@^2.0.0:
+pinkie-promise@^2.0.0, pinkie-promise@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
   integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
@@ -12871,6 +12871,14 @@ scheduler@^0.15.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+screenshot-desktop@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/screenshot-desktop/-/screenshot-desktop-1.12.2.tgz#7f45f247ee14fc31a11cd027967b278aaee74f07"
+  integrity sha512-0MdHZgWsojyJ5NzCPISrNqArfuygkrZuhpcqisYg/6JqoqV7qoDFLP5ZNqH1TpZoLbFDTqjZwuIMI+0dsHLRdg==
+  dependencies:
+    pinkie-promise "^2.0.1"
+    temp "^0.9.0"
+
 sec@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sec/-/sec-1.0.0.tgz#033d60a3ad20ecf2e00940d14f97823465774335"
@@ -13783,6 +13791,13 @@ temp@^0.8.1:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.4.tgz#8c97a33a4770072e0a05f919396c7665a7dd59f2"
   integrity sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==
+  dependencies:
+    rimraf "~2.6.2"
+
+temp@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.1.tgz#2d666114fafa26966cd4065996d7ceedd4dd4697"
+  integrity sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==
   dependencies:
     rimraf "~2.6.2"
 


### PR DESCRIPTION
This change enables the new tests to run in CI. In this process we found a few issues with both RNW and the framework. For the framework, we fixup an issue where we accidentally run code on the wrong thread (and add thread checks), add some clearer error messages, and add a specific error message if the instance fails to load instead of timing out.

Apart from built-in measures to show signal for when things go wrong, we add a utility to screenshot the CI desktop and run it before and after tests. We also upload crash dumps, and CI built symbols on failure for cases where we see native crashes.

## Design considerations

- **Debug vs Release:** We run the debug build of the app to help catch extra assertions and build a binary who should be easier to debug if failures show up. Things are quick enough that there aren't performance implications in doing this, but it might be worth running in release as well in the future for more coverage.
- **New job vs combination with existing**: This adds enough build time that it makes sense to be its own slice, especially if we see any instability that would cause needing to trigger multiple times.
- **Packaged vs Bundler:** We don't get accurate sourcemaps when bundling. Using a packager helps with that instead,
- **Inline CI scripts vs separate:** The CI steps for integration tests aren't representative of the normal process, so there isn't much use of separate scripts. We do  more inline with the YAML instead for clarity.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6087)