### PR TITLE
Integrate 9/17 Nightly RN Build

### DIFF
--- a/change/@office-iss-react-native-win32-2020-10-29-17-44-48-integrate-9-17.json
+++ b/change/@office-iss-react-native-win32-2020-10-29-17-44-48-integrate-9-17.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 9/17 Nightly RN Build",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T00:44:47.009Z"
+}

--- a/change/react-native-windows-2020-10-29-17-44-48-integrate-9-17.json
+++ b/change/react-native-windows-2020-10-29-17-44-48-integrate-9-17.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 9/17 Nightly RN Build",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-30T00:44:48.187Z"
+}

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "appium-android-driver": "4.12.0-stub.0",
     "appium-selendroid-driver": "1.13.4-stub.0",
     "appium-tizen-driver": "1.1.1-stub.0",
-    "hermes-engine-comment": "The hermes-engine resolution can be removed when we integrate the 9/17 Nightly RN Build",
-    "hermes-engine": "0.7.0",
     "eslint-plugin-react": "^7.14.1",
     "eslint-plugin-react-hooks": "4.0.7",
     "node-fetch": "2.6.1",

--- a/packages/@react-native-windows/tester/overrides.json
+++ b/packages/@react-native-windows/tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win/**"
   ],
-  "baseVersion": "0.0.0-f0e80ae22",
+  "baseVersion": "0.0.0-9b094ee77",
   "overrides": [
     {
       "type": "patch",

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -14,7 +14,7 @@
     "@react-native/tester": "0.0.1"
   },
   "peerDependencies": {
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-windows": "^0.0.0-canary.191"
   },
   "devDependencies": {
@@ -22,7 +22,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "eslint": "6.8.0",
     "just-scripts": "^0.44.7",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-platform-override": "^0.4.1",
     "react-native-windows": "^0.0.0-canary.191",
     "typescript": "^3.8.3"

--- a/packages/@react-native/repo-config/overrides.json
+++ b/packages/@react-native/repo-config/overrides.json
@@ -1,11 +1,11 @@
 {
-  "baseVersion": "0.0.0-f0e80ae22",
+  "baseVersion": "0.0.0-9b094ee77",
   "overrides": [
     {
       "type": "copy",
       "file": "package.json",
       "baseFile": "repo-config/package.json",
-      "baseHash": "1d23e0d9dbae684933d01c65efea363656eb0476"
+      "baseHash": "0a4d3b76d2a7c5771370a13ffb49603a3afb9349"
     }
   ]
 }

--- a/packages/@react-native/repo-config/package.json
+++ b/packages/@react-native/repo-config/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react-hooks": "^4.0.7",
     "eslint-plugin-react-native": "3.8.1",
     "eslint-plugin-relay": "1.7.1",
-    "flow-bin": "^0.132.0",
+    "flow-bin": "^0.133.0",
     "jest": "^26.0.1",
     "jest-junit": "^10.0.0",
     "jscodeshift": "^0.9.0",

--- a/packages/@react-native/tester/js/examples/Alert/AlertExample.js
+++ b/packages/@react-native/tester/js/examples/Alert/AlertExample.js
@@ -9,119 +9,188 @@
 
 'use strict';
 
-const React = require('react');
-const {
-  Alert,
-  StyleSheet,
-  Text,
-  TouchableHighlight,
-  View,
-} = require('react-native');
+import React, {useState} from 'react';
+import {Alert, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
 
-// corporate ipsum > lorem ipsum
-const alertMessage =
-  'Credibly reintermediate next-generation potentialities after goal-oriented ' +
-  'catalysts for change. Dynamically revolutionize.';
+// Shows log on the screen
+const Log = ({message}) =>
+  message ? (
+    <View style={styles.logContainer}>
+      <Text>
+        <Text style={styles.bold}>Log</Text>: {message}
+      </Text>
+    </View>
+  ) : null;
 
 /**
  * Simple alert examples.
  */
-type Props = $ReadOnly<{||}>;
 
