### PR TITLE
Fix issues that cause fast refresh issues in playground app

### DIFF
--- a/packages/playground/Samples/rntester.tsx
+++ b/packages/playground/Samples/rntester.tsx
@@ -1,3 +1,19 @@
-// require('react-native').unstable_enableLogBox();
+/* 
+  RNTestApp exports a single ReactComponent, so react
+  sees it as a Fast Refresh boundary.  If this module
+  imports only RNTestApp, then all edits of any file
+  will bubble up the refresh dependencies into
+  RNTesterApp, which will be a Fast Refresh boundary,
+  and all edits will be treated as Fast Refresh safe.
+  Actually many edits in react-native core JS files are
+  not safe for Fast Refresh.  In most apps, the root
+  file imports react-native, which causes edits within
+  react-native to reload the entire instance, unless its
+  within a fast refresh boundary within react-native.
+  To avoid these issues, we add a dependency edge by
+  requiring react-native directly here in addition to
+  RNTesterApp
+*/
+require('react-native');
 
 require('react-native-windows/RNTester/js/RNTesterApp');


### PR DESCRIPTION
I've been hitting issues in RNTester where vscode is doing something to files that I have open which causes metro to think those files have changed.  When this happens with most react-native[-windows] files it causes RNTester to crash the instance while doing a FastRefresh of most of the components of react-native.  (This usually shows up as an error `nativeFabricUIManager not defined`)

It turns out most of RN core is not fast refresh safe and assumes changes that reach the boundary of react-native will reach the boundary of the app and trigger full reloads.

RNTestApp exports a single ReactComponent, so react sees it as a Fast Refresh boundary.  If Samples/rntester.tsx imports only RNTestApp, then all edits of any file will bubble up the refresh dependencies into RNTesterApp, which will be a Fast Refresh boundary, and all edits will be treated as Fast Refresh safe. Actually, many edits in react-native core JS files are not safe for Fast Refresh.  In most apps, the root file imports react-native, which causes edits within react-native to reload the entire instance, unless its within a fast refresh boundary within react-native. To avoid these issues, we add a dependency edge by requiring react-native directly here in addition to RNTesterApp

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6127)