### PR TITLE
Free Up Some Memory for react-native-init CI Jobs

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -122,6 +122,10 @@ steps:
       workingDirectory: $(Agent.BuildDirectory)\testcli
     condition: and(succeeded(), ${{ not(parameters.useNuGet) }})
 
+  # Reclaim memory used by Verdaccio to reduce the chance of build OOM issues
+  - script: tskill node
+    displayName: Kill Verdaccio
+
   - task: PowerShell@2
     displayName: List Visual Studio Components
     inputs:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -125,6 +125,7 @@ steps:
   # Reclaim memory used by Verdaccio to reduce the chance of build OOM issues
   - script: tskill node
     displayName: Kill Verdaccio
+    condition: succeededOrFailed()
 
   - task: PowerShell@2
     displayName: List Visual Studio Components
@@ -200,15 +201,6 @@ steps:
 
   # We are experiencing random package restore failures.
   # We want to uploading the vedaccio logs to aid in diagnosing if it is verdaccio or npmjs.org
-  # To do so we have to kill the existing server because it keeps a file-lock on the log file
-  - task: PowerShell@2
-    displayName: Stop test npm server (verdaccio) to upload it's logs (on failure)
-    inputs:
-      targetType: inline
-      script: |
-        stop-process -name node
-    condition: failed()
-
   - task: PublishPipelineArtifact@1
     displayName: Upload Verdaccio.log (on failure)
     inputs:


### PR DESCRIPTION
For the integration test job I discovered we get  more reliable builds if we do build-work when daemons are not active. For react-native-init tests, we don't need Verdaccio by the time we're ready to build, so we can kill it to reclaim a bit of memory.

Testing locally, Verdaccio without any packages seems to use ~50MB while idle, which is enough to be worth reclaiming, but less than I had hoped for. Not sure if the number would be different when packages are present.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6111)