### PR TITLE
Fix CPanel leak when a transform is applied

### DIFF
--- a/change/react-native-windows-47f0ee14-4ccf-47a3-98c0-c2d982c53259.json
+++ b/change/react-native-windows-47f0ee14-4ccf-47a3-98c0-c2d982c53259.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix panels with transforms leaking",
+  "packageName": "react-native-windows",
+  "email": "stecrain@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -227,9 +227,9 @@ bool FrameworkElementViewManager::UpdateProperty(
           transformMatrix.m44 = static_cast<float>(propertyValue[15].AsDouble());
 
           if (!element.IsLoaded()) {
-            element.Loaded([=](auto &&, auto &&) -> auto {
-              ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
-            });
+            element.Loaded([=](auto sender, auto&&) -> auto {
+              ApplyTransformMatrix(sender.as<xaml::UIElement>(), nodeToUpdate, transformMatrix);
+             });
           } else {
             ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
           }

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -227,7 +227,7 @@ bool FrameworkElementViewManager::UpdateProperty(
           transformMatrix.m44 = static_cast<float>(propertyValue[15].AsDouble());
 
           if (!element.IsLoaded()) {
-            element.Loaded([=](auto sender, auto&&) -> auto {
+            element.Loaded([=](auto sender, auto &&) -> auto {
               ApplyTransformMatrix(sender.as<xaml::UIElement>(), nodeToUpdate, transformMatrix);
             });
           } else {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -229,7 +229,7 @@ bool FrameworkElementViewManager::UpdateProperty(
           if (!element.IsLoaded()) {
             element.Loaded([=](auto sender, auto&&) -> auto {
               ApplyTransformMatrix(sender.as<xaml::UIElement>(), nodeToUpdate, transformMatrix);
-             });
+            });
           } else {
             ApplyTransformMatrix(element, nodeToUpdate, transformMatrix);
           }


### PR DESCRIPTION
While looking at memory usage for my App I noticed that the number of CPanels identified by !idallocs kept increasing without going down. The number of CPanel objects in the !idallocs dump did not match the printout from !xamlstats.

With this change everything matches up again! Same number of CPanels on the heap as their are in the tree :)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6592)