### PR TITLE
Expose getters for some instance settings on reactcontext

### DIFF
--- a/change/react-native-windows-2020-09-30-09-05-50-syncplaygroundsettings.json
+++ b/change/react-native-windows-2020-09-30-09-05-50-syncplaygroundsettings.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Expose getters for some instance settings on reactcontext",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-30T16:05:50.324Z"
+}

--- a/packages/E2ETest/windows/ReactUWPTestApp/App.xaml.cs
+++ b/packages/E2ETest/windows/ReactUWPTestApp/App.xaml.cs
@@ -30,7 +30,7 @@ namespace ReactUWPTestApp
             InstanceSettings.UseWebDebugger = false;
             InstanceSettings.UseFastRefresh = false;
 #else
-            JavaScriptMainModuleName = "app/index";
+            JavaScriptBundleFile = "app/index";
             InstanceSettings.UseWebDebugger = true;
             InstanceSettings.UseFastRefresh = true;
 #endif

--- a/packages/IntegrationTest/windows/integrationtest/App.cpp
+++ b/packages/IntegrationTest/windows/integrationtest/App.cpp
@@ -26,7 +26,7 @@ App::App() noexcept {
   InstanceSettings().UseWebDebugger(false);
   InstanceSettings().UseFastRefresh(false);
 #else
-  JavaScriptMainModuleName(L"index");
+  JavaScriptBundleFile(L"index");
   InstanceSettings().UseWebDebugger(true);
   InstanceSettings().UseFastRefresh(true);
 #endif

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.cpp
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.cpp
@@ -31,7 +31,7 @@ App::App() noexcept {
   InstanceSettings().UseWebDebugger(false);
   InstanceSettings().UseFastRefresh(false);
 #else
-  JavaScriptMainModuleName(L"index");
+  JavaScriptBundleFile(L"index");
   InstanceSettings().UseWebDebugger(true);
   InstanceSettings().UseFastRefresh(true);
 #endif

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/App.xaml.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/App.xaml.cs
@@ -28,7 +28,7 @@ namespace SampleAppCS
             InstanceSettings.UseWebDebugger = false;
             InstanceSettings.UseFastRefresh = false;
 #else
-            JavaScriptMainModuleName = "index";
+            JavaScriptBundleFile = "index";
             InstanceSettings.UseWebDebugger = true;
             InstanceSettings.UseFastRefresh = true;
 #endif

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -73,6 +73,24 @@ void MainPage::OnLoadClick(
     host.InstanceSettings().DebugHost(m_bundlerHostname);
   }
 
+  host.InstanceSettings().InstanceCreated(
+      [wkThis = get_weak()](auto sender, winrt::Microsoft::ReactNative::InstanceCreatedEventArgs args) {
+      if (auto strongThis = wkThis.get()) {
+          args.Context().UIDispatcher().Post([wkThis, context = args.Context()]() {
+          if (auto strongThis = wkThis.get()) {
+            strongThis->x_UseWebDebuggerCheckBox().IsChecked(context.UseWebDebugger());
+            strongThis->x_UseFastRefreshCheckBox().IsChecked(context.UseFastRefresh());
+            strongThis->x_UseDirectDebuggerCheckBox().IsChecked(context.UseDirectDebugger());
+            strongThis->x_BreakOnFirstLineCheckBox().IsChecked(context.DebuggerBreakOnNextLine());
+            if (context.UseWebDebugger()) {
+              strongThis->RequestedTheme(xaml::ElementTheme::Light);
+            } else {
+              strongThis->RequestedTheme(xaml::ElementTheme::Default);
+            }
+          }
+        });
+        }
+      });
   // Nudge the ReactNativeHost to create the instance and wrapping context
   host.ReloadInstance();
 }

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -75,20 +75,22 @@ void MainPage::OnLoadClick(
 
   host.InstanceSettings().InstanceCreated(
       [wkThis = get_weak()](auto sender, winrt::Microsoft::ReactNative::InstanceCreatedEventArgs args) {
-      if (auto strongThis = wkThis.get()) {
+        if (auto strongThis = wkThis.get()) {
           args.Context().UIDispatcher().Post([wkThis, context = args.Context()]() {
-          if (auto strongThis = wkThis.get()) {
-            strongThis->x_UseWebDebuggerCheckBox().IsChecked(context.UseWebDebugger());
-            strongThis->x_UseFastRefreshCheckBox().IsChecked(context.UseFastRefresh());
-            strongThis->x_UseDirectDebuggerCheckBox().IsChecked(context.UseDirectDebugger());
-            strongThis->x_BreakOnFirstLineCheckBox().IsChecked(context.DebuggerBreakOnNextLine());
-            if (context.UseWebDebugger()) {
-              strongThis->RequestedTheme(xaml::ElementTheme::Light);
-            } else {
-              strongThis->RequestedTheme(xaml::ElementTheme::Default);
+            if (auto strongThis = wkThis.get()) {
+              strongThis->x_UseWebDebuggerCheckBox().IsChecked(context.UseWebDebugger());
+              strongThis->x_UseFastRefreshCheckBox().IsChecked(context.UseFastRefresh());
+              strongThis->x_UseDirectDebuggerCheckBox().IsChecked(context.UseDirectDebugger());
+              strongThis->x_BreakOnFirstLineCheckBox().IsChecked(context.DebuggerBreakOnNextLine());
+              strongThis->x_entryPointCombo().SelectedItem(winrt::box_value(context.DebugBundlePath()));
+              strongThis->x_DebuggerPort().Text(winrt::to_hstring(context.DebuggerPort()));
+              if (context.UseWebDebugger()) {
+                strongThis->RequestedTheme(xaml::ElementTheme::Light);
+              } else {
+                strongThis->RequestedTheme(xaml::ElementTheme::Default);
+              }
             }
-          }
-        });
+          });
         }
       });
   // Nudge the ReactNativeHost to create the instance and wrapping context

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -5,8 +5,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:react="using:Microsoft.ReactNative"
-    mc:Ignorable="d">
-    <Grid>
+    mc:Ignorable="d"
+    Foreground="{ThemeResource ApplicationForegroundThemeBrush}">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" >
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
@@ -22,7 +23,7 @@
             x:Name="x_LoadButton"
             Label="Load"
             Icon="Play"
-            Style="{StaticResource AppBarButtonRevealStyle}"
+            Style="{ThemeResource AppBarButtonRevealStyle}"
             VerticalAlignment="Center"
             Grid.Column="0"
             Grid.RowSpan="2"
@@ -34,7 +35,7 @@
             Grid.Row="0"
             Grid.Column="1"
             BorderThickness="1,0,0,0"
-            BorderBrush="{StaticResource SystemBaseMediumColor}">
+            BorderBrush="{ThemeResource SystemBaseMediumColor}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition Width="*"/>
@@ -103,7 +104,7 @@
             Grid.Column="1"
             Orientation="Horizontal"
             BorderThickness="1,0,0,0"
-            BorderBrush="{StaticResource SystemBaseMediumColor}">
+            BorderBrush="{ThemeResource SystemBaseMediumColor}">
             <CheckBox x:Name="x_UseWebDebuggerCheckBox"
                  Margin="8,4,4,4"
                  VerticalAlignment="Center"
@@ -152,9 +153,9 @@
         </StackPanel>
         <react:ReactRootView x:Name="ReactRootView"
             BorderThickness="0,1,0,0"
-            BorderBrush="{StaticResource SystemBaseMediumColor}"
+            BorderBrush="{ThemeResource SystemBaseMediumColor}"
             Grid.Row="3"
             Grid.ColumnSpan="2"
-            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"/>
+            />
     </Grid>
 </Page>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -52,6 +52,26 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     paramsArgWriter(writer);
     Args = TakeJSValue(writer);
   }
+  
+  uint16_t DebuggerPort() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool DebuggerBreakOnNextLine() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool UseDirectDebugger() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool UseFastRefresh() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool UseWebDebugger() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
 
   std::wstring Module;
   std::wstring Method;

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -52,7 +52,7 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     paramsArgWriter(writer);
     Args = TakeJSValue(writer);
   }
