### PR TITLE
Fix desktop publish

### DIFF
--- a/change/react-native-windows-2020-10-30-10-59-47-master.json
+++ b/change/react-native-windows-2020-10-30-10-59-47-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix publish job by updating path of moved header file",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-30T17:59:47.401Z"
+}

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -35,7 +35,7 @@
 
     <file src="$nugetroot$\inc\Shared\AbiSafe.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\DevSettings.h" target="inc"/>
-    <file src="$nugetroot$\inc\Desktop\INativeUIManagerLegacy.h" target="inc"/>
+    <file src="$nugetroot$\inc\ReactWin32\INativeUIManagerLegacy.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\InstanceManager.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\IReactRootView.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\IRedBoxHandler.h" target="inc"/>


### PR DESCRIPTION
#6268 changed the location of the header file to be included in the win32 nuget package. We seem to lack coverage in PR validation. This fixes the nuspec file to point to the new path.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6395)