-class SimpleAlertExampleBlock extends React.Component<Props> {
-  render() {
-    return (
-      <View>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() => Alert.alert('Alert Title', alertMessage)}>
-          <View style={styles.button}>
-            <Text>Alert with message and default button</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('Alert Title', alertMessage, [
-              {text: 'OK', onPress: () => console.log('OK Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert with one button</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('Alert Title', alertMessage, [
-              {text: 'Cancel', onPress: () => console.log('Cancel Pressed!')},
-              {text: 'OK', onPress: () => console.log('OK Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert with two buttons</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('Alert Title', null, [
-              {text: 'Foo', onPress: () => console.log('Foo Pressed!')},
-              {text: 'Bar', onPress: () => console.log('Bar Pressed!')},
-              {text: 'Baz', onPress: () => console.log('Baz Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert with three buttons</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert(
-              'Foo Title',
-              alertMessage,
-              '..............'.split('').map((dot, index) => ({
-                text: 'Button ' + index,
-                onPress: () => console.log('Pressed ' + index),
-              })),
-            )
-          }>
-          <View style={styles.button}>
-            <Text>Alert with too many buttons</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert(
-              'Alert Title',
-              null,
-              [{text: 'OK', onPress: () => console.log('OK Pressed!')}],
-              {
-                cancelable: false,
-              },
-            )
-          }>
-          <View style={styles.button}>
-            <Text>Alert that cannot be dismissed</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('', alertMessage, [
-              {text: 'OK', onPress: () => console.log('OK Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert without title</Text>
-          </View>
-        </TouchableHighlight>
-      </View>
-    );
-  }
-}
+const AlertWithDefaultButton = () => {
+  const alertMessage = 'An external USB drive has been detected!';
+
+  return (
+    <View>
+      <TouchableHighlight
+        testID="alert-with-default-button"
+        style={styles.wrapper}
+        onPress={() => Alert.alert('Alert', alertMessage)}>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+    </View>
+  );
+};
+
+const AlertWithTwoButtons = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Your subscription has expired!';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Action Required!', alertMessage, [
+            {text: 'Ignore', onPress: () => setMessage('Ignore Pressed!')},
+            {text: 'Renew', onPress: () => setMessage('Renew Pressed!')},
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithThreeButtons = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Do you want to save your changes?';
+
+  return (
+    <View>
+      <TouchableHighlight
+        testID="alert-with-three-buttons"
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Unsaved Changes!', alertMessage, [
+            {text: 'Cancel', onPress: () => setMessage('Cancel Pressed!')},
+            {text: 'No', onPress: () => setMessage('No Pressed!')},
+            {text: 'Yes', onPress: () => setMessage('Yes Pressed!')},
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithManyButtons = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage =
+    'Credibly reintermediate next-generation potentialities after goal-oriented ' +
+    'catalysts for change. Dynamically revolutionize.';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert(
+            'Foo Title',
+            alertMessage,
+            '..............'.split('').map((dot, index) => ({
+              text: 'Button ' + index,
+              onPress: () => setMessage(`Button ${index} Pressed!`),
+            })),
+          )
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithCancelableTrue = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Tapping outside this dialog will dismiss this alert.';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert(
+            'Alert Title',
+            alertMessage,
+            [{text: 'OK', onPress: () => setMessage('OK Pressed!')}],
+            {
+              cancelable: true,
+              onDismiss: () =>
+                setMessage(
+                  'This alert was dismissed by tapping outside of the alert dialog.',
+                ),
+            },
+          )
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithStyles = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Look at the button styles!';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Styled Buttons!', alertMessage, [
+            {
+              text: 'Default',
+              onPress: () => setMessage('Default Pressed!'),
+              style: 'default',
+            },
+            {
+              text: 'Cancel',
+              onPress: () => setMessage('Cancel Pressed!'),
+              style: 'cancel',
+            },
+            {
+              text: 'Destructive',
+              onPress: () => setMessage('Destructive Pressed!'),
+              style: 'destructive',
+            },
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -132,20 +201,67 @@ const styles = StyleSheet.create({
     backgroundColor: '#eeeeee',
     padding: 10,
   },
+  logContainer: {
+    paddingVertical: 8,
+    paddingHorizontal: 5,
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
 });
 
-exports.title = 'Alert';
-exports.category = 'UI';
+exports.title = 'Alerts';
 exports.description =
   'Alerts display a concise and informative message ' +
   'and prompt the user to make a decision.';
+exports.documentationURL = 'https://reactnative.dev/docs/alert';
 exports.examples = [
   {
-    title: 'Alerts',
+    title: 'Alert with default Button',
+    description:
+      "It can be used to show some information to user that doesn't require an action.",
     render(): React.Node {
-      return <SimpleAlertExampleBlock />;
+      return <AlertWithDefaultButton />;
+    },
+  },
+  {
+    title: 'Alert with two Buttons',
+    description: 'It can be used when an action is required from the user.',
+    render(): React.Node {
+      return <AlertWithTwoButtons />;
+    },
+  },
+  {
+    title: 'Alert with three Buttons',
+    description: 'It can be used when there are three possible actions',
+    render(): React.Node {
+      return <AlertWithThreeButtons />;
+    },
+  },
+  {
+    title: 'Alert with many Buttons',
+    platform: 'ios',
+    description: 'It can be used when more than three actions are required.',
+    render(): React.Node {
+      return <AlertWithManyButtons />;
+    },
+  },
+  {
+    title: 'Alert with cancelable={true}',
+    platform: 'android',
+    description:
+      'By passing cancelable={false} prop to alerts on Android, they can be dismissed by tapping outside of the alert box.',
+    render(): React.Node {
+      return <AlertWithCancelableTrue />;
+    },
+  },
+  {
+    title: 'Alert with styles',
+    platform: 'ios',
+    description:
+      "Alert buttons can be styled. There are three button styles - 'default' | 'cancel' | 'destructive'.",
+    render(): React.Node {
+      return <AlertWithStyles />;
     },
   },
 ];
-
-exports.SimpleAlertExampleBlock = SimpleAlertExampleBlock;

--- a/packages/@react-native/tester/js/examples/Alert/AlertIOSExample.js
+++ b/packages/@react-native/tester/js/examples/Alert/AlertIOSExample.js
@@ -11,8 +11,6 @@
 'use strict';
 
 const React = require('react');
-
-const {SimpleAlertExampleBlock} = require('./AlertExample');
 const {
   StyleSheet,
   View,
@@ -20,6 +18,10 @@ const {
   TouchableHighlight,
   Alert,
 } = require('react-native');
+
+const {examples: SharedAlertExamples} = require('./AlertExample');
+
+import type {RNTesterExampleModuleItem} from '../../types/RNTesterTypes';
 
 type Props = $ReadOnly<{||}>;
 type State = {|promptValue: ?string|};
@@ -152,15 +154,11 @@ const styles = StyleSheet.create({
 });
 
 exports.framework = 'React';
-exports.title = 'Alert';
+exports.title = 'Alerts';
 exports.description = 'iOS alerts and action sheets';
-exports.examples = [
-  {
-    title: 'Alerts',
-    render(): React.Node {
-      return <SimpleAlertExampleBlock />;
-    },
-  },
+exports.documentationURL = 'https://reactnative.dev/docs/alert';
+exports.examples = ([
+  ...SharedAlertExamples,
   {
     title: 'Prompt Options',
     render(): React.Element<any> {
@@ -201,4 +199,4 @@ exports.examples = [
       );
     },
   },
-];
+]: RNTesterExampleModuleItem[]);

--- a/packages/@react-native/tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/@react-native/tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -5,80 +5,161 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';
 
 const React = require('react');
 const {
+  Alert,
   KeyboardAvoidingView,
   Modal,
-  SegmentedControlIOS,
   StyleSheet,
   Text,
   TextInput,
-  TouchableHighlight,
+  Button,
+  Pressable,
+  TouchableOpacity,
   View,
 } = require('react-native');
 
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const RNTesterPage = require('../../components/RNTesterPage');
+const {useState} = require('react');
 
-type Props = $ReadOnly<{||}>;
-type State = {|
-  behavior: string,
-  modalOpen: boolean,
-|};
+const onButtonPress = () => {
+  Alert.alert('Successfully Registered!');
+};
 
-class KeyboardAvoidingViewExample extends React.Component<Props, State> {
-  state = {
-    behavior: 'padding',
-    modalOpen: false,
-  };
+const TextInputForm = () => {
+  return (
+    <View>
+      <TextInput placeholder="Email" style={styles.textInput} />
+      <TextInput placeholder="Username" style={styles.textInput} />
+      <TextInput placeholder="Password" style={styles.textInput} />
+      <TextInput placeholder="Confirm Password" style={styles.textInput} />
+      <Button title="Register" onPress={onButtonPress} />
+    </View>
+  );
+};
 
-  onSegmentChange = (segment: String) => {
-    this.setState({behavior: segment.toLowerCase()});
-  };
+const CloseButton = props => {
+  return (
+    <View
+      style={[
+        styles.closeView,
+        {marginHorizontal: props.behavior === 'position' ? 0 : 25},
+      ]}>
+      <Pressable
+        onPress={() => props.setModdalOpen(false)}
+        style={styles.closeButton}>
+        <Text>Close</Text>
+      </Pressable>
+    </View>
+  );
+};
 
-  renderExample = () => {
-    return (
-      <View style={styles.outerContainer}>
-        <Modal animationType="fade" visible={this.state.modalOpen}>
-          <KeyboardAvoidingView
-            behavior={this.state.behavior}
-            style={styles.container}>
-            <SegmentedControlIOS
-              onValueChange={this.onSegmentChange}
-              selectedIndex={this.state.behavior === 'padding' ? 0 : 1}
-              style={styles.segment}
-              values={['Padding', 'Position']}
-            />
-            <TextInput placeholder="<TextInput />" style={styles.textInput} />
-          </KeyboardAvoidingView>
-          <TouchableHighlight
-            onPress={() => this.setState({modalOpen: false})}
-            style={styles.closeButton}>
-            <Text>Close</Text>
-          </TouchableHighlight>
-        </Modal>
-
-        <TouchableHighlight onPress={() => this.setState({modalOpen: true})}>
+const KeyboardAvoidingViewBehaviour = () => {
+  const [modalOpen, setModdalOpen] = useState(false);
+  const [behavior, setBehavior] = useState('padding');
+  return (
+    <View style={styles.outerContainer}>
+      <Modal animationType="fade" visible={modalOpen}>
+        <KeyboardAvoidingView behavior={behavior} style={styles.container}>
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'center',
+            }}>
+            <TouchableOpacity
+              onPress={() => setBehavior('padding')}
+              style={[
+                styles.pillStyle,
+                {backgroundColor: behavior === 'padding' ? 'blue' : 'white'},
+              ]}>
+              <Text style={{color: behavior === 'padding' ? 'white' : 'blue'}}>
+                Padding
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => setBehavior('position')}
+              style={[
+                styles.pillStyle,
+                {backgroundColor: behavior === 'position' ? 'blue' : 'white'},
+              ]}>
+              <Text style={{color: behavior === 'position' ? 'white' : 'blue'}}>
+                Padding
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => setBehavior('height')}
+              style={[
+                styles.pillStyle,
+                {backgroundColor: behavior === 'height' ? 'blue' : 'white'},
+              ]}>
+              <Text
+                style={{
+                  color: behavior === 'height' ? 'white' : 'blue',
+                }}>
+                Height
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <CloseButton behavior={behavior} setModdalOpen={setModdalOpen} />
+          <TextInputForm />
+        </KeyboardAvoidingView>
+      </Modal>
+      <View>
+        <Pressable onPress={() => setModdalOpen(true)}>
           <Text>Open Example</Text>
-        </TouchableHighlight>
+        </Pressable>
       </View>
-    );
-  };
+    </View>
+  );
+};
 
-  render() {
-    return (
-      <RNTesterPage title="Keyboard Avoiding View">
-        <RNTesterBlock title="Keyboard-avoiding views move out of the way of the keyboard.">
-          {this.renderExample()}
-        </RNTesterBlock>
-      </RNTesterPage>
-    );
-  }
-}
+const KeyboardAvoidingDisabled = () => {
+  const [modalOpen, setModdalOpen] = useState(false);
+  return (
+    <View style={styles.outerContainer}>
+      <Modal animationType="fade" visible={modalOpen}>
+        <KeyboardAvoidingView
+          enabled={false}
+          behavior={'height'}
+          style={styles.container}>
+          <CloseButton behavior={'height'} setModdalOpen={setModdalOpen} />
+          <TextInputForm />
+        </KeyboardAvoidingView>
+      </Modal>
+      <View>
+        <Pressable onPress={() => setModdalOpen(true)}>
+          <Text>Open Example</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const KeyboardAvoidingVerticalOffset = () => {
+  const [modalOpen, setModdalOpen] = useState(false);
+  return (
+    <View style={styles.outerContainer}>
+      <Modal animationType="fade" visible={modalOpen}>
+        <KeyboardAvoidingView
+          keyboardVerticalOffset={20}
+          behavior={'padding'}
+          style={styles.container}>
+          <CloseButton behavior={'height'} setModdalOpen={setModdalOpen} />
+          <TextInputForm />
+        </KeyboardAvoidingView>
+      </Modal>
+      <View>
+        <Pressable onPress={() => setModdalOpen(true)}>
+          <Text>Open Example</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   outerContainer: {
@@ -87,6 +168,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+    alignItems: 'center',
     paddingHorizontal: 20,
     paddingTop: 20,
   },
@@ -94,29 +176,53 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     borderWidth: 1,
     height: 44,
+    width: 300,
+    marginBottom: 20,
     paddingHorizontal: 10,
   },
-  segment: {
-    marginBottom: 10,
+  closeView: {
+    alignSelf: 'stretch',
+  },
+  pillStyle: {
+    padding: 10,
+    marginHorizontal: 5,
+    marginVertical: 10,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: 'blue',
   },
   closeButton: {
-    position: 'absolute',
-    top: 40,
-    left: 10,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginVertical: 10,
     padding: 10,
   },
 });
 
 exports.title = 'KeyboardAvoidingView';
-exports.category = 'Basic';
-exports.documentationURL = 'https://reactnative.dev/docs/keyboardavoidingview';
 exports.description =
   'Base component for views that automatically adjust their height or position to move out of the way of the keyboard.';
 exports.examples = [
   {
-    title: 'Simple keyboard view',
-    render: function(): React.Element<typeof KeyboardAvoidingViewExample> {
-      return <KeyboardAvoidingViewExample />;
+    title: 'Keyboard Avoiding View with different behaviors',
+    description: ('Specify how to react to the presence of the keyboard. Android and iOS both interact' +
+      'with this prop differently. On both iOS and Android, setting behavior is recommended.': string),
+    render(): React.Node {
+      return <KeyboardAvoidingViewBehaviour />;
+    },
+  },
+  {
+    title: 'Keyboard Avoiding View with keyboardVerticalOffset={distance}',
+    description: ('This is the distance between the top of the user screen and the react native' +
+      'view, may be non-zero in some use cases. Defaults to 0.': string),
+    render(): React.Node {
+      return <KeyboardAvoidingVerticalOffset />;
+    },
+  },
+  {
+    title: 'Keyboard Avoiding View with enabled={false}',
+    render(): React.Node {
+      return <KeyboardAvoidingDisabled />;
     },
   },
 ];

--- a/packages/@react-native/tester/js/examples/ToastAndroid/ToastAndroidExample.android.js
+++ b/packages/@react-native/tester/js/examples/ToastAndroid/ToastAndroidExample.android.js
@@ -5,117 +5,113 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict-local
+ * @flow
  */
 
 'use strict';
 
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const RNTesterPage = require('../../components/RNTesterPage');
 const React = require('react');
 
-const {
-  StyleSheet,
-  Text,
-  ToastAndroid,
-  TouchableWithoutFeedback,
-} = require('react-native');
+const {StyleSheet, Text, ToastAndroid, Pressable} = require('react-native');
 
-type Props = $ReadOnly<{||}>;
-class ToastExample extends React.Component<Props> {
-  render(): React.Node {
-    return (
-      <RNTesterPage title="ToastAndroid">
-        <RNTesterBlock title="Simple toast">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.show(
-                'This is a toast with short duration',
-                ToastAndroid.SHORT,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-        <RNTesterBlock title="Toast with long duration">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.show(
-                'This is a toast with long duration',
-                ToastAndroid.LONG,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-        <RNTesterBlock title="Toast with top gravity">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.showWithGravity(
-                'This is a toast with top gravity',
-                ToastAndroid.SHORT,
-                ToastAndroid.TOP,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-        <RNTesterBlock title="Toast with center gravity">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.showWithGravity(
-                'This is a toast with center gravity',
-                ToastAndroid.SHORT,
-                ToastAndroid.CENTER,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-        <RNTesterBlock title="Toast with bottom gravity">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.showWithGravity(
-                'This is a toast with bottom gravity',
-                ToastAndroid.SHORT,
-                ToastAndroid.BOTTOM,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-        <RNTesterBlock title="Toast with x offset">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.showWithGravityAndOffset(
-                'This is a toast with x offset',
-                ToastAndroid.SHORT,
-                ToastAndroid.CENTER,
-                50,
-                0,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-        <RNTesterBlock title="Toast with y offset">
-          <TouchableWithoutFeedback
-            onPress={() =>
-              ToastAndroid.showWithGravityAndOffset(
-                'This is a toast with y offset',
-                ToastAndroid.SHORT,
-                ToastAndroid.BOTTOM,
-                0,
-                50,
-              )
-            }>
-            <Text style={styles.text}>Click me.</Text>
-          </TouchableWithoutFeedback>
-        </RNTesterBlock>
-      </RNTesterPage>
-    );
-  }
-}
+const ToastWithShortDuration = () => {
+  return (
+    <Pressable
+      onPress={() =>
+        ToastAndroid.show('Copied to clipboard!', ToastAndroid.SHORT)
+      }>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
+
+const ToastWithLongDuration = () => {
+  return (
+    <Pressable
+      onPress={() => ToastAndroid.show('Sending message..', ToastAndroid.LONG)}>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
+
+const ToastWithTopGravity = () => {
+  return (
+    <Pressable
+      onPress={() =>
+        ToastAndroid.showWithGravity(
+          'Download Started..',
+          ToastAndroid.SHORT,
+          ToastAndroid.TOP,
+        )
+      }>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
+
+const ToastWithCenterGravity = () => {
+  return (
+    <Pressable
+      onPress={() =>
+        ToastAndroid.showWithGravity(
+          'A problem has been occured while submitting your data.',
+          ToastAndroid.SHORT,
+          ToastAndroid.CENTER,
+        )
+      }>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
+
+const ToastWithBottomGravity = () => {
+  return (
+    <Pressable
+      onPress={() =>
+        ToastAndroid.showWithGravity(
+          'Please read the contents carefully.',
+          ToastAndroid.SHORT,
+          ToastAndroid.BOTTOM,
+        )
+      }>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
+
+const ToastWithXOffset = () => {
+  return (
+    <Pressable
+      onPress={() =>
+        ToastAndroid.showWithGravityAndOffset(
+          'Alex sent you a friend request',
+          ToastAndroid.SHORT,
+          ToastAndroid.TOP,
+          250,
+          0,
+        )
+      }>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
+
+const ToastWithYOffset = () => {
+  return (
+    <Pressable
+      onPress={() =>
+        ToastAndroid.showWithGravityAndOffset(
+          'There was a problem with your internet connection',
+          ToastAndroid.SHORT,
+          ToastAndroid.BOTTOM,
+          0,
+          100,
+        )
+      }>
+      <Text style={styles.text}>Tap to view toast</Text>
+    </Pressable>
+  );
+};
 
 const styles = StyleSheet.create({
   text: {
@@ -129,9 +125,45 @@ exports.description =
   'Example that demonstrates the use of an Android Toast to provide feedback.';
 exports.examples = [
   {
-    title: 'Basic toast',
-    render: function(): React.Element<typeof ToastExample> {
-      return <ToastExample />;
+    title: 'Toast with Short Duration',
+    render(): React.Node {
+      return <ToastWithShortDuration />;
+    },
+  },
+  {
+    title: 'Toast with Long Duration',
+    render(): React.Node {
+      return <ToastWithLongDuration />;
+    },
+  },
+  {
+    title: 'Toast with Top Gravity',
+    render(): React.Node {
+      return <ToastWithTopGravity />;
+    },
+  },
+  {
+    title: 'Toast with Center Gravity',
+    render(): React.Node {
+      return <ToastWithCenterGravity />;
+    },
+  },
+  {
+    title: 'Toast with Bottom Gravity',
+    render(): React.Node {
+      return <ToastWithBottomGravity />;
+    },
+  },
+  {
+    title: 'Toast with X Offset',
+    render(): React.Node {
+      return <ToastWithXOffset />;
+    },
+  },
+  {
+    title: 'Toast with Y Offset',
+    render(): React.Node {
+      return <ToastWithYOffset />;
     },
   },
 ];

--- a/packages/@react-native/tester/overrides.json
+++ b/packages/@react-native/tester/overrides.json
@@ -1,11 +1,11 @@
 {
-  "baseVersion": "0.0.0-f0e80ae22",
+  "baseVersion": "0.0.0-9b094ee77",
   "overrides": [
     {
       "type": "copy",
       "directory": "js",
       "baseDirectory": "packages/rn-tester/js",
-      "baseHash": "0a19766b09b7fc4d3ccb7744b8a5ef0347c8a733",
+      "baseHash": "ac4675d1929fb72ac177caa25c6feb96202e1b93",
       "issue": 4054
     },
     {

--- a/packages/@react-native/tester/package.json
+++ b/packages/@react-native/tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22"
+    "react-native": "0.0.0-9b094ee77"
   },
   "devDependencies": {
     "react-native-platform-override": "^0.4.1"

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -24,7 +24,7 @@
     "@react-native-windows/tester": "0.0.1",
     "prompt-sync": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-windows": "0.0.0-canary.191"
   },
   "devDependencies": {

--- a/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
+++ b/packages/E2ETest/wdio/test/VisitAllPages.spec.ts
@@ -44,7 +44,7 @@ const apiExamples = [
   'AccessibilityInfo',
   'Accessibility Windows',
   'AsyncStorage Windows',
-  'Alert',
+  'Alerts',
   'Animated - Examples',
   'Animated - Gratuitous App',
   'Appearance',

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-windows": "^0.0.0-canary.191"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-windows": "0.0.0-canary.191"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-native-windows/tester": "0.0.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-windows": "0.0.0-canary.191"
   },
   "devDependencies": {

--- a/packages/react-native-win32-tester/overrides.json
+++ b/packages/react-native-win32-tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win32/**"
   ],
-  "baseVersion": "0.0.0-f0e80ae22",
+  "baseVersion": "0.0.0-9b094ee77",
   "overrides": [
     {
       "type": "patch",

--- a/packages/react-native-win32-tester/package.json
+++ b/packages/react-native-win32-tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.0.0-canary.60",
-    "react-native": "0.0.0-f0e80ae22"
+    "react-native": "0.0.0-9b094ee77"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "^0.0.0-canary.60",
@@ -23,7 +23,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "eslint": "6.8.0",
     "just-scripts": "^0.44.7",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-platform-override": "^0.4.1",
     "typescript": "^3.8.3"
   }

--- a/packages/react-native-win32/.flowconfig
+++ b/packages/react-native-win32/.flowconfig
@@ -118,4 +118,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.132.0
+^0.133.0

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -4,13 +4,13 @@
     "flow-typed",
     "src/**"
   ],
-  "baseVersion": "0.0.0-f0e80ae22",
+  "baseVersion": "0.0.0-9b094ee77",
   "overrides": [
     {
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseHash": "86d79e561c8ce6b2dd89ba20ec7d42246cb2a50f"
+      "baseHash": "77450a7acd7bb309e5470e541cab5e85d7e4aa36"
     },
     {
       "type": "copy",
@@ -154,7 +154,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/TextInput/TextInput.win32.tsx",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseHash": "b49b732f6a88bdc4e5783b5ac2339ee6105523fd"
+      "baseHash": "309ff04ae5312224c992b9119a12c691149280cd"
     },
     {
       "type": "patch",

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -33,7 +33,7 @@
     "base64-js": "^1.1.2",
     "event-target-shim": "^5.0.1",
     "fbjs-scripts": "^1.1.0",
-    "hermes-engine": "~0.6.0",
+    "hermes-engine": "~0.7.0",
     "invariant": "^2.2.4",
     "jsc-android": "^245459.0.0",
     "metro-babel-register": "0.63.0",
@@ -65,19 +65,19 @@
     "@types/react-native": "^0.63.18",
     "babel-eslint": "^10.1.0",
     "eslint": "6.8.0",
-    "flow-bin": "^0.132.0",
+    "flow-bin": "^0.133.0",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-platform-override": "^0.4.1",
     "react-shallow-renderer": "^16.13.1",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22"
+    "react-native": "0.0.0-9b094ee77"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -126,4 +126,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.132.0
+^0.133.0

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -12,13 +12,13 @@
     "src/tsconfig.json",
     "**/*.windesktop.js"
   ],
-  "baseVersion": "0.0.0-f0e80ae22",
+  "baseVersion": "0.0.0-9b094ee77",
   "overrides": [
     {
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseHash": "86d79e561c8ce6b2dd89ba20ec7d42246cb2a50f"
+      "baseHash": "77450a7acd7bb309e5470e541cab5e85d7e4aa36"
     },
     {
       "type": "patch",
@@ -213,7 +213,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Pressable/Pressable.windows.js",
       "baseFile": "Libraries/Components/Pressable/Pressable.js",
-      "baseHash": "b55d01b28764b9bfc75b903383b7b0c08d744b87"
+      "baseHash": "db754c4d52fbd1f79f6370f85352e031613315eb"
     },
     {
       "type": "derived",
@@ -249,7 +249,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInput.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInput.js",
-      "baseHash": "b49b732f6a88bdc4e5783b5ac2339ee6105523fd"
+      "baseHash": "309ff04ae5312224c992b9119a12c691149280cd"
     },
     {
       "type": "patch",
@@ -271,7 +271,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseHash": "9b1b8d8b8d7a26c1e8d16617a4c9e7a686018912"
+      "baseHash": "2e51013f1c2c36d5bc34bbe51d59125e175251f1"
     },
     {
       "type": "patch",
@@ -357,7 +357,7 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseHash": "72a2fea2216d144cc985f243c6d27274f8f4edb6",
+      "baseHash": "e1418d31343ca11ce165a87f82224ccc8d801052",
       "issue": 4379
     },
     {
@@ -380,7 +380,7 @@
       "type": "derived",
       "file": "src/Libraries/Text/Text.windows.js",
       "baseFile": "Libraries/Text/Text.js",
-      "baseHash": "bf4306bd49457c2b82ee8f85147aa458505a5150"
+      "baseHash": "b14e205e0c11eadf8fc4b50618227e6ac8e666ee"
     },
     {
       "type": "patch",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -34,7 +34,7 @@
     "base64-js": "^1.1.2",
     "event-target-shim": "^5.0.1",
     "fbjs-scripts": "^1.1.0",
-    "hermes-engine": "~0.6.0",
+    "hermes-engine": "~0.7.0",
     "invariant": "^2.2.4",
     "jsc-android": "^245459.0.0",
     "metro-babel-register": "0.63.0",
@@ -63,12 +63,12 @@
     "@types/react-native": "^0.63.18",
     "eslint": "6.8.0",
     "eslint-plugin-prettier": "2.6.2",
-    "flow-bin": "^0.132.0",
+    "flow-bin": "^0.133.0",
     "jscodeshift": "^0.9.0",
     "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22",
+    "react-native": "0.0.0-9b094ee77",
     "react-native-platform-override": "^0.4.1",
     "react-native-windows-codegen": "0.1.7",
     "react-refresh": "^0.4.0",
@@ -77,7 +77,7 @@
   },
   "peerDependencies": {
     "react": "16.13.1",
-    "react-native": "0.0.0-f0e80ae22"
+    "react-native": "0.0.0-9b094ee77"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -147,6 +147,11 @@ type Props = $ReadOnly<{|
    * Used only for documentation or testing (e.g. snapshot testing).
    */
   testOnly_pressed?: ?boolean,
+
+  /**
+   * Duration to wait after press down before calling `onPressIn`.
+   */
+  unstable_pressDelay?: ?number,
 |}>;
 
 /**
@@ -173,6 +178,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
     pressRetentionOffset,
     style,
     testOnly_pressed,
+    unstable_pressDelay,
     ...restProps
   } = props;
 
@@ -208,6 +214,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       pressRectOffset: pressRetentionOffset,
       android_disableSound,
       delayLongPress,
+      delayPressIn: unstable_pressDelay,
       onLongPress,
       onPress,
       onPressIn(event: PressEvent): void {
@@ -250,6 +257,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       // Windows]
       pressRetentionOffset,
       setPressed,
+      unstable_pressDelay,
     ],
   );
   const eventHandlers = usePressability(config);

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -582,6 +582,16 @@ export type Props = $ReadOnly<{|
   onEndEditing?: ?(e: EditingEvent) => mixed,
 
   /**
+   * Called when a touch is engaged.
+   */
+  onPressIn?: ?(event: PressEvent) => mixed,
+
+  /**
+   * Called when a touch is released.
+   */
+  onPressOut?: ?(event: PressEvent) => mixed,
+
+  /**
    * Callback that is called when the text input selection is changed.
    * This will be called with
    * `{ nativeEvent: { selection: { start, end } } }`.
@@ -1169,6 +1179,8 @@ function InternalTextInput(props: Props): React.Node {
       <TouchableWithoutFeedback
         onLayout={props.onLayout}
         onPress={_onPress}
+        onPressIn={props.onPressIn}
+        onPressOut={props.onPressOut}
         accessible={props.accessible}
         accessibilityLabel={props.accessibilityLabel}
         accessibilityRole={props.accessibilityRole}

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -195,11 +195,7 @@ class TouchableHighlight extends React.Component<Props, State> {
           this.props.onFocus(event);
         }
       },
-      onLongPress: event => {
-        if (this.props.onLongPress != null) {
-          this.props.onLongPress(event);
-        }
-      },
+      onLongPress: this.props.onLongPress,
       onPress: event => {
         if (this._hideTimeout != null) {
           clearTimeout(this._hideTimeout);

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -297,8 +297,7 @@ const isPressInSignal = signal =>
 const isTerminalSignal = signal =>
   signal === 'RESPONDER_TERMINATED' || signal === 'RESPONDER_RELEASE';
 
-const DEFAULT_LONG_PRESS_DELAY_MS = 370; // 500 - 130
-const DEFAULT_PRESS_DELAY_MS = 130;
+const DEFAULT_LONG_PRESS_DELAY_MS = 500;
 const DEFAULT_PRESS_RECT_OFFSETS = {
   bottom: 30,
   left: 20,
@@ -493,12 +492,7 @@ export default class Pressability {
         this._touchState = 'NOT_RESPONDER';
         this._receiveSignal('RESPONDER_GRANT', event);
 
-        const delayPressIn = normalizeDelay(
-          this._config.delayPressIn,
-          0,
-          DEFAULT_PRESS_DELAY_MS,
-        );
-
+        const delayPressIn = normalizeDelay(this._config.delayPressIn);
         if (delayPressIn > 0) {
           this._pressDelayTimeout = setTimeout(() => {
             this._receiveSignal('DELAY', event);
@@ -510,7 +504,7 @@ export default class Pressability {
         const delayLongPress = normalizeDelay(
           this._config.delayLongPress,
           10,
-          DEFAULT_LONG_PRESS_DELAY_MS,
+          DEFAULT_LONG_PRESS_DELAY_MS - delayPressIn,
         );
         this._longPressDelayTimeout = setTimeout(() => {
           this._handleLongPress(event);
@@ -750,6 +744,11 @@ export default class Pressability {
     }
 
     if (isPressInSignal(prevState) && signal === 'RESPONDER_RELEASE') {
+      // If we never activated (due to delays), activate and deactivate now.
+      if (!isNextActive && !isPrevActive) {
+        this._activate(event);
+        this._deactivate(event);
+      }
       const {onLongPress, onPress, android_disableSound} = this._config;
       if (onPress != null) {
         const isPressCanceledByLongPress =
@@ -757,11 +756,6 @@ export default class Pressability {
           prevState === 'RESPONDER_ACTIVE_LONG_PRESS_IN' &&
           this._shouldLongPressCancelPress();
         if (!isPressCanceledByLongPress) {
-          // If we never activated (due to delays), activate and deactivate now.
-          if (!isNextActive && !isPrevActive) {
-            this._activate(event);
-            this._deactivate(event);
-          }
           if (Platform.OS === 'android' && android_disableSound !== true) {
             SoundManager.playTouchSound();
           }

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -104,10 +104,7 @@ class TouchableText extends React.Component<Props, State> {
   touchableHandleActivePressOut: ?() => void;
   touchableHandleLongPress: ?(event: PressEvent) => void;
   touchableHandlePress: ?(event: PressEvent) => void;
-  touchableHandleResponderGrant: ?(
-    event: PressEvent,
-    dispatchID: string,
-  ) => void;
+  touchableHandleResponderGrant: ?(event: PressEvent) => void;
   touchableHandleResponderMove: ?(event: PressEvent) => void;
   touchableHandleResponderRelease: ?(event: PressEvent) => void;
   touchableHandleResponderTerminate: ?(event: PressEvent) => void;
@@ -164,7 +161,15 @@ class TouchableText extends React.Component<Props, State> {
       <TextAncestor.Consumer>
         {hasTextAncestor => {
           if (hasTextAncestor) {
-            return <RCTVirtualText {...props} ref={props.forwardedRef} />;
+            return (
+              <RCTVirtualText
+                {...props}
+                // This is used on Android to call a nested Text component's press handler from the context menu.
+                // TODO T75145059 Clean this up once Text is migrated off of Touchable
+                onClick={props.onPress}
+                ref={props.forwardedRef}
+              />
+            );
           } else {
             // View.js resets the TextAncestor, as a reportedly temporary change,
             // in order to properly handle nested images inside <Text> on Android/iOS:
@@ -248,10 +253,10 @@ class TouchableText extends React.Component<Props, State> {
         }
         return shouldSetResponder;
       },
-      onResponderGrant: (event: PressEvent, dispatchID: string): void => {
-        nullthrows(this.touchableHandleResponderGrant)(event, dispatchID);
+      onResponderGrant: (event: PressEvent): void => {
+        nullthrows(this.touchableHandleResponderGrant)(event);
         if (this.props.onResponderGrant != null) {
-          this.props.onResponderGrant.call(this, event, dispatchID);
+          this.props.onResponderGrant.call(this, event);
         }
       },
       onResponderMove: (event: PressEvent): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,10 +7110,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.132.0:
-  version "0.132.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
-  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
+flow-bin@^0.133.0:
+  version "0.133.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.133.0.tgz#2ee44e3f5d0c0256cfe8e99d9a85e9801c281c50"
+  integrity sha512-01T5g8GdhtJEn+lhAwuv5zkrMStrmkuHrY3Nn9/aS9y6waNmNgimMKlzRpFH66S0F6Ez9EqU9psz5QaRveSJIA==
 
 flow-parser@0.*:
   version "0.113.0"
@@ -7765,7 +7765,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-engine@0.7.0, hermes-engine@~0.6.0:
+hermes-engine@0.7.0, hermes-engine@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.7.0.tgz#c4a13e09811d7bc975a0662bd2ca7120003d6ef8"
   integrity sha512-lU9OenFWXXOzYldqn15QvbiD0kDc+uw2arhCOkR+9D+PhrLFcbEqnaXFESgchN77JYEf77KkqXncTZA8aoXw2A==
@@ -12074,10 +12074,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-f0e80ae22:
-  version "0.0.0-f0e80ae22"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-f0e80ae22.tgz#f83cf1c102a24e2840da2400ee5eabbca0f9a4c8"
-  integrity sha512-ojn3pfFo9MpX2pjUipmVBaC+6w6niNnoZYZCyAbOqlg6I7aLAU7jnq3Za7izsDeFbViJ3ezXflIvzjQ3zcntVA==
+react-native@0.0.0-9b094ee77:
+  version "0.0.0-9b094ee77"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-9b094ee77.tgz#17c909262dc215b0dc3592614ea52bf89f24a43f"
+  integrity sha512-T5FhgUnp4kzXxru/VdR7h5GffTGowyY04HqsPMZSF02Izgf21+hmEDREpAZ3mUJ63PFgb4zkjdwAKAUK0VFZ8A==
   dependencies:
     "@react-native-community/cli" "^4.10.0"
     "@react-native-community/cli-platform-android" "^4.10.0"
@@ -12090,7 +12090,7 @@ react-native@0.0.0-f0e80ae22:
     base64-js "^1.1.2"
     event-target-shim "^5.0.1"
     fbjs-scripts "^1.1.0"
-    hermes-engine "~0.6.0"
+    hermes-engine "~0.7.0"
     invariant "^2.2.4"
     jsc-android "^245459.0.0"
     metro-babel-register "0.63.0"


### PR DESCRIPTION
Commits: https://github.com/facebook/react-native/compare/f0e80ae22...9b094ee77

This brings a new version of the hermes-engine npm pacakge which we don't directly use, but previously had a resolution for in order to avoid component governenace warnings about security issues.

It brings fixes to the touchable long press issues that were reported in #5906.

It brings in `onPressIn` and `onPressOut` on TextInput. This doesn't work correctly for us yet, which is tracked with #6101.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6385)