### PR TITLE
Add Yellowbox warnings for Windows Variants of Lean Core Components

### DIFF
--- a/change/react-native-windows-a6aebc81-adec-4938-a41a-28b6ce245133.json
+++ b/change/react-native-windows-a6aebc81-adec-4938-a41a-28b6ce245133.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Yellowbox warnings for WIndows Variants of Lean Core Components",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/index.windows.js
+++ b/vnext/src/index.windows.js
@@ -503,6 +503,12 @@ module.exports = {
 
   // Additional windows exports (Typescript components exported as flow any)
   get DatePicker(): any {
+    warnOnce(
+      'datepicker-moved',
+      'DatePicker has been extracted from react-native-windows and will be removed in a future release. ' +
+        "It can now be installed and imported as DateTimePicker from '@react-native-community/datetimepicker'. " +
+        'See https://github.com/react-native-datetimepicker/datetimepicker',
+    );
     return (require('./Libraries/Components/DatePicker/DatePicker'): any)
       .DatePicker;
   },
@@ -513,6 +519,12 @@ module.exports = {
     return require('./Libraries/Components/Glyph/Glyph').Glyph;
   },
   get PickerWindows(): any {
+    warnOnce(
+      'picker-windows-moved',
+      'PickerWindows has been extracted from react-native-windows and will be removed in a future release. ' +
+        "It can now be installed and imported as Picker from '@react-native-picker/picker'. " +
+        'See https://github.com/react-native-picker/picker',
+    );
     return require('./Libraries/Components/Picker/PickerWindows').Picker;
   },
   get Popup(): any {


### PR DESCRIPTION
You will be warned when using Picker, but not PickerWIndows, or will be warned when using DatePickerIOS, but not DatePicker. Point folks towards the community module before these are removed, if they're using the Windows variant directly.

These are not yet removed as of 0.64, so we should have at least a release of warning.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6560)