-  
+
   uint16_t DebuggerPort() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
@@ -70,6 +70,26 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
   }
 
   bool UseWebDebugger() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring DebugBundlePath() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring BundleRootPath() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring SourceBundleHost() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  uint16_t SourceBundlePort() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring JavaScriptBundleFile() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -162,6 +162,26 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  hstring DebugBundlePath() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring BundleRootPath() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring SourceBundleHost() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  uint16_t SourceBundlePort() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  hstring JavaScriptBundleFile() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
  private:
   ReactModuleBuilderMock *m_builderMock;
 };

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -142,6 +142,26 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
       hstring const &eventName,
       JSValueArgWriter const &paramsArgWriter) noexcept;
 
+  uint16_t DebuggerPort() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool DebuggerBreakOnNextLine() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool UseDirectDebugger() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool UseFastRefresh() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
+  bool UseWebDebugger() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
  private:
   ReactModuleBuilderMock *m_builderMock;
 };

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -342,5 +342,15 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     bool IReactContext.UseFastRefresh => throw new NotImplementedException();
 
     bool IReactContext.UseWebDebugger => throw new NotImplementedException();
+
+    string IReactContext.BundleRootPath => throw new NotImplementedException();
+
+    string IReactContext.DebugBundlePath => throw new NotImplementedException();
+
+    string IReactContext.JavaScriptBundleFile => throw new NotImplementedException();
+
+    string IReactContext.SourceBundleHost => throw new NotImplementedException();
+
+    ushort IReactContext.SourceBundlePort => throw new NotImplementedException();
   }
 }

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -332,5 +332,15 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_builder.EmitJSEvent(eventEmitterName, eventName, paramsArgWriter);
     }
+
+    bool IReactContext.DebuggerBreakOnNextLine => throw new NotImplementedException();
+
+    ushort IReactContext.DebuggerPort => throw new NotImplementedException();
+
+    bool IReactContext.UseDirectDebugger => throw new NotImplementedException();
+
+    bool IReactContext.UseFastRefresh => throw new NotImplementedException();
+
+    bool IReactContext.UseWebDebugger => throw new NotImplementedException();
   }
 }

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -68,28 +68,44 @@ void ReactContext::EmitJSEvent(
   m_context->CallJSFunction(to_string(eventEmitterName), "emit", std::move(params));
 }
 
