### PR TITLE
Add some basic telemetry collection

### DIFF
--- a/change/@react-native-windows-cli-2020-09-26-01-27-12-telemetry.json
+++ b/change/@react-native-windows-cli-2020-09-26-01-27-12-telemetry.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add telemetry to react-native-windows CLI",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-26T08:26:53.444Z"
+}

--- a/change/react-native-windows-init-2020-09-26-01-27-12-telemetry.json
+++ b/change/react-native-windows-init-2020-09-26-01-27-12-telemetry.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add telemetry to react-native-windows CLI",
+  "packageName": "react-native-windows-init",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-26T08:27:12.809Z"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -17,6 +17,7 @@
     "watch": "just-scripts watch"
   },
   "dependencies": {
+    "applicationinsights": "^1.8.7",
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -252,11 +252,11 @@ export function tryFindPropertyValue(
 export function findPropertyValue(
   projectContents: Node,
   propertyName: string,
-  path: string,
+  filePath: string,
 ): string {
   const res = tryFindPropertyValue(projectContents, propertyName);
   if (!res) {
-    throw new Error(`Couldn't find property ${propertyName} from ${path}`);
+    throw new Error(`Couldn't find property ${propertyName} from ${filePath}`);
   }
   return res;
 }

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -232,7 +232,7 @@ export function readProjectFile(projectPath: string) {
  * @param propertyName The property to look for.
  * @return The value of the tag if it exists.
  */
-export function findPropertyValue(
+export function tryFindPropertyValue(
   projectContents: Node,
   propertyName: string,
 ): string | null {
@@ -247,6 +247,18 @@ export function findPropertyValue(
   }
 
   return null;
+}
+
+export function findPropertyValue(
+  projectContents: Node,
+  propertyName: string,
+  path: string,
+): string {
+  const res = tryFindPropertyValue(projectContents, propertyName);
+  if (!res) {
+    throw new Error(`Couldn't find property ${propertyName} from ${path}`);
+  }
+  return res;
 }
 
 /**
@@ -275,8 +287,8 @@ export function importProjectExists(
  */
 export function getProjectName(projectContents: Node): string {
   const name =
-    findPropertyValue(projectContents, 'ProjectName') ||
-    findPropertyValue(projectContents, 'AssemblyName') ||
+    tryFindPropertyValue(projectContents, 'ProjectName') ||
+    tryFindPropertyValue(projectContents, 'AssemblyName') ||
     '';
 
   return name;
@@ -288,7 +300,7 @@ export function getProjectName(projectContents: Node): string {
  * @return The project namespace.
  */
 export function getProjectNamespace(projectContents: Node): string | null {
-  return findPropertyValue(projectContents, 'RootNamespace');
+  return tryFindPropertyValue(projectContents, 'RootNamespace');
 }
 
 /**
@@ -297,5 +309,5 @@ export function getProjectNamespace(projectContents: Node): string | null {
  * @return The project guid.
  */
 export function getProjectGuid(projectContents: Node): string | null {
-  return findPropertyValue(projectContents, 'ProjectGuid');
+  return tryFindPropertyValue(projectContents, 'ProjectGuid');
 }

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -140,7 +140,7 @@ export async function copyProjectTemplateAndReplace(
   // Similar to the above, but we want to retain namespace separators
   if (projectType === 'lib') {
     namespace = namespace
-      .split(/[\.\:]+/)
+      .split(/[.:]+/)
       .map(pascalCase)
       .join('.');
   }
@@ -190,7 +190,11 @@ export async function copyProjectTemplateAndReplace(
     {paths: [process.cwd()]},
   );
   const winui3Props = readProjectFile(winui3PropsPath);
-  const winui3Version = findPropertyValue(winui3Props, 'WinUI3Version', winui3PropsPath);
+  const winui3Version = findPropertyValue(
+    winui3Props,
+    'WinUI3Version',
+    winui3PropsPath,
+  );
 
   const csNugetPackages: NugetPackage[] = [
     {

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -190,10 +190,7 @@ export async function copyProjectTemplateAndReplace(
     {paths: [process.cwd()]},
   );
   const winui3Props = readProjectFile(winui3PropsPath);
-  const winui3Version = findPropertyValue(winui3Props, 'WinUI3Version');
-  if (winui3Version === null) {
-    throw new Error('Unable to find WinUI3 version from property sheets');
-  }
+  const winui3Version = findPropertyValue(winui3Props, 'WinUI3Version', winui3PropsPath);
 
   const csNugetPackages: NugetPackage[] = [
     {

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -7,16 +7,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as findUp from 'find-up';
-
+import {randomBytes} from 'crypto';
 import * as appInsights from 'applicationinsights';
 
 appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
 const telClient = appInsights.defaultClient;
 if (!telClient.commonProperties.sessionId) {
-  telClient.commonProperties['sessionId'] = (new Date()).getTime().toString(36) + Math.random().toString(36).slice(2);
+  telClient.commonProperties.sessionId = randomBytes(16).toString('hex');
 }
 if (process.env.RNW_CLI_TEST) {
-  telClient.commonProperties['isTest'] = process.env.RNW_CLI_TEST;
+  telClient.commonProperties.isTest = process.env.RNW_CLI_TEST;
 }
 
 import {
@@ -28,7 +28,6 @@ import {autoLinkCommand} from './runWindows/utils/autolink';
 import {runWindowsCommand} from './runWindows/runWindows';
 import {dependencyConfigWindows} from './config/dependencyConfig';
 import {projectConfigWindows} from './config/projectConfig';
-
 
 /**
  * Project generation options
@@ -66,8 +65,8 @@ function scrubOptions(opt: GenerateOptions) {
     language: opt.language,
     projectType: opt.projectType,
     experimentalNuGetDependency: opt.experimentalNuGetDependency,
-    nuGetTestFeed: (opt.nuGetTestFeed !== undefined) ? true : false,
-    nuGetTestVersion: (opt.nuGetTestVersion !== undefined) ? true : false,
+    nuGetTestFeed: opt.nuGetTestFeed !== undefined ? true : false,
+    nuGetTestVersion: opt.nuGetTestVersion !== undefined ? true : false,
     useWinUI3: opt.useWinUI3,
     useHermes: opt.useHermes,
     verbose: opt.verbose,
@@ -111,7 +110,7 @@ export async function generateWindows(
     );
   } catch (e) {
     error = e;
-    telClient.trackException({ exception: error });
+    telClient.trackException({exception: error});
     throw e;
   } finally {
     if (!options.noTelemetry && !process.env.AGENT_NAME) {

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -19,7 +19,7 @@ import {projectConfigWindows} from './config/projectConfig';
 
 import * as appInsights from 'applicationinsights';
 
-appInsights.setup('a7b9ed40-e2a4-4166-bf80-230540f4dcff').start();
+appInsights.setup('a7b9ed40-e2a4-4166-bf80-230540f4dcff');
 const telClient = appInsights.defaultClient;
 
 /**
@@ -91,7 +91,7 @@ export async function generateWindows(
     error = e;
     throw e;
   } finally {
-    if (!options.noTelemetry || process.env.AGENT_NAME) {
+    if (!options.noTelemetry && !process.env.AGENT_NAME) {
       const cwd = process.cwd();
       const pkgJsonPath = findUp.sync('package.json', {cwd});
       let rnVersion = '';

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -19,10 +19,8 @@ import {projectConfigWindows} from './config/projectConfig';
 
 import * as appInsights from 'applicationinsights';
 
-console.log('setting up telemetry client');
 appInsights.setup('a7b9ed40-e2a4-4166-bf80-230540f4dcff').start();
-let client = appInsights.defaultClient;
-console.log('done');
+const telClient = appInsights.defaultClient;
 
 /**
  * Project generation options
@@ -67,7 +65,7 @@ export async function generateWindows(
   ns: string,
   options: GenerateOptions,
 ) {
-  let success = false;
+  let error;
   try {
     if (!fs.existsSync(projectDir)) {
       fs.mkdirSync(projectDir);
@@ -88,7 +86,9 @@ export async function generateWindows(
       ns,
       options,
     );
-    success = true;
+  } catch (e) {
+    error = e;
+    throw e;
   } finally {
     const cwd = process.cwd();
     const pkgJsonPath = findUp.sync('package.json', {cwd});
@@ -101,16 +101,16 @@ export async function generateWindows(
         rnVersion = pkgJson.dependencies['react-native'];
       }
     }
-    client.trackEvent({
+    telClient.trackEvent({
       name: 'generate-windows',
       properties: {
-        success: success,
+        error: error,
         ...options,
         'react-native': rnVersion,
       },
     });
 
-    client.flush();
+    telClient.flush();
   }
 }
 

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -7,6 +7,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as findUp from 'find-up';
+
+import * as appInsights from 'applicationinsights';
+
+appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
+const telClient = appInsights.defaultClient;
+
 import {
   copyProjectTemplateAndReplace,
   installDependencies,
@@ -17,10 +23,6 @@ import {runWindowsCommand} from './runWindows/runWindows';
 import {dependencyConfigWindows} from './config/dependencyConfig';
 import {projectConfigWindows} from './config/projectConfig';
 
-import * as appInsights from 'applicationinsights';
-
-appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
-const telClient = appInsights.defaultClient;
 
 /**
  * Project generation options
@@ -50,6 +52,20 @@ export interface GenerateOptions {
   useHermes: boolean;
   verbose: boolean;
   noTelemetry: boolean;
+}
+
+function scrubOptions(opt: GenerateOptions) {
+  return {
+    overwrite: opt.overwrite,
+    language: opt.language,
+    projectType: opt.projectType,
+    experimentalNuGetDependency: opt.experimentalNuGetDependency,
+    nuGetTestFeed: opt.nuGetTestFeed ? true : false,
+    nuGetTestVersion: opt.nuGetTestVersion ? true : false,
+    useWinUI3: opt.useWinUI3,
+    useHermes: opt.useHermes,
+    verbose: opt.verbose,
+  };
 }
 
 /**
@@ -109,11 +125,12 @@ export async function generateWindows(
 
       const rnwPkgJson = require('../package.json');
 
+      const optScrubbed = scrubOptions(options);
       telClient.trackEvent({
         name: 'generate-windows',
         properties: {
           error: error,
-          ...options,
+          ...optScrubbed,
           'react-native': rnVersion,
           'cli-version': rnwPkgJson.version,
         },

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -15,6 +15,9 @@ const telClient = appInsights.defaultClient;
 if (!telClient.commonProperties.sessionId) {
   telClient.commonProperties['sessionId'] = (new Date()).getTime().toString(36) + Math.random().toString(36).slice(2);
 }
+if (process.env.RNW_CLI_TEST) {
+  telClient.commonProperties['isTest'] = process.env.RNW_CLI_TEST;
+}
 
 import {
   copyProjectTemplateAndReplace,

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -130,7 +130,7 @@ export async function generateWindows(
         }
       }
 
-      const rnwPkgJson = require('../package.json');
+      const rnwCliPkgJson = require('../package.json');
 
       const optScrubbed = scrubOptions(options);
       telClient.trackEvent({
@@ -139,7 +139,7 @@ export async function generateWindows(
           error: error,
           ...optScrubbed,
           'react-native': rnVersion,
-          'cli-version': rnwPkgJson.version,
+          'cli-version': rnwCliPkgJson.version,
         },
       });
 

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -12,6 +12,9 @@ import * as appInsights from 'applicationinsights';
 
 appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
 const telClient = appInsights.defaultClient;
+if (!telClient.commonProperties.sessionId) {
+  telClient.commonProperties['sessionId'] = (new Date()).getTime().toString(36) + Math.random().toString(36).slice(2);
+}
 
 import {
   copyProjectTemplateAndReplace,
@@ -60,8 +63,8 @@ function scrubOptions(opt: GenerateOptions) {
     language: opt.language,
     projectType: opt.projectType,
     experimentalNuGetDependency: opt.experimentalNuGetDependency,
-    nuGetTestFeed: opt.nuGetTestFeed ? true : false,
-    nuGetTestVersion: opt.nuGetTestVersion ? true : false,
+    nuGetTestFeed: (opt.nuGetTestFeed !== undefined) ? true : false,
+    nuGetTestVersion: (opt.nuGetTestVersion !== undefined) ? true : false,
     useWinUI3: opt.useWinUI3,
     useHermes: opt.useHermes,
     verbose: opt.verbose,

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -91,7 +91,7 @@ export async function generateWindows(
     error = e;
     throw e;
   } finally {
-    if (!options.noTelemetry || process.env.AGENT_JOBID) {
+    if (!options.noTelemetry || process.env.AGENT_NAME) {
       const cwd = process.cwd();
       const pkgJsonPath = findUp.sync('package.json', {cwd});
       let rnVersion = '';

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -19,7 +19,7 @@ import {projectConfigWindows} from './config/projectConfig';
 
 import * as appInsights from 'applicationinsights';
 
-appInsights.setup('a7b9ed40-e2a4-4166-bf80-230540f4dcff');
+appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
 const telClient = appInsights.defaultClient;
 
 /**

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -85,7 +85,7 @@ export interface GenerateOptions {
   useWinUI3: boolean;
   useHermes: boolean;
   verbose: boolean;
-  noTelemetry: boolean;
+  telemetry: boolean;
 }
 
 function scrubOptions(opt: GenerateOptions) {
@@ -142,7 +142,7 @@ export async function generateWindows(
     telClient.trackException({exception: error});
     throw e;
   } finally {
-    if (!options.noTelemetry && !process.env.AGENT_NAME) {
+    if (options.telemetry && !process.env.AGENT_NAME) {
       const cwd = process.cwd();
       const pkgJsonPath = findUp.sync('package.json', {cwd});
       let rnVersion = '';

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -108,6 +108,7 @@ export async function generateWindows(
     );
   } catch (e) {
     error = e;
+    telClient.trackException({ exception: error });
     throw e;
   } finally {
     if (!options.noTelemetry && !process.env.AGENT_NAME) {

--- a/packages/react-native-windows-init/README.md
+++ b/packages/react-native-windows-init/README.md
@@ -15,9 +15,14 @@ npx react-native-windows-init --language cpp
 Options:
 | option      | description                                    | type                                             |
 |-------------|------------------------------------------------|--------------------------------------------------|
-| --help      | Show help                                      | [boolean]                                        |
-| --version   | The version of react-native-windows to use.    | [string]                                         |
-| --namespace | The native project namespace.                  | [string]                                         |
-| --verbose   | Enables logging.                               | [boolean]                                        |
-| --language  | Which language the app is written in.          | [string] [choices: "cs", "cpp"] [default: "cpp"] |
-| --overwrite | Overwrite any existing files without prompting | [boolean]                                        |
+| `--help`      | Show help                                      | [boolean]                                        |
+| `--version`   | The version of react-native-windows to use.    | [string]                                         |
+| `--namespace` | The native project namespace.                  | [string]                                         |
+| `--verbose`   | Enables logging.                               | [boolean]                                        |
+| `--language`  | Which language the app is written in.          | [string] [choices: "cs", "cpp"] [default: "cpp"] |
+| `--overwrite` | Overwrite any existing files without prompting | [boolean]                                        |
+| `--noTelemetry` | Disables sending telemetry that allows analysis of failures of the react-native-windows CLI | [boolean] |
+
+
+## Data Collection
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/packages/react-native-windows-init/README.md
+++ b/packages/react-native-windows-init/README.md
@@ -26,3 +26,5 @@ Options:
 
 ## Data Collection
 The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+
+This data collection notice only applies to the process of **creating** a new React Native for Windows app with the CLI.

--- a/packages/react-native-windows-init/README.md
+++ b/packages/react-native-windows-init/README.md
@@ -21,7 +21,7 @@ Options:
 | `--verbose`   | Enables logging.                               | [boolean]                                        |
 | `--language`  | Which language the app is written in.          | [string] [choices: "cs", "cpp"] [default: "cpp"] |
 | `--overwrite` | Overwrite any existing files without prompting | [boolean]                                        |
-| `--noTelemetry` | Disables sending telemetry that allows analysis of failures of the react-native-windows CLI | [boolean] |
+| `--no-telemetry` | Disables sending telemetry that allows analysis of failures of the react-native-windows CLI | [boolean] |
 
 
 ## Data Collection

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -18,6 +18,7 @@
     "react-native-windows-init": "./bin.js"
   },
   "dependencies": {
+    "applicationinsights": "^1.8.7",
     "chalk": "^4.1.0",
     "mustache": "^4.0.1",
     "npm-registry": "^0.1.13",

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -442,7 +442,7 @@ function installReactNativeWindows(
 function isMSFTInternal(): boolean {
   return (
     process.env.USERDNSDOMAIN !== undefined &&
-    process.env.USERDNSDOMAIN.endsWith('microsoft.com')
+    process.env.USERDNSDOMAIN.endsWith('.microsoft.com')
   );
 }
 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -114,11 +114,11 @@ const argv = yargs
       describe: 'Enables logging.',
       default: false,
     },
-    noTelemetry: {
+    telemetry: {
       type: 'boolean',
       describe:
-        'Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI',
-      default: false,
+        'Controls sending telemetry that allows analysis of usage and failures of the react-native-windows CLI',
+      default: true,
     },
     language: {
       type: 'string',
@@ -187,7 +187,7 @@ if (argv.verbose) {
   console.log(argv);
 }
 
-if (argv.noTelemetry || process.env.AGENT_NAME) {
+if (!argv.telemetry || process.env.AGENT_NAME) {
   if (argv.verbose) {
     console.log('Disabling telemetry');
   }
@@ -625,7 +625,7 @@ function isProjectUsingYarn(cwd: string): boolean {
       useHermes: argv.useHermes,
       nuGetTestVersion: argv.nuGetTestVersion,
       nuGetTestFeed: argv.nuGetTestFeed,
-      noTelemetry: argv.noTelemetry,
+      telemetry: argv.telemetry,
     });
     return setExit(ExitCode.SUCCESS);
   } catch (error) {

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -409,6 +409,16 @@ function isMSFTInternal(): boolean {
   return process.env.USERDNSDOMAIN !== undefined && process.env.USERDNSDOMAIN.endsWith('microsoft.com');
 }
 
+function getRNWInitVersion(): string {
+  try {
+    const pkgJson = require('../package.json');
+    if (pkgJson.name === 'react-native-windows-init' && pkgJson.version !== undefined) {
+      return pkgJson.version;
+    }
+  } catch { }
+  return '';
+}
+
 function setExit(exitCode: ExitCode, error?: String): void {
   if (!process.exitCode || process.exitCode === ExitCode.SUCCESS) {
     telClient.trackEvent({
@@ -417,6 +427,7 @@ function setExit(exitCode: ExitCode, error?: String): void {
         durationInSecs: process.uptime(),
         msftInternal: isMSFTInternal(),
         exitCode: ExitCode[exitCode],
+        rnwinitVersion: getRNWInitVersion(),
         errorMessage: error,
       },
     });

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -316,7 +316,7 @@ function installReactNativeWindows(
     }
   } else if (!version) {
     internalError(
-      'Unexpected error ecountered. If you are able, please file an issue on: https://github.com/microsoft/react-native-windows/issues/new/choose',
+      'Unexpected error encountered. If you are able, please file an issue on: https://github.com/microsoft/react-native-windows/issues/new/choose',
     );
   }
 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -28,6 +28,9 @@ import * as appInsights from 'applicationinsights';
 appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
 const telClient = appInsights.defaultClient;
 telClient.commonProperties['sessionId'] = (new Date()).getTime().toString(36) + Math.random().toString(36).slice(2);
+if (process.env.RNW_CLI_TEST) {
+  telClient.commonProperties['isTest'] = process.env.RNW_CLI_TEST;
+}
 
 import requireGenerateWindows from './requireGenerateWindows';
 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -405,12 +405,17 @@ function installReactNativeWindows(
   );
 }
 
+function isMSFTInternal(): boolean {
+  return process.env.USERDNSDOMAIN !== undefined && process.env.USERDNSDOMAIN.endsWith('microsoft.com');
+}
+
 function setExit(exitCode: ExitCode, error?: String): void {
   if (!process.exitCode || process.exitCode === ExitCode.SUCCESS) {
     telClient.trackEvent({
       name: 'init-exit',
       properties: {
         durationInSecs: process.uptime(),
+        msftInternal: isMSFTInternal(),
         exitCode: ExitCode[exitCode],
         errorMessage: error,
       },

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -152,7 +152,7 @@ if (argv.verbose) {
   console.log(argv);
 }
 
-if (argv.noTelemetry || process.env.AGENT_JOBID) {
+if (argv.noTelemetry || process.env.AGENT_NAME) {
   telClient.config.disableAppInsights = true;
 }
 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -27,7 +27,7 @@ import * as appInsights from 'applicationinsights';
  * See https://github.com/microsoft/ApplicationInsights-node.js/issues/580
  */
 
-appInsights.setup('a7b9ed40-e2a4-4166-bf80-230540f4dcff');
+appInsights.setup('795006ca-cf54-40ee-8bc6-03deb91401c3');
 const telClient = appInsights.defaultClient;
 
 const npmConfReg = execSync('npm config get registry')

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -402,7 +402,7 @@ function installReactNativeWindows(
 }
 
 function setExit(exitCode: ExitCode, error?: String): void {
-  if (!process.exitCode || process.exitCode == ExitCode.SUCCESS) {
+  if (!process.exitCode || process.exitCode === ExitCode.SUCCESS) {
     telClient.trackEvent({
       name: 'init-exit',
       properties: {
@@ -573,7 +573,7 @@ function isProjectUsingYarn(cwd: string): boolean {
       error instanceof UserError
         ? (error as UserError).exitCode
         : ExitCode.UNKNOWN_ERROR;
-    if (exitCode != ExitCode.SUCCESS) {
+    if (exitCode !== ExitCode.SUCCESS) {
       console.error(chalk.red(error.message));
       console.error(error);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3903,6 +3903,16 @@ appium@1.14.1:
   optionalDependencies:
     fsevents "2.x"
 
+applicationinsights@^1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.8.7.tgz#f98774b2da03fdb95afb9d9042ae9d6f10025db6"
+  integrity sha512-+HENzPBdSjnWL9mc+9o+j9pEaVNI4WsH5RNvfmRLfwQYvbJumcBi4S5bUzclug5KCcFP0S4bYJOmm9MV3kv2GA==
+  dependencies:
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "0.3.1"
+    diagnostic-channel-publishers "0.4.1"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -4209,10 +4219,12 @@ async-exit-hook@^2.0.1:
   resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
   integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
 
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
 
 async-listener@^0.6.0:
   version "0.6.10"
@@ -5115,6 +5127,15 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -5411,7 +5432,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-continuation-local-storage@3.x:
+continuation-local-storage@3.x, continuation-local-storage@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
   integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
@@ -5999,6 +6020,18 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
+diagnostic-channel-publishers@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.1.tgz#a1147ee0d5a4a06cd2b0795433bc1aee1dbc9801"
+  integrity sha512-NpZ7IOVUfea/kAx4+ub4NIYZyRCSymjXM5BZxnThs3ul9gAKqjm7J8QDDQW3Ecuo2XxjNLoWLeKmrPUWKNZaYw==
+
+diagnostic-channel@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz#7faa143e107f861be3046539eb4908faab3f53fd"
+  integrity sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==
+  dependencies:
+    semver "^5.3.0"
+
 diagnostics@1.0.x:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.0.1.tgz#accdb080c82bb25d0dd73430a9e6a87fbb431541"
@@ -6146,7 +6179,7 @@ emits@3.0.x:
   resolved "https://registry.yarnpkg.com/emits/-/emits-3.0.0.tgz#32752bba95e1707b219562384ab9bb8b1fd62f70"
   integrity sha1-MnUrupXhcHshlWI4Srm7ix/WL3A=
 
-emitter-listener@^1.1.1:
+emitter-listener@^1.0.1, emitter-listener@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
   integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
@@ -13241,6 +13274,11 @@ ssri@^6.0.0, ssri@^6.0.1:
   integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
   dependencies:
     figgy-pudding "^3.5.1"
+
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 stack-trace@0.0.x:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4226,6 +4226,11 @@ async-hook-jl@^1.7.6:
   dependencies:
     stack-chain "^1.3.7"
 
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
 async-listener@^0.6.0:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"


### PR DESCRIPTION
This starts adding some telemetry so we can learn about when/how the CLI is failing. I'm starting off with adding it to the project generation scenario, with similar logic to be added to run-windows.

Fixes #5183

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6103)