### PR TITLE
Fix switch events

### DIFF
--- a/change/react-native-windows-2020-10-19-13-20-12-fixSwitchEvents.json
+++ b/change/react-native-windows-2020-10-19-13-20-12-fixSwitchEvents.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Switch was generating spurious events which could result on two events (on/off) being sent before the first event was fully handled",
+  "packageName": "react-native-windows",
+  "email": "gill.peacegood@axsy.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-19T12:20:12.307Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -28,8 +28,7 @@ class SwitchShadowNode : public ShadowNodeBase {
   void updateProperties(const folly::dynamic &&props) override;
   void UpdateThumbColor();
   void UpdateTrackColor();
-  void dispatchCommand(const std::string& commandId, const folly::dynamic& commandArgs) override;
-
+  void dispatchCommand(const std::string &commandId, const folly::dynamic &commandArgs) override;
 
  private:
   static void OnToggled(const Mso::React::IReactContext &context, int64_t tag, bool newValue);
@@ -104,16 +103,17 @@ void SwitchShadowNode::updateProperties(const folly::dynamic &&props) {
   m_updating = false;
 }
 
-void SwitchShadowNode::dispatchCommand(
-  const std::string& commandId,
-  const folly::dynamic& commandArgs) {
+void SwitchShadowNode::dispatchCommand(const std::string &commandId, const folly::dynamic &commandArgs) {
   if (commandId == "setValue") {
-      m_updating = true;
-      Super::dispatchCommand(commandId, commandArgs);
-      m_updating = false;
-  }
-  else {
-      Super::dispatchCommand( commandId, commandArgs);
+    m_updating = true;
+    auto value = commandArgs[0].asBool();
+    auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();
+    if (toggleSwitch == nullptr)
+      return;
+    toggleSwitch.IsOn(value);
+    m_updating = false;
+  } else {
+    Super::dispatchCommand(commandId, commandArgs);
   }
 }
 
@@ -171,18 +171,6 @@ bool SwitchViewManager::UpdateProperty(
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }
   return true;
-}
-
-void SwitchViewManager::DispatchCommand(
-    const XamlView &viewToUpdate,
-    const std::string &commandId,
-    const folly::dynamic &commandArgs) {
-  if (commandId == "setValue") {
-    auto value = commandArgs[0].asBool();
-    viewToUpdate.as<winrt::ToggleSwitch>().IsOn(value);
-  } else {
-    Super::DispatchCommand(viewToUpdate, commandId, commandArgs);
-  }
 }
 
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -107,8 +107,6 @@ void SwitchShadowNode::dispatchCommand(const std::string &commandId, const folly
   if (commandId == "setValue") {
     auto value = commandArgs[0].asBool();
     auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();
-    if (toggleSwitch == nullptr)
-      return;
     m_updating = true;
     toggleSwitch.IsOn(value);
     m_updating = false;

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -28,6 +28,8 @@ class SwitchShadowNode : public ShadowNodeBase {
   void updateProperties(const folly::dynamic &&props) override;
   void UpdateThumbColor();
   void UpdateTrackColor();
+  void dispatchCommand(const std::string& commandId, const folly::dynamic& commandArgs) override;
+
 
  private:
   static void OnToggled(const Mso::React::IReactContext &context, int64_t tag, bool newValue);
@@ -100,6 +102,19 @@ void SwitchShadowNode::updateProperties(const folly::dynamic &&props) {
   }
 
   m_updating = false;
+}
+
+void SwitchShadowNode::dispatchCommand(
+  const std::string& commandId,
+  const folly::dynamic& commandArgs) {
+  if (commandId == "setValue") {
+      m_updating = true;
+      Super::dispatchCommand(commandId, commandArgs);
+      m_updating = false;
+  }
+  else {
+      Super::dispatchCommand( commandId, commandArgs);
+  }
 }
 
 /*static*/ void SwitchShadowNode::OnToggled(const Mso::React::IReactContext &context, int64_t tag, bool newValue) {

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -105,11 +105,11 @@ void SwitchShadowNode::updateProperties(const folly::dynamic &&props) {
 
 void SwitchShadowNode::dispatchCommand(const std::string &commandId, const folly::dynamic &commandArgs) {
   if (commandId == "setValue") {
-    m_updating = true;
     auto value = commandArgs[0].asBool();
     auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();
     if (toggleSwitch == nullptr)
       return;
+    m_updating = true;
     toggleSwitch.IsOn(value);
     m_updating = false;
   } else {

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.h
@@ -16,8 +16,6 @@ class SwitchViewManager : public ControlViewManager {
   const char *GetName() const override;
   folly::dynamic GetNativeProps() const override;
   facebook::react::ShadowNode *createShadow() const override;
-  void DispatchCommand(const XamlView &viewToUpdate, const std::string &commandId, const folly::dynamic &commandArgs)
-      override;
 
  protected:
   bool UpdateProperty(


### PR DESCRIPTION
The switch was generating spurious events as a result of setValue command being called by the JS after the first switch event and before the props had been changed by the app. This resulted in the switch not changing state

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6264)