### PR TITLE
Fix deploy of C# apps in Release x86

### DIFF
--- a/change/@react-native-windows-cli-2020-10-15-13-12-42-csx86deploy.json
+++ b/change/@react-native-windows-cli-2020-10-15-13-12-42-csx86deploy.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "C# apps have x86 platform=x86 but C++ apps have Win32",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T20:12:42.642Z"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -78,7 +78,7 @@ function getAppPackage(
 
     const rootGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*}`;
     const newGlob = `${rootGlob}/*_${
-      options.arch === 'x86' ? 'Win32' : options.arch
+      options.arch === 'x86' ? '{Win32,x86}' : options.arch
     }_${options.release ? '' : 'Debug_'}Test`;
 
     const result = glob.sync(newGlob);
@@ -244,7 +244,6 @@ export async function deployToDesktop(
   )[0];
 
   const vsVersion = buildTools.installationVersion;
-
   if (vsVersion.startsWith('16.5') || vsVersion.startsWith('16.6')) {
     // VS 16.5 and 16.6 introduced a regression in packaging where the certificates created in the UI will render the package uninstallable.
     // This will be fixed in 16.7. In the meantime we need to copy the Add-AppDevPackage that has the fix for this EKU issue:


### PR DESCRIPTION
C# apps use the "x86" platform identified whereas C++ use Win32. Fix the CLI to account for this.