### PR TITLE
Fix invalidation bug

### DIFF
--- a/change/react-native-windows-3460da96-2737-4874-8f5a-a79d89eb0942.json
+++ b/change/react-native-windows-3460da96-2737-4874-8f5a-a79d89eb0942.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix invalidation bug and use Canvas.Top/Left",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -138,14 +138,11 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
 void ViewPanel::InvalidateForArrange(xaml::UIElement element) {
   // If the element's position has changed, we must invalidate the parent for arrange,
   // as it's the parent's responsibility to arrange its children.
-  auto parent = VisualTreeHelper::GetParent(element);
-  if (parent) {
-    parent.try_as<xaml::UIElement>().InvalidateArrange();
+  if (auto parent = VisualTreeHelper::GetParent(element)) {
+    if (auto parentUIE = parent.try_as<xaml::UIElement>()) {
+      parentUIE.InvalidateArrange();
+    }
   }
-
-  // Also update Canvas.Top/Left as we actually use that for XAML Arrange
-  Canvas::SetTop(element, ViewPanel::GetTop(element));
-  Canvas::SetLeft(element, ViewPanel::GetLeft(element));
 }
 
 winrt::Size ViewPanel::MeasureOverride(winrt::Size /*availableSize*/) {
@@ -198,8 +195,8 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
     childWidth = std::max<double>(0.0f, childWidth);
     childHeight = std::max<double>(0.0f, childHeight);
 
-    float adjustedLeft = static_cast<float>(Canvas::GetLeft(child)) - outerBorderLeft;
-    float adjustedTop = static_cast<float>(Canvas::GetTop(child)) - outerBorderTop;
+    float adjustedLeft = static_cast<float>(ViewPanel::GetLeft(child)) - outerBorderLeft;
+    float adjustedTop = static_cast<float>(ViewPanel::GetTop(child)) - outerBorderTop;
 
     child.Arrange(
         winrt::Rect(adjustedLeft, adjustedTop, static_cast<float>(childWidth), static_cast<float>(childHeight)));

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -91,6 +91,8 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
 
   void UpdateClip(winrt::Windows::Foundation::Size &finalSize);
 
+  static void InvalidateForArrange(xaml::UIElement element);
+
  private:
   bool m_propertiesChanged{false};
 


### PR DESCRIPTION
Fixes #6586

This fixes a long standing bug in layout that was discovered recently in RNTester.  This recent bug fix exposed the bug:
https://github.com/microsoft/react-native-windows/pull/6451

The bug is straightforward.  In ViewPanel we do this to invalidate for arrange when top/left changes:

```
/*static*/ void ViewPanel::SetTop(xaml::UIElement const &element, double value) {
  element.SetValue(TopProperty(), winrt::box_value<double>(value));
  element.InvalidateArrange();
}
```
The call to element.InvdliateArrange() is the bug.

This is making the assumption that the ViewPanel is responsible for positioning itself.  This isn't correct.  It is the parent's responsibility for positioning its children.  Thus we are invalidating the wrong element.  We should invalidate the parent, not ourselves.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6593)