### PR TITLE
 Collect anonymized project name

### DIFF
--- a/change/@react-native-windows-cli-63a88995-cd00-4c15-8f81-7366247a68ad.json
+++ b/change/@react-native-windows-cli-63a88995-cd00-4c15-8f81-7366247a68ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Collect anonymized project name",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/projects/BarPackage/package.json
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/BarPackage/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bar",
+  "version": "1.2.3",
+  "description": "Synthetic project.json for testing project.json logic",
+  "license": "MIT"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/projects/BarPackage/package.json
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/BarPackage/package.json
@@ -2,5 +2,6 @@
   "name": "bar",
   "version": "1.2.3",
   "description": "Synthetic project.json for testing project.json logic",
-  "license": "MIT"
+  "license": "MIT",
+  "private":"true"
 }

--- a/packages/@react-native-windows/cli/src/e2etest/projects/FooPackage/package.json
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/FooPackage/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "1.2.3",
+  "description": "Synthetic project.json for testing project.json logic",
+  "license": "MIT"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/projects/FooPackage/package.json
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/FooPackage/package.json
@@ -2,5 +2,6 @@
   "name": "foo",
   "version": "1.2.3",
   "description": "Synthetic project.json for testing project.json logic",
-  "license": "MIT"
+  "license": "MIT",
+  "private":"true"
 }

--- a/packages/@react-native-windows/cli/src/e2etest/runWindows.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/runWindows.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {getAnonymizedProjectName} from '../runWindows/runWindows';
+
+test('getAnonymizedProjectName - Project Exists', async () => {
+  const fooName = await getAnonymizedProjectName(
+    `${__dirname}/projects/FooPackage`,
+  );
+  const barName = await getAnonymizedProjectName(
+    `${__dirname}/projects/BarPackage`,
+  );
+
+  expect(typeof fooName).toBe('string');
+  expect(typeof barName).toBe('string');
+
+  expect(fooName!.length).toBeGreaterThan(0);
+  expect(barName!.length).toBeGreaterThan(0);
+
+  expect(fooName).not.toBe(barName);
+});
+
+test('getAnonymizedProjectName - Project Doesnt Exist', async () => {
+  const emptyPackageName = await getAnonymizedProjectName(
+    `${__dirname}/projects/BlankApp`,
+  );
+  expect(emptyPackageName).toBeNull();
+});


### PR DESCRIPTION
This lets us pivot on projects, helping us to answer questions like "how many project using RNW exist" or "How long does it take for projects to adopt a new version".

The project name could contain confidential information/PII, so we put it through a cryptographically strong irreversible hash to prevent the possibility leaking it.

Validated through automated tests + CI doing run-windows in init tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6452)