### PR TITLE
[0.63] Fix Generator Failing to Overwrite Template Files (#6382)

### DIFF
--- a/change/@react-native-windows-cli-2020-10-29-15-59-32-fix-inquirer.json
+++ b/change/@react-native-windows-cli-2020-10-29-15-59-32-fix-inquirer.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Generator Failing to Overwrite Template Files",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-29T22:59:32.771Z"
+}

--- a/packages/@react-native-windows/cli/src/generator-common/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-common/index.ts
@@ -285,7 +285,7 @@ async function upgradeFileContentChangedCallback(
         `You can see the new version here: ${absoluteSrcFilePath}`,
     );
 
-    const {shoudReplace} = await inquirer.prompt([
+    const {shouldReplace} = await inquirer.prompt([
       {
         name: 'shouldReplace',
         type: 'confirm',
@@ -294,7 +294,7 @@ async function upgradeFileContentChangedCallback(
       },
     ]);
 
-    return shoudReplace ? 'overwrite' : 'keep';
+    return shouldReplace ? 'overwrite' : 'keep';
   }
   if (contentChanged === 'identical') {
     return 'keep';


### PR DESCRIPTION
* Fix Generator Failing to Overwrite Template Files

Fixes #6380

During project initialization, we prompt to ask users whether to replace certain files, like the default metro config. We used to have a custom prompt to do this, but replaced it with Inquirer in 0.63. A typo + lack of type safety from inquirer means that we  regardless of user response, we treat `shouldReplace` as undefined which is coerced to false.

Validated the stock metro config is correctly replaced after the change.

* Change files

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6394)