### PR TITLE
Embed docs in winmd

### DIFF
--- a/change/react-native-windows-af66f506-7c5a-4ccb-ba10-2ba824bb8074.json
+++ b/change/react-native-windows-af66f506-7c5a-4ccb-ba10-2ba824bb8074.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Embed documentation of WinRT APIs in the winmd",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/DocString.h
+++ b/vnext/Microsoft.ReactNative/DocString.h
@@ -5,7 +5,9 @@
 
 #ifdef USE_DOCSTRING
 #define DOC_STRING(x) [doc_string(x)]
+#define DOC_DEFAULT(x) [doc_default(x)]
 import "DocString.idl";
 #else
 #define DOC_STRING(x)
+#define DOC_DEFAULT(x)
 #endif

--- a/vnext/Microsoft.ReactNative/DocString.idl
+++ b/vnext/Microsoft.ReactNative/DocString.idl
@@ -7,9 +7,14 @@
 
 namespace Windows.Foundation.Metadata{
 
-  [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method)]
+  [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
   [attributename("doc_string")]
   attribute DocStringAttribute {
+    String Content;
+  }
+
+  [attributeusage(target_property, target_method)]
+  [attributename("doc_default")] attribute DocDefaultAttribute {
     String Content;
   }
 }

--- a/vnext/Microsoft.ReactNative/DocString.idl
+++ b/vnext/Microsoft.ReactNative/DocString.idl
@@ -5,7 +5,7 @@
   This exposes a custom WinRT attribute that can be applied to add documentation text used by winmd2markdown
 */
 
