### PR TITLE
Reduce Microsoft.ReactNative PCH By 155MB-260MB

### DIFF
--- a/change/react-native-windows-2020-09-27-10-42-45-reduce-pch.json
+++ b/change/react-native-windows-2020-09-27-10-42-45-reduce-pch.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Reduce Microsoft.ReactNative PCH By 155MB-260MB",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-27T17:42:45.125Z"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -699,7 +699,6 @@
   <Target Name="InjecForcedXamlIncludes" BeforeTargets="CompileXamlGeneratedFiles" >
     <ItemGroup>
       <ClCompile Condition="'%(ClCompile.CompilerIteration)' == 'XamlGenerated'">
-        <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
         <ForcedIncludeFiles>%(ForcedIncludeFiles);winrt/Microsoft.UI.Xaml.Controls.h;winrt/Microsoft.UI.Xaml.XamlTypeInfo.h</ForcedIncludeFiles>
       </ClCompile>
     </ItemGroup>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -702,7 +702,5 @@
         <ForcedIncludeFiles>%(ForcedIncludeFiles);winrt/Microsoft.UI.Xaml.Controls.h;winrt/Microsoft.UI.Xaml.XamlTypeInfo.h</ForcedIncludeFiles>
       </ClCompile>
     </ItemGroup>
-
-    <Message Importance="High" Text="Test"/>
   </Target>
 </Project>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -696,7 +696,7 @@
   </Target>
 
   <!-- https://github.com/microsoft/microsoft-ui-xaml/issues/3133 -->
-  <Target Name="InjecForcedXamlIncludes" BeforeTargets="CompileXamlGeneratedFiles" >
+  <Target Name="InjectForcedXamlIncludes" BeforeTargets="CompileXamlGeneratedFiles" >
     <ItemGroup>
       <ClCompile Condition="'%(ClCompile.CompilerIteration)' == 'XamlGenerated'">
         <ForcedIncludeFiles>%(ForcedIncludeFiles);winrt/Microsoft.UI.Xaml.Controls.h;winrt/Microsoft.UI.Xaml.XamlTypeInfo.h</ForcedIncludeFiles>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -694,4 +694,16 @@
     <Error Condition="'$(Source)'==''" Text="To generate a pre-processed file, please specify a source file with msbuild /p:Source=nameOfTheSource.cpp" />
     <CL PreprocessToFile="true" Sources="$(Source)" AdditionalIncludeDirectories="%(ClCompile.AdditionalIncludeDirectories)" PreprocessorDefinitions="%(ClCompile.PreprocessorDefinitions)" AdditionalOptions="%(ClCompile.AdditionalOptions) /d1PP" PreprocessKeepComments="true" PreprocessOutputPath="$(Source.Replace('.cpp', '.pp'))" />
   </Target>
+
+  <!-- https://github.com/microsoft/microsoft-ui-xaml/issues/3133 -->
+  <Target Name="InjecForcedXamlIncludes" BeforeTargets="CompileXamlGeneratedFiles" >
+    <ItemGroup>
+      <ClCompile Condition="'%(ClCompile.CompilerIteration)' == 'XamlGenerated'">
+        <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+        <ForcedIncludeFiles>%(ForcedIncludeFiles);winrt/Microsoft.UI.Xaml.Controls.h;winrt/Microsoft.UI.Xaml.XamlTypeInfo.h</ForcedIncludeFiles>
+      </ClCompile>
+    </ItemGroup>
+
+    <Message Importance="High" Text="Test"/>
+  </Target>
 </Project>

--- a/vnext/Microsoft.ReactNative/Pch/pch.h
+++ b/vnext/Microsoft.ReactNative/Pch/pch.h
@@ -53,7 +53,3 @@
 
 #include <activeObject/activeObject.h>
 #include <future/future.h>
-
-// https://github.com/microsoft/microsoft-ui-xaml/issues/3133
-#include <winrt/Microsoft.UI.Xaml.Controls.h>
-#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>


### PR DESCRIPTION
We see frequent OOM issues compiling our PCH due to its size. This change removes some of the heavier headers that are included in the PCH to get around XAML codegen issues and instead injects forced header inclusion into the CLCompile items used by XAML codegen. This is quite dirty, but should significantly reduce the increased OOM issues seen since adding these headers.

Goes from 1024MB to 869MB for normal builds
Goes from 1006 to 740MB for WinUI3 builds

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6114)