### PR TITLE
Fix project config and package deploy to support the windows code in a different location

### DIFF
--- a/change/@react-native-windows-cli-2020-10-12-16-26-22-master.json
+++ b/change/@react-native-windows-cli-2020-10-12-16-26-22-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix config and app publish to allow for the windows native source code to live in a different location",
+  "packageName": "@react-native-windows/cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T23:26:21.917Z"
+}

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -93,15 +93,12 @@ export function projectConfigWindows(
 
   var result: DeepPartial<WindowsProjectConfig> = {
     folder: folder,
-    sourceDir: sourceDir.substr(folder.length + 1),
+    sourceDir: path.relative(folder, sourceDir),
   };
-
+  console.log(result.sourceDir + '----' + sourceDir);
   var validProject = false;
 
   if (usingManualOverride) {
-    // Copy the sourceDir from the user config.
-    result.sourceDir = userConfig.sourceDir;
-
     // Manual override, try to use it for solutionFile
     if (!('solutionFile' in userConfig)) {
       result.solutionFile =

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -99,6 +99,9 @@ export function projectConfigWindows(
   var validProject = false;
 
   if (usingManualOverride) {
+    // Copy the sourceDir from the user config.
+    result.sourceDir = userConfig.sourceDir;
+
     // Manual override, try to use it for solutionFile
     if (!('solutionFile' in userConfig)) {
       result.solutionFile =

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -9,6 +9,7 @@ import * as chalk from 'chalk';
 import * as deploy from './utils/deploy';
 import {newError, newInfo, newWarn} from './utils/commandWithProgress';
 import * as info from './utils/info';
+import * as path from 'path';
 import MSBuildTools from './utils/msbuildtools';
 
 import {Command, Config} from '@react-native-community/cli-types';
@@ -158,7 +159,7 @@ async function runWindows(
 
     try {
       if (options.device || options.emulator || options.target) {
-        await deploy.deployToDevice(options, verbose);
+        await deploy.deployToDevice(options, path.dirname(slnFile), verbose);
       } else {
         await deploy.deployToDesktop(options, verbose, config, buildTools);
       }

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -242,7 +242,7 @@ export async function deployToDesktop(
   const windowsRoot =
     windowsConfig && windowsConfig.folder && windowsConfig.sourceDir
       ? path.join(windowsConfig.folder, windowsConfig.sourceDir)
-      : path.join(options.root, 'windows');
+      : path.dirname(slnFile);
   const appPackageFolder = getAppPackage(options, windowsRoot, projectName);
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(


### PR DESCRIPTION
There were 2 problems:

###autolink
Auto-Linking was picking up the wrong path, when a custom `react-native.config.js` configures the windows folder with the users code in a different location.
This PR ensures that the custom sourcePath property is copied to the final configuration so it works.

###app deployment
App deployment hardcoded in a bunch of places to optoins.root\windows. This change updates the code to pass the windowsRoot which is where the native app code lives.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6232)