### PR TITLE
Update Nuget publish to not overwrite the created anycpu version

### DIFF
--- a/.ado/templates/publish-build-artifacts-for-nuget.yml
+++ b/.ado/templates/publish-build-artifacts-for-nuget.yml
@@ -9,7 +9,7 @@ steps:
     displayName: Copy NuGet header files
     inputs:
       filePath: vnext/Scripts/Tfs/Layout-Headers.ps1
-      arguments: -TargetRoot $(Build.StagingDirectory)
+      arguments: -TargetRoot $(Build.StagingDirectory) -BuildRoot $(Build.SourcesDirectory)\vnext\target
     condition: ${{ parameters.layoutHeaders }}
 
   - task: CopyFiles@2

--- a/change/react-native-windows-ad5982b9-fb47-405a-9abd-6ee2b6d23e72.json
+++ b/change/react-native-windows-ad5982b9-fb47-405a-9abd-6ee2b6d23e72.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Nuget publish to not overwrite the created anycpu version",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/PublishNugetPackagesLocally.cmd
+++ b/vnext/Scripts/PublishNugetPackagesLocally.cmd
@@ -10,7 +10,7 @@ set baseConfiguration=%5
 set ScriptFolder=%~dp0
 
 set defaultTargetDir=c:\temp\RnWNugetTesting
-set defaultSlices="@('x64.Debug','x64.Release','x86.Debug')"
+set defaultSlices="@('x64.Debug')"
 set defaultBaseConfiguration=Debug
 set defaultBasePlatform=x64
 

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -3,6 +3,7 @@
 
 param(
 	[string] $SourceRoot = ($PSScriptRoot | Split-Path | Split-Path | Split-Path),
+	[string] $BuildRoot = "$SourceRoot\vnext\target",
 	[string] $TargetRoot = "$SourceRoot\vnext\target",
 	[System.IO.DirectoryInfo] $ReactWindowsRoot = "$SourceRoot\vnext",
 	[System.IO.DirectoryInfo] $ReactNativeRoot = "$SourceRoot\node_modules\react-native",	
@@ -15,6 +16,7 @@ $FollyVersion = $FollyVersion.Trim() # The extracted FollyVersion contains a spa
 [System.IO.DirectoryInfo] $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}";
 
 Write-Host "Source root: [$SourceRoot]"
+Write-Host "Build root: [$BuildRoot]"
 Write-Host "Destination root: [$TargetRoot]"
 Write-Host "React Native root: [$ReactNativeRoot]"
 
@@ -136,11 +138,11 @@ Copy-Item -Force -Path $ReactWindowsRoot\Folly\Folly.natvis -Destination (New-It
 # Therefore this step will simply ildasm and ilasm the reference assembly and store it as which strips the bitness and generates anycpu msil.
 # These reference assemblies are just regular assemblies but with empty bodies
 
-ForEach ($refFolder in (Get-ChildItem -Path  $TargetRoot -Recurse -Include "ref"))
+ForEach ($refFolder in (Get-ChildItem -Path  $BuildRoot -Recurse -Include "ref"))
 { 
 	ForEach ($refAsm in Get-ChildItem -Path $refFolder -Recurse  -Include "*.dll" ) 
 	{
-		$outputFolder=[System.IO.Path]::GetDirectoryName($refAsm) + ".anycpu";
+		$outputFolder=([System.IO.Path]::GetDirectoryName($refAsm)).Replace($BuildRoot, $TargetRoot) + ".anycpu";
 		$outputAsm = [System.IO.Path]::Combine($outputFolder, [System.IO.Path]::GetFileName($refAsm));
 		$outputIl = [System.IO.Path]::ChangeExtension($outputAsm, ".il");
 


### PR DESCRIPTION
Unfortunatley there is no good way to the Publish pipeline this other than through checking in via PR. So attempting another fix because the Paths in the Publish jobs are not the same as the build machines.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6557)