### PR TITLE
 Add command to diff overrides

### DIFF
--- a/change/react-native-platform-override-2020-10-01-19-45-20-override-diff.json
+++ b/change/react-native-platform-override-2020-10-01-19-45-20-override-diff.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add command to diff overrides",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T02:45:20.196Z"
+}

--- a/packages/react-native-platform-override/README.md
+++ b/packages/react-native-platform-override/README.md
@@ -81,13 +81,12 @@ Attempts to automatically merge new changes into out-of-date overrides.
 | `--no-conflicts`    | Optional | Whether to allow upgraded files to contain conlict markers | `--conflicts`                   |
 
 ### `diff <override>`
-Diffs an override against its base file. By default it it compared to the base file of the overrides current version, even if the manifest
-targets a different react-native version.
+Diffs an override against its base file. It it compared to the base file of the override's current version, even if a newer verison of
+react-native is installed.
 
 | Option                 | Required | Description                                                                                                    | Default |
 |------------------------|----------|----------------------------------------------------------------------------------------------------------------|---------|
 | `<override>`           | Required | The override to diff against                                                                                   |         |
-| `--useManifestVersion` | Optional | Compare against the base file of the current manifest react-native-version instead of current override version | false   |
 
 ## GitHub Tokens
 `react-native-platform-override` makes requests to GitHub's API. An OAuth token may optionally be provided by using the `--githubToken`

--- a/packages/react-native-platform-override/README.md
+++ b/packages/react-native-platform-override/README.md
@@ -80,6 +80,16 @@ Attempts to automatically merge new changes into out-of-date overrides.
 | `--version <v>`     | Optional | A version of React Native to check against                 | The currently installed version |
 | `--no-conflicts`    | Optional | Whether to allow upgraded files to contain conlict markers | `--conflicts`                   |
 
+### `diff <override>`
+Diffs an override against its base file. By default it it compared to the base file of the overrides current version, even if the manifest
+targets a different react-native version.
+
+| Option                 | Required | Description                                                                                                    | Default |
+|------------------------|----------|----------------------------------------------------------------------------------------------------------------|---------|
+| `<override>`           | Required | The override to diff against                                                                                   |         |
+| `--useManifestVersion` | Optional | Compare against the base file of the current manifest react-native-version instead of current override version | false   |
+| `--version`            | Optional | Compare the override against the base file of a specific react-native version                                  |         |
+
 ## GitHub Tokens
 `react-native-platform-override` makes requests to GitHub's API. An OAuth token may optionally be provided by using the `--githubToken`
 parameter or setting the PLATFORM_OVERRIDE_GITHUB_TOKEN environment variable.

--- a/packages/react-native-platform-override/README.md
+++ b/packages/react-native-platform-override/README.md
@@ -88,7 +88,6 @@ targets a different react-native version.
 |------------------------|----------|----------------------------------------------------------------------------------------------------------------|---------|
 | `<override>`           | Required | The override to diff against                                                                                   |         |
 | `--useManifestVersion` | Optional | Compare against the base file of the current manifest react-native-version instead of current override version | false   |
-| `--version`            | Optional | Compare the override against the base file of a specific react-native version                                  |         |
 
 ## GitHub Tokens
 `react-native-platform-override` makes requests to GitHub's API. An OAuth token may optionally be provided by using the `--githubToken`

