### PR TITLE
Update to nuget 5.8.0 as earlier versions have compatibility bugs with VS 16.8 and later

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -199,10 +199,10 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      # The commit tag in the nuspec requires that we use at least nuget 4.6
+      # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
       - task: NuGetToolInstaller@0
         inputs:
-          versionSpec: ">=4.6.0"
+          versionSpec: ">=5.8.0"
 
       - template: templates/prep-and-pack-nuget.yml
         parameters:

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -23,9 +23,10 @@ steps:
       script: |
         Get-WmiObject Win32_LogicalDisk
 
+  # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
   - task: NuGetToolInstaller@0
     inputs:
-      versionSpec: ">=4.6.0"
+      versionSpec: ">=5.8.0"
 
   - template: yarn-install.yml
 

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -67,9 +67,10 @@ steps:
 
   - template: set-version-vars.yml
 
+  # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
   - task: NuGetToolInstaller@0
     inputs:
-      versionSpec: ">=4.6.0"
+      versionSpec: ">=5.8.0"
 
   - ${{ if eq(parameters.useNuGet, true) }}:
     - template: prep-and-pack-nuget.yml

--- a/change/@react-native-windows-cli-4dacc674-7590-486d-8603-e83505ab6301.json
+++ b/change/@react-native-windows-cli-4dacc674-7590-486d-8603-e83505ab6301.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update nuget version in preparation of VS16.8 which has a breaking change compatibility issue with earlier nuget versoins",
+  "packageName": "@react-native-windows/cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-c270659d-5e61-4b4f-9fe6-c95c2b7d5ee4.json
+++ b/change/@react-native-windows-cli-c270659d-5e61-4b4f-9fe6-c95c2b7d5ee4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update nuget version in preparation of VS16.8 which has a breaking change compatibility issue with earlier nuget versoins",
+  "packageName": "@react-native-windows/cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/nuget-exe-531f8eeb-8a3a-4c50-b2e3-b4847e21de93.json
+++ b/change/nuget-exe-531f8eeb-8a3a-4c50-b2e3-b4847e21de93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update nuget version in preparation of VS16.8 which has a breaking change compatibility issue with earlier nuget versoins",
+  "packageName": "nuget-exe",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/nuget-exe-807cc9de-9a9e-4b72-82d5-2eaed832859c.json
+++ b/change/nuget-exe-807cc9de-9a9e-4b72-82d5-2eaed832859c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update nuget version in preparation of VS16.8 which has a breaking change compatibility issue with earlier nuget versoins",
+  "packageName": "nuget-exe",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -19,7 +19,7 @@ module.exports = {
       'js/**',
       "lib/**",
       "lib-commonjs/**",
-      "nuget-4.9.2.exe",
+      "nuget-*.exe",
     ],
   }
 };

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -24,7 +24,7 @@
     "glob": "^7.1.1",
     "inquirer": "^3.0.6",
     "mustache": "^4.0.1",
-    "nuget-exe": "4.9.2",
+    "nuget-exe": "5.8.0",
     "ora": "^3.4.0",
     "semver": "^7.3.2",
     "shelljs": "^0.8.4",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -24,7 +24,7 @@
     "glob": "^7.1.1",
     "inquirer": "^3.0.6",
     "mustache": "^4.0.1",
-    "nuget-exe": "5.8.0",
+    "nuget-exe": "5.8.0-0",
     "ora": "^3.4.0",
     "semver": "^7.3.2",
     "shelljs": "^0.8.4",

--- a/packages/nuget-exe/just-task.js
+++ b/packages/nuget-exe/just-task.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const https = require('https');
 const {argv, task, cleanTask, logger, option} = require('just-scripts');
 
-const NUGET_VERSION = '4.9.2';
+const NUGET_VERSION = '5.8.0';
 const nugetBinary = `./nuget-${NUGET_VERSION}.exe`;
 const nugetUrl = `https://dist.nuget.org/win-x86-commandline/v${NUGET_VERSION}/nuget.exe`;
 

--- a/packages/nuget-exe/package.json
+++ b/packages/nuget-exe/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nuget-exe",
-  "version": "4.9.2",
+  "version": "5.8.0",
   "description": "Repackaged NuGet.exe binary",
-  "main": "nuget-4.9.2.exe",
+  "main": "nuget-5.8.0.exe",
   "repository": "https://github.com/microsoft/react-native-windows",
   "license": "MIT",
   "scripts": {
@@ -13,6 +13,6 @@
     "just-scripts": "^0.44.7"
   },
   "files": [
-    "nuget-4.9.2.exe"
+    "nuget-5.8.0.exe"
   ]
 }

--- a/packages/nuget-exe/package.json
+++ b/packages/nuget-exe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuget-exe",
-  "version": "5.8.0",
+  "version": "5.8.0-0",
   "description": "Repackaged NuGet.exe binary",
   "main": "nuget-5.8.0.exe",
   "repository": "https://github.com/microsoft/react-native-windows",


### PR DESCRIPTION
This PR updates the nuget version used to build this repo during CI, as well as the nuget version customers use when they build their projects via the react-native-cli.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6501)