### PR TITLE
Degrade CornerRadius in RS4

### DIFF
--- a/change/react-native-windows-dea2927a-a5e6-4784-a71a-14e423a40d2e.json
+++ b/change/react-native-windows-dea2927a-a5e6-4784-a71a-14e423a40d2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CornerRadius only exists on RS5, restore the behavior to gracefully degrade on older OS releases",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/UI.Xaml.Controls.h
+++ b/vnext/Microsoft.ReactNative.Cxx/UI.Xaml.Controls.h
@@ -5,6 +5,9 @@
 
 #ifdef USE_WINUI3
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
+namespace winrt::Microsoft::UI::Xaml::Controls {
+using IControl7 = Control;
+} // namespace winrt::Microsoft::UI::Xaml::Controls
 #else
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #endif //  USE_WINUI3

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -40,7 +40,7 @@ void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlV
   TransferProperty(oldView, newView, TAB_INDEX_PROPERTY());
 
   // Control.CornerRadius is only supported on >= RS5
-  if (oldView.try_as<xaml::Controls::Control>() && newView.try_as<xaml::Controls::Control>()) {
+  if (oldView.try_as<xaml::Controls::IControl7>() && newView.try_as<xaml::Controls::IControl7>()) {
     TransferProperty(oldView, newView, xaml::Controls::Control::CornerRadiusProperty());
   }
   Super::TransferProperties(oldView, newView);
@@ -78,7 +78,7 @@ bool ControlViewManager::UpdateProperty(
     }
   }
 
-  if (finalizeBorderRadius && control.try_as<xaml::Controls::Control>()) {
+  if (finalizeBorderRadius && control.try_as<xaml::Controls::IControl7>()) {
     // Control.CornerRadius is only supported on >= RS5, setting borderRadius on Controls have no effect < RS5
     UpdateCornerRadiusOnElement(nodeToUpdate, control);
   }
@@ -87,8 +87,8 @@ bool ControlViewManager::UpdateProperty(
 
 void ControlViewManager::OnViewCreated(XamlView view) {
   // Set the default cornerRadius to 0 for Control: WinUI usually default cornerRadius to 2
-  // Only works on >= RS5 becuase Control.CornerRadius is only supported >= RS5
-  if (auto control = view.try_as<xaml::Controls::Control>()) {
+  // Only works on >= RS5 because Control.CornerRadius is only supported >= RS5
+  if (auto control = view.try_as<xaml::Controls::IControl7>()) {
     control.CornerRadius({0, 0, 0, 0});
   }
 }


### PR DESCRIPTION
When I ported RNW to WinUI3 I wrongly changed a cast from IControl7 to Control. CornerRadius only works on RS5 so trying to access the property on RS4 will crash the app. 

Fixes #6544 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6551)