### PR TITLE
[0.63] Disable telemetry in other CI systems

### DIFF
--- a/change/@react-native-windows-cli-2020-11-10-10-54-55-CItel-0.63.json
+++ b/change/@react-native-windows-cli-2020-11-10-10-54-55-CItel-0.63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Disable telemetry in other CI systems",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-10T18:54:52.539Z"
+}

--- a/change/@react-native-windows-telemetry-2020-11-10-10-54-55-CItel-0.63.json
+++ b/change/@react-native-windows-telemetry-2020-11-10-10-54-55-CItel-0.63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Disable telemetry in other CI systems",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-10T18:54:55.009Z"
+}

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -93,7 +93,7 @@ export async function generateWindows(
     Telemetry.client?.trackException({exception: error});
     throw e;
   } finally {
-    if (options.telemetry && !process.env.AGENT_NAME) {
+    if (Telemetry.client) {
       let rnVersion = '';
       let cliVersion = '';
       try {

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -68,7 +68,7 @@ async function runWindows(
   config: Config,
   options: RunWindowsOptions,
 ) {
-  if (!options.telemetry || process.env.AGENT_NAME) {
+  if (!options.telemetry) {
     if (options.logging) {
       console.log('Disabling telemetry');
     }

--- a/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/sanitize.test.ts
@@ -14,6 +14,7 @@ import {
 import * as appInsights from 'applicationinsights';
 import {basename} from 'path';
 
+delete process.env.AGENT_NAME; // allow this test to run in Azure DevOps / GHA
 Telemetry.setup();
 Telemetry.client!.config.disableAppInsights = true;
 

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -136,7 +136,7 @@ if (argv.verbose) {
   console.log(argv);
 }
 
-if (!argv.telemetry || process.env.AGENT_NAME) {
+if (!argv.telemetry) {
   if (argv.verbose) {
     console.log('Disabling telemetry');
   }


### PR DESCRIPTION
We currently exclude AzureDevOps/GH actions, this change extends that exemption to CircleCI and Travis, and any other system that sets `CI=true`

Fixes #6477 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6478)