### PR TITLE
Integrate RN 7/7 nightly build.

### DIFF
--- a/change/@office-iss-react-native-win32-2020-09-28-19-25-36-integrate_7_7.json
+++ b/change/@office-iss-react-native-win32-2020-09-28-19-25-36-integrate_7_7.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "integrate RN 7/7 build",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-29T02:25:32.767Z"
+}

--- a/change/react-native-windows-2020-09-28-19-25-36-integrate_7_7.json
+++ b/change/react-native-windows-2020-09-28-19-25-36-integrate_7_7.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "integrate RN 7/7 build",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-29T02:25:36.326Z"
+}

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "prompt-sync": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e",
+    "react-native": "0.0.0-e96f1e1d8",
     "react-native-windows": "0.0.0-canary.173"
   },
   "devDependencies": {

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e",
+    "react-native": "0.0.0-e96f1e1d8",
     "react-native-windows": "^0.0.0-canary.173"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e",
+    "react-native": "0.0.0-e96f1e1d8",
     "react-native-windows": "0.0.0-canary.173"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e",
+    "react-native": "0.0.0-e96f1e1d8",
     "react-native-windows": "0.0.0-canary.173"
   },
   "devDependencies": {

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -8,14 +8,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "7a6f6c114931f8459a2a4d84f86bb80ab7b07a13"
     },
     {
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -23,7 +23,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -31,7 +31,7 @@
       "type": "patch",
       "file": "src/Libraries/BatchedBridge/MessageQueue.win32.js",
       "baseFile": "Libraries/BatchedBridge/MessageQueue.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "2971684d702beed9825dca81523731c1852ba388",
       "issue": 5807
     },
@@ -39,7 +39,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "92d307268ed976bcbfdc880cbcadfbb27f61447c",
       "issue": "LEGACY_FIXME"
     },
@@ -47,7 +47,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "b3e2c37d96de6f00066495267f7c32d6e9d3f840",
       "issue": "LEGACY_FIXME"
     },
@@ -63,7 +63,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.win32.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea",
       "issue": 4378
     },
@@ -71,7 +71,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.win32.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc",
       "issue": 4378
     },
@@ -79,7 +79,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -91,7 +91,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.win32.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b",
       "issue": 4378
     },
@@ -103,7 +103,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerAndroid.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -111,7 +111,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerIOS.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6",
       "issue": 4378
     },
@@ -119,7 +119,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -127,14 +127,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.win32.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
       "issue": "LEGACY_FIXME"
     },
@@ -142,7 +142,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": 4378
     },
@@ -166,7 +166,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "4508091254e184ee4dfc383c091186ba6ed60f01",
       "issue": "LEGACY_FIXME"
     },
@@ -174,7 +174,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -182,7 +182,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.win32.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0",
       "issue": 4378
     },
@@ -214,7 +214,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
       "issue": "LEGACY_FIXME"
     },
@@ -222,7 +222,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -234,7 +234,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.win32.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "147459dc889f04f2405db051445833f791726895",
       "issue": 5843
     },
@@ -250,7 +250,7 @@
       "type": "patch",
       "file": "src/Libraries/core/ReactNativeVersionCheck.win32.js",
       "baseFile": "Libraries/core/ReactNativeVersionCheck.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "599ad6d6c8485cd453cd926cdf89f06640d439f6",
       "issue": 5170
     },
@@ -258,7 +258,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/Image.win32.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4320
     },
@@ -270,7 +270,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
       "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "6161ce89a0b45b24e8df69aa108af22a7b591483",
       "issue": 4320
     },
@@ -314,7 +314,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75",
       "issue": "LEGACY_FIXME"
     },
@@ -322,7 +322,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
       "baseFile": "Libraries/Inspector/InspectorOverlay.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "a1d045fb2d0fb751d8f0518fd40af63454b88b04",
       "issue": "LEGACY_FIXME"
     },
