### PR TITLE
Allow E2ETest to Work Without Back Button (And lots of cleanup)

### DIFF
--- a/.ado/templates/macos-tests-job.yml
+++ b/.ado/templates/macos-tests-job.yml
@@ -5,7 +5,8 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: macOS Tests
     dependsOn: Setup
-    condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
+    condition: false #6353
+    # condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
 
     variables:
       - template: ../variables/macos.yml

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/Consts.ts
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/Consts.ts
@@ -1,7 +1,7 @@
 // Framework
-export const SEARCH_BOX = 'explorer_search';
-export const BACK_BUTTON = 'BackButton';
-export const REACT_CONTROL_ERROR_TEST_ID = 'ReactControlErrorMessage';
+export const TESTER_LIST_SEARCH_BOX = 'explorer_search';
+export const COMPONENTS_NAV_BUTTON = 'components-tab';
+export const APIS_NAV_BUTTON = 'apis-tab';
 export const TREE_DUMP_RESULT = 'TreeDump';
 
 // TextInputTestPage

--- a/packages/E2ETest/.eslintrc.js
+++ b/packages/E2ETest/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   parserOptions: {tsconfigRootDir : __dirname},
   globals: {
     '$': 'readonly',
-    'browser': 'readonly'
+    'browser': 'readonly',
+    'expect': 'readonly',
   }
 };

