### PR TITLE
Automatically run yarn + yarn build after checkout/pull

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
       "vnext"
     ]
   },
+  "husky": {
+    "hooks": {
+      "post-checkout": "yarn & yarn build",
+      "post-merge": "yarn & yarn build"
+    }
+  },
   "devDependencies": {
     "beachball": "^1.32.0",
     "husky": "^4.2.5",


### PR DESCRIPTION
A common source of dev issues on RNW is forgetting to install packages + build after checking out a new branch. This change adds git hooks to automatically build after checkout out a branch, or meging (or pulling by proxy).

Manually validated

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6453)