### PR TITLE
Convert WinUI3 Build Failures to Warnings

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -26,6 +26,9 @@ parameters:
   - name: additionalInitArguments
     type: string
     default: ''
+  - name: continueOnBuildFailure
+    type: boolean
+    default: false
 
 steps:
   - checkout: self # self represents the repo where the initial Pipelines YAML file was found
@@ -179,6 +182,7 @@ steps:
     inputs:
       script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --logging --buildLogDirectory $(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs --release ${{ parameters.additionalRunArguments }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
+    continueOnError: ${{ parameters.continueOnBuildFailure }}
     condition: and(succeeded(), eq('Release', variables['localConfig']))
 
   - task: CmdLine@2
@@ -186,6 +190,7 @@ steps:
     inputs:
       script: npx --no-install react-native run-windows --arch ${{ parameters.platform }} --no-launch --logging --buildLogDirectory $(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs ${{ parameters.additionalRunArguments }}
       workingDirectory: $(Agent.BuildDirectory)\testcli
+    continueOnError: ${{ parameters.continueOnBuildFailure }}
     condition: and(succeeded(), eq('Debug', variables['localConfig']))
 
   - template: upload-build-logs.yml

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -187,6 +187,7 @@ jobs:
             /p:BaseIntDir=$(BaseIntDir)
             /p:AppxPackageSigningEnabled=false
             /p:UseWinUI3=true
+        continueOnError: true # See issue #6129
 
       - task: PublishBuildArtifacts@1
         displayName: Upload crash dumps
@@ -582,6 +583,7 @@ jobs:
           projectType: app
           additionalInitArguments: --useWinUI3 true
           additionalRunArguments:
+          continueOnBuildFailure: true # See issue #6129
         WinUI3_X86DebugCs:
           language: cs
           configuration: Debug
@@ -589,6 +591,7 @@ jobs:
           projectType: app
           additionalInitArguments: --useWinUI3 true
           additionalRunArguments:
+          continueOnBuildFailure: true # See issue #6129
         X86DebugCppLib:
           language: cpp
           configuration: Debug


### PR DESCRIPTION
After removing some added headers to the PCH we're seeing non-WinUI3 builds are stable again. WinUI3 builds, despite having a smaller PCH, seem to still be effected by OOM issues compiling individual translation units. Investigation is possibly needed as to why these jobs specifically are using more memory. We might be able to just ignore this until we have a new pool.

Converting the WinUI3 jobs to warnings in the meantime. This creates some risk of lost coverage, but in most cases where we would break the WinUI3 build, seeing all jobs fail would be a good indicator, and customers aren't using WinUI3 yet.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6130)