### PR TITLE
Increase react-native-init CI timeout

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -604,7 +604,7 @@ jobs:
           additionalInitArguments:
           additionalRunArguments: --no-autolink --no-deploy
 
-    timeoutInMinutes: 40 # how long to run the job before automatically cancelling
+    timeoutInMinutes: 50 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     pool:
       vmImage: $(VmImage)


### PR DESCRIPTION
Hit a timeout here on one of my jobs, where we seemed to get a machine with slow network conditions (slow yarn install + apply template). We also seem to have regressed native build time with PCH size reduction efforts as well, though this is bringing back in line with the stability vs time tradeoff we had earlier in 0.63.

Increase the timeout of the test job.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6128)