### PR TITLE
Add ReactContext::ExecuteJsi method to use JSI in NativeModules

### DIFF
--- a/change/react-native-windows-e6f9e1a2-9958-4c28-af55-80100258ac48.json
+++ b/change/react-native-windows-e6f9e1a2-9958-4c28-af55-80100258ac48.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add ReactContext::ExecuteJsi method to use JSI in NativeModules",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -24,6 +24,10 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  JsiRuntime JsiRuntime() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   void DispatchEvent(
       xaml::FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -127,6 +127,10 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  JsiRuntime JsiRuntime() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   void DispatchEvent(
       xaml::FrameworkElement const & /*view*/,
       hstring const & /*eventName*/,

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -272,9 +272,12 @@ JsiAbiRuntimeHolder ::~JsiAbiRuntimeHolder() noexcept {
 // JsiAbiRuntime implementation
 //===========================================================================
 
+// This map allows us to associate JsiAbiRuntime with JsiRuntime.
+// TODO: store JsiAbiRuntime* in JsiRuntime instance.
 static thread_local std::map<void *, JsiAbiRuntime *> *tls_jsiAbiRuntimeMap{nullptr};
 
 JsiAbiRuntime::JsiAbiRuntime(JsiRuntime const &runtime) noexcept : m_runtime{runtime} {
+  VerifyElseCrashSz(runtime, "JSI runtime is null");
   VerifyElseCrashSz(
       GetFromJsiRuntime(runtime) == nullptr,
       "We can have only one instance of JsiAbiRuntime for JsiRuntime in the thread.");
@@ -306,7 +309,7 @@ JsiAbiRuntime::~JsiAbiRuntime() {
 
 /*static*/ JsiAbiRuntimeHolder JsiAbiRuntime::GetOrCreate(JsiRuntime const &runtime) noexcept {
   JsiAbiRuntimeHolder result{GetFromJsiRuntime(runtime)};
-  if (!result && runtime) {
+  if (!result) {
     result = std::make_unique<JsiAbiRuntime>(runtime);
   }
   return result;

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -272,8 +272,11 @@ JsiAbiRuntimeHolder ::~JsiAbiRuntimeHolder() noexcept {
 // JsiAbiRuntime implementation
 //===========================================================================
 
-// This map allows us to associate JsiAbiRuntime with JsiRuntime.
-// TODO: store JsiAbiRuntime* in JsiRuntime instance.
+// The tls_jsiAbiRuntimeMap map allows us to associate JsiAbiRuntime with JsiRuntime.
+// The association is thread-specific and DLL-specific.
+// It is thread specific because we want to have the safe access only in JS thread.
+// It is DLL-specific because JsiAbiRuntime is not ABI-safe and each module DLL will
+// have their own JsiAbiRuntime instance.
 static thread_local std::map<void *, JsiAbiRuntime *> *tls_jsiAbiRuntimeMap{nullptr};
 
 JsiAbiRuntime::JsiAbiRuntime(JsiRuntime const &runtime) noexcept : m_runtime{runtime} {

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -122,7 +122,7 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
   static JsiAbiRuntime *GetFromJsiRuntime(JsiRuntime const &runtime) noexcept;
 
   // Get JsiAbiRuntime from JsiRuntime in current thread or create a new one.
-  static JsiAbiRuntimeHolder GetOrCreateFromJsiRuntime(JsiRuntime const &runtime) noexcept;
+  static JsiAbiRuntimeHolder GetOrCreate(JsiRuntime const &runtime) noexcept;
 
   facebook::jsi::Value evaluateJavaScript(
       const std::shared_ptr<const facebook::jsi::Buffer> &buffer,

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -91,12 +91,38 @@ struct JsiHostFunctionWrapper {
   static std::map<uint64_t, JsiHostFunctionWrapper *> s_functionDataToFunctionWrapper;
 };
 
+struct JsiAbiRuntime;
+
+// Keeps owning or not owning pointer to JsiAbiRuntime
+struct JsiAbiRuntimeHolder {
+  JsiAbiRuntimeHolder(std::unique_ptr<JsiAbiRuntime> jsiRuntime) noexcept;
+  JsiAbiRuntimeHolder(JsiAbiRuntime *jsiRuntime) noexcept;
+  ~JsiAbiRuntimeHolder() noexcept;
+
+  JsiAbiRuntimeHolder(JsiAbiRuntimeHolder const &) = delete;
+  JsiAbiRuntimeHolder &operator=(JsiAbiRuntimeHolder const &) = delete;
+  JsiAbiRuntimeHolder(JsiAbiRuntimeHolder &&) = default;
+  JsiAbiRuntimeHolder &operator=(JsiAbiRuntimeHolder &&) = default;
+
+  explicit operator bool() noexcept;
+  JsiAbiRuntime &operator*() noexcept;
+  JsiAbiRuntime *operator->() noexcept;
+
+ private:
+  std::unique_ptr<JsiAbiRuntime> m_jsiRuntime;
+  bool m_isOwning{false};
+};
+
 // JSI runtime implementation as a wrapper for the ABI-safe JsiRuntime.
 struct JsiAbiRuntime : facebook::jsi::Runtime {
   JsiAbiRuntime(JsiRuntime const &runtime) noexcept;
   ~JsiAbiRuntime() noexcept;
 
-  static JsiAbiRuntime *FromJsiRuntime(JsiRuntime const &jsiRuntime) noexcept;
+  // Get JsiAbiRuntime from JsiRuntime in current thread.
+  static JsiAbiRuntime *GetFromJsiRuntime(JsiRuntime const &runtime) noexcept;
+
+  // Get JsiAbiRuntime from JsiRuntime in current thread or create a new one.
+  static JsiAbiRuntimeHolder GetOrCreateFromJsiRuntime(JsiRuntime const &runtime) noexcept;
 
   facebook::jsi::Value evaluateJavaScript(
       const std::shared_ptr<const facebook::jsi::Buffer> &buffer,
@@ -308,9 +334,6 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
 
  private:
   JsiRuntime m_runtime;
-
-  static std::mutex s_mutex;
-  static std::map<void *, JsiAbiRuntime *> s_jsiAbiRuntimeMap;
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
@@ -6,8 +6,12 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JSValueTreeWriter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ModuleRegistration.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ReactPromise.cpp" />
-    <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)JSI\JsiAbiApi.cpp" />
+    <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp">
+      <Filter>JSI</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)JSI\JsiAbiApi.cpp">
+      <Filter>JSI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)Crash.h" />
@@ -90,12 +94,24 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)NamespaceRedirect.h">
       <Filter>UI</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)UI.Xaml.Hosting.DesktopWindowXamlSource.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)UI.Xaml.Hosting.h" />
-    <ClInclude Include="$(JSI_SourcePath)\jsi\instrumentation.h" />
-    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi-inl.h" />
-    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JsiAbiApi.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JsiAbiApi.h">
+      <Filter>JSI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi.h">
+      <Filter>JSI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(JSI_SourcePath)\jsi\jsi-inl.h">
+      <Filter>JSI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)UI.Xaml.Hosting.DesktopWindowXamlSource.h">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)UI.Xaml.Hosting.h">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(JSI_SourcePath)\jsi\instrumentation.h">
+      <Filter>JSI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="JSI">

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -58,15 +58,11 @@ struct ReactContext {
   void ExecuteJsi(TCodeWithRuntime const &code) const {
     ReactDispatcher jsDispatcher = JSDispatcher();
     if (jsDispatcher.HasThreadAccess()) {
-      if (auto runtime = JsiAbiRuntime::GetOrCreate(m_handle.JsiRuntime())) {
-        code(*runtime); // Execute immediately if we are in JS thread.
-      }
+      code(*JsiAbiRuntime::GetOrCreate(m_handle.JsiRuntime())); // Execute immediately if we are in JS thread.
     } else {
       // Otherwise, schedule work in JS thread.
       jsDispatcher.Post([ context = ReactContext{*this}, code ]() noexcept {
-        if (auto runtime = JsiAbiRuntime::GetOrCreate(context.m_handle.JsiRuntime())) {
-          code(*runtime);
-        }
+        code(*JsiAbiRuntime::GetOrCreate(context.m_handle.JsiRuntime()));
       });
     }
   }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/AddValues.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/AddValues.js
@@ -6,7 +6,10 @@ class TestHostModuleFunctions {
     }
 }
 
-global.__fbBatchedBridge.registerLazyCallableModule('TestHostModuleFunctions', () => new TestHostModuleFunctions());
+// Accessing TestHostModule has a side effect of initializing global.__fbBatchedBridge
+if (NativeModules.TestHostModule) {
+  global.__fbBatchedBridge.registerLazyCallableModule('TestHostModuleFunctions', () => new TestHostModuleFunctions());
 
-// Native modules are created on demand from JavaScript code.
-NativeModules.TestHostModule.start();
+  // Native modules are created on demand from JavaScript code.
+  NativeModules.TestHostModule.start();
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -17,9 +17,11 @@ struct TestHostModule {
     TestHostModule::Instance.set_value(*this);
 
     bool jsiExecuted{false};
-    reactContext.ExecuteJsi([&](facebook::jsi::Runtime &runtime) {
+    reactContext.ExecuteJsi([&](facebook::jsi::Runtime &rt) {
       jsiExecuted = true;
-      TestCheckEqual("ChakraRuntime", runtime.description());
+      auto eval = rt.global().getPropertyAsFunction(rt, "eval");
+      auto addFunc = eval.call(rt, "(function(x, y) { return x + y; })").getObject(rt).getFunction(rt);
+      TestCheckEqual(7, addFunc.call(rt, 3, 4).getNumber());
     });
     TestCheck(jsiExecuted);
   }

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -318,6 +318,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public IReactDispatcher JSDispatcher => Properties.Get(ReactDispatcherHelper.JSDispatcherProperty) as IReactDispatcher;
 
+    public JsiRuntime JsiRuntime => throw new NotImplementedException();
+
     public void DispatchEvent(FrameworkElement view, string eventName, JSValueArgWriter eventDataArgWriter)
     {
       throw new NotImplementedException();

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -68,6 +68,10 @@ void ReactContext::EmitJSEvent(
   m_context->CallJSFunction(to_string(eventEmitterName), "emit", std::move(params));
 }
 
+ReactNative::JsiRuntime ReactContext::JsiRuntime() noexcept {
+  return m_context->JsiRuntime();
+}
+
 #ifndef CORE_ABI
 bool ReactContext::UseWebDebugger() const noexcept {
   return m_context->UseWebDebugger();

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -31,6 +31,8 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
       hstring const &eventName,
       JSValueArgWriter const &paramsArgWriter) noexcept;
 
+  ReactNative::JsiRuntime JsiRuntime() noexcept;
+
   bool UseWebDebugger() const noexcept;
   bool UseFastRefresh() const noexcept;
   bool UseDirectDebugger() const noexcept;

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -4,6 +4,7 @@
 import "IJSValueWriter.idl";
 import "IReactNotificationService.idl";
 import "IReactPropertyBag.idl";
+import "JsiApi.idl";
 
 #ifndef CORE_ABI
 #include "NamespaceRedirect.h"
@@ -46,6 +47,9 @@ The subscriptions added to the `IReactInstanceSettings.Notifications` are kept a
     // Get ReactDispatcherHelper::JSDispatcherProperty from the Properties property bag.
     DOC_STRING("Get `ReactDispatcherHelper::JSDispatcherProperty` from the Properties property bag.")
     IReactDispatcher JSDispatcher { get; };
+
+    DOC_STRING("Get the JSI runtime for the running React instance. It can be null if Web debugging is used.")
+    JsiRuntime JsiRuntime { get; };
 
 #ifndef CORE_ABI
     // Deprecated: Use DispatchEvent on XamlUIService instead

--- a/vnext/Microsoft.ReactNative/JsiApi.cpp
+++ b/vnext/Microsoft.ReactNative/JsiApi.cpp
@@ -330,15 +330,15 @@ ReactNative::JsiRuntime JsiRuntime::MakeChakraRuntime() {
   auto runtimeHolder = std::make_shared<::Microsoft::JSI::ChakraRuntimeHolder>(
       std::move(devSettings), std::move(jsThread), nullptr, nullptr);
   auto runtime = runtimeHolder->getRuntime();
-  ReactNative::JsiRuntime result{make<JsiRuntime>(std::move(runtimeHolder), runtime)};
+  ReactNative::JsiRuntime result{make<JsiRuntime>(std::move(runtimeHolder), Mso::Copy(runtime))};
   std::scoped_lock lock{s_mutex};
   s_jsiRuntimeMap.try_emplace(reinterpret_cast<uintptr_t>(runtime.get()), result);
   return result;
 }
 
 JsiRuntime::JsiRuntime(
-    std::shared_ptr<::Microsoft::JSI::ChakraRuntimeHolder> runtimeHolder,
-    std::shared_ptr<facebook::jsi::Runtime> runtime) noexcept
+    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> &&runtimeHolder,
+    std::shared_ptr<facebook::jsi::Runtime> &&runtime) noexcept
     : m_runtimeHolder{std::move(runtimeHolder)}, m_runtime{std::move(runtime)} {}
 
 JsiRuntime::~JsiRuntime() noexcept {

--- a/vnext/Microsoft.ReactNative/JsiApi.h
+++ b/vnext/Microsoft.ReactNative/JsiApi.h
@@ -48,8 +48,8 @@ struct JsiError : JsiErrorT<JsiError> {
 
 struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   JsiRuntime(
-      std::shared_ptr<::Microsoft::JSI::ChakraRuntimeHolder> runtimeHolder,
-      std::shared_ptr<facebook::jsi::Runtime> runtime) noexcept;
+      std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> &&runtimeHolder,
+      std::shared_ptr<facebook::jsi::Runtime> &&runtime) noexcept;
   ~JsiRuntime() noexcept;
 
   static ReactNative::JsiRuntime FromRuntime(facebook::jsi::Runtime &runtime) noexcept;
@@ -142,7 +142,7 @@ struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   void SetError(facebook::jsi::JSINativeException const &nativeException) noexcept;
 
  private:
-  std::shared_ptr<::Microsoft::JSI::ChakraRuntimeHolder> m_runtimeHolder;
+  std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_runtimeHolder;
   std::shared_ptr<facebook::jsi::Runtime> m_runtime;
   std::mutex m_mutex;
   ReactNative::JsiError m_error{nullptr};

--- a/vnext/Microsoft.ReactNative/JsiApi.idl
+++ b/vnext/Microsoft.ReactNative/JsiApi.idl
@@ -3,8 +3,6 @@
 
 namespace Microsoft.ReactNative
 {
-  interface IJsiRuntime;
-
   // JsiByteArrayUser delegate receives a range of bytes as a byte array.
   // The array of bytes is implemented in ABI as two parameters: array length and a pointer to the array start.
   // It effectively provides a 'view' to the byte array provided by the delegate invoker.

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -91,6 +91,7 @@ struct IReactContext : IUnknown {
   virtual winrt::Microsoft::ReactNative::IReactPropertyBag Properties() const noexcept = 0;
   virtual void CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept = 0;
   virtual void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept = 0;
+  virtual winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() const noexcept = 0;
 #ifndef CORE_ABI
   virtual ReactInstanceState State() const noexcept = 0;
   virtual bool IsLoaded() const noexcept = 0;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
@@ -49,6 +49,18 @@ void ReactContext::DispatchEvent(int64_t viewTag, std::string &&eventName, folly
 #endif
 }
 
+winrt::Microsoft::ReactNative::JsiRuntime ReactContext::JsiRuntime() const noexcept {
+#ifndef CORE_ABI // requires instance
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->JsiRuntime();
+  } else {
+    return nullptr;
+  }
+#else
+  return nullptr;
+#endif
+}
+
 #ifndef CORE_ABI
 ReactInstanceState ReactContext::State() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -5,6 +5,10 @@
 
 #include "React.h"
 
+namespace facebook::jsi {
+struct RuntimeHolderLazyInit;
+} // namespace facebook::jsi
+
 namespace Mso::React {
 
 class ReactInstanceWin;
@@ -26,6 +30,7 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   winrt::Microsoft::ReactNative::IReactNotificationService Notifications() const noexcept override;
   void CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept override;
   void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept override;
+  winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() const noexcept override;
 #ifndef CORE_ABI
   ReactInstanceState State() const noexcept override;
   bool IsLoaded() const noexcept override;
@@ -42,7 +47,6 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   uint16_t SourceBundlePort() const noexcept override;
   std::string JavaScriptBundleFile() const noexcept override;
   bool UseDeveloperSupport() const noexcept override;
-
 #endif
 
  private:
@@ -50,4 +54,5 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   winrt::Microsoft::ReactNative::IReactPropertyBag m_properties;
   winrt::Microsoft::ReactNative::IReactNotificationService m_notifications;
 };
+
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -64,6 +64,8 @@
 #include <tuple>
 #include "ChakraRuntimeHolder.h"
 
+#include "JsiApi.h"
+
 namespace Microsoft::ReactNative {
 
 void AddStandardViewManagers(
@@ -380,6 +382,8 @@ void ReactInstanceWin::Initialize() noexcept {
                     devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
                 break;
             }
+
+            m_jsiRuntimeHolder = devSettings->jsiRuntimeHolder;
           }
 
           try {
@@ -539,6 +543,12 @@ Mso::Future<void> ReactInstanceWin::Destroy() noexcept {
 
   // Make sure that the instance is not destroyed yet
   if (auto instance = m_instance.Exchange(nullptr)) {
+    {
+      // Release the JSI runtime
+      std::scoped_lock lock{m_mutex};
+      m_jsiRuntimeHolder = nullptr;
+      m_jsiRuntime = nullptr;
+    }
     // Release the message queues before the ui manager and instance.
     m_nativeMessageThread.Exchange(nullptr);
     m_jsMessageThread.Exchange(nullptr);
@@ -810,6 +820,31 @@ void ReactInstanceWin::CallJsFunction(
 void ReactInstanceWin::DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) noexcept {
   folly::dynamic params = folly::dynamic::array(viewTag, std::move(eventName), std::move(eventData));
   CallJsFunction("RCTEventEmitter", "receiveEvent", std::move(params));
+}
+
+winrt::Microsoft::ReactNative::JsiRuntime ReactInstanceWin::JsiRuntime() noexcept {
+  std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> jsiRuntimeHolder;
+  {
+    std::scoped_lock lock{m_mutex};
+    if (m_jsiRuntime) {
+      return m_jsiRuntime;
+    } else {
+      jsiRuntimeHolder = m_jsiRuntimeHolder;
+    }
+  }
+
+  auto jsiRuntime = jsiRuntimeHolder ? jsiRuntimeHolder->getRuntime() : nullptr;
+
+  {
+    std::scoped_lock lock{m_mutex};
+    if (!m_jsiRuntime && jsiRuntime) {
+      // Set only if other thread did not do it yet.
+      m_jsiRuntime = winrt::make<winrt::Microsoft::ReactNative::implementation::JsiRuntime>(
+          std::move(jsiRuntimeHolder), std::move(jsiRuntime));
+    }
+
+    return m_jsiRuntime;
+  }
 }
 
 std::shared_ptr<facebook::react::Instance> ReactInstanceWin::GetInnerInstance() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -63,6 +63,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
  public:
   void CallJsFunction(std::string &&moduleName, std::string &&method, folly::dynamic &&params) noexcept;
   void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) noexcept;
+  winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() noexcept;
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept;
   bool IsLoaded() const noexcept;
 #ifndef CORE_ABI
@@ -175,6 +176,9 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
 #endif
   Mso::DispatchQueue m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
+
+  std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_jsiRuntimeHolder;
+  winrt::Microsoft::ReactNative::JsiRuntime m_jsiRuntime{nullptr};
 };
 
 } // namespace Mso::React


### PR DESCRIPTION
This PR adds ability to use JSI in NativeModules in case if it is executed in an JS engine that implements JSI.
When we use Web Debugging, there is no JSI and the new `ExecuteJsi` method does nothing.

The new `ReactContext::ExecuteJsi` takes as a parameter a lambda that has `facebook::jsi::Runtime&` argument.
Inside of this lambda we can run any code that uses the `facebook::jsi::Runtime&`.
The code is always run in the `JSDispatcher`. 
- If we are already in the `JSDispatcher` thread, then the code is executed synchronously.
- If we are in a different thread, then the lambda is posted to be executed in `JSDispatcher`.

This is an example of usage taken from the ReactNativeHostTests.cpp:
```C++
reactContext.ExecuteJsi([&](facebook::jsi::Runtime &rt) {
  auto eval = rt.global().getPropertyAsFunction(rt, "eval");
  auto addFunc = eval.call(rt, "(function(x, y) { return x + y; })").getObject(rt).getFunction(rt);
  TestCheckEqual(7, addFunc.call(rt, 3, 4).getNumber());
});
```

To implement this change we had to do a number of other related changes:
- Add `IReactContext::JsiRuntime { get; }` property to expose the JsiRuntime ABI from the context.
- Fix failing JSI tests to allow accepting Symbol as a property name in Chakra JSI implementation.
- Add `JsiAbiRuntime::GetOrCreate` method to get or create JsiAbiRuntime associated with JsiRuntime.
- Fix `JsFunctionCall_Succeeds` integration test and augment it with a call to `ReactContext::ExecuteJsi`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6582)