### PR TITLE
Expose placeholder prop on Picker

### DIFF
--- a/change/react-native-windows-f17be011-07a0-426f-aeea-4f1ec36dbb37.json
+++ b/change/react-native-windows-f17be011-07a0-426f-aeea-4f1ec36dbb37.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add placeholder prop to Picker",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@fb.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
@@ -131,6 +131,12 @@ void PickerShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueOb
     } else if (propertyName == "items") {
       m_items = propertyValue.AsArray().Copy();
       RepopulateItems();
+    } else if (propertyName == "placeholder") {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+        combobox.PlaceholderText(react::uwp::asHstring(propertyValue));
+      } else if (propertyValue.IsNull()) {
+        combobox.ClearValue(xaml::Controls::ComboBox::PlaceholderTextProperty());
+      }
     }
   }
 
@@ -194,6 +200,7 @@ void PickerViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSV
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"items", L"array");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"selectedIndex", L"number");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"text", L"string");
+  winrt::Microsoft::ReactNative::WriteProperty(writer, L"placeholder", L"string");
 }
 
 ShadowNode *PickerViewManager::createShadow() const {

--- a/vnext/src/Libraries/Components/Picker/PickerProps.ts
+++ b/vnext/src/Libraries/Components/Picker/PickerProps.ts
@@ -18,6 +18,7 @@ export interface IPickerProps extends ViewProps {
   // tslint:disable-next-line:no-any
   selectedValue?: any;
   enabled?: boolean;
+  placeholder?: string;
   prompt?: string;
   testID?: string;
   onChange?: (event: IPickerChangeEvent) => void;


### PR DESCRIPTION
This exposes the ComboBox PlaceholderText as a prop on Picker called placeholder.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6552)