### PR TITLE
Integrate 8/19 Nightly RN Build

### DIFF
--- a/change/@office-iss-react-native-win32-2020-10-02-12-44-11-integrate-8-19.json
+++ b/change/@office-iss-react-native-win32-2020-10-02-12-44-11-integrate-8-19.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 8/19 Nightly RN Build",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T19:44:09.744Z"
+}

--- a/change/@rnw-scripts-integrate-rn-2020-10-02-12-44-11-integrate-8-19.json
+++ b/change/@rnw-scripts-integrate-rn-2020-10-02-12-44-11-integrate-8-19.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Allow Missing react-native devDependencies",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T19:44:07.724Z"
+}

--- a/change/react-native-windows-2020-10-02-12-44-11-integrate-8-19.json
+++ b/change/react-native-windows-2020-10-02-12-44-11-integrate-8-19.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 8/19 Nightly RN Build",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T19:44:11.089Z"
+}

--- a/packages/@rnw-scripts/integrate-rn/src/integrateRN.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/integrateRN.ts
@@ -171,7 +171,7 @@ async function applyRnDependencyChanges(
   )) {
     if (
       newDevDeps[name] &&
-      newDevDeps[name] === oldRnJson.devDependencies[name]
+      newDevDeps[name] === (oldRnJson.devDependencies || {})[name]
     ) {
       newDevDeps[name] = version;
     }

--- a/packages/@rnw-scripts/integrate-rn/src/integrateRN.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/integrateRN.ts
@@ -166,7 +166,9 @@ async function applyRnDependencyChanges(
   // differs more and react-native itself cannot depend on these. Just make
   // sure our versions match core where we were matching before.
   const newDevDeps = pkg.json.devDependencies;
-  for (const [name, version] of Object.entries(newRNJson.devDependencies)) {
+  for (const [name, version] of Object.entries(
+    newRNJson.devDependencies || {},
+  )) {
     if (
       newDevDeps[name] &&
       newDevDeps[name] === oldRnJson.devDependencies[name]

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "prompt-sync": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127",
+    "react-native": "0.0.0-f8e5423c8",
     "react-native-windows": "0.0.0-canary.176"
   },
   "devDependencies": {

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127",
+    "react-native": "0.0.0-f8e5423c8",
     "react-native-windows": "^0.0.0-canary.176"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127",
+    "react-native": "0.0.0-f8e5423c8",
     "react-native-windows": "0.0.0-canary.176"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127",
+    "react-native": "0.0.0-f8e5423c8",
     "react-native-windows": "0.0.0-canary.176"
   },
   "devDependencies": {

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -9,14 +9,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "f177c2ce170c403708153db596577a436d71e5dc"
     },
     {
       "type": "copy",
       "directory": "flow-typed",
       "baseDirectory": "flow-typed",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "f1491d073bd76e90b6c185d818ec807ac52346b9",
       "issue": 6139
     },
@@ -24,7 +24,7 @@
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -32,7 +32,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -40,7 +40,7 @@
       "type": "patch",
       "file": "src/Libraries/BatchedBridge/MessageQueue.win32.js",
       "baseFile": "Libraries/BatchedBridge/MessageQueue.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "85eea8e9510b516c12e19fcfedc4553b990feb11",
       "issue": 5807
     },
@@ -48,7 +48,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "525b7ac5ec31febba5f57c8faa7ccc9a6e0fa34c",
       "issue": "LEGACY_FIXME"
     },
@@ -56,7 +56,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "7b519b61f8100b5997c999b21552fd270abafce7",
       "issue": "LEGACY_FIXME"
     },
@@ -72,7 +72,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.win32.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea",
       "issue": 4378
     },
@@ -80,7 +80,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.win32.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc",
       "issue": 4378
     },
@@ -88,7 +88,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -100,7 +100,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.win32.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b",
       "issue": 4378
     },
@@ -112,7 +112,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerAndroid.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -120,7 +120,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/Picker/PickerIOS.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6",
       "issue": 4378
     },
