### PR TITLE
Update just-scipts (remove npm-registry-fetch)

### DIFF
--- a/change/@office-iss-react-native-win32-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@office-iss-react-native-win32-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:30.605Z"
+}

--- a/change/@react-native-windows-cli-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@react-native-windows-cli-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:12.995Z"
+}

--- a/change/@rnw-scripts-create-github-releases-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-create-github-releases-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:16.940Z"
+}

--- a/change/@rnw-scripts-find-repo-root-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-find-repo-root-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/find-repo-root",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:18.236Z"
+}

--- a/change/@rnw-scripts-format-files-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-format-files-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/format-files",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:19.426Z"
+}

--- a/change/@rnw-scripts-integrate-rn-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-integrate-rn-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:20.554Z"
+}

--- a/change/@rnw-scripts-just-task-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-just-task-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/just-task",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:22.783Z"
+}

--- a/change/@rnw-scripts-package-utils-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-package-utils-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/package-utils",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:24.010Z"
+}

--- a/change/@rnw-scripts-promote-release-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-promote-release-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:25.468Z"
+}

--- a/change/@rnw-scripts-take-screenshot-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/@rnw-scripts-take-screenshot-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "@rnw-scripts/take-screenshot",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:26.651Z"
+}

--- a/change/nuget-exe-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/nuget-exe-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "nuget-exe",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:27.869Z"
+}

--- a/change/react-native-platform-override-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/react-native-platform-override-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:29.289Z"
+}

--- a/change/react-native-windows-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/react-native-windows-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:35.004Z"
+}

--- a/change/react-native-windows-codegen-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/react-native-windows-codegen-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "react-native-windows-codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:32.111Z"
+}

--- a/change/react-native-windows-init-2020-10-05-15-49-35-npm-registry-fetch.json
+++ b/change/react-native-windows-init-2020-10-05-15-49-35-npm-registry-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update just-scipts (remove npm-registry-fetch)",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-05T22:49:33.399Z"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -52,7 +52,7 @@
     "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
     "jest": "^26.4.2",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -33,7 +33,7 @@
     "@types/semver": "^7.3.3",
     "@types/yargs": "^15.0.5",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/find-repo-root/package.json
+++ b/packages/@rnw-scripts/find-repo-root/package.json
@@ -19,7 +19,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/find-up": "^4.0.0",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -22,7 +22,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/async": "^3.2.3",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -32,7 +32,7 @@
     "@types/semver": "^7.3.3",
     "@types/yargs": "^15.0.5",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/just-task/package.json
+++ b/packages/@rnw-scripts/just-task/package.json
@@ -7,9 +7,9 @@
     "@rnw-scripts/jest-e2e-config": "0.1.1"
   },
   "devDependencies": {
-    "just-scripts": "^0.36.1"
+    "just-scripts": "^0.44.7"
   },
   "peerDependencies": {
-    "just-scripts": "^0.36.1"
+    "just-scripts": "^0.44.7"
   }
 }

--- a/packages/@rnw-scripts/package-utils/package.json
+++ b/packages/@rnw-scripts/package-utils/package.json
@@ -21,7 +21,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/lodash": "^4.14.161",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -26,7 +26,7 @@
     "@types/chalk": "^2.2.0",
     "@types/yargs": "^15.0.5",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -22,7 +22,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/yargs": "^15.0.5",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -44,7 +44,7 @@
     "@wdio/sync": "5.12.1",
     "appium": "1.14.1",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "metro-react-native-babel-preset": "^0.56.0",
     "prettier": "1.19.1",
     "react-test-renderer": "16.9.0",

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -32,7 +32,7 @@
     "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
     "jest": "^26.4.2",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "ora": "^3.4.0",
     "prettier": "1.19.1",
     "ps-list": "^7.2.0",

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -22,7 +22,7 @@
     "@types/react": "16.9.0",
     "@types/react-native": "^0.63.18",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "metro-react-native-babel-preset": "^0.56.0",
     "prettier": "1.19.1",
     "react-native-windows-codegen": "0.1.7",

--- a/packages/nuget-exe/package.json
+++ b/packages/nuget-exe/package.json
@@ -10,7 +10,7 @@
     "clean": "just-scripts clean"
   },
   "devDependencies": {
-    "just-scripts": "^0.36.1"
+    "just-scripts": "^0.44.7"
   },
   "files": [
     "nuget-4.9.2.exe"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -22,7 +22,7 @@
     "@types/react": "16.9.0",
     "@types/react-native": "^0.63.18",
     "eslint": "6.8.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "metro-react-native-babel-preset": "^0.56.0",
     "prettier": "1.19.1",
     "react-test-renderer": "16.9.0"

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -62,7 +62,7 @@
     "diff-match-patch": "^1.0.4",
     "eslint": "6.8.0",
     "jest": "^26.4.2",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "minimatch": "^3.0.4",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -69,7 +69,7 @@
     "eslint": "6.8.0",
     "flow-bin": "^0.131.0",
     "jscodeshift": "^0.9.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "react": "16.13.1",
     "react-native": "0.0.0-f8e5423c8",

--- a/packages/react-native-windows-codegen/package.json
+++ b/packages/react-native-windows-codegen/package.json
@@ -36,7 +36,7 @@
     "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
     "jest": "^26.4.2",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   }

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -41,7 +41,7 @@
     "babel-jest": "^26.3.0",
     "eslint": "6.8.0",
     "jest": "^26.4.2",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
   },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "flow-bin": "^0.131.0",
     "jscodeshift": "^0.9.0",
