### PR TITLE
Make native modules to use JS queue

### DIFF
--- a/change/react-native-windows-2020-10-20-09-59-36-FixDefaultJSQueue.json
+++ b/change/react-native-windows-2020-10-20-09-59-36-FixDefaultJSQueue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Make native modules to use JS queue",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T16:59:36.270Z"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -284,7 +284,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
           if (m_options.ModuleProvider != nullptr) {
             std::vector<facebook::react::NativeModuleDescription> customCxxModules =
-                m_options.ModuleProvider->GetModules(m_reactContext, m_batchingUIThread);
+                m_options.ModuleProvider->GetModules(m_reactContext, m_jsMessageThread.Load());
             cxxModules.insert(std::end(cxxModules), std::begin(customCxxModules), std::end(customCxxModules));
           }
 


### PR DESCRIPTION
Surprisingly, we had a bug that all NativeModules 2.0 use UI queue to run their code. We call NativeModules 2.0 the native modules that run on top of the ABI safe API in the ReactNative for Windows.
In this change we switch them to use the JS queue as it supposed to be.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6284)