### PR TITLE
Treat toast argument as launch uri queryString

### DIFF
--- a/change/react-native-windows-2020-09-25-14-24-25-treat-toast-argument-as-launch-uri.json
+++ b/change/react-native-windows-2020-09-25-14-24-25-treat-toast-argument-as-launch-uri.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Let Toast actions open URIs in the application",
+  "packageName": "react-native-windows",
+  "email": "ryan.fowler@singlewire.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T20:24:25.120Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -105,12 +105,7 @@ void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActiv
     react::uwp::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
   } else if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::ToastNotification) {
     auto toastActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ToastNotificationActivatedEventArgs>()};
-    try {
-      Windows::Foundation::Uri u{toastActivatedEventArgs.Argument()};
-      react::uwp::LinkingManagerModule::OpenUri(u);
-    } catch (...) {
-      // Don't crash, but also don't let the application know what the toast argument was.
-    }
+    Windows::Foundation::Uri u{L"toast:///?" + toastActivatedEventArgs.Argument()};
   }
   this->OnCreate(e);
 }

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -103,6 +103,14 @@ void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActiv
   if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
     auto protocolActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
     react::uwp::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
+  } else if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::ToastNotification) {
+    auto toastActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ToastNotificationActivatedEventArgs>()};
+    try {
+      Windows::Foundation::Uri u{toastActivatedEventArgs.Argument()};
+      react::uwp::LinkingManagerModule::OpenUri(u);
+    } catch (...) {
+      // Don't crash, but also don't let the application know what the toast argument was.
+    }
   }
   this->OnCreate(e);
 }


### PR DESCRIPTION
If a Toast activates the application, try to treat the
argument as a URI in order to send the argument to JS
via react-native.Linking.

This solves the specific Toast case of #5852 but does not address other types of activation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6100)