@@ -128,7 +128,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a",
       "issue": 4378
     },
@@ -136,14 +136,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.win32.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
       "issue": "LEGACY_FIXME"
     },
@@ -151,7 +151,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": 4378
     },
@@ -175,7 +175,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "05c8c1e9142210b472c9c1ce891314b786ecc50f",
       "issue": "LEGACY_FIXME"
     },
@@ -183,7 +183,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -191,7 +191,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.win32.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0",
       "issue": 4378
     },
@@ -223,7 +223,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
       "issue": "LEGACY_FIXME"
     },
@@ -231,7 +231,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -243,7 +243,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.win32.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "147459dc889f04f2405db051445833f791726895",
       "issue": 5843
     },
@@ -259,7 +259,7 @@
       "type": "patch",
       "file": "src/Libraries/Core/ReactNativeVersionCheck.win32.js",
       "baseFile": "Libraries/Core/ReactNativeVersionCheck.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "1158beed7e691478c59af78c5a1097d76890cec8",
       "issue": 5170
     },
@@ -267,7 +267,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/Image.win32.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4320
     },
@@ -279,7 +279,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
       "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "6161ce89a0b45b24e8df69aa108af22a7b591483",
       "issue": 4320
     },
@@ -323,7 +323,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75",
       "issue": "LEGACY_FIXME"
     },
@@ -331,7 +331,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
       "baseFile": "Libraries/Inspector/InspectorOverlay.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "b11d03daa2e3f828a350667f543b2cda4fa65dbf",
       "issue": "LEGACY_FIXME"
     },
@@ -339,7 +339,7 @@
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxInspectorStackFrame.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "a1f75145b083be2bc83ddc240cadbcdf93931e0d",
       "issue": 5885
     },
@@ -347,7 +347,7 @@
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxStyle.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxStyle.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "118cad1437e07c7cb6c5c1fc3bb927b0c4dd1d52",
       "issue": 5886
     },
@@ -355,7 +355,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworking.win32.js",
       "baseFile": "Libraries/Network/RCTNetworking.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "ede560ee51b68436768eca79166c4fb40a3cf20a",
       "issue": 4318
     },
@@ -375,7 +375,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -395,7 +395,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheet.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84",
       "issue": "LEGACY_FIXME"
     },
@@ -403,7 +403,7 @@
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.win32.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "69605da09902165f866377d7eda5897029ef4d62",
       "issue": 4629
     },
@@ -411,7 +411,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
       "issue": "LEGACY_FIXME"
     },
@@ -419,7 +419,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
       "issue": "LEGACY_FIXME"
     },
@@ -427,7 +427,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "71ec2fb1dbf35d65562538d2c63d099ec1392d00",
       "issue": "LEGACY_FIXME"
     },
@@ -435,7 +435,7 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "750d5a0afc192d9ec98c27d28402285c9e3155a0",
       "issue": "LEGACY_FIXME"
     },
@@ -451,7 +451,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/ListExampleShared.win32.js",
       "baseFile": "RNTester/js/components/ListExampleShared.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
       "issue": "LEGACY_FIXME"
     },
@@ -459,7 +459,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "RNTester/js/components/RNTesterExampleFilter.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
       "issue": "LEGACY_FIXME"
     },
@@ -471,7 +471,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.win32.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -479,7 +479,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.win32.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0ac04af15d7ff9d34b3abe1a11110c24480fba4b",
       "issue": "LEGACY_FIXME"
     },

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -53,7 +53,8 @@
     "scheduler": "0.19.1",
     "stacktrace-parser": "^0.1.3",
     "use-subscription": "^1.0.0",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.0.0",
+    "ws": "^6.1.4"
   },
   "devDependencies": {
     "@office-iss/rex-win32": "0.62.7-tenantreactnativewin-13222",
@@ -71,14 +72,14 @@
     "just-scripts": "^0.36.1",
     "prettier": "1.19.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127",
+    "react-native": "0.0.0-f8e5423c8",
     "react-native-platform-override": "^0.3.2",
     "react-shallow-renderer": "^16.13.1",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127"
+    "react-native": "0.0.0-f8e5423c8"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -18,14 +18,14 @@
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "f177c2ce170c403708153db596577a436d71e5dc"
     },
     {
       "type": "patch",
       "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "caab3561363f0adf848ffd7da38f07aad5bb70cb",
       "issue": 3994
     },
