### PR TITLE
Update vnext/Microsoft.ReactNative.Cxx/README.md

### DIFF
--- a/change/react-native-windows-2020-10-07-07-18-23-tm-port.json
+++ b/change/react-native-windows-2020-10-07-07-18-23-tm-port.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update vnext/Microsoft.ReactNative.Cxx/README.md",
+  "packageName": "react-native-windows",
+  "email": "zihanc@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T14:18:23.505Z"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/Crash.h
+++ b/vnext/Microsoft.ReactNative.Cxx/Crash.h
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-// IMPORTANT: Before updating this file
-// please read react-native-windows repo:
-// vnext/Microsoft.ReactNative.Cxx/README.md
 
 #pragma once
 

--- a/vnext/Microsoft.ReactNative.Cxx/README.md
+++ b/vnext/Microsoft.ReactNative.Cxx/README.md
@@ -19,12 +19,12 @@ Whenever:
 - files are added to the following folders
 - listed files are edited
 
-You are required to create a pull requeset in `react-native-macos` to prove that your change is compatible with macOS by doing:
+You are required to create a pull request in `react-native-macos` to prove that your change is compatible with macOS by doing:
 
 - Update this file: https://github.com/microsoft/react-native-macos/blob/master/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec
   - Change `s.source` to your own fork and commit
   - Follow the instruction to build and test `RNTester/RNTester-macOS` by running the `Snapshot/Screenshot` test page
-  - Create a PR to `react-native-macos` to show the result
+  - Create a PR in `react-native-macos` to show the result
   - In some cases, you will also need to update files in https://github.com/microsoft/react-native-macos/tree/master/ReactTurboModuleCxx to make your change work in macOS
 - Submit your change to `react-native-windows`
 - Update the podspec file again with `s.source` pointing to the commit that is just submitted to `react-native-windows`

--- a/vnext/Microsoft.ReactNative.Cxx/README.md
+++ b/vnext/Microsoft.ReactNative.Cxx/README.md
@@ -5,24 +5,25 @@
 In order to make `REACT_MODULE` cross-platform,
 some C++ source files need to be shared between `react-native-windows` repo and `react-native-macos` repo.
 
-Before finishing the effort of porting `REACT_MODULE` to macOS,
-some C++ source files are copied from `react-native-windows` to `react-native-macos`.
+Whenever:
 
-During this moment,
-if anyone want to update these files,
-please ensure that the same change to these files must be committed to both
-`react-native-windows` repo and `react-native-macos` repo.
+- files are added to the following folder
+- listed files are edited
 
-It is important to **keep these files in sync between the two repos**.
+You are required to create a pull requeset in `react-native-macos` to prove that your change is compatible with macOS by doing:
 
-After finishing the porting work,
-files will be shared in some way,
-and manual sync will be no longer needed.
+- Update this file: https://github.com/microsoft/react-native-macos/blob/master/ReactTurboModuleCxx/React-TurboModuleCxx-RNW.podspec
+  - Change `s.source` to your own fork and commit
+  - Follow the instruction to build and test `RNTester/RNTester-macOS` by running the `Snapshot/Screenshot` test page
+  - Create a PR to `react-native-macos` to show the result
+  - In some cases, you will also need to update files in https://github.com/microsoft/react-native-macos/tree/master/ReactTurboModuleCxx to make your change work in macOS
+- Submit your change to `react-native-windows`
+- Update the podspec file again with `s.source` pointing to the commit that is just submitted to `react-native-windows`
+- Submit your change to `react-native-macos`
 
 ## Affected Files
 
 - vnext\Microsoft.ReactNative.Cxx
-  - Crash.h
   - StructInfo.h
   - JSValue.h
   - JSValue.cpp

--- a/vnext/Microsoft.ReactNative.Cxx/README.md
+++ b/vnext/Microsoft.ReactNative.Cxx/README.md
@@ -6,8 +6,17 @@ In order to make `REACT_MODULE` cross-platform,
 some C++ source files need to be shared between `react-native-windows` repo and `react-native-macos` repo.
 
 Whenever:
+- new files need to be shared
 
-- files are added to the following folder
+Please add this comment as in other files:
+```C++
+// IMPORTANT: Before updating this file
+// please read react-native-windows repo:
+// vnext/Microsoft.ReactNative.Cxx/README.md
+```
+
+Whenever:
+- files are added to the following folders
 - listed files are edited
 
 You are required to create a pull requeset in `react-native-macos` to prove that your change is compatible with macOS by doing:


### PR DESCRIPTION
- File sharing from `react-native-windows` to `react-native-macos` is done.
- Update the instruction so that future works on affected files are able to themselves keep cross-platform.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6202)