### PR TITLE
Have the universal x64/release build do the header layouts.

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -119,7 +119,6 @@ jobs:
         X64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
-          LayoutHeaders: true
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
@@ -132,6 +131,7 @@ jobs:
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
+          LayoutHeaders: true
         X86Release:
           BuildConfiguration: Release
           BuildPlatform: x86


### PR DESCRIPTION
Have the universal x64/release build do the header layouts, rather than the x64/debug one. Since we use x64/release as the default for nuget packages.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6579)