--- a/packages/E2ETest/run_wdio.js
+++ b/packages/E2ETest/run_wdio.js
@@ -54,22 +54,6 @@ function selectSpecs(folder) {
 let opts = selectSpecs(specFolder);
 console.log(`Selected tests: ${opts}`);
 
-function ensureRunningInHyperV() {
-  const baseboardMfr = child_process
-    .execSync('powershell.exe -NoProfile (gwmi Win32_BaseBoard).Manufacturer')
-    .toString()
-    .replace(/[\r\n]/, '');
-  if (!baseboardMfr.startsWith('Microsoft Corporation')) {
-    console.log(`Not running in HyperV. Mfr = ${baseboardMfr}`);
-    const answer = prompt(
-      'E2ETest is meant to be run in a HyperV VM. Continue? (Y/N)'
-    );
-    if (answer.toUpperCase() !== 'Y') {
-      process.exit(0);
-    }
-  }
-}
-
 const Launcher = require('@wdio/cli').default;
 
 const wdio = new Launcher('wdio.conf.js', { specs: opts });
@@ -143,8 +127,6 @@ function doProcess(code) {
 }
 
 function runWdio() {
-  ensureRunningInHyperV();
-
   // Ensure that directory exists for error screenshots to be saved to
   if (!fs.existsSync(path.resolve(__dirname, 'errorShots'))) {
     fs.mkdirSync(path.resolve(__dirname, 'errorShots'));

--- a/packages/E2ETest/wdio.conf.js
+++ b/packages/E2ETest/wdio.conf.js
@@ -165,7 +165,8 @@ exports.config = {
   },
 
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 60000,
+    // Needs to be longer than the 1m webdriverio timeout to let its errors be propgated
+    defaultTimeoutInterval: 100000,
   },
 
   //

--- a/packages/E2ETest/wdio/pages/BasePage.ts
+++ b/packages/E2ETest/wdio/pages/BasePage.ts
@@ -3,20 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import {
-  REACT_CONTROL_ERROR_TEST_ID,
-  BACK_BUTTON,
-  TREE_DUMP_RESULT,
-} from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
+import { TREE_DUMP_RESULT } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
+
+const ELEMENT_LOADED_TIMEOUT = 60000;
 
 export function By(testId: string): WebdriverIO.Element {
   return $('~' + testId);
-}
-
-export function wait(timeout: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, timeout);
-  });
 }
 
 export class BasePage {
@@ -24,68 +16,31 @@ export class BasePage {
     return By(element).isDisplayed();
   }
 
-  waitForElementLoaded(element: string, timeout?: number) {
+  waitForElementLoaded(element: string) {
     browser.waitUntil(
-      () => {
-        return this.isElementLoadedOrLoadBundleError(element);
-      },
-      this.timeoutForPageLoaded(timeout),
-      'Wait for element ' + element + ' timeout'
+      () => this.isElementLoaded(element),
+      ELEMENT_LOADED_TIMEOUT,
+      `Failed to find element with testId "${element}" within ${ELEMENT_LOADED_TIMEOUT}ms`
     );
   }
 
-  getTreeDumpResult(): boolean {
-    var testResult = false;
-    const maxWait = 20;
-    var waitCount = 1;
-    do {
-      testResult = this.treeDumpResult.getText() === 'TreeDump:Passed';
-      if (!testResult) {
-        console.log(
-          '####Waiting for treedump comparison result ' +
-            waitCount +
-            '/' +
-            maxWait +
-            '...####'
-        );
-        // #6041 this line doesn't do anything because of missing await, but
-        // adding the await causes test failures.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        wait(100);
-        waitCount += 1;
-      }
-    } while (waitCount <= maxWait && !testResult);
-
-    return testResult;
+  waitForElementHidden(element: string) {
+    browser.waitUntil(
+      () => !this.isElementLoaded(element),
+      ELEMENT_LOADED_TIMEOUT,
+      `Element with testId "${element}" was not hidden within ${ELEMENT_LOADED_TIMEOUT}ms`
+    );
   }
 
-  protected timeoutForPageLoaded(currentTimeout?: number) {
-    if (currentTimeout) {
-      return currentTimeout;
-    }
-    return this.waitforPageTimeout;
-  }
-
-  protected get homeButton() {
-    return By(BACK_BUTTON);
-  }
-
-  private get reactControlErrorMessage() {
-    return By(REACT_CONTROL_ERROR_TEST_ID);
-  }
-
-  private isElementLoadedOrLoadBundleError(element: string): boolean {
-    if (this.reactControlErrorMessage.isDisplayed()) {
-      throw "ReactControl doesn't load bundle successfully: " +
-        this.reactControlErrorMessage.getText();
-    }
-    return this.isElementLoaded(element);
+  waitForTreeDumpPassed(errorMessage: string) {
+    browser.waitUntil(
+      () => this.treeDumpResult.getText() === 'TreeDump:Passed',
+      ELEMENT_LOADED_TIMEOUT,
+      errorMessage
+    );
   }
 
   private get treeDumpResult() {
     return By(TREE_DUMP_RESULT);
   }
-
-  // Default timeout for waitForPageLoaded command in PageObject
-  private waitforPageTimeout: number = 60000;
 }

--- a/packages/E2ETest/wdio/pages/HomePage.ts
+++ b/packages/E2ETest/wdio/pages/HomePage.ts
@@ -5,23 +5,35 @@
 
 import { BasePage, By } from './BasePage';
 import {
-  SEARCH_BOX,
-  BACK_BUTTON,
+  APIS_NAV_BUTTON,
+  COMPONENTS_NAV_BUTTON,
+  TESTER_LIST_SEARCH_BOX,
 } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 class HomePage extends BasePage {
-  goToTestPage(page: string) {
-    // Filter the list down to the one test, to improve the stability of selectors
-    this.waitForElementLoaded(SEARCH_BOX);
-    let editBox = By(SEARCH_BOX);
-    editBox.setValue(page);
-    let pageItem = By(page);
-    pageItem.click();
-    super.waitForElementLoaded(BACK_BUTTON);
+  goToComponentExample(example: string) {
+    this.waitForElementLoaded(COMPONENTS_NAV_BUTTON);
+    By(COMPONENTS_NAV_BUTTON).click();
+    this.goToExampleOnCurrentTab(example);
   }
 
-  backToHomePage() {
-    this.homeButton.click();
+  goToApiExample(example: string) {
+    this.waitForElementLoaded(APIS_NAV_BUTTON);
+    By(APIS_NAV_BUTTON).click();
+    this.goToExampleOnCurrentTab(example);
+  }
+
+  private goToExampleOnCurrentTab(example: string) {
+    // Filter the list down to the one test, to improve the stability of selectors
+    this.waitForElementLoaded(TESTER_LIST_SEARCH_BOX);
+    const editBox = By(TESTER_LIST_SEARCH_BOX);
+    editBox.setValue(example);
+    const pageItem = By(example);
+    pageItem.click();
+
+    // Make sure we've launched the example by waiting until the search box is
+    // no longer present
+    this.waitForElementHidden(TESTER_LIST_SEARCH_BOX);
   }
 }
 

--- a/packages/E2ETest/wdio/pages/HomePage.ts
+++ b/packages/E2ETest/wdio/pages/HomePage.ts
@@ -32,8 +32,10 @@ class HomePage extends BasePage {
     pageItem.click();
 
     // Make sure we've launched the example by waiting until the search box is
-    // no longer present
+    // no longer present, but make sure we haven't crashed by checking that nav
+    // buttons are still visible
     this.waitForElementHidden(TESTER_LIST_SEARCH_BOX);
+    this.waitForElementLoaded(COMPONENTS_NAV_BUTTON);
   }
 }
 

--- a/packages/E2ETest/wdio/test/DirectManipulation.spec.ts
+++ b/packages/E2ETest/wdio/test/DirectManipulation.spec.ts
@@ -5,28 +5,27 @@
 
 import HomePage from '../pages/HomePage';
 import DirectManipulationPage from '../pages/DirectManipulationPage';
-import assert from 'assert';
 import { DIRECT_MANIPULATION_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 beforeAll(() => {
-  HomePage.goToTestPage(DIRECT_MANIPULATION_TESTPAGE);
+  HomePage.goToComponentExample(DIRECT_MANIPULATION_TESTPAGE);
 });
 
 describe('DirectManipulationTest', () => {
   it('measureInWindow Success', () => {
     const result = DirectManipulationPage.clickMeasureInWindowAndGetResult();
-    assert.ok(
-      result.includes('width='),
+    expect(result.includes('width=')).toBe(
+      true,
       'measureInWindow response include width'
     );
   });
 
   it('measureLayout Test', () => {
     const result = DirectManipulationPage.clickMeasureLayoutAndGetResult();
-    assert.ok(
-      result.includes('width=50'),
+    expect(result.includes('width=50')).toBe(
+      true,
       'measureLayout response has correct width'
     );
-    assert.ok(result.includes('x=20;'), 'measureLayout response x=20');
+    expect(result.includes('x=20')).toBe(true, 'measureLayout response x=20');
   });
 });

--- a/packages/E2ETest/wdio/test/Image.spec.ts
+++ b/packages/E2ETest/wdio/test/Image.spec.ts
@@ -5,37 +5,38 @@
 
 import HomePage from '../pages/HomePage';
 import ImageTestPage from '../pages/ImageTestPage';
-import assert from 'assert';
 import { IMAGE_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 beforeAll(() => {
-  HomePage.goToTestPage(IMAGE_TESTPAGE);
+  HomePage.goToComponentExample(IMAGE_TESTPAGE);
 });
 
 describe('ImageWithoutBorderTest', () => {
   /* Test case #1: view and image displayed with no border and cornerRadius */
   it('ImageWithoutBorderTest', () => {
-    const result = ImageTestPage.getTreeDumpResult();
-    assert(result, '#1. Dump comparison for image without border!');
+    ImageTestPage.waitForTreeDumpPassed(
+      '#1. Dump comparison for image without border!'
+    );
   });
 
   /* Test case #2: Click button once, update view and image with round border*/
   it('ImageWithBorderTest', () => {
     ImageTestPage.toggleImageBorder();
-    const result = ImageTestPage.getTreeDumpResult();
-    assert(result, '#2. Dump comparison for image with border!');
+    ImageTestPage.waitForTreeDumpPassed(
+      '#2. Dump comparison for image with border!'
+    );
   });
 
   /* Test case #3: Click button one more, remove border from view and image but tree sturcture is different from #1*/
   it('ImageWithoutBorderTestOneMoreClick', () => {
     ImageTestPage.toggleImageBorder();
-    const result = ImageTestPage.getTreeDumpResult();
-    assert(result, '#3. Second dump comparison for image without border!');
+    ImageTestPage.waitForTreeDumpPassed(
+      '#3. Second dump comparison for image without border!'
+    );
   });
 
   it('ImageRTLTest', () => {
     ImageTestPage.toggleRTLMode();
-    const result = ImageTestPage.getTreeDumpResult();
-    assert(result, '#4. Dump comparison for image RTL');
+    ImageTestPage.waitForTreeDumpPassed('#4. Dump comparison for image RTL');
   });
 });

--- a/packages/E2ETest/wdio/test/TransformTest.spec.ts
+++ b/packages/E2ETest/wdio/test/TransformTest.spec.ts
@@ -5,18 +5,20 @@
 
 import HomePage from '../pages/HomePage';
 import TransformTestPage from '../pages/TransformTestPage';
-import assert from 'assert';
 import { TRANSFORM_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 beforeAll(() => {
-  HomePage.goToTestPage(TRANSFORM_TESTPAGE);
+  HomePage.goToComponentExample(TRANSFORM_TESTPAGE);
 });
 
 describe('TransformTest', () => {
   it('Measure original size and position', () => {
     const result = TransformTestPage.clickMeasureLayoutAndGetResult();
-    assert.ok(result.includes('width=60'), 'measureLayout response width=60');
-    assert.ok(result.includes('x=0;'), 'measureLayout response x=20');
+    expect(result.includes('width=60')).toBe(
+      true,
+      'measureLayout response width=60'
+    );
+    expect(result.includes('x=0;')).toBe(true, 'measureLayout response x=20');
   });
 
   // Uncomment and run this test on 19h1+ when Platform.Version is available.

--- a/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
+++ b/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
+ * @format
  */
 
 import HomePage from '../pages/HomePage';

--- a/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
+++ b/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
@@ -1,12 +1,9 @@
 /**
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
- * @format
  */
 
 import HomePage from '../pages/HomePage';
-
-import { By } from '../pages/BasePage';
 
 const componentExamples = [
   'ActivityIndicator',
@@ -73,23 +70,8 @@ const apiExamples = [
 ];
 
 describe('VisitAllPagesTest', () => {
-  componentExamples.forEach(ex => visitTestPage(ex, 'component'));
-  apiExamples.forEach(ex => visitTestPage(ex, 'api'));
+  componentExamples.forEach(ex =>
+    it(ex, () => HomePage.goToComponentExample(ex))
+  );
+  apiExamples.forEach(ex => it(ex, () => HomePage.goToApiExample(ex)));
 });
-
-function visitTestPage(name: string, type: 'api' | 'component') {
-  it(name, () => {
-    console.log('loading page ' + name);
-
-    if (type === 'api') {
-      HomePage.waitForElementLoaded('apis-tab');
-      By('apis-tab').click();
-    } else {
-      HomePage.waitForElementLoaded('components-tab');
-      By('components-tab').click();
-    }
-
-    HomePage.goToTestPage(name);
-    HomePage.backToHomePage();
-  });
-}

--- a/packages/E2ETest/wdio/test/controlStyle.spec.ts
+++ b/packages/E2ETest/wdio/test/controlStyle.spec.ts
@@ -5,20 +5,17 @@
 
 import HomePage from '../pages/HomePage';
 import ControlStyleTestPage from '../pages/ControlStylePage';
-import assert from 'assert';
 import { CONTROL_STYLE_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 beforeAll(() => {
-  HomePage.goToTestPage(CONTROL_STYLE_TESTPAGE);
+  HomePage.goToComponentExample(CONTROL_STYLE_TESTPAGE);
 });
 
 describe('ControlStyleTest', () => {
   /* Test case #1: Controls style with regular border */
 
   it('ControlStyleTestWithRegularBorder', () => {
-    const result = ControlStyleTestPage.getTreeDumpResult();
-    assert(
-      result,
+    ControlStyleTestPage.waitForTreeDumpPassed(
       '#1. Dump comparison for Control style with regular border!'
     );
   });
@@ -26,16 +23,15 @@ describe('ControlStyleTest', () => {
   /* Test case #2: Click button once, update controls style and round border*/
   it('ControlStyleTestWithRoundBorder', () => {
     ControlStyleTestPage.toggleControlBorder();
-    const result = ControlStyleTestPage.getTreeDumpResult();
-    assert(result, '#2. Dump comparison for Control style with round border!');
+    ControlStyleTestPage.waitForTreeDumpPassed(
+      '#2. Dump comparison for Control style with round border!'
+    );
   });
 
   /* Test case #3: Click button one more, return to #1*/
   it('ControlStyleTestWithRegularBorder #2', () => {
     ControlStyleTestPage.toggleControlBorder();
-    const result = ControlStyleTestPage.getTreeDumpResult();
-    assert(
-      result,
+    ControlStyleTestPage.waitForTreeDumpPassed(
       '#3. Second dump comparison for Control style with regular border!'
     );
   });

--- a/packages/E2ETest/wdio/test/login.spec.ts
+++ b/packages/E2ETest/wdio/test/login.spec.ts
@@ -5,37 +5,36 @@
 
 import LoginPage from '../pages/LoginPage';
 import HomePage from '../pages/HomePage';
-import assert from 'assert';
 import { LOGIN_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 beforeAll(() => {
-  HomePage.goToTestPage(LOGIN_TESTPAGE);
+  HomePage.goToComponentExample(LOGIN_TESTPAGE);
 });
 
 describe('LoginTest', () => {
   it('Login Success', () => {
     LoginPage.setLoginInfo('username', 'password');
     LoginPage.submitForm();
-    assert.equal(LoginPage.getLoginResult(), 'Success');
+    expect(LoginPage.getLoginResult()).toBe('Success');
   });
 
   it('Login Fail due to user email', () => {
     LoginPage.setLoginInfo('username@microsoft.com', 'password');
     LoginPage.submitForm();
-    assert.equal(LoginPage.getLoginResult(), 'Fail');
+    expect(LoginPage.getLoginResult()).toBe('Fail');
   });
 
   it('Login Fail due to wrong password', () => {
     LoginPage.setLoginInfo('username', 'abcdefg');
     LoginPage.submitForm();
-    assert.equal(LoginPage.getLoginResult(), 'Fail');
+    expect(LoginPage.getLoginResult()).toBe('Fail');
   });
 
   it('Login Success with secureTextEntry off', () => {
     LoginPage.toggleShowPassword();
     LoginPage.setLoginInfo('username', 'password');
     LoginPage.submitForm();
-    assert.equal(LoginPage.getLoginResult(), 'Success');
+    expect(LoginPage.getLoginResult()).toBe('Success');
   });
 
   it('Login Success with secureTextEntry off then on', () => {
@@ -43,7 +42,7 @@ describe('LoginTest', () => {
     LoginPage.toggleShowPassword();
     LoginPage.appendPassword('word');
     LoginPage.submitForm();
-    assert.equal(LoginPage.getLoginResult(), 'Success');
+    expect(LoginPage.getLoginResult()).toBe('Success');
   });
 
   it('Login Success with secureTextEntry on then off', () => {
@@ -51,6 +50,6 @@ describe('LoginTest', () => {
     LoginPage.toggleShowPassword();
     LoginPage.appendPassword('word');
     LoginPage.submitForm();
-    assert.equal(LoginPage.getLoginResult(), 'Success');
+    expect(LoginPage.getLoginResult()).toBe('Success');
   });
 });

--- a/packages/E2ETest/wdio/test/testInput.spec.ts
+++ b/packages/E2ETest/wdio/test/testInput.spec.ts
@@ -5,17 +5,19 @@
 
 import TextInputTestPage from '../pages/TextInputTestPage';
 import HomePage from '../pages/HomePage';
-import assert from 'assert';
 import { TEXTINPUT_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 beforeAll(() => {
-  HomePage.goToTestPage(TEXTINPUT_TESTPAGE);
+  HomePage.goToComponentExample(TEXTINPUT_TESTPAGE);
 });
 
 function assertLogContains(text: string) {
   const log = TextInputTestPage.getTextInputCurText();
-  assert.ok(log, `${log} should not be falsy`);
-  assert.ok(log.split('\n').includes(text), `${log} did not contain "${text}"`);
+  expect(log).toBeTruthy();
+  expect(log.split('\n').includes(text)).toBe(
+    true,
+    `${log} did not contain "${text}"`
+  );
 }
 
 describe('First', () => {
@@ -31,7 +33,7 @@ describe('First', () => {
 
   it('Type abc on TextInput', () => {
     TextInputTestPage.clearAndTypeOnTextInput('abc');
-    assert.equal(TextInputTestPage.getTextInputText(), 'abc');
+    expect(TextInputTestPage.getTextInputText()).toBe('abc');
 
     // Due to some timing issues between the JS and native, the order of events
     // might cause more onChange events to happen after the onKeyPress event
@@ -41,12 +43,12 @@ describe('First', () => {
 
   it('Type def on TextInput', () => {
     TextInputTestPage.clearAndTypeOnTextInput('def');
-    assert.equal(TextInputTestPage.getTextInputText(), 'def');
+    expect(TextInputTestPage.getTextInputText()).toBe('def');
   });
 
   it('Type hello world on autoCap TextInput', () => {
     TextInputTestPage.clearAndTypeOnAutoCapTextInput('hello world');
-    assert.equal(TextInputTestPage.getAutoCapTextInput(), 'HELLO WORLD');
+    expect(TextInputTestPage.getAutoCapTextInput()).toBe('HELLO WORLD');
   });
 
   it('Type abc on multiline TextInput then press Enter key', () => {
@@ -56,11 +58,11 @@ describe('First', () => {
 
   it('Type abc on multiline TextInput', () => {
     TextInputTestPage.clearAndTypeOnMLTextInput('abc');
-    assert.equal(TextInputTestPage.getMLTextInputText(), 'abc');
+    expect(TextInputTestPage.getMLTextInputText()).toBe('abc');
   });
 
   it('Enter key then type def on multiline TextInput', () => {
     TextInputTestPage.appendNewLineOnMLText('def');
-    assert.equal(TextInputTestPage.getMLTextInputText(), 'abc\rdef');
+    expect(TextInputTestPage.getMLTextInputText()).toBe('abc\rdef');
   });
 });


### PR DESCRIPTION
An upcoming RNTester change removes the back button. E2ETest relies on this as a signal that a test page has been loaded, so we need to replace it with something else. In this case we use the absence of the RNTesterList search box. Note that a search box may still be present, but will have a different test id than the RNTesterList one.

Now that we have visual separation between component examples and API examples, we update HomePage to let it know the difference instead of keeping that logic just in the VisitAllPages test. Doing this led to some discoveries that led to quite a bit of house-cleaning.

Verified everything runs locally, and that artificially created tree dump failures show correctly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6344)