### PR TITLE
 Drop Issue Requirement from Override Manifest Schema Validation

### DIFF
--- a/change/@office-iss-react-native-win32-2020-10-19-05-08-08-no-issue-schema.json
+++ b/change/@office-iss-react-native-win32-2020-10-19-05-08-08-no-issue-schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Drop Issue Requirement from Override Manifest Schema Validation",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T12:08:07.615Z"
+}

--- a/change/react-native-platform-override-2020-10-19-05-08-08-no-issue-schema.json
+++ b/change/react-native-platform-override-2020-10-19-05-08-08-no-issue-schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Drop Issue Requirement from Override Manifest Schema Validation",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T12:08:05.488Z"
+}

--- a/change/react-native-windows-2020-10-19-05-08-08-no-issue-schema.json
+++ b/change/react-native-windows-2020-10-19-05-08-08-no-issue-schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Drop Issue Requirement from Override Manifest Schema Validation",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T12:08:08.642Z"
+}

--- a/packages/@react-native-windows/tester/overrides.json
+++ b/packages/@react-native-windows/tester/overrides.json
@@ -74,8 +74,7 @@
       "type": "patch",
       "file": "src/js/examples/View/ViewExample.windows.js",
       "baseFile": "packages/rn-tester/js/examples/View/ViewExample.js",
-      "baseHash": "2425a6f8fb8b7c7633b5744811c75edf77f29c2f",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "2425a6f8fb8b7c7633b5744811c75edf77f29c2f"
     },
     {
       "type": "derived",
@@ -88,8 +87,7 @@
       "type": "derived",
       "file": "src/js/utils/RNTesterList.windows.js",
       "baseFile": "packages/rn-tester/js/utils/RNTesterList.android.js",
-      "baseHash": "0ac04af15d7ff9d34b3abe1a11110c24480fba4b",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "0ac04af15d7ff9d34b3abe1a11110c24480fba4b"
     }
   ]
 }

--- a/packages/react-native-platform-override/src/Override.ts
+++ b/packages/react-native-platform-override/src/Override.ts
@@ -162,8 +162,9 @@ abstract class BaseFileOverride implements Override {
     );
   }
 
