### PR TITLE
Fix TextInput not rendering sometimes

### DIFF
--- a/change/react-native-windows-9310cb02-467c-4f9a-9aae-0d74ea7dc001.json
+++ b/change/react-native-windows-9310cb02-467c-4f9a-9aae-0d74ea7dc001.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add force_layout to TextInput",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -117,6 +117,10 @@ class TextInputShadowNode : public ShadowNodeBase {
     return true;
   }
 
+  bool NeedsForceLayout() {
+    return true;
+  }
+
  private:
   void dispatchTextInputChangeEvent(winrt::hstring newText);
   void registerEvents();

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -117,7 +117,7 @@ class TextInputShadowNode : public ShadowNodeBase {
     return true;
   }
 
-  bool NeedsForceLayout() {
+  virtual bool NeedsForceLayout() override {
     return true;
   }
 


### PR DESCRIPTION
If placed inside a ScrollView, TextInput requires the height prop to be provided in order to appear on the screen - fixing this by forcing a XAML layout run before Yoga layout happens; verified in Playground\TextInput

Detailed explanation in #2642 
Based on fix from PR react-native-windows/pull/2859.

Fixes  #5686 Related #5437

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6451)