### PR TITLE
Fix ReactContext::EmitJSEvent arg passing

### DIFF
--- a/change/react-native-windows-2020-10-20-16-28-00-FixEmitJSEvent.json
+++ b/change/react-native-windows-2020-10-20-16-28-00-FixEmitJSEvent.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactContext::EmitJSEvent arg passing",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T23:28:00.709Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/index.windows.js
+++ b/packages/microsoft-reactnative-sampleapps/index.windows.js
@@ -43,6 +43,12 @@ var getCallback = function(prefix) {
   };
 };
 
+var getCallback2 = function(prefix) {
+  return function(arg1, arg2) {
+    log(prefix + "arg1: " + arg1 + " arg2: " + arg2);
+  };
+};
+
 var getErrorCallback = function(prefix) {
   return function(error) {
     log(prefix + (error || {}).message);
@@ -63,6 +69,12 @@ class SampleApp extends Component {
   componentDidMount() {
     this.timedEventCSSub = SampleModuleCSEmitter.addListener('TimedEventCS', getCallback('SampleModuleCS.TimedEventCS() => '));
     this.timedEventCppSub = SampleModuleCppEmitter.addListener('TimedEventCpp', getCallback('SampleModuleCpp.TimedEventCpp() => '));
+    this.EmitJSEvent1CppSub = SampleModuleCppEmitter.addListener('EmitJSEvent1Cpp', getCallback('SampleModuleCpp.EmitJSEvent1Cpp => '));
+    this.EmitJSEvent2CppSub = SampleModuleCppEmitter.addListener('EmitJSEvent2Cpp', getCallback2('SampleModuleCpp.EmitJSEvent2Cpp => '));
+    this.EmitJSEvent3CppSub = SampleModuleCppEmitter.addListener('EmitJSEvent3Cpp', getCallback2('SampleModuleCpp.EmitJSEvent3Cpp => '));
+    this.EmitJSEvent1CSSub = SampleModuleCppEmitter.addListener('EmitJSEvent1CS', getCallback('SampleModuleCS.EmitJSEvent1CS => '));
+    this.EmitJSEvent2CSSub = SampleModuleCppEmitter.addListener('EmitJSEvent2CS', getCallback2('SampleModuleCS.EmitJSEvent2CS => '));
+    this.EmitJSEvent3CSSub = SampleModuleCppEmitter.addListener('EmitJSEvent3CS', getCallback2('SampleModuleCS.EmitJSEvent3CS => '));
     this.openURLSub = Linking.addListener('url', (event) => log('Open URL => ' + event.url));
 
     Linking.getInitialURL()
@@ -73,6 +85,12 @@ class SampleApp extends Component {
   componentWillUnmount() {
     this.timedEventCSSub.remove();
     this.timedEventCppSub.remove();
+    this.EmitJSEvent1CppSub.remove();
+    this.EmitJSEvent2CppSub.remove();
+    this.EmitJSEvent3CppSub.remove();
+    this.EmitJSEvent1CSSub.remove();
+    this.EmitJSEvent2CSSub.remove();
+    this.EmitJSEvent3CSSub.remove();
     this.openURLSub.remove();
   }
 
@@ -165,10 +183,13 @@ class SampleApp extends Component {
       .then(getCallback('SampleModuleCS.TaskOfTTwoArgs then => '))
       .catch(getErrorCallback('SampleModuleCS.TaskOfTTwoArgs catch => '));
 
+    NativeModules.SampleModuleCS.EmitJSEvent1(43);
+    NativeModules.SampleModuleCS.EmitJSEvent2(8, 52);
+    NativeModules.SampleModuleCS.EmitJSEvent3(15, 79);
 
-    log('SampleModuleCS.SyncReturnMethod => ' + NativeModules.SampleModuleCS.SyncReturnMethod());
-
-    log('SampleModuleCS.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCS.SyncReturnMethodWithArgs(numberArg));
+    //TODO: make sync method accessible only in non-web debugger scenarios
+    //log('SampleModuleCS.SyncReturnMethod => ' + NativeModules.SampleModuleCS.SyncReturnMethod());
+    //log('SampleModuleCS.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCS.SyncReturnMethodWithArgs(numberArg));
   }
 
   onPressSampleModuleCpp() {
@@ -244,9 +265,13 @@ class SampleApp extends Component {
 
     NativeModules.SampleModuleCpp.callDistanceFunction({x: 2, y: 3}, {x: 5, y: 6});
 
-    log('SampleModuleCpp.SyncReturnMethod => ' + NativeModules.SampleModuleCpp.SyncReturnMethod());
+    NativeModules.SampleModuleCpp.EmitJSEvent1(42);
+    NativeModules.SampleModuleCpp.EmitJSEvent2(7, 51);
+    NativeModules.SampleModuleCpp.EmitJSEvent3(14, 78);
 
-    log('SampleModuleCpp.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCpp.SyncReturnMethodWithArgs(numberArg));
+    //TODO: make sync method accessible only in non-web debugger scenarios
+    //log('SampleModuleCpp.SyncReturnMethod => ' + NativeModules.SampleModuleCpp.SyncReturnMethod());
+    //log('SampleModuleCpp.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCpp.SyncReturnMethodWithArgs(numberArg));
   }
 
   onPressCustomUserControlCS() {

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -254,10 +254,11 @@ struct SampleModuleCppImpl {
   REACT_METHOD(EmitJSEvent3)
   void EmitJSEvent3(int value1, int value2) noexcept {
     // Test the ReactContext::EmitJSEvent
-    m_reactContext.EmitJSEvent(L"RCTDeviceEventEmitter", L"EmitJSEvent3Cpp", [&](IJSValueWriter const argWriter) noexcept {
-      WriteValue(argWriter, value1);
-      WriteValue(argWriter, value2);
-    });
+    m_reactContext.EmitJSEvent(
+        L"RCTDeviceEventEmitter", L"EmitJSEvent3Cpp", [&](IJSValueWriter const argWriter) noexcept {
+          WriteValue(argWriter, value1);
+          WriteValue(argWriter, value2);
+        });
   }
 
 #pragma endregion

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -34,6 +34,8 @@ struct SampleModuleCppImpl {
 
   REACT_INIT(Initialize)
   void Initialize(ReactContext const &reactContext) noexcept {
+    m_reactContext = reactContext;
+
     const ReactPropertyId<int> myProp1{L"Prop1"};
     const ReactPropertyId<winrt::hstring> myProp2{L"Prop2"};
     DEBUG_OUTPUT("C++ Properties.Prop1:", *reactContext.Properties().Get(myProp1));
@@ -237,6 +239,27 @@ struct SampleModuleCppImpl {
   REACT_EVENT(TimedEvent, L"TimedEventCpp");
   std::function<void(int)> TimedEvent;
 
+  REACT_METHOD(EmitJSEvent1)
+  void EmitJSEvent1(int value) noexcept {
+    // Test the ReactContext::EmitJSEvent
+    m_reactContext.EmitJSEvent(L"RCTDeviceEventEmitter", L"EmitJSEvent1Cpp", value);
+  }
+
+  REACT_METHOD(EmitJSEvent2)
+  void EmitJSEvent2(int value1, int value2) noexcept {
+    // Test the ReactContext::EmitJSEvent
+    m_reactContext.EmitJSEvent(L"RCTDeviceEventEmitter", L"EmitJSEvent2Cpp", value1, value2);
+  }
+
+  REACT_METHOD(EmitJSEvent3)
+  void EmitJSEvent3(int value1, int value2) noexcept {
+    // Test the ReactContext::EmitJSEvent
+    m_reactContext.EmitJSEvent(L"RCTDeviceEventEmitter", L"EmitJSEvent3Cpp", [&](IJSValueWriter const argWriter) noexcept {
+      WriteValue(argWriter, value1);
+      WriteValue(argWriter, value2);
+    });
+  }
+
 #pragma endregion
 
 #pragma region JS Functions
@@ -255,6 +278,7 @@ struct SampleModuleCppImpl {
   winrt::Windows::System::Threading::ThreadPoolTimer m_timer{nullptr};
   int m_timerCount{0};
   static constexpr std::chrono::milliseconds TimedEventInterval{5000};
+  ReactContext m_reactContext;
 };
 
 // SampleSharedCppModule shows how to inherited native modules from std::enable_shared_from_this

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
@@ -6,6 +6,7 @@ using Microsoft.ReactNative.Managed;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Windows.Security.Cryptography.Core;
 using Windows.System.Threading;
 
 namespace SampleLibraryCS
@@ -26,6 +27,8 @@ namespace SampleLibraryCS
         [ReactInitializer]
         public void Initialize(ReactContext reactContext)
         {
+            _reactContext = reactContext;
+
             Debug.WriteLine($"C# Properties.Prop1: {reactContext.Handle.Properties.Get(ReactPropertyBagHelper.GetName(null, "Prop1"))}");
             Debug.WriteLine($"C# Properties.Prop2: {reactContext.Handle.Properties.Get(ReactPropertyBagHelper.GetName(null, "Prop2"))}");
 
@@ -278,11 +281,36 @@ namespace SampleLibraryCS
         [ReactEvent("TimedEventCS")]
         public Action<int> TimedEvent { get; set; }
 
-        #endregion
+        [ReactMethod]
+        public void EmitJSEvent1(int value)
+        {
+            // Test the ReactContext.EmitJSEvent
+            _reactContext.EmitJSEvent("RCTDeviceEventEmitter", "EmitJSEvent1CS", value);
+        }
 
-        #region JS Functions
+        [ReactMethod]
+        public void EmitJSEvent2(int value1, int value2)
+        {
+            // Test the ReactContext::EmitJSEvent
+            _reactContext.EmitJSEvent("RCTDeviceEventEmitter", "EmitJSEvent2CS", value1, value2);
+        }
 
-        [ReactFunction("calcDistance", ModuleName = "SampleModuleCpp")]
+        [ReactMethod]
+        public void EmitJSEvent3(int value1, int value2)
+        {
+            // Test the ReactContext::EmitJSEvent
+            _reactContext.EmitJSEvent<JSValueArgWriter>("RCTDeviceEventEmitter", "EmitJSEvent3CS", (IJSValueWriter argWriter) =>
+            {
+                argWriter.WriteValue(value1);
+                argWriter.WriteValue(value2);
+            });
+        }
+
+#endregion
+
+#region JS Functions
+
+[ReactFunction("calcDistance", ModuleName = "SampleModuleCpp")]
         public Action<Point, Point> CalcDistance = null;
 
         [ReactMethod("callDistanceFunction")]
@@ -297,5 +325,6 @@ namespace SampleLibraryCS
         private ThreadPoolTimer _timer;
         private int _timerCount = 0;
         private const int TimedEventIntervalMS = 5000;
+        private ReactContext _reactContext;
     }
 }

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -272,6 +272,18 @@ inline JSValueArgWriter MakeJSValueArgWriter(TArgs &&... args) noexcept {
   };
 }
 
+template <class T, std::enable_if_t<std::is_invocable_v<T, IJSValueWriter const &>, int> = 0>
+inline JSValueArgWriter MakeJSValueWriter(T &&argWriter) noexcept {
+  return std::forward<T>(argWriter);
+}
+
+template <class... TArgs>
+inline JSValueArgWriter MakeJSValueWriter(TArgs &&... args) noexcept {
+  return [&args...](IJSValueWriter const &writer) noexcept {
+    (WriteValue(writer, args), ...);
+  };
+}
+
 } // namespace winrt::Microsoft::ReactNative
 
 #endif // MICROSOFT_REACTNATIVE_JSVALUEWRITER

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -62,7 +62,7 @@ struct ReactContext {
   // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>
   void EmitJSEvent(std::wstring_view eventEmitterName, std::wstring_view eventName, TArgs &&... args) const noexcept {
-    m_handle.EmitJSEvent(eventEmitterName, eventName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
+    m_handle.EmitJSEvent(eventEmitterName, eventName, MakeJSValueWriter(std::forward<TArgs>(args)...));
   }
 
 #if !defined(CORE_ABI) && !defined(__APPLE__)


### PR DESCRIPTION
This change is to fix the bug in ReactContext::EmitJSEvent where the event arguments were unnecessary wrapped into an array.
As a part of this change we adding functions to the sample project to verify that ReactContext::EmitJSEvent works for C++ and C# code.
The bug was only in the C++ version of ReactContext::EmitJSEvent. The C# version is working correctly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6285)