### PR TITLE
Implement backgroundColor prop for Text.

### DIFF
--- a/change/react-native-windows-2020-10-21-14-32-36-highlight_feature.json
+++ b/change/react-native-windows-2020-10-21-14-32-36-highlight_feature.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Implement backgroundColor for Text.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-21T21:32:36.354Z"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -72,6 +72,58 @@ export class AttributeToggler extends React.Component<
   }
 }
 
+export class BackgroundColorDemo extends React.Component<{}> {
+  public render() {
+    return (
+      <View>
+        <Text>
+          Outer no_color{' '}
+          <Text style={{backgroundColor: 'green'}}>
+            START_NESTED green{' '}
+            <Text style={{backgroundColor: 'blue'}}>DEEPER_NESTED blue</Text>{' '}
+            END_NESTED
+          </Text>{' '}
+          attributes.
+        </Text>
+        <Text>
+          Outer no_color{' '}
+          <Text>
+            START_NESTED no_color{' '}
+            <Text style={{backgroundColor: 'blue'}}>DEEPER_NESTED blue</Text>{' '}
+            END_NESTED
+          </Text>{' '}
+          attributes.
+        </Text>
+        <Text>
+          Outer no_color{' '}
+          <Text style={{backgroundColor: 'green'}}>
+            START_NESTED green <Text>DEEPER_NESTED inherit green</Text>{' '}
+            END_NESTED
+          </Text>{' '}
+          attributes.
+        </Text>
+        <Text style={{backgroundColor: 'red'}}>
+          Outer red{' '}
+          <Text>
+            START_NESTED inherit red <Text>DEEPER_NESTED inherit red</Text>{' '}
+            END_NESTED
+          </Text>{' '}
+          attributes.
+        </Text>
+        <Text style={{backgroundColor: 'red'}}>
+          Outer red{' '}
+          <Text style={{backgroundColor: 'green'}}>
+            START_NESTED green{' '}
+            <Text style={{backgroundColor: 'blue'}}>DEEPER_NESTED blue</Text>{' '}
+            END_NESTED
+          </Text>{' '}
+          attributes.
+        </Text>
+      </View>
+    );
+  }
+}
+
 export class TextExample extends React.Component<{}> {
   public render() {
     const lorumIpsum =
@@ -441,6 +493,11 @@ export class TextExample extends React.Component<{}> {
         <RNTesterBlock title="Toggling Attributes">
           <AttributeToggler />
         </RNTesterBlock>
+
+        <RNTesterBlock title="backgroundColor new examples">
+          <BackgroundColorDemo />
+        </RNTesterBlock>
+
         <RNTesterBlock title="backgroundColor attribute">
           <Text style={{backgroundColor: '#ffaaaa'}}>
             Red background,

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -20,6 +20,7 @@ namespace react::uwp {
 
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
 xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSValue &v);
+xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color);
 
 REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const folly::dynamic &d);
 REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const winrt::Microsoft::ReactNative::JSValue &d);

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -39,7 +39,7 @@ void VirtualTextShadowNode::AddView(ShadowNode &child, int64_t index) {
       }
     }
 
-    m_highlightData->data.emplace_back(std::move(childVTSN.m_highlightData));
+    m_highlightData.data.emplace_back(childVTSN.m_highlightData);
   }
   Super::AddView(child, index);
 }
@@ -72,9 +72,9 @@ bool VirtualTextViewManager::UpdateProperty(
     auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
     node->transformableText.textTransform = TransformableText::GetTextTransform(propertyValue);
   } else if (propertyName == "backgroundColor") {
-    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData->isHighlighted =
-        IsValidColorValue(propertyValue);
-    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData->color = propertyValue;
+    if (react::uwp::IsValidColorValue(propertyValue)) {
+      static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.color = react::uwp::ColorFrom(propertyValue);
+    }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -38,6 +38,8 @@ void VirtualTextShadowNode::AddView(ShadowNode &child, int64_t index) {
         }
       }
     }
+
+    m_highlightData->data.emplace_back(std::move(childVTSN.m_highlightData));
   }
   Super::AddView(child, index);
 }