-bool ReactContext::UseWebDebugger() noexcept
-{
+bool ReactContext::UseWebDebugger() noexcept {
   return m_context->UseWebDebugger();
 }
 
-bool ReactContext::UseFastRefresh() noexcept
-{
+bool ReactContext::UseFastRefresh() noexcept {
   return m_context->UseFastRefresh();
 }
 
-bool ReactContext::UseDirectDebugger() noexcept
-{
+bool ReactContext::UseDirectDebugger() noexcept {
   return m_context->UseDirectDebugger();
 }
 
-bool ReactContext::DebuggerBreakOnNextLine() noexcept
-{
+bool ReactContext::DebuggerBreakOnNextLine() noexcept {
   return m_context->DebuggerBreakOnNextLine();
 }
 
 uint16_t ReactContext::DebuggerPort() noexcept {
   return m_context->DebuggerPort();
+}
+
+hstring ReactContext::DebugBundlePath() noexcept {
+  return winrt::to_hstring(m_context->DebugBundlePath());
+}
+
+hstring ReactContext::BundleRootPath() noexcept {
+  return winrt::to_hstring(m_context->BundleRootPath());
+}
+
+hstring ReactContext::SourceBundleHost() noexcept {
+  return winrt::to_hstring(m_context->SourceBundleHost());
+}
+
+uint16_t ReactContext::SourceBundlePort() noexcept {
+  return m_context->SourceBundlePort();
+}
+
+hstring ReactContext::JavaScriptBundleFile() noexcept {
+  return winrt::to_hstring(m_context->JavaScriptBundleFile());
 }
 
 Mso::React::IReactContext &ReactContext::GetInner() const noexcept {

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -70,22 +70,26 @@ void ReactContext::EmitJSEvent(
 
 bool ReactContext::UseWebDebugger() noexcept
 {
-  return Mso::React::ReactOptions::UseWebDebugger(m_context->Properties());
+  return m_context->UseWebDebugger();
 }
 
 bool ReactContext::UseFastRefresh() noexcept
 {
-  return Mso::React::ReactOptions::UseFastRefresh(m_context->Properties());
+  return m_context->UseFastRefresh();
 }
 
 bool ReactContext::UseDirectDebugger() noexcept
 {
-  return Mso::React::ReactOptions::UseDirectDebugger(m_context->Properties());
+  return m_context->UseDirectDebugger();
 }
 
 bool ReactContext::DebuggerBreakOnNextLine() noexcept
 {
-  return Mso::React::ReactOptions::DebuggerBreakOnNextLine(m_context->Properties());
+  return m_context->DebuggerBreakOnNextLine();
+}
+
+uint16_t ReactContext::DebuggerPort() noexcept {
+  return m_context->DebuggerPort();
 }
 
 Mso::React::IReactContext &ReactContext::GetInner() const noexcept {

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -68,45 +68,47 @@ void ReactContext::EmitJSEvent(
   m_context->CallJSFunction(to_string(eventEmitterName), "emit", std::move(params));
 }
 
-bool ReactContext::UseWebDebugger() noexcept {
+#ifndef CORE_ABI
+bool ReactContext::UseWebDebugger() const noexcept {
   return m_context->UseWebDebugger();
 }
 
-bool ReactContext::UseFastRefresh() noexcept {
+bool ReactContext::UseFastRefresh() const noexcept {
   return m_context->UseFastRefresh();
 }
 
-bool ReactContext::UseDirectDebugger() noexcept {
+bool ReactContext::UseDirectDebugger() const noexcept {
   return m_context->UseDirectDebugger();
 }
 
-bool ReactContext::DebuggerBreakOnNextLine() noexcept {
+bool ReactContext::DebuggerBreakOnNextLine() const noexcept {
   return m_context->DebuggerBreakOnNextLine();
 }
 
-uint16_t ReactContext::DebuggerPort() noexcept {
+uint16_t ReactContext::DebuggerPort() const noexcept {
   return m_context->DebuggerPort();
 }
 
-hstring ReactContext::DebugBundlePath() noexcept {
+hstring ReactContext::DebugBundlePath() const noexcept {
   return winrt::to_hstring(m_context->DebugBundlePath());
 }
 
-hstring ReactContext::BundleRootPath() noexcept {
+hstring ReactContext::BundleRootPath() const noexcept {
   return winrt::to_hstring(m_context->BundleRootPath());
 }
 
-hstring ReactContext::SourceBundleHost() noexcept {
+hstring ReactContext::SourceBundleHost() const noexcept {
   return winrt::to_hstring(m_context->SourceBundleHost());
 }
 
-uint16_t ReactContext::SourceBundlePort() noexcept {
+uint16_t ReactContext::SourceBundlePort() const noexcept {
   return m_context->SourceBundlePort();
 }
 
-hstring ReactContext::JavaScriptBundleFile() noexcept {
+hstring ReactContext::JavaScriptBundleFile() const noexcept {
   return winrt::to_hstring(m_context->JavaScriptBundleFile());
 }
+#endif
 
 Mso::React::IReactContext &ReactContext::GetInner() const noexcept {
   return *m_context;

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -68,6 +68,26 @@ void ReactContext::EmitJSEvent(
   m_context->CallJSFunction(to_string(eventEmitterName), "emit", std::move(params));
 }
 
+bool ReactContext::UseWebDebugger() noexcept
+{
+  return Mso::React::ReactOptions::UseWebDebugger(m_context->Properties());
+}
+
+bool ReactContext::UseFastRefresh() noexcept
+{
+  return Mso::React::ReactOptions::UseFastRefresh(m_context->Properties());
+}
+
+bool ReactContext::UseDirectDebugger() noexcept
+{
+  return Mso::React::ReactOptions::UseDirectDebugger(m_context->Properties());
+}
+
+bool ReactContext::DebuggerBreakOnNextLine() noexcept
+{
+  return Mso::React::ReactOptions::DebuggerBreakOnNextLine(m_context->Properties());
+}
+
 Mso::React::IReactContext &ReactContext::GetInner() const noexcept {
   return *m_context;
 }

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -35,6 +35,7 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   bool UseFastRefresh() noexcept;
   bool UseDirectDebugger() noexcept;
   bool DebuggerBreakOnNextLine() noexcept;
+  uint16_t DebuggerPort() noexcept;
 
   // Not part of the public ABI interface
   // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -31,16 +31,16 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
       hstring const &eventName,
       JSValueArgWriter const &paramsArgWriter) noexcept;
 
-  bool UseWebDebugger() noexcept;
-  bool UseFastRefresh() noexcept;
-  bool UseDirectDebugger() noexcept;
-  bool DebuggerBreakOnNextLine() noexcept;
-  uint16_t DebuggerPort() noexcept;
-  hstring DebugBundlePath() noexcept;
-  hstring BundleRootPath() noexcept;
-  hstring SourceBundleHost() noexcept;
-  uint16_t SourceBundlePort() noexcept;
-  hstring JavaScriptBundleFile() noexcept;
+  bool UseWebDebugger() const noexcept;
+  bool UseFastRefresh() const noexcept;
+  bool UseDirectDebugger() const noexcept;
+  bool DebuggerBreakOnNextLine() const noexcept;
+  uint16_t DebuggerPort() const noexcept;
+  hstring DebugBundlePath() const noexcept;
+  hstring BundleRootPath() const noexcept;
+  hstring SourceBundleHost() const noexcept;
+  uint16_t SourceBundlePort() const noexcept;
+  hstring JavaScriptBundleFile() const noexcept;
 
   // Not part of the public ABI interface
   // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -36,6 +36,11 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   bool UseDirectDebugger() noexcept;
   bool DebuggerBreakOnNextLine() noexcept;
   uint16_t DebuggerPort() noexcept;
+  hstring DebugBundlePath() noexcept;
+  hstring BundleRootPath() noexcept;
+  hstring SourceBundleHost() noexcept;
+  uint16_t SourceBundlePort() noexcept;
+  hstring JavaScriptBundleFile() noexcept;
 
   // Not part of the public ABI interface
   // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -31,6 +31,11 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
       hstring const &eventName,
       JSValueArgWriter const &paramsArgWriter) noexcept;
 
+  bool UseWebDebugger() noexcept;
+  bool UseFastRefresh() noexcept;
+  bool UseDirectDebugger() noexcept;
+  bool DebuggerBreakOnNextLine() noexcept;
+
   // Not part of the public ABI interface
   // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods
   Mso::React::IReactContext &GetInner() const noexcept;

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -45,6 +45,7 @@ namespace Microsoft.ReactNative {
     // Call JavaScript module event. It is a specialized CallJSFunction call where method name is always 'emit'.
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
 
+#ifndef CORE_ABI
     Boolean UseWebDebugger { get; };
     Boolean UseFastRefresh { get; };
     Boolean UseDirectDebugger { get; };
@@ -55,5 +56,6 @@ namespace Microsoft.ReactNative {
     String SourceBundleHost { get; };
     UInt16 SourceBundlePort { get; };
     String JavaScriptBundleFile { get; };
+#endif
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -44,5 +44,10 @@ namespace Microsoft.ReactNative {
 
     // Call JavaScript module event. It is a specialized CallJSFunction call where method name is always 'emit'.
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
+
+    Boolean UseWebDebugger { get; };
+    Boolean UseFastRefresh { get; };
+    Boolean UseDirectDebugger { get; };
+    Boolean DebuggerBreakOnNextLine { get; };
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -49,5 +49,6 @@ namespace Microsoft.ReactNative {
     Boolean UseFastRefresh { get; };
     Boolean UseDirectDebugger { get; };
     Boolean DebuggerBreakOnNextLine { get; };
+    UInt16 DebuggerPort { get; };
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -50,5 +50,10 @@ namespace Microsoft.ReactNative {
     Boolean UseDirectDebugger { get; };
     Boolean DebuggerBreakOnNextLine { get; };
     UInt16 DebuggerPort { get; };
+    String DebugBundlePath { get; };
+    String BundleRootPath { get; };
+    String SourceBundleHost { get; };
+    UInt16 SourceBundlePort { get; };
+    String JavaScriptBundleFile { get; };
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -16,6 +16,7 @@ namespace Microsoft.ReactNative {
     ReactNativeHost Host { get; };
 
     Boolean UseDeveloperSupport { get; set; };
+    // Deprecated - Use JavaScriptBundleFile instead
     String JavaScriptMainModuleName { get; set; };
     String JavaScriptBundleFile { get; set; };
   }

--- a/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
@@ -48,7 +48,7 @@ struct IReactInstance {
 
   // Returns the root path of the JS bundle. This is needed for
   // classes that do not have access to the settings object.
-  virtual std::string GetBundleRootPath() const noexcept = 0;
+  virtual std::string BundleRootPath() const noexcept = 0;
 
   // Test Hooks
   virtual void SetXamlViewCreatedTestHook(std::function<void(react::uwp::XamlView)> &&testHook) noexcept = 0;

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -84,6 +84,11 @@ struct IReactContext : IUnknown {
   virtual std::string GetBundleRootPath() const noexcept = 0;
   virtual facebook::react::INativeUIManager *NativeUIManager() const noexcept = 0;
   virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept = 0;
+  virtual bool UseWebDebugger() noexcept = 0;
+  virtual bool UseFastRefresh() noexcept = 0;
+  virtual bool UseDirectDebugger() noexcept = 0;
+  virtual bool DebuggerBreakOnNextLine() noexcept = 0;
+  virtual uint16_t DebuggerPort() noexcept = 0;
 #endif
 };
 

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -81,14 +81,19 @@ struct IReactContext : IUnknown {
 #ifndef CORE_ABI
   virtual ReactInstanceState State() const noexcept = 0;
   virtual bool IsLoaded() const noexcept = 0;
-  virtual std::string GetBundleRootPath() const noexcept = 0;
   virtual facebook::react::INativeUIManager *NativeUIManager() const noexcept = 0;
   virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept = 0;
-  virtual bool UseWebDebugger() noexcept = 0;
-  virtual bool UseFastRefresh() noexcept = 0;
-  virtual bool UseDirectDebugger() noexcept = 0;
-  virtual bool DebuggerBreakOnNextLine() noexcept = 0;
-  virtual uint16_t DebuggerPort() noexcept = 0;
+  virtual bool UseWebDebugger() const noexcept = 0;
+  virtual bool UseFastRefresh() const noexcept = 0;
+  virtual bool UseDirectDebugger() const noexcept = 0;
+  virtual bool DebuggerBreakOnNextLine() const noexcept = 0;
+  virtual uint16_t DebuggerPort() const noexcept = 0;
+  virtual std::string DebugBundlePath() const noexcept = 0;
+  virtual std::string BundleRootPath() const noexcept = 0;
+  virtual std::string SourceBundleHost() const noexcept = 0;
+  virtual uint16_t SourceBundlePort() const noexcept = 0;
+  virtual std::string JavaScriptBundleFile() const noexcept = 0;
+
 #endif
 };
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
@@ -89,6 +89,44 @@ std::shared_ptr<facebook::react::Instance> ReactContext::GetInnerInstance() cons
 
   return nullptr;
 }
+
+
+bool ReactContext::UseWebDebugger() noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseWebDebugger();
+  }
+  return false;
+}
+
+bool ReactContext::UseFastRefresh() noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseFastRefresh();
+  }
+  return false;
+}
+
+bool ReactContext::UseDirectDebugger() noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseDirectDebugger();
+  }
+  return false;
+}
+
+bool ReactContext::DebuggerBreakOnNextLine() noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->DebuggerBreakOnNextLine();
+  }
+  return false;
+}
+
+uint16_t ReactContext::DebuggerPort() noexcept {
+    if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->DebuggerPort();
+  }
+  return false;
+}
+
+
 #endif
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
@@ -66,14 +66,6 @@ bool ReactContext::IsLoaded() const noexcept {
   return false;
 }
 
-std::string ReactContext::GetBundleRootPath() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->GetBundleRootPath();
-  }
-
-  return "";
-}
-
 facebook::react::INativeUIManager *ReactContext::NativeUIManager() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->NativeUIManager();
@@ -90,42 +82,75 @@ std::shared_ptr<facebook::react::Instance> ReactContext::GetInnerInstance() cons
   return nullptr;
 }
 
-
-bool ReactContext::UseWebDebugger() noexcept {
+bool ReactContext::UseWebDebugger() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->UseWebDebugger();
   }
   return false;
 }
 
-bool ReactContext::UseFastRefresh() noexcept {
+bool ReactContext::UseFastRefresh() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->UseFastRefresh();
   }
   return false;
 }
 
-bool ReactContext::UseDirectDebugger() noexcept {
+bool ReactContext::UseDirectDebugger() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->UseDirectDebugger();
   }
   return false;
 }
 
-bool ReactContext::DebuggerBreakOnNextLine() noexcept {
+bool ReactContext::DebuggerBreakOnNextLine() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->DebuggerBreakOnNextLine();
   }
   return false;
 }
 
-uint16_t ReactContext::DebuggerPort() noexcept {
-    if (auto instance = m_reactInstance.GetStrongPtr()) {
+uint16_t ReactContext::DebuggerPort() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->DebuggerPort();
   }
-  return false;
+  return 0;
 }
 
+std::string ReactContext::DebugBundlePath() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->DebugBundlePath();
+  }
+  return {};
+}
+
+std::string ReactContext::BundleRootPath() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->BundleRootPath();
+  }
+  return {};
+}
+
+std::string ReactContext::SourceBundleHost() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->SourceBundleHost();
+  }
+  return {};
+}
+
+uint16_t ReactContext::SourceBundlePort() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->SourceBundlePort();
+  }
+  return 0;
+}
+
+std::string ReactContext::JavaScriptBundleFile() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->JavaScriptBundleFile();
+  }
+  return {};
+}
 
 #endif
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -29,15 +29,20 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
 #ifndef CORE_ABI
   ReactInstanceState State() const noexcept override;
   bool IsLoaded() const noexcept override;
