### PR TITLE
Add some extra error handling to GitReactFileRepository

### DIFF
--- a/change/react-native-platform-override-2020-09-30-17-46-03-extra-git-error-handing.json
+++ b/change/react-native-platform-override-2020-09-30-17-46-03-extra-git-error-handing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add some extra error handling to GitReactFileRepository",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-01T00:46:03.775Z"
+}

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -112,14 +112,7 @@ export default class GitReactFileRepository
     newContent: Buffer,
   ): Promise<string> {
     return this.usingVersion(reactNativeVersion, async () => {
-      const stat = await this.fileRepo.stat(filename);
-      if (stat === 'none') {
-        throw new Error(
-          `Cannot find file "${filename}" in react-native@${reactNativeVersion}`,
-        );
-      } else if (stat === 'directory') {
-        throw new Error(`"${filename}" refers to a directory`);
-      }
+      await this.ensureFile(filename);
 
       try {
         await this.fileRepo.writeFile(filename, newContent);
@@ -155,14 +148,7 @@ export default class GitReactFileRepository
     patchContent: string,
   ): Promise<{patchedFile: Buffer | null; hasConflicts: boolean}> {
     return this.usingVersion(reactNativeVersion, async () => {
-      const stat = await this.fileRepo.stat(filename);
-      if (stat === 'none') {
-        throw new Error(
-          `Cannot find file "${filename}" in react-native@${reactNativeVersion}`,
-        );
-      } else if (stat === 'directory') {
-        throw new Error(`"${filename}" refers to a directory`);
-      }
+      await this.ensureFile(filename);
 
       try {
         await this.fileRepo.writeFile('rnwgit.patch', patchContent);
@@ -291,5 +277,18 @@ export default class GitReactFileRepository
 
   private static async defaultGitDirectory(): Promise<string> {
     return path.join(os.tmpdir(), (await getNpmPackage()).name, 'git');
+  }
+
+  private async ensureFile(filename: string): Promise<void> {
+    const stat = await this.fileRepo.stat(filename);
+    if (stat === 'none') {
+      throw new Error(
+        `Cannot find file "${filename}" in react-native@${
+          this.checkedOutVersion
+        }`,
+      );
+    } else if (stat === 'directory') {
+      throw new Error(`"${filename}" refers to a directory`);
+    }
   }
 }

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -112,6 +112,15 @@ export default class GitReactFileRepository
     newContent: Buffer,
   ): Promise<string> {
     return this.usingVersion(reactNativeVersion, async () => {
+      const stat = await this.fileRepo.stat(filename);
+      if (stat === 'none') {
+        throw new Error(
+          `Cannot find file "${filename}" in react-native@${reactNativeVersion}`,
+        );
+      } else if (stat === 'directory') {
+        throw new Error(`"${filename}" refers to a directory`);
+      }
+
       try {
         await this.fileRepo.writeFile(filename, newContent);
         const patch = await this.gitClient.diff([
@@ -146,6 +155,15 @@ export default class GitReactFileRepository
     patchContent: string,
   ): Promise<{patchedFile: Buffer | null; hasConflicts: boolean}> {
     return this.usingVersion(reactNativeVersion, async () => {
+      const stat = await this.fileRepo.stat(filename);
+      if (stat === 'none') {
+        throw new Error(
+          `Cannot find file "${filename}" in react-native@${reactNativeVersion}`,
+        );
+      } else if (stat === 'directory') {
+        throw new Error(`"${filename}" refers to a directory`);
+      }
+
       try {
         await this.fileRepo.writeFile('rnwgit.patch', patchContent);
 

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -281,9 +281,7 @@ export default class GitReactFileRepository
     const stat = await this.fileRepo.stat(filename);
     if (stat === 'none') {
       throw new Error(
-        `Cannot find file "${filename}" in react-native@${
-          this.checkedOutVersion
-        }`,
+        `Cannot find file "${filename}" in react-native@${this.checkedOutVersion}`,
       );
     } else if (stat === 'directory') {
       throw new Error(`"${filename}" refers to a directory`);


### PR DESCRIPTION
We get confusing errors if we get into a state where we try to patch a file that doesn't exist. Add some checks for some clearer ones.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6144)