@@ -69,6 +71,10 @@ bool VirtualTextViewManager::UpdateProperty(
   } else if (propertyName == "textTransform") {
     auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
     node->transformableText.textTransform = TransformableText::GetTextTransform(propertyValue);
+  } else if (propertyName == "backgroundColor") {
+    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData->isHighlighted =
+        IsValidColorValue(propertyValue);
+    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData->color = propertyValue;
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -17,18 +17,13 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   void AddView(ShadowNode &child, int64_t index) override;
 
-  bool m_isHighlighted = false;
-  folly::dynamic m_ColorValue = nullptr;
-  size_t m_length = 0;
-
-  typedef struct HighlightData {
-    std::vector<std::unique_ptr<HighlightData>> data;
+  struct HighlightData {
+    std::vector<HighlightData> data;
     size_t spanIdx = 0;
-    bool isHighlighted = false;
-    folly::dynamic color;
-  } HighlightData;
+    std::optional<winrt::Windows::UI::Color> color;
+  };
 
-  std::unique_ptr<HighlightData> m_highlightData = std::make_unique<HighlightData>();
+  HighlightData m_highlightData;
 };
 
 class VirtualTextViewManager : public ViewManagerBase {

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -16,6 +16,19 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   TransformableText transformableText{};
 
   void AddView(ShadowNode &child, int64_t index) override;
+
+  bool m_isHighlighted = false;
+  folly::dynamic m_ColorValue = nullptr;
+  size_t m_length = 0;
+
+  typedef struct HighlightData {
+    std::vector<std::unique_ptr<HighlightData>> data;
+    size_t spanIdx = 0;
+    bool isHighlighted = false;
+    folly::dynamic color;
+  } HighlightData;
+
+  std::unique_ptr<HighlightData> m_highlightData = std::make_unique<HighlightData>();
 };
 
 class VirtualTextViewManager : public ViewManagerBase {

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -30,6 +30,7 @@ const processColor = require('../StyleSheet/processColor');
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 import type {PressRetentionOffset, TextProps} from './TextProps';
+import {string} from 'prop-types';
 
 type ResponseHandlers = $ReadOnly<{|
   onStartShouldSetResponder: () => boolean,

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -30,7 +30,6 @@ const processColor = require('../StyleSheet/processColor');
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 import type {PressRetentionOffset, TextProps} from './TextProps';
-import {string} from 'prop-types';
 
 type ResponseHandlers = $ReadOnly<{|
   onStartShouldSetResponder: () => boolean,


### PR DESCRIPTION
RNW represents nested \<Text> components as a tree structure of XAML Run and Span elements.. The TextBlock (TB) doesn't have a backgroundColor prop that RN does, but portions of its contents can be highlighted using its Highlighters() element collection, each consisting of a color and a set of text ranges. 

The TextBlock tree gets constructed in a bottom-up fashion by appending Run elements and nested Spans, and the offsets of the different elements from the TextBlock's beginning are not known in advance; therefore information about whether a given Span (i.e. nested \<Text>) is highlighted needs to be cached and propagated up the tree. When all Run and Span elements are created, they get appended to the TB from left to right. Whenever a Run is added, we can keep track of its end position; when a Span is added to the TB, we know that is has been fully constructed and so we can recurse through it to retrieve information about highlighting and Run offsets, and advance the cursor accordingly.

Because the TextViewManager and VirtualTextViewManager don't maintain a tree of RNW ShadowNodes - only the Inline collections are available on TB and Span, I'm adding an auxiliary structure to the VirtualTextShadowNode to form a parallel tree to the ShadowNode hierarchy, in order to store information about highlighting of nested \<Text> components.

```
  struct HighlightData {
    std::vector<HighlightData> data;
    size_t spanIdx = 0;
    std::optional<winrt::Windows::UI::Color> color;
  };

  HighlightData m_highlightData;
```
Algorithm outline: 
```
// inside VirtualTextShadowNode::AddView()
// caching info about nested Spans only - left-to-right creation order deterministic, can be used when iterating through the list of nested Spans of each Span
[...]
if child is Span:
  m_highlightData->data.add(spanChild.highlightData));


// inside TextShadowNode::AddView(child); 
// TextShadowNode maintains a text cursor, advanced with each element addition)

 if child is Run:
    AddHighlighter(color, sizeof);
 elif child is Span:
    AddNestedHighlighter(child, ..., highlightData) {
      inherit_parent_highlight();
      foreach el : child.Inlines():
        if el is Run:
          AddHighlighter();
        elif el is Span:
          AddNestedTextHighlighter(next_child_span);
    }

```

Performance considerations:
- I didn't add references to children shadow nodes - only a lightweight tree struct containing necessary info, using unique_ptr<>
- Time complexity O(N) in the number of Run/Span blocks of a TB
- Can be made much faster, if necessary, by trimming tree branches that don't contain any nested highlighted \<Text> below current element: cache total length of all Runs in a Span that inherits highlighting from parent. Didn't want to prematurely optimize, so submitting as is; total tree size shouldn't be too large anyway.

Added example in RNTester demonstrating basic scenarios, nesting and inheritance.

![image](https://user-images.githubusercontent.com/12816515/96794841-caf41680-13b3-11eb-8dd0-fe3277602310.png)





###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6300)