### PR TITLE
Add treedump test for TextBlock.TextHighlighters

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/Consts.ts
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/Consts.ts
@@ -43,3 +43,6 @@ export const SHOWBORDER_ON_CONTROLSTYLE = 'ShowBorder';
 export const TRANSFORM_TESTPAGE = 'LegacyTransformTest';
 export const TRANSFORM_TEST_RESULT = 'TransfromTestResult';
 export const APPLY_SCALE_TRANSFORM_BUTTON = 'ApplyScaleTransformButton';
+
+// Text backgroundColor Page
+export const TEXT_BACKGROUND_COLOR_TESTPAGE = '<LegacyTextBackgroundColorTest>';

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextBackgroundColorTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextBackgroundColorTestPage.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+import * as React from 'react'
+import {
+  Text,
+  View,
+} from 'react-native';
+import {
+  TREE_DUMP_RESULT
+} from './Consts';
+import { TreeDumpControl } from './TreeDumpControl';
+
+export function TextBackgroundColorTestPage() {
+  return (
+    <View>
+      <View testID={'TextColorBackgroundView'}>
+        <Text>
+          Outer no_color{' '}
+          <Text style={{ backgroundColor: 'green' }}>
+            START_NESTED green{' '}
+            <Text style={{ backgroundColor: 'blue' }}>DEEPER_NESTED blue</Text>{' '}
+          END_NESTED
+        </Text>{' '}
+        attributes.
+      </Text>
+        <Text>
+          Outer no_color{' '}
+          <Text>
+            START_NESTED no_color{' '}
+            <Text style={{ backgroundColor: 'blue' }}>DEEPER_NESTED blue</Text>{' '}
+          END_NESTED
+        </Text>{' '}
+        attributes.
+      </Text>
+        <Text>
+          Outer no_color{' '}
+          <Text style={{ backgroundColor: 'green' }}>
+            START_NESTED green <Text>DEEPER_NESTED inherit green</Text>{' '}
+          END_NESTED
+        </Text>{' '}
+        attributes.
+      </Text>
+        <Text style={{ backgroundColor: 'red' }}>
+          Outer red{' '}
+          <Text>
+            START_NESTED inherit red <Text>DEEPER_NESTED inherit red</Text>{' '}
+          END_NESTED
+        </Text>{' '}
+        attributes.
+      </Text>
+        <Text style={{ backgroundColor: 'red' }}>
+          Outer red{' '}
+          <Text style={{ backgroundColor: 'green' }}>
+            START_NESTED green{' '}
+            <Text style={{ backgroundColor: 'blue' }}>DEEPER_NESTED blue</Text>{' '}
+          END_NESTED
+        </Text>{' '}
+        attributes.
+      </Text>
+      </View>
+
+      <TreeDumpControl
+        style={{
+          height: 150,
+          width: 500,
+          margin: 10,
+        }}
+        dumpID={'TextColorBackground'}
+        uiaID={'TextColorBackgroundView'}
+        testID={TREE_DUMP_RESULT}
+        additionalProperties={['TextHighlighters']}
+      />
+    </View>
+  );
+}
+
+export const displayName = (_undefined?: string) => { };
+export const title = '<LegacyTextBackgroundColorTest>';
+export const description = 'Legacy e2e test for Text with backgroundColor';
+export const examples = [
+  {
+    render: function (): JSX.Element {
+      return <TextBackgroundColorTestPage />;
+    },
+  },
+];

--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -165,6 +165,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'LegacyAccessibilityTest',
     module: require('../examples-win/LegacyTests/AccessibilityTestPage'),
   },