@@ -330,7 +330,7 @@
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxInspectorStackFrame.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "a1f75145b083be2bc83ddc240cadbcdf93931e0d",
       "issue": 5885
     },
@@ -338,7 +338,7 @@
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxStyle.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxStyle.js",
-      "baseVersion": "0.0.0-3346ac7f9",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "118cad1437e07c7cb6c5c1fc3bb927b0c4dd1d52",
       "issue": 5886
     },
@@ -346,7 +346,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworking.win32.js",
       "baseFile": "Libraries/Network/RCTNetworking.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "ede560ee51b68436768eca79166c4fb40a3cf20a",
       "issue": 4318
     },
@@ -366,7 +366,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -386,7 +386,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheet.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84",
       "issue": "LEGACY_FIXME"
     },
@@ -394,7 +394,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/BackHandler.win32.ts",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": "LEGACY_FIXME"
     },
@@ -402,7 +402,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
       "issue": "LEGACY_FIXME"
     },
@@ -410,7 +410,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
       "issue": "LEGACY_FIXME"
     },
@@ -418,7 +418,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5",
       "issue": "LEGACY_FIXME"
     },
@@ -426,7 +426,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f",
       "issue": "LEGACY_FIXME"
     },
@@ -442,7 +442,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.win32.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -450,7 +450,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": "LEGACY_FIXME"
     },
@@ -462,7 +462,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.win32.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -470,7 +470,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.win32.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -66,13 +66,13 @@
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.36.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e",
+    "react-native": "0.0.0-e96f1e1d8",
     "react-native-platform-override": "^0.2.8",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e"
+    "react-native": "0.0.0-e96f1e1d8"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/ReactCopies/RNTester/js/examples/View/ViewExample.js
+++ b/vnext/ReactCopies/RNTester/js/examples/View/ViewExample.js
@@ -442,6 +442,79 @@ exports.examples = [
     },
   },
   {
+    title: '`display: none` style',
+    render(): React.Node {
+      type Props = $ReadOnly<{||}>;
+      type State = {|
+        index: number,
+      |};
+
+      class DisplayNoneStyle extends React.Component<Props, State> {
+        state = {
+          index: 0,
+        };
+
+        render() {
+          return (
+            <TouchableWithoutFeedback onPress={this._handlePress}>
+              <View>
+                <Text style={{paddingBottom: 10}}>
+                  Press to toggle `display: none`
+                </Text>
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'red',
+                    display: this.state.index % 2 === 0 ? 'none' : 'flex',
+                  }}
+                />
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'blue',
+                    display: this.state.index % 3 === 0 ? 'none' : 'flex',
+                  }}
+                />
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'yellow',
+                    display: this.state.index % 5 === 0 ? 'none' : 'flex',
+                  }}>
+                  <View
+                    style={{
+                      height: 30,
+                      width: 30,
+                      backgroundColor: 'salmon',
+                      display: this.state.index % 11 === 0 ? 'none' : 'flex',
+                    }}
+                  />
+                </View>
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'magenta',
+                    display: this.state.index % 7 === 0 ? 'none' : 'flex',
+                  }}
+                />
+              </View>
+            </TouchableWithoutFeedback>
+          );
+        }
+
+        _handlePress = () => {
+          this.setState({index: this.state.index + 1});
+        };
+      }
+
+      return <DisplayNoneStyle />;
+    },
+  },
+  {
     title: 'BackfaceVisibility',
     render: function(): React.Node {
       return (

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -17,14 +17,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "7a6f6c114931f8459a2a4d84f86bb80ab7b07a13"
     },
     {
       "type": "patch",
       "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "fc9f1020bf6ea3ab580171bdb19e0b82df4f8d00",
       "issue": 3994
     },
@@ -32,7 +32,7 @@
       "type": "copy",
       "directory": "ReactCopies/IntegrationTests",
       "baseDirectory": "IntegrationTests",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "d59aae6476410d0994afd939c8ab9becf3d9dbaa",
       "issue": 4054
     },
@@ -40,15 +40,15 @@
       "type": "copy",
       "directory": "ReactCopies/RNTester/js",
       "baseDirectory": "RNTester/js",
-      "baseVersion": "0.0.0-a36d9cd7e",
-      "baseHash": "d2f05c9a8245653374f8de62766f382f359edf8f",
+      "baseVersion": "0.0.0-e96f1e1d8",
+      "baseHash": "c0c6c91d0ed71eb7ce8ea148aca7440da2dcbeeb",
       "issue": 4054
     },
     {
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/GenerateViewConfigJs.js",
       "baseFile": "packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "80aa1fe96412a5f027dbf5e3df3feddab91c3ccb",
       "issue": 5430
     },
