### PR TITLE
Eagerly initialize UIManager

### DIFF
--- a/change/react-native-windows-2020-10-29-12-55-29-uimaneager.json
+++ b/change/react-native-windows-2020-10-29-12-55-29-uimaneager.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Initialize UIManager turbomodule eagerly",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-29T19:55:29.217Z"
+}

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -308,7 +308,12 @@ TurboModulesProvider::TurboModulePtr TurboModulesProvider::getModule(
 }
 
 std::vector<std::string> TurboModulesProvider::getEagerInitModuleNames() noexcept {
-  return {};
+  std::vector<std::string> eagerModules;
+  auto it = m_moduleProviders.find("UIManager");
+  if (it != m_moduleProviders.end()) {
+    eagerModules.push_back("UIManager");
+  }
+  return eagerModules;
 }
 
 void TurboModulesProvider::SetReactContext(const IReactContext &reactContext) noexcept {


### PR DESCRIPTION
If the native side finishes loading and attempts to register the root view before the UIManager is initialized then in ReactInstanceWin::AttachMeasuredRootView we'd end up notifying JS that the rootViewTag is -1, which would end crash later when UI attempts to add UI to node -1.


Fixes #6368

Filed #6377 to track how to do needsEagerInit more generically.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6378)