### PR TITLE
Add ReactNativeHost::FromContext method

### DIFF
--- a/change/react-native-windows-2020-11-02-10-56-27-PR-ReactNativeHostFromContext.json
+++ b/change/react-native-windows-2020-11-02-10-56-27-PR-ReactNativeHostFromContext.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add ReactNativeHost::FromContext method",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-02T18:56:27.284Z"
+}

--- a/packages/microsoft-reactnative-sampleapps/index.windows.js
+++ b/packages/microsoft-reactnative-sampleapps/index.windows.js
@@ -310,6 +310,16 @@ class SampleApp extends Component {
     log(`SampleApp.onLabelChangedCustomUserControlCpp("${label}")`);
   }
 
+  onReloadSampleModuleCS() {
+    log('SampleApp.onReloadSampleModuleCS()');
+    NativeModules.SampleModuleCS.ReloadInstance();
+  }
+
+  onReloadSampleModuleCpp() {
+    log('SampleApp.onReloadSampleModuleCpp()');
+    NativeModules.SampleModuleCpp.ReloadInstance();
+  }
+
   render() {
     return (
       <View style={styles.container}>
@@ -332,6 +342,9 @@ class SampleApp extends Component {
 
         <CustomUserControlCpp style={styles.customcontrol} label="CustomUserControlCpp!" ref={(ref) => { this._CustomUserControlCppRef = ref; }} onLabelChanged={(evt) => { this.onLabelChangedCustomUserControlCpp(evt); }} />
         <Button onPress={() => { this.onPressCustomUserControlCpp(); }} title="Call CustomUserControlCpp Commands!" />
+
+        <Button onPress={() => { this.onReloadSampleModuleCS(); }} title="Reload from SampleModuleCS" disabled={NativeModules.SampleModuleCS == null} />
+        <Button onPress={() => { this.onReloadSampleModuleCpp(); }} title="Reload from SampleModuleCpp" disabled={NativeModules.SampleModuleCpp == null} />
 
         <CircleCS style={styles.circle}>
           <View style={styles.box}>

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCPP/SampleModuleCPP.h
@@ -27,6 +27,9 @@ struct Point {
 };
 
 // Sample REACT_MODULE
+// The important notes about the module class:
+// - The module class must have the REACT_MODULE attribute.
+// - All exported methods with custom attributes must be public and noexcept.
 
 REACT_MODULE(SampleModuleCppImpl, L"SampleModuleCpp");
 struct SampleModuleCppImpl {
@@ -274,6 +277,11 @@ struct SampleModuleCppImpl {
   }
 
 #pragma endregion
+
+  REACT_METHOD(ReloadInstance)
+  void ReloadInstance() noexcept {
+    ReactNativeHost::FromContext(m_reactContext.Handle()).ReloadInstance();
+  }
 
  private:
   winrt::Windows::System::Threading::ThreadPoolTimer m_timer{nullptr};

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleLibraryCS/SampleModuleCS.cs
@@ -306,11 +306,11 @@ namespace SampleLibraryCS
             });
         }
 
-#endregion
+        #endregion
 
-#region JS Functions
+        #region JS Functions
 
-[ReactFunction("calcDistance", ModuleName = "SampleModuleCpp")]
+        [ReactFunction("calcDistance", ModuleName = "SampleModuleCpp")]
         public Action<Point, Point> CalcDistance = null;
 
         [ReactMethod("callDistanceFunction")]
@@ -321,6 +321,12 @@ namespace SampleLibraryCS
         }
 
         #endregion
+
+        [ReactMethod]
+        public void ReloadInstance()
+        {
+            ReactNativeHost.FromContext(_reactContext.Handle).ReloadInstance();
+        }
 
         private ThreadPoolTimer _timer;
         private int _timerCount = 0;

--- a/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.cpp
@@ -4,21 +4,12 @@
 #include "pch.h"
 #include "DevSettingsModule.h"
 #include "IReactContext.h"
