### PR TITLE
Change order of JavaScript tests to get failures earlier

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -696,21 +696,6 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      # Run unbroken checking local filebefore installing packages to avoid scanning node_modules
-      # The exclusions of unbroken don't support wildcards yet and we have many throughout the repo
-      - task: CmdLine@2
-        displayName: check local links in .md files
-        inputs:
-          script: npx unbroken -q --local-only --allow-local-line-sections
-
-      # This runs will check for web-links. If broken links are found, since external changes could affect this.
-      # It will report a warning if this step fails so we'll pay attention to fix quickly.
-      - task: CmdLine@2
-        displayName: check web links in .md files
-        inputs:
-          script: npx unbroken -q --allow-local-line-sections
-        continueOnError: true
-
       - template: templates/yarn-install.yml
 
       - task: CmdLine@2
@@ -747,6 +732,21 @@ jobs:
         displayName: yarn api
         inputs:
           script: yarn api
+
+      # Run unbroken checking local files before installing packages to avoid scanning node_modules
+      # The exclusions of unbroken don't support wildcards yet and we have many throughout the repo
+      - task: CmdLine@2
+        displayName: check local links in .md files
+        inputs:
+          script: npx unbroken -q --local-only --allow-local-line-sections
+
+      # This runs will check for web-links. If broken links are found, since external changes could affect this.
+      # It will report a warning if this step fails so we'll pay attention to fix quickly.
+      - task: CmdLine@2
+        displayName: check web links in .md files
+        inputs:
+          script: npx unbroken -q --allow-local-line-sections
+        continueOnError: true
 
   - template: templates/e2e-test-job.yml
     parameters:

--- a/.unbroken_exclusions
+++ b/.unbroken_exclusions
@@ -1,4 +1,4 @@
-!node_modules
+!**/node_modules
 !vnext/packages
 !vnext/ReactCopies
 !packages/react-native-platform-override/node_modules

--- a/change/react-native-windows-2020-10-07-16-06-16-master.json
+++ b/change/react-native-windows-2020-10-07-16-06-16-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Change order of JavaScript tests to get failures earlier",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T23:06:16.578Z"
+}

--- a/vnext/.gitignore
+++ b/vnext/.gitignore
@@ -99,6 +99,7 @@ temp
 
 # Copied from root as part of build
 /README.md
+/LICENCE
 
 # Keep the template certificates
 !template/**/*.pfx

--- a/vnext/LICENSE
+++ b/vnext/LICENSE
@@ -1,0 +1,25 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+
+Portions derived from React Native:
+
+Copyright (c) 2015-present, Facebook, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vnext/just-task.js
+++ b/vnext/just-task.js
@@ -50,10 +50,14 @@ task('eslint:fix', eslintTask({fix: true}));
 
 task('copyRNLibraries', copyRNLibaries.copyTask(__dirname));
 
-task('copyReadmeFromRoot', () => {
+task('copyReadmeAndLicenseFromRoot', () => {
   fs.copyFileSync(
     path.resolve(__dirname, '../README.md'),
     path.resolve(__dirname, 'README.md'),
+  );
+  fs.copyFileSync(
+    path.resolve(__dirname, '../LICENSE'),
+    path.resolve(__dirname, 'LICENSE'),
   );
 });
 
@@ -76,7 +80,7 @@ task(
   series(
     condition('clean', () => argv().clean),
     'copyRNLibraries',
-    'copyReadmeFromRoot',
+    'copyReadmeAndLicenseFromRoot',
     'compileTsPlatformOverrides',
     'codegen',
     condition('apiExtractorVerify', () => argv().ci),

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -122,6 +122,7 @@
     "/index.windows.js.map",
     "/interface.js",
     "/just-task.js",
+    "/LICENCE",
     "/metro-react-native-platform.js",
     "/metro.config.js",
     "/react-native.config.js",


### PR DESCRIPTION
The most common failure we have in this test are:
a) Missing Change File
b) Linting errors

This PR moves the link checks to the end of this job to ensure we get a failure signal as fast as possible.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6198)