@@ -33,7 +33,7 @@
       "type": "copy",
       "directory": "flow-typed",
       "baseDirectory": "flow-typed",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "f1491d073bd76e90b6c185d818ec807ac52346b9",
       "issue": 6139
     },
@@ -41,7 +41,7 @@
       "type": "copy",
       "directory": "ReactCopies/IntegrationTests",
       "baseDirectory": "IntegrationTests",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "3536f993a01e0fc159d357d944df0d93e2ede812",
       "issue": 4054
     },
@@ -49,7 +49,7 @@
       "type": "copy",
       "directory": "ReactCopies/RNTester/js",
       "baseDirectory": "RNTester/js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "4f53cbff777d251f6a105b44727f8554daaeb90d",
       "issue": 4054
     },
@@ -57,7 +57,7 @@
       "type": "patch",
       "file": "src/babel-plugin-codegen/GenerateViewConfigJs.js",
       "baseFile": "packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "8c9bb33fcf4aed06aa913aca6f5cc65478761f84",
       "issue": 5430
     },
@@ -65,7 +65,7 @@
       "type": "patch",
       "file": "src/babel-plugin-codegen/index.js",
       "baseFile": "packages/babel-plugin-codegen/index.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "02590f3430fb57fcd954357c9dbeeaa8bdc01d06",
       "issue": 5430
     },
@@ -73,7 +73,7 @@
       "type": "patch",
       "file": "src/babel-plugin-codegen/package.json",
       "baseFile": "packages/babel-plugin-codegen/package.json",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "bc3f1d26bd0fcbcb8dc09023e8889575c0adbc80",
       "issue": 5430
     },
@@ -81,7 +81,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
       "issue": "LEGACY_FIXME"
     },
@@ -109,7 +109,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
       "issue": "LEGACY_FIXME"
     },
@@ -125,7 +125,7 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "525b7ac5ec31febba5f57c8faa7ccc9a6e0fa34c",
       "issue": 4578
     },
@@ -133,7 +133,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Button.windows.js",
       "baseFile": "Libraries/Components/Button.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "93f4b6047b238d31c2c72c44f11cd689c6a4b071",
       "issue": "LEGACY_FIXME"
     },
@@ -145,7 +145,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePicker/DatePickerIOS.windows.js",
       "baseFile": "Libraries/Components/DatePicker/DatePickerIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "218895e2a5f3d7614a2cb577da187800857850ea"
     },
     {
@@ -156,14 +156,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/DatePickerAndroid/DatePickerAndroid.windows.js",
       "baseFile": "Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "09d82215c57ca5873a53523a63006daebf07ffbc"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js",
       "baseFile": "Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
@@ -194,14 +194,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/MaskedView/MaskedViewIOS.windows.js",
       "baseFile": "Libraries/Components/MaskedView/MaskedViewIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0b409391c852a1001cee74a84414a13c4fe88f8b"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Picker/Picker.windows.js",
       "baseFile": "Libraries/Components/Picker/Picker.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "ebfef6691cf4634daa34c025327f837d292ef44f",
       "issue": 4611
     },
@@ -209,14 +209,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerAndroid.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerIOS.windows.js",
       "baseFile": "Libraries/Components/Picker/PickerIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0c6bf0751e053672123cbad30d67851ba0007af6"
     },
     {
@@ -227,7 +227,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
       "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "1a94e2e99474b15141d1c67c1211ac1dc2c2a62d",
       "issue": 4611
     },
@@ -243,21 +243,21 @@
       "type": "derived",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e5bb18f4dc9ddbf96ab9b83cfc21b1c0495ac59a"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/ProgressViewIOS/ProgressViewIOS.windows.js",
       "baseFile": "Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "f0b35fdee6b1c9e7bfe860a9e0aefc00337ea7fd"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45",
       "issue": "LEGACY_FIXME"
     },
