### PR TITLE
Update Microsoft.ReactNative Nuget Package to support layout convention

### DIFF
--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,11 +1,11 @@
 parameters:
   publishCommitId: '0'
   npmVersion: '0.0.1-pr'
-  # Note: NuGet pack expects platform-specific file spearators ('\' on Windows).
+  # Note: NuGet pack expects platform-specific file separators ('\' on Windows).
   nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
   desktopId: 'OfficeReact.Win32'
   microsoftRNId: 'Microsoft.ReactNative'
-  slices: '("x64.Release", "x64.Debug", "x86.Release", "x86.Debug", "ARM.Release", "ARM.Debug", "ARM64.Release", "ARM64.Debug")'
+  slices: '("x64.Release","x86.Release", "ARM.Release", "ARM64.Release")'
   packDesktop: true
   packMicrosoftReactNative: true
   packMicrosoftReactNativeCxx: true

--- a/change/react-native-windows-2020-10-30-11-37-43-master.json
+++ b/change/react-native-windows-2020-10-30-11-37-43-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update Microsoft.ReactNative NuGet Package to only contain release bits",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T18:37:42.949Z"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -25,43 +25,43 @@
     <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml"   target="lib\uap10.0"/> 
     -->
 
-    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\release" />
-    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\release" />
-    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\release" />
+    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
 
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native\debug" />
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native\debug" />
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native\debug" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm\native" />
 
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native\release" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native\release" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native\release" />
+    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
 
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native\debug" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native\debug" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native\debug" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
 
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native\release" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native\release" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native\release" />
+    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
 
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native\debug" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native\debug" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native\debug" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
 
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native\release" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native\release" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native\release" />
+    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
 
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native\debug" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native\debug" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native\debug" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
 
     <!-- XBF files need to be included for Debug since they are not embedded in the PRI -->
-    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm\native\debug" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm64\native\debug" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x86\native\debug" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x64\native\debug" />
+    <file src="$nugetroot$\ARM\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm\native" />
+    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x64\native" />
 
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -5,8 +5,7 @@
   <PropertyGroup>
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
-    <_rnwDebugFolder>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\debug\</_rnwDebugFolder>
-    <_rnwReleaseFolder>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\release\</_rnwReleaseFolder>
+    <_rnwFolder>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\</_rnwFolder>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
@@ -14,20 +13,9 @@
       <Implementation>Microsoft.ReactNative.dll</Implementation>
     </Reference>
     
-    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug' and Exists('$(_rnwDebugFolder)Microsoft.ReactNative.dll')" Include="$(_rnwDebugFolder)Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug' and Exists('$(_rnwDebugFolder)Microsoft.ReactNative.pri')" Include="$(_rnwDebugFolder)Microsoft.ReactNative.pri" />
-    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(_rnwDebugFolder)**\*.xbf" />
-
-    <!-- fall back to release bits if debug bits are not in package -->
-    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug' and !Exists('$(_rnwDebugFolder)Microsoft.ReactNative.dll') and Exists('$(_rnwReleaseFolder)Microsoft.ReactNative.dll')" Include="$(_rnwReleaseFolder)Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug' and !Exists('$(_rnwDebugFolder)Microsoft.ReactNative.pri') and Exists('$(_rnwReleaseFolder)Microsoft.ReactNative.dll')" Include="$(_rnwReleaseFolder)Microsoft.ReactNative.pri" />
-
-
-    <ReferenceCopyLocalPaths Condition="$(Configuration) != 'Debug' and Exists('$(_rnwReleaseFolder)Microsoft.ReactNative.dll')" Include="$(_rnwReleaseFolder)Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="$(Configuration) != 'Debug' and Exists('$(_rnwReleaseFolder)Microsoft.ReactNative.pri')" Include="$(_rnwReleaseFolder)Microsoft.ReactNative.pri" />
-    <!-- fall back to debug bits if release bits are not in package -->
-    <ReferenceCopyLocalPaths Condition="$(Configuration) != 'Debug' and !Exists('$(_rnwReleaseFolder)Microsoft.ReactNative.dll') and Exists('$(_rnwDebugFolder)Microsoft.ReactNative.dll')" Include="$(_rnwDebugFolder)Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="$(Configuration) != 'Debug' and !Exists('$(_rnwReleaseFolder)Microsoft.ReactNative.pri') and Exists('$(_rnwDebugFolder)Microsoft.ReactNative.dll')" Include="$(_rnwDebugFolder)Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="Exists('$(_rnwFolder)Microsoft.ReactNative.dll')" Include="$(_rnwFolder)Microsoft.ReactNative.dll" />
+    <ReferenceCopyLocalPaths Condition="Exists('$(_rnwFolder)Microsoft.ReactNative.pri')" Include="$(_rnwFolder)Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(_rnwFolder)**\*.xbf" />
 
   </ItemGroup>
 </Project>

