### PR TITLE
Add error for users who try to build apps/libs via project instead of solution

### DIFF
--- a/change/react-native-windows-2c7c8288-f17e-42f0-b803-1449fea26904.json
+++ b/change/react-native-windows-2c7c8288-f17e-42f0-b803-1449fea26904.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add error for users who try to build apps/libs via project instead of solution",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -35,4 +35,6 @@
   <!-- Due to visual studio unconditionally showing references, we have to trick it by making it impossible for VS to find the reference differences between building as source and building as NuGet -->
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.SourceReferences.targets"
           Condition="!$(UseExperimentalNuget)" />
+
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
@@ -23,4 +23,6 @@
   <Target Name="Deploy" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ManagedCodeGen\Microsoft.ReactNative.Managed.CodeGen.targets" 
           Condition="'$(ReactNativeCodeGenEnabled)' == 'true' and '$(UseExperimentalNuget)' != 'true'" />
+
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -42,4 +42,6 @@
   </Target>
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\CppAppConsumeCSharpModule.targets" />
+
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
@@ -18,4 +18,6 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="Deploy" />
+
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
 </Project>

--- a/vnext/PropertySheets/RequireSolution.targets
+++ b/vnext/PropertySheets/RequireSolution.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+  Copyright (c) Microsoft Corporation. All rights reserved.
+ Licensed under the MIT License.. 
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="RequireSolutionTargets" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>The property SolutionDir is blank. This project requires being built via a valid solution file.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="'$(SolutionDir)' == ''" Text="$(ErrorText)" />
+  </Target>
+
+</Project>

--- a/vnext/PropertySheets/RequireSolution.targets
+++ b/vnext/PropertySheets/RequireSolution.targets
@@ -7,9 +7,11 @@
 
   <Target Name="RequireSolutionTargets" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>The property SolutionDir is blank. This project requires being built via a valid solution file.</ErrorText>
+      <ErrorText>The property {0} is not defined. This project requires being built via a valid solution file.</ErrorText>
     </PropertyGroup>
-    <Error Condition="'$(SolutionDir)' == ''" Text="$(ErrorText)" />
+    <Error Condition="'$(SolutionPath)' == '' OR '$(SolutionPath)' == '*Undefined*'" Text="$([System.String]::Format('$(ErrorText)', 'SolutionPath'))" />
+    <Error Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'" Text="$([System.String]::Format('$(ErrorText)', 'SolutionDir'))" />
+    <Error Condition="'$(SolutionFileName)' == '' OR '$(SolutionFileName)' == '*Undefined*'" Text="$([System.String]::Format('$(ErrorText)', 'SolutionFileName'))" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This adds a new target to be included by external apps and libs, which will throw an error if they attempt to build without a solution file.

Closes #6581

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6585)