### PR TITLE
fix(cli): Also look for .msix* extensions in CheckIfNeedInstallCertificate

### DIFF
--- a/change/@react-native-windows-cli-7e62c157-c852-4a1e-b408-b1215790f7c6.json
+++ b/change/@react-native-windows-cli-7e62c157-c852-4a1e-b408-b1215790f7c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(cli): Also look for .msix* extensions in CheckIfNeedInstallCertificate",
+  "packageName": "@react-native-windows/cli",
+  "email": "tonguye@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/powershell/WindowsStoreAppUtils.ps1
+++ b/packages/@react-native-windows/cli/powershell/WindowsStoreAppUtils.ps1
@@ -143,7 +143,17 @@ function CheckIfNeedInstallCertificate
     )
 
     $PackagePath = Get-ChildItem (Join-Path $ScriptDir "*.appx") | Where-Object { $_.Mode -NotMatch "d" }
+    if ($PackagePath -eq $null)
+    {
+        $PackagePath = Get-ChildItem (Join-Path $ScriptDir "*.msix") | Where-Object { $_.Mode -NotMatch "d" }
+    }
+
     $BundlePath = Get-ChildItem (Join-Path $ScriptDir "*.appxbundle") | Where-Object { $_.Mode -NotMatch "d" }
+    if ($BundlePath -eq $null)
+    {
+        $BundlePath = Get-ChildItem (Join-Path $ScriptDir "*.msixbundle") | Where-Object { $_.Mode -NotMatch "d" }
+    }
+
     # There must be exactly 1 package/bundle
     if (($PackagePath.Count + $BundlePath.Count) -lt 1)
     {


### PR DESCRIPTION
When WindowsTargetPlatformMinVersion is set to >10.0.17134.0, a .msix is output instead of .appx. This causes CheckIfNeedInstallCertificate() to fail since it only looks for .msix.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6421)