### PR TITLE
Fixed missing folly headers on publish

### DIFF
--- a/change/react-native-windows-2020-10-09-13-04-00-folly6212.json
+++ b/change/react-native-windows-2020-10-09-13-04-00-folly6212.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed missing folly headers on publish",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T20:04:00.363Z"
+}

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -11,6 +11,7 @@ param(
 
 [xml]$props = gc $PSScriptRoot\..\..\Directory.Build.props
 [string] $FollyVersion = $props.Project.PropertyGroup.FollyVersion;
+$FollyVersion = $FollyVersion.Trim() # The extracted FollyVersion contains a space at the end that isn't actually present, issue #6216
 [System.IO.DirectoryInfo] $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}";
 
 if (!$ReactNativeRoot) {


### PR DESCRIPTION
* Updated the Layout-Headers.ps1 script to trim the folly version string
  it extracts from Directory.Build.props

Closes #6212

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6222)