### PR TITLE
Generate XML doc for Managed attributes

### DIFF
--- a/change/react-native-windows-b710a4b9-1aaf-443b-a261-38ee6551146d.json
+++ b/change/react-native-windows-b710a4b9-1aaf-443b-a261-38ee6551146d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "mark all classes in codegen intended to be internal as such",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/App.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/App.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ReactNative.Managed.CodeGen
 {
-    public class App
+    internal class App
     {
         private readonly CancellationToken m_cancellationToken;
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
     /// <summary>
     /// Primary class 
     /// </summary>
-    public class CodeAnalyzer
+    internal class CodeAnalyzer
     {
         public int ConcurrencyLevel { get; set; } = DataflowBlockOptions.Unbounded;
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Module.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Module.cs
@@ -14,7 +14,7 @@ using static Microsoft.ReactNative.Managed.CodeGen.SyntaxHelpers;
 
 namespace Microsoft.ReactNative.Managed.CodeGen
 {
-  public partial class CodeGenerator
+  internal partial class CodeGenerator
   {
     internal MemberDeclarationSyntax CreateModules(IEnumerable<ReactModule> modules)
     {

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Serializers.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.Serializers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// <summary>
   /// Code generation for serialization
   /// </summary>
-  public partial class CodeGenerator
+  internal partial class CodeGenerator
   {
     internal IEnumerable<MemberDeclarationSyntax> CreateSerializers(IEnumerable<INamedTypeSymbol> typesToSerialize)
     {

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.ViewManager.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.ViewManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// <summary>
   /// Code generation for View Managers
   /// </summary>
-  public partial class CodeGenerator
+  internal partial class CodeGenerator
   {
     internal MemberDeclarationSyntax CreateViewManagers(IEnumerable<INamedTypeSymbol> viewManagers)
     {

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeGenerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// <summary>
   /// Class to generate code given the passed in models
   /// </summary>
-  public partial class CodeGenerator
+  internal partial class CodeGenerator
   {
     internal readonly ReactTypes ReactTypes;
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Commandline/Parser.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Commandline/Parser.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Commandline
 {
-  public class Parser
+  internal class Parser
   {
     internal static bool TryParseArgs(IEnumerable<string> args, out IList<ParsedArgument> parsedArgs)
     {

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/ConsoleMeasurement.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/ConsoleMeasurement.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// <summary>
   /// Little helper to measure and print durations of phases of execution
   /// </summary>
-  public readonly struct ConsoleMeasurement : IDisposable
+  internal readonly struct ConsoleMeasurement : IDisposable
   {
     private readonly Stopwatch m_stopWatch;
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -16,10 +16,6 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DocumentationFile>$(OutDir)\Microsoft.ReactNative.Managed.CodeGen.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <!--
       This file is linked because we want to use this to ensure the names of the code we parse line up and gives us compile errors if not.

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -16,6 +16,10 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DocumentationFile>$(OutDir)\Microsoft.ReactNative.Managed.CodeGen.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <!--
       This file is linked because we want to use this to ensure the names of the code we parse line up and gives us compile errors if not.
@@ -65,11 +69,7 @@
   <!-- 
     This is used during the PR build to ensure we have the artifacts published during the build.
   -->
-  <Target 
-    Name="PublishToolDuringBuild" 
-    DependsOnTargets="Publish" 
-    AfterTargets="Build" 
-    Condition="'$(PublishToolDuringBuild)' == 'true' and '$(Platform)' == 'x64'">
+  <Target Name="PublishToolDuringBuild" DependsOnTargets="Publish" AfterTargets="Build" Condition="'$(PublishToolDuringBuild)' == 'true' and '$(Platform)' == 'x64'">
   </Target>
 
   <!-- Override -->

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactAssembly.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactAssembly.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactAssembly
+  internal class ReactAssembly
   {
     public ICollection<INamedTypeSymbol> ViewManagers { get; } = new List<INamedTypeSymbol>();
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactCallback.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactCallback.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.ContractsLight;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public abstract class ReactCallback
+  internal abstract class ReactCallback
   {
     public ISymbol Symbol { get; }
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactConstant.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactConstant.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.ContractsLight;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactConstant
+  internal class ReactConstant
   {
     public ISymbol Symbol { get; }
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactConstantProvider.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactConstantProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactConstantProvider
+  internal class ReactConstantProvider
   {
     public IMethodSymbol Method { get; }
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactEvent.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactEvent.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactEvent : ReactCallback
+  internal class ReactEvent : ReactCallback
   {
     public ReactEvent(ISymbol symbol, ImmutableArray<IParameterSymbol> callbackParameters, string name, string emitterName)
     : base(symbol, callbackParameters, name, emitterName)

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactFunction.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactFunction.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactFunction : ReactCallback
+  internal class ReactFunction : ReactCallback
   {
     public ReactFunction(ISymbol symbol, ImmutableArray<IParameterSymbol> callbackParameters, string name, string emitterName)
       : base(symbol, callbackParameters, name, emitterName)

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactInitializer.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactInitializer.cs
@@ -5,10 +5,10 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactInitializer
+  internal class ReactInitializer
   {
     public IMethodSymbol Method { get; }
-    
+
     public ReactInitializer(IMethodSymbol method)
     {
       Method = method;

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactMethod.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactMethod.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactMethod
+  internal class ReactMethod
   {
     public IMethodSymbol Method { get; }
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactModule.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactModule.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.ReactNative.Managed.CodeGen.Model
 {
-  public class ReactModule
+  internal class ReactModule
   {
     public INamedTypeSymbol ModuleType { get; }
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactTypes.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Model/ReactTypes.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen.Model
     /// Helper class that stores all types needed for analysis and code generation
     /// from Microsoft.ReactNative and Microsoft.ReactNative.Managed
     /// </summary>
-    public class ReactTypes
+    internal class ReactTypes
     {
         private const string m_ReactNativeAssemblyName = "Microsoft.ReactNative";
         private const string m_ReactNativeNamespace = "Microsoft.ReactNative";

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Options.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Options.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
     /// Captures the options needed to run the Code Generators.
     /// This class is typically populated from the commandline arguments
     /// </summary>
-    public class Options
+    internal class Options
     {
         private const string m_defaultName = "Microsoft.ReactNative.Managed.CodeGen";
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Program.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Program.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ReactNative.Managed.CodeGen
 {
-  public class Program
+  internal class Program
   {
     /// <summary>
     /// Main entry point

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/SyntaxHelpers.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/SyntaxHelpers.cs
@@ -15,7 +15,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
   /// This class adds some extra convenience helpers. The method names typically follow the
   /// naming convention used in Roslyn but sets common defaults.
   /// </summary>
-  public static class SyntaxHelpers
+  internal static class SyntaxHelpers
   {
     private static readonly SymbolDisplayFormat s_symbolFormat = SymbolDisplayFormat.FullyQualifiedFormat;
 

--- a/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
+++ b/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(SolutionDir)\BuildFlags.props" Condition="Exists('$(SolutionDir)\BuildFlags.props')" />
@@ -98,6 +98,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <DocumentationFile>$(OutDir)\Microsoft.ReactNative.Managed.xml</DocumentationFile>
   </PropertyGroup>
   <Import Project="..\PropertySheets\WinUI.props" />
   <ItemGroup>

--- a/vnext/Microsoft.ReactNative.Managed/ReactAttributes.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactAttributes.cs
@@ -8,8 +8,12 @@ using System;
 
 namespace Microsoft.ReactNative.Managed
 {
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Class)]
-  public class ReactModuleAttribute : Attribute
+  public sealed class ReactModuleAttribute : Attribute
   {
     public ReactModuleAttribute(string moduleName = null)
     {
@@ -21,13 +25,21 @@ namespace Microsoft.ReactNative.Managed
     public string EventEmitterName { get; set; }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Method)]
-  public class ReactInitializerAttribute : Attribute
+  public sealed class ReactInitializerAttribute : Attribute
   {
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-  public class ReactConstantAttribute : Attribute
+  public sealed class ReactConstantAttribute : Attribute
   {
     public ReactConstantAttribute(string constantName = null)
     {
@@ -37,13 +49,21 @@ namespace Microsoft.ReactNative.Managed
     public string ConstantName { get; set; }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Method)]
-  public class ReactConstantProviderAttribute : Attribute
+  public sealed class ReactConstantProviderAttribute : Attribute
   {
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Method)]
-  public class ReactMethodAttribute : Attribute
+  public sealed class ReactMethodAttribute : Attribute
   {
     public ReactMethodAttribute(string methodName = null)
     {
@@ -53,8 +73,12 @@ namespace Microsoft.ReactNative.Managed
     public string MethodName { get; set; }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Method)]
-  public class ReactSyncMethodAttribute : Attribute
+  public sealed class ReactSyncMethodAttribute : Attribute
   {
     public ReactSyncMethodAttribute(string methodName = null)
     {
@@ -64,8 +88,12 @@ namespace Microsoft.ReactNative.Managed
     public string MethodName { get; set; }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-  public class ReactEventAttribute : Attribute
+  public sealed class ReactEventAttribute : Attribute
   {
     public ReactEventAttribute(string eventName = null)
     {
@@ -77,8 +105,12 @@ namespace Microsoft.ReactNative.Managed
     public string EventEmitterName { get; set; }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-  public class ReactFunctionAttribute : Attribute
+  public sealed class ReactFunctionAttribute : Attribute
   {
     public ReactFunctionAttribute(string functionName = null)
     {

--- a/vnext/Microsoft.ReactNative.Managed/ReactPackageBuilderExtensions.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactPackageBuilderExtensions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.ReactNative.Managed
     private static readonly Assembly s_currentAssembly = typeof(ReactPackageBuilderExtensions).Assembly;
 
     /// <summary>
-    /// This caches for each assembly (keyed on location
+    /// This caches for each assembly (keyed on location)
     /// </summary>
     /// <remarks>
-    /// We use concurrentDictionary instead of ConcurrentBag due to it's performance charateristics.
+    /// We use concurrentDictionary instead of ConcurrentBag for better performance.
     /// </remarks>
     private static readonly ConcurrentDictionary<Assembly, Lazy<Dictionary<string, AttributedModule>>> s_registeredAssemblies =
       new ConcurrentDictionary<Assembly, Lazy<Dictionary<string, AttributedModule>>>();

--- a/vnext/Microsoft.ReactNative.Managed/ReflectionReactPackageProvider.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReflectionReactPackageProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ReactNative.Managed
   /// A default implementation that uses reflection to extract the Modules and ViewManagers
   /// to be registered on the package builder.
   /// </summary>
-  /// <typeparam name="T">This must be thea type defined in the assembly where the items for the react package should be extracted.</typeparam>
+  /// <typeparam name="T">This must be the type defined in the assembly where the items for the react package should be extracted.</typeparam>
   /// <remarks>
   /// The common use case of this type is adding this to the PackageProviders from the constructor of your application (say: in <c>App()</c> of App.g.cs) like <c>PackageProviders.Add(new ReflectionReactPackageProvider&lt;App&gt;());</c>.
   /// </remarks>
@@ -24,12 +24,12 @@ namespace Microsoft.ReactNative.Managed
   /// <summary>
   /// Extensions for registring a reflection based package provider
   /// </summary>
-  public static class ReflectionReactPackageProviderExtensions
+  internal static class ReflectionReactPackageProviderExtensions
   {
     /// <summary>
-    /// Helper extension method to register a reflection
+    /// Helper extension method to register a reflection package provider
     /// </summary>
-    /// <typeparam name="T">This must be thea type defined in the assembly where the items for the react package should be extracted.</typeparam>
+    /// <typeparam name="T">This must be the type defined in the assembly where the items for the react package should be extracted.</typeparam>
     /// <remarks>
     /// The common use case of this type is when you have a react library. Then you would call this from the <see cref="IReactPackageProvider.CreatePackage"/> function in ReactPackageProvider class that implements <see cref="IReactPackageProvider"/> like:
     /// <c>

--- a/vnext/Microsoft.ReactNative.Managed/ViewManagerAttributes.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ViewManagerAttributes.cs
@@ -5,8 +5,12 @@ using System;
 
 namespace Microsoft.ReactNative.Managed
 {
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-  public class ViewManagerExportedViewConstantAttribute : Attribute
+  public sealed class ViewManagerExportedViewConstantAttribute : Attribute
   {
     public string ConstantName { get; set; }
 
@@ -18,8 +22,12 @@ namespace Microsoft.ReactNative.Managed
     }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Method)]
-  public class ViewManagerPropertyAttribute : Attribute
+  public sealed class ViewManagerPropertyAttribute : Attribute
   {
     public string PropertyName { get; set; }
 
@@ -38,8 +46,12 @@ namespace Microsoft.ReactNative.Managed
     }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Method)]
-  public class ViewManagerCommandAttribute : Attribute
+  public sealed class ViewManagerCommandAttribute : Attribute
   {
     public string CommandName { get; set; }
 
@@ -51,7 +63,11 @@ namespace Microsoft.ReactNative.Managed
     }
   }
 
-  public class ViewManagerExportedDirectEventTypeConstantAttribute : Attribute
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
+  public sealed class ViewManagerExportedDirectEventTypeConstantAttribute : Attribute
   {
     public string EventName { get; private set; }
 
@@ -66,8 +82,12 @@ namespace Microsoft.ReactNative.Managed
     }
   }
 
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <publicapi>true</publicapi>
   [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-  public class ViewManagerExportedBubblingEventTypeConstantAttribute : Attribute
+  public sealed class ViewManagerExportedBubblingEventTypeConstantAttribute : Attribute
   {
     public string EventName { get; private set; }
 


### PR DESCRIPTION
This enables the creation of the XML doc which can then be used to generate markdown for documenting these types in our docs.
Marks internal types as such.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6550)