### PR TITLE
 Fix Crash when Logbox shown on pre-19H1

### DIFF
--- a/change/react-native-windows-2020-10-20-09-06-20-fix-redbox-logbox-actualsize.json
+++ b/change/react-native-windows-2020-10-20-09-06-20-fix-redbox-logbox-actualsize.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Crash when Logbox shown on pre-19H1",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T16:06:20.477Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -58,10 +58,10 @@ void LogBox::ShowOnUIThread() noexcept {
     root = window.Content().as<xaml::FrameworkElement>();
   }
 
-  m_logBoxContent.MaxHeight(root.ActualSize().y);
-  m_logBoxContent.Height(root.ActualSize().y);
-  m_logBoxContent.MaxWidth(root.ActualSize().x);
-  m_logBoxContent.Width(root.ActualSize().x);
+  m_logBoxContent.MaxHeight(root.ActualHeight());
+  m_logBoxContent.Height(root.ActualHeight());
+  m_logBoxContent.MaxWidth(root.ActualWidth());
+  m_logBoxContent.Width(root.ActualWidth());
   m_logBoxContent.UpdateLayout();
 
   m_sizeChangedRevoker = root.SizeChanged(

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -132,10 +132,10 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
       root = window.Content().as<xaml::FrameworkElement>();
     }
 
-    m_redboxContent.MaxHeight(root.ActualSize().y);
-    m_redboxContent.Height(root.ActualSize().y);
-    m_redboxContent.MaxWidth(root.ActualSize().x);
-    m_redboxContent.Width(root.ActualSize().x);
+    m_redboxContent.MaxHeight(root.ActualHeight());
+    m_redboxContent.Height(root.ActualHeight());
+    m_redboxContent.MaxWidth(root.ActualWidth());
+    m_redboxContent.Width(root.ActualWidth());
 
     m_sizeChangedRevoker = root.SizeChanged(
         winrt::auto_revoke,


### PR DESCRIPTION
ActualSize was added to UIElement in 19H1, but is being used in native code for Logbox/legacy redbox. This will also cause integration tests to crash on redbox, since they're running on debug build on Windows Server 2019.

Replace usages with ActualHeight/ActualWidth.

Initial thoughts are to not backport this, since it's dev only and has existed for a couple of versions.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6283)