### PR TITLE
Fix run-windows Warnings Using Node 14

### DIFF
--- a/change/@react-native-windows-cli-2020-09-28-00-39-44-fix-node14.json
+++ b/change/@react-native-windows-cli-2020-09-28-00-39-44-fix-node14.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix run-windows Warnings Using Node 14",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T07:39:44.002Z"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -26,7 +26,7 @@
     "nuget-exe": "4.9.2",
     "ora": "^3.4.0",
     "semver": "^7.3.2",
-    "shelljs": "^0.7.8",
+    "shelljs": "^0.8.4",
     "username": "^5.1.0",
     "uuid": "^3.3.2",
     "xml-parser": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13079,10 +13079,10 @@ shelljs@0.8.x:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
run-windows prints out a large number of warnings on Node 14:

```
$ react-native run-windows
 √ Auto-linking...
Success: No auto-linking changes necessary. (181ms)
(node:10936) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:10936) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
(node:10936) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
```

These come from shelljs, and are fixed in [shelljs 0.8.4](https://github.com/shelljs/shelljs/releases/tag/v0.8.4)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6116)