--- a/packages/react-native-platform-override/src/Api.ts
+++ b/packages/react-native-platform-override/src/Api.ts
@@ -100,6 +100,35 @@ export async function addOverride(
 }
 
 /**
+ * Ouputs a patch-style diff of an override compared to its original source
+ */
+export async function diffOverride(
+  overrideName: string,
+  opts: {manifestPath?: string; reactNativeVersion?: string},
+): Promise<string> {
+  const ctx = await createManifestContext(opts);
+
+  const override = ctx.manifest.findOverride(overrideName);
+  if (!override) {
+    throw new Error(`Could not find override with name "${overrideName}"`);
+  }
+
+  return override
+    .diffStrategy(opts.reactNativeVersion)
+    .diff(ctx.gitReactRepo, ctx.overrideRepo);
+}
+
+/**
+ * Returns the react-native version of the override manifest
+ */
+export async function manifestVersion(opts: {
+  manifestPath?: string;
+}): Promise<string> {
+  const {reactNativeVersion} = await createManifestContext(opts);
+  return reactNativeVersion;
+}
+
+/**
  * Receives notifications on progress during overide upgrades
  */
 export type UpgradeProgressListener = (

--- a/packages/react-native-platform-override/src/Api.ts
+++ b/packages/react-native-platform-override/src/Api.ts
@@ -104,7 +104,7 @@ export async function addOverride(
  */
 export async function diffOverride(
   overrideName: string,
-  opts: {manifestPath?: string; reactNativeVersion?: string},
+  opts: {manifestPath?: string},
 ): Promise<string> {
   const ctx = await createManifestContext(opts);
 
@@ -113,19 +113,7 @@ export async function diffOverride(
     throw new Error(`Could not find override with name "${overrideName}"`);
   }
 
-  return override
-    .diffStrategy(opts.reactNativeVersion)
-    .diff(ctx.gitReactRepo, ctx.overrideRepo);
-}
-
-/**
- * Returns the react-native version of the override manifest
- */
-export async function manifestVersion(opts: {
-  manifestPath?: string;
-}): Promise<string> {
-  const {reactNativeVersion} = await createManifestContext(opts);
-  return reactNativeVersion;
+  return override.diffStrategy().diff(ctx.gitReactRepo, ctx.overrideRepo);
 }
 
 /**

--- a/packages/react-native-platform-override/src/Cli.ts
+++ b/packages/react-native-platform-override/src/Cli.ts
@@ -74,15 +74,9 @@ void doMain(async () => {
         cmdYargs =>
           cmdYargs.options({
             override: {type: 'string', describe: 'The override to add'},
-            useManifestVersion: {
-              type: 'boolean',
-              default: false,
-              describe:
-                'Compare against the base file of the current manifest react-native-version instead of current override version',
-            },
           }),
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        cmdArgv => diffOverride(cmdArgv.override!, cmdArgv.useManifestVersion),
+        cmdArgv => diffOverride(cmdArgv.override!),
       )
       .command(
         'upgrade',
@@ -209,23 +203,14 @@ async function removeOverride(overridePath: string) {
 /**
  * Diffs an override against its base file
  */
-async function diffOverride(overridePath: string, useManifestVersion: boolean) {
+async function diffOverride(overridePath: string) {
   const manifestPath = await findManifest(path.dirname(overridePath));
   const manifestDir = path.dirname(manifestPath);
   const overrideName = path.relative(manifestDir, path.resolve(overridePath));
-
-  const reactNativeVersion = useManifestVersion
-    ? await Api.manifestVersion({manifestPath})
-    : undefined;
-
-  const diff = await Api.diffOverride(overrideName, {
-    manifestPath,
-    reactNativeVersion,
-  });
+  const diff = await Api.diffOverride(overrideName, {manifestPath});
 
   const colorizedDiff = diff
     .split('\n')
-    .slice(4) // Ignore Git gunk
     .map(line =>
       line.startsWith('+')
         ? chalk.green(line)

--- a/packages/react-native-platform-override/src/Cli.ts
+++ b/packages/react-native-platform-override/src/Cli.ts
@@ -72,28 +72,17 @@ void doMain(async () => {
         'diff <override>',
         'Compares an override to the base file of its current version',
         cmdYargs =>
-          cmdYargs
-            .options({
-              override: {type: 'string', describe: 'The override to add'},
-              useManifestVersion: {
-                type: 'boolean',
-                default: false,
-                describe:
-                  'Compare against the base file of the current manifest react-native-version instead of current override version',
-              },
-              version: {
-                type: 'string',
-                describe: 'Optional React Native version to check against',
-              },
-            })
-            .conflicts('useManifestVersion', 'version'),
+          cmdYargs.options({
+            override: {type: 'string', describe: 'The override to add'},
+            useManifestVersion: {
+              type: 'boolean',
+              default: false,
+              describe:
+                'Compare against the base file of the current manifest react-native-version instead of current override version',
+            },
+          }),
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        cmdArgv =>
-          diffOverride(
-            cmdArgv.override!,
-            cmdArgv.useManifestVersion,
-            cmdArgv.version,
-          ),
+        cmdArgv => diffOverride(cmdArgv.override!, cmdArgv.useManifestVersion),
       )
       .command(
         'upgrade',
@@ -220,18 +209,14 @@ async function removeOverride(overridePath: string) {
 /**
  * Diffs an override against its base file
  */
-async function diffOverride(
-  overridePath: string,
-  useManifestVersion: boolean,
-  version?: string,
-) {
+async function diffOverride(overridePath: string, useManifestVersion: boolean) {
   const manifestPath = await findManifest(path.dirname(overridePath));
   const manifestDir = path.dirname(manifestPath);
   const overrideName = path.relative(manifestDir, path.resolve(overridePath));
 
   const reactNativeVersion = useManifestVersion
     ? await Api.manifestVersion({manifestPath})
-    : version;
+    : undefined;
 
   const diff = await Api.diffOverride(overrideName, {
     manifestPath,

--- a/packages/react-native-platform-override/src/DiffStrategy.ts
+++ b/packages/react-native-platform-override/src/DiffStrategy.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import GitReactFileRepository from './GitReactFileRepository';
+import {WritableFileRepository} from './FileRepository';
+
+/**
+ * An UpgradeStrategy describes the process to diff an override to its base
+ */
+export default interface DiffStrategy {
+  diff(
+    gitReactRepo: GitReactFileRepository,
+    overrideRepo: WritableFileRepository,
+  ): Promise<string>;
+}
+
+export const DiffStrategies = {
+  /**
+   * Assume the override is the same as the original
+   */
+  asssumeSame: (): DiffStrategy => ({
+    diff: async () => '',
+  }),
+
+  /**
+   * Assume the override is the same as the original
+   */
+  compareBaseFile: (
+    overrideFile: string,
+    baseFile: string,
+    baseVersion: string,
+  ): DiffStrategy => ({
+    diff: async (gitReactRepo, overrideRepo) => {
+      const overrideContents = await overrideRepo.readFile(overrideFile);
+      if (!overrideContents) {
+        throw new Error(`Couldn't read override "${overrideFile}"`);
+      }
+
+      return gitReactRepo.generatePatch(
+        baseFile,
+        baseVersion,
+        overrideContents,
+      );
+    },
+  }),
+};

--- a/packages/react-native-platform-override/src/DiffStrategy.ts
+++ b/packages/react-native-platform-override/src/DiffStrategy.ts
@@ -40,11 +40,17 @@ export const DiffStrategies = {
         throw new Error(`Couldn't read override "${overrideFile}"`);
       }
 
-      return gitReactRepo.generatePatch(
+      const patch = await gitReactRepo.generatePatch(
         baseFile,
         baseVersion,
         overrideContents,
       );
+
+      return patch
+        .trim()
+        .split('\n')
+        .slice(4) // Ignore Git gunk
+        .join('\n');
     },
   }),
 };

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -124,10 +124,6 @@ export default class GitReactFileRepository
           filename,
         ]);
 
-        if (patch.length === 0) {
-          throw new Error(`Generated patch for ${filename} was empty`);
-        }
-
         return patch;
       } finally {
         await this.gitClient.reset('hard');

--- a/packages/react-native-platform-override/src/Override.ts
+++ b/packages/react-native-platform-override/src/Override.ts
@@ -8,6 +8,7 @@
 import * as Serialized from './Serialized';
 import * as path from 'path';
 
+import DiffStrategy, {DiffStrategies} from './DiffStrategy';
 import UpgradeStrategy, {UpgradeStrategies} from './UpgradeStrategy';
 import ValidationStrategy, {ValidationStrategies} from './ValidationStrategy';
 import {normalizePath, unixPath} from './PathUtils';
@@ -49,6 +50,12 @@ export default interface Override {
    * Specifies how to check if the override contents are valid and up to date.
    */
   validationStrategies(): ValidationStrategy[];
+
+  /**
+   * Specifies how to diff an override against its base version
+   * @param reactNativeVersion a specific version of react-native to compare against
+   */
+  diffStrategy(reactNativeVersion?: string): DiffStrategy;
 }
 
 /**
@@ -89,6 +96,10 @@ export class PlatformOverride implements Override {
 
   validationStrategies(): ValidationStrategy[] {
     return [ValidationStrategies.overrideFileExists(this.overrideFile)];
+  }
+
+  diffStrategy(): DiffStrategy {
+    return DiffStrategies.asssumeSame();
   }
 }
 
@@ -138,6 +149,14 @@ abstract class BaseFileOverride implements Override {
         this.baseHash,
       ),
     ];
+  }
+
+  diffStrategy(reactNativeVersion?: string): DiffStrategy {
+    return DiffStrategies.compareBaseFile(
+      this.overrideFile,
+      this.baseFile,
+      reactNativeVersion || this.baseVersion,
+    );
   }
 
   protected serialzeBase() {
@@ -389,6 +408,10 @@ export class DirectoryCopyOverride implements Override {
         this.baseDirectory,
       ),
     ];
+  }
+
+  diffStrategy(): DiffStrategy {
+    return DiffStrategies.asssumeSame();
   }
 }
 

--- a/packages/react-native-platform-override/src/Override.ts
+++ b/packages/react-native-platform-override/src/Override.ts
@@ -53,9 +53,8 @@ export default interface Override {
 
   /**
    * Specifies how to diff an override against its base version
-   * @param reactNativeVersion a specific version of react-native to compare against
    */
-  diffStrategy(reactNativeVersion?: string): DiffStrategy;
+  diffStrategy(): DiffStrategy;
 }
 
 /**
@@ -151,11 +150,11 @@ abstract class BaseFileOverride implements Override {
     ];
   }
 
-  diffStrategy(reactNativeVersion?: string): DiffStrategy {
+  diffStrategy(): DiffStrategy {
     return DiffStrategies.compareBaseFile(
       this.overrideFile,
       this.baseFile,
-      reactNativeVersion || this.baseVersion,
+      this.baseVersion,
     );
   }
 

--- a/packages/react-native-platform-override/src/UpgradeStrategy.ts
+++ b/packages/react-native-platform-override/src/UpgradeStrategy.ts
@@ -64,6 +64,10 @@ export const UpgradeStrategies = {
         ovrContent,
       );
 
+      if (ovrAsPatch.length === 0) {
+        throw new Error(`Generated patch for ${overrideName} was empty`);
+      }
+
       const {patchedFile, hasConflicts} = await gitReactRepo.getPatchedFile(
         baseFile,
         newVersion,

--- a/packages/react-native-platform-override/src/e2etest/Api.test.ts
+++ b/packages/react-native-platform-override/src/e2etest/Api.test.ts
@@ -134,6 +134,17 @@ test('upgradeOverrides', async () => {
   });
 });
 
+test('diffOverride', async () => {
+  await usingRepository('sampleOverrideRepo', async (_, repoPath) => {
+    const opts = {
+      manifestPath: path.join(repoPath, 'overrides.json'),
+    };
+
+    const diff = await Api.diffOverride('ReactCommon/yoga/yoga/Yoga.cpp', opts);
+    expect(diff.length).toBeGreaterThan(0);
+  });
+});
+
 function expectIncrementing(
   expectedTotal: number,
 ): Api.UpgradeProgressListener {

--- a/packages/react-native-platform-override/src/e2etest/DiffStrategy.test.ts
+++ b/packages/react-native-platform-override/src/e2etest/DiffStrategy.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import DiffStrategy, {DiffStrategies} from '../DiffStrategy';
+import {acquireGitRepo, usingFiles} from './Resource';
+import GitReactFileRepository from '../GitReactFileRepository';
+
+let gitReactRepo: GitReactFileRepository;
+let disposeReactRepo: () => Promise<void>;
+
+beforeAll(async () => {
+  [gitReactRepo, disposeReactRepo] = await acquireGitRepo();
+});
+
+afterAll(async () => {
+  await disposeReactRepo();
+});
+
+test('assumeSame', async () => {
+  const overrideFile = '0.62.2/flowconfig.pristine';
+  const diff = await evaluateStrategy(
+    DiffStrategies.asssumeSame(),
+    overrideFile,
+  );
+  expect(diff).toBe('');
+});
+
+test('compareBaseFile - No Difference', async () => {
+  const overrideFile = '0.62.2/flowconfig.pristine';
+  const diff = await evaluateStrategy(
+    DiffStrategies.compareBaseFile(overrideFile, '.flowconfig', '0.62.2'),
+    overrideFile,
+  );
+  expect(diff).toBe('');
+});
+
+test('compareBaseFile - Difference', async () => {
+  const overrideFile = '0.62.2/flowconfig.windows.addition';
+  const diff = await evaluateStrategy(
+    DiffStrategies.compareBaseFile(overrideFile, '.flowconfig', '0.62.2'),
+    overrideFile,
+  );
+  expect(diff).toBe(
+    `@@ -15,6 +15,8 @@
+ ; require from fbjs/lib instead: require('fbjs/lib/warning')
+ .*/node_modules/warning/.*
+ 
++; This change is Windows only
++
+ ; Flow doesn't support platforms
+ .*/Libraries/Utilities/LoadingView.js`,
+  );
+});
+
+async function evaluateStrategy(
+  strategy: DiffStrategy,
+  overrideFile: string,
+): Promise<string> {
+  return usingFiles([overrideFile], async overrideRepo => {
+    return strategy.diff(gitReactRepo, overrideRepo);
+  });
+}


### PR DESCRIPTION
This can be convenient to quickly discover what we changed in certain files, which often aren't consistently annotated where we have forked code.

Will add e2etests before merging.

Example usage:
![image](https://user-images.githubusercontent.com/835219/94883134-b3fa7e00-041e-11eb-8aa2-49121b1facbd.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6168)