### PR TITLE
Don't require elevating when only checking RNW dependencies

### DIFF
--- a/change/react-native-windows-2020-10-23-17-54-31-rnwDepsCheckDontElevate.json
+++ b/change/react-native-windows-2020-10-23-17-54-31-rnwDepsCheckDontElevate.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Don't require elevation just to check dev dependencies",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-24T00:54:30.899Z"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -267,7 +267,7 @@ function IsElevated {
     return [bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544");
 }
 
-if (!(IsElevated)) {
+if (!($NoPrompt) -and !(IsElevated)) {
     Write-Output "rnw-dependencies - this script must run elevated. Exiting.";
     return;
 }


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6323)