### PR TITLE
Use lessthrow_await_adapter in WebSocketJSExecutor::ConnectAsync

### DIFF
--- a/change/react-native-windows-6336eb07-86e6-461a-a24c-79311b382c98.json
+++ b/change/react-native-windows-6336eb07-86e6-461a-a24c-79311b382c98.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use lessthrow_await_adapter for WebSocketJSExecutor::ConnectAsync",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
`WebSocketJSExecutor::ConnectAsync` does not handle errors arising from `m_socket.ConnectAsync(uri)`.

This change uses the no-exception coroutine adapter to handle errors using the `ErrorCode` function from `IAsyncAction`.

Closes #6569.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6573)