### PR TITLE
Better Override Validation Messages When Errors Exist in Multiple Packages

### DIFF
--- a/change/react-native-platform-override-2020-10-27-13-13-55-better-monorepo-validation.json
+++ b/change/react-native-platform-override-2020-10-27-13-13-55-better-monorepo-validation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Better Override Validation Messages When Errors Exist in Multiple Packages",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T20:13:55.222Z"
+}


### PR DESCRIPTION
If multiple packages have override validation errors, we currently print errors of each type per-package. This change makes it so that we instead group by type, which cleans up the output.

Validated by artistically creating validation errors in multiple packages, since we don't have tests for the CLI interface layer.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6349)