### PR TITLE
Fix Bundling With "react-native-windows-init --useDevMode" 

### DIFF
--- a/change/@react-native-windows-cli-59008ac8-ff8a-45af-a889-1ef869803be6.json
+++ b/change/@react-native-windows-cli-59008ac8-ff8a-45af-a889-1ef869803be6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Bundling With \"react-native-windows-init --useDevMode\"",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-0e3c72b2-c464-4a57-a02c-e8c1f3ee5830.json
+++ b/change/react-native-windows-0e3c72b2-c464-4a57-a02c-e8c1f3ee5830.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Bundling With \"react-native-windows-init --useDevMode\"",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-d324dc3a-e64d-44b2-9227-76b94e4a1bbd.json
+++ b/change/react-native-windows-init-d324dc3a-e64d-44b2-9227-76b94e4a1bbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Bundling With \"react-native-windows-init --useDevMode\"",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -295,7 +295,12 @@ export async function copyProjectTemplateAndReplace(
       ? [
           // app common mappings
           {
-            from: path.join(srcRootPath, 'metro.config.js'),
+            from: path.join(
+              srcRootPath,
+              options.useDevMode
+                ? 'metro.devMode.config.js'
+                : 'metro.config.js',
+            ),
             to: 'metro.config.js',
           },
           {

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -42,6 +42,7 @@ export interface GenerateOptions {
   nuGetTestFeed?: string;
   useWinUI3: boolean;
   useHermes: boolean;
+  useDevMode: boolean;
   verbose: boolean;
 }
 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -517,6 +517,7 @@ function isProjectUsingYarn(cwd: string): boolean {
       experimentalNuGetDependency: argv.experimentalNuGetDependency,
       useWinUI3: argv.useWinUI3,
       useHermes: argv.useHermes,
+      useDevMode: argv.useDevMode,
       nuGetTestVersion: argv.nuGetTestVersion,
       nuGetTestFeed: argv.nuGetTestFeed,
     });

--- a/vnext/template/metro.devMode.config.js
+++ b/vnext/template/metro.devMode.config.js
@@ -1,0 +1,31 @@
+/**
+ * Metro configuration for React Native
+ * https://github.com/facebook/react-native
+ *
+ * @format
+ */
+const fs = require('fs');
+const path = require('path');
+const rnwPath = fs.realpathSync(
+  path.resolve(require.resolve('react-native-windows/package.json'), '..'),
+);
+const hoistedModules = fs.realpathSync(
+  path.resolve(rnwPath, '..', 'node_modules'),
+);
+module.exports = {
+  watchFolders: [rnwPath, hoistedModules],
+  resolver: {
+    extraNodeModules: {
+      // Redirect react-native-windows to avoid symlink (metro doesn't like symlinks)
+      'react-native-windows': rnwPath,
+    },
+  },
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
+};


### PR DESCRIPTION
Fixes #5605

`--useDevMode` operates using `yarn link`, which symlinks the `react-native-windows` directory in node_modules. This confuses Metro, which doesn't understand symlinks, and doesn't know how to find modules hoisted above `react-native-windows`.

Copy a custom metro config when using `--useDevMode` so we can bundle in the symlinked environment.

Validated creating a new app, validating we have the devmode config, then launching the app.

Note that we still run into cross-package asset issues, where we're missing an image from the new app screen. This isn't super needed for the new app screen, but maybe something we should fix as well.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6399)