### PR TITLE
Implement focus/blur functionality on Pressable.

### DIFF
--- a/change/react-native-windows-2020-10-08-15-56-54-enable_presaability_onFocus.json
+++ b/change/react-native-windows-2020-10-08-15-56-54-enable_presaability_onFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enable onFocus() and onBlur() callbacks on Pressable. Allow calling .focus() and .blur() on Pressable.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-08T22:56:54.532Z"
+}

--- a/packages/@react-native-windows/tester/overrides.json
+++ b/packages/@react-native-windows/tester/overrides.json
@@ -58,6 +58,13 @@
     },
     {
       "type": "patch",
+      "file": "src/js/examples/Pressable/PressableExample.windows.js",
+      "baseFile": "packages/rn-tester/js/examples/Pressable/PressableExample.js",
+      "baseHash": "060fb16f36ade354b3a7e3efd05576f3fc8bfe19",
+      "issue": 6240
+    },
+    {
+      "type": "patch",
       "file": "src/js/examples/SectionList/SectionListExample.windows.js",
       "baseFile": "packages/rn-tester/js/examples/SectionList/SectionListExample.js",
       "baseHash": "a67bae2ac5eac82dacaf0c90fa11978afdd0e824",

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -526,8 +526,8 @@ exports.examples = [
   },
   {
     title: 'Focusability in Pressable',
-    description: ('<Pressable> components can be receive focus by calling the focus() and blur() methods on them.' + 
-    'They also expose onFocus and onBlur callbacks to hadle incoming native events.': string),
+    description: ('<Pressable> components can be receive focus by calling the focus() and blur() methods on them.' +
+      'They also expose onFocus and onBlur callbacks to hadle incoming native events.': string),
     render: function(): React.Node {
       return <PressableFocusCallbacks />;
     },

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -1,0 +1,535 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  Platform,
+  TouchableHighlight,
+  Pressable,
+  View,
+} from 'react-native';
+
+const nullthrows = require('nullthrows');
+
+const {useEffect, useRef, useState} = React;
+
+const forceTouchAvailable =
+  (Platform.OS === 'ios' && Platform.constants.forceTouchAvailable) || false;
+
+function ContentPress() {
+  const [timesPressed, setTimesPressed] = useState(0);
+
+  let textLog = '';
+  if (timesPressed > 1) {
+    textLog = timesPressed + 'x onPress';
+  } else if (timesPressed > 0) {
+    textLog = 'onPress';
+  }
+
+  return (
+    <>
+      <View style={styles.row}>
+        <Pressable
+          onPress={() => {
+            setTimesPressed(current => current + 1);
+          }}>
+          {({pressed}) => (
+            <Text style={styles.text}>{pressed ? 'Pressed!' : 'Press Me'}</Text>
+          )}
+        </Pressable>
+      </View>
+      <View style={styles.logBox}>
+        <Text testID="pressable_press_console">{textLog}</Text>
+      </View>
+    </>
+  );
+}
+
+function TextOnPressBox() {
+  const [timesPressed, setTimesPressed] = useState(0);
+
+  let textLog = '';
+  if (timesPressed > 1) {
+    textLog = timesPressed + 'x text onPress';
+  } else if (timesPressed > 0) {
+    textLog = 'text onPress';
+  }
+
+  return (
+    <>
+      <Text
+        style={styles.textBlock}
+        testID="tappable_text"
+        onPress={() => {
+          setTimesPressed(prev => prev + 1);
+        }}>
+        Text has built-in onPress handling
+      </Text>
+      <View style={styles.logBox}>
+        <Text testID="tappable_text_console">{textLog}</Text>
+      </View>
+    </>
+  );
+}
+
+function PressableFeedbackEvents() {
+  const [eventLog, setEventLog] = useState([]);
+
+  function appendEvent(eventName) {
+    const limit = 6;
+    setEventLog(current => {
+      return [eventName].concat(current.slice(0, limit - 1));
+    });
+  }
+
+  return (
+    <View testID="pressable_feedback_events">
+      <View style={[styles.row, styles.centered]}>
+        <Pressable
+          style={styles.wrapper}
+          testID="pressable_feedback_events_button"
+          accessibilityLabel="pressable feedback events"
+          accessibilityRole="button"
+          onPress={() => appendEvent('press')}
+          onPressIn={() => appendEvent('pressIn')}
+          onPressOut={() => appendEvent('pressOut')}
+          onLongPress={() => appendEvent('longPress')}>
+          <Text style={styles.button}>Press Me</Text>
+        </Pressable>
+      </View>
+      <View
+        testID="pressable_feedback_events_console"
+        style={styles.eventLogBox}>
+        {eventLog.map((e, ii) => (
+          <Text key={ii}>{e}</Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function PressableDelayEvents() {
+  const [eventLog, setEventLog] = useState([]);
+
+  function appendEvent(eventName) {
+    const limit = 6;
+    const newEventLog = eventLog.slice(0, limit - 1);
+    newEventLog.unshift(eventName);
+    setEventLog(newEventLog);
+  }
+
+  return (
+    <View testID="pressable_delay_events">
+      <View style={[styles.row, styles.centered]}>
+        <Pressable
+          style={styles.wrapper}
+          testID="pressable_delay_events_button"
+          onPress={() => appendEvent('press')}
+          onPressIn={() => appendEvent('pressIn')}
+          onPressOut={() => appendEvent('pressOut')}
+          delayLongPress={800}
+          onLongPress={() => appendEvent('longPress - 800ms delay')}>
+          <Text style={styles.button}>Press Me</Text>
+        </Pressable>
+      </View>
+      <View style={styles.eventLogBox} testID="pressable_delay_events_console">
+        {eventLog.map((e, ii) => (
+          <Text key={ii}>{e}</Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function ForceTouchExample() {
+  const [force, setForce] = useState(0);
+
+  const consoleText = forceTouchAvailable
+    ? 'Force: ' + force.toFixed(3)
+    : '3D Touch is not available on this device';
+
+  return (
+    <View testID="pressable_3dtouch_event">
+      <View style={styles.forceTouchBox} testID="pressable_3dtouch_output">
+        <Text>{consoleText}</Text>
+      </View>
+      <View style={[styles.row, styles.centered]}>
+        <View
+          style={styles.wrapper}
+          testID="pressable_3dtouch_button"
+          onStartShouldSetResponder={() => true}
+          onResponderMove={event => setForce(event.nativeEvent?.force || 1)}
+          onResponderRelease={event => setForce(0)}>
+          <Text style={styles.button}>Press Me</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function PressableHitSlop() {
+  const [timesPressed, setTimesPressed] = useState(0);
+
+  let log = '';
+  if (timesPressed > 1) {
+    log = timesPressed + 'x onPress';
+  } else if (timesPressed > 0) {
+    log = 'onPress';
+  }
+
+  return (
+    <View testID="pressable_hit_slop">
+      <View style={[styles.row, styles.centered]}>
+        <Pressable
+          onPress={() => setTimesPressed(num => num + 1)}
+          style={styles.hitSlopWrapper}
+          hitSlop={{top: 30, bottom: 30, left: 60, right: 60}}
+          testID="pressable_hit_slop_button">
+          <Text style={styles.hitSlopButton}>Press Outside This View</Text>
+        </Pressable>
+      </View>
+      <View style={styles.logBox}>
+        <Text>{log}</Text>
+      </View>
+    </View>
+  );
+}
+
+function PressableNativeMethods() {
+  const [status, setStatus] = useState<?boolean>(null);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    setStatus(ref.current != null && typeof ref.current.measure === 'function');
+  }, []);
+
+  return (
+    <>
+      <View style={[styles.row, styles.block]}>
+        <Pressable ref={ref}>
+          <View />
+        </Pressable>
+        <Text>
+          {status == null
+            ? 'Missing Ref!'
+            : status === true
+            ? 'Native Methods Exist'
+            : 'Native Methods Missing!'}
+        </Text>
+      </View>
+    </>
+  );
+}
+
+function PressableDisabled() {
+  return (
+    <>
+      <Pressable disabled={true} style={[styles.row, styles.block]}>
+        <Text style={styles.disabledButton}>Disabled Pressable</Text>
+      </Pressable>
+
+      <Pressable
+        disabled={false}
+        style={({pressed}) => [
+          {opacity: pressed ? 0.5 : 1},
+          styles.row,
+          styles.block,
+        ]}>
+        <Text style={styles.button}>Enabled Pressable</Text>
+      </Pressable>
+    </>
+  );
+}
+
+function PressableFocusCallbacks() {
+  const [timesPressed, setTimesPressed] = useState(0);
+
+  let textLog = '';
+  if (timesPressed > 1) {
+    textLog = timesPressed + 'x onPress';
+  } else if (timesPressed > 0) {
+    textLog = 'onPress';
+  }
+  const viewRef = useRef<React.ElementRef<typeof Pressable> | null>(null);
+
+  const focusViewPressed = () => {
+    nullthrows(viewRef.current).focus();
+  };
+
+  return (
+    <>
+      <View style={styles.row}>
+        <Pressable
+          ref={viewRef}
+          onFocus={() => console.log('Pressable onFocus')}
+          onBlur={() => console.log('Pressable onBlur')}
+          onPress={() => {
+            setTimesPressed(current => current + 1);
+          }}>
+          {({pressed}) => (
+            <Text style={styles.text}>{pressed ? 'Pressed!' : 'Press Me'}</Text>
+          )}
+        </Pressable>
+      </View>
+      <View style={styles.logBox}>
+        <Text testID="pressable_press_console">{textLog}</Text>
+      </View>
+      <TouchableHighlight
+        style={{height: 30}}
+        onPress={focusViewPressed}
+        underlayColor={'transparent'}>
+        <View>
+          <Text>Click to focus textbox</Text>
+        </View>
+      </TouchableHighlight>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  centered: {
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 16,
+  },
+  block: {
+    padding: 10,
+  },
+  button: {
+    color: '#007AFF',
+  },
+  disabledButton: {
+    color: '#007AFF',
+    opacity: 0.5,
+  },
+  hitSlopButton: {
+    color: 'white',
+  },
+  wrapper: {
+    borderRadius: 8,
+  },
+  wrapperCustom: {
+    borderRadius: 8,
+    padding: 6,
+  },
+  hitSlopWrapper: {
+    backgroundColor: 'red',
+    marginVertical: 30,
+  },
+  logBox: {
+    padding: 20,
+    margin: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9',
+  },
+  eventLogBox: {
+    padding: 10,
+    margin: 10,
+    height: 120,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9',
+  },
+  forceTouchBox: {
+    padding: 10,
+    margin: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9',
+    alignItems: 'center',
+  },
+  textBlock: {
+    fontWeight: '500',
+    color: 'blue',
+  },
+});
+
+exports.displayName = (undefined: ?string);
+exports.description = 'Component for making views pressable.';
+exports.title = '<Pressable>';
+exports.examples = [
+  {
+    title: 'Change content based on Press',
+    render(): React.Node {
+      return <ContentPress />;
+    },
+  },
+  {
+    title: 'Change style based on Press',
+    render(): React.Node {
+      return (
+        <View style={styles.row}>
+          <Pressable
+            style={({pressed}) => [
+              {
+                backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
+              },
+              styles.wrapperCustom,
+            ]}>
+            <Text style={styles.text}>Press Me</Text>
+          </Pressable>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Pressable feedback events',
+    description: ('<Pressable> components accept onPress, onPressIn, ' +
+      'onPressOut, and onLongPress as props.': string),
+    render: function(): React.Node {
+      return <PressableFeedbackEvents />;
+    },
+  },
+  {
+    title: 'Pressable with Ripple and Animated child',
+    description: ('Pressable can have an AnimatedComponent as a direct child.': string),
+    platform: 'android',
+    render: function(): React.Node {
+      const mScale = new Animated.Value(1);
+      Animated.timing(mScale, {
+        toValue: 0.3,
+        duration: 1000,
+        useNativeDriver: false,
+      }).start();
+      const style = {
+        backgroundColor: 'rgb(180, 64, 119)',
+        width: 200,
+        height: 100,
+        transform: [{scale: mScale}],
+      };
+      return (
+        <View style={styles.row}>
+          <Pressable android_ripple={{color: 'green'}}>
+            <Animated.View style={style} />
+          </Pressable>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Pressable with custom Ripple',
+    description: ("Pressable can specify ripple's radius, color and borderless params": string),
+    platform: 'android',
+    render: function(): React.Node {
+      const nativeFeedbackButton = {
+        textAlign: 'center',
+        margin: 10,
+      };
+      return (
+        <View>
+          <View
+            style={[
+              styles.row,
+              {justifyContent: 'space-around', alignItems: 'center'},
+            ]}>
+            <Pressable
+              android_ripple={{color: 'orange', borderless: true, radius: 30}}>
+              <View>
+                <Text style={[styles.button, nativeFeedbackButton]}>
+                  radius 30
+                </Text>
+              </View>
+            </Pressable>
+
+            <Pressable android_ripple={{borderless: true, radius: 150}}>
+              <View>
+                <Text style={[styles.button, nativeFeedbackButton]}>
+                  radius 150
+                </Text>
+              </View>
+            </Pressable>
+
+            <Pressable android_ripple={{borderless: false, radius: 70}}>
+              <View style={styles.block}>
+                <Text style={[styles.button, nativeFeedbackButton]}>
+                  radius 70, with border
+                </Text>
+              </View>
+            </Pressable>
+          </View>
+
+          <Pressable android_ripple={{borderless: false}}>
+            <View style={styles.block}>
+              <Text style={[styles.button, nativeFeedbackButton]}>
+                with border, default color and radius
+              </Text>
+            </View>
+          </Pressable>
+        </View>
+      );
+    },
+  },
+  {
+    title: '<Text onPress={fn}> with highlight',
+    render: function(): React.Node {
+      return <TextOnPressBox />;
+    },
+  },
+  {
+    title: 'Pressable delay for events',
+    description: ('<Pressable> also accept delayPressIn, ' +
+      'delayPressOut, and delayLongPress as props. These props impact the ' +
+      'timing of feedback events.': string),
+    render: function(): React.Node {
+      return <PressableDelayEvents />;
+    },
+  },
+  {
+    title: '3D Touch / Force Touch',
+    description:
+      'iPhone 8 and 8 plus support 3D touch, which adds a force property to touches',
+    render: function(): React.Node {
+      return <ForceTouchExample />;
+    },
+    platform: 'ios',
+  },
+  {
+    title: 'Pressable Hit Slop',
+    description: ('<Pressable> components accept hitSlop prop which extends the touch area ' +
+      'without changing the view bounds.': string),
+    render: function(): React.Node {
+      return <PressableHitSlop />;
+    },
+  },
+  {
+    title: 'Pressable Native Methods',
+    description: ('<Pressable> components expose native methods like `measure`.': string),
+    render: function(): React.Node {
+      return <PressableNativeMethods />;
+    },
+  },
+  {
+    title: 'Disabled Pressable',
+    description: ('<Pressable> components accept disabled prop which prevents ' +
+      'any interaction with component': string),
+    render: function(): React.Node {
+      return <PressableDisabled />;
+    },
+  },
+  {
+    title: 'Focusability in Pressable',
+    description: ('<Pressable> components can be receive focus by calling the focus() and blur() methods on them.' + 
+    'They also expose onFocus and onBlur callbacks to hadle incoming native events.': string),
+    render: function(): React.Node {
+      return <PressableFocusCallbacks />;
+    },
+  },
+];

--- a/packages/playground/Samples/view.tsx
+++ b/packages/playground/Samples/view.tsx
@@ -165,11 +165,7 @@ export default class Bootstrap extends React.Component<
                   ? styles.radial
                   : styles.noBorder
                 : null
-            }
-            {...{
-              // Use weird format as work around for the fact that these props are not part of the @types/react-native yet
-              focusable: true,
-            }}>
+            }>
             <Text style={styles.child}>The Text</Text>
           </View>
         </View>

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -3,13 +3,12 @@
 
 #include "pch.h"
 
-#include "Modules/I18nManagerModule.h"
-#include "NativeUIManager.h"
-
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.h>
 #include <Views/ShadowNodeBase.h>
+#include "Modules/I18nManagerModule.h"
+#include "NativeUIManager.h"
 
 #include "CppWinRTIncludes.h"
 #include "IXamlRootView.h"
@@ -1087,7 +1086,7 @@ void NativeUIManager::findSubviewIn(
 
 void NativeUIManager::focus(int64_t reactTag) {
   if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(reactTag))) {
-    xaml::Input::FocusManager::TryFocusAsync(shadowNode->GetView(), winrt::FocusState::Programmatic);
+    xaml::Input::FocusManager::TryFocusAsync(shadowNode->GetView(), winrt::FocusState::Keyboard);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -64,17 +64,15 @@ class ViewShadowNode : public ShadowNodeBase {
         });
   }
 
-  void dispatchCommand(const std::string &commandId, const folly::dynamic &commandArgs) override {
-    if (commandId == "focus") {
-      if (auto uiManager = GetViewManager()->GetReactContext().NativeUIManager()) {
-        uiManager->focus(m_tag);
-      }
+  void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) {
+    if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+      uiManager->focus(m_tag);
     } else if (commandId == "blur") {
-      if (auto uiManager = GetViewManager()->GetReactContext().NativeUIManager()) {
+      if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
         uiManager->blur(m_tag);
       }
     } else {
-      Super::dispatchCommand(commandId, commandArgs);
+      Super::dispatchCommand(commandId, std::move(commandArgs));
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -64,6 +64,20 @@ class ViewShadowNode : public ShadowNodeBase {
         });
   }
 
+  void dispatchCommand(const std::string &commandId, const folly::dynamic &commandArgs) override {
+    if (commandId == "focus") {
+      if (auto uiManager = GetViewManager()->GetReactContext().NativeUIManager()) {
+        uiManager->focus(m_tag);
+      }
+    } else if (commandId == "blur") {
+      if (auto uiManager = GetViewManager()->GetReactContext().NativeUIManager()) {
+        uiManager->blur(m_tag);
+      }
+    } else {
+      Super::dispatchCommand(commandId, commandArgs);
+    }
+  }
+
   bool IsControl() {
     return m_isControl;
   }

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -258,6 +258,10 @@
       "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7"
     },
     {
+      "type": "platform",
+      "file": "src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js"
+    },
+    {
       "type": "copy",
       "file": "src/Libraries/Components/ToastAndroid/ToastAndroid.windows.js",
       "baseFile": "Libraries/Components/ToastAndroid/ToastAndroid.ios.js",

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -210,6 +210,12 @@
       "file": "src/Libraries/Components/Popup/PopupProps.ts"
     },
     {
+      "type": "patch",
+      "file": "src/Libraries/Components/Pressable/Pressable.windows.js",
+      "baseFile": "Libraries/Components/Pressable/Pressable.js",
+      "baseHash": "b55d01b28764b9bfc75b903383b7b0c08d744b87"
+    },
+    {
       "type": "derived",
       "file": "src/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.windows.js",
       "baseFile": "Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js",

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {useMemo, useState, useRef, useImperativeHandle} from 'react';
+import useAndroidRippleForView, {
+  type RippleConfig,
+} from './useAndroidRippleForView';
+import type {
+  AccessibilityActionEvent,
+  AccessibilityActionInfo,
+  AccessibilityRole,
+  AccessibilityState,
+  AccessibilityValue,
+} from '../View/ViewAccessibility';
+import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
+import usePressability from '../../Pressability/usePressability';
+import {normalizeRect, type RectOrSize} from '../../StyleSheet/Rect';
+import type {
+  LayoutEvent,
+  PressEvent,
+  // [Windows
+  BlurEvent,
+  FocusEvent, // Windows]
+} from '../../Types/CoreEventTypes';
+import View from '../View/View';
+import TextInputState from '../TextInput/TextInputState';
+
+type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
+
+export type StateCallbackType = $ReadOnly<{|
+  pressed: boolean,
+|}>;
+
+type Props = $ReadOnly<{|
+  /**
+   * Accessibility.
+   */
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  accessibilityElementsHidden?: ?boolean,
+  accessibilityHint?: ?Stringish,
+  accessibilityIgnoresInvertColors?: ?boolean,
+  accessibilityLabel?: ?Stringish,
+  accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+  accessibilityRole?: ?AccessibilityRole,
+  accessibilityState?: ?AccessibilityState,
+  accessibilityValue?: ?AccessibilityValue,
+  accessibilityViewIsModal?: ?boolean,
+  accessible?: ?boolean,
+  focusable?: ?boolean,
+  importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+
+  /**
+   * Either children or a render prop that receives a boolean reflecting whether
+   * the component is currently pressed.
+   */
+  children: React.Node | ((state: StateCallbackType) => React.Node),
+
+  /**
+   * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
+   */
+  delayLongPress?: ?number,
+
+  /**
+   * Whether the press behavior is disabled.
+   */
+  disabled?: ?boolean,
+
+  /**
+   * Additional distance outside of this view in which a press is detected.
+   */
+  hitSlop?: ?RectOrSize,
+
+  /**
+   * Additional distance outside of this view in which a touch is considered a
+   * press before `onPressOut` is triggered.
+   */
+  pressRetentionOffset?: ?RectOrSize,
+
+  /**
+   * Called when this view's layout changes.
+   */
+  onLayout?: ?(event: LayoutEvent) => void,
+
+  /**
+   * Called when a long-tap gesture is detected.
+   */
+  onLongPress?: ?(event: PressEvent) => void,
+
+  /**
+   * Called when a single tap gesture is detected.
+   */
+  onPress?: ?(event: PressEvent) => void,
+
+  /**
+   * Called when a touch is engaged before `onPress`.
+   */
+  onPressIn?: ?(event: PressEvent) => void,
+
+  /**
+   * Called when a touch is released before `onPress`.
+   */
+  onPressOut?: ?(event: PressEvent) => void,
+
+  /**
+   * Called after the element loses focus.
+   */
+  onBlur?: ?(event: BlurEvent) => mixed,
+
+  /**
+   * Called after the element is focused.
+   */
+  onFocus?: ?(event: FocusEvent) => mixed,
+
+  /**
+   * Either view styles or a function that receives a boolean reflecting whether
+   * the component is currently pressed and returns view styles.
+   */
+  style?: ViewStyleProp | ((state: StateCallbackType) => ViewStyleProp),
+
+  /**
+   * Identifier used to find this view in tests.
+   */
+  testID?: ?string,
+
+  /**
+   * If true, doesn't play system sound on touch.
+   */
+  android_disableSound?: ?boolean,
+
+  /**
+   * Enables the Android ripple effect and configures its color.
+   */
+  android_ripple?: ?RippleConfig,
+
+  /**
+   * Used only for documentation or testing (e.g. snapshot testing).
+   */
+  testOnly_pressed?: ?boolean,
+|}>;
+
+/**
+ * Component used to build display components that should respond to whether the
+ * component is currently pressed or not.
+ */
+function Pressable(props: Props, forwardedRef): React.Node {
+  const {
+    accessible,
+    android_disableSound,
+    android_ripple,
+    children,
+    delayLongPress,
+    disabled,
+    focusable,
+    onLongPress,
+    onPress,
+    onPressIn,
+    onPressOut,
+    // [Windows
+    onBlur,
+    onFocus,
+    // Windows]
+    pressRetentionOffset,
+    style,
+    testOnly_pressed,
+    ...restProps
+  } = props;
+
+  const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
+  useImperativeHandle(forwardedRef, () => viewRef.current);
+
+  // [Windows
+  const _onBlur = (event: BlurEvent) => {
+    TextInputState.blurInput(viewRef.current);
+    if (props.onBlur) {
+      props.onBlur(event);
+    }
+  };
+
+  const _onFocus = (event: FocusEvent) => {
+    TextInputState.focusInput(viewRef.current);
+    if (props.onFocus) {
+      props.onFocus(event);
+    }
+  };
+  // Windows]
+
+  const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
+
+  const [pressed, setPressed] = usePressState(testOnly_pressed === true);
+
+  const hitSlop = normalizeRect(props.hitSlop);
+
+  const config = useMemo(
+    () => ({
+      disabled,
+      hitSlop,
+      pressRectOffset: pressRetentionOffset,
+      android_disableSound,
+      delayLongPress,
+      onLongPress,
+      onPress,
+      onPressIn(event: PressEvent): void {
+        if (android_rippleConfig != null) {
+          android_rippleConfig.onPressIn(event);
+        }
+        setPressed(true);
+        if (onPressIn != null) {
+          onPressIn(event);
+        }
+      },
+      onPressMove: android_rippleConfig?.onPressMove,
+      onPressOut(event: PressEvent): void {
+        if (android_rippleConfig != null) {
+          android_rippleConfig.onPressOut(event);
+        }
+        setPressed(false);
+        if (onPressOut != null) {
+          onPressOut(event);
+        }
+      },
+      // [Windows
+      onBlur,
+      onFocus,
+      // Windows]
+    }),
+    [
+      android_disableSound,
+      android_rippleConfig,
+      delayLongPress,
+      disabled,
+      hitSlop,
+      onLongPress,
+      onPress,
+      onPressIn,
+      onPressOut,
+      // [Windows
+      onBlur,
+      onFocus,
+      // Windows]
+      pressRetentionOffset,
+      setPressed,
+    ],
+  );
+  const eventHandlers = usePressability(config);
+
+  return (
+    <View
+      {...restProps}
+      {...eventHandlers}
+      {...android_rippleConfig?.viewProps}
+      // [Windows
+      onBlur={_onBlur}
+      onFocus={_onFocus}
+      // Windows]
+      accessible={accessible !== false}
+      focusable={focusable !== false}
+      hitSlop={hitSlop}
+      ref={viewRef}
+      style={typeof style === 'function' ? style({pressed}) : style}>
+      {typeof children === 'function' ? children({pressed}) : children}
+      {__DEV__ ? <PressabilityDebugView color="red" hitSlop={hitSlop} /> : null}
+    </View>
+  );
+}
+
+function usePressState(forcePressed: boolean): [boolean, (boolean) => void] {
+  const [pressed, setPressed] = useState(false);
+  return [pressed || forcePressed, setPressed];
+}
+
+const MemoedPressable = React.memo(React.forwardRef(Pressable));
+MemoedPressable.displayName = 'Pressable';
+
+export default (MemoedPressable: React.AbstractComponent<
+  Props,
+  React.ElementRef<typeof View>,
+>);

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -21,7 +21,6 @@ const TouchableWithoutFeedback = require('../Touchable/TouchableWithoutFeedback'
 
 // [Windows
 const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
-import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
 // Windows]
 
 const invariant = require('invariant');
@@ -67,9 +66,8 @@ if (Platform.OS === 'android') {
 // [Windows
 else if (Platform.OS === 'windows') {
   WindowsTextInput = requireNativeComponent('RCTTextInput');
-  WindowsTextInputCommands = codegenNativeCommands<
-    TextInputNativeCommands<HostComponent<any>>,
-  >({supportedCommands: ['focus', 'blur', 'setTextAndSelection']});
+  WindowsTextInputCommands = require('./WindowsTextInputNativeCommands')
+    .Commands;
 }
 // Windows]
 
@@ -978,12 +976,10 @@ function InternalTextInput(props: Props): React.Node {
 
       /*
         Hi reader from the future. I'm sorry for this.
-
         This is a hack. Ideally we would forwardRef to the underlying
         host component. However, since TextInput has it's own methods that can be
         called as well, if we used the standard forwardRef then these
         methods wouldn't be accessible and thus be a breaking change.
-
         We have a couple of options of how to handle this:
         - Return a new ref with everything we methods from both. This is problematic
           because we need React to also know it is a host component which requires
@@ -1123,7 +1119,7 @@ function InternalTextInput(props: Props): React.Node {
 
     textInput = (
       /* $FlowFixMe the types for AndroidTextInput don't match up exactly with
-        the props for TextInput. This will need to get fixed */
+      the props for TextInput. This will need to get fixed */
       <AndroidTextInput
         ref={_setNativeRef}
         {...props}

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -19,10 +19,6 @@ const TextAncestor = require('../../Text/TextAncestor');
 const TextInputState = require('./TextInputState');
 const TouchableWithoutFeedback = require('../Touchable/TouchableWithoutFeedback');
 
-// [Windows
-const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
-// Windows]
-
 const invariant = require('invariant');
 const nullthrows = require('nullthrows');
 const setAndForwardRef = require('../../Utilities/setAndForwardRef');
@@ -65,8 +61,8 @@ if (Platform.OS === 'android') {
 }
 // [Windows
 else if (Platform.OS === 'windows') {
-  WindowsTextInput = requireNativeComponent('RCTTextInput');
-  WindowsTextInputCommands = require('./WindowsTextInputNativeCommands')
+  WindowsTextInput = require('./WindowsTextInputNativeComponent').default;
+  WindowsTextInputCommands = require('./WindowsTextInputNativeComponent')
     .Commands;
 }
 // Windows]
@@ -976,10 +972,12 @@ function InternalTextInput(props: Props): React.Node {
 
       /*
         Hi reader from the future. I'm sorry for this.
+
         This is a hack. Ideally we would forwardRef to the underlying
         host component. However, since TextInput has it's own methods that can be
         called as well, if we used the standard forwardRef then these
         methods wouldn't be accessible and thus be a breaking change.
+
         We have a couple of options of how to handle this:
         - Return a new ref with everything we methods from both. This is problematic
           because we need React to also know it is a host component which requires
@@ -1119,7 +1117,7 @@ function InternalTextInput(props: Props): React.Node {
 
     textInput = (
       /* $FlowFixMe the types for AndroidTextInput don't match up exactly with
-      the props for TextInput. This will need to get fixed */
+        the props for TextInput. This will need to get fixed */
       <AndroidTextInput
         ref={_setNativeRef}
         {...props}

--- a/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
@@ -19,6 +19,7 @@ const Platform = require('../../Utilities/Platform');
 const {findNodeHandle} = require('../../Renderer/shims/ReactNative');
 import {Commands as AndroidTextInputCommands} from '../../Components/TextInput/AndroidTextInputNativeComponent';
 import {Commands as iOSTextInputCommands} from '../../Components/TextInput/RCTSingelineTextInputNativeComponent';
+import {Commands as WindowsTextInputCommands} from '../../Components/TextInput/WindowsTextInputNativeCommands';
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import {UIManager} from 'react-native';
@@ -103,7 +104,7 @@ function focusTextInput(textField: ?ComponentRef) {
     }
     // [Windows
     else if (Platform.OS === 'windows') {
-      UIManager.focus(findNodeHandle(textField));
+      WindowsTextInputCommands.focus(textField);
     }
     // Windows]
   }
@@ -139,7 +140,7 @@ function blurTextInput(textField: ?ComponentRef) {
     }
     // [Windows
     else if (Platform.OS === 'windows') {
-      UIManager.blur(findNodeHandle(textField));
+      WindowsTextInputCommands.blur(textField);
     }
     // Windows]
   }

--- a/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
@@ -19,7 +19,7 @@ const Platform = require('../../Utilities/Platform');
 const {findNodeHandle} = require('../../Renderer/shims/ReactNative');
 import {Commands as AndroidTextInputCommands} from '../../Components/TextInput/AndroidTextInputNativeComponent';
 import {Commands as iOSTextInputCommands} from '../../Components/TextInput/RCTSingelineTextInputNativeComponent';
-import {Commands as WindowsTextInputCommands} from '../../Components/TextInput/WindowsTextInputNativeCommands';
+import {Commands as WindowsTextInputCommands} from '../../Components/TextInput/WindowsTextInputNativeComponent';
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import {UIManager} from 'react-native';

--- a/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeCommands.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeCommands.windows.js
@@ -1,0 +1,17 @@
+/**
+ * @flow
+ * @format
+ */
+
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+
+import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
+import type {TextInputNativeCommands} from './TextInputNativeCommands';
+
+type NativeType = HostComponent<mixed>;
+
+type NativeCommands = TextInputNativeCommands<NativeType>;
+
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['focus', 'blur', 'setTextAndSelection'],
+}); // [Windows]

--- a/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js
+++ b/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js
@@ -5,13 +5,20 @@
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
 import type {TextInputNativeCommands} from './TextInputNativeCommands';
-
 type NativeType = HostComponent<mixed>;
 
 type NativeCommands = TextInputNativeCommands<NativeType>;
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['focus', 'blur', 'setTextAndSelection'],
-}); // [Windows]
+});
+
+const WindowsTextInputComponent: NativeType = requireNativeComponent<mixed>(
+  'RCTTextInput',
+);
+
+export default WindowsTextInputComponent;
+// [Windows]


### PR DESCRIPTION
Closes #5589 

Enable onFocus/onBlur callbacks on the Pressable component.
Allow calling .focus()/.blur() to move focus to or away from Pressable elements.

Forking Pressable.js until I upstream this change to RN.
Added PressableFocusCallbacks() to the list of examples for Pressable. You can click on a button to move focus to a Pressable, and see log being printed in console in the onFocus() callback; tabbing away from it results in onBlur() getting invoked - also visible in browser console.


You may notice that all invocations of .focus()/.blur() go through TextInputState.js, which stores a ComponentRef to the currently focused element. This is because there's a hard-coded call to it in **react-native-renderer/src/ReactFabricHostConfig.js**
(See: https://github.com/facebook/react/blob/ded2a83ebfb7d0d755b0527bb221fa1a2b19b3b8/packages/react-native-renderer/src/ReactFabricHostConfig.js#L122-L128)
This will continue to work if we want to implement .focus() for other components, since the reference stored is of the generic ComponentRef type, and there can only be one element in focus at a time. Still, a refactor of RNW and the renderer package would be nice, in order to extract the focus-tracking code out of TextInputState.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6220)