### PR TITLE
Remove Special UI When Debugger Attached

### DIFF
--- a/change/react-native-windows-2020-09-27-07-13-43-remove-debug-backbutton.json
+++ b/change/react-native-windows-2020-09-27-07-13-43-remove-debug-backbutton.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Special UI When Debugger Attached",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-27T14:13:43.227Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -156,14 +156,6 @@ void ApplyArguments(ReactNative::ReactNativeHost const &host, std::wstring const
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
 void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
-#if defined _DEBUG
-  if (IsDebuggerPresent()) {
-    this->DebugSettings().EnableFrameRateCounter(TRUE);
-
-    SystemNavigationManager::GetForCurrentView().AppViewBackButtonVisibility(AppViewBackButtonVisibility::Visible);
-  }
-#endif
-
   bool isPrelaunchActivated = false;
   if (auto prelauchActivatedArgs = e.try_as<Windows::ApplicationModel::Activation::IPrelaunchActivatedEventArgs>()) {
     isPrelaunchActivated = prelauchActivatedArgs.PrelaunchActivated();


### PR DESCRIPTION
When discussed internally, we thought this was confusing. These were carryovers from legacy, with the back button especially odd since we had it before we had a BackHandler. Removing both the debugger only back button, and debugger only frame counter that are automatically added.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6112)