@@ -56,7 +56,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/index.js",
       "baseFile": "packages/babel-plugin-inline-view-configs/index.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "02590f3430fb57fcd954357c9dbeeaa8bdc01d06",
       "issue": 5430
     },
@@ -64,7 +64,7 @@
       "type": "patch",
       "file": "src/babel-plugin-inline-view-configs/package.json",
       "baseFile": "packages/babel-plugin-inline-view-configs/package.json",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "8d37fac510a533c0badffacd9c3aa9c392fd58c6",
       "issue": 5430
     },
@@ -72,7 +72,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -100,7 +100,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -116,7 +116,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "92d307268ed976bcbfdc880cbcadfbb27f61447c",
       "issue": 4578
     },
@@ -124,7 +124,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Button.windows.js",
       "baseFile": "Libraries/Components/Button.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "3c1baecf9171422511a08436edd423c5da9cf5c2",
       "issue": "LEGACY_FIXME"
     },
@@ -136,7 +136,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windows.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
@@ -147,14 +147,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windows.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
@@ -185,14 +185,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windows.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Picker/Picker.windows.js",
       "baseFile": "Libraries/Components/Picker/Picker.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "ebfef6691cf4634daa34c025327f837d292ef44f",
       "issue": 4611
     },
@@ -200,14 +200,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerAndroid.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerIOS.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
@@ -218,7 +218,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
       "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "1a94e2e99474b15141d1c67c1211ac1dc2c2a62d",
       "issue": 4611
     },
@@ -234,21 +234,21 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windows.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45",
       "issue": "LEGACY_FIXME"
     },
@@ -256,7 +256,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
       "issue": "LEGACY_FIXME"
     },
@@ -264,7 +264,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
@@ -272,7 +272,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "4508091254e184ee4dfc383c091186ba6ed60f01",
       "issue": "LEGACY_FIXME"
     },
@@ -280,7 +280,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -288,14 +288,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912",
       "issue": "LEGACY_FIXME"
     },
@@ -303,7 +303,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95",
       "issue": "LEGACY_FIXME"
     },
@@ -311,7 +311,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "58698d349b3327660c71708f7128c2247caaef3f",
       "issue": "LEGACY_FIXME"
     },
@@ -319,7 +319,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -327,7 +327,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.windows.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "147459dc889f04f2405db051445833f791726895",
       "issue": 5843
     },
@@ -335,7 +335,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
       "baseFile": "Libraries/Components/View/ViewAccessibility.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
       "issue": "LEGACY_FIXME"
     },
@@ -343,7 +343,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
       "baseFile": "Libraries/Components/View/ViewPropTypes.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "2b12228aa1ab0e12844996a99ff5d38fbff689a1",
       "issue": "LEGACY_FIXME"
     },
@@ -359,7 +359,7 @@
       "type": "patch",
       "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
       "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
       "issue": "LEGACY_FIXME"
     },
@@ -367,7 +367,7 @@
       "type": "copy",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4590
     },
@@ -379,7 +379,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "fda9d378c3b67f4aa819fb9c4fb663f9b3227e06",
       "issue": "LEGACY_FIXME"
     },
