### PR TITLE
Better error handling of Views inside Text components

### DIFF
--- a/change/@office-iss-react-native-win32-2020-10-27-13-09-58-viewintexterrors.json
+++ b/change/@office-iss-react-native-win32-2020-10-27-13-09-58-viewintexterrors.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Better error handling of Views inside Text components",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T20:09:55.071Z"
+}

--- a/change/react-native-windows-2020-10-27-13-09-58-viewintexterrors.json
+++ b/change/react-native-windows-2020-10-27-13-09-58-viewintexterrors.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Better error handling of Views inside Text components",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T20:09:58.222Z"
+}

--- a/packages/@react-native-windows/tester/src/js/components/RNTesterExampleList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/components/RNTesterExampleList.windows.js
@@ -414,13 +414,9 @@ const EmptyState = () => (
       <View>
         <Text style={styles.heading}>Bookmarks are empty</Text>
         <Text style={styles.subheading}>
-          Please tap the{' '}
-          <Image
-            source={require('../assets/bookmark-outline-gray.png')}
-            resizeMode="contain"
-            style={styles.bookmarkIcon}
-          />{' '}
-          icon to bookmark examples.
+          {/* [Windows replace Bookmark inline image with text Bookmark */}
+          Please tap the Bookmark icon to bookmark examples.
+          {/* Windows] */}
         </Text>
       </View>
     </View>

--- a/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -39,9 +39,20 @@ const View: React.AbstractComponent<
   // Win32]
 
   return (
-    <TextAncestor.Provider value={false}>
-      <ViewNativeComponent {...props} ref={forwardedRef} />
-    </TextAncestor.Provider>
+    // [Windows
+    // In core this is a TextAncestor.Provider value={false} See
+    // https://github.com/facebook/react-native/commit/66601e755fcad10698e61d20878d52194ad0e90c
+    // But since Views are not currently supported in Text, we do not need the extra provider
+    <TextAncestor.Consumer>
+      {hasTextAncestor => {
+        invariant(
+          !hasTextAncestor,
+          'Nesting of <View> within <Text> is not currently supported.',
+        );
+
+        return <ViewNativeComponent {...props} ref={forwardedRef} />;
+      }}
+    </TextAncestor.Consumer>
   );
 });
 

--- a/packages/react-native-win32/src/Libraries/Image/Image.win32.js
+++ b/packages/react-native-win32/src/Libraries/Image/Image.win32.js
@@ -18,6 +18,8 @@ const StyleSheet = require('../StyleSheet/StyleSheet');
 const ImageAnalyticsTagContext = require('./ImageAnalyticsTagContext').default;
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const resolveAssetSource = require('./resolveAssetSource');
+const TextAncestor = require('../Text/TextAncestor'); // [Windows]
+import invariant from 'invariant'; // [Windows]
 
 import type {ImageProps as ImagePropsType} from './ImageProps';
 