--- a/vnext/Scripts/PublishNugetPackagesLocally.cmd
+++ b/vnext/Scripts/PublishNugetPackagesLocally.cmd
@@ -10,7 +10,7 @@ set baseConfiguration=%5
 set ScriptFolder=%~dp0
 
 set defaultTargetDir=c:\temp\RnWNugetTesting
-set defaultSlices="@('x64.Debug')"
+set defaultSlices="@('x64.Debug','x64.Release','x86.Debug')"
 set defaultBaseConfiguration=Debug
 set defaultBasePlatform=x64
 
@@ -70,7 +70,7 @@ echo Invoking publish nuget packages with: %0 %*
     )
 
 
-call :ProcessNuget Microsoft.ReactNative                 strip
+call :ProcessNuget Microsoft.ReactNative                 strip -preferRelease $true
 call :ProcessNuget Microsoft.ReactNative.Cxx             nostrip
 call :ProcessNuget Microsoft.ReactNative.Managed         strip -preferRelease $true
 call :ProcessNuget Microsoft.ReactNative.Managed.CodeGen nostrip

--- a/vnext/Scripts/StripAdditionalPlatformsFromNuspec.ps1
+++ b/vnext/Scripts/StripAdditionalPlatformsFromNuspec.ps1
@@ -51,10 +51,11 @@ foreach($file in $filesSection.ChildNodes) {
 
             if ($preferRelease -and $flavor -eq "Debug" -and $slices.Contains("$platform.Release")) {
                 Write-Debug "          remove because it is debug and there is a release version requested"
-                # We are checking for the debug version. THere is a release version and we prefer release bits1111
+                # We are checking for the debug version. THere is a release version and we prefer release bits
                 $nodesToRemove += $file
                 break;
             }
+
         }
     }
 }

--- a/vnext/Scripts/StripAdditionalPlatformsFromNuspec.ps1
+++ b/vnext/Scripts/StripAdditionalPlatformsFromNuspec.ps1
@@ -51,7 +51,7 @@ foreach($file in $filesSection.ChildNodes) {
 
             if ($preferRelease -and $flavor -eq "Debug" -and $slices.Contains("$platform.Release")) {
                 Write-Debug "          remove because it is debug and there is a release version requested"
-                # We are checking for the debug version. THere is a release version and we prefer release bits
+                # We are checking for the debug version. There is a release version and we prefer release bits
                 $nodesToRemove += $file
                 break;
             }


### PR DESCRIPTION
    NuGet defines a layout semantic for UWP projects. CSharp projects use the directory
    convention which is to copy all dll's and pdb recursivley under the 'native' folder
    This means that if we have native\release\foo.dll and native\debug\foo.dll
    UWP will try to copy both versions of foo.dll to the output app and will
    collide. Cpp projects don't have this problem because they don't support Nuget
    properly, and require the producing nuget package to ship a targets file
    that overrides the behavior manually where we accounted for.

    This change drops including the debug bits in Microsoft.ReactNative.
    Just like the Microsoft.ReactNative.Managed package if a debug slice is build for a
    platform without a release versions, that debug version will be included.

Closing #6375 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6381)