@@ -265,7 +265,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
       "issue": "LEGACY_FIXME"
     },
@@ -273,7 +273,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
       "issue": "LEGACY_FIXME"
     },
@@ -281,7 +281,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "05c8c1e9142210b472c9c1ce891314b786ecc50f",
       "issue": "LEGACY_FIXME"
     },
@@ -289,7 +289,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
       "issue": "LEGACY_FIXME"
     },
@@ -297,14 +297,14 @@
       "type": "derived",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "614b7e88c38f5820656c79d64239bfb74ca308c0"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912",
       "issue": "LEGACY_FIXME"
     },
@@ -312,7 +312,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95",
       "issue": "LEGACY_FIXME"
     },
@@ -320,7 +320,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "58698d349b3327660c71708f7128c2247caaef3f",
       "issue": "LEGACY_FIXME"
     },
@@ -328,7 +328,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
       "issue": "LEGACY_FIXME"
     },
@@ -336,7 +336,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.windows.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "147459dc889f04f2405db051445833f791726895",
       "issue": 5843
     },
@@ -344,7 +344,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
       "baseFile": "Libraries/Components/View/ViewAccessibility.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
       "issue": "LEGACY_FIXME"
     },
@@ -352,7 +352,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
       "baseFile": "Libraries/Components/View/ViewPropTypes.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "2b12228aa1ab0e12844996a99ff5d38fbff689a1",
       "issue": "LEGACY_FIXME"
     },
@@ -368,7 +368,7 @@
       "type": "patch",
       "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
       "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
       "issue": "LEGACY_FIXME"
     },
@@ -376,7 +376,7 @@
       "type": "copy",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",
       "issue": 4590
     },
@@ -388,7 +388,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "8ffebf68a136054311f723682864c4c609ad0587",
       "issue": "LEGACY_FIXME"
     },
@@ -396,7 +396,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
       "issue": "LEGACY_FIXME"
     },
@@ -404,7 +404,7 @@
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
       "issue": "LEGACY_FIXME"
     },
@@ -412,7 +412,7 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "72a2fea2216d144cc985f243c6d27274f8f4edb6",
       "issue": 4379
     },
@@ -420,7 +420,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.windows.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
       "issue": "LEGACY_FIXME"
     },
@@ -432,14 +432,14 @@
       "type": "derived",
       "file": "src/Libraries/Text/Text.windows.js",
       "baseFile": "Libraries/Text/Text.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "bf4306bd49457c2b82ee8f85147aa458505a5150"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e8f8ce02645228b423fdda317e5d1d9e69b54e6d",
       "issue": "LEGACY_FIXME"
     },
@@ -447,7 +447,7 @@
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.windows.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "69605da09902165f866377d7eda5897029ef4d62",
       "issue": 4629
     },
@@ -455,14 +455,14 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "71ec2fb1dbf35d65562538d2c63d099ec1392d00"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.windows.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "750d5a0afc192d9ec98c27d28402285c9e3155a0"
     },
     {
@@ -473,7 +473,7 @@
       "type": "patch",
       "file": "src/RNTester/js/components/RNTesterExampleList.windows.js",
       "baseFile": "RNTester/js/components/RNTesterExampleList.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "282bb1231e430fe2263a4cae29ac5d8254c0cab8",
       "issue": 5834
     },
@@ -485,7 +485,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/ScrollView/ScrollViewExample.windows.js",
       "baseFile": "RNTester/js/examples/ScrollView/ScrollViewExample.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "e622893fe0a5ce9d48b10644cd29a38de72b6a26",
       "issue": "LEGACY_FIXME"
     },
@@ -493,7 +493,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/TextInput/TextInputExample.windows.js",
       "baseFile": "RNTester/js/examples/TextInput/TextInputExample.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "1755bffd6ae353838f1779007dc4a512b8dddcdc",
       "issue": 5688
     },
