### PR TITLE
Remove the other TimingModule Assertion

### DIFF
--- a/change/react-native-windows-2020-10-02-12-58-35-remove-other-timingmodule-assert.json
+++ b/change/react-native-windows-2020-10-02-12-58-35-remove-other-timingmodule-assert.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove the other TimingModule Assertion",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T19:58:35.058Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -121,8 +121,6 @@ void Timing::createTimer(int64_t id, double duration, double jsSchedulingTime, b
     if (auto instance = getInstance().lock()) {
       folly::dynamic params = folly::dynamic::array(id);
       instance->callJSFunction("JSTimers", "callTimers", folly::dynamic::array(params));
-    } else {
-      assert(false && "getInstance().lock failed");
     }
 
     return;


### PR DESCRIPTION
TimingModule methods are dispatched to the UI thread. The instance/Module may be gone by the time its methods are processed in the UI queue. We removed an assertion that an instance is available on render callback, but there is a second assertion on method call as well. Remove the assertion.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6174)