+  {
+    key: 'LegacyTextBackgroundColorTest',
+    module: require('../examples-win/LegacyTests/TextBackgroundColorTestPage'),
+  },
 ];
 
 const APIExamples: Array<RNTesterExample> = [

--- a/packages/E2ETest/wdio/pages/TextBackgroundColorTestPage.ts
+++ b/packages/E2ETest/wdio/pages/TextBackgroundColorTestPage.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+import { BasePage } from './BasePage';
+
+class TextBackgroundColorTestPage extends BasePage {}
+
+export default new TextBackgroundColorTestPage();

--- a/packages/E2ETest/wdio/test/TextColorBackground.spec.ts
+++ b/packages/E2ETest/wdio/test/TextColorBackground.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+import HomePage from '../pages/HomePage';
+import TextBackgroundColorTestPage from '../pages/TextBackgroundColorTestPage';
+import { TEXT_BACKGROUND_COLOR_TESTPAGE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
+
+beforeAll(() => {
+  HomePage.goToComponentExample(TEXT_BACKGROUND_COLOR_TESTPAGE);
+});
+
+describe('TextBackgroundColorTest', () => {
+  /* Test case #1: view and image displayed with no border and cornerRadius */
+  it('TextBackgroundColorTest', () => {
+    TextBackgroundColorTestPage.waitForTreeDumpPassed(
+      '#1. Dump comparison for nested text with backgroundColor!'
+    );
+  });
+});

--- a/packages/E2ETest/windows/ReactUWPTestApp/Assets/TreeDump/masters/TextColorBackground.json
+++ b/packages/E2ETest/windows/ReactUWPTestApp/Assets/TreeDump/masters/TextColorBackground.json
@@ -1,0 +1,207 @@
+{
+  "XamlType": "Microsoft.ReactNative.ViewPanel",
+  "Background": null,
+  "BorderBrush": "#00000000",
+  "BorderThickness": "0,0,0,0",
+  "Clip": null,
+  "CornerRadius": "0,0,0,0",
+  "FlowDirection": "LeftToRight",
+  "Height": 95,
+  "HorizontalAlignment": "Stretch",
+  "Margin": "0,0,0,0",
+  "RenderSize": [800, 95],
+  "VerticalAlignment": "Stretch",
+  "Visibility": "Visible",
+  "Width": 800,
+  "AutomationId": "TextColorBackgroundView",
+  "children": [
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer no_color START_NESTED green DEEPER_NESTED blue END_NESTED attributes.",
+    "TextHighlighters": [{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":15,"Length":18}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":33,"Length":1}]
+}
+,{
+"Background": "#FF0000FF",
+"Ranges": [{"StartIndex":34,"Length":18}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":52,"Length":1}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":53,"Length":10}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer no_color START_NESTED no_color DEEPER_NESTED blue END_NESTED attributes.",
+    "TextHighlighters": [{
+"Background": "#FF0000FF",
+"Ranges": [{"StartIndex":37,"Length":18}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer no_color START_NESTED green DEEPER_NESTED inherit green END_NESTED attributes.",
+    "TextHighlighters": [{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":15,"Length":19}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":34,"Length":27}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":61,"Length":1}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":62,"Length":10}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer red START_NESTED inherit red DEEPER_NESTED inherit red END_NESTED attributes.",
+    "TextHighlighters": [{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":0,"Length":9}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":9,"Length":1}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":10,"Length":25}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":35,"Length":25}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":60,"Length":1}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":61,"Length":10}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":71,"Length":1}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":72,"Length":11}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer red START_NESTED green DEEPER_NESTED blue END_NESTED attributes.",
+    "TextHighlighters": [{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":0,"Length":9}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":9,"Length":1}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":10,"Length":18}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":28,"Length":1}]
+}
+,{
+"Background": "#FF0000FF",
+"Ranges": [{"StartIndex":29,"Length":18}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":47,"Length":1}]
+}
+,{
+"Background": "#FF008000",
+"Ranges": [{"StartIndex":48,"Length":10}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":58,"Length":1}]
+}
+,{
+"Background": "#FFFF0000",
+"Ranges": [{"StartIndex":59,"Length":11}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  }
+  ]
+}

--- a/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -160,7 +160,7 @@
       <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="XamlTreeDump">
-      <Version>1.0.3</Version>
+      <Version>1.0.5</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Follow-up PR to #6300 adding a tree dump test, building on the extensions to the xamltreedump library.

![image](https://user-images.githubusercontent.com/12816515/97511937-7e758180-1945-11eb-9ebd-f3a9c3879b2f.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6364)