### PR TITLE
Improve path telemetry sanitization

### DIFF
--- a/change/@react-native-windows-telemetry-8939f9d3-227e-4c1d-a8ff-77767de329e4.json
+++ b/change/@react-native-windows-telemetry-8939f9d3-227e-4c1d-a8ff-77767de329e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "sanitize paths in other drives too",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -22,6 +22,7 @@ export function sanitizeMessage(msg: string): string {
   const parts = msg.split(/['[\]"]/g);
   const clean = [];
   const projectRoot = process.cwd().toLowerCase();
+  const pathRegEx = /[A-Za-z]:\\([^<>:;,?"*|/\\]+\\)*[^<>:;,?"*|/\\]+/gi;
   for (const part of parts) {
     if (part.toLowerCase().startsWith(projectRoot)) {
       const ext = path.extname(part);
@@ -43,6 +44,8 @@ export function sanitizeMessage(msg: string): string {
       );
 
       clean.push(part.replace(filepathRegEx, '[project_dir]\\...'));
+    } else if (pathRegEx.test(part)) {
+      clean.push(part.replace(pathRegEx, '[path]'));
     } else {
       clean.push(part);
     }

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -33,7 +33,7 @@ function getAnonymizedPath(filepath: string): string {
         process.env[knownPath] &&
         filepath.toLowerCase().startsWith(process.env[knownPath]!.toLowerCase())
       ) {
-        return `[${knownPath}]`;
+        return `[${knownPath}]\\???(${filepath.length})`;
       }
     }
   }
@@ -46,7 +46,7 @@ function getAnonymizedPath(filepath: string): string {
 export function sanitizeMessage(msg: string): string {
   const parts = msg.split(/['[\]"]/g);
   const clean = [];
-  const pathRegEx = /[A-Za-z]:\\([^<>:;,?"*\t\r\n|/\\]+\\)*([^<>:;,?"*\t\r\n|/\\]+)/gi;
+  const pathRegEx = /[A-Za-z]:\\([^<>:;,?"*\t\r\n|/\\]+\\)+([^<>:;,?"*\t\r\n|/]+)/gi;
   for (const part of parts) {
     if (pathRegEx.test(part)) {
       pathRegEx.lastIndex = -1;

--- a/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
@@ -40,7 +40,11 @@ test('Sanitize message, project_dir', () => {
     telemetry.sanitizeMessage(
       `this is the cwd: ${process.cwd()} and something else`,
     ),
-  ).toEqual(`this is the cwd: [project_dir]\\???(${(process.cwd() + ' and something else').length})`);
+  ).toEqual(
+    `this is the cwd: [project_dir]\\???(${
+      (process.cwd() + ' and something else').length
+    })`,
+  );
 });
 
 test('Sanitize message, node_modules', () => {
@@ -77,12 +81,19 @@ test('Sanitize message, node_modules', () => {
     telemetry.sanitizeMessage(
       `this is the cwd: ${process.cwd()}\\node_modules and something else that could be part of the path`,
     ),
-  ).toEqual(`this is the cwd: [project_dir]\\???(${(process.cwd() + '\\node_modules and something else that could be part of the path').length})`);
+  ).toEqual(
+    `this is the cwd: [project_dir]\\???(${
+      (
+        process.cwd() +
+        '\\node_modules and something else that could be part of the path'
+      ).length
+    })`,
+  );
   expect(
     telemetry.sanitizeMessage(
       `this is the cwd: ${process.cwd()}\\node_modules\\ a file under nm`,
     ),
-    ).toEqual(`this is the cwd: node_modules\\ a file under nm`);
+  ).toEqual(`this is the cwd: node_modules\\ a file under nm`);
 });
 
 test('Sanitize message, other path', () => {
@@ -103,8 +114,18 @@ test('Sanitize message, other path', () => {
     ),
   ).toEqual(`Cannot find module  react-native/package.json 
       Require stack:
-      - [appdata]\\???(${(process.env.APPDATA + '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\lib-commonjs\\Cli.js').length})
-      - [appdata]\\???(${(process.env.APPDATA + '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\bin.js').length})`);
+      - [appdata]\\???(${
+        (
+          process.env.APPDATA +
+          '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\lib-commonjs\\Cli.js'
+        ).length
+      })
+      - [appdata]\\???(${
+        (
+          process.env.APPDATA +
+          '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\bin.js'
+        ).length
+      })`);
 });
 
 test('Sanitize stack frame', () => {
@@ -219,7 +240,9 @@ test('thrown exception a->b, hello path', done => {
       const data = (envelope.data as any).baseData;
       expect(data.exceptions).toBeDefined();
       expect(data.exceptions.length).toEqual(1);
-      expect(data.exceptions[0].message).toEqual(`hello [project_dir]\\???(${process.cwd().length})`);
+      expect(data.exceptions[0].message).toEqual(
+        `hello [project_dir]\\???(${process.cwd().length})`,
+      );
 
       const stack = data.exceptions[0].parsedStack;
       expect(stack).toBeDefined();

--- a/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
@@ -40,7 +40,7 @@ test('Sanitize message, project_dir', () => {
     telemetry.sanitizeMessage(
       `this is the cwd: ${process.cwd()} and something else`,
     ),
-  ).toEqual('this is the cwd: [project_dir]\\...');
+  ).toEqual(`this is the cwd: [project_dir]\\???(${(process.cwd() + ' and something else').length})`);
 });
 
 test('Sanitize message, node_modules', () => {
@@ -55,14 +55,14 @@ test('Sanitize message, node_modules', () => {
   );
   expect(
     telemetry.sanitizeMessage(
-      `this is the cwd: '${process.cwd()}\\node_modules\\'`,
+      `this is the cwd: '${process.cwd()}\\node_modules\\foo'`,
     ),
-  ).toEqual('this is the cwd:  node_modules\\');
+  ).toEqual('this is the cwd:  node_modules\\foo');
   expect(
     telemetry.sanitizeMessage(
-      `uppercase: '${process.cwd().toUpperCase()}\\NODE_MODULES\\'`,
+      `uppercase: '${process.cwd().toUpperCase()}\\NODE_MODULES\\foo'`,
     ),
-  ).toEqual('uppercase:  node_modules\\');
+  ).toEqual('uppercase:  node_modules\\foo');
   expect(
     telemetry.sanitizeMessage(
       `lowercase: '${process.cwd().toLowerCase()}\\NODE_MODULES\\'`,
@@ -77,12 +77,12 @@ test('Sanitize message, node_modules', () => {
     telemetry.sanitizeMessage(
       `this is the cwd: ${process.cwd()}\\node_modules and something else that could be part of the path`,
     ),
-  ).toEqual('this is the cwd: [project_dir]\\...');
+  ).toEqual(`this is the cwd: [project_dir]\\???(${(process.cwd() + '\\node_modules and something else that could be part of the path').length})`);
   expect(
     telemetry.sanitizeMessage(
-      `this is the cwd: ${process.cwd()}\\node_modules\\ and something else that could be part of the path`,
+      `this is the cwd: ${process.cwd()}\\node_modules\\ a file under nm`,
     ),
-  ).toEqual('this is the cwd: [project_dir]\\...');
+    ).toEqual(`this is the cwd: node_modules\\ a file under nm`);
 });
 
 test('Sanitize message, other path', () => {
@@ -101,10 +101,10 @@ test('Sanitize message, other path', () => {
       - ${process.env.APPDATA}\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\lib-commonjs\\Cli.js
       - ${process.env.APPDATA}\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\bin.js`,
     ),
-  ).toEqual(`Cannot find module 'react-native/package.json'
-  Require stack:
-  - [appdata]
-  - [appdata]`);
+  ).toEqual(`Cannot find module  react-native/package.json 
+      Require stack:
+      - [appdata]\\???(${(process.env.APPDATA + '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\lib-commonjs\\Cli.js').length})
+      - [appdata]\\???(${(process.env.APPDATA + '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\bin.js').length})`);
 });
 
 test('Sanitize stack frame', () => {
@@ -219,7 +219,7 @@ test('thrown exception a->b, hello path', done => {
       const data = (envelope.data as any).baseData;
       expect(data.exceptions).toBeDefined();
       expect(data.exceptions.length).toEqual(1);
-      expect(data.exceptions[0].message).toEqual('hello [project_dir]\\...');
+      expect(data.exceptions[0].message).toEqual(`hello [project_dir]\\???(${process.cwd().length})`);
 
       const stack = data.exceptions[0].parsedStack;
       expect(stack).toBeDefined();

--- a/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
@@ -85,6 +85,23 @@ test('Sanitize message, node_modules', () => {
   ).toEqual('this is the cwd: [project_dir]\\...');
 });
 
+test('Sanitize message, other path', () => {
+  expect(
+    telemetry.sanitizeMessage(
+      `this is another path: 'A:\\foo\\bar\\baz'`,
+    ),
+  ).toEqual(
+    `this is another path:  [path]`,
+  );
+  expect(
+    telemetry.sanitizeMessage(
+      `this is another path: A:\\foo\\bar\\baz`,
+    ),
+  ).toEqual(
+    `this is another path: [path]`,
+  );
+});
+
 test('Sanitize stack frame', () => {
   const emptyFrame: appInsights.Contracts.StackFrame = {
     level: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.1", "@babel/generator@^7.5.0":
+"@babel/generator@^7.12.1", "@babel/generator@^7.12.5", "@babel/generator@^7.5.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.5.tgz#a2c50de5c8b6d708ab95be5e6053936c1884a4de"
   integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
@@ -264,7 +264,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.1", "@babel/parser@^7.12.3", "@babel/parser@^7.7.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5", "@babel/parser@^7.7.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
@@ -961,16 +961,16 @@
     "@babel/types" "^7.10.4"
 
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
-  integrity sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
+  integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.1"
+    "@babel/generator" "^7.12.5"
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.12.1"
-    "@babel/types" "^7.12.1"
+    "@babel/parser" "^7.12.5"
+    "@babel/types" "^7.12.5"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,6 +4228,11 @@ async-hook-jl@^1.7.6:
   dependencies:
     stack-chain "^1.3.7"
 
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
 async-listener@^0.6.0:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"


### PR DESCRIPTION
- sanitize non-project root paths
- map things like appdata/localappdata back to "[appdata]" etc.
follow up to #6403 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6434)