### PR TITLE
Fix resetting of playground comboboxes upon load

### DIFF
--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -119,8 +119,7 @@ void winrt::playground::implementation::MainPage::x_entryPointCombo_SelectionCha
       auto selectedItem = winrt::to_string(winrt::unbox_value<winrt::hstring>(content));
       if (selectedItem == "Samples\\rntester") {
         x_rootComponentNameCombo().SelectedIndex(0);
-      }
-      else {
+      } else {
         x_rootComponentNameCombo().SelectedIndex(1);
       }
     }


### PR DESCRIPTION
Fixes #6177 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6178)