@@ -387,7 +387,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
       "issue": "LEGACY_FIXME"
     },
@@ -395,7 +395,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
       "issue": "LEGACY_FIXME"
     },
@@ -403,7 +403,7 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "b7ab4262be21b1c2db00dd52e345529181c45aa8",
       "issue": 4379
     },
@@ -411,7 +411,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.windows.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -423,14 +423,14 @@
       "type": "derived",
       "file": "src/Libraries/Text/Text.windows.js",
       "baseFile": "Libraries/Text/Text.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "bf4306bd49457c2b82ee8f85147aa458505a5150"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e8f8ce02645228b423fdda317e5d1d9e69b54e6d",
       "issue": "LEGACY_FIXME"
     },
@@ -438,7 +438,7 @@
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.windows.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "2fbb5d988289f3678809dd440b15828df1bae56d",
       "issue": 4629
     },
@@ -446,14 +446,14 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "168fe4a9608c0b151237122eea94d78f7b0093e5"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.windows.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "bcaebbe089a41de46724b00e69fcdba7e6b1ed7f"
     },
     {
@@ -464,7 +464,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleList.windows.js",
       "baseFile": "RNTester/js/components/RNTesterExampleList.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "282bb1231e430fe2263a4cae29ac5d8254c0cab8",
       "issue": 5834
     },
@@ -476,7 +476,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/ScrollView/ScrollViewExample.windows.js",
       "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "e622893fe0a5ce9d48b10644cd29a38de72b6a26",
       "issue": "LEGACY_FIXME"
     },
@@ -484,7 +484,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/TextInput/TextInputExample.windows.js",
       "baseFile": "RNTester/js/examples/TextInput/TextInputExample.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "1755bffd6ae353838f1779007dc4a512b8dddcdc",
       "issue": 5688
     },
@@ -492,15 +492,15 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/View/ViewExample.windows.js",
       "baseFile": "RNTester/js/examples/View/ViewExample.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
-      "baseHash": "76d4a9914e731bffefefd3b0de90c97a1726e2a9",
+      "baseVersion": "0.0.0-e96f1e1d8",
+      "baseHash": "2425a6f8fb8b7c7633b5744811c75edf77f29c2f",
       "issue": "LEGACY_FIXME"
     },
     {
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.windows.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -508,7 +508,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.windows.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-a36d9cd7e",
+      "baseVersion": "0.0.0-e96f1e1d8",
       "baseHash": "20a6f5c42266beb017dccc7f22d45bde02907d89",
       "issue": "LEGACY_FIXME"
     },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -64,7 +64,7 @@
     "just-scripts": "^0.36.1",
     "prettier": "1.17.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e",
+    "react-native": "0.0.0-e96f1e1d8",
     "react-native-platform-override": "^0.2.8",
     "react-native-windows-codegen": "0.1.6",
     "react-refresh": "^0.4.0",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-a36d9cd7e"