@@ -501,7 +501,7 @@
       "type": "patch",
       "file": "src/RNTester/js/examples/View/ViewExample.windows.js",
       "baseFile": "RNTester/js/examples/View/ViewExample.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "2425a6f8fb8b7c7633b5744811c75edf77f29c2f",
       "issue": "LEGACY_FIXME"
     },
@@ -509,7 +509,7 @@
       "type": "derived",
       "file": "src/RNTester/js/RNTesterApp.windows.js",
       "baseFile": "RNTester/js/RNTesterApp.ios.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "34d2517461704840a508ce1856bc3a364fb3fc7e",
       "issue": 4586
     },
@@ -517,7 +517,7 @@
       "type": "derived",
       "file": "src/RNTester/js/utils/RNTesterList.windows.js",
       "baseFile": "RNTester/js/utils/RNTesterList.android.js",
-      "baseVersion": "0.0.0-423155127",
+      "baseVersion": "0.0.0-f8e5423c8",
       "baseHash": "0ac04af15d7ff9d34b3abe1a11110c24480fba4b",
       "issue": "LEGACY_FIXME"
     },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -53,7 +53,8 @@
     "scheduler": "0.19.1",
     "stacktrace-parser": "^0.1.3",
     "use-subscription": "^1.0.0",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.0.0",
+    "ws": "^6.1.4"
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.3.8",
@@ -68,7 +69,7 @@
     "just-scripts": "^0.36.1",
     "prettier": "1.19.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127",
+    "react-native": "0.0.0-f8e5423c8",
     "react-native-platform-override": "^0.3.2",
     "react-native-windows-codegen": "0.1.7",
     "react-refresh": "^0.4.0",
@@ -77,7 +78,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-423155127"
+    "react-native": "0.0.0-f8e5423c8"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4524,6 +4524,11 @@ async-exit-hook@^2.0.1:
   resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
   integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
 
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
 async-listener@^0.6.0:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
@@ -12216,10 +12221,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-423155127:
-  version "0.0.0-423155127"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-423155127.tgz#d3b728ecb098cca1d2395969150eab032721c5f7"
-  integrity sha512-hw7ksXBjeWyMbfsF1CPgc87FMukFW4z7YyyIRajxWG5w8NsqPS49OCsaqK1Bo9gC1JswdLfjHdEpylhBk1k+jw==
+react-native@0.0.0-f8e5423c8:
+  version "0.0.0-f8e5423c8"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-f8e5423c8.tgz#b8e25bcb59e30eee165df989280dce708a15f855"
+  integrity sha512-FTX7JcxzG7kmn7T3x6FLU2LjNfJsEYq6LBsAy8EAK71DdaL7jwgcsiOL2fuDodySdqS9D50DOKGD3bPgYPsFVQ==
   dependencies:
     "@react-native-community/cli" "^4.10.0"
     "@react-native-community/cli-platform-android" "^4.10.0"
@@ -12252,6 +12257,7 @@ react-native@0.0.0-423155127:
     stacktrace-parser "^0.1.3"
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
+    ws "^6.1.4"
 
 react-refresh@^0.4.0:
   version "0.4.3"
@@ -14797,6 +14803,13 @@ ws@^1.1.0, ws@^1.1.5:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@^6.1.4:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  dependencies:
+    async-limiter "~1.0.0"
 
 ws@^7, ws@^7.0.0, ws@^7.2.3, ws@^7.3.1:
   version "7.3.1"


### PR DESCRIPTION
Commits: https://github.com/facebook/react-native/compare/423155127...f8e5423c8

This is two days from current, but the last build before RNTester is moved to its own package, which I want to do by itself. This is the first build where Core started moving dev dependencies out of the react-native package into a "repo-config" metapackage.

The "repo-config" package was designed in such a way where syncing it doesn't make sense in our repo, and after that change, some devDependencies started moving back to the RN package. It does create unexpected errors for our integration script which expects the RN package to have dev dependencies, but instead we just do nothing if there is anything missing for now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6173)