### PR TITLE
fix ViewViewManager command typo

### DIFF
--- a/change/react-native-windows-f97e6ea8-db5f-4659-9224-a77e2c3fadd4.json
+++ b/change/react-native-windows-f97e6ea8-db5f-4659-9224-a77e2c3fadd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix typo",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -65,8 +65,10 @@ class ViewShadowNode : public ShadowNodeBase {
   }
 
   void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) {
-    if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
-      uiManager->focus(m_tag);
+    if (commandId == "focus") {
+      if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+        uiManager->focus(m_tag);
+      }
     } else if (commandId == "blur") {
       if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
         uiManager->blur(m_tag);


### PR DESCRIPTION
While implementing #6220 I made a typo and missed an outer if-statement, which results in both focus and blur commands invoking "focus".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6567)