### PR TITLE
Rethread After Resuming Timeout Coroutine

### DIFF
--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.cpp
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.cpp
@@ -154,21 +154,26 @@ winrt::fire_and_forget TestHostHarness::OnTestCommand(TestCommand command, TestC
   }
 }
 
-winrt::fire_and_forget TestHostHarness::TimeoutOnInactivty(winrt::weak_ref<TestTransaction> transaction) noexcept {
+winrt::fire_and_forget TestHostHarness::TimeoutOnInactivty(winrt::weak_ref<TestTransaction> weakTransaction) noexcept {
   VerifyElseCrash(m_dispatcher.HasThreadAccess());
 
   constexpr auto CommandTimeout = 20s;
 
+  auto dispatcher = m_dispatcher;
   auto weakThis = get_weak();
   co_await CommandTimeout;
 
-  if (auto strongTransaction = transaction.get()) {
-    if (auto strongThis = weakThis.get()) {
-      if (m_currentTransaction == strongTransaction) {
-        HandleHostAction(m_currentTransaction->OnTimeout());
+  // co_awaiting a timespan calls winrt::resume_after, which uses
+  // CreateThreadPoolTimer and will not resume us back on the same thread.
+  dispatcher.Post([ weakTransaction, weakThis ]() noexcept {
+    if (auto strongTransaction = weakTransaction.get()) {
+      if (auto strongThis = weakThis.get()) {
+        if (strongThis->m_currentTransaction == strongTransaction) {
+          strongThis->HandleHostAction(strongThis->m_currentTransaction->OnTimeout());
+        }
       }
     }
-  }
+  });
 }
 
 winrt::fire_and_forget TestHostHarness::HandleHostAction(HostAction action) noexcept {

--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.cpp
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.cpp
@@ -169,7 +169,7 @@ winrt::fire_and_forget TestHostHarness::TimeoutOnInactivty(winrt::weak_ref<TestT
     if (auto strongTransaction = weakTransaction.get()) {
       if (auto strongThis = weakThis.get()) {
         if (strongThis->m_currentTransaction == strongTransaction) {
-          strongThis->HandleHostAction(strongThis->m_currentTransaction->OnTimeout());
+          strongThis->HandleHostAction(strongTransaction->OnTimeout());
         }
       }
     }

--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
@@ -28,7 +28,7 @@ class TestHostHarness : public winrt::implements<TestHostHarness, winrt::Windows
   void OnInstanceLoaded(const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) noexcept;
   winrt::fire_and_forget StartListening() noexcept;
   winrt::fire_and_forget OnTestCommand(TestCommand command, TestCommandResponse response) noexcept;
-  winrt::fire_and_forget TimeoutOnInactivty(winrt::weak_ref<TestTransaction> weakTransaction) noexcept;
+  winrt::fire_and_forget TimeoutOnInactivty(winrt::weak_ref<TestTransaction> transaction) noexcept;
   winrt::fire_and_forget HandleHostAction(HostAction action) noexcept;
 
   winrt::Windows::Foundation::IAsyncAction FlushJSQueue() noexcept;

--- a/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
+++ b/packages/IntegrationTest/windows/integrationtest/TestHostHarness.h
@@ -28,7 +28,7 @@ class TestHostHarness : public winrt::implements<TestHostHarness, winrt::Windows
   void OnInstanceLoaded(const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) noexcept;
   winrt::fire_and_forget StartListening() noexcept;
   winrt::fire_and_forget OnTestCommand(TestCommand command, TestCommandResponse response) noexcept;
-  winrt::fire_and_forget TimeoutOnInactivty(winrt::weak_ref<TestTransaction> transaction) noexcept;
+  winrt::fire_and_forget TimeoutOnInactivty(winrt::weak_ref<TestTransaction> weakTransaction) noexcept;
   winrt::fire_and_forget HandleHostAction(HostAction action) noexcept;
 
   winrt::Windows::Foundation::IAsyncAction FlushJSQueue() noexcept;


### PR DESCRIPTION
Fixes #6108

We added thread checks to TestHostHarness which has UI thread affinity. This led to crashes on test timeout instead of a graceful error message, stemmed from our timeout coroutine being resumed on a different thread. Rethread after resuming the coroutine.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6109)