### PR TITLE
Enable documenting WinRT API inline

### DIFF
--- a/change/react-native-windows-061ca216-e9e4-40f7-ac44-e00e60862e93.json
+++ b/change/react-native-windows-061ca216-e9e4-40f7-ac44-e00e60862e93.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add a custom WinRT attribute to be used to store documentation strings for WinRT types",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/DocString.h
+++ b/vnext/Microsoft.ReactNative/DocString.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_DOCSTRING
+#define DOC_STRING(x) [doc_string(x)]
+import "DocString.idl";
+#else
+#define DOC_STRING(x)
+#endif

--- a/vnext/Microsoft.ReactNative/DocString.idl
+++ b/vnext/Microsoft.ReactNative/DocString.idl
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/*
+  This exposes a custom WinRT attribute that can be applied to add documentation text used by winmd2markdown
+*/
+
+namespace Windows.Foundation.Metadata{
+
+  [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method)]
+  [attributename("doc_string")]
+  attribute DocStringAttribute {
+    String Content;
+  }
+}
+

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -156,6 +156,9 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Midl>
+      <PreprocessorDefinitions>USE_DOCSTRING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </Midl>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -181,6 +184,7 @@
       <DependentUpon>DevMenuControl.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="DocString.h" />
     <ClInclude Include="DynamicReader.h">
       <DependentUpon>IJSValueReader.idl</DependentUpon>
     </ClInclude>
@@ -564,6 +568,7 @@
       <DependentUpon>DevMenuControl.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="DocString.idl" />
     <Midl Include="IReactNonAbiValue.idl" />
     <Midl Include="IJSValueReader.idl" />
     <Midl Include="IJSValueWriter.idl" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -305,6 +305,10 @@
     <ClCompile Include="GlyphViewManager.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\ReactRootViewTagGenerator.cpp" />
+    <ClCompile Include="Modules\PaperUIManagerModule.cpp" />
+    <ClCompile Include="Views\PaperShadowNode.cpp" />
+    <ClCompile Include="Views\ShadowNodeRegistry.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABICxxModule.h" />
@@ -654,6 +658,11 @@
       <Filter>Utils</Filter>
     </ClInclude>
     <ClInclude Include="GlyphViewManager.h" />
+    <ClInclude Include="Modules\ReactRootViewTagGenerator.h" />
+    <ClInclude Include="Modules\PaperUIManagerModule.h" />
+    <ClInclude Include="Views\PaperShadowNode.h" />
+    <ClInclude Include="Views\ShadowNodeRegistry.h" />
+    <ClInclude Include="DocString.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />
@@ -689,6 +698,7 @@
     </Midl>
     <Midl Include="IViewManagerCore.idl" />
     <Midl Include="JsiApi.idl" />
+    <Midl Include="DocString.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="microsoft.reactnative.def" />


### PR DESCRIPTION
This change adds a custom WinRT attribute so that types, methods, structs, properties, etc. can be documented inline with the IDL definition. 
The string content used in the IDLs are picked up by a separate tool (winmd2markdown) and is only added to the Microsoft.ReactNative.winmd file in Debug builds.

To add a description to a WinRT method/type/member, in the corresponding IDL you can now do:

```diff
+#include "DocString.h"
  ... // other stuff
+ DOC_STRING("This is an enum")
  enum JSIEngine {
    Chakra = 0,
    Hermes = 1,
    V8 = 2
  };
```

similarly
```diff
+#include "DocString.h"
  ... // other stuff
  [default_interface]
  [webhosthidden]
+ DOC_STRING("foo bar")
  runtimeclass ReactRootView : XAML_NAMESPACE.Controls.Grid {
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6506)