@@ -144,21 +146,34 @@ let Image = (props: ImagePropsType, forwardedRef) => {
   }
 
   return (
-    <ImageAnalyticsTagContext.Consumer>
-      {analyticTag => {
+    // [Win32
+    <TextAncestor.Consumer>
+      {hasTextAncestor => {
+        invariant(
+          !hasTextAncestor,
+          'Nesting of <Image> within <Text> is not currently supported.',
+        );
+        // Win32]
+
         return (
-          <ImageViewNativeComponent
-            {...props}
-            ref={forwardedRef}
-            style={style}
-            resizeMode={resizeMode}
-            tintColor={tintColor}
-            source={sources}
-            internal_analyticTag={analyticTag}
-          />
+          <ImageAnalyticsTagContext.Consumer>
+            {analyticTag => {
+              return (
+                <ImageViewNativeComponent
+                  {...props}
+                  ref={forwardedRef}
+                  style={style}
+                  resizeMode={resizeMode}
+                  tintColor={tintColor}
+                  source={sources}
+                  internal_analyticTag={analyticTag}
+                />
+              );
+            }}
+          </ImageAnalyticsTagContext.Consumer>
         );
       }}
-    </ImageAnalyticsTagContext.Consumer>
+    </TextAncestor.Consumer>
   );
 };
 

--- a/vnext/.gitignore
+++ b/vnext/.gitignore
@@ -23,10 +23,6 @@ project.xcworkspace
 
 # Gradle
 /build/
-/RNTester/android/app/build/
-/RNTester/android/app/gradle/
-/RNTester/android/app/gradlew
-/RNTester/android/app/gradlew.bat
 /ReactAndroid/build/
 
 # Buck
@@ -50,7 +46,6 @@ node_modules
 /lib
 /Libraries
 /jest
-/RNTester
 /RNTester.*
 /index.*
 /interface.*

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -325,7 +325,7 @@
       "baseHash": "c6d80f9ea60e5802d2e67ed50a78f2b6840d1162"
     },
     {
-      "type": "copy",
+      "type": "patch",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
       "baseHash": "9bd6a85eef7bb41373df9eb7dd9b21a986848cbd",

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -39,9 +39,20 @@ const View: React.AbstractComponent<
   // Windows]
 
   return (
-    <TextAncestor.Provider value={false}>
-      <ViewNativeComponent {...props} ref={forwardedRef} />
-    </TextAncestor.Provider>
+    // [Windows
+    // In core this is a TextAncestor.Provider value={false} See
+    // https://github.com/facebook/react-native/commit/66601e755fcad10698e61d20878d52194ad0e90c
+    // But since Views are not currently supported in Text, we do not need the extra provider
+    <TextAncestor.Consumer>
+      {hasTextAncestor => {
+        invariant(
+          !hasTextAncestor,
+          'Nesting of <View> within <Text> is not currently supported.',
+        );
+        return <ViewNativeComponent {...props} ref={forwardedRef} />;
+      }}
+    </TextAncestor.Consumer>
+    // Windows]
   );
 });
 

--- a/vnext/src/Libraries/Image/Image.windows.js
+++ b/vnext/src/Libraries/Image/Image.windows.js
@@ -18,6 +18,8 @@ const StyleSheet = require('../StyleSheet/StyleSheet');
 const ImageAnalyticsTagContext = require('./ImageAnalyticsTagContext').default;
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const resolveAssetSource = require('./resolveAssetSource');
+const TextAncestor = require('../Text/TextAncestor'); // [Windows]
+import invariant from 'invariant'; // [Windows]
 
 import type {ImageProps as ImagePropsType} from './ImageProps';
 
@@ -125,21 +127,34 @@ let Image = (props: ImagePropsType, forwardedRef) => {
   }
 
   return (
-    <ImageAnalyticsTagContext.Consumer>
-      {analyticTag => {
+    // [Windows
+    <TextAncestor.Consumer>
+      {hasTextAncestor => {
+        invariant(
+          !hasTextAncestor,
+          'Nesting of <Image> within <Text> is not currently supported.',
+        );
+        // windows]
+
         return (
-          <ImageViewNativeComponent
-            {...props}
-            ref={forwardedRef}
-            style={style}
-            resizeMode={resizeMode}
-            tintColor={tintColor}
-            source={sources}
-            internal_analyticTag={analyticTag}
-          />
+          <ImageAnalyticsTagContext.Consumer>
+            {analyticTag => {
+              return (
+                <ImageViewNativeComponent
+                  {...props}
+                  ref={forwardedRef}
+                  style={style}
+                  resizeMode={resizeMode}
+                  tintColor={tintColor}
+                  source={sources}
+                  internal_analyticTag={analyticTag}
+                />
+              );
+            }}
+          </ImageAnalyticsTagContext.Consumer>
         );
       }}
-    </ImageAnalyticsTagContext.Consumer>
+    </TextAncestor.Consumer>
   );
 };
 


### PR DESCRIPTION
Fixes #4927

Currently we display a yellowbox from native when a view is put inside a text component.  But it doesn't provide any context to the user of where in their UI the issue is.

This change adds code on the JS side which will provide a redbox with the complete component tree of where the error is occurring.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6348)