### PR TITLE
[0.62] Fix word-wrapping behavior of tooltips (#5626)

### DIFF
--- a/change/react-native-windows-2020-08-03-16-13-47-tooltip.json
+++ b/change/react-native-windows-2020-08-03-16-13-47-tooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use string object for tooltips instead of textblocks since that breaks wordwrap etc",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T23:13:47.059Z"
+}

--- a/change/react-native-windows-2020-08-03-16-13-47-tooltip.json
+++ b/change/react-native-windows-2020-08-03-16-13-47-tooltip.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Use string object for tooltips instead of textblocks since that breaks wordwrap etc",
   "packageName": "react-native-windows",
   "email": "asklar@microsoft.com",

--- a/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
+++ b/vnext/ReactUWP/Views/FrameworkElementViewManager.cpp
@@ -449,9 +449,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (propertyName == "tooltip") {
       if (propertyValue.isString()) {
-        winrt::TextBlock tooltip = winrt::TextBlock();
-        tooltip.Text(asHstring(propertyValue));
-        winrt::ToolTipService::SetToolTip(element, tooltip);
+        winrt::ToolTipService::SetToolTip(element, winrt::box_value(asHstring(propertyValue)));
       }
     } else if (propertyName == "zIndex") {
       if (propertyValue.isNumber()) {


### PR DESCRIPTION
* Use string object for tooltips instead of textblocks since that breaks wordwrap etc

* Change files

* box hstring

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6432)