### PR TITLE
Update System.Private.Uri version for C# codegen for unittest

### DIFF
--- a/change/react-native-windows-2020-10-06-11-02-39-master.json
+++ b/change/react-native-windows-2020-10-06-11-02-39-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update System.Private.Uri version for C# codegen for unittest",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-06T18:02:39.503Z"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -20,6 +20,16 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
+
+    <!-- 
+      NuGet decides to pull in packages with issues. There is no seeming way to diagnose why NuGet is pulling in those versions. 
+      Running restore with -Verbosity Detailed and environment variables:
+       * NUGET_RESTORE_MSBUILD_ARGS=/bl:c:\temp\nuget.binlog
+       * NUGET_RESTORE_MSBUILD_VERBOSITY=diag
+      resulted in no mention of version 4.3.0 anywhere until NuGet just starts downloading it.
+      Therefore manually overriding the version so NuGet uses the latest.
+    -->
+     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
    <!-- Ensure the Win10 SDK binaries loaded by the unittest match our apps SDK versions -->


### PR DESCRIPTION
I noticed when testing PR #6184 that the unittest project had to be updated too. I thought I pushed new changes to the PR but perhaps I didn't or mistyped the branch name.

This change addressed that.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6199)