### PR TITLE
Update Template Metro Config to Enable Inline Requires By Default

### DIFF
--- a/change/react-native-windows-2020-10-29-09-49-44-template-inline-requires.json
+++ b/change/react-native-windows-2020-10-29-09-49-44-template-inline-requires.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update Template Metro Config to Enable Inline Requires By Default",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-29T16:49:44.555Z"
+}

--- a/vnext/template/metro.config.js
+++ b/vnext/template/metro.config.js
@@ -22,7 +22,7 @@ module.exports = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },


### PR DESCRIPTION
We have a custom Metro config that replaces the default used by core, in order to work around MSBuild related issues, The MSBuild related issues will be going away eventually so we don't need to do this.

RN 0.64 defaults inlineRequires to true, but our template Metro config hasn't been updated to do this. Update our template.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6371)