### PR TITLE
Fix second oncreate

### DIFF
--- a/change/react-native-windows-2020-09-25-14-02-31-fix-second-oncreate.json
+++ b/change/react-native-windows-2020-09-25-14-02-31-fix-second-oncreate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't reload the ReactNativeHost multiple times",
+  "packageName": "react-native-windows",
+  "email": "ryan.fowler@singlewire.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T20:02:31.788Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -182,7 +182,8 @@ void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivate
 
   // Do not repeat app initialization when the Window already has content,
   // just ensure that the window is active
-  if (rootFrame == nullptr) {
+  bool previouslyInitialized = (rootFrame != nullptr);
+  if (!previouslyInitialized) {
     // Create a Frame to act as the navigation context and associate it with
     // a SuspensionManager key
     rootFrame = Frame();
@@ -198,8 +199,10 @@ void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivate
 
   ApplyArguments(Host(), args.c_str());
 
-  // Nudge the ReactNativeHost to create the instance and wrapping context
-  Host().ReloadInstance();
+  if (!previouslyInitialized) {
+    // Nudge the ReactNativeHost to create the instance and wrapping context
+    Host().ReloadInstance();
+  }
 
   Window::Current().Activate();
 }


### PR DESCRIPTION
When OnCreate is called via OnActivate on an already-running instance,
the Host should not be reloaded so we don't lose the native modules.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6099)