-  protected serializeBase(opts?: SerializeOpts) {
+  protected serializeBase<T>(type: T, opts?: SerializeOpts) {
     return {
+      type,
       file: unixPath(this.overrideFile),
       baseFile: unixPath(this.baseFile),
       baseVersion:
@@ -198,10 +199,7 @@ export class CopyOverride extends BaseFileOverride {
   }
 
   serialize(opts?: SerializeOpts): Serialized.CopyOverride {
-    return {
-      type: 'copy',
-      ...this.serializeBase(opts),
-    };
+    return this.serializeBase('copy', opts);
   }
 
   async createUpdated(factory: OverrideFactory): Promise<Override> {
@@ -247,10 +245,7 @@ export class DerivedOverride extends BaseFileOverride {
   }
 
   serialize(opts?: SerializeOpts): Serialized.DerivedOverride {
-    return {
-      type: 'derived',
-      ...this.serializeBase(opts),
-    };
+    return this.serializeBase('derived', opts);
   }
 
   async createUpdated(factory: OverrideFactory): Promise<Override> {
@@ -303,10 +298,7 @@ export class PatchOverride extends BaseFileOverride {
   }
 
   serialize(opts?: SerializeOpts): Serialized.PatchOverride {
-    return {
-      type: 'patch',
-      ...this.serializeBase(opts),
-    };
+    return this.serializeBase('patch', opts);
   }
 
   async createUpdated(factory: OverrideFactory): Promise<Override> {

--- a/packages/react-native-platform-override/src/Override.ts
+++ b/packages/react-native-platform-override/src/Override.ts
@@ -114,20 +114,20 @@ abstract class BaseFileOverride implements Override {
   protected baseFile: string;
   protected baseVersion: string;
   protected baseHash: string;
-  protected issueNumber: number | null | 'LEGACY_FIXME';
+  protected issueNumber?: number;
 
   constructor(args: {
     file: string;
     baseFile: string;
     baseVersion: string;
     baseHash: string;
-    issue?: number | 'LEGACY_FIXME';
+    issue?: number;
   }) {
     this.overrideFile = normalizePath(args.file);
     this.baseFile = normalizePath(args.baseFile);
     this.baseVersion = args.baseVersion;
     this.baseHash = args.baseHash;
-    this.issueNumber = args.issue || null;
+    this.issueNumber = args.issue;
   }
 
   name(): string {
@@ -162,7 +162,7 @@ abstract class BaseFileOverride implements Override {
     );
   }
 
-  protected serialzeBase(opts?: SerializeOpts) {
+  protected serializeBase(opts?: SerializeOpts) {
     return {
       file: unixPath(this.overrideFile),
       baseFile: unixPath(this.baseFile),
@@ -171,6 +171,7 @@ abstract class BaseFileOverride implements Override {
           ? undefined
           : this.baseVersion,
       baseHash: this.baseHash,
+      issue: this.issueNumber,
     };
   }
 }
@@ -184,7 +185,7 @@ export class CopyOverride extends BaseFileOverride {
     baseFile: string;
     baseVersion: string;
     baseHash: string;
-    issue: number;
+    issue?: number;
   }) {
     super(args);
   }
@@ -199,8 +200,7 @@ export class CopyOverride extends BaseFileOverride {
   serialize(opts?: SerializeOpts): Serialized.CopyOverride {
     return {
       type: 'copy',
-      ...this.serialzeBase(opts),
-      issue: this.issueNumber as number,
+      ...this.serializeBase(opts),
     };
   }
 
@@ -234,7 +234,7 @@ export class DerivedOverride extends BaseFileOverride {
     baseFile: string;
     baseVersion: string;
     baseHash: string;
-    issue?: number | 'LEGACY_FIXME';
+    issue?: number;
   }) {
     super(args);
   }
@@ -249,8 +249,7 @@ export class DerivedOverride extends BaseFileOverride {
   serialize(opts?: SerializeOpts): Serialized.DerivedOverride {
     return {
       type: 'derived',
-      ...this.serialzeBase(opts),
-      issue: this.issueNumber || undefined,
+      ...this.serializeBase(opts),
     };
   }
 
@@ -291,7 +290,7 @@ export class PatchOverride extends BaseFileOverride {
     baseFile: string;
     baseVersion: string;
     baseHash: string;
-    issue?: number | 'LEGACY_FIXME';
+    issue?: number;
   }) {
     super(args);
   }
@@ -306,8 +305,7 @@ export class PatchOverride extends BaseFileOverride {
   serialize(opts?: SerializeOpts): Serialized.PatchOverride {
     return {
       type: 'patch',
-      ...this.serialzeBase(opts),
-      issue: this.issueNumber as number,
+      ...this.serializeBase(opts),
     };
   }
 
@@ -346,14 +344,14 @@ export class DirectoryCopyOverride implements Override {
   private baseDirectory: string;
   private baseVersion: string;
   private baseHash: string;
-  private issue: number;
+  private issue?: number;
 
   constructor(args: {
     directory: string;
     baseDirectory: string;
     baseVersion: string;
     baseHash: string;
-    issue: number;
+    issue?: number;
   }) {
     this.directory = normalizePath(args.directory);
     this.baseDirectory = normalizePath(args.baseDirectory);

--- a/packages/react-native-platform-override/src/OverrideFactory.ts
+++ b/packages/react-native-platform-override/src/OverrideFactory.ts
@@ -26,25 +26,25 @@ export default interface OverrideFactory {
   createCopyOverride(
     file: string,
     baseFile: string,
-    issue: number,
+    issue?: number,
   ): Promise<CopyOverride>;
 
   createDerivedOverride(
     file: string,
     baseFile: string,
-    issue?: number | 'LEGACY_FIXME',
+    issue?: number,
   ): Promise<DerivedOverride>;
 
   createPatchOverride(
     file: string,
     baseFile: string,
-    issue: number | 'LEGACY_FIXME',
+    issue?: number,
   ): Promise<PatchOverride>;
 
   createDirectoryCopyOverride(
     directory: string,
     baseDirectory: string,
-    issue: number,
+    issue?: number,
   ): Promise<DirectoryCopyOverride>;
 }
 
@@ -68,7 +68,7 @@ export class OverrideFactoryImpl implements OverrideFactory {
   async createCopyOverride(
     file: string,
     baseFile: string,
-    issue: number,
+    issue?: number,
   ): Promise<CopyOverride> {
     await this.checkOverrideExists(file, 'file');
     return new CopyOverride({
@@ -96,7 +96,7 @@ export class OverrideFactoryImpl implements OverrideFactory {
   async createPatchOverride(
     file: string,
     baseFile: string,
-    issue: number | 'LEGACY_FIXME',
+    issue?: number,
   ): Promise<PatchOverride> {
     await this.checkOverrideExists(file, 'file');
     return new PatchOverride({
@@ -110,7 +110,7 @@ export class OverrideFactoryImpl implements OverrideFactory {
   async createDirectoryCopyOverride(
     directory: string,
     baseDirectory: string,
-    issue: number,
+    issue?: number,
   ): Promise<DirectoryCopyOverride> {
     await this.checkOverrideExists(directory, 'directory');
     return new DirectoryCopyOverride({

--- a/packages/react-native-platform-override/src/Serialized.ts
+++ b/packages/react-native-platform-override/src/Serialized.ts
@@ -28,9 +28,7 @@ const PatchOverrideType = t.type({
   baseFile: t.string,
   baseVersion: t.union([t.undefined, t.string]),
   baseHash: t.string,
-
-  // Allow LEGACY_FIXME for existing overrides that don't have issues yet
-  issue: t.union([t.number, t.literal('LEGACY_FIXME')]),
+  issue: t.union([t.undefined, t.number]),
 });
 
 /**
@@ -42,9 +40,7 @@ const DerivedOverrideType = t.type({
   baseFile: t.string,
   baseVersion: t.union([t.undefined, t.string]),
   baseHash: t.string,
-
-  // Allow LEGACY_FIXME for existing overrides that don't have issues yet
-  issue: t.union([t.undefined, t.number, t.literal('LEGACY_FIXME')]),
+  issue: t.union([t.undefined, t.number]),
 });
 
 /**
@@ -56,7 +52,7 @@ const CopyOverrideType = t.type({
   baseFile: t.string,
   baseVersion: t.union([t.undefined, t.string]),
   baseHash: t.string,
-  issue: t.number,
+  issue: t.union([t.undefined, t.number]),
 });
 
 /**
@@ -68,7 +64,7 @@ const DirectoryCopyOverrideType = t.type({
   baseDirectory: t.string,
   baseVersion: t.union([t.undefined, t.string]),
   baseHash: t.string,
-  issue: t.number,
+  issue: t.union([t.undefined, t.number]),
 });
 
 /**

--- a/packages/react-native-platform-override/src/e2etest/collateral/sampleOverrideRepo/overrides.json
+++ b/packages/react-native-platform-override/src/e2etest/collateral/sampleOverrideRepo/overrides.json
@@ -9,16 +9,14 @@
       "file": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.cpp",
       "baseFile": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.cpp",
       "baseVersion": "0.62.0-rc.3",
-      "baseHash": "b8840ecbf1d0a61d5e13d6f9690722e41cacb7ab",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "b8840ecbf1d0a61d5e13d6f9690722e41cacb7ab"
     },
     {
       "type": "patch",
       "file": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.h",
       "baseFile": "ReactCommon\\turbomodule\\samples\\SampleTurboCxxModule.h",
       "baseVersion": "0.62.0-rc.3",
-      "baseHash": "2e4e38798e5504d891342e46da17ef3b073123d8",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "2e4e38798e5504d891342e46da17ef3b073123d8"
     },
     {
       "type": "patch",

--- a/packages/react-native-platform-override/src/scripts/generateManifest.ts
+++ b/packages/react-native-platform-override/src/scripts/generateManifest.ts
@@ -90,7 +90,7 @@ async function tryAddCopy(
     baseFile: filename,
     baseVersion: undefined,
     baseHash: hashContent(baseContent),
-    issue: 0,
+    issue: undefined,
   });
 
   return true;

--- a/packages/react-native-platform-override/src/scripts/generateManifest.ts
+++ b/packages/react-native-platform-override/src/scripts/generateManifest.ts
@@ -117,7 +117,7 @@ async function tryAddPatch(
       baseFile: baseFile,
       baseVersion: undefined,
       baseHash: hashContent(baseContent),
-      issue: 'LEGACY_FIXME',
+      issue: undefined,
     });
   } else {
     addUnknown(filename, manifest);
@@ -168,7 +168,7 @@ async function tryAddDerived(
     baseFile: bestMatch.file,
     baseVersion: undefined,
     baseHash: hashContent(bestMatch.contents),
-    issue: 'LEGACY_FIXME',
+    issue: undefined,
   });
 
   return true;
@@ -180,7 +180,6 @@ function addUnknown(filename: string, manifest: Serialized.Manifest) {
     file: filename,
     baseFile: '???',
     baseHash: '???',
-    issue: 'LEGACY_FIXME',
   });
 }
 

--- a/packages/react-native-platform-override/src/test/Manifest.test.ts
+++ b/packages/react-native-platform-override/src/test/Manifest.test.ts
@@ -393,7 +393,7 @@ test('Serialization (Indivudal Base) Round-Trip', () => {
         baseFile: 'defg.js',
         baseVersion: '0.65.3',
         baseHash: 'sdfssfsfsf',
-        issue: 'LEGACY_FIXME',
+        issue: undefined,
       },
       {
         type: 'copy',
@@ -435,7 +435,7 @@ test('Serialization (Default Base) Round-Trip', () => {
         baseFile: 'defg.js',
         baseVersion: undefined,
         baseHash: 'sdfssfsfsf',
-        issue: 'LEGACY_FIXME',
+        issue: undefined,
       },
       {
         type: 'copy',
@@ -477,7 +477,7 @@ test('Serialization (Differing Bases) Round-Trip', () => {
         baseFile: 'defg.js',
         baseVersion: '0.64.3',
         baseHash: 'sdfssfsfsf',
-        issue: 'LEGACY_FIXME',
+        issue: undefined,
       },
       {
         type: 'copy',
@@ -515,7 +515,7 @@ test('String Exact Serialization Round-Trip', () => {
         baseFile: 'defg.js',
         baseVersion: '0.65.3',
         baseHash: 'sdfssfsfsf',
-        issue: 'LEGACY_FIXME',
+        issue: undefined,
       },
       {
         type: 'copy',

--- a/packages/react-native-platform-override/src/test/Serialized.test.ts
+++ b/packages/react-native-platform-override/src/test/Serialized.test.ts
@@ -136,58 +136,6 @@ test('Well Formed Directory Copy', () => {
   expect(Serialized.parseManifest(JSON.stringify(manifest))).toEqual(manifest);
 });
 
-test('Fixme Allowed As Issue', () => {
-  const manifest: Serialized.Manifest = {
-    includePatterns: undefined,
-    excludePatterns: undefined,
-    baseVersion: undefined,
-    overrides: [
-      {
-        type: 'patch',
-        file: 'foo.win32.js',
-        baseFile: 'foo.js',
-        baseVersion: '0.61.5',
-        baseHash: 'AAAABBBB',
-        issue: 'LEGACY_FIXME',
-      },
-    ],
-  };
-
-  expect(Serialized.parseManifest(JSON.stringify(manifest))).toEqual(manifest);
-});
-
-test('Issue Must Be Present For Patch', () => {
-  const manifest = {
-    overrides: [
-      {
-        type: 'patch',
-        file: 'foo.win32.js',
-        baseFile: 'foo.js',
-        baseVersion: '0.61.5',
-        baseHash: 'AAAABBBB',
-      },
-    ],
-  };
-
-  expect(() => Serialized.parseManifest(JSON.stringify(manifest))).toThrow();
-});
-
-test('Issue Must Be Present For Copy', () => {
-  const manifest = {
-    overrides: [
-      {
-        type: 'copy',
-        file: 'foo.win32.js',
-        baseFile: 'foo.js',
-        baseVersion: '0.61.5',
-        baseHash: 'AAAABBBB',
-      },
-    ],
-  };
-
-  expect(() => Serialized.parseManifest(JSON.stringify(manifest))).toThrow();
-});
-
 test('Issue Cannot Be Arbitrary String', () => {
   const manifest = {
     overrides: [

--- a/packages/react-native-win32-tester/overrides.json
+++ b/packages/react-native-win32-tester/overrides.json
@@ -11,15 +11,13 @@
       "type": "patch",
       "file": "src/js/components/ListExampleShared.win32.js",
       "baseFile": "packages/rn-tester/js/components/ListExampleShared.js",
-      "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "d7be07e3fd8d9c1df8e23d5674ce3eb067d00865"
     },
     {
       "type": "patch",
       "file": "src/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "packages/rn-tester/js/components/RNTesterExampleFilter.js",
-      "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "8a8182f7c36e8184b7bbfe1445263ceca622b2c1"
     },
     {
       "type": "patch",
@@ -46,8 +44,7 @@
       "type": "derived",
       "file": "src/js/utils/RNTesterList.win32.js",
       "baseFile": "packages/rn-tester/js/utils/RNTesterList.android.js",
-      "baseHash": "0ac04af15d7ff9d34b3abe1a11110c24480fba4b",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "0ac04af15d7ff9d34b3abe1a11110c24480fba4b"
     }
   ]
 }

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -23,15 +23,13 @@
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa"
     },
     {
       "type": "patch",
@@ -44,15 +42,13 @@
       "type": "derived",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseHash": "525b7ac5ec31febba5f57c8faa7ccc9a6e0fa34c",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "525b7ac5ec31febba5f57c8faa7ccc9a6e0fa34c"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js",
-      "baseHash": "7b519b61f8100b5997c999b21552fd270abafce7",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "7b519b61f8100b5997c999b21552fd270abafce7"
     },
     {
       "type": "platform",
@@ -129,8 +125,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.win32.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee"
     },
     {
       "type": "copy",
@@ -159,15 +154,13 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseHash": "05c8c1e9142210b472c9c1ce891314b786ecc50f",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "05c8c1e9142210b472c9c1ce891314b786ecc50f"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7"
     },
     {
       "type": "copy",
@@ -204,15 +197,13 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewAttributes.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
-      "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "0825b0257e19cfef2d626f19d219256a01c54b67"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68"
     },
     {
       "type": "platform",
@@ -298,15 +289,13 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "60aa482532caac00745f8ae8611a36c756fb5b75"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Inspector/InspectorOverlay.win32.js",
       "baseFile": "Libraries/Inspector/InspectorOverlay.js",
-      "baseHash": "b11d03daa2e3f828a350667f543b2cda4fa65dbf",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "b11d03daa2e3f828a350667f543b2cda4fa65dbf"
     },
     {
       "type": "derived",
@@ -345,8 +334,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d"
     },
     {
       "type": "platform",
@@ -364,8 +352,7 @@
       "type": "patch",
       "file": "src/Libraries/StyleSheet/StyleSheet.win32.js",
       "baseFile": "Libraries/StyleSheet/StyleSheet.js",
-      "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "95ed8a2da162e168c7d740640a9d6c0fdb282c84"
     },
     {
       "type": "copy",
@@ -378,29 +365,25 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "6a61022dbe92a0683a82669ace739fc7ca110c7d"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseHash": "71ec2fb1dbf35d65562538d2c63d099ec1392d00",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "71ec2fb1dbf35d65562538d2c63d099ec1392d00"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseHash": "750d5a0afc192d9ec98c27d28402285c9e3155a0",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "750d5a0afc192d9ec98c27d28402285c9e3155a0"
     },
     {
       "type": "platform",

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -66,8 +66,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "27967b6f36e9bc2bc3f4ac79c1320b7152d93f83"
     },
     {
       "type": "platform",
@@ -93,8 +92,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa"
     },
     {
       "type": "platform",
@@ -115,8 +113,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Button.windows.js",
       "baseFile": "Libraries/Components/Button.js",
-      "baseHash": "93f4b6047b238d31c2c72c44f11cd689c6a4b071",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "93f4b6047b238d31c2c72c44f11cd689c6a4b071"
     },
     {
       "type": "platform",
@@ -228,36 +225,31 @@
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "0efdf9cc52f5411bbf296f92e30aa44f83668b45"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/SafeAreaView/SafeAreaView.windows.js",
       "baseFile": "Libraries/Components/SafeAreaView/SafeAreaView.js",
-      "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "db15a0f43bd49e0be23b74b192fb28ee70fd3fee"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.windows.js",
       "baseFile": "Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js",
-      "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "37cea8b532ea4e4335120c6f8b2d3d3548e31b18"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseHash": "05c8c1e9142210b472c9c1ce891314b786ecc50f",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "05c8c1e9142210b472c9c1ce891314b786ecc50f"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7"
     },
     {
       "type": "derived",
@@ -269,29 +261,25 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "9a1867dd466facf4eda43cafe747b8b019713a95"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseHash": "58698d349b3327660c71708f7128c2247caaef3f",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "58698d349b3327660c71708f7128c2247caaef3f"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "8d5d480284b4cdaf7d8d86935967370d455b7b68"
     },
     {
       "type": "patch",
@@ -304,15 +292,13 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewAccessibility.windows.js",
       "baseFile": "Libraries/Components/View/ViewAccessibility.js",
-      "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "2d01902a9edd76f728e9044e2ed8a35d44f34424"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/View/ViewPropTypes.windows.js",
       "baseFile": "Libraries/Components/View/ViewPropTypes.js",
-      "baseHash": "2b12228aa1ab0e12844996a99ff5d38fbff689a1",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "2b12228aa1ab0e12844996a99ff5d38fbff689a1"
     },
     {
       "type": "platform",
@@ -326,8 +312,7 @@
       "type": "patch",
       "file": "src/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.windows.js",
       "baseFile": "Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js",
-      "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162"
     },
     {
       "type": "copy",
@@ -344,22 +329,19 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseHash": "8ffebf68a136054311f723682864c4c609ad0587",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "8ffebf68a136054311f723682864c4c609ad0587"
     },
     {
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/DebugInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/DebugInstructions.js",
-      "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "a9f4db370db2e34a8708abd57bc5a7ab5c44ccf1"
     },
     {
       "type": "patch",
       "file": "src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js",
       "baseFile": "Libraries/NewAppScreen/components/ReloadInstructions.js",
-      "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "39326801da6c9ce8c350aa8ba971be4a386499bc"
     },
     {
       "type": "patch",
@@ -372,8 +354,7 @@
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.windows.js",
       "baseFile": "Libraries/Settings/Settings.android.js",
-      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "00604dd0ab624b3f5b80d460f48dbc3ac7ee905d"
     },
     {
       "type": "platform",
@@ -389,8 +370,7 @@
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseHash": "e8f8ce02645228b423fdda317e5d1d9e69b54e6d",
-      "issue": "LEGACY_FIXME"
+      "baseHash": "e8f8ce02645228b423fdda317e5d1d9e69b54e6d"
     },
     {
       "type": "copy",


### PR DESCRIPTION
Most types of overrides require an issue number. This is done on the schema level, and is done inconsistently per-type, where some allow no issues or LEGACY_FIXME, where others allow none. This was done to add barriers to forking, but ends up being a bit too broad/heavy-handed, and the differences between requirements of override types is confusing.

This changes makes the schema uniform, dropping the special LEGACY_FIXME issue and universally allowing missing issues.

To guide engineers to the right path, we still do require issues depending on types in the override prompt, but these can be altered manually.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6263)