### PR TITLE
Layout-Headers During NuGet Pack

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -119,7 +119,6 @@ jobs:
         X64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
-          LayoutHeaders: true
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
@@ -154,7 +153,6 @@ jobs:
       - template: templates/publish-build-artifacts-for-nuget.yml
         parameters:
           artifactName: ReactWindows
-          layoutHeaders: eq('true', variables['LayoutHeaders'])
           contents: |
             Microsoft.ReactNative\**
             Microsoft.ReactNative.Managed\**

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -20,7 +20,7 @@ steps:
       artifact: ReactWindows
       path: $(System.DefaultWorkingDirectory)/ReactWindows
 
-  - powershell: PowerShell@2
+  - task: PowerShell@2
     displayName: Layout NuGet header files
     inputs:
       filePath: vnext/Scripts/Tfs/Layout-Headers.ps1

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -20,6 +20,12 @@ steps:
       artifact: ReactWindows
       path: $(System.DefaultWorkingDirectory)/ReactWindows
 
+  - powershell: PowerShell@2
+    displayName: Layout NuGet header files
+    inputs:
+      filePath: vnext/Scripts/Tfs/Layout-Headers.ps1
+      arguments: -TargetRoot $(System.DefaultWorkingDirectory)/ReactWindows
+
   - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true), eq(parameters.packMicrosoftReactNativeManaged, true), eq(parameters.packMicrosoftReactNativeManagedCodeGen, true)) }}:
     - powershell: |
         (Get-Content -Path $(System.DefaultWorkingDirectory)\ReactWindows\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '${{parameters.npmVersion}}' | Set-Content -Path  $(System.DefaultWorkingDirectory)\ReactWindows\Microsoft.ReactNative.VersionCheck.targets

--- a/.ado/templates/prep-and-pack-single.yml
+++ b/.ado/templates/prep-and-pack-single.yml
@@ -13,7 +13,7 @@ steps:
     displayName: '${{ parameters.packageId }} - Strip slices from nuspec'
     inputs:
       targetType: filePath
-      filePath: $(System.DefaultWorkingDirectory)\ReactWindows\StripAdditionalPlatformsFromNuspec.ps1
+      filePath: vnext\Scripts\StripAdditionalPlatformsFromNuspec.ps1
       arguments: -nuspec $(System.DefaultWorkingDirectory)/ReactWindows/${{parameters.packageId}}.nuspec -outfile $(System.DefaultWorkingDirectory)/ReactWindows/${{parameters.packageId}}.nuspec -slices ${{ parameters.slices }} -debug
     condition: and(succeeded(), ne('', '${{ parameters.slices }}'))
 

--- a/.ado/templates/publish-build-artifacts-for-nuget.yml
+++ b/.ado/templates/publish-build-artifacts-for-nuget.yml
@@ -1,17 +1,8 @@
 parameters:
   artifactName:
   contents:
-  layoutHeaders: false
 
 steps:
-  # Prepare headers for NuGet deployment
-  - task: PowerShell@2
-    displayName: Copy NuGet header files
-    inputs:
-      filePath: vnext/Scripts/Tfs/Layout-Headers.ps1
-      arguments: -TargetRoot $(Build.StagingDirectory)
-    condition: ${{ parameters.layoutHeaders }}
-
   - task: CopyFiles@2
     displayName: Copy NuGet artifacts
     inputs:

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -39,7 +39,6 @@ jobs:
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
-          LayoutHeaders: true
         #X86Release:
         #  BuildConfiguration: Release
         #  BuildPlatform: x86
@@ -139,7 +138,6 @@ jobs:
       - template: templates/publish-build-artifacts-for-nuget.yml
         parameters:
           artifactName: ReactWindows
-          layoutHeaders: eq('true', variables['LayoutHeaders'])
           contents: |
             Microsoft.ReactNative\**
             Microsoft.ReactNative.Managed\**

--- a/change/react-native-windows-169bc1b1-60aa-46f5-a483-7c7251a24e1b.json
+++ b/change/react-native-windows-169bc1b1-60aa-46f5-a483-7c7251a24e1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Layout-Headers During NuGet Pack",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -100,9 +100,6 @@ Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\threadsafe.h -Destin
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\*.nuspec -Destination $TargetRoot
 
 
-#Copy StripAdditionalPlatformsFromNuspec.ps1 for use by publish task
-Copy-Item -Force -Path $ReactWindowsRoot\Scripts\StripAdditionalPlatformsFromNuspec.ps1 -Destination $TargetRoot
-
 # Microsoft.ReactNative.VersionCheck.targets
 Copy-Item -Force -Path $ReactWindowsRoot\Scripts\Microsoft.ReactNative.VersionCheck.targets -Destination $TargetRoot
 


### PR DESCRIPTION
PR and publish are set up to expect that some NuGet processing work is done before uploading artifacts. It is expected a single job does this work, and uploads for all NuGet consumers. If multiple jobs due this work, we would potentially see conflicting artifacts.

This work also uploads build scripts as an artifact, leading to a race condition where the Desktop Packing job might fail if Desktop finishes before the designated job to upload header artifacts. We would otherwise need to wait for the designated job to be done before starting desktop packing.

These headers can now be fully derived from source in the repo, so we can remove some of this fragility and group the work with NuGet packing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6561)