### PR TITLE
Mark packages published from master as private when cutting branch

### DIFF
--- a/change/@rnw-scripts-promote-release-9a8b047d-00a8-4a96-875d-31968fd0a4f6.json
+++ b/change/@rnw-scripts-promote-release-9a8b047d-00a8-4a96-875d-31968fd0a4f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark packages published from master as private when cutting branch",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes #5616

There are packages like react-native-windows-init that we publish only from our master branch. Publishing outside of our master branch would break both PR and publish pipelines in our master branch, along with creating confusion. The lack of guardrails for this is an especially sharp edge, as bumps to the react-native-windows version will now bump react-native-windows-init, as the latter takes a devDependency on the former to use its typings.

This change prevents the wrong thing from happening by marking most packages as private in stable branches.

Validated by locally running the script and inspecting results.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6543)