### PR TITLE
Use new command-line tool for appx deployment

### DIFF
--- a/change/@react-native-windows-cli-f2b98d50-5bed-4a85-abfd-c8a0cabcf7ee.json
+++ b/change/@react-native-windows-cli-f2b98d50-5bed-4a85-abfd-c8a0cabcf7ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Deploy using VS tool",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/commandWithProgress.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/commandWithProgress.ts
@@ -113,7 +113,7 @@ export function commandWithProgress(
         resolve();
       } else {
         spinner.fail();
-        reject();
+        reject(new Error(`${taskDoingName} returned error code ${code}`));
       }
     });
   });

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -239,28 +239,7 @@ export async function deployToDesktop(
   })[0];
   const appName = identity.attributes.Name;
 
-  const vsVersion = buildTools.installationVersion;
-  if (vsVersion.startsWith('16.5') || vsVersion.startsWith('16.6')) {
-    // VS 16.5 and 16.6 introduced a regression in packaging where the certificates created in the UI will render the package uninstallable.
-    // This will be fixed in 16.7. In the meantime we need to copy the Add-AppDevPackage that has the fix for this EKU issue:
-    // https://developercommunity.visualstudio.com/content/problem/1012921/uwp-packaging-generates-incompatible-certificate.html
-    if (verbose) {
-      newWarn(
-        'Applying Add-AppDevPackage.ps1 workaround for VS 16.5-16.6 bug - see https://developercommunity.visualstudio.com/content/problem/1012921/uwp-packaging-generates-incompatible-certificate.html',
-      );
-    }
-    fs.copyFileSync(
-      path.join(
-        path.resolve(__dirname),
-        '..',
-        '..',
-        '..',
-        'powershell',
-        'Add-AppDevPackage.ps1',
-      ),
-      script,
-    );
-  }
+  // const vsVersion = buildTools.installationVersion;
 
   let args = [];
   if (options.remoteDebugging) {
@@ -301,9 +280,6 @@ export async function deployToDesktop(
     const IDE_folder = `${buildTools.installationPath}\\Common7\\IDE`;
     const deployAppxRecipe_exe = `${IDE_folder}\\DeployAppRecipe.exe`;
     if (fs.existsSync(deployAppxRecipe_exe)) {
-      // Need fix for VS's DeployAppxRecipe to return error code on failure and to be able to be run from any directory
-      const oldDir = process.cwd();
-      process.chdir(IDE_folder);
       await commandWithProgress(
         newSpinner('Deploying'),
         `Deploying ${appxRecipe}`,
@@ -313,7 +289,6 @@ export async function deployToDesktop(
         ],
         verbose,
       );
-      process.chdir(oldDir);
     } else {
       // Install the app package's dependencies before attempting to deploy.
       await runPowerShellScriptFunction(

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -298,17 +298,22 @@ export async function deployToDesktop(
     );
   } else {
     const appxRecipe = path.join(path.dirname(appxManifestPath), `${projectName}.build.appxrecipe`);
-    const deployAppxRecipe_exe = `${buildTools.installationVersion}\\Common7\\IDE\\DeployAppRecipe.exe`;
+    const IDE_folder = `${buildTools.installationPath}\\Common7\\IDE`;
+    const deployAppxRecipe_exe = `${IDE_folder}\\DeployAppRecipe.exe`;
     if (fs.existsSync(deployAppxRecipe_exe)) {
+      // Need fix for VS's DeployAppxRecipe to return error code on failure and to be able to be run from any directory
+      const oldDir = process.cwd();
+      process.chdir(IDE_folder);
       await commandWithProgress(
         newSpinner('Deploying'),
-        'Deploying',
+        `Deploying ${appxRecipe}`,
         deployAppxRecipe_exe,
         [
-          appxRecipe
+          appxRecipe,
         ],
         verbose,
       );
+      process.chdir(oldDir);
     } else {
       // Install the app package's dependencies before attempting to deploy.
       await runPowerShellScriptFunction(

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -231,7 +231,6 @@ export async function deployToDesktop(
     windowsConfig && windowsConfig.project && windowsConfig.project.projectName
       ? windowsConfig.project.projectName
       : options.proj!;
-  const appPackageFolder = getAppPackage(options, projectName);
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(options, projectName);
   const appxManifest = parseAppxManifest(appxManifestPath);
@@ -239,9 +238,6 @@ export async function deployToDesktop(
     return x.name === 'Identity';
   })[0];
   const appName = identity.attributes.Name;
-  const script = glob.sync(
-    path.join(appPackageFolder, 'Add-AppDevPackage.ps1'),
-  )[0];
 
   const vsVersion = buildTools.installationVersion;
   if (vsVersion.startsWith('16.5') || vsVersion.startsWith('16.6')) {
@@ -266,7 +262,7 @@ export async function deployToDesktop(
     );
   }
 
-  const args = [];
+  let args = [];
   if (options.remoteDebugging) {
     args.push('--remote-debugging');
   }
@@ -276,20 +272,24 @@ export async function deployToDesktop(
   }
 
   await runPowerShellScriptFunction(
-    'Removing old version of the app',
-    windowsStoreAppUtils,
-    `Uninstall-App ${appName}`,
-    verbose,
-  );
-
-  await runPowerShellScriptFunction(
     'Enabling Developer Mode',
     windowsStoreAppUtils,
     'EnableDevMode',
     verbose,
   );
 
+  const appPackageFolder = getAppPackage(options, projectName);
+
   if (options.release) {
+    await runPowerShellScriptFunction(
+        'Removing old version of the app',
+        windowsStoreAppUtils,
+        `Uninstall-App ${appName}`,
+        verbose,
+      ); 
+    const script = glob.sync(
+      path.join(appPackageFolder, 'Add-AppDevPackage.ps1'),
+    )[0];
     await runPowerShellScriptFunction(
       'Installing new version of the app',
       windowsStoreAppUtils,
@@ -297,23 +297,38 @@ export async function deployToDesktop(
       verbose,
     );
   } else {
-    // Install the app package's dependencies before attempting to deploy.
-    await runPowerShellScriptFunction(
-      'Installing dependent framework packages',
-      windowsStoreAppUtils,
-      `Install-AppDependencies ${appxManifestPath} ${appPackageFolder} ${options.arch}`,
-      verbose,
-    );
-    await build.buildSolution(
-      buildTools,
-      slnFile,
-      'Debug',
-      options.arch,
-      {DeployLayout: 'true'},
-      verbose,
-      'deploy',
-      options.buildLogDirectory,
-    );
+    const appxRecipe = path.join(path.dirname(appxManifestPath), `${projectName}.build.appxrecipe`);
+    const deployAppxRecipe_exe = `${buildTools.installationVersion}\\Common7\\IDE\\DeployAppRecipe.exe`;
+    if (fs.existsSync(deployAppxRecipe_exe)) {
+      await commandWithProgress(
+        newSpinner('Deploying'),
+        'Deploying',
+        deployAppxRecipe_exe,
+        [
+          appxRecipe
+        ],
+        verbose,
+      );
+    } else {
+      // Install the app package's dependencies before attempting to deploy.
+      await runPowerShellScriptFunction(
+        'Installing dependent framework packages',
+        windowsStoreAppUtils,
+        `Install-AppDependencies ${appxManifestPath} ${appPackageFolder} ${options.arch}`,
+        verbose,
+      );
+      await build.buildSolution(
+        buildTools,
+        slnFile,
+        options.release ? 'Release' : 'Debug',
+        options.arch,
+        {DeployLayout: 'true'},
+        verbose,
+        'deploy',
+        options.buildLogDirectory,
+      );
+
+    }
   }
 
   const appFamilyName = execSync(

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -164,7 +164,7 @@ export default class MSBuildTools {
       'Microsoft.Component.MSBuild',
       getVCToolsByArch(buildArch),
     ];
-    const minVersion = process.env.VisualStudioVersion || '16.5';
+    const minVersion = process.env.VisualStudioVersion || '16.9';
     const vsInstallation = findLatestVsInstall({
       requires,
       minVersion,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -36,14 +36,11 @@ export default class MSBuildTools {
     public readonly installationVersion: string,
   ) {}
 
-   /**
-    * @returns directory where x86 msbuild can be found
-    */
-   msbuildPath() {
-    return path.join(
-      this.installationPath,
-      'MSBuild/Current/Bin',
-    );
+  /**
+   * @returns directory where x86 msbuild can be found
+   */
+  msbuildPath() {
+    return path.join(this.installationPath, 'MSBuild/Current/Bin');
   }
 
   cleanProject(slnFile: string) {
@@ -164,7 +161,7 @@ export default class MSBuildTools {
       'Microsoft.Component.MSBuild',
       getVCToolsByArch(buildArch),
     ];
-    const minVersion = process.env.VisualStudioVersion || '16.9';
+    const minVersion = process.env.VisualStudioVersion || '16.7';
     const vsInstallation = findLatestVsInstall({
       requires,
       minVersion,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -27,18 +27,28 @@ import {findLatestVsInstall} from './vsInstalls';
 export default class MSBuildTools {
   /**
    * @param version is something like 16.0 for 2019
-   * @param msbuildPath  Path to MSBuild.exe (x86)
+   * @param installationPath  Path to installation root
    * @param installationVersion is the full version e.g. 16.3.29411.108
    */
   constructor(
     public readonly version: string,
-    public readonly msbuildPath: string,
+    public readonly installationPath: string,
     public readonly installationVersion: string,
   ) {}
 
+   /**
+    * @returns directory where x86 msbuild can be found
+    */
+   msbuildPath() {
+    return path.join(
+      this.installationPath,
+      'MSBuild/Current/Bin',
+    );
+  }
+
   cleanProject(slnFile: string) {
     const cmd = `"${path.join(
-      this.msbuildPath,
+      this.msbuildPath(),
       'msbuild.exe',
     )}" "${slnFile}" /t:Clean`;
     const results = child_process
@@ -123,7 +133,7 @@ export default class MSBuildTools {
       await commandWithProgress(
         spinner,
         progressName,
-        path.join(this.msbuildPath, 'msbuild.exe'),
+        path.join(this.msbuildPath(), 'msbuild.exe'),
         [slnFile].concat(args),
         verbose,
       );
@@ -185,7 +195,7 @@ export default class MSBuildTools {
       );
       return new MSBuildTools(
         minVersion,
-        toolsPath,
+        vsInstallation.installationPath,
         vsInstallation.installationVersion,
       );
     } else {


### PR DESCRIPTION
Fixes #6102 

This requires a fix to VS's DeployAppxRecipe.exe that I'm waiting to get serviced so marking this as draft for now
Update: VS is fixing the tool in 16.9 P2

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6594)