### PR TITLE
[0.63] Set Content-Length on the content object and not on the request itself.

### DIFF
--- a/change/react-native-windows-2020-11-03-18-19-29-fix-content-length.json
+++ b/change/react-native-windows-2020-11-03-18-19-29-fix-content-length.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Set Content-Length on the content object and not on the request itself.",
+  "packageName": "react-native-windows",
+  "email": "i@mandrigin.ru",
+  "dependentChangeType": "patch",
+  "date": "2020-11-03T17:19:29.549Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
@@ -289,7 +289,7 @@ void NetworkingModule::NetworkingHelper::SendRequest(
         else if (_stricmp(name.c_str(), "content-encoding") == 0)
           contentEncoding = value;
         else if (_stricmp(name.c_str(), "content-length") == 0)
-            contentLength = value;
+          contentLength = value;
         else if (_stricmp(name.c_str(), "authorization") == 0)
           request.Headers().TryAppendWithoutValidation(
               Microsoft::Common::Unicode::Utf8ToUtf16(name), Microsoft::Common::Unicode::Utf8ToUtf16(value));

--- a/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
@@ -229,11 +229,16 @@ void NetworkingModule::NetworkingHelper::OnRequestError(int64_t requestId, std::
 void AttachContentHeaders(
     winrt::Windows::Web::Http::IHttpContent content,
     winrt::Windows::Web::Http::Headers::HttpMediaTypeHeaderValue contentType,
-    std::string contentEncoding) {
+    std::string contentEncoding,
+    std::string contentLength) {
   if (contentType != nullptr)
     content.Headers().ContentType(contentType);
   if (!contentEncoding.empty())
     content.Headers().ContentEncoding().ParseAdd(Microsoft::Common::Unicode::Utf8ToUtf16(contentEncoding));
+  if (!contentLength.empty()) {
+    auto contentLengthHeader = atoi(contentLength.c_str());
+    content.Headers().ContentLength() = contentLengthHeader;
+  }
 }
 
 void AttachMultipartHeaders(winrt::Windows::Web::Http::IHttpContent content, const folly::dynamic &headers) {
@@ -271,6 +276,7 @@ void NetworkingModule::NetworkingHelper::SendRequest(
 
     winrt::Windows::Web::Http::Headers::HttpMediaTypeHeaderValue contentType(nullptr);
     std::string contentEncoding;
+    std::string contentLength;
 
     if (!headers.empty()) {
       for (auto &header : headers.items()) {
@@ -282,6 +288,8 @@ void NetworkingModule::NetworkingHelper::SendRequest(
               Microsoft::Common::Unicode::Utf8ToUtf16(value), contentType);
         else if (_stricmp(name.c_str(), "content-encoding") == 0)
           contentEncoding = value;
+        else if (_stricmp(name.c_str(), "content-length") == 0)
+            contentLength = value;
         else if (_stricmp(name.c_str(), "authorization") == 0)
           request.Headers().TryAppendWithoutValidation(
               Microsoft::Common::Unicode::Utf8ToUtf16(name), Microsoft::Common::Unicode::Utf8ToUtf16(value));
@@ -341,7 +349,7 @@ void NetworkingModule::NetworkingHelper::SendRequest(
       }
 
       if (content != nullptr) {
-        AttachContentHeaders(content, contentType, contentEncoding);
+        AttachContentHeaders(content, contentType, contentEncoding, contentLength);
         request.Content(content);
       }
     }

--- a/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
@@ -236,7 +236,7 @@ void AttachContentHeaders(
   if (!contentEncoding.empty())
     content.Headers().ContentEncoding().ParseAdd(Microsoft::Common::Unicode::Utf8ToUtf16(contentEncoding));
   if (!contentLength.empty()) {
-    auto contentLengthHeader = atoi(contentLength.c_str());
+    const auto contentLengthHeader = _atoi64(contentLength.c_str());
     content.Headers().ContentLength(contentLengthHeader);
   }
 }

--- a/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NetworkingModule.cpp
@@ -237,7 +237,7 @@ void AttachContentHeaders(
     content.Headers().ContentEncoding().ParseAdd(Microsoft::Common::Unicode::Utf8ToUtf16(contentEncoding));
   if (!contentLength.empty()) {
     auto contentLengthHeader = atoi(contentLength.c_str());
-    content.Headers().ContentLength() = contentLengthHeader;
+    content.Headers().ContentLength(contentLengthHeader);
   }
 }
 


### PR DESCRIPTION
fixes #6407

I made it similarly to `Content-Encoding`. I'm open for suggestions if something else needs to be adjusted here.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6414)