### PR TITLE
[0.63] Fix crash during instance destruction if there are outstanding animations

### DIFF
--- a/change/react-native-windows-2020-10-23-11-35-02-animreloadcrash63.json
+++ b/change/react-native-windows-2020-10-23-11-35-02-animreloadcrash63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix crash during instance destruction if there are outstanding animations",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T18:35:02.029Z"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -94,8 +94,8 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
 
   modules.emplace_back(
       NativeAnimatedModule::name,
-      [wpUwpInstance = std::weak_ptr(uwpInstance)]() mutable {
-        return std::make_unique<NativeAnimatedModule>(std::move(wpUwpInstance));
+      [wpUwpInstance = std::weak_ptr(uwpInstance), uiMessageQueue]() mutable {
+        return std::make_unique<NativeAnimatedModule>(std::move(wpUwpInstance), uiMessageQueue);
       },
       messageQueue);
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
@@ -55,8 +55,10 @@
 namespace react::uwp {
 class NativeAnimatedModule final : public facebook::xplat::module::CxxModule {
  public:
-  NativeAnimatedModule(const std::weak_ptr<IReactInstance> &reactInstance);
-  virtual ~NativeAnimatedModule() = default;
+  NativeAnimatedModule(
+      const std::weak_ptr<IReactInstance> &reactInstance,
+      std::shared_ptr<facebook::react::MessageQueueThread> uiMessageQueue);
+  virtual ~NativeAnimatedModule();
 
   // CxxModule
   std::string getName() override {
@@ -93,6 +95,7 @@ class NativeAnimatedModule final : public facebook::xplat::module::CxxModule {
  private:
   std::shared_ptr<NativeAnimatedNodeManager> m_nodesManager{};
   std::weak_ptr<IReactInstance> m_wkReactInstance;
+  std::weak_ptr<facebook::react::MessageQueueThread> m_uiMessageQueue;
 
   static const char *s_createAnimatedNodeName;
   static const char *s_connectAnimatedNodeToViewName;

--- a/vnext/Microsoft.ReactNative/Threading/BatchingQueueThread.cpp
+++ b/vnext/Microsoft.ReactNative/Threading/BatchingQueueThread.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "Threading/BatchingQueueThread.h"
 #include <cassert>
+#include <eventWaitHandle/eventWaitHandle.h>
 
 namespace react::uwp {
 
@@ -14,7 +15,7 @@ BatchingQueueThread::BatchingQueueThread(
 BatchingQueueThread::~BatchingQueueThread() noexcept {}
 
 void BatchingQueueThread::runOnQueue(std::function<void()> &&func) noexcept {
-  ThreadCheck();
+  std::scoped_lock lck(m_mutex);
   EnsureQueue();
   m_taskQueue->emplace_back(std::move(func));
 
@@ -44,8 +45,7 @@ void BatchingQueueThread::EnsureQueue() noexcept {
   }
 }
 
-void BatchingQueueThread::onBatchComplete() noexcept {
-  ThreadCheck();
+void BatchingQueueThread::PostBatch() noexcept {
   if (m_taskQueue) {
     m_queueThread->runOnQueue([taskQueue{std::move(m_taskQueue)}]() noexcept {
       for (auto &task : *taskQueue) {
@@ -56,15 +56,20 @@ void BatchingQueueThread::onBatchComplete() noexcept {
   }
 }
 
+void BatchingQueueThread::onBatchComplete() noexcept {
+  std::scoped_lock lck(m_mutex);
+  PostBatch();
+}
+
 void BatchingQueueThread::runOnQueueSync(std::function<void()> && /*func*/) noexcept {
   assert(false && "Not supported");
   std::terminate();
 }
 
 void BatchingQueueThread::quitSynchronous() noexcept {
-  // Used by OInstance
-  // assert(false && "Not supported");
-  // std::terminate();
+  std::scoped_lock lck(m_mutex);
+  PostBatch();
+  m_queueThread->quitSynchronous();
 }
 
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Threading/BatchingQueueThread.h
+++ b/vnext/Microsoft.ReactNative/Threading/BatchingQueueThread.h
@@ -27,12 +27,14 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
  private:
   void EnsureQueue() noexcept;
   void ThreadCheck() noexcept;
+  void PostBatch() noexcept;
 
  private:
   std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
 
   using WorkItemQueue = std::vector<std::function<void()>>;
   std::shared_ptr<WorkItemQueue> m_taskQueue;
+  std::mutex m_mutex;
 
 #if DEBUG
   std::thread::id m_expectedThreadId{};

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -213,8 +213,9 @@ void ReactRootControl::UninitRootView() noexcept {
     return;
   }
 
-  if (auto fbReactInstance = m_fbReactInstance.lock()) {
-    fbReactInstance->DetachRootView(this);
+  if (auto reactInstance = m_weakReactInstance.GetStrongPtr()) {
+    auto &legacyInstance = query_cast<Mso::React::ILegacyReactInstance &>(*reactInstance);
+    legacyInstance.DetachRootView(this);
   }
 
   if (m_touchEventHandler != nullptr) {
@@ -238,12 +239,52 @@ void ReactRootControl::UninitRootView() noexcept {
   m_isInitialized = false;
 }
 
+void ReactRootControl::ClearLoadingUI() noexcept {
+  if (XamlView xamlRootView = m_weakXamlRootView.get()) {
+    auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
+
+    auto children = xamlRootGrid.Children();
+    uint32_t index{0};
+    if (m_greenBoxGrid && children.IndexOf(m_greenBoxGrid, index)) {
+      children.RemoveAt(index);
+    }
+  }
+}
+
+void ReactRootControl::EnsureLoadingUI() noexcept {
+  if (XamlView xamlRootView = m_weakXamlRootView.get()) {
+    auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
+
+    // Create Grid & TextBlock to hold text
+    if (m_waitingTextBlock == nullptr) {
+      m_waitingTextBlock = winrt::TextBlock();
+      m_greenBoxGrid = winrt::Grid{};
+      m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
+      m_greenBoxGrid.Children().Append(m_waitingTextBlock);
+      m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Center);
+
+      // Format TextBlock
+      m_waitingTextBlock.TextAlignment(winrt::TextAlignment::Center);
+      m_waitingTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
+      m_waitingTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
+      m_waitingTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
+      winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
+      m_waitingTextBlock.Margin(margin);
+    }
+
+    auto children = xamlRootGrid.Children();
+    uint32_t index;
+    if (m_greenBoxGrid && !children.IndexOf(m_greenBoxGrid, index)) {
+      children.Append(m_greenBoxGrid);
+    }
+  }
+}
+
 void ReactRootControl::ShowInstanceLoaded(Mso::React::IReactInstance &reactInstance) noexcept {
   if (XamlView xamlRootView = m_weakXamlRootView.get()) {
     auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
 
-    // Remove existing children from root view (from the hosted app)
-    xamlRootGrid.Children().Clear();
+    ClearLoadingUI();
 
     auto &legacyInstance = query_cast<Mso::React::ILegacyReactInstance &>(reactInstance);
     legacyInstance.AttachMeasuredRootView(this, Mso::Copy(m_reactViewOptions->InitialProps));
@@ -252,44 +293,17 @@ void ReactRootControl::ShowInstanceLoaded(Mso::React::IReactInstance &reactInsta
 }
 
 void ReactRootControl::ShowInstanceError() noexcept {
-  if (XamlView xamlRootView = m_weakXamlRootView.get()) {
-    auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
-
-    // Remove existing children from root view (from the hosted app)
-    xamlRootGrid.Children().Clear();
-  }
+  ClearLoadingUI();
 }
 
 void ReactRootControl::ShowInstanceWaiting(Mso::React::IReactInstance & /*reactInstance*/) noexcept {
   if (XamlView xamlRootView = m_weakXamlRootView.get()) {
-    auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
 
-    // Remove existing children from root view (from the hosted app)
-    xamlRootGrid.Children().Clear();
-
-    // Create Grid & TextBlock to hold text
-    if (m_waitingTextBlock == nullptr) {
-      m_waitingTextBlock = winrt::TextBlock();
-      m_greenBoxGrid = winrt::Grid{};
-      m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
-      m_greenBoxGrid.Children().Append(m_waitingTextBlock);
-      m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Center);
-    }
-
-    // Add box grid to root view
-    xamlRootGrid.Children().Append(m_greenBoxGrid);
-
+    EnsureLoadingUI();
+    
     // Place message into TextBlock
     std::wstring wstrMessage(L"Connecting to remote debugger");
     m_waitingTextBlock.Text(wstrMessage);
-
-    // Format TextBlock
-    m_waitingTextBlock.TextAlignment(winrt::TextAlignment::Center);
-    m_waitingTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
-    m_waitingTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
-    m_waitingTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
-    winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
-    m_waitingTextBlock.Margin(margin);
   }
 }
 
@@ -298,34 +312,11 @@ void ReactRootControl::ShowInstanceLoading(Mso::React::IReactInstance & /*reactI
     return;
 
   if (XamlView xamlRootView = m_weakXamlRootView.get()) {
-    auto xamlRootGrid{xamlRootView.as<winrt::Grid>()};
-
-    // Remove existing children from root view (from the hosted app)
-    xamlRootGrid.Children().Clear();
-
-    // Create Grid & TextBlock to hold text
-    if (m_waitingTextBlock == nullptr) {
-      m_waitingTextBlock = winrt::TextBlock();
-      m_greenBoxGrid = winrt::Grid{};
-      m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0xff, 0x03, 0x59, 0)));
-      m_greenBoxGrid.Children().Append(m_waitingTextBlock);
-      m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Center);
-    }
-
-    // Add box grid to root view
-    xamlRootGrid.Children().Append(m_greenBoxGrid);
+    EnsureLoadingUI();
 
     // Place message into TextBlock
     std::wstring wstrMessage(L"Loading bundle.");
     m_waitingTextBlock.Text(wstrMessage);
-
-    // Format TextBlock
-    m_waitingTextBlock.TextAlignment(winrt::TextAlignment::Center);
-    m_waitingTextBlock.TextWrapping(xaml::TextWrapping::Wrap);
-    m_waitingTextBlock.FontFamily(winrt::FontFamily(L"Consolas"));
-    m_waitingTextBlock.Foreground(xaml::Media::SolidColorBrush(winrt::Colors::White()));
-    winrt::Thickness margin = {10.0f, 10.0f, 10.0f, 10.0f};
-    m_waitingTextBlock.Margin(margin);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
@@ -78,6 +78,9 @@ struct ReactRootControl final : std::enable_shared_from_this<ReactRootControl>, 
   bool OnBackRequested() noexcept;
 
  private:
+  void ClearLoadingUI() noexcept;
+  void EnsureLoadingUI() noexcept;
+  
   int64_t m_rootTag{-1};
 
   std::shared_ptr<TouchEventHandler> m_touchEventHandler;


### PR DESCRIPTION
Port of #6271 to 0.63

We were never notifying JS to detach a root view when the rootview went away.  So JS would not send commands to clean up animations from that rootview.  

There was an issue in ReactRootControl where it would clear out the UI the JS created as part of reload, which would cause a crash when the JS then tried to remove that UI.

We were not properly quitting the main UI queue, so things would get run there after the instance was gone.