### PR TITLE
Add -UseBasicParsing to all powershell Invoke-WebRequest calls to avoid dependency on IE

### DIFF
--- a/.ado/VSComponentList.ps1
+++ b/.ado/VSComponentList.ps1
@@ -9,7 +9,7 @@ $installationPath = . $installerPath\vswhere.exe -latest -property installationP
 $vsconfig = "$dir\vsconfig"
 Write-Host "VSConfig will be at $vsconfig"
 
-Invoke-WebRequest -Uri 'https://download.visualstudio.microsoft.com/download/pr/c4fef23e-cc45-4836-9544-70e213134bc8/1ee5717e9a1e05015756dff77eb27d554a79a6db91f2716d836df368381af9a1/vs_Enterprise.exe' -OutFile $dir\vs_enterprise.exe
+Invoke-WebRequest -UseBasicParsing -Uri 'https://download.visualstudio.microsoft.com/download/pr/c4fef23e-cc45-4836-9544-70e213134bc8/1ee5717e9a1e05015756dff77eb27d554a79a6db91f2716d836df368381af9a1/vs_Enterprise.exe' -OutFile $dir\vs_enterprise.exe
 $p = Start-Process -PassThru $dir\vs_enterprise.exe -RedirectStandardError $dir\err -RedirectStandardOutput $dir\out -ArgumentList "export --installpath `"$installationPath`" --quiet --config $vsconfig" 
 $p.WaitForExit()
 $x = [Datetime]::Now.AddSeconds(60)

--- a/.ado/templates/integration-test-job.yml
+++ b/.ado/templates/integration-test-job.yml
@@ -49,7 +49,7 @@ jobs:
       - powershell: |
           while ($true) {
             try {
-              Invoke-WebRequest -Uri "http://localhost:8081/index.bundle?platform=windows&dev=true"
+              Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/index.bundle?platform=windows&dev=true"
               break
             } catch [Exception] {
               echo $_.Exception

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -452,7 +452,7 @@ jobs:
         displayName: Check the metro bundle server
         inputs:
           targetType: 'inline'
-          script: Invoke-WebRequest -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true"
+          script: Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true"
 
       - task: VSTest@2
         displayName: Run Desktop Integration Tests

--- a/change/react-native-windows-2020-09-24-09-10-11-master.json
+++ b/change/react-native-windows-2020-09-24-09-10-11-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add -UseBasicParsing to all powershell Invoke-WebRequest calls to avoid dependency on IE",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T16:10:11.701Z"
+}

--- a/vnext/Microsoft.ReactNative/getLayoutProps.ps1
+++ b/vnext/Microsoft.ReactNative/getLayoutProps.ps1
@@ -1,5 +1,5 @@
 # This script produces the values for the layoutProperties vector
 # in TestHook.cpp
-$page = Invoke-WebRequest "https://reactnative.dev/docs/layout-props"
+$page = Invoke-WebRequest -UseBasicParsing "https://reactnative.dev/docs/layout-props"
 $lines = $page.Content.Split('</a><code>') | select -skip 1
 $lines -replace ('\n','')  -replace ('</code>.*', '') | % { Write-Host "`"$_`", "}

--- a/vnext/Scripts/IntegrationTests.ps1
+++ b/vnext/Scripts/IntegrationTests.ps1
@@ -80,7 +80,7 @@ if (! $NoServers) {
 		Start-Sleep -Seconds $Delay
 
 		# Preload the RNTesterApp integration bundle for better performance in integration tests.
-		Invoke-WebRequest -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true" | Out-Null
+		Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true" | Out-Null
 	}
 }
 

--- a/vnext/Scripts/Tfs/Install-VSFeatures.ps1
+++ b/vnext/Scripts/Tfs/Install-VSFeatures.ps1
@@ -30,7 +30,9 @@ $UseWebInstaller = $UseWebInstaller -or -not (Test-Path -Path "$LocalVsInstaller
 if ($UseWebInstaller) {
 	Write-Host "Downloading web installer..."
 
-	Invoke-WebRequest -Method Get `
+	Invoke-WebRequest `
+		-UseBasicParsing `
+		-Method Get `
 		-Uri $InstallerUri `
 		-OutFile $VsInstaller
 
@@ -90,7 +92,9 @@ if ($UseWebInstaller) {
 }
 
 if ($Collect) {
-	Invoke-WebRequest -Method Get `
+	Invoke-WebRequest `
+		-UseBasicParsing `
+		-Method Get `
 		-Uri 'https://download.microsoft.com/download/8/3/4/834E83F6-C377-4DCE-A757-69A418B6C6DF/Collect.exe' `
 		-OutFile ${env:System_DefaultWorkingDirectory}\Collect.exe
 

--- a/vnext/Scripts/Tfs/Start-TestServers.ps1
+++ b/vnext/Scripts/Tfs/Start-TestServers.ps1
@@ -39,7 +39,7 @@ if ($Preload) {
 	Start-Sleep -Seconds $SleepSeconds
 
 	# Preload the RNTesterApp integration bundle for better performance in integration tests.
-	Invoke-WebRequest -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true" | Out-Null
+	Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true" | Out-Null
 
 	Write-Host 'Done preloading bundles.'
 }

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -212,7 +212,7 @@ $requirements = @(
             # don't install from choco as we need an exact version match. appium-windows-driver checks the checksum of WAD.
             # See \node_modules\appium-windows-driver\build\lib\installer.js
             $ProgressPreference = 'Ignore';
-            Invoke-WebRequest https://github.com/microsoft/WinAppDriver/releases/download/v1.1/WindowsApplicationDriver.msi  -OutFile $env:TEMP\WindowsApplicationDriver.msi
+            Invoke-WebRequest -UseBasicParsing https://github.com/microsoft/WinAppDriver/releases/download/v1.1/WindowsApplicationDriver.msi -OutFile $env:TEMP\WindowsApplicationDriver.msi
             & $env:TEMP\WindowsApplicationDriver.msi /q
         };
         Optional = $true;


### PR DESCRIPTION
Without this flag PowerShell relies on IE to perform downloads. On server images with IE security enhancements this will fail unless they are disabled....

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6088)