+#include "ReactNativeHost.h"
 
 namespace Microsoft::ReactNative {
 
-React::ReactPropertyId<React::ReactNonAbiValue<Mso::VoidFunctor>> ReloadProperty() noexcept {
-  static React::ReactPropertyId<React::ReactNonAbiValue<Mso::VoidFunctor>> propId{L"ReactNative.DevSettings",
-                                                                                  L"Reload"};
-  return propId;
-}
-
 void DevSettings::Initialize(React::ReactContext const &reactContext) noexcept {
   m_context = reactContext;
-}
-
-/*static*/ void DevSettings::SetReload(Mso::React::ReactOptions const &options, Mso::VoidFunctor &&func) noexcept {
-  React::ReactPropertyBag(options.Properties).Set(ReloadProperty(), std::move(func));
 }
 
 void DevSettings::reload() noexcept {
@@ -26,7 +17,7 @@ void DevSettings::reload() noexcept {
 }
 
 /*static*/ void DevSettings::Reload(winrt::Microsoft::ReactNative::ReactPropertyBag const &properties) noexcept {
-  properties.Get(ReloadProperty())();
+  winrt::Microsoft::ReactNative::implementation::ReactNativeHost::GetReactNativeHost(properties).ReloadInstance();
 }
 
 void DevSettings::reloadWithReason(std::string /*reason*/) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.h
@@ -29,7 +29,6 @@ struct DevSettings {
   REACT_METHOD(removeListeners)
   static void removeListeners(double count) noexcept;
 
-  static void SetReload(Mso::React::ReactOptions const &options, Mso::VoidFunctor &&func) noexcept;
   static void Reload(winrt::Microsoft::ReactNative::ReactPropertyBag const &properties) noexcept;
 
   //! Toggles the element inspector UI, allowing visual inspection of the react UI

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -337,12 +337,6 @@ void ReactInstanceWin::Initialize() noexcept {
 
           auto nmp = std::make_shared<winrt::Microsoft::ReactNative::NativeModulesProvider>();
 
-          ::Microsoft::ReactNative::DevSettings::SetReload(
-              strongThis->Options(), [weakReactHost = m_weakReactHost]() noexcept {
-                if (auto reactHost = weakReactHost.GetStrongPtr()) {
-                  reactHost->ReloadInstance();
-                }
-              });
           LoadModules(nmp, m_options.TurboModuleProvider);
 
           auto modules = nmp->GetModules(m_reactContext, m_jsMessageThread.Load());

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -34,6 +34,11 @@ ReactNativeHost::ReactNativeHost() noexcept : m_reactHost{Mso::React::MakeReactH
 #endif
 }
 
+/*static*/ ReactNative::ReactNativeHost ReactNativeHost::FromContext(
+    ReactNative::IReactContext const &reactContext) noexcept {
+  return GetReactNativeHost(ReactPropertyBag{reactContext.Properties()});
+}
+
 IVector<IReactPackageProvider> ReactNativeHost::PackageProviders() noexcept {
   return InstanceSettings().PackageProviders();
 }

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.h
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.h
@@ -17,6 +17,8 @@ struct ReactNativeHost : ReactNativeHostT<ReactNativeHost> {
  public: // ReactNativeHost ABI API
   ReactNativeHost() noexcept;
 
+  static ReactNative::ReactNativeHost FromContext(ReactNative::IReactContext const &reactContext) noexcept;
+
   // property PackageProviders
   Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
 
@@ -30,7 +32,7 @@ struct ReactNativeHost : ReactNativeHostT<ReactNativeHost> {
 
  public:
   Mso::React::IReactHost *ReactHost() noexcept;
-  static winrt::Microsoft::ReactNative::ReactNativeHost GetReactNativeHost(ReactPropertyBag const &properties) noexcept;
+  static ReactNative::ReactNativeHost GetReactNativeHost(ReactPropertyBag const &properties) noexcept;
 
  private:
   Mso::CntPtr<Mso::React::IReactHost> m_reactHost;

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.idl
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.idl
@@ -17,5 +17,7 @@ namespace Microsoft.ReactNative {
     Windows.Foundation.IAsyncAction LoadInstance();
     Windows.Foundation.IAsyncAction ReloadInstance();
     Windows.Foundation.IAsyncAction UnloadInstance();
+
+    static ReactNativeHost FromContext(IReactContext reactContext);
   }
 } // namespace Microsoft.ReactNative


### PR DESCRIPTION
For CodePush native module we need ability to reload React instance after the new bundle is loaded.
It means that a native module must have access to the ReactNativeHost.
Unfortunately, we cannot expose it from the IReactContext because it created a circular import dependency among IDL files.
In this PR we do the next best thing: add static `ReactNativeHost::FromContext` to acquire `ReactNativeHost` from the `IReactContext`.
Internally we store a weak pointer to `ReactNativeHost` inside of the Context Properties. When we retrieve the `ReactNativeHost`, we try to resolve the weak pointer. It may happen that `ReactNativeHost::FromContext` returns null if the `ReactNativeHost` is already deleted.
The Sample project changed to show how to use the new method to reload React instance.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6408)