-  std::string GetBundleRootPath() const noexcept override;
   facebook::react::INativeUIManager *NativeUIManager() const noexcept override;
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept override;
 
-  bool UseWebDebugger() noexcept;
-  bool UseFastRefresh() noexcept;
-  bool UseDirectDebugger() noexcept;
-  bool DebuggerBreakOnNextLine() noexcept;
-  uint16_t DebuggerPort() noexcept;
+  bool UseWebDebugger() const noexcept override;
+  bool UseFastRefresh() const noexcept override;
+  bool UseDirectDebugger() const noexcept override;
+  bool DebuggerBreakOnNextLine() const noexcept override;
+  uint16_t DebuggerPort() const noexcept override;
+  std::string DebugBundlePath() const noexcept override;
+  std::string BundleRootPath() const noexcept override;
+  std::string SourceBundleHost() const noexcept override;
+  uint16_t SourceBundlePort() const noexcept override;
+  std::string JavaScriptBundleFile() const noexcept override;
+
 #endif
 
  private:

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -32,6 +32,12 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   std::string GetBundleRootPath() const noexcept override;
   facebook::react::INativeUIManager *NativeUIManager() const noexcept override;
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept override;
+
+  bool UseWebDebugger() noexcept;
+  bool UseFastRefresh() noexcept;
+  bool UseDirectDebugger() noexcept;
+  bool DebuggerBreakOnNextLine() noexcept;
+  uint16_t DebuggerPort() noexcept;
 #endif
 
  private:

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -230,15 +230,9 @@ void ReactInstanceWin::Initialize() noexcept {
 
           auto devSettings = std::make_shared<facebook::react::DevSettings>();
           devSettings->useJITCompilation = m_options.EnableJITCompilation;
-          devSettings->sourceBundleHost = m_options.DeveloperSettings.SourceBundleHost.empty()
-              ? facebook::react::DevServerHelper::DefaultPackagerHost
-              : m_options.DeveloperSettings.SourceBundleHost;
-          devSettings->sourceBundlePort = m_options.DeveloperSettings.SourceBundlePort
-              ? m_options.DeveloperSettings.SourceBundlePort
-              : facebook::react::DevServerHelper::DefaultPackagerPort;
-          devSettings->debugBundlePath = m_options.DeveloperSettings.SourceBundleName.empty()
-              ? m_options.Identity
-              : m_options.DeveloperSettings.SourceBundleName;
+          devSettings->sourceBundleHost = SourceBundleHost();
+          devSettings->sourceBundlePort = SourceBundlePort();
+          devSettings->debugBundlePath = DebugBundlePath();
           devSettings->liveReloadCallback = GetLiveReloadCallback();
           devSettings->errorCallback = GetErrorCallback();
           devSettings->loggingCallback = GetLoggingCallback();
@@ -250,9 +244,7 @@ void ReactInstanceWin::Initialize() noexcept {
           devSettings->useWebDebugger = m_useWebDebugger;
           devSettings->useFastRefresh = m_isFastReloadEnabled;
           // devSettings->memoryTracker = GetMemoryTracker();
-          devSettings->bundleRootPath =
-              m_options.BundleRootPath.empty() ? "ms-appx:///Bundle/" : m_options.BundleRootPath;
-          m_bundleRootPath = devSettings->bundleRootPath;
+          devSettings->bundleRootPath = BundleRootPath();
 
           devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
           devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
@@ -359,13 +351,9 @@ void ReactInstanceWin::Initialize() noexcept {
             if (m_options.UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
               folly::dynamic params = folly::dynamic::array(
                   STRING(RN_PLATFORM),
-                  m_options.DeveloperSettings.SourceBundleName.empty() ? m_options.Identity
-                                                                       : m_options.DeveloperSettings.SourceBundleName,
-                  m_options.DeveloperSettings.SourceBundleHost.empty()
-                      ? facebook::react::DevServerHelper::DefaultPackagerHost
-                      : m_options.DeveloperSettings.SourceBundleHost,
-                  m_options.DeveloperSettings.SourceBundlePort ? m_options.DeveloperSettings.SourceBundlePort
-                                                               : facebook::react::DevServerHelper::DefaultPackagerPort,
+                  DebugBundlePath(),
+                  SourceBundleHost(),
+                  SourceBundlePort(),
                   m_isFastReloadEnabled);
               m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
             }
@@ -406,7 +394,7 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
   if (m_useWebDebugger || m_isFastReloadEnabled) {
     // Getting bundle from the packager, so do everything async.
     auto instanceWrapper = m_instanceWrapper.LoadWithLock();
-    instanceWrapper->loadBundle(Mso::Copy(m_options.Identity));
+    instanceWrapper->loadBundle(Mso::Copy(JavaScriptBundleFile()));
 
     m_jsMessageThread.Load()->runOnQueue([
       weakThis = Mso::WeakPtr{this},
@@ -433,7 +421,7 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
         auto &options = strongThis->m_options;
 
         try {
-          instanceWrapper->loadBundleSync(Mso::Copy(options.Identity));
+          instanceWrapper->loadBundleSync(Mso::Copy(strongThis->JavaScriptBundleFile()));
         } catch (...) {
           strongThis->m_state = ReactInstanceState::HasError;
           strongThis->AbandonJSCallQueue();
@@ -572,7 +560,7 @@ facebook::react::NativeLoggingHook ReactInstanceWin::GetLoggingCallback() noexce
   } else {
     // When no logging callback was specified, use a default one in DEBUG builds
 #if DEBUG
-    return [telemetryTag{m_options.Identity}](facebook::react::RCTLogLevel logLevel, const char *message) {
+    return [telemetryTag{JavaScriptBundleFile()}](facebook::react::RCTLogLevel logLevel, const char *message) {
       std::ostringstream ss;
       ss << "ReactNative ['" << telemetryTag << "'] (";
       switch (logLevel) {
@@ -759,10 +747,6 @@ std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() 
   return m_instance.LoadWithLock();
 }
 
-std::string ReactInstanceWin::GetBundleRootPath() noexcept {
-  return m_bundleRootPath.empty() ? m_options.BundleRootPath : m_bundleRootPath;
-}
-
 std::shared_ptr<react::uwp::IReactInstance> ReactInstanceWin::UwpReactInstance() noexcept {
   return m_legacyInstance;
 }
@@ -803,24 +787,47 @@ std::string ReactInstanceWin::getApplicationLocalFolder() {
 }
 #endif
 
-bool ReactInstanceWin::UseWebDebugger() noexcept {
+bool ReactInstanceWin::UseWebDebugger() const noexcept {
   return m_useWebDebugger;
 }
 
-bool ReactInstanceWin::UseFastRefresh() noexcept {
+bool ReactInstanceWin::UseFastRefresh() const noexcept {
   return m_isFastReloadEnabled;
 }
 
-bool ReactInstanceWin::UseDirectDebugger() noexcept {
+bool ReactInstanceWin::UseDirectDebugger() const noexcept {
   return m_useDirectDebugger;
 }
 
-bool ReactInstanceWin::DebuggerBreakOnNextLine() noexcept {
+bool ReactInstanceWin::DebuggerBreakOnNextLine() const noexcept {
   return m_debuggerBreakOnNextLine;
 }
 
-uint16_t ReactInstanceWin::DebuggerPort() noexcept {
-  return Options().DeveloperSettings.DebuggerPort;
+uint16_t ReactInstanceWin::DebuggerPort() const noexcept {
+  return m_options.DeveloperSettings.DebuggerPort;
+}
+
+std::string ReactInstanceWin::DebugBundlePath() const noexcept {
+  return m_options.DeveloperSettings.SourceBundleName.empty() ? m_options.Identity
+                                                              : m_options.DeveloperSettings.SourceBundleName;
+}
+
+std::string ReactInstanceWin::BundleRootPath() const noexcept {
+  return m_options.BundleRootPath.empty() ? "ms-appx:///Bundle/" : m_options.BundleRootPath;
+}
+
+std::string ReactInstanceWin::SourceBundleHost() const noexcept {
+  return m_options.DeveloperSettings.SourceBundleHost.empty() ? facebook::react::DevServerHelper::DefaultPackagerHost
+                                                              : m_options.DeveloperSettings.SourceBundleHost;
+}
+
+uint16_t ReactInstanceWin::SourceBundlePort() const noexcept {
+  return m_options.DeveloperSettings.SourceBundlePort ? m_options.DeveloperSettings.SourceBundlePort
+                                                      : facebook::react::DevServerHelper::DefaultPackagerPort;
+}
+
+std::string ReactInstanceWin::JavaScriptBundleFile() const noexcept {
+  return m_options.Identity;
 }
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -803,4 +803,24 @@ std::string ReactInstanceWin::getApplicationLocalFolder() {
 }
 #endif
 
+bool ReactInstanceWin::UseWebDebugger() noexcept {
+  return m_useWebDebugger;
+}
+
+bool ReactInstanceWin::UseFastRefresh() noexcept {
+  return m_isFastReloadEnabled;
+}
+
+bool ReactInstanceWin::UseDirectDebugger() noexcept {
+  return m_useDirectDebugger;
+}
+
+bool ReactInstanceWin::DebuggerBreakOnNextLine() noexcept {
+  return m_debuggerBreakOnNextLine;
+}
+
+uint16_t ReactInstanceWin::DebuggerPort() noexcept {
+  return Options().DeveloperSettings.DebuggerPort;
+}
+
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -69,6 +69,12 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
       facebook::react::IReactRootView *rootView,
       folly::dynamic &&initialProps) noexcept override;
   void DetachRootView(facebook::react::IReactRootView *rootView) noexcept override;
+
+  bool UseWebDebugger() noexcept;
+  bool UseFastRefresh() noexcept;
+  bool UseDirectDebugger() noexcept;
+  bool DebuggerBreakOnNextLine() noexcept;
+  uint16_t DebuggerPort() noexcept;
 #endif
 
  private:

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -59,7 +59,6 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
   facebook::react::INativeUIManager *NativeUIManager() noexcept override;
 #endif
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept override;
-  std::string GetBundleRootPath() noexcept override;
 #ifndef CORE_ABI
   std::shared_ptr<react::uwp::IReactInstance> UwpReactInstance() noexcept override;
 #endif
@@ -70,11 +69,16 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
       folly::dynamic &&initialProps) noexcept override;
   void DetachRootView(facebook::react::IReactRootView *rootView) noexcept override;
 
-  bool UseWebDebugger() noexcept;
-  bool UseFastRefresh() noexcept;
-  bool UseDirectDebugger() noexcept;
-  bool DebuggerBreakOnNextLine() noexcept;
-  uint16_t DebuggerPort() noexcept;
+  bool UseWebDebugger() const noexcept;
+  bool UseFastRefresh() const noexcept;
+  bool UseDirectDebugger() const noexcept;
+  bool DebuggerBreakOnNextLine() const noexcept;
+  uint16_t DebuggerPort() const noexcept;
+  std::string DebugBundlePath() const noexcept;
+  std::string BundleRootPath() const noexcept;
+  std::string SourceBundleHost() const noexcept;
+  uint16_t SourceBundlePort() const noexcept;
+  std::string JavaScriptBundleFile() const noexcept;
 #endif
 
  private:
@@ -175,7 +179,6 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal, 
   std::shared_ptr<react::uwp::AppTheme> m_appTheme;
   Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
 #endif
-  std::string m_bundleRootPath;
   Mso::DispatchQueue m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
 };

--- a/vnext/Microsoft.ReactNative/ReactHost/React_Win.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React_Win.h
@@ -26,7 +26,7 @@ struct ILegacyReactInstance : IUnknown {
   virtual facebook::react::INativeUIManager *NativeUIManager() noexcept = 0;
 #endif
   virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept = 0;
-  virtual std::string GetBundleRootPath() noexcept = 0;
+  virtual std::string BundleRootPath() const noexcept = 0;
 
   virtual bool IsLoaded() const noexcept = 0;
 #ifndef CORE_ABI

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.cpp
@@ -44,8 +44,8 @@ ExpressionAnimationStore &UwpReactInstanceProxy::GetExpressionAnimationStore() n
   return m_expressionAnimationStore;
 }
 
-std::string UwpReactInstanceProxy::GetBundleRootPath() const noexcept {
-  return m_context->GetBundleRootPath();
+std::string UwpReactInstanceProxy::BundleRootPath() const noexcept {
+  return m_context->BundleRootPath();
 }
 
 bool UwpReactInstanceProxy::IsLoaded() const noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/UwpReactInstanceProxy.h
@@ -31,7 +31,7 @@ struct UwpReactInstanceProxy : IReactInstance, std::enable_shared_from_this<UwpR
   bool IsInError() const noexcept override;
   bool IsWaitingForDebugger() const noexcept override;
   ExpressionAnimationStore &GetExpressionAnimationStore() noexcept override;
-  std::string GetBundleRootPath() const noexcept override;
+  std::string BundleRootPath() const noexcept override;
   bool IsLoaded() const noexcept override;
 
   // Test hooks

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -44,6 +44,7 @@ namespace Microsoft.ReactNative {
     IReactNotificationService Notifications { get; };
     IVector<IReactPackageProvider> PackageProviders { get; };
     Boolean UseDeveloperSupport { get; set; };
+    // Deprecated - use JavaScriptBundleFile instead
     String JavaScriptMainModuleName { get; set; };
     String JavaScriptBundleFile { get; set; };
     Boolean UseWebDebugger { get; set; };

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -117,7 +117,8 @@ void DevMenuManager::CreateAndShowUI() noexcept {
                                                                                  : L"Enable Break on First Line");
 
   m_reloadJSRevoker = devMenu.Reload().Click(
-      winrt::auto_revoke, [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
         if (auto strongThis = wkThis.lock()) {
           strongThis->Hide();
           DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
@@ -197,8 +198,7 @@ void DevMenuManager::CreateAndShowUI() noexcept {
           : xaml::Visibility::Collapsed);
 
   m_cancelRevoker = devMenu.Cancel().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) {
+      winrt::auto_revoke, [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) {
         if (auto strongThis = wkThis.lock()) {
           strongThis->Hide();
         }

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -117,53 +117,77 @@ void DevMenuManager::CreateAndShowUI() noexcept {
                                                                                  : L"Enable Break on First Line");
 
   m_reloadJSRevoker = devMenu.Reload().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        DevSettings::Reload(React::ReactPropertyBag(m_context->Properties()));
+      winrt::auto_revoke, [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+        }
       });
 
   m_remoteDebugJSRevoker = devMenu.RemoteDebug().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        Mso::React::ReactOptions::SetUseWebDebugger(
-            m_context->Properties(), !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()));
-        DevSettings::Reload(React::ReactPropertyBag(m_context->Properties()));
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          Mso::React::ReactOptions::SetUseWebDebugger(
+              strongThis->m_context->Properties(),
+              !Mso::React::ReactOptions::UseWebDebugger(strongThis->m_context->Properties()));
+          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+        }
       });
 
   m_directDebuggingRevoker = devMenu.DirectDebug().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        Mso::React::ReactOptions::SetUseDirectDebugger(
-            m_context->Properties(), !Mso::React::ReactOptions::UseDirectDebugger(m_context->Properties()));
-        DevSettings::Reload(React::ReactPropertyBag(m_context->Properties()));
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          Mso::React::ReactOptions::SetUseDirectDebugger(
+              strongThis->m_context->Properties(),
+              !Mso::React::ReactOptions::UseDirectDebugger(strongThis->m_context->Properties()));
+          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+        }
       });
 
   m_breakOnNextLineRevoker = devMenu.BreakOnNextLine().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        Mso::React::ReactOptions::SetDebuggerBreakOnNextLine(
-            m_context->Properties(), !Mso::React::ReactOptions::DebuggerBreakOnNextLine(m_context->Properties()));
-        DevSettings::Reload(React::ReactPropertyBag(m_context->Properties()));
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          Mso::React::ReactOptions::SetDebuggerBreakOnNextLine(
+              strongThis->m_context->Properties(),
+              !Mso::React::ReactOptions::DebuggerBreakOnNextLine(strongThis->m_context->Properties()));
+          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+        }
       });
 
   m_fastRefreshRevoker = devMenu.FastRefresh().Click(
-      winrt::auto_revoke, [this](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        Mso::React::ReactOptions::SetUseFastRefresh(
-            m_context->Properties(), !Mso::React::ReactOptions::UseFastRefresh(m_context->Properties()));
-        DevSettings::Reload(React::ReactPropertyBag(m_context->Properties()));
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          Mso::React::ReactOptions::SetUseFastRefresh(
+              strongThis->m_context->Properties(),
+              !Mso::React::ReactOptions::UseFastRefresh(strongThis->m_context->Properties()));
+          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+        }
       });
 
   m_toggleInspectorRevoker = devMenu.Inspector().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        DevSettings::ToggleElementInspector(*m_context);
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          DevSettings::ToggleElementInspector(*(strongThis->m_context));
+        }
       });
 
   m_configBundlerRevoker = devMenu.ConfigBundler().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        Hide();
-        React::ReactPropertyBag(m_context->Properties()).Get(ConfigureBundlerProperty())();
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+          React::ReactPropertyBag(strongThis->m_context->Properties()).Get(ConfigureBundlerProperty())();
+        }
       });
   // Only show Configure Bundler when connected to a bundler
   devMenu.ConfigBundler().Visibility(
@@ -173,7 +197,12 @@ void DevMenuManager::CreateAndShowUI() noexcept {
           : xaml::Visibility::Collapsed);
 
   m_cancelRevoker = devMenu.Cancel().Click(
-      winrt::auto_revoke, [this](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) { Hide(); });
+      winrt::auto_revoke,
+      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) {
+        if (auto strongThis = wkThis.lock()) {
+          strongThis->Hide();
+        }
+      });
 
   m_flyout = xaml::Controls::Flyout{};
   m_flyout.Content(devMenu);

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -166,7 +166,7 @@ void ImageViewManager::setSource(winrt::Grid grid, const folly::dynamic &data) {
     return;
 
   auto sources{json_type_traits<std::vector<ReactImageSource>>::parseJson(data)};
-  sources[0].bundleRootPath = instance->GetBundleRootPath();
+  sources[0].bundleRootPath = instance->BundleRootPath();
 
   if (sources[0].packagerAsset && sources[0].uri.find("file://") == 0) {
     sources[0].uri.replace(0, 7, sources[0].bundleRootPath);

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -110,15 +110,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\NetworkingModule.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Threading\BatchingQueueThread.cpp">
-      <Filter>Source Files\Threading</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Threading\MessageDispatchQueue.cpp">
-      <Filter>Source Files\Threading</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Threading\MessageQueueThreadFactory.cpp">
-      <Filter>Source Files\Threading</Filter>
-    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)Threading\BatchingQueueThread.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Threading\MessageDispatchQueue.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Threading\MessageQueueThreadFactory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -327,15 +321,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\NetworkingModule.h">
       <Filter>Header Files\Modules</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)Threading\BatchingQueueThread.h">
