### PR TITLE
Increase NuGet Credential Provider Timeout

### DIFF
--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -4,3 +4,5 @@ variables:
   GoogleTestAdapterPathExpression: '(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\" -Directory | Where-Object -FilterScript { Test-Path $_\GoogleTestAdapter.Core.dll}).FullName'
   BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:
   runCodesignValidationInjection: false
+  NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
+  NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60


### PR DESCRIPTION
We've been seeing intermittent errors doing a NuGet restore due to the credential provider timing out. Reccomendations online are to increase the default 5s timeout to something longer.

See
- https://developercommunity.visualstudio.com/content/problem/1014284/nuget-restore-fails-due-to-credentialprovidermicro.html
- https://github.com/microsoft/artifacts-credprovider/issues/192

Hopefully fixes #6131

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6147)