### PR TITLE
Fix default tab order for ScrollView + a couple other controls

### DIFF
--- a/change/react-native-windows-2020-10-23-00-31-23-taborder-fix.json
+++ b/change/react-native-windows-2020-10-23-00-31-23-taborder-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix tab ordering on ScrollViewer, TextInput, and Picker",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T07:31:23.257Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
@@ -66,8 +66,6 @@ PickerShadowNode::PickerShadowNode() : Super() {
 void PickerShadowNode::createView() {
   Super::createView();
   auto combobox = GetView().as<xaml::Controls::ComboBox>();
-  combobox.TabIndex(0);
-
   combobox.AllowFocusOnInteraction(true);
 
   m_comboBoxSelectionChangedRevoker = combobox.SelectionChanged(winrt::auto_revoke, [=](auto &&, auto &&) {

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -95,7 +95,6 @@ void ScrollViewShadowNode::createView() {
   Super::createView();
 
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
-  scrollViewer.TabIndex(0);
   const auto scrollViewUWPImplementation = react::uwp::ScrollViewUWPImplementation(scrollViewer);
   scrollViewUWPImplementation.ScrollViewerSnapPointManager();
 

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -703,7 +703,6 @@ ShadowNode *TextInputViewManager::createShadow() const {
 
 XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/) {
   xaml::Controls::TextBox textBox;
-  textBox.TabIndex(0);
   return textBox;
 }
 


### PR DESCRIPTION
Fixes #6181 

This issue was discovered by Facebook.  With a simple setup like this:

```
function ScrollViewBugExample() {
  return (
    <View>
      <Button title="Button 1" />
      <ScrollView>
        <Button title="Button 2" />
      </ScrollView>
      <Button title="Button 3" />
    </View>
  );
}
```

the tab order goes in the reverse order from what you would expect (Button 3 => Button 2 => Button 1, oops!  should be Button 1 => Button 2 => Button 3)

The issue here was caused by a simple bug in RNW code - we're setting the TabIndex on ScrollViewer to 0.  This is not the default tab index in XAML, which is max int.  Thus when XAML's FocusManager goes through the search algorithm, it compares max int to 0 and this throws off the algorithm.

The fix is simple:  Don't bother setting a TabIndex on ScrollViewer.  It is ALREADY being set to max int by XAML.

I also noticed two other controls have the same bug, so I went ahead and fixed those as well.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6320)