### PR TITLE
Print out sessionId if verbose

### DIFF
--- a/change/@react-native-windows-cli-edfb8099-c06e-41ab-a9c1-7c2385019025.json
+++ b/change/@react-native-windows-cli-edfb8099-c06e-41ab-a9c1-7c2385019025.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "print out sessionId when erroring out in run-windows so people can choose to let us know when filing bugs",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -29,6 +29,11 @@ function setExitProcessWithError(loggingWasEnabled: boolean): void {
     console.log(
       `Re-run the command with ${chalk.bold('--logging')} for more information`,
     );
+    if (Telemetry.client) {
+      console.log(
+        `Your session id was ${Telemetry.client.commonProperties.sessionId}`,
+      );
+    }
   }
   process.exitCode = 1;
 }


### PR DESCRIPTION
When the user encounters an error, if running with `--verbose` we can print out the sessionId so that if they decide to file a bug, they can provide the session id so that we can look up the telemetry to help us investigate and hopefully unblock them more easily.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6510)