-namespace Windows.Foundation.Metadata{
+namespace Microsoft.ReactNative {
 
   [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
   [attributename("doc_string")]

--- a/vnext/Microsoft.ReactNative/IJSValueReader.idl
+++ b/vnext/Microsoft.ReactNative/IJSValueReader.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // Type of value read from JavaScript by IJSValueReader
@@ -16,13 +18,27 @@ namespace Microsoft.ReactNative {
 
   // Forward only reader for JSON like streams or trees.
   [webhosthidden]
+  DOC_STRING("`IJSIValueReader` is used to read data from JavaScript in custom native modules.  It acts as a stream and supports all the types in [`JSValueType`](JSValueType.md).")
   interface IJSValueReader {
+    DOC_STRING("Returns the type of the current value.")
     JSValueType ValueType { get; };
+
+    DOC_STRING("Returns whether there is another property in the current object.  If there is `propertyName` indicates the name of the property.")
     Boolean GetNextObjectProperty(out String propertyName);
+
+    DOC_STRING("Moves the reader to the next array item.  Returns if there is another item in the array.")
     Boolean GetNextArrayItem();
+
+    DOC_STRING("Gets the current string value.")
     String GetString();
+
+    DOC_STRING("Gets the current boolean value.")
     Boolean GetBoolean();
+
+    DOC_STRING("Gets the current number value as an int.")
     Int64 GetInt64();
+
+    DOC_STRING("Gets the current number value as a double.")
     Double GetDouble();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IJSValueWriter.idl
+++ b/vnext/Microsoft.ReactNative/IJSValueWriter.idl
@@ -1,24 +1,48 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // Writer for JSON-like streams or tree structures
   [webhosthidden]
+  DOC_STRING("``IJSValueWriter`` is used to read data from JavaScript in custom native modules.  It acts as a stream and supports all the types in [`JSValueType`](JSValueType.md).")
   interface IJSValueWriter {
+    DOC_STRING("Write a null value.")
     void WriteNull();
+
+    DOC_STRING("Write a boolean value.")
     void WriteBoolean(Boolean value);
+
+    DOC_STRING("Write a number value from an integer.")
     void WriteInt64(Int64 value);
+
+    DOC_STRING("Write a number value from a double.")
     void WriteDouble(Double value);
+
+    DOC_STRING("Write a string value")
     void WriteString(String value);
+
+    DOC_STRING("Start writing an object.")
     void WriteObjectBegin();
+
+    DOC_STRING("Write a property within an object.  This should then be followed by writing the value of that property.")
     void WritePropertyName(String name);
+
+    DOC_STRING("Complete writing an object.")
     void WriteObjectEnd();
+
+    DOC_STRING("Start writing an array.")
     void WriteArrayBegin();
+
+    DOC_STRING("Complete writing an array.")
     void WriteArrayEnd();
   }
 
   // Use this delegate to pass arbitrary value to ABI API.
   // In a function that implements the delegate use the provided writer to stream custom values.
+  DOC_STRING("Use this delegate to pass arbitrary value to ABI API. \n\
+In a function that implements the delegate use the provided writer to stream custom values.")
   delegate void JSValueArgWriter(IJSValueWriter writer);
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IJSValueWriter.idl
+++ b/vnext/Microsoft.ReactNative/IJSValueWriter.idl
@@ -7,7 +7,7 @@ namespace Microsoft.ReactNative {
 
   // Writer for JSON-like streams or tree structures
   [webhosthidden]
-  DOC_STRING("``IJSValueWriter`` is used to read data from JavaScript in custom native modules.  It acts as a stream and supports all the types in [`JSValueType`](JSValueType.md).")
+  DOC_STRING("`IJSValueWriter` is used to read data from JavaScript in custom native modules.  It acts as a stream and supports all the types in [`JSValueType`](JSValueType.md).")
   interface IJSValueWriter {
     DOC_STRING("Write a null value.")
     void WriteNull();

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -9,6 +9,8 @@ import "IReactPropertyBag.idl";
 #include "NamespaceRedirect.h"
 #endif
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // The IReactContext is given to native modules to communicate with
@@ -19,30 +21,44 @@ namespace Microsoft.ReactNative {
   // Use the Notifications to exchange events with other components.
   // Use CallJSFunction to call JavaScript functions, and EmitJSEvent to raise JavaScript events.
   [webhosthidden]
+  DOC_STRING("The `IReactContext` object is given to native modules to communicate with other native modules, views, application, and the React Native instance. \n\
+It has the same lifetime as the React instance. When the React instance is reloaded or unloaded, the `IReactContext` is destroyed. \n\
+- Use the Properties to share native module's data with other components. \n\
+- Use the Notifications to exchange events with other components. \n\
+- Use `CallJSFunction` to call JavaScript functions, and `EmitJSEvent` to raise JavaScript events.")
   interface IReactContext {
     // Properties shared with the IReactInstanceSettings.Properties. It can be used to share values and state between components.
+    DOC_STRING("Properties shared with the [`IReactInstanceSettings.Properties`](IReactInstanceSettings.md#Properties). It can be used to share values and state between components.")
     IReactPropertyBag Properties { get; };
 
     // Notifications shared with the IReactInstanceSettings.Notifications. They can be used to exchange events between components.
     // All subscriptions added to the IReactContext.Notifications are automatically removed after the IReactContext is destroyed.
     // The subscriptions added to IReactInstanceSettings.Notifications kept as long as IReactInstanceSettings alive.
+    DOC_STRING("Notifications shared with the [`IReactInstanceSettings.Notifications`](IReactInstanceSettings.md#Notifications). They can be used to exchange events between components. \n\
+All subscriptions added to the `IReactContext.Notifications` are automatically removed after the `IReactContext` is destroyed. \n\
+The subscriptions added to the `IReactInstanceSettings.Notifications` are kept as long as `IReactInstanceSettings` is alive.")
     IReactNotificationService Notifications { get; };
 
     // Get ReactDispatcherHelper::UIDispatcherProperty from the Properties property bag.
+    DOC_STRING("Get `ReactDispatcherHelper::UIDispatcherProperty` from the Properties property bag.")
     IReactDispatcher UIDispatcher { get; };
 
     // Get ReactDispatcherHelper::JSDispatcherProperty from the Properties property bag.
+    DOC_STRING("Get `ReactDispatcherHelper::JSDispatcherProperty` from the Properties property bag.")
     IReactDispatcher JSDispatcher { get; };
 
 #ifndef CORE_ABI
     // Deprecated: Use DispatchEvent on XamlUIService instead
+    DOC_STRING("> Deprecated: Use `DispatchEvent` on [`XamlUIService`](XamlUIService.md) instead")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 #endif
 
     // Call JavaScript function methodName of moduleName.
+    DOC_STRING("Call the JavaScript function named `methodName` of `moduleName`.")
     void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
 
     // Call JavaScript module event. It is a specialized CallJSFunction call where method name is always 'emit'.
+    DOC_STRING("Call JavaScript module event. It is a specialized `CallJSFunction` call where method name is always 'emit'.")
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
 
 #ifndef CORE_ABI

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -2,20 +2,26 @@
 // Licensed under the MIT License.
 
 import "IReactPropertyBag.idl";
+#include "DocString.h"
 
 namespace Microsoft.ReactNative {
 
   // The delegate is used to create property value on-demand.
   [webhosthidden]
+  DOC_STRING("The delegate is used to create property value on-demand.")
   delegate void ReactDispatcherCallback();
 
   [webhosthidden]
+  DOC_STRING("`IReactDispatcher` provides the core threading/task management interface for ensuring code happens in the right order on the right thread. \
+One primary dispatcher that applications may require is the [`UIDispatcher`](IReactContext.md#uidispatcher) which provides native modules access to the UI thread associated with this react instance.   Another one is the [`JSDispatcher`](IReactContext.md#jsdispatcher) which allows apps to post tasks to the JS engine thread.")
   interface IReactDispatcher
   {
     // True if dispatcher uses current thread.
+    DOC_STRING("`true` if the dispatcher uses current thread.")
     Boolean HasThreadAccess { get; };
 
     // Post task for the asynchronous execution.
+    DOC_STRING("Post a task to the dispatcher.  This callback will be called asynchronously on the thread/queue associated with this dispatcher.")
     void Post(ReactDispatcherCallback callback);
   }
 

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
@@ -5,10 +5,13 @@ import "IJSValueReader.idl";
 import "IJSValueWriter.idl";
 import "IReactContext.idl";
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // A delegate that will set reactContext for a module.
   // We use it for a stand-alone initialize method, strongly typed JS events and functions.
+  DOC_STRING("A delegate that will set `reactContext` for a module. We use it for a stand-alone initialize method, strongly typed JS events and functions.")
   delegate void InitializerDelegate(IReactContext reactContext);
 
   // Native method return type.
@@ -20,9 +23,11 @@ namespace Microsoft.ReactNative {
   };
 
   // A callback to call JS code with results.
+  DOC_STRING("A callback to call JS code with results.")
   delegate void MethodResultCallback(IJSValueWriter outputWriter);
 
   // A delegate to call native asynchronous method.
+  DOC_STRING("A delegate to call native asynchronous method.")
   delegate void MethodDelegate(
       IJSValueReader inputReader,
       IJSValueWriter outputWriter,
@@ -30,17 +35,27 @@ namespace Microsoft.ReactNative {
       MethodResultCallback reject);
 
   // A delegate to call native synchronous method.
+  DOC_STRING("A delegate to call native synchronous method.")
   delegate void SyncMethodDelegate(IJSValueReader inputReader, IJSValueWriter outputWriter);
 
   // A delegate to gather constants from native modules.
+  DOC_STRING("A delegate to gather constants from native modules.")
   delegate void ConstantProviderDelegate(IJSValueWriter constantWriter);
 
   // Builds native modules inside of React Native code based on the provided meta-data.
   [webhosthidden]
+  DOC_STRING("Builds native modules inside of React native code based on the provided meta-data. \
+See [Native Modules](native-modules.md) for more usage information.")
   interface IReactModuleBuilder {
+
+    DOC_STRING("An initializer is a method that will be called when the react instance starts.  It provides the native module with the [`IReactContext`](IReactContext.md) for the running instance. See [`InitializerDelegate`](#initializerdelegate).")
     void AddInitializer(InitializerDelegate initializer);
+
+    DOC_STRING("The [`JSValue`](JSValue.md) written by the [`ConstantProviderDelegate`](ConstantProviderDelegate.md) will be available as constants on the native module is JavaScript.")
     void AddConstantProvider(ConstantProviderDelegate constantProvider);
     void AddMethod(String name, MethodReturnType returnType, MethodDelegate method);
+
+    DOC_STRING("Adds a synchronous method to the native module.  See [`SyncMethodDelegate`](SyncMethodDelegate.md).")
     void AddSyncMethod(String name, SyncMethodDelegate method);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactNonAbiValue.idl
+++ b/vnext/Microsoft.ReactNative/IReactNonAbiValue.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // IReactNonAbiValue helps to wrap up a non-ABI safe C++ values into an
@@ -8,9 +10,12 @@ namespace Microsoft.ReactNative {
   // It also can be used to store values in the IReactPropertyBag that do not
   // need to go through the EXE/DLL boundary.
   [webhosthidden]
+  DOC_STRING("`IReactNonAbiValue` helps wrap a non-ABI-safe C++ value into an `IInspectable` object. Use it to handle native module lifetime. \
+It also can be used to store values in the [`IReactPropertyBag`](IReactPropertyBag.md) that do not need to go through the EXE/DLL boundary.")
   interface IReactNonAbiValue
   {
     // Get a pointer to the stored value.
+    DOC_STRING("Get a pointer to the stored value.")
     Int64 GetPtr();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.idl
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.idl
@@ -4,22 +4,28 @@
 import "IReactDispatcher.idl";
 import "IReactPropertyBag.idl";
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // A subscription to a notification.
   // The subscription is removed when this object is deleted or the Unsubscribe method is called.
   [webhosthidden]
+  DOC_STRING("A subscription to a notification. The subscription is removed when this object is deleted or the [`Unsubscribe`](#Unsubscribe) method is called.")
   interface IReactNotificationSubscription
   {
     // Name of the notification.
+    DOC_STRING("Name of the notification.")
     IReactPropertyName NotificationName { get; };
 
     // The IReactDispatcher provided when the notification subscription created.
     // All notifications will be handled using this dispatcher.
+    DOC_STRING("The [`IReactDispatcher`](IReactDispatcher.md) provided when the notification subscription created. All notifications will be handled using this dispatcher.")
     IReactDispatcher Dispatcher { get; };
 
     // True if the subscription is still active.
     // This property is checked before notification handler is invoked.
+    DOC_STRING("True if the subscription is still active. This property is checked before notification handler is invoked.")
     Boolean IsSubscribed { get; };
 
     // Remove the subscription.
@@ -27,6 +33,10 @@ namespace Microsoft.ReactNative {
     // after the Unsubscribe method called if the IsSubscribed property is already checked.
     // Consider calling the Unsubscribe method and the handler in the same IReactDispatcher
     // to ensure that no handler is invoked after the Unsubscribe method call.
+    DOC_STRING("Remove the subscription. Because of the multi-threaded nature of the notifications, the handler can be still called \
+after the Unsubscribe method called if the IsSubscribed property is already checked. \
+Consider calling the Unsubscribe method and the handler in the same [`IReactDispatcher`](IReactDispatcher.md) \
+to ensure that no handler is invoked after the Unsubscribe method call.")
     void Unsubscribe();
   }
 
@@ -52,6 +62,7 @@ namespace Microsoft.ReactNative {
 
   // The notification service is used to subscribe to notifications and to send notifications.
   [webhosthidden]
+  DOC_STRING("The notification service is used to subscribe to notifications and to send notifications")
   interface IReactNotificationService
   {
     // Subscribe to a notification.
@@ -60,6 +71,12 @@ namespace Microsoft.ReactNative {
     // The handler is a delegate that can be implemented as a lambda to handle notifications.
     // The method returns IReactNotificationSubscription that must be kept alive while the subscription
     // is active. The subscription is removed when the IReactNotificationSubscription is destroyed.
+    DOC_STRING("Subscribe to a notification. \
+    The `notificationName` is a non-null property name and can belong to a specific namespace. \n\
+    The dispatcher is used to call notification handlers. If it is null, then the handler is called synchronously. \
+    The handler is a delegate that can be implemented as a lambda to handle notifications. \
+    The method returns a [`IReactNotificationSubscription`](IReactNotificationSubscription.md) that must be kept alive while the subscription \
+    is active. The subscription is removed when the [`IReactNotificationSubscription`](IReactNotificationSubscription.md) is destroyed.")
     IReactNotificationSubscription Subscribe(
       IReactPropertyName notificationName, IReactDispatcher dispatcher, ReactNotificationHandler handler);
 
@@ -68,14 +85,19 @@ namespace Microsoft.ReactNative {
     // The data is the data associated with the notification. It can be null.
     // Consider using IReactPropertyBag for sending semi-structured data. It can be created
     // using the ReactPropertyBagHelper.CreatePropertyBag method.
+    DOC_STRING("Send the notification with `notificationName`. The sender is the object that sends notification and can be null. The `data` is the data \
+associated with the notification and can be null. Consider using [`IReactPropertyBag`](IReactPropertyBag.md) for sending semi-structured data. \
+It can be created using the [`ReactPropertyBagHelper.CreatePropertyBag`](ReactPropertyBagHelper.md#CreatePropertyBag) method.")
     void SendNotification(IReactPropertyName notificationName, Object sender, Object data);
   }
 
   // Helper methods for the notification service implementation.
   [webhosthidden]
+  DOC_STRING("Helper methods for the notification service implementation.")
   static runtimeclass ReactNotificationServiceHelper
   {
     // Create new instance of IReactNotificationService
+    DOC_STRING("Create new instance of IReactNotificationService")
     static IReactNotificationService CreateNotificationService();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -7,17 +7,26 @@ import "IReactModuleBuilder.idl";
 import "IViewManager.idl";
 #endif
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
+  DOC_STRING("Provides information about a custom native module.  See [`IReactModuleBuilder`](IReactModuleBuilder.md).")
   delegate Object ReactModuleProvider(IReactModuleBuilder moduleBuilder);
+
 #ifndef CORE_ABI
+  DOC_STRING("Provides information about a custom view manager.  See [`IViewManager`](IViewManager.md).")
   delegate IViewManager ReactViewManagerProvider();
 #endif
 
   [webhosthidden]
+  DOC_STRING("A `ReactPackageBuilder` provides the react instance with all the native modules and view managers that will be available in the React instance.")
   interface IReactPackageBuilder {
+    DOC_STRING("Adds a custom native module. See [`ReactModuleProvider`](#reactmoduleprovider).")
     void AddModule(String moduleName, ReactModuleProvider moduleProvider);
+
 #ifndef CORE_ABI
+    DOC_STRING("Adds a custom native module. See [`ReactViewManagerProvider`](#reactviewmanagerprovider).")
     void AddViewManager(String viewManagerName, ReactViewManagerProvider viewManagerProvider);
 #endif
   }

--- a/vnext/Microsoft.ReactNative/IReactPackageProvider.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageProvider.idl
@@ -3,11 +3,15 @@
 
 import "IReactPackageBuilder.idl";
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // This interface is to be implemented by package creators.
   [webhosthidden]
+  DOC_STRING("This interface is to be implemented by package creators.")
   interface IReactPackageProvider {
+    DOC_STRING("Provides a [`IReactPackageBuilder`](IReactPackageBuilder.md) which the app or package will use to register custom native modules and view managers.")
     void CreatePackage(IReactPackageBuilder packageBuilder);
   };
 

--- a/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
+++ b/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // The delegate is used to create property value on-demand.
   [webhosthidden]
+  DOC_STRING("This delegate is used to create a property value on-demand.")
   delegate Object ReactCreatePropertyValue();
 
   // Namespace for the property name.
@@ -33,9 +36,11 @@ namespace Microsoft.ReactNative {
   // It is expected that there will be no direct use of this interface.
   // Ideally, all usage should happen through a strongly typed accessors.
   [webhosthidden]
+  DOC_STRING("`IReactPropertyBag` provides a thread-safe property storage. Properties are identified by an instance of `IReactPropertyName`. It is expected that there will be no direct use of this interface. Ideally, all usage should happen through strongly-typed accessors.")
   interface IReactPropertyBag
   {
-    // Get property value by its name. It returns null if the property does not exist.
+    // Get a property's value. It returns null if the property does not exist.
+    DOC_STRING("Get a property's value. It returns null if the property does not exist.")
     Object Get(IReactPropertyName name);
 
     // Get property value for the property name.
@@ -44,12 +49,20 @@ namespace Microsoft.ReactNative {
     // The createValue is called outside of lock. It is possible that its
     // result is not used in case if other thread sets the property value before
     // the created value is applied.
+    DOC_STRING("Get a property's value. If the property does not exist, this method creates it by calling the `createValue` delegate. \
+The function may return null if the `createValue` returns null when called.\
+The `createValue` is called outside of any locks. \
+It is possible that its result is not used in case another thread sets the property value before the created value is applied.")
     Object GetOrCreate(IReactPropertyName name, ReactCreatePropertyValue createValue);
 
     // Set property value for the property name.
     // It returns previously stored property value.
     // It returns null if property did not exist.
     // If the new value is null, then the property is removed.
+    DOC_STRING("Set a property's value. \
+It returns the previously-stored property value. \
+It returns null if the property did not exist. \
+If the new value is null, then the property is removed.")
     Object Set(IReactPropertyName name, Object value);
   }
 

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -4,11 +4,14 @@
 import "IViewManagerCore.idl";
 
 #include "NamespaceRedirect.h"
+#include "DocString.h"
 
 namespace Microsoft.ReactNative
 {
 
   [webhosthidden]
+  DOC_STRING("See the documentation of [Native UI Components](view-managers.md) for information on how to author a view manager.\n\
+>**This documentation and the underlying platform code is a work in progress.**")
   interface IViewManager
   {
     String Name { get; };

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -3,21 +3,33 @@
 
 import "ReactNativeHost.idl";
 #include "NamespaceRedirect.h"
+#include "DocString.h"
 
 namespace Microsoft.ReactNative {
 
   [webhosthidden]
   [default_interface]
+  DOC_STRING("`ReactApplication` provides a base application class for use in applications that are entirely written in React Native. `ReactApplication` will load the React instance on launch of your app for you and provide accessors to your application's [`ReactInstanceSettings`](ReactInstanceSettings.md) and [`ReactNativeHost`](ReactNativeHost.md) to customize your React instance.")
   unsealed runtimeclass ReactApplication : XAML_NAMESPACE.Application {
     ReactApplication();
 
+    DOC_STRING("Provides access to your application's [`ReactInstanceSettings`](ReactInstanceSettings.md).  Generally, changes to these settings will not take effect if the React instance is already loaded, unless the React instance is reloaded, so most settings should be set in your applications constructor.")
     ReactInstanceSettings InstanceSettings { get; set; };
+
+    DOC_STRING("Provides access to the list of `IReactPackageProvider`'s that the instance will use to provide native modules to the application. This can be used to register additional package providers, such as package providers from community modules. See [`ReactNativeHost`](ReactNativeHost.md) for more information.")
     IVector<IReactPackageProvider> PackageProviders { get; };
+
+    DOC_STRING("Access to the [`ReactNativeHost`](ReactNativeHost.md) of your application.")
     ReactNativeHost Host { get; };
 
+    DOC_STRING("Should the developer experience features such as the developer menu and `RedBox` be enabled.  See [`ReactInstanceSettings.UseDeveloperSupport`](ReactInstanceSettings.md#usedevelopersupport).")
     Boolean UseDeveloperSupport { get; set; };
+
     // Deprecated - Use JavaScriptBundleFile instead
+    DOC_STRING("See [`ReactInstanceSettings.JavaScriptMainModuleName`](ReactInstanceSettings.md#javascriptmainmodulename).")
     String JavaScriptMainModuleName { get; set; };
+
+    DOC_STRING("See [`ReactInstanceSettings.JavaScriptBundleFile`](ReactInstanceSettings.md#javascriptbundlefile).")
     String JavaScriptBundleFile { get; set; };
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -8,6 +8,8 @@ import "IReactPackageProvider.idl";
 import "IReactPropertyBag.idl";
 import "RedBoxHandler.idl";
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   // Keep in sync with enum in IReactInstance.h
@@ -36,35 +38,106 @@ namespace Microsoft.ReactNative {
   }
 
   [webhosthidden]
+  DOC_STRING("Provides configuration of the react instance.")
   runtimeclass ReactInstanceSettings 
   {
     ReactInstanceSettings();
 
+    DOC_STRING("Properties are shared with [`IReactContext.Properties`](IReactContext.md#properties). It can be used to configure and share values and state between components.")
     IReactPropertyBag Properties { get; };
+
+    DOC_STRING("Provides access to the `IReactNotificationService`, which allows easy communication between custom native modules or view managers.")
     IReactNotificationService Notifications { get; };
+
+    DOC_STRING("Provides a list of additional native modules and custom view managers that should be included in the instance.")
     IVector<IReactPackageProvider> PackageProviders { get; };
+
+    DOC_STRING("This controls whether various developer experience features are available for this instance.  In particular the developer menu, the default `RedBox` and `LogBox` experience and loading UI during bundle load.")
     Boolean UseDeveloperSupport { get; set; };
+
     // Deprecated - use JavaScriptBundleFile instead
+    DOC_STRING("Name of the JavaScript bundle file.  If [`JavaScriptBundleFile`](#javascriptbundlefile) is specified it is used instead.")
     String JavaScriptMainModuleName { get; set; };
+
+    DOC_STRING("The name of the JavaScript bundle file to load. This should be a relative path from [`BundleRootPath`](#bundlerootpath).  `.bundle` will be appended to the end, when looking for the bundle file.")
+    DOC_DEFAULT("index.windows")
     String JavaScriptBundleFile { get; set; };
+
+    DOC_STRING("Should the instance run in a remote environment such as within a browser.\n\
+By default, this is using a browser navigated to  http://localhost:8081/debugger-ui served by Metro/Haul.\n\
+Debugging will start as soon as the react native instance is loaded.")
     Boolean UseWebDebugger { get; set; };
+
+    DOC_STRING("Should the instance trigger the hot module reload logic when it first loads the instance.\n\
+Most edits should be visible within a second or two without the instance having to reload.\n\
+Non-compatible changes still cause full reloads.\n\
+See [Fast Refresh](https://reactnative.dev/docs/fast-refresh) for more information on Fast Refresh.")
     Boolean UseFastRefresh { get; set; };
+
+    DOC_STRING("Enable live reload to load the source bundle from the React Native packager.\n\
+When the file is saved, the packager will trigger reloading.\n\
+**For general use this has been replaced by [`UseFastRefresh`](#usefastrefresh).**")
     Boolean UseLiveReload { get; set; };
+
+    DOC_STRING("Enables debugging in the JavaScript engine (if supported).  \n\
+For Chakra this enables you to debug the JS runtime directly within your app using Visual Studio -> Attach to process (Script)")
     Boolean UseDirectDebugger { get; set; };
+
+    DOC_STRING("For direct debugging, whether to break on the next line of JavaScript that is executed.  This can help debug issues hit early in the JavaScript bundle load.\n\
+***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine***")
     Boolean DebuggerBreakOnNextLine { get; set; };
+
+    DOC_STRING("This controls if the JavaScript bridge should use the newer JSI runtime or use the legacy executor.  The JSI runtime is used by default, and the legacy executor will be removed in a future release. **It is not recommended to change this setting.**")
     Boolean UseJsi { get; set; };
+
+    DOC_STRING("Flag controlling whether the JavaScript engine uses JIT compilation.")
+    DOC_DEFAULT("true")
     Boolean EnableJITCompilation { get; set; };
+
+    DOC_STRING("For JS engines that support bytecode generation, this controls if bytecode should be generated when a JavaScript bundle is first loaded.\n\
+Subsequent runs of the application should be faster as the JavaScript will be loaded from bytecode instead of the raw JavaScript.  \n\
+[`ByteCodeFileUri`](#bytecodefileuri) must be set to a location the application has write access to in order for the bytecode to be successfully cached.")
+    DOC_DEFAULT("false")
     Boolean EnableByteCodeCaching { get; set; };
+
+    DOC_STRING("This controls whether various developer experience features are available for this instance.  In particular the developer menu, the default `RedBox` experience and the loading UI during bundle load.\n\
+> This property will be removed in a future version of **react-native-windows**\n\
+This property has been replaced by [`UseDeveloperSupport`](#usedevelopersupport). In the 0.63 both properties will do the same thing.")
     Boolean EnableDeveloperMenu { get; set; };
+
+    DOC_STRING("Set this to a location the application has write access to in order for bytecode to be successfully cached. See [`EnableByteCodeCaching`](#enablebytecodecaching).")
     String ByteCodeFileUri { get; set; };
+
+    DOC_STRING("When using a [`UseFastRefresh`](#usefastrefresh), [`UseLiveReload`](#uselivereload) or [`UseWebDebugger`](#usewebdebugger) this is the server that will be used to load the bundle from.\n\
+> This has been replaced with `SourceBundleHost` and `SourceBundlePort` and will be removed in a future version.\n")
+    DOC_DEFAULT("localhost:8081")
     String DebugHost { get; set; };
+
+    DOC_STRING("When loading from a bundle server (such as metro), this is the path that will be requested from the server.  If this is not provided the value of [`JavaScriptBundleFile`](#javascriptbundlefile) or [`JavaScriptMainModuleName`](#javascriptmainmodulename) is used.")
     String DebugBundlePath { get; set; };
+
+    DOC_STRING("Base path used for the location of the bundle.")
+    DOC_DEFAULT("ms-appx:///Bundle/")
     String BundleRootPath { get; set; };
+
+    DOC_STRING("When [`UseDirectDebugger`](#usedirectdebugger) is enabled, this controls the port that the JavaScript engine debugger will run on.")
+    DOC_DEFAULT("9229")
     UInt16 DebuggerPort { get; set; };
+
+    DOC_STRING("Provides an extension point to allow custom error handling within the react instance. See [`IRedBoxHandler`](IRedBoxHandler.md) for more information.")
     IRedBoxHandler RedBoxHandler { get; set; };
+
+    DOC_STRING("Control the main UI dispatcher to be used by the React instance.  If the `ReactSettingsInstance` object is initially created on a UI thread, then this will default to that thread.  The value provided here will be available to native modules and view managers using [`IReactContext.UIDispatcher`](IReactContext.md#uidispatcher)")
     IReactDispatcher UIDispatcher { get; set; };
+
+    DOC_STRING("When using a [`UseFastRefresh`](#usefastrefresh), [`UseLiveReload`](#uselivereload) or [`UseWebDebugger`](#usewebdebugger) this is the server hostname that will be used to load the bundle from.")
+    DOC_DEFAULT("localhost")
     String SourceBundleHost { get; set; };
+
+    DOC_STRING("When using a [`UseFastRefresh`](#usefastrefresh), [`UseLiveReload`](#uselivereload) or [`UseWebDebugger`](#usewebdebugger) this is the server port that will be used to load the bundle from.")
+    DOC_DEFAULT("8081")
     UInt16 SourceBundlePort { get; set; };
+
     JSIEngine JSIEngineOverride { get; set; };
     event Windows.Foundation.EventHandler<InstanceCreatedEventArgs> InstanceCreated;
     event Windows.Foundation.EventHandler<InstanceLoadedEventArgs> InstanceLoaded;

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.idl
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.idl
@@ -4,17 +4,26 @@
 import "IReactPackageProvider.idl";
 import "ReactInstanceSettings.idl";
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   [webhosthidden]
   [default_interface]
+  DOC_STRING("This is the main entry-point to create a react-native instance.  The `ReactNativeHost` object exists to configure the instance using [`ReactInstanceSettings`](ReactInstanceSettings.md) before its loaded, as well as enabling control of when to load the instance. \n\
+_In the future more lifecycle events will be added to this object to provide better information on when an instance is loaded and unloaded._")
   runtimeclass ReactNativeHost {
     ReactNativeHost();
 
+    DOC_STRING("Provides access to the list of `IReactPackageProvider`'s that the react instance will use to provide native modules to the application.  This can be used to register additional package providers, such as package providers from community modules or other shared libraries")
     IVector<IReactPackageProvider> PackageProviders { get; };
+
+    DOC_STRING("Provides access to your this host's [`ReactInstanceSettings`](ReactInstanceSettings.md) to configure the react instance.")
     ReactInstanceSettings InstanceSettings { get; set; };
 
     Windows.Foundation.IAsyncAction LoadInstance();
+
+    DOC_STRING("This is used to load the instance, which will create an instance of the JS engine and launch your JavaScript code.  If an instance of this host is already running, this will shutdown the already running instance, and load a new instance.")
     Windows.Foundation.IAsyncAction ReloadInstance();
     Windows.Foundation.IAsyncAction UnloadInstance();
 

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.idl
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.idl
@@ -3,37 +3,143 @@
 
 import "ReactNativeHost.idl";
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative {
 
   enum RedBoxErrorType {
+    DOC_STRING("A JS Exception was thrown and not caught or otherwise fatal error")
     JavaScriptFatal, // A JS Exception was thrown or otherwise fatal error
+
+    DOC_STRING("An error coming from JS that isn't fatal, such as `console.error`")
     JavaScriptSoft, // An error coming from JS that isn't fatal, such as console.error
+
+    DOC_STRING("An error happened in native code")
     Native,
   };
 
-  [webhosthidden] interface IRedBoxErrorFrameInfo {
+  [webhosthidden]
+  DOC_STRING("This object represents a single frame within the call stack of an error.")
+  interface IRedBoxErrorFrameInfo {
+    DOC_STRING("The file location of this frame")
     String File { get; };
+
+    DOC_STRING("The method name of this frame")
     String Method { get; };
+
+    DOC_STRING("The line number within the file")
     UInt32 Line { get; };
+
+    DOC_STRING("The column within the line")
     UInt32 Column { get; };
+
+    DOC_STRING("True if this frame is part of the internals of `react-native`, that is likely not useful for the developer to see.")
     Boolean Collapse { get; };
   }
 
-  [webhosthidden] interface IRedBoxErrorInfo {
+  [webhosthidden]
+  DOC_STRING("This object provides information about the error.  For JavaScript errors, a call stack is also provided.")
+  interface IRedBoxErrorInfo {
+    DOC_STRING("The error message.")
     String Message { get; };
+
+    DOC_STRING("If the message was adjusted for formatting, or otherwise processed, this contains the message before those modifications")
     String OriginalMessage { get; };
+
+    DOC_STRING("An identifier for this error.")
     String Name { get; };
+
+    DOC_STRING("This will contain the component stack where the error occurred, which can help identify the component that is producing the error")
     String ComponentStack { get; };
+
+    DOC_STRING("This Id can be used in [`UpdateError`](#updateerror) to identify which error is being updated.  For native errors, this is currently always `0`, and [`UpdateError`](#updateerror) will never be called.")
     UInt32 Id { get; };
+
+    DOC_STRING("For JavaScript errors, this will contain the call stack of where the error occurred.")
     IVectorView<IRedBoxErrorFrameInfo> Callstack { get; };
+
+    DOC_STRING("Provides access to extra data attached to the error.  Adding additional data to the errors is not yet part of the stable API.")
     IJSValueReader ExtraData { get; };
   }
 
   [webhosthidden]
+#ifdef USE_DOCSTRING
+  [doc_string(
+    "`IRedBoxHandler` provides an extension point to allow custom error handling within the React instance.  This can be useful if you have an existing error reporting system that you want React errors to be reported to.  The default implementation of `RedBoxHandler` shows an error messages in a error screen that covers the whole application window.
+
+-- Insert Screenshot here --
+
+If you want to maintain the existing `RedBox` behaviors, and also report errors to your own reporting system, your implementation can call into the default `RedBoxHandler`, which can be obtained by calling :
+
+```csharp
+RedBoxHelper::CreateDefaultHandler(Host);
+```
+
+Sample settings up a `RedBoxHandler` that reports errors to an external system, and displays the default `RedBox` experience within the application:
+
+```csharp
+
+class MyRedBoxHandler : IRedBoxHandler
+{
+    MyRedBoxHandler(IRedBoxHandler defaultHandler) {
+      innerHandler = defaultHandler;
+    }
+
+   public
+    void ShowNewError(IRedBoxErrorInfo info, RedBoxErrorType type) {
+      /-/ Dont report non-fatal errors (optional)
+      if (type != RedBoxErrorType.JavaScriptSoft)
+        ReportErrorToMyErrorReportingSystem(info, type);
+
+      /-/ Display errors in app if the instance is running with DevSupportEnabled
+      if (innerHandler.IsDevSupportEnabled)
+        innerHandler.ShowNewError(info, type);
+    }
+
+   public
+    bool IsDevSupportEnabled {
+      get;
+    }
+    {
+      /-/ The default handler will return true if the instance has DevSupport turned on
+      /-/ But if you want to record error information in released versions of your app
+      /-/ Then you should return true here, so that all errors get reported.
+      return true;
+    }
+
+   public
+    void UpdateError(IRedBoxErrorInfo info) {
+      if (innerHandler.IsDevSupportEnabled)
+        innerHandler.UpdateError(info);
+    }
+
+   public
+    void DismissRedBox() {
+      if (innerHandler.IsDevSupportEnabled)
+        innerHandler.DismissRedBox();
+    }
+
+   private
+    IRedBoxHandler innerHandler;
+}
+
+
+RegisterMyRedBoxHandler()
+{
+    Host.InstanceSettings.RedBoxHandler = new MyRedBoxHandler(RedBoxHelper.CreateDefaultHandler(Host));
+}
+
+```")]
+#endif
   interface IRedBoxHandler 
   {
+    DOC_STRING("This method is called when an error is initially hit.")
     void ShowNewError(IRedBoxErrorInfo info, RedBoxErrorType type);
+
+    DOC_STRING("This property will control if errors should be reported to the handler.  If this returns false, [`ShowNewError`](#shownewerror) and [`UpdateError`](#updateerror) will not be called.")
     Boolean IsDevSupportEnabled { get; };
+
+    DOC_STRING("This method is called when updated information about an error has been resolved.  For JavaScript errors, this is called if source map information was able to be resolved to provide a more useful call stack.")
     void UpdateError(IRedBoxErrorInfo info);
     void DismissRedBox();
   }
@@ -42,6 +148,8 @@ namespace Microsoft.ReactNative {
   [default_interface]
   runtimeclass RedBoxHelper {
     RedBoxHelper();
+
+    DOC_STRING("This provides access to the default `IRedBoxHandler`. This can be used to display the default `RedBox` as part of a custom `RedBoxHandler` implementation.")
     static IRedBoxHandler CreateDefaultHandler(Microsoft.ReactNative.ReactNativeHost host);
   }
 

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -4,16 +4,21 @@
 import "IReactContext.idl";
 
 #include "NamespaceRedirect.h"
+#include "DocString.h"
 
 namespace Microsoft.ReactNative {
 
   [default_interface]
   [webhosthidden]
+  DOC_STRING("Provides access to XAML UI-specific functionality. It provides access to APIs to get a XAML element from a react tag, and to dispatch events to JS components.")
   runtimeclass XamlUIService {
+    DOC_STRING("Use this method to gain access to the `XamlUIService` from a `ReactContext`.")
     static XamlUIService FromContext(IReactContext context);
 
+    DOC_STRING("Get the backing XAML element from a react tag.")
     XAML_NAMESPACE.DependencyObject ElementFromReactTag(Int64 reactTag);
 
+    DOC_STRING("Dispatch an event to a JS component.")
     // Dispatch UI event. This method is to be moved to IReactViewContext.
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 


### PR DESCRIPTION
Builds upon #6506 
Fixes #6509

Moves the documentation text from samples onto the winmd so there is one source of truth and it makes it clear what APIs are still undocumented.

Added another attribute to signify default value for a property.

Also added some docs for things we had // style comments, now those will show up in the winmd and be interpreted as part of the native API generation pass.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6508)