### PR TITLE
Fix native modules not being re-initialized on reload

### DIFF
--- a/change/react-native-windows-2020-10-02-00-03-14-HEAD.json
+++ b/change/react-native-windows-2020-10-02-00-03-14-HEAD.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix native modules not being re-initialized on reload",
+  "packageName": "react-native-windows",
+  "email": "tn0502@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-01T22:03:14.221Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -81,18 +81,16 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
 
   auto turboModulesProvider = std::make_shared<TurboModulesProvider>();
 
-  if (!m_packageBuilder) {
-    m_packageBuilder = make<ReactPackageBuilder>(
-        modulesProvider,
+  m_packageBuilder = make<ReactPackageBuilder>(
+      modulesProvider,
 #ifndef CORE_ABI
-        viewManagersProvider,
+      viewManagersProvider,
 #endif
-        turboModulesProvider);
+      turboModulesProvider);
 
-    if (auto packageProviders = InstanceSettings().PackageProviders()) {
-      for (auto const &packageProvider : packageProviders) {
-        packageProvider.CreatePackage(m_packageBuilder);
-      }
+  if (auto packageProviders = InstanceSettings().PackageProviders()) {
+    for (auto const &packageProvider : packageProviders) {
+      packageProvider.CreatePackage(m_packageBuilder);
     }
   }
 


### PR DESCRIPTION
When calling `ReactNativeHost::ReloadInstance()`, `ReactPackageProvider`s are not reiterated and thus not calling `AddAttributedModules()`. As a consequence, the native modules that were loaded the first time the app was loaded, no longer "exist" after a reload.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6159)