-      <Filter>Header Files\Threading</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)Threading\MessageDispatchQueue.h">
-      <Filter>Header Files\Threading</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)Threading\MessageQueueThreadFactory.h">
-      <Filter>Header Files\Threading</Filter>
-    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)Threading\BatchingQueueThread.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Threading\MessageDispatchQueue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Threading\MessageQueueThreadFactory.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)etw\build.bat">

--- a/vnext/template/cpp-app/src/App.cpp
+++ b/vnext/template/cpp-app/src/App.cpp
@@ -26,7 +26,7 @@ App::App() noexcept
     InstanceSettings().UseWebDebugger(false);
     InstanceSettings().UseFastRefresh(false);
 #else
-    JavaScriptMainModuleName(L"index");
+    JavaScriptBundleFile(L"index");
     InstanceSettings().UseWebDebugger(true);
     InstanceSettings().UseFastRefresh(true);
 #endif

--- a/vnext/template/cs-app/src/App.xaml.cs
+++ b/vnext/template/cs-app/src/App.xaml.cs
@@ -16,7 +16,7 @@ namespace {{ namespace }}
             InstanceSettings.UseWebDebugger = false;
             InstanceSettings.UseFastRefresh = false;
 #else
-            JavaScriptMainModuleName = "index";
+            JavaScriptBundleFile = "index";
             InstanceSettings.UseWebDebugger = true;
             InstanceSettings.UseFastRefresh = true;
 #endif


### PR DESCRIPTION
Expose some getters for examining the instance settings from react context.  This is useful if users want to be able to conditionally change behavior when using web debugging.  In particular I'm using in the playground app to change the apps theme to light theme when using web debugger, since that's what the JS code will think the theme is, and helps keep the native / JS UI in alignment.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6135)