+    "react-native": "0.0.0-e96f1e1d8"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/src/RNTester/js/examples/View/ViewExample.windows.js
+++ b/vnext/src/RNTester/js/examples/View/ViewExample.windows.js
@@ -442,7 +442,79 @@ exports.examples = [
     },
   },
   {
-    // [TODO(macOS ISS#2323203)
+    title: '`display: none` style',
+    render(): React.Node {
+      type Props = $ReadOnly<{||}>;
+      type State = {|
+        index: number,
+      |};
+
+      class DisplayNoneStyle extends React.Component<Props, State> {
+        state = {
+          index: 0,
+        };
+
+        render() {
+          return (
+            <TouchableWithoutFeedback onPress={this._handlePress}>
+              <View>
+                <Text style={{paddingBottom: 10}}>
+                  Press to toggle `display: none`
+                </Text>
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'red',
+                    display: this.state.index % 2 === 0 ? 'none' : 'flex',
+                  }}
+                />
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'blue',
+                    display: this.state.index % 3 === 0 ? 'none' : 'flex',
+                  }}
+                />
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'yellow',
+                    display: this.state.index % 5 === 0 ? 'none' : 'flex',
+                  }}>
+                  <View
+                    style={{
+                      height: 30,
+                      width: 30,
+                      backgroundColor: 'salmon',
+                      display: this.state.index % 11 === 0 ? 'none' : 'flex',
+                    }}
+                  />
+                </View>
+                <View
+                  style={{
+                    height: 50,
+                    width: 50,
+                    backgroundColor: 'magenta',
+                    display: this.state.index % 7 === 0 ? 'none' : 'flex',
+                  }}
+                />
+              </View>
+            </TouchableWithoutFeedback>
+          );
+        }
+
+        _handlePress = () => {
+          this.setState({index: this.state.index + 1});
+        };
+      }
+
+      return <DisplayNoneStyle />;
+    },
+  },
+  {
     title: 'ToolTip',
     render(): React.Node {
       return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -12198,12 +12198,11 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-a36d9cd7e:
-  version "0.0.0-a36d9cd7e"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-a36d9cd7e.tgz#862bf357a4ebed932e2b6b9119f849f3fd914b3d"
-  integrity sha512-kV8DKXQbOiPhtcCj0uY9Fm1x3q8sHOezHbdokEkHYj2276KCt4lSrYQBl6S4FOUrLpYRECIH1h4czFfa7aYgWA==
+react-native@0.0.0-e96f1e1d8:
+  version "0.0.0-e96f1e1d8"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-e96f1e1d8.tgz#343a83dd420a6162d787e5233c8f98ee68b6826c"
+  integrity sha512-lpIEDYXChuaxN26kGaGEXo2CjhDvx+Guv37y0il+vwAr/xyNSMfYHUDWG9b7NLaU0y0kWRbxMxUYkz0rWqgLqA==
   dependencies:
-    "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^4.10.0"
     "@react-native-community/cli-platform-android" "^4.10.0"
     "@react-native-community/cli-platform-ios" "^4.10.0"


### PR DESCRIPTION
## Changelog

Not much happening in this one - only had to reconcile ViewExample.windows.js - upstream added an example of using 'display': none, which created a conflict with the tooltip example below it. Could use a confirmation that the tooltip example should stay, It's annotated with: "// ]TODO(macOS ISS#2323203)" but I don't know how to locate the issue number (we make several references to it across the repo, btw).

### Breaking


#### iOS specific

- Remove CameraRoll from React Native ([824d3a9770](https://github.com/facebook/react-native/commit/824d3a977057b336d81237ec3cec3a49a9d5e34d) by [@seanyusa](https://github.com/seanyusa))

### Added


#### iOS specific

- `getRectWithAttributedString()` aims to get the rect of the fragment with embedded link, which is necessary when building the `accessibilityElement`. In this function, we first enumerate attributedString to find the range of fragments whose `accessibilityRole` is @"link". Then we calculate the rect of the fragment and send to the block and we would define what to do in the block in `RCTParagraphComponentAccessibilityProvider`. ([96708d58e4](https://github.com/facebook/react-native/commit/96708d58e4b413032f4e5ffcc71e8da67ef99ea0) by [@ZHUANGPP](https://github.com/ZHUANGPP))
- This is the first step to build RCTParagraphComponentAccessibilityProvider.  The main idea of RCTParagraphComponentAccessibilityProvider is to provide an array of accessible elements for the AttributedString in PCTParagraphComponentView. ([ffa07254de](https://github.com/facebook/react-native/commit/ffa07254de914f7876a17ec2d1ecac1dc10b116a) by [@ZHUANGPP](https://github.com/ZHUANGPP))

### Changed



#### Android specific

- Bump Gradle to 6.5 ([e559aee642](https://github.com/facebook/react-native/commit/e559aee64275126eaa135486e6bf09138be70f4d) by [@dulmandakh](https://github.com/dulmandakh))
- ViewCommands on Android now execute earlier, as a perf optimization. ([c6b9cc36da](https://github.com/facebook/react-native/commit/c6b9cc36da4f7d190d05122048aa4ada9c152b73) by [@JoshuaGross](https://github.com/JoshuaGross))


### Fixed


#### Android specific

- Fix crash when enabling debug ([8c42c01977](https://github.com/facebook/react-native/commit/8c42c019772ba373030558fdbc15b2470f1d7137) by [@devon94](https://github.com/devon94))
- Do not call setHyphenationFrequency on AndroidSdk < 23 ([7d8aeb4955](https://github.com/facebook/react-native/commit/7d8aeb4955a4101ca7e8e486f935309c21ab76ff) by [@fabriziobertoglio1987](https://github.com/fabriziobertoglio1987))

#### iOS specific

- Fix TurboModule eager init race ([103c863eaa](https://github.com/facebook/react-native/commit/103c863eaa325b191107e58d59c64243f67d37cd) by [@RSNara](https://github.com/RSNara))


### Unknown


#### iOS Unknown

- Correct JSRequireEnding marker start in RCTModuleData gatherConstants ([5c24746a48](https://github.com/facebook/react-native/commit/5c24746a4837b785fa18831a3740a3a5bdd1f304) by [@RSNara](https://github.com/RSNara))

#### Failed to parse

- Refactor: Attach TurboModuleRegistry to bridge in FBReactModule ([e96f1e1d83](https://github.com/facebook/react-native/commit/e96f1e1d830d20f88f020afa9a34a8f3b710b30e) by [@RSNara](https://github.com/RSNara))
- Rename RCTTurboModuleLookupDelegate to RCTTurboModuleRegistry ([a27c295f53](https://github.com/facebook/react-native/commit/a27c295f5338cd7f68a6601b928f109574b91dc7) by [@RSNara](https://github.com/RSNara))
- Make ShadowTreeRegistry `remove` API safer ([90287ca536](https://github.com/facebook/react-native/commit/90287ca5364d6ee8a3e4f50afe6d1256c21a65e3) by [@JoshuaGross](https://github.com/JoshuaGross))
- Fabric: Simplifying RCTPerformMountInstructions ([f2fdc1a5df](https://github.com/facebook/react-native/commit/f2fdc1a5dfd5fe03b42d46978edc68f4a3fc0e1f) by [@shergin](https://github.com/shergin))
- Fabric: Geometry.h is spit to several separate files ([e23e9328aa](https://github.com/facebook/react-native/commit/e23e9328aa164d0a70fe4f16042c982e7801d924) by [@shergin](https://github.com/shergin))
- Add additional accessibilityElements for embedded links ([ac0f4b42c5](https://github.com/facebook/react-native/commit/ac0f4b42c55aa344133bae773c14422b1d518a26) by [@ZHUANGPP](https://github.com/ZHUANGPP))
- Add accessibilityRole to RCTAttributedTextUtils ([c4c6204029](https://github.com/facebook/react-native/commit/c4c6204029a08faf855700a0c3b3f9f615f6203a) by [@ZHUANGPP](https://github.com/ZHUANGPP))
- Complete the basic RCTParagraphComponentAccessibilityProvider ([10a800da25](https://github.com/facebook/react-native/commit/10a800da251e90bdf9bbc531075cad7e9c658765) by [@ZHUANGPP](https://github.com/ZHUANGPP))
- Check whether packager is running in RCTBundleURLProvider for saved JSLocation ([3d882495d5](https://github.com/facebook/react-native/commit/3d882495d5e4415c2ebb8f4280e18e16025e0736) by [@jimmy623](https://github.com/jimmy623))
- Don't call config->setLogger(nullptr) directly to avoid having no logger at all ([8a14b98193](https://github.com/facebook/react-native/commit/8a14b9819320c3062b5013025c10be27e6481784) by [@amir-shalem](https://github.com/amir-shalem))
- Fabric: Fixes in computing visible frame in `RCTScrollViewComponentView` ([4716d2282e](https://github.com/facebook/react-native/commit/4716d2282ee06b6e1b1e04abcc50154017adf7c4) by [@shergin](https://github.com/shergin))
- Restore contentOffset from state if necesarry ([42c8dead62](https://github.com/facebook/react-native/commit/42c8dead621c80f25ef0980466e0ff7902af2913) by [@sammy-SC](https://github.com/sammy-SC))
- Small cleanup of package.json ([b2c775ca7a](https://github.com/facebook/react-native/commit/b2c775ca7a1cecfaf8f5bb357c09b357096d8a7b) by [@cpojer](https://github.com/cpojer))
- "The Metro Server" -> Metro ([6d6c68c2c6](https://github.com/facebook/react-native/commit/6d6c68c2c639b6473e049f7d916690b92e921c7e) by [@cpojer](https://github.com/cpojer))
- Move ART out of OSS ([c4de0c7a0a](https://github.com/facebook/react-native/commit/c4de0c7a0ab5042424b70f06e1e4195a12706cc4) by [@mdvacca](https://github.com/mdvacca))
- Add accessibilityRole to TextAttributes ([8fb1bb8da7](https://github.com/facebook/react-native/commit/8fb1bb8da70c6003614dc7959193e546ba89d560) by [@ZHUANGPP](https://github.com/ZHUANGPP))
- Temporarily disable support for transformations in findNodeAtPoint infrastructure ([40f37b986b](https://github.com/facebook/react-native/commit/40f37b986b9dda4a08b50702513676e50ea16aaa) by [@sammy-SC](https://github.com/sammy-SC))
- Remove JSDeltaBundleClient ([e881b244ca](https://github.com/facebook/react-native/commit/e881b244ca60adeb003c7af2b8e8b55f0cabf503) by [@cpojer](https://github.com/cpojer))
- Codegen: Generate ObjC structs for type aliases ([7e7706cb7d](https://github.com/facebook/react-native/commit/7e7706cb7daf72541a378d40304ec2b990565ee5) by [@hramos](https://github.com/hramos))
- Codegen: Enable generation of ObjC FBReactNativeSpec with CocoaPods ([e255748d12](https://github.com/facebook/react-native/commit/e255748d12df334bd35d8096e970141bafac886b) by [@hramos](https://github.com/hramos))
- Fabric: A demo in RNTester for `display: none` ([4776ebd7c3](https://github.com/facebook/react-native/commit/4776ebd7c3678494b97933bf8f50f54de4877646) by [@shergin](https://github.com/shergin))
- Fabric: `display: none` nodes do not create views anymore ([3c69a9eb4b](https://github.com/facebook/react-native/commit/3c69a9eb4b53c5f1b6f480cf96d88df27bb596f1) by [@shergin](https://github.com/shergin))
- Fabric: More asserts in iOS mounting infra ([26d8d41735](https://github.com/facebook/react-native/commit/26d8d4173581541d137a30c2bbe4d996888c49c9) by [@shergin](https://github.com/shergin))
- Fabric: Using `overflowInset` in on-demain view mounting in <ScrollView> ([8320ad37f2](https://github.com/facebook/react-native/commit/8320ad37f247e3c9e78a349d15e72c9bc4758f50) by [@shergin](https://github.com/shergin))
- Fabric: Gating for on-demand view mounting in ScrollView ([e223f2c2bf](https://github.com/facebook/react-native/commit/e223f2c2bf31e9712d0ea2a36f614958aeb286fb) by [@shergin](https://github.com/shergin))
- Fabric: On-demand view mounting for <ScrollView> ([9a72702b44](https://github.com/facebook/react-native/commit/9a72702b4432d0d037688aee4a063282fbfb1969) by [@shergin](https://github.com/shergin))


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6120)