### PR TITLE
 Update lib template to default prefer RNW dir of consuming app

### DIFF
--- a/change/react-native-windows-588ea8f6-b37e-4b9f-8452-a2d02804859d.json
+++ b/change/react-native-windows-588ea8f6-b37e-4b9f-8452-a2d02804859d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update lib template to default prefer RNW dir of consuming app",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/cpp-lib/proj/MyLib.vcxproj
+++ b/vnext/template/cpp-lib/proj/MyLib.vcxproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
     {{#useExperimentalNuget}}
     <UseExperimentalNuget>true</UseExperimentalNuget>    <!-- This will eventually default to true and this property should be removed -->
     {{/useExperimentalNuget}}

--- a/vnext/template/cs-lib/proj/MyLib.csproj
+++ b/vnext/template/cs-lib/proj/MyLib.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Label="ReactNativeWindowsProps">
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
This update to the lib templates helps fix the issue where native module repos also have example apps in their codebase, and two copies of M.RN get restored and built against.

When setting for `ReactNativeWindowsDir`, we start searching for RNW based on the location of the project file and looking upwards for node_modules/react-native-windows. In the case of a regular app repo with  a single root package.json, where every native module is under the app's node_modules, the app and native module projects all find the same version.

In other repo layouts, we run into cases with multiple package.json files, and where the app is lower in the folder hierarchy than the native module it's consuming (such as an example app within a native module repo, as per issue #6576). You can then up with multiple copies of RNW, and worse, the app can build against one version while the native module builds against another, and then build/packaging fails.

However, since we always build from a single solution file, by instead starting the search for `ReactNativeWindowsDir` at the location of the solution file, we can make sure that all the modules build against the copy of RNW that the app building against.

Closes #6576

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6577)