### PR TITLE
[0.62] Replace WinAppDriver 1.2.1 with WinAppDriver 1.1 (#6502)

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -36,6 +36,13 @@ jobs:
           noCache: true
           restoreSolution: packages/E2ETest/windows/ReactUWPTestApp.sln
           verbosityRestore: Detailed # Options: quiet, normal, detailed
+
+      # See Issue 6393 for details
+      - powershell: |
+          Invoke-WebRequest https://github.com/microsoft/WinAppDriver/releases/download/v1.1/WindowsApplicationDriver.msi -OutFile $(Agent.TempDirectory)\WinAppDriver.msi
+          Start-Process msiexec -ArgumentList "/quiet","/x","{087BBF93-D9E3-4D27-BDBE-9C702E0066FC}" -Verb runAs -Wait
+          Start-Process msiexec -ArgumentList "/quiet","/i","$(Agent.TempDirectory)\WinAppDriver.msi" -Verb runAs -Wait
+        displayName: Replace WinAppDriver 1.2.1 with WinAppDriver 1.1
          
       - task: CmdLine@2
         displayName: run-windows


### PR DESCRIPTION
WinAppDriver 1.2 is being deployed across the MS hosted pool. appium-windows-driver is tied to a specific version of WinAppDriver, failing if a hash is mismatched. The latest current available package supports 1.2rc.

Uninstall WinAppDriver 1.2.1 if installed and instead install WinAppDriver 1.1 for now

See #6393 for details

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6522)