### PR TITLE
Force hermes-engine 0.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@wdio/utils": "5.12.1",
     "acorn": "^7.1.1",
     "bl": "3.0.1",
+    "hermes-engine-comment": "The hermes-engine resolution can be removed when we integrate the 9/17 Nightly RN Build",
+    "hermes-engine": "0.7.0",
     "logkitty": "^0.7.1",
     "eslint-plugin-react": "^7.14.1",
     "eslint-plugin-react-hooks": "4.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7916,10 +7916,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-engine@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.6.0.tgz#82c0738b89afb3253dcc4b322888a8bf0f52930b"
-  integrity sha512-WrKfVJ8zsaTz31GHuoX2rJl7AV85Y9bFQkWhqalbObwPusanSsvU+viByDXccUU3khs9CjLBTm0O6DAH3Yls8g==
+hermes-engine@0.7.0, hermes-engine@~0.6.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.7.0.tgz#c4a13e09811d7bc975a0662bd2ca7120003d6ef8"
+  integrity sha512-lU9OenFWXXOzYldqn15QvbiD0kDc+uw2arhCOkR+9D+PhrLFcbEqnaXFESgchN77JYEf77KkqXncTZA8aoXw2A==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
The version of Hermes used by RN 0.63 up to recent RN nightlies is vulerable to CVE-2020-1912, which shows up in component governance alerts. We don't actually use the npm package binary in any way, so this change pins a newer version of Hermes until we integrate the 9/17 Nightly RN build that will be part of RN 0.64.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6183)