### PR TITLE
Bugfix:  Dimensions never fires change events

### DIFF
--- a/change/react-native-windows-2020-10-20-17-25-59-dimsfix.json
+++ b/change/react-native-windows-2020-10-20-17-25-59-dimsfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "raise change event when dimensions change",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-21T00:25:59.575Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -112,6 +112,7 @@ void DeviceInfoHolder::updateDeviceInfo() noexcept {
   m_dpi = displayInfo.LogicalDpi();
   m_screenWidth = displayInfo.ScreenWidthInRawPixels();
   m_screenHeight = displayInfo.ScreenHeightInRawPixels();
+  notifyChanged();
 }
 
 void DeviceInfo::GetConstants(React::ReactConstantProvider &provider) noexcept {


### PR DESCRIPTION
Fixes #6269

This regression crept in when DeviceInfoModule was migrated to the new module system.  Super simple bug:  when the dimensions change, we update everything but forget to fire the change event.  This fix adds the missing line of code.

You can verify the scenario in the already existing Dimensions RNTester page.  We'll want to eventually add an automated test for this, but that can be done later.

Note that this fix also requires https://github.com/microsoft/react-native-windows/pull/6285.  Any app with a Dimensions listener will throw a redbox when the window is resized without that fix.  Will wait for that fix before submitting this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6286)