-    "just-scripts": "^0.36.1",
+    "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "react": "16.13.1",
     "react-native": "0.0.0-f8e5423c8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4748,7 +4748,7 @@ babel-runtime@=5.8.24:
   dependencies:
     core-js "^1.0.0"
 
-bach@^1.0.0:
+bach@^1.0.0, bach@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/bach/-/bach-1.2.0.tgz#4b3ce96bf27134f79a1b414a51c14e34c3bd9880"
   integrity sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=
@@ -5042,26 +5042,6 @@ cac@^3.0.3:
     read-pkg-up "^1.0.1"
     suffix "^0.1.0"
     text-table "^0.2.0"
-
-cacache@^11.3.3:
-  version "11.3.3"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.3.tgz#8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc"
-  integrity sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
-  dependencies:
-    bluebird "^3.5.5"
-    chownr "^1.1.1"
-    figgy-pudding "^3.5.1"
-    glob "^7.1.4"
-    graceful-fs "^4.1.15"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.3"
-    ssri "^6.0.1"
-    unique-filename "^1.1.1"
-    y18n "^4.0.0"
 
 cacache@^12.0.0, cacache@^12.0.3:
   version "12.0.3"
@@ -7093,6 +7073,11 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
+fast-levenshtein@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz#e6a754cc8f15e58987aa9cbd27af66fd6f4e5af9"
+  integrity sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=
 
 fast-levenshtein@~2.0.6:
   version "2.0.6"
@@ -9455,10 +9440,10 @@ junit-report-builder@^1.3.0:
     mkdirp "^0.5.0"
     xmlbuilder "^10.0.0"
 
-"just-scripts-utils@>=0.8.4 <1.0.0":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/just-scripts-utils/-/just-scripts-utils-0.8.4.tgz#228a0d8296ad20236ece61cf9c0a985521e4724c"
-  integrity sha512-Amx6OGrV8DoIyLnU8QUxs6uMY12CAZy3WmENGgpePzOJK2q7XUeBEHN3a8aSRDpzy7Wc/cL7+ZYbt7UZ6cGsfQ==
+"just-scripts-utils@>=0.9.1 <1.0.0":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/just-scripts-utils/-/just-scripts-utils-0.9.1.tgz#ae23f4a658d860081124496cafdabc954c8537c0"
+  integrity sha512-9vVBV7JpvYjAPMyNVyzyAwYqVTqMRhuMV4erhLLb3JJ44UiuRkMB/1RmYrTsIekn0K74OrPMUInZYEATvyfthA==
   dependencies:
     fs-extra "^7.0.1"
     glob "^7.1.3"
@@ -9471,19 +9456,18 @@ junit-report-builder@^1.3.0:
     tar "^4.4.8"
     yargs "^12.0.5"
 
-just-scripts@^0.36.1:
-  version "0.36.1"
-  resolved "https://registry.yarnpkg.com/just-scripts/-/just-scripts-0.36.1.tgz#ccb1930c922cf47c7237456f218263acbf5e53b1"
-  integrity sha512-7mQVfjWYLJqw+fkr/BNSO05tG0Eyg/rrt6gqt2yscG4zjsTAk1h1q5Nnw9j07liJPb0lcEwmMiyNM8KBZNMYug==
+just-scripts@^0.44.7:
+  version "0.44.7"
+  resolved "https://registry.yarnpkg.com/just-scripts/-/just-scripts-0.44.7.tgz#7ad66355b6e8f31739b5080c217797c875fcaab3"
+  integrity sha512-nqqXDKmYPlXzBP8aqTsiHMt7ezPvCghiYFOUxFAwwzLFHZpFx3e+pOGSAKuwdCQdMFeMzPUS1iTplGKwz5Jvww==
   dependencies:
     "@types/node" "^10.12.18"
     chalk "^2.4.1"
     diff-match-patch "1.0.4"
     fs-extra "^7.0.1"
     glob "^7.1.3"
-    just-scripts-utils ">=0.8.4 <1.0.0"
-    just-task ">=0.14.3 <1.0.0"
-    npm-registry-fetch "^3.9.0"
+    just-scripts-utils ">=0.9.1 <1.0.0"
+    just-task ">=0.17.0 <1.0.0"
     prompts "^2.0.1"
     run-parallel-limit "^1.0.5"
     supports-color "^7.1.0"
@@ -9497,19 +9481,20 @@ just-scripts@^0.36.1:
     chalk "^2.4.1"
     yargs "^12.0.5"
 
-"just-task@>=0.14.3 <1.0.0":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/just-task/-/just-task-0.14.3.tgz#f1ebb44953a1ee81f9e16d936f73b55389801e61"
-  integrity sha512-qUeDRmS/qHCjexYNvxCJAqK1aSIoQ9AeNFhaBLvJkfXNsAOlKzPKZd1FhdJ86ct86vJu77wG3i0bIuBKAO8O6w==
+"just-task@>=0.17.0 <1.0.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/just-task/-/just-task-0.17.0.tgz#d09a6ff544c986dbd1bdc1d73c7c4dd66922cbc3"
+  integrity sha512-ULgstQzv18qj7EbVKAG4TkH4hkBwIpUe82Vfp2mhOjW95/k8fQ2X4xTsBKFIJDto6LsONq38otMlbzA0syOd3w==
   dependencies:
     "@microsoft/package-deps-hash" "^2.2.153"
+    bach "^1.2.0"
     chalk "^2.4.1"
     fs-extra "^7.0.1"
     just-task-logger ">=0.3.0 <1.0.0"
     resolve "^1.8.1"
-    undertaker "^1.2.0"
+    undertaker "^1.2.1"
     undertaker-registry "^1.0.1"
-    yargs "^12.0.5"
+    yargs-parser "^18.1.2"
 
 kind-of@^1.1.0:
   version "1.1.0"
@@ -9985,23 +9970,6 @@ make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
-
-make-fetch-happen@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.2.tgz#2d156b11696fb32bffbafe1ac1bc085dd6c78a79"
-  integrity sha512-YMJrAjHSb/BordlsDEcVcPyTbiJKkzqMf48N8dAJZT9Zjctrkb6Yg4TY9Sq2AwSIQJFn5qBBKVTYt3vP5FMIHA==
-  dependencies:
-    agentkeepalive "^3.4.1"
-    cacache "^11.3.3"
-    http-cache-semantics "^3.8.1"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.1"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    node-fetch-npm "^2.0.2"
-    promise-retry "^1.1.1"
-    socks-proxy-agent "^4.0.0"
-    ssri "^6.0.0"
 
 make-fetch-happen@^5.0.0:
   version "5.0.0"
@@ -11129,18 +11097,6 @@ npm-pick-manifest@^3.0.0:
     figgy-pudding "^3.5.1"
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
-
-npm-registry-fetch@^3.9.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.9.1.tgz#00ff6e4e35d3f75a172b332440b53e93f4cb67de"
-  integrity sha512-VQCEZlydXw4AwLROAXWUR7QDfe2Y8Id/vpAgp6TI1/H78a4SiQ1kQrKZALm5/zxM5n4HIi+aYb+idUAV/RuY0Q==
-  dependencies:
-    JSONStream "^1.3.4"
-    bluebird "^3.5.1"
-    figgy-pudding "^3.4.1"
-    lru-cache "^5.1.1"
-    make-fetch-happen "^4.0.2"
-    npm-package-arg "^6.1.0"
 
 npm-registry@0.1.x, npm-registry@^0.1.13:
   version "0.1.13"
@@ -14241,16 +14197,17 @@ undertaker-registry@^1.0.0, undertaker-registry@^1.0.1:
   resolved "https://registry.yarnpkg.com/undertaker-registry/-/undertaker-registry-1.0.1.tgz#5e4bda308e4a8a2ae584f9b9a4359a499825cc50"
   integrity sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=
 
-undertaker@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/undertaker/-/undertaker-1.2.1.tgz#701662ff8ce358715324dfd492a4f036055dfe4b"
-  integrity sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==
+undertaker@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/undertaker/-/undertaker-1.3.0.tgz#363a6e541f27954d5791d6fa3c1d321666f86d18"
+  integrity sha512-/RXwi5m/Mu3H6IHQGww3GNt1PNXlbeCuclF2QYR14L/2CHPz3DFZkvB5hZ0N/QUkiXWCACML2jXViIQEQc2MLg==
   dependencies:
     arr-flatten "^1.0.1"
     arr-map "^2.0.0"
     bach "^1.0.0"
     collection-map "^1.0.0"
     es6-weak-map "^2.0.1"
+    fast-levenshtein "^1.0.0"
     last-run "^1.1.0"
     object.defaults "^1.0.0"
     object.reduce "^1.0.0"


### PR DESCRIPTION
Updating these to fix component governance warnings. Looked through the just-scripts changelog and I don't think any of the changes should hurt us.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6189)