### PR TITLE
Fix pre-1903 crash when loading certain images

### DIFF
--- a/change/react-native-windows-2020-10-02-11-24-41-imagecrash.json
+++ b/change/react-native-windows-2020-10-02-11-24-41-imagecrash.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix pre-1903 crash when loading certain images",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T18:24:41.653Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -248,9 +248,10 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
 
                 // If we are dynamically switching the resizeMode to 'repeat', then
                 // the SizeChanged event has already fired and the ReactImageBrush's
-                // size has not been set. Use ActualSize in that case.
+                // size has not been set. Use ActualWidth/Height in that case.
                 if (compositionBrush->AvailableSize() == winrt::Size{0, 0}) {
-                  compositionBrush->AvailableSize(strong_this->ActualSize());
+                  compositionBrush->AvailableSize({static_cast<float>(strong_this->ActualWidth()),
+                                                   static_cast<float>(strong_this->ActualHeight())});
                 }
 
                 compositionBrush->Source(surface);


### PR DESCRIPTION
Backport for #6162 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6172)