### PR TITLE
Wait until UWP Jobs are Finished Before Desktop Packing

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -782,7 +782,9 @@ jobs:
     variables:
       - template: variables/vs2019.yml
     displayName: Pack Desktop NuGet Package
-    dependsOn: RNWDesktopPR
+    dependsOn:
+      - RNWDesktopPR
+      - RNWUniversalPR # Needed to have artifacts uploaded from LayoutHeaders
     condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
     pool:
       vmImage: $(VmImage)


### PR DESCRIPTION
NuGet generation in CI is dependent on a single job creating and uploading shared headers for all NuGet packages. This job requires doing the build, but seemingly cannot be done by multiple machines, as they would upload overlapping artifacts.

This is currently done in PR by one of the UWP build steps. Ensure these are completed before packing the desktop NuGet package to avoid the race condition.

We should consider splitting out desktop and UWP NuGet generation artifacts in the future to avoid tying them together in this way. I spent a bit of time looking for cleaner fixes, but there likely isn't anything too much better we can do without structural changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6562)