### PR TITLE
Enable more ESLint rules

### DIFF
--- a/change/@office-iss-react-native-win32-5bb8c9d6-9cd0-4fbb-98ef-acb34550f829.json
+++ b/change/@office-iss-react-native-win32-5bb8c9d6-9cd0-4fbb-98ef-acb34550f829.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add more eslint rules",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-656b5015-a1b3-480a-a2a4-46aede6983ad.json
+++ b/change/@react-native-windows-cli-656b5015-a1b3-480a-a2a4-46aede6983ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add more eslint rules",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-f8738f42-3993-452f-9832-d1b6fd410c67.json
+++ b/change/@react-native-windows-telemetry-f8738f42-3993-452f-9832-d1b6fd410c67.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixup naming convention rules",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-eslint-config-dd72e2db-bbcf-4313-8d8a-a1d8d7c7f544.json
+++ b/change/@rnw-scripts-eslint-config-dd72e2db-bbcf-4313-8d8a-a1d8d7c7f544.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "@rnw-scripts/eslint-config",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-format-files-eb4a1061-6ba7-4303-adcc-113eca433d72.json
+++ b/change/@rnw-scripts-format-files-eb4a1061-6ba7-4303-adcc-113eca433d72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "@rnw-scripts/format-files",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-integrate-rn-b9671523-8d57-4a55-bf2d-e7955d4b6d17.json
+++ b/change/@rnw-scripts-integrate-rn-b9671523-8d57-4a55-bf2d-e7955d4b6d17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-package-utils-06e93ca4-8184-4421-b09b-54d08c4de2af.json
+++ b/change/@rnw-scripts-package-utils-06e93ca4-8184-4421-b09b-54d08c4de2af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "@rnw-scripts/package-utils",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-e232cf59-3213-4bc8-bbc9-1e8807c51e5b.json
+++ b/change/react-native-platform-override-e232cf59-3213-4bc8-bbc9-1e8807c51e5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-ac79d9c8-97e9-42e8-bd31-2ba634a9dd99.json
+++ b/change/react-native-windows-ac79d9c8-97e9-42e8-bd31-2ba634a9dd99.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add more eslint rules",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-codegen-da07b8d8-0706-446b-a35a-15a02dca2842.json
+++ b/change/react-native-windows-codegen-da07b8d8-0706-446b-a35a-15a02dca2842.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "react-native-windows-codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-63ab462f-87c3-4ef2-b4f0-fa1a290e0620.json
+++ b/change/react-native-windows-init-63ab462f-87c3-4ef2-b4f0-fa1a290e0620.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add more eslint rules",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -83,7 +83,7 @@ export function findSolutionFiles(winFolder: string): string[] {
     return [allSolutions[0]];
   }
 
-  var solutionFiles = [];
+  const solutionFiles = [];
 
   // Try to find any solution file that appears to be a React Native solution
   for (const solutionFile of allSolutions) {
@@ -136,7 +136,7 @@ export function findDependencyProjectFiles(winFolder: string): string[] {
     return [];
   }
 
-  var dependencyProjectFiles = [];
+  const dependencyProjectFiles = [];
 
   // Try to find any project file that appears to be a dependency project
   for (const projectFile of allProjects) {
@@ -189,7 +189,7 @@ export function findAppProjectFiles(winFolder: string): string[] {
     return [];
   }
 
-  var appProjectFiles = [];
+  const appProjectFiles = [];
 
   // Try to find any project file that appears to be an app project
   for (const projectFile of allProjects) {
@@ -236,7 +236,7 @@ export function tryFindPropertyValue(
   projectContents: Node,
   propertyName: string,
 ): string | null {
-  var nodes = msbuildSelect(
+  const nodes = msbuildSelect(
     `//msbuild:PropertyGroup/msbuild:${propertyName}`,
     projectContents,
   );
@@ -271,7 +271,7 @@ export function importProjectExists(
   projectContents: Node,
   projectName: string,
 ): boolean {
-  var nodes = msbuildSelect(
+  const nodes = msbuildSelect(
     `//msbuild:Import[contains(@Project,'${projectName}')]`,
     projectContents,
   );

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -4,6 +4,11 @@
  * @format
  */
 
+// Types in this file are inaccurate compared to usage in terms of falsiness.
+// We should try to rewrite some of this to do automated schema validation to
+// guarantee correct types
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
 import * as path from 'path';
 
 import * as configUtils from './configUtils';
@@ -106,6 +111,8 @@ export interface WindowsDependencyConfig {
  * @param userConfig A manually specified override config.
  * @return The config if any RNW native modules exist.
  */
+// Disabled due to existing high cyclomatic complexity
+// eslint-disable-next-line complexity
 export function dependencyConfigWindows(
   folder: string,
   userConfig: Partial<WindowsDependencyConfig> | null = {},
@@ -120,7 +127,7 @@ export function dependencyConfigWindows(
   const usingManualNugetPackagesOverride =
     'nugetPackages' in userConfig && Array.isArray(userConfig.nugetPackages);
 
-  var result: WindowsDependencyConfig = {
+  const result: WindowsDependencyConfig = {
     folder,
     projects: usingManualProjectsOverride ? userConfig.projects! : [],
     solutionFile: null,
@@ -135,15 +142,15 @@ export function dependencyConfigWindows(
     if (!('sourceDir' in userConfig)) {
       sourceDir =
         'Error: Source dir is required if projects are specified, but it is not specified in react-native.config.';
-    } else if (userConfig.sourceDir === null) {
+    } else if (!userConfig.sourceDir) {
       sourceDir =
-        'Error: Source dir is required if projects are specified, but it is null in react-native.config.';
+        'Error: Source dir is required if projects are specified, but it is not defined in react-native.config.';
     } else {
       sourceDir = path.join(folder, userConfig.sourceDir!);
     }
   } else if (!usingManualProjectsOverride) {
     // No manually provided projects, try to find sourceDir
-    if ('sourceDir' in userConfig && userConfig.sourceDir !== null) {
+    if ('sourceDir' in userConfig && userConfig.sourceDir) {
       sourceDir = path.join(folder, userConfig.sourceDir!);
     } else {
       sourceDir = configUtils.findWindowsFolder(folder);
@@ -175,7 +182,7 @@ export function dependencyConfigWindows(
 
   const usingManualSolutionFile = 'solutionFile' in userConfig;
 
-  var solutionFile = null;
+  let solutionFile = null;
   if (usingManualSolutionFile && userConfig.solutionFile !== null) {
     // Manually provided solutionFile, so extract it
     solutionFile = path.join(sourceDir, userConfig.solutionFile!);
@@ -198,9 +205,10 @@ export function dependencyConfigWindows(
       'directDependency',
     ];
 
-    for (let project of result.projects) {
+    for (const project of result.projects) {
       // Verifying (req) items
-      var errorFound = false;
+      let errorFound = false;
+
       alwaysRequired.forEach(item => {
         if (!(item in project)) {
           (project[
@@ -265,10 +273,10 @@ export function dependencyConfigWindows(
 
       const directDependency = true;
 
-      let cppHeaders: string[] = [];
-      let cppPackageProviders: string[] = [];
-      let csNamespaces: string[] = [];
-      let csPackageProviders: string[] = [];
+      const cppHeaders: string[] = [];
+      const cppPackageProviders: string[] = [];
+      const csNamespaces: string[] = [];
+      const csPackageProviders: string[] = [];
 
       if (projectNamespace !== null) {
         const cppNamespace = projectNamespace.replace(/\./g, '::');

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -142,15 +142,15 @@ export function dependencyConfigWindows(
     if (!('sourceDir' in userConfig)) {
       sourceDir =
         'Error: Source dir is required if projects are specified, but it is not specified in react-native.config.';
-    } else if (!userConfig.sourceDir) {
+    } else if (userConfig.sourceDir === null) {
       sourceDir =
-        'Error: Source dir is required if projects are specified, but it is not defined in react-native.config.';
+        'Error: Source dir is required if projects are specified, but it is null in react-native.config.';
     } else {
       sourceDir = path.join(folder, userConfig.sourceDir!);
     }
   } else if (!usingManualProjectsOverride) {
     // No manually provided projects, try to find sourceDir
-    if ('sourceDir' in userConfig && userConfig.sourceDir) {
+    if ('sourceDir' in userConfig && userConfig.sourceDir !== null) {
       sourceDir = path.join(folder, userConfig.sourceDir!);
     } else {
       sourceDir = configUtils.findWindowsFolder(folder);

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -92,21 +92,21 @@ export function projectConfigWindows(
     return null;
   }
 
-  var result: DeepPartial<WindowsProjectConfig> = {
+  const result: DeepPartial<WindowsProjectConfig> = {
     folder: folder,
     sourceDir: path.relative(folder, sourceDir),
   };
 
-  var validProject = false;
+  let validProject = false;
 
   if (usingManualOverride) {
     // Manual override, try to use it for solutionFile
     if (!('solutionFile' in userConfig)) {
       result.solutionFile =
         'Error: Solution file is required but not specified in react-native.config.';
-    } else if (userConfig.solutionFile === null) {
+    } else if (!userConfig.solutionFile) {
       result.solutionFile =
-        'Error: Solution file is null in react-native.config.';
+        'Error: Solution file is not defined in react-native.config.';
     } else {
       result.solutionFile = userConfig.solutionFile;
     }
@@ -127,9 +127,10 @@ export function projectConfigWindows(
           projectFile:
             'Error: Project file is required for project in react-native.config.',
         };
-      } else if (userConfig.project.projectFile === null) {
+      } else if (!userConfig.project.projectFile) {
         result.project = {
-          projectFile: 'Error: Project file is null in react-native.config.',
+          projectFile:
+            'Error: Project file is not defined in react-native.config.',
         };
       } else {
         result.project = {

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -4,6 +4,11 @@
  * @format
  */
 
+// Types in this file are inaccurate compared to usage in terms of falsiness.
+// We should try to rewrite some of this to do automated schema validation to
+// guarantee correct types
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
 import * as path from 'path';
 
 import * as configUtils from './configUtils';
@@ -104,9 +109,9 @@ export function projectConfigWindows(
     if (!('solutionFile' in userConfig)) {
       result.solutionFile =
         'Error: Solution file is required but not specified in react-native.config.';
-    } else if (!userConfig.solutionFile) {
+    } else if (userConfig.solutionFile === null) {
       result.solutionFile =
-        'Error: Solution file is not defined in react-native.config.';
+        'Error: Solution file is null in react-native.config.';
     } else {
       result.solutionFile = userConfig.solutionFile;
     }
@@ -127,10 +132,9 @@ export function projectConfigWindows(
           projectFile:
             'Error: Project file is required for project in react-native.config.',
         };
-      } else if (!userConfig.project.projectFile) {
+      } else if (userConfig.project.projectFile === null) {
         result.project = {
-          projectFile:
-            'Error: Project file is not defined in react-native.config.',
+          projectFile: 'Error: Project file is null in react-native.config.',
         };
       } else {
         result.project = {

--- a/packages/@react-native-windows/cli/src/e2etest/dependencyConfig.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/dependencyConfig.test.ts
@@ -133,7 +133,7 @@ test.each(projects)(
 
     const userConfig: Partial<WindowsDependencyConfig> =
       rnc.dependency.platforms.windows;
-    let expectedConfig: WindowsDependencyConfig | null = rnc.expectedConfig;
+    const expectedConfig: WindowsDependencyConfig | null = rnc.expectedConfig;
 
     if (expectedConfig !== null) {
       expectedConfig.folder = folder;

--- a/packages/@react-native-windows/cli/src/e2etest/projectConfig.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/projectConfig.test.ts
@@ -132,7 +132,7 @@ test.each(projects)(
     }
 
     const userConfig: Partial<WindowsProjectConfig> = rnc.project.windows;
-    let expectedConfig: WindowsProjectConfig | null = rnc.expectedConfig;
+    const expectedConfig: WindowsProjectConfig | null = rnc.expectedConfig;
 
     if (expectedConfig !== null) {
       expectedConfig.folder = folder;

--- a/packages/@react-native-windows/cli/src/generator-common/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-common/index.ts
@@ -93,7 +93,7 @@ export async function copyAndReplace(
   }
 
   const extension = path.extname(srcPath);
-  if (binaryExtensions.indexOf(extension) !== -1) {
+  if (binaryExtensions.includes(extension)) {
     // Binary file
     let shouldOverwrite = 'overwrite';
     if (contentChangedCallback) {
@@ -123,7 +123,7 @@ export async function copyAndReplace(
   } else {
     // Text file
     const srcPermissions = fs.statSync(srcPath).mode;
-    let content = resolveContents(srcPath, replacements);
+    const content = resolveContents(srcPath, replacements);
 
     let shouldOverwrite = 'overwrite';
     if (contentChangedCallback) {

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -32,7 +32,6 @@ async function generateCertificate(
   currentUser: string,
 ): Promise<string | null> {
   console.log('Generating self-signed certificate...');
-  let toCopyTempKey = false;
   if (os.platform() === 'win32') {
     try {
       const timeout = 10000; // 10 seconds;
@@ -59,30 +58,18 @@ async function generateCertificate(
       );
       return thumbprint;
     } catch (err) {
-      console.log(
-        chalk.yellow(
-          'Failed to generate Self-signed certificate. Using Default Certificate. Use Visual Studio to renew it.',
-        ),
-      );
-      toCopyTempKey = true;
+      console.log(chalk.yellow('Failed to generate Self-signed certificate.'));
     }
-  } else {
-    console.log(
-      chalk.yellow('Using Default Certificate. Use Visual Studio to renew it.'),
-    );
-    toCopyTempKey = true;
   }
-  if (toCopyTempKey) {
-    await copyAndReplaceWithChangedCallback(
-      path.join(srcPath, 'keys', 'MyApp_TemporaryKey.pfx'),
-      destPath,
-      path.join(
-        windowsDir,
-        newProjectName,
-        newProjectName + '_TemporaryKey.pfx',
-      ),
-    );
-  }
+
+  console.log(
+    chalk.yellow('Using Default Certificate. Use Visual Studio to renew it.'),
+  );
+  await copyAndReplaceWithChangedCallback(
+    path.join(srcPath, 'keys', 'MyApp_TemporaryKey.pfx'),
+    destPath,
+    path.join(windowsDir, newProjectName, newProjectName + '_TemporaryKey.pfx'),
+  );
 
   return null;
 }
@@ -110,6 +97,8 @@ function pascalCase(str: string) {
   return camelCase[0].toUpperCase() + camelCase.substr(1);
 }
 
+// Existing high cyclomatic complexity
+// eslint-disable-next-line complexity
 export async function copyProjectTemplateAndReplace(
   srcRootPath: string,
   destPath: string,
@@ -455,7 +444,7 @@ export async function copyProjectTemplateAndReplace(
 
   // shared proj
   if (fs.existsSync(path.join(sharedPath, projDir))) {
-    let sharedProjMappings = [];
+    const sharedProjMappings = [];
 
     // Once we are publishing to nuget.org, this shouldn't be needed anymore
     if (options.experimentalNuGetDependency) {

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -122,7 +122,7 @@ export async function generateWindows(
         cliVersion = rnwCliPkgJson.version;
       } catch {}
       const optScrubbed = scrubOptions(options);
-      Telemetry.client?.trackEvent({
+      Telemetry.client.trackEvent({
         name: 'generate-windows',
         properties: {
           error: error,
@@ -132,7 +132,7 @@ export async function generateWindows(
         },
       });
 
-      Telemetry.client?.flush();
+      Telemetry.client.flush();
     }
   }
 }

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -121,7 +121,6 @@ async function runWindows(
       name: 'run-windows',
       properties: {
         release: options.release,
-        root: options.root !== undefined,
         arch: options.arch,
         singleproc: options.singleproc,
         emulator: options.emulator,
@@ -243,7 +242,7 @@ async function runWindowsInternal(
 
     // Get build/deploy options
     const buildType = deploy.getBuildConfiguration(options);
-    let msBuildProps = build.parseMsBuildProps(options);
+    const msBuildProps = build.parseMsBuildProps(options);
 
     // Disable the autolink check since we just ran it
     msBuildProps.RunAutolinkCheck = 'false';

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -4,6 +4,11 @@
  * @format
  */
 
+// Types in this file are inaccurate compared to usage in terms of falsiness.
+// We should try to rewrite some of this to do automated schema validation to
+// guarantee correct types
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as chalk from 'chalk';
@@ -65,7 +70,7 @@ function getNormalizedContents(
   replacements: generatorCommon.Replacements,
 ) {
   // Template files are CRLF, JS-generated replacements are LF, normalize replacements to CRLF
-  for (var key in replacements) {
+  for (const key of Object.keys(replacements)) {
     replacements[key] = replacements[key].replace(/\n/g, '\r\n');
   }
 
@@ -118,6 +123,8 @@ function updateFile(
  * @param config Config passed from react-native CLI.
  * @param options Options passed from react-native CLI.
  */
+// Disabling lint warnings due to high existing cyclomatic complexity
+// eslint-disable-next-line complexity
 async function updateAutoLink(
   args: string[],
   config: Config,
@@ -129,7 +136,7 @@ async function updateAutoLink(
 
   const checkMode = options.check;
 
-  var changesNecessary = false;
+  let changesNecessary = false;
 
   const spinner = newSpinner(
     checkMode ? 'Checking auto-linked files...' : 'Auto-linking...',
@@ -245,9 +252,9 @@ async function updateAutoLink(
 
     const dependenciesConfig = config.dependencies;
 
-    let windowsDependencies: Record<string, WindowsDependencyConfig> = {};
+    const windowsDependencies: Record<string, WindowsDependencyConfig> = {};
 
-    for (const dependencyName in dependenciesConfig) {
+    for (const dependencyName of Object.keys(dependenciesConfig)) {
       const windowsDependency: WindowsDependencyConfig | undefined =
         dependenciesConfig[dependencyName].platforms.windows;
 
@@ -258,7 +265,7 @@ async function updateAutoLink(
         );
         verboseMessage(windowsDependency, verbose);
 
-        var dependencyIsValid = true;
+        let dependencyIsValid = true;
 
         dependencyIsValid = !!(
           dependencyIsValid &&
@@ -299,7 +306,7 @@ async function updateAutoLink(
       let csUsingNamespaces = '';
       let csReactPackageProviders = '';
 
-      for (const dependencyName in windowsDependencies) {
+      for (const dependencyName of Object.keys(windowsDependencies)) {
         windowsDependencies[dependencyName].projects.forEach(project => {
           if (project.directDependency) {
             csUsingNamespaces += `\n\n// Namespaces from ${dependencyName}`;
@@ -343,7 +350,7 @@ async function updateAutoLink(
       let cppIncludes = '';
       let cppPackageProviders = '';
 
-      for (const dependencyName in windowsDependencies) {
+      for (const dependencyName of Object.keys(windowsDependencies)) {
         windowsDependencies[dependencyName].projects.forEach(project => {
           if (project.directDependency) {
             cppIncludes += `\n\n// Includes from ${dependencyName}`;
@@ -393,10 +400,10 @@ async function updateAutoLink(
 
     // Generating props for app project consumption
     let propertiesForProps = '';
-    let csModuleNames: string[] = [];
+    const csModuleNames: string[] = [];
 
     if (projectLang === 'cpp') {
-      for (const dependencyName in windowsDependencies) {
+      for (const dependencyName of Object.keys(windowsDependencies)) {
         windowsDependencies[dependencyName].projects.forEach(project => {
           if (project.directDependency && project.projectLang === 'cs') {
             csModuleNames.push(project.projectName);
@@ -437,7 +444,7 @@ async function updateAutoLink(
     // Generating targets for app project consumption
     let projectReferencesForTargets = '';
 
-    for (const dependencyName in windowsDependencies) {
+    for (const dependencyName of Object.keys(windowsDependencies)) {
       windowsDependencies[dependencyName].projects.forEach(project => {
         if (project.directDependency) {
           const dependencyProjectFile = path.join(
@@ -484,9 +491,9 @@ async function updateAutoLink(
       changesNecessary;
 
     // Generating project entries for solution
-    let projectsForSolution: Project[] = [];
+    const projectsForSolution: Project[] = [];
 
-    for (const dependencyName in windowsDependencies) {
+    for (const dependencyName of Object.keys(windowsDependencies)) {
       // Process dependency projects
       windowsDependencies[dependencyName].projects.forEach(project => {
         const dependencyProjectFile = path.join(
@@ -543,7 +550,7 @@ async function updateAutoLink(
     });
 
     spinner.succeed();
-    var endTime = performance.now();
+    const endTime = performance.now();
 
     if (!changesNecessary) {
       console.log(
@@ -577,7 +584,7 @@ async function updateAutoLink(
     }
   } catch (e) {
     spinner.fail();
-    var endTime = performance.now();
+    const endTime = performance.now();
     console.log(
       `${chalk.red('Error:')} ${e.toString()}. (${Math.round(
         endTime - startTime,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/build.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/build.ts
@@ -112,12 +112,12 @@ export function getAppProjectFile(options: RunWindowsOptions, config: Config) {
 export function parseMsBuildProps(
   options: RunWindowsOptions,
 ): Record<string, string> {
-  let result: Record<string, string> = {};
+  const result: Record<string, string> = {};
   if (options.msbuildprops) {
     const props = options.msbuildprops.split(',');
-    for (let i = 0; i < props.length; i++) {
-      const prop = props[i].split('=');
-      result[prop[0]] = prop[1];
+    for (const prop of props) {
+      const propAssignment = prop.split('=');
+      result[propAssignment[0]] = propAssignment[1];
     }
   }
   return result;

--- a/packages/@react-native-windows/cli/src/runWindows/utils/checkRequirements.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/checkRequirements.ts
@@ -50,8 +50,8 @@ function getInstalledWindowsSdks(): Version[] {
   }
 
   const re = /\\Microsoft SDKs\\Windows\\v(\d+\.\d+)\s*InstallationFolder\s+REG_SZ\s+(.*)/gim;
-  let match: RegExpExecArray;
-  while ((match = re.exec(output)!)) {
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(output))) {
     const sdkPath = match[2];
     if (shell.test('-e', path.join(sdkPath, 'SDKManifest.xml'))) {
       const sdkVersion = Version.tryParse(match[1]);

--- a/packages/@react-native-windows/cli/src/runWindows/utils/commandWithProgress.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/commandWithProgress.ts
@@ -76,7 +76,7 @@ export function commandWithProgress(
   args: string[],
   verbose: boolean,
 ) {
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     const spawnOptions: SpawnOptions = verbose ? {stdio: 'inherit'} : {};
 
     if (verbose) {
@@ -95,9 +95,6 @@ export function commandWithProgress(
         if (!firstErrorLine) {
           firstErrorLine = text;
         }
-        if (verbose) {
-          console.error(chalk.red(text));
-        }
         if (text) {
           setSpinnerText(spinner, taskDoingName + ': ERROR: ', firstErrorLine);
         }
@@ -110,7 +107,7 @@ export function commandWithProgress(
       }
       spinner.fail(e.toString());
       reject(e);
-    }).on('close', function(code) {
+    }).on('close', code => {
       if (code === 0) {
         spinner.succeed(taskDoingName);
         resolve();

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -79,7 +79,7 @@ function getAppPackage(
     const rootGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*}`;
     const newGlob = `${rootGlob}/*_${
       options.arch === 'x86' ? '{Win32,x86}' : options.arch
-    }_${options.release ? '' : 'Debug_'}Test`;
+    }_Test`;
 
     const result = glob.sync(newGlob);
     if (result.length > 1 && projectName) {
@@ -128,7 +128,7 @@ function getAppxManifestPath(
   if (globs.length === 1 || !projectName) {
     appxPath = globs[0];
   } else {
-    const filteredGlobs = globs.filter(x => x.indexOf(projectName) !== -1);
+    const filteredGlobs = globs.filter(x => x.includes(projectName));
     if (filteredGlobs.length > 1) {
       newWarn(
         `More than one appxmanifest for ${projectName}: ${filteredGlobs.join(
@@ -178,7 +178,7 @@ export async function deployToDevice(
   const deployTool = new WinAppDeployTool();
   const appxManifest = getAppxManifest(options);
   const shouldLaunch = shouldLaunchApp(options);
-  const identity = appxManifest.root.children.filter(function(x) {
+  const identity = appxManifest.root.children.filter(x => {
     return x.name === 'mp:PhoneIdentity';
   })[0];
   const appName = identity.attributes.PhoneProductId;
@@ -235,7 +235,7 @@ export async function deployToDesktop(
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(options, projectName);
   const appxManifest = parseAppxManifest(appxManifestPath);
-  const identity = appxManifest.root.children.filter(function(x) {
+  const identity = appxManifest.root.children.filter(x => {
     return x.name === 'Identity';
   })[0];
   const appName = identity.attributes.Name;
@@ -266,7 +266,7 @@ export async function deployToDesktop(
     );
   }
 
-  let args = [];
+  const args = [];
   if (options.remoteDebugging) {
     args.push('--remote-debugging');
   }
@@ -307,7 +307,7 @@ export async function deployToDesktop(
     await build.buildSolution(
       buildTools,
       slnFile,
-      options.release ? 'Release' : 'Debug',
+      'Release',
       options.arch,
       {DeployLayout: 'true'},
       verbose,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -307,7 +307,7 @@ export async function deployToDesktop(
     await build.buildSolution(
       buildTools,
       slnFile,
-      'Release',
+      'Debug',
       options.arch,
       {DeployLayout: 'true'},
       verbose,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -72,7 +72,7 @@ export default class MSBuildTools {
     const errorLog = logPrefix + '.err';
     const warnLog = logPrefix + '.wrn';
 
-    const localBinLog = target === 'build' ? '' : 'deploy.binlog';
+    const localBinLog = target === 'build' ? '' : ':deploy.binlog';
     const binlog = buildLogDirectory ? `:${logPrefix}.binlog` : localBinLog;
 
     const args = [

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -61,7 +61,6 @@ export default class MSBuildTools {
     newSuccess(`Found Solution: ${slnFile}`);
     newInfo(`Build configuration: ${buildType}`);
     newInfo(`Build platform: ${buildArch}`);
-    newInfo(`Build target: ${target}`);
 
     const verbosityOption = verbose ? 'normal' : 'minimal';
     const logPrefix = path.join(

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -72,7 +72,7 @@ export default class MSBuildTools {
     const errorLog = logPrefix + '.err';
     const warnLog = logPrefix + '.wrn';
 
-    const localBinLog = `:${target}.binlog`;
+    const localBinLog = target === 'build' ? '' : 'deploy.binlog';
     const binlog = buildLogDirectory ? `:${logPrefix}.binlog` : localBinLog;
 
     const args = [

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -61,19 +61,18 @@ export default class MSBuildTools {
     newSuccess(`Found Solution: ${slnFile}`);
     newInfo(`Build configuration: ${buildType}`);
     newInfo(`Build platform: ${buildArch}`);
-    if (target) {
-      newInfo(`Build target: ${target}`);
-    }
+    newInfo(`Build target: ${target}`);
+
     const verbosityOption = verbose ? 'normal' : 'minimal';
     const logPrefix = path.join(
       buildLogDirectory || os.tmpdir(),
-      `msbuild_${process.pid}${target ? '_' + target : ''}`,
+      `msbuild_${process.pid}_${target}`,
     );
 
     const errorLog = logPrefix + '.err';
     const warnLog = logPrefix + '.wrn';
 
-    const localBinLog = target ? `:${target}.binlog` : '';
+    const localBinLog = `:${target}.binlog`;
     const binlog = buildLogDirectory ? `:${logPrefix}.binlog` : localBinLog;
 
     const args = [
@@ -99,15 +98,13 @@ export default class MSBuildTools {
 
     if (target === 'build') {
       args.push('/restore', '/p:RestorePackagesConfig=true');
-    } else if (target === 'deploy') {
+    } else {
       args.push(`/t:Deploy`);
     }
 
-    if (msBuildProps) {
-      Object.keys(msBuildProps).forEach(function(key) {
-        args.push(`/p:${key}=${msBuildProps[key]}`);
-      });
-    }
+    Object.keys(msBuildProps).forEach(key => {
+      args.push(`/p:${key}=${msBuildProps[key]}`);
+    });
 
     try {
       checkRequirements.isWinSdkPresent('10.0');

--- a/packages/@react-native-windows/cli/src/runWindows/utils/version.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/version.ts
@@ -8,10 +8,10 @@ const VERSION_EXPRESSION = /^\d{1,8}(\.\d{1,8}){0,3}$/;
 
 export default class Version {
   constructor(
-    private major: number,
-    private minor: number = 0,
-    private build: number = 0,
-    private qfe: number = 0,
+    private readonly major: number,
+    private readonly minor: number = 0,
+    private readonly build: number = 0,
+    private readonly qfe: number = 0,
   ) {}
 
   eq(other: Version): boolean {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
@@ -25,7 +25,7 @@ export const dotNetCoreProjectTypeGuid =
  */
 function linesContainsBlock(lines: string[], block: string[]): boolean {
   if (block.length > 0) {
-    var startIndex = lines.indexOf(block[0]);
+    const startIndex = lines.indexOf(block[0]);
 
     if (startIndex >= 0) {
       for (let i = 1; i < block.length; i++) {
@@ -108,7 +108,7 @@ export function addProjectToSolution(
     );
   }
 
-  let slnLines = fs
+  const slnLines = fs
     .readFileSync(slnFile)
     .toString()
     .split('\r\n');
@@ -151,7 +151,7 @@ export function addProjectToSolution(
     false,
   ).map(line => line.match(/\s+([\w|]+)\s=/)![1]);
 
-  let projectConfigLines: string[] = [];
+  const projectConfigLines: string[] = [];
 
   slnConfigs.forEach(slnConfig => {
     projectConfigLines.push(
@@ -175,7 +175,7 @@ export function addProjectToSolution(
   );
 
   projectConfigLines.forEach(projectConfigLine => {
-    if (slnLines.indexOf(projectConfigLine) < 0) {
+    if (!slnLines.includes(projectConfigLine)) {
       if (verbose) {
         const configLine = projectConfigLine.substr(
           projectConfigLine.indexOf('= ') + 2,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/winappdeploytool.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/winappdeploytool.ts
@@ -19,8 +19,8 @@ class DeviceInfo {
     public readonly guid: string,
     public readonly ip: string,
 
-    private index: number,
-    private type: string,
+    private readonly index: number,
+    private readonly type: string,
   ) {}
 
   toString() {
@@ -29,7 +29,7 @@ class DeviceInfo {
 }
 
 export default class WinAppDeployTool {
-  private path: string;
+  private readonly path: string;
 
   constructor() {
     const programFilesPath =
@@ -57,9 +57,8 @@ export default class WinAppDeployTool {
 
     if (target === 'emulator') {
       const sortedList = devices.sort(sortDevices);
-      for (let i = 0; i < sortedList.length; i++) {
-        const sortedItem = sortedList[i];
-        if (sortedItem.toString().indexOf(target) > -1) {
+      for (const sortedItem of sortedList) {
+        if (sortedItem.toString().includes(target)) {
           return sortedItem;
         }
       }

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -65,12 +65,12 @@ function getAnonymizedPath(filepath: string): string {
   if (filepath.toLowerCase().startsWith(projectRoot)) {
     const ext = path.extname(filepath);
     const rest = filepath.slice(projectRoot.length);
-    const node_modules = '\\node_modules\\';
+    const nodeModules = '\\node_modules\\';
     // this is in the project dir but not under node_modules
     if (rest.toLowerCase().startsWith('\\windows\\')) {
       return `[windows]\\???${ext}(${filepath.length})`;
-    } else if (rest.toLowerCase().startsWith(node_modules)) {
-      return 'node_modules' + rest.slice(node_modules.length - 1);
+    } else if (rest.toLowerCase().startsWith(nodeModules)) {
+      return 'node_modules' + rest.slice(nodeModules.length - 1);
     } else {
       return `[project_dir]\\???${ext}(${filepath.length})`;
     }

--- a/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -250,7 +250,7 @@ class TouchableExamples extends React.Component<{}, any> {
     );
   }
 
-  private press = () => {
+  private readonly press = () => {
     this.setState({pressedCount: this.state.pressedCount + 1});
   };
 }
@@ -270,7 +270,7 @@ class AccessibilityStateExamples extends React.Component {
   };
 
   public render() {
-    var selectableItems = [{}, {}, {}];
+    const selectableItems = [{}, {}, {}];
     return (
       <View>
         <Text>
@@ -463,17 +463,17 @@ class AccessibilityStateExamples extends React.Component {
     );
   }
 
-  private disablePress = () => {
+  private readonly disablePress = () => {
     this.setState({viewDisabled: !this.state.viewDisabled});
   };
 
-  private selectPress = (index: number) => {
-    let tmp = this.state.itemsSelected;
+  private readonly selectPress = (index: number) => {
+    const tmp = this.state.itemsSelected;
     tmp[index] = !tmp[index];
     this.setState({itemsSelected: tmp});
   };
 
-  private checkedPress = () => {
+  private readonly checkedPress = () => {
     let newChecked = this.state.viewChecked + 1;
     if (newChecked === 3) {
       newChecked = 0;
@@ -481,22 +481,22 @@ class AccessibilityStateExamples extends React.Component {
     this.setState({viewChecked: newChecked});
   };
 
-  private busyPress = () => {
+  private readonly busyPress = () => {
     this.setState({viewBusy: !this.state.viewBusy});
   };
 
-  private collapsePress = () => {
+  private readonly collapsePress = () => {
     this.setState({viewCollapsed: !this.state.viewCollapsed});
   };
 
-  private rangePress = () => {
+  private readonly rangePress = () => {
     this.setState({viewRangeNow: this.state.viewRangeNow + 1});
   };
 }
 
 class AccessibilityListExamples extends React.Component {
   public render() {
-    var items = [{}, {}, {}];
+    const items = [{}, {}, {}];
     return (
       <View>
         <Text>

--- a/packages/@react-native-windows/tester/src/js/examples-win/AsyncStorage/AsyncStorageExampleWindows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/AsyncStorage/AsyncStorageExampleWindows.tsx
@@ -39,9 +39,9 @@ class AsyncStorageExample extends React.Component<
 
   private updateAsyncStorageData(key: string, value: string) {
     this.setState(prevState => {
-      let asyncStorageData = [...prevState.asyncStorageData];
+      const asyncStorageData = [...prevState.asyncStorageData];
       let foundVal = false;
-      for (let kvp of asyncStorageData) {
+      for (const kvp of asyncStorageData) {
         if (kvp[0] === key) {
           kvp[1] = value;
           foundVal = true;
@@ -59,7 +59,7 @@ class AsyncStorageExample extends React.Component<
     return () => {
       void AsyncStorage.removeItem(key);
       this.setState(prevState => {
-        let asyncStorageData = prevState.asyncStorageData.filter(
+        const asyncStorageData = prevState.asyncStorageData.filter(
           kvp => kvp[0] !== key,
         );
         return {asyncStorageData: asyncStorageData};
@@ -67,20 +67,20 @@ class AsyncStorageExample extends React.Component<
     };
   }
 
-  private setName = (name: string) => {
+  private readonly setName = (name: string) => {
     this.setState({name: name});
   };
 
-  private setValue = (value: string) => {
+  private readonly setValue = (value: string) => {
     this.setState({value: value});
   };
 
-  private onAddEntryPress = () => {
+  private readonly onAddEntryPress = () => {
     void AsyncStorage.setItem(this.state.name, this.state.value);
     this.updateAsyncStorageData(this.state.name, this.state.value);
   };
 
-  private onClearAllKeysPress = () => {
+  private readonly onClearAllKeysPress = () => {
     void AsyncStorage.clear();
     this.setState({asyncStorageData: []});
   };

--- a/packages/@react-native-windows/tester/src/js/examples-win/Flyout/FlyoutExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Flyout/FlyoutExample.windows.tsx
@@ -19,7 +19,7 @@ interface IFlyoutExampleState {
   placementOptions: Placement;
 }
 
-let placementValues: string[] = [
+const placementValues: string[] = [
   'top',
   'bottom',
   'left',
@@ -36,7 +36,6 @@ let placementValues: string[] = [
 ];
 
 class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
-  // tslint:disable-next-line:no-any
   private _anchor: any;
   private _anchorTwo: any;
 
@@ -218,7 +217,7 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
     );
   }
 
-  private _setRef = (textInput: TextInput) => {
+  private readonly _setRef = (textInput: TextInput) => {
     this._anchor = textInput;
   };
 

--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExtensionExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExtensionExample.windows.tsx
@@ -140,7 +140,7 @@ class ViewWindowsKeyboardExample extends React.Component<
     );
   }
 
-  private _onKeyUp = (ev: IKeyboardEvent) => {
+  private readonly _onKeyUp = (ev: IKeyboardEvent) => {
     this.setState({
       lastKeyUp: ev.nativeEvent.key,
       lastKeyDown: null,
@@ -149,7 +149,7 @@ class ViewWindowsKeyboardExample extends React.Component<
     });
   };
 
-  private _onKeyDown = (ev: IKeyboardEvent) => {
+  private readonly _onKeyDown = (ev: IKeyboardEvent) => {
     this.setState({
       lastKeyDown: ev.nativeEvent.key,
       lastKeyUp: null,
@@ -157,7 +157,7 @@ class ViewWindowsKeyboardExample extends React.Component<
       lastKeyUpCode: null,
     });
   };
-  private _onKeyUpCapture = (ev: IKeyboardEvent) => {
+  private readonly _onKeyUpCapture = (ev: IKeyboardEvent) => {
     this.setState({
       lastKeyUpCapture: ev.nativeEvent.key,
       lastKeyDownCapture: null,
@@ -166,7 +166,7 @@ class ViewWindowsKeyboardExample extends React.Component<
     });
   };
 
-  private _onKeyDownCapture = (ev: IKeyboardEvent) => {
+  private readonly _onKeyDownCapture = (ev: IKeyboardEvent) => {
     this.setState({
       lastKeyDownCapture: ev.nativeEvent.key,
       lastKeyUpCapture: null,

--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardFocusExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardFocusExample.windows.tsx
@@ -60,7 +60,6 @@ interface IKeyboardFocusComponentState {
 const pickerRef = React.createRef<Picker>();
 const viewWindowsRef = React.createRef<ViewWindows>();
 const textInputRef = React.createRef<TextInput>();
-// tslint:disable-next-line
 const textInputRef2 = React.createRef<any>();
 const touchableHighlightRef = React.createRef<TouchableHighlight>();
 const touchableOpacityRef = React.createRef<TouchableOpacity>();
@@ -176,11 +175,11 @@ class KeyboardFocusExample extends React.Component<
     );
   }
 
-  private _textInputKeyDown = (ev: IKeyboardEvent) => {
+  private readonly _textInputKeyDown = (ev: IKeyboardEvent) => {
     this.setState({keyOnKeyDown: ev.nativeEvent.key});
   };
 
-  private _selectionChanged = (selected: string) => {
+  private readonly _selectionChanged = (selected: string) => {
     switch (selected) {
       case 'View':
         viewWindowsRef.current && viewWindowsRef.current.focus();
@@ -217,24 +216,24 @@ class KeyboardFocusExample extends React.Component<
     }
   };
 
-  private _touchableHighlightFocus = () => {
+  private readonly _touchableHighlightFocus = () => {
     this.setState({focusMessageHighlight: 'TouchableHighlight onFocus'});
   };
-  private _touchableHighlightBlur = () => {
+  private readonly _touchableHighlightBlur = () => {
     this.setState({focusMessageHighlight: 'TouchableHighlight onBlur'});
   };
-  private _touchableOpacityFocus = () => {
+  private readonly _touchableOpacityFocus = () => {
     this.setState({focusMessageOpacity: 'TouchableOpacity onFocus'});
   };
-  private _touchableOpacityBlur = () => {
+  private readonly _touchableOpacityBlur = () => {
     this.setState({focusMessageOpacity: 'TouchableOpacity onBlur'});
   };
-  private _touchableWithoutFeedbackFocus = () => {
+  private readonly _touchableWithoutFeedbackFocus = () => {
     this.setState({
       focusMessageWithoutFeedback: 'TouchableWithoutFeedback onFocus',
     });
   };
-  private _touchableWithoutFeedbackBlur = () => {
+  private readonly _touchableWithoutFeedbackBlur = () => {
     this.setState({
       focusMessageWithoutFeedback: 'TouchableWithoutFeedback onBlur',
     });

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ControlStyleTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ControlStyleTestPage.tsx
@@ -56,7 +56,7 @@ export function ControlStyleTestPage() {
   const [showRoundBorder, setShowRoundBorder] = useState(false);
 
   const onPressShowRoundBorder = () => {
-    var previousState = showRoundBorder;
+    const previousState = showRoundBorder;
     setShowRoundBorder(!previousState);
   };
 

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ImageTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ImageTestPage.tsx
@@ -61,9 +61,9 @@ export function ImageTestPage() {
   const [rltMode, setRtlMode] = useState(false);
   const [clickCount, setClickCount] = useState(0);
   const onPressBorder = () => {
-    var previousImageBorderState = imageWithBorder;
+    const previousImageBorderState = imageWithBorder;
     setImageBorder(!previousImageBorderState);
-    var previousClickCount = clickCount;
+    const previousClickCount = clickCount;
     setClickCount(previousClickCount + 1);
   };
 

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/LoginTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/LoginTestPage.tsx
@@ -50,7 +50,7 @@ export function LoginTestPage() {
   const [passwordHidden, setPasswordHidden] = useState(true);
 
   const onPressShowPassword = () => {
-    var previousState = passwordHidden;
+    const previousState = passwordHidden;
     setPasswordHidden(!previousState);
   };
 

--- a/packages/@react-native-windows/tester/src/js/examples-win/Picker/PickerWindowsExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Picker/PickerWindowsExample.tsx
@@ -261,7 +261,11 @@ class PickerEditableExample extends React.Component<{}, any> {
     );
   }
 
-  private onValueChange = (selected: string, _index: number, text: string) => {
+  private readonly onValueChange = (
+    selected: string,
+    _index: number,
+    text: string,
+  ) => {
     this.setState({selected, text});
   };
 }

--- a/packages/@react-native-windows/tester/src/js/examples-win/Popup/PopupExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Popup/PopupExample.windows.tsx
@@ -17,7 +17,7 @@ class AnchoredPopupExample extends React.Component<
   {},
   IAnchoredPopupExampleState
 > {
-  private _textInput: React.RefObject<TextInput>;
+  private readonly _textInput: React.RefObject<TextInput>;
 
   public state: IAnchoredPopupExampleState = {
     showPopup: false,

--- a/packages/@rnw-scripts/eslint-config/eslintrc.js
+++ b/packages/@rnw-scripts/eslint-config/eslintrc.js
@@ -27,11 +27,72 @@ module.exports = {
         project: './tsconfig.json',
       },
       rules: {
+        '@typescript-eslint/await-thenable': 'error',
+        '@typescript-eslint/ban-tslint-comment': 'error',
+        '@typescript-eslint/ban-types': [
+          'error',
+          {
+            'extendDefaults': true,
+            'types': {
+              // See https://github.com/typescript-eslint/typescript-eslint/issues/2063
+              '{}': false
+            }
+          }
+        ],
+         // Avoid some naming convention checks for JSX files where function components are capitalized
+         '@typescript-eslint/naming-convention': [
+          'error',
+          { "selector": "class", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+          { "selector": "interface", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+          { "selector": "typeAlias", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+        ],
+        '@typescript-eslint/no-confusing-non-null-assertion': 'error',
+        '@typescript-eslint/no-extra-non-null-assertion': 'error',
         '@typescript-eslint/no-floating-promises': [
           'error',
           {ignoreIIFE: true},
         ],
+        '@typescript-eslint/no-for-in-array': 'error',
+        '@typescript-eslint/no-misused-new': 'error',
         '@typescript-eslint/no-misused-promises': 'error',
+        '@typescript-eslint/no-namespace': 'error',
+        '@typescript-eslint/no-this-alias': 'error',
+        '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+        '@typescript-eslint/no-unnecessary-condition': ['error', {
+          allowConstantLoopConditions: true
+        }],
+        '@typescript-eslint/prefer-for-of': 'error',
+        '@typescript-eslint/prefer-includes': 'error',
+        '@typescript-eslint/prefer-readonly': 'error',
+        '@typescript-eslint/prefer-string-starts-ends-with': 'error',
+        '@typescript-eslint/switch-exhaustiveness-check': 'error',
+        'no-restricted-syntax': ['error', {
+          selector: 'TSEnumDeclaration',
+          message: `Prefer union types (e.g. type Foo = 'bar' | 'baz') to TypeScript enums`
+        }],
+        'block-scoped-var': 'error',
+        'complexity': 'warn',
+        'guard-for-in': 'error',
+        'no-constructor-return': 'error',
+        'no-useless-concat': 'error',
+        'no-var': 'error',
+        'prefer-arrow-callback': 'error',
+        'prefer-const': 'error',
+        'prefer-rest-params': 'error',
+        'radix': 'error',
+      },
+    },
+    {
+      files: ['*.ts'],
+      excludedFiles: ['*.d.ts'],
+      rules: {
+        // Avoid some naming convention checks for JSX files where function components are capitalized
+        '@typescript-eslint/naming-convention': [
+          'error',
+          { "selector": "class", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+          { "selector": "interface", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+          { "selector": "typeAlias", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+        ],
       },
     },
   ],

--- a/packages/@rnw-scripts/eslint-config/eslintrc.js
+++ b/packages/@rnw-scripts/eslint-config/eslintrc.js
@@ -30,8 +30,7 @@ module.exports = {
         '@typescript-eslint/await-thenable': 'error',
         '@typescript-eslint/ban-tslint-comment': 'error',
         '@typescript-eslint/ban-types': [
-          'error',
-          {
+          'error', {
             'extendDefaults': true,
             'types': {
               // See https://github.com/typescript-eslint/typescript-eslint/issues/2063
@@ -39,18 +38,11 @@ module.exports = {
             }
           }
         ],
-         // Avoid some naming convention checks for JSX files where function components are capitalized
-         '@typescript-eslint/naming-convention': [
-          'error',
-          { "selector": "class", "format": ["PascalCase"], leadingUnderscore: 'allow' },
-          { "selector": "interface", "format": ["PascalCase"], leadingUnderscore: 'allow' },
-          { "selector": "typeAlias", "format": ["PascalCase"], leadingUnderscore: 'allow' },
-        ],
         '@typescript-eslint/no-confusing-non-null-assertion': 'error',
         '@typescript-eslint/no-extra-non-null-assertion': 'error',
         '@typescript-eslint/no-floating-promises': [
           'error',
-          {ignoreIIFE: true},
+          { ignoreIIFE: true },
         ],
         '@typescript-eslint/no-for-in-array': 'error',
         '@typescript-eslint/no-misused-new': 'error',
@@ -58,18 +50,21 @@ module.exports = {
         '@typescript-eslint/no-namespace': 'error',
         '@typescript-eslint/no-this-alias': 'error',
         '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
-        '@typescript-eslint/no-unnecessary-condition': ['error', {
-          allowConstantLoopConditions: true
-        }],
+        '@typescript-eslint/no-unnecessary-condition': [
+          'error',
+          { allowConstantLoopConditions: true },
+        ],
         '@typescript-eslint/prefer-for-of': 'error',
         '@typescript-eslint/prefer-includes': 'error',
         '@typescript-eslint/prefer-readonly': 'error',
         '@typescript-eslint/prefer-string-starts-ends-with': 'error',
         '@typescript-eslint/switch-exhaustiveness-check': 'error',
-        'no-restricted-syntax': ['error', {
-          selector: 'TSEnumDeclaration',
-          message: `Prefer union types (e.g. type Foo = 'bar' | 'baz') to TypeScript enums`
-        }],
+        'no-restricted-syntax': [
+          'error', {
+            selector: 'TSEnumDeclaration',
+            message: `Prefer union types (e.g. type Foo = 'bar' | 'baz') to TypeScript enums`
+          }
+        ],
         'block-scoped-var': 'error',
         'complexity': 'warn',
         'guard-for-in': 'error',
@@ -86,12 +81,30 @@ module.exports = {
       files: ['*.ts'],
       excludedFiles: ['*.d.ts'],
       rules: {
-        // Avoid some naming convention checks for JSX files where function components are capitalized
         '@typescript-eslint/naming-convention': [
           'error',
-          { "selector": "class", "format": ["PascalCase"], leadingUnderscore: 'allow' },
-          { "selector": "interface", "format": ["PascalCase"], leadingUnderscore: 'allow' },
-          { "selector": "typeAlias", "format": ["PascalCase"], leadingUnderscore: 'allow' },
+          { 'selector': 'typeLike', 'format': ['PascalCase'] },
+          { 'selector': 'variable', 'format': ['camelCase', 'PascalCase', 'UPPER_CASE'] },
+          { 'selector': 'method', 'format': ['camelCase'], leadingUnderscore: 'allow' },
+          { 'selector': 'accessor', 'format': ['camelCase'], leadingUnderscore: 'allow' },
+          // Don't allow PascalCase functions or params in normal TS files
+          { 'selector': 'parameter', 'format': ['camelCase'], leadingUnderscore: 'allow' },
+          { 'selector': 'function', 'format': ['camelCase'], leadingUnderscore: 'allow' },
+        ],
+      },
+    },
+    {
+      files: ['*.tsx'],
+      rules: {
+        '@typescript-eslint/naming-convention': [
+          'error',
+          { 'selector': 'typeLike', 'format': ['PascalCase'] },
+          { 'selector': 'variable', 'format': ['camelCase', 'PascalCase', 'UPPER_CASE'] },
+          { 'selector': 'method', 'format': ['camelCase'], leadingUnderscore: 'allow' },
+          { 'selector': 'accessor', 'format': ['camelCase'], leadingUnderscore: 'allow' },
+          // Allow PascalCase functions and params in TSX files for function components
+          { 'selector': 'parameter', 'format': ['camelCase', 'PascalCase'], leadingUnderscore: 'allow' },
+          { 'selector': 'function', 'format': ['camelCase', 'PascalCase'], leadingUnderscore: 'allow' },
         ],
       },
     },

--- a/packages/@rnw-scripts/format-files/src/formatFiles.ts
+++ b/packages/@rnw-scripts/format-files/src/formatFiles.ts
@@ -29,7 +29,7 @@ const VERIFY_FLAG = '-verify';
 function main() {
   // Run clang-format.
   try {
-    let verify = process.argv.indexOf(VERIFY_FLAG) > 0;
+    const verify = process.argv.indexOf(VERIFY_FLAG) > 0;
     const args = process.argv.slice(2).filter(_ => _ !== VERIFY_FLAG);
 
     // Pass all arguments to clang-format, including e.g. -version etc.
@@ -114,10 +114,10 @@ function spawnClangFormat(
   );
 
   // split file array into chunks of 30
-  let i,
-    j,
-    chunks = [],
-    chunkSize = 30;
+  let i: number;
+  let j: number;
+  const chunks = [];
+  const chunkSize = 30;
 
   for (i = 0, j = files.length; i < j; i += chunkSize) {
     chunks.push(files.slice(i, i + chunkSize));
@@ -125,12 +125,12 @@ function spawnClangFormat(
 
   // launch a new process for each chunk
   async.series<number, Error>(
-    chunks.map(function(chunk) {
+    chunks.map(chunk => {
       return function(callback) {
         const clangFormatProcess = spawn(nativeBinary, args.concat(chunk), {
           stdio: stdio,
         });
-        clangFormatProcess.on('close', function(exit) {
+        clangFormatProcess.on('close', exit => {
           if (exit !== 0) {
             callback(errorFromExitCode(exit));
           } else {
@@ -139,7 +139,7 @@ function spawnClangFormat(
         });
       };
     }),
-    function(err) {
+    err => {
       if (err) {
         done(err);
         return;

--- a/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
@@ -65,7 +65,7 @@ export default async function upgradeDependencies(
     outOfTreePlatform: OUT_OF_TREE_PLATFORMS.includes(pkg.json.name),
   }));
 
-  const newDeps = await calcPackageDependencies(
+  const newDeps = calcPackageDependencies(
     newReactNativeVersion,
     reactNativeDiff,
     repoConfigDiff,

--- a/packages/@rnw-scripts/package-utils/src/packageUtils.ts
+++ b/packages/@rnw-scripts/package-utils/src/packageUtils.ts
@@ -21,7 +21,7 @@ const getMonorepoPackages: (
  * Represents an NPM package
  */
 export class NpmPackage {
-  private pkgPath: string;
+  private readonly pkgPath: string;
   protected pkgJson: any;
 
   /**
@@ -54,12 +54,16 @@ export class WritableNpmPackage extends NpmPackage {
    */
   static async fromPath(pkgPath: string): Promise<WritableNpmPackage | null> {
     const jsonPath = path.join(pkgPath, 'package.json');
-    const jsonBuffer = await fs.promises.readFile(jsonPath);
-    if (!jsonBuffer) {
-      return null;
-    }
+    try {
+      const jsonBuffer = await fs.promises.readFile(jsonPath);
+      return new WritableNpmPackage(pkgPath, JSON.parse(jsonBuffer.toString()));
+    } catch (ex) {
+      if (ex.code === 'ENOENT') {
+        return null;
+      }
 
-    return new WritableNpmPackage(pkgPath, JSON.parse(jsonBuffer.toString()));
+      throw ex;
+    }
   }
 
   /**

--- a/packages/E2ETest/wdio/pages/BasePage.ts
+++ b/packages/E2ETest/wdio/pages/BasePage.ts
@@ -9,13 +9,13 @@ import { TREE_DUMP_RESULT } from '@react-native-windows/tester/js/examples-win/L
 
 const ELEMENT_LOADED_TIMEOUT = 60000;
 
-export function By(testId: string): WebdriverIO.Element {
+export function by(testId: string): WebdriverIO.Element {
   return $('~' + testId);
 }
 
 export class BasePage {
   isElementLoaded(element: string): boolean {
-    return By(element).isDisplayed();
+    return by(element).isDisplayed();
   }
 
   waitForElementLoaded(element: string) {
@@ -43,6 +43,6 @@ export class BasePage {
   }
 
   private get treeDumpResult() {
-    return By(TREE_DUMP_RESULT);
+    return by(TREE_DUMP_RESULT);
   }
 }

--- a/packages/E2ETest/wdio/pages/ControlStylePage.ts
+++ b/packages/E2ETest/wdio/pages/ControlStylePage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BasePage, By } from './BasePage';
+import { BasePage, by } from './BasePage';
 import { SHOWBORDER_ON_CONTROLSTYLE } from '@react-native-windows/tester/js/examples-win/LegacyTests/Consts';
 
 class ControlStyleTestPage extends BasePage {
@@ -12,7 +12,7 @@ class ControlStyleTestPage extends BasePage {
   }
 
   private get _controlBorder() {
-    return By(SHOWBORDER_ON_CONTROLSTYLE);
+    return by(SHOWBORDER_ON_CONTROLSTYLE);
   }
 }
 

--- a/packages/E2ETest/wdio/pages/HomePage.ts
+++ b/packages/E2ETest/wdio/pages/HomePage.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import { BasePage, By } from './BasePage';
+import { BasePage, by } from './BasePage';
 import {
   APIS_NAV_BUTTON,
   COMPONENTS_NAV_BUTTON,
@@ -15,22 +15,22 @@ import {
 class HomePage extends BasePage {
   goToComponentExample(example: string) {
     this.waitForElementLoaded(COMPONENTS_NAV_BUTTON);
-    By(COMPONENTS_NAV_BUTTON).click();
+    by(COMPONENTS_NAV_BUTTON).click();
     this.goToExampleOnCurrentTab(example);
   }
 
   goToApiExample(example: string) {
     this.waitForElementLoaded(APIS_NAV_BUTTON);
-    By(APIS_NAV_BUTTON).click();
+    by(APIS_NAV_BUTTON).click();
     this.goToExampleOnCurrentTab(example);
   }
 
   private goToExampleOnCurrentTab(example: string) {
     // Filter the list down to the one test, to improve the stability of selectors
     this.waitForElementLoaded(TESTER_LIST_SEARCH_BOX);
-    const editBox = By(TESTER_LIST_SEARCH_BOX);
+    const editBox = by(TESTER_LIST_SEARCH_BOX);
     editBox.setValue(example);
-    const pageItem = By(example);
+    const pageItem = by(example);
     pageItem.click();
 
     // Make sure we've launched the example by waiting until the search box is

--- a/packages/E2ETest/wdio/pages/ImageTestPage.ts
+++ b/packages/E2ETest/wdio/pages/ImageTestPage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BasePage, By } from './BasePage';
+import { BasePage, by } from './BasePage';
 import {
   SHOW_IMAGE_BORDER,
   SET_RTL_MODE,
@@ -19,11 +19,11 @@ class ImageTestPage extends BasePage {
   }
 
   private get _imageBorder() {
-    return By(SHOW_IMAGE_BORDER);
+    return by(SHOW_IMAGE_BORDER);
   }
 
   private get _rtlButton() {
-    return By(SET_RTL_MODE);
+    return by(SET_RTL_MODE);
   }
 }
 

--- a/packages/E2ETest/wdio/pages/LoginPage.ts
+++ b/packages/E2ETest/wdio/pages/LoginPage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BasePage, By } from './BasePage';
+import { BasePage, by } from './BasePage';
 import {
   USERNAME_ON_LOGIN,
   PASSWORD_ON_LOGIN,
@@ -36,23 +36,23 @@ class LoginPage extends BasePage {
   }
 
   private get _userName() {
-    return By(USERNAME_ON_LOGIN);
+    return by(USERNAME_ON_LOGIN);
   }
 
   private get _password() {
-    return By(PASSWORD_ON_LOGIN);
+    return by(PASSWORD_ON_LOGIN);
   }
 
   private get _submit() {
-    return By(SUBMIT_ON_LOGIN);
+    return by(SUBMIT_ON_LOGIN);
   }
 
   private get _showPassword() {
-    return By(SHOWPASSWORD_ON_LOGIN);
+    return by(SHOWPASSWORD_ON_LOGIN);
   }
 
   private get _loginResult() {
-    return By(LOGINRESULT_ON_LOGIN);
+    return by(LOGINRESULT_ON_LOGIN);
   }
 }
 

--- a/packages/E2ETest/wdio/pages/TextInputTestPage.ts
+++ b/packages/E2ETest/wdio/pages/TextInputTestPage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BasePage, By } from './BasePage';
+import { BasePage, by } from './BasePage';
 import {
   TEXTINPUT_ON_TEXTINPUT,
   ML_TEXTINPUT_ON_TEXTINPUT,
@@ -60,19 +60,19 @@ class TextInputTestPage extends BasePage {
   }
 
   private get textInput() {
-    return By(TEXTINPUT_ON_TEXTINPUT);
+    return by(TEXTINPUT_ON_TEXTINPUT);
   }
 
   private get curTextInput() {
-    return By(CURTEXT_ON_TEXTINPUT);
+    return by(CURTEXT_ON_TEXTINPUT);
   }
 
   private get multiLineTextInput() {
-    return By(ML_TEXTINPUT_ON_TEXTINPUT);
+    return by(ML_TEXTINPUT_ON_TEXTINPUT);
   }
 
   private get autoCapTextInput() {
-    return By(CAP_TEXTINPUT_ON_TEXTINPUT);
+    return by(CAP_TEXTINPUT_ON_TEXTINPUT);
   }
 }
 

--- a/packages/IntegrationTest/runner/lib/BaseTest.ts
+++ b/packages/IntegrationTest/runner/lib/BaseTest.ts
@@ -9,8 +9,8 @@ import {TestBlock} from './TestDescription';
 import IntegrationTestRunner from './IntegrationTestRunner';
 import TestWebSocketServer from './TestWebSocketServer';
 
-let testRunner: IntegrationTestRunner;
-let websocketServer: TestWebSocketServer;
+let testRunner: IntegrationTestRunner | undefined;
+let websocketServer: TestWebSocketServer | undefined;
 
 beforeAll(async () => {
   testRunner = await IntegrationTestRunner.initialize('TestInstructions');
@@ -33,12 +33,12 @@ export function registerTests(blocks: TestBlock[]) {
         if (typeof component === 'string') {
           test(
             component,
-            async () => await testRunner.runTestComponent(component),
+            async () => await testRunner!.runTestComponent(component),
           );
         } else {
           test.skip(
             component.skip,
-            async () => await testRunner.runTestComponent(component.skip),
+            async () => await testRunner!.runTestComponent(component.skip),
           );
         }
       });

--- a/packages/IntegrationTest/runner/lib/IntegrationTestClient.ts
+++ b/packages/IntegrationTest/runner/lib/IntegrationTestClient.ts
@@ -34,8 +34,8 @@ export type CallStackFrame = {
 };
 
 export default class IntegrationTestClient {
-  private socket: Socket;
-  private commandQueue: SerialQueue;
+  private readonly socket: Socket;
+  private readonly commandQueue: SerialQueue;
 
   private constructor(socket: Socket) {
     this.socket = socket;

--- a/packages/IntegrationTest/runner/lib/IntegrationTestRunner.ts
+++ b/packages/IntegrationTest/runner/lib/IntegrationTestRunner.ts
@@ -16,7 +16,7 @@ import IntegrationTestClient, {
 
 export default class IntegrationTestRunner {
   private connectionReset: boolean = false;
-  private constructor(private testClient: IntegrationTestClient) {}
+  private constructor(private readonly testClient: IntegrationTestClient) {}
 
   static async initialize(
     startingComponent: string,

--- a/packages/IntegrationTest/runner/lib/SerialQueue.ts
+++ b/packages/IntegrationTest/runner/lib/SerialQueue.ts
@@ -10,7 +10,7 @@
  * result/exception
  */
 export default class SerialQueue {
-  private actions: Array<() => Promise<void>> = [];
+  private readonly actions: Array<() => Promise<void>> = [];
 
   enqueue<T>(action: () => Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {

--- a/packages/IntegrationTest/runner/lib/TestWebSocketServer.ts
+++ b/packages/IntegrationTest/runner/lib/TestWebSocketServer.ts
@@ -11,7 +11,7 @@ import {Server} from 'ws';
  * A web socket server with behavior expected for the upstream WebSocketTest
  */
 export default class TestWebSocketServer {
-  private server: Server;
+  private readonly server: Server;
 
   private constructor(server: Server) {
     this.server = server;

--- a/packages/IntegrationTest/runner/lib/discoverTests.ts
+++ b/packages/IntegrationTest/runner/lib/discoverTests.ts
@@ -54,7 +54,7 @@ function enumerateTypeScriptFiles(rootPath: string): string[] {
   const files = walkdir.sync(rootPath, {return_object: true});
   return Object.entries(files).flatMap(([filePath, stat]) => {
     if (
-      (stat.isFile && filePath.endsWith('.ts')) ||
+      (stat.isFile() && filePath.endsWith('.ts')) ||
       filePath.endsWith('.tsx')
     ) {
       return [filePath];

--- a/packages/IntegrationTest/runner/lib/discoverTests.ts
+++ b/packages/IntegrationTest/runner/lib/discoverTests.ts
@@ -72,6 +72,7 @@ function extractComponents(file: File): TestComponent[] {
   const components: TestComponent[] = [];
 
   traverse(file, {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     CallExpression: nodePath => {
       if (
         nodePath.node.callee.type === 'Identifier' &&

--- a/packages/IntegrationTest/tests/MountComponentTests.tsx
+++ b/packages/IntegrationTest/tests/MountComponentTests.tsx
@@ -31,7 +31,8 @@ function mountAndMeasure(
     useEffect(() => {
       onNativeRender(() => {
         // Not all components offer forwarded refs to native components. Only
-        // try to measure those who do.
+        // try to measure those who do. Typings aren't great here...
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!ref.current!.measure) {
           pass();
           return;

--- a/packages/playground/Samples/calculator.tsx
+++ b/packages/playground/Samples/calculator.tsx
@@ -46,20 +46,20 @@ const styles = StyleSheet.create({
   },
 });
 
-enum operators {
-  clearEntry = 'CE',
-  clear = 'C',
-  backspace = '⌫',
-  decimal = '.',
-  sign = '±',
-  add = '+',
-  subtract = '−',
-  multiply = '×',
-  divide = '÷',
-  equals = '=',
-}
+const operators = {
+  clearEntry: 'CE',
+  clear: 'C',
+  backspace: '⌫',
+  decimal: '.',
+  sign: '±',
+  add: '+',
+  subtract: '−',
+  multiply: '×',
+  divide: '÷',
+  equals: ':',
+};
 
-var calc = {
+const calc = {
   stackValue: NaN,
   pendingOperator: '',
   decimalPressed: false,
@@ -91,6 +91,8 @@ export default class Bootstrap extends React.Component {
     displayText: '0',
   };
 
+  // Existing high cyclomatic complexity
+  // eslint-disable-next-line complexity
   buttonPress(btn: string) {
     let text = this.state.displayText;
 
@@ -112,7 +114,7 @@ export default class Bootstrap extends React.Component {
 
           if (text.length === 0) {
             text = '0';
-          } else if (text[text.length - 1] === operators.decimal) {
+          } else if (text.endsWith(operators.decimal)) {
             text = text.substring(0, text.length - 1);
           }
 
@@ -122,7 +124,7 @@ export default class Bootstrap extends React.Component {
     } else if (btn === operators.decimal) {
       // Decimal
       if (isFinite(Number(text))) {
-        if (!calc.decimalPressed && text.indexOf(operators.decimal) === -1) {
+        if (!calc.decimalPressed && !text.includes(operators.decimal)) {
           calc.decimalPressed = true;
         }
       }
@@ -178,11 +180,11 @@ export default class Bootstrap extends React.Component {
     this.setState({displayText: '0'});
   }
 
-  computeAndUpdate(nextOperator: operators) {
+  computeAndUpdate(nextOperator: string) {
     if (!isNaN(calc.stackValue)) {
       // There's something on the stack, let's compute
       let o1 = calc.stackValue;
-      let o2 = Number(this.state.displayText);
+      const o2 = Number(this.state.displayText);
 
       if (calc.pendingOperator === operators.add) {
         o1 = o1 + o2;
@@ -196,7 +198,7 @@ export default class Bootstrap extends React.Component {
 
       calc.stackValue = o1;
     } else {
-      let num = Number(this.state.displayText);
+      const num = Number(this.state.displayText);
       calc.stackValue = num;
     }
     calc.pendingOperator = nextOperator;

--- a/packages/playground/Samples/callbackTest.tsx
+++ b/packages/playground/Samples/callbackTest.tsx
@@ -21,11 +21,11 @@ export default class Bootstrap extends React.Component<
 
     NativeModules.ReadingPane.CurrentConversation(
       (js: {Subject: string; Messages: string[]}) =>
-        this.LoadedConversation(js),
+        this.loadedConversation(js),
     );
   }
 
-  LoadedConversation(js: {Subject: string; Messages: string[]}) {
+  loadedConversation(js: {Subject: string; Messages: string[]}) {
     this.setState({
       subject: js.Subject,
       msgs: js.Messages,

--- a/packages/playground/Samples/flexbox.tsx
+++ b/packages/playground/Samples/flexbox.tsx
@@ -38,7 +38,7 @@ export default class FlexboxLayoutPlayground extends React.Component<
 
   _onClick() {
     this.setState(s => {
-      let state = {...s};
+      const state = {...s};
 
       if (state.currentAlignStyle === styles.endAlignStyle) {
         state.currentAlignStyle = styles.emptyStyle;

--- a/packages/playground/Samples/geosample.tsx
+++ b/packages/playground/Samples/geosample.tsx
@@ -45,7 +45,7 @@ export default class Bootstrap extends React.Component<
 
   watchID: number;
 
-  ResetState() {
+  resetState() {
     this.setState({
       lat: '?',
       long: '?',
@@ -54,47 +54,47 @@ export default class Bootstrap extends React.Component<
     });
   }
 
-  OnRequestAuth() {
+  onRequestAuth() {
     // Instead of importing the Geolocation module, use browser polyfill
     navigator.geolocation.requestAuthorization();
 
-    this.ResetState();
+    this.resetState();
     this.setState({lastCmd: 'RequestAuth'});
   }
 
-  OnGetCurrentPos() {
+  onGetCurrentPos() {
     // Instead of importing the Geolocation module, use browser polyfill
     navigator.geolocation.getCurrentPosition(
       (result: GeoPos) => {
-        this.OnPosChanged(result);
+        this.onPosChanged(result);
       },
       (error: any) => {
         this.setState({lastError: error});
       },
     );
 
-    this.ResetState();
+    this.resetState();
     this.setState({lastCmd: 'GetCurrentPos'});
   }
 
-  OnStartWatching() {
+  onStartWatching() {
     this.watchID = navigator.geolocation.watchPosition((pos: GeoPos) => {
-      this.OnPosChanged(pos);
+      this.onPosChanged(pos);
     });
-    this.ResetState();
+    this.resetState();
     this.setState({lastCmd: 'StartWatching'});
   }
 
-  OnStopWatching() {
+  onStopWatching() {
     if (this.watchID !== -1) {
       navigator.geolocation.clearWatch(this.watchID);
     }
     this.watchID = -1;
-    this.ResetState();
+    this.resetState();
     this.setState({lastCmd: 'StopWatching'});
   }
 
-  OnPosChanged(pos: {
+  onPosChanged(pos: {
     coords: {latitude: string; longitude: string};
     timestamp: string;
   }) {
@@ -108,22 +108,22 @@ export default class Bootstrap extends React.Component<
   render() {
     return (
       <View style={styles.container}>
-        <TouchableWithoutFeedback onPress={() => this.OnRequestAuth()}>
+        <TouchableWithoutFeedback onPress={() => this.onRequestAuth()}>
           <View style={styles.fauxbutton}>
             <Text style={{textAlign: 'center'}}>Request Auth</Text>
           </View>
         </TouchableWithoutFeedback>
-        <TouchableWithoutFeedback onPress={() => this.OnGetCurrentPos()}>
+        <TouchableWithoutFeedback onPress={() => this.onGetCurrentPos()}>
           <View style={styles.fauxbutton}>
             <Text style={{textAlign: 'center'}}>GetCurrentPosition</Text>
           </View>
         </TouchableWithoutFeedback>
-        <TouchableWithoutFeedback onPress={() => this.OnStartWatching()}>
+        <TouchableWithoutFeedback onPress={() => this.onStartWatching()}>
           <View style={styles.fauxbutton}>
             <Text style={{textAlign: 'center'}}>StartWatching</Text>
           </View>
         </TouchableWithoutFeedback>
-        <TouchableWithoutFeedback onPress={() => this.OnStopWatching()}>
+        <TouchableWithoutFeedback onPress={() => this.onStopWatching()}>
           <View style={styles.fauxbutton}>
             <Text style={{textAlign: 'center'}}>StopWatching</Text>
           </View>

--- a/packages/playground/Samples/messages.tsx
+++ b/packages/playground/Samples/messages.tsx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
   },
 });
 
-var TextValues = [
+const TextValues = [
   'What time did the man go to the dentist?',
   "I don't know.",
   'Tooth hurt-y.',
@@ -73,9 +73,9 @@ var TextValues = [
   'Because if they had four, they would be chicken sedans!',
 ];
 
-var UserNameValues = ['Parent', 'Child'];
+const UserNameValues = ['Parent', 'Child'];
 
-var AvatarValues = [
+const AvatarValues = [
   require('./images/blueuser.png'),
   require('./images/reduser.png'),
 ];
@@ -103,7 +103,7 @@ function GetValue(index: number, values: Array<any>) {
 }
 
 function CreateMessage(id: number) {
-  let m = new Message();
+  const m = new Message();
   m.MessageId = 'm' + (id + 1);
   m.Text = GetValue(id, TextValues);
   m.UserName = GetValue(id, UserNameValues);
@@ -120,8 +120,8 @@ function CreateMessage(id: number) {
 }
 
 function LoadMessages(count: number) {
-  let messages = [];
-  for (var i = 0; i < count; i++) {
+  const messages = [];
+  for (let i = 0; i < count; i++) {
     messages[i] = CreateMessage(i);
   }
   return messages;

--- a/packages/playground/Samples/scrollViewSnapSample.tsx
+++ b/packages/playground/Samples/scrollViewSnapSample.tsx
@@ -72,7 +72,7 @@ export default class Bootstrap extends React.Component<{}, any> {
     void wait(2000).then(() => this.setState({refreshing: false}));
   };
 
-  makeItems = (nItems: number, styles: Object): Array<any> => {
+  makeItems = (nItems: number, styles: Record<string, any>): Array<any> => {
     const items = [];
     for (let i = 0; i < nItems; i++) {
       items[i] = (

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -42,7 +42,7 @@ export default class Bootstrap extends React.Component<{}, any> {
   };
 
   onPressShowPassword = () => {
-    var previousState = this.state.passwordHidden;
+    const previousState = this.state.passwordHidden;
     this.setState({passwordHidden: !previousState});
   };
 

--- a/packages/playground/Samples/ticTacToe.tsx
+++ b/packages/playground/Samples/ticTacToe.tsx
@@ -38,7 +38,7 @@ export default class Bootstrap extends React.Component<
   }
 
   onMove(i: number) {
-    let newSquares = this.state.squares.slice();
+    const newSquares = this.state.squares.slice();
     const turn = this.whoseTurn();
     if (this.state.squares[i] || winner(this.state.squares)) {
       return null;
@@ -161,13 +161,13 @@ const winner = (squares: SquareValue[]) => {
     [2, 4, 6],
   ];
 
-  for (let i = 0; i < lines.length; i++) {
-    const [a, b, c] = lines[i];
+  for (const line of lines) {
+    const [a, b, c] = line;
     if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a];
     }
   }
-  if (squares.indexOf(null) === -1) {
+  if (!squares.includes(null)) {
     return null;
   } // tie game
   return undefined;

--- a/packages/react-native-platform-override/src/Api.ts
+++ b/packages/react-native-platform-override/src/Api.ts
@@ -101,7 +101,7 @@ export async function addOverride(
   manifestPath: string,
 ): Promise<void> {
   const {manifest} = await createManifestContext(manifestPath);
-  await manifest.addOverride(override);
+  manifest.addOverride(override);
   await Serialized.writeManifestToFile(manifest.serialize(), manifestPath);
 }
 
@@ -183,7 +183,7 @@ export async function upgradeOverrides(
   // check out for future upgrades.
   const upToDateOverrides = [
     ..._.difference(
-      await ctx.manifest.listOverrides(),
+      ctx.manifest.listOverrides(),
       validationErrors.map(err => ctx.manifest.findOverride(err.overrideName)!),
     ).map(ovr => ovr.name()),
 

--- a/packages/react-native-platform-override/src/BatchingQueue.ts
+++ b/packages/react-native-platform-override/src/BatchingQueue.ts
@@ -9,7 +9,10 @@
  * Executes actions, attempting to group by a given key
  */
 export default class BatchingQueue<TKey> {
-  private keyedQueues: Map<TKey, Array<() => Promise<void>>> = new Map();
+  private readonly keyedQueues: Map<
+    TKey,
+    Array<() => Promise<void>>
+  > = new Map();
   private currentKey?: TKey;
 
   enqueue<T>(key: TKey, action: () => Promise<T>): Promise<T> {

--- a/packages/react-native-platform-override/src/CrossProcessLock.ts
+++ b/packages/react-native-platform-override/src/CrossProcessLock.ts
@@ -21,9 +21,9 @@ import {platform, tmpdir} from 'os';
  *   the pipe server)
  */
 export default class CrossProcessLock {
-  private ipcPath: string;
-  private server: net.Server;
-  private connections: Set<net.Socket>;
+  private readonly ipcPath: string;
+  private readonly server: net.Server;
+  private readonly connections: Set<net.Socket>;
 
   /**
    * Create the lock instance. Does not yet allocate any resources.

--- a/packages/react-native-platform-override/src/FileSystemRepository.ts
+++ b/packages/react-native-platform-override/src/FileSystemRepository.ts
@@ -15,7 +15,7 @@ import {WritableFileRepository} from './FileRepository';
  * Allows reading phsyical files based on a passed in directory
  */
 export default class FileSystemRepository implements WritableFileRepository {
-  private baseDir: string;
+  private readonly baseDir: string;
 
   constructor(baseDir: string) {
     this.baseDir = baseDir;

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -27,15 +27,15 @@ const RN_GITHUB_URL = 'https://github.com/facebook/react-native.git';
  */
 export default class GitReactFileRepository
   implements VersionedReactFileRepository {
-  private fileRepo: FileSystemRepository;
-  private gitClient: simplegit.SimpleGit;
+  private readonly fileRepo: FileSystemRepository;
+  private readonly gitClient: simplegit.SimpleGit;
   private checkedOutVersion?: string;
   private static githubToken?: string;
 
   // We need to ensure it is impossible to check out a new React Native
   // version while an operation hasn't yet finished. We queue each operation to
   // ensure they are performed atomically.
-  private batchingQueue: BatchingQueue<string>;
+  private readonly batchingQueue: BatchingQueue<string>;
 
   private constructor(gitDirectory: string, gitClient: simplegit.SimpleGit) {
     this.batchingQueue = new BatchingQueue();

--- a/packages/react-native-platform-override/src/Hash.ts
+++ b/packages/react-native-platform-override/src/Hash.ts
@@ -15,7 +15,7 @@ import isutf8 from 'isutf8';
  * Creates a hash from content, attempting to normalize for line-feeds
  */
 export class Hasher {
-  private hash: crypto.Hash;
+  private readonly hash: crypto.Hash;
 
   constructor() {
     this.hash = crypto.createHash('sha1');

--- a/packages/react-native-platform-override/src/Manifest.ts
+++ b/packages/react-native-platform-override/src/Manifest.ts
@@ -21,10 +21,10 @@ import {normalizePath} from './PathUtils';
  * performing aggregate operations on the overrides.
  */
 export default class Manifest {
-  private includePatterns?: string[];
-  private excludePatterns?: string[];
+  private readonly includePatterns?: string[];
+  private readonly excludePatterns?: string[];
   private baseVersion?: string;
-  private overrides: Override[];
+  private readonly overrides: Override[];
 
   /**
    * Construct the manifest

--- a/packages/react-native-platform-override/src/Override.ts
+++ b/packages/react-native-platform-override/src/Override.ts
@@ -64,7 +64,7 @@ export default interface Override {
  * Platform overrides represent logic not derived from upstream sources.
  */
 export class PlatformOverride implements Override {
-  private overrideFile: string;
+  private readonly overrideFile: string;
 
   constructor(args: {file: string}) {
     this.overrideFile = normalizePath(args.file);
@@ -332,11 +332,11 @@ export class PatchOverride extends BaseFileOverride {
  * DirectoryCopy overrides copy files from an upstream directory
  */
 export class DirectoryCopyOverride implements Override {
-  private directory: string;
-  private baseDirectory: string;
-  private baseVersion: string;
-  private baseHash: string;
-  private issue?: number;
+  private readonly directory: string;
+  private readonly baseDirectory: string;
+  private readonly baseVersion: string;
+  private readonly baseHash: string;
+  private readonly issue?: number;
 
   constructor(args: {
     directory: string;

--- a/packages/react-native-platform-override/src/OverrideFactory.ts
+++ b/packages/react-native-platform-override/src/OverrideFactory.ts
@@ -52,8 +52,8 @@ export default interface OverrideFactory {
  * Conrete implementation of an OverrideFactory
  */
 export class OverrideFactoryImpl implements OverrideFactory {
-  private reactRepo: ReactFileRepository;
-  private overrideRepo: FileRepository;
+  private readonly reactRepo: ReactFileRepository;
+  private readonly overrideRepo: FileRepository;
 
   constructor(reactRepo: ReactFileRepository, overrideRepo: FileRepository) {
     this.reactRepo = reactRepo;

--- a/packages/react-native-platform-override/src/test/MockFileRepository.ts
+++ b/packages/react-native-platform-override/src/test/MockFileRepository.ts
@@ -22,7 +22,7 @@ export interface MockFile {
 export default class MockFileRepository implements FileRepository {
   protected files: MockFile[];
   protected emptyDirectories: string[];
-  private normalize: (file: string) => string;
+  private readonly normalize: (file: string) => string;
 
   constructor(
     files: MockFile[],

--- a/packages/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
+++ b/packages/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
@@ -98,31 +98,31 @@ class ButtonExample extends React.Component<{}, IFocusableComponentState & IExpa
     }
   }
 
-  private _expand = () => {
+  private readonly _expand = () => {
     this.setState({
       expanded: true,
     });
   };
 
-  private _collapse = () => {
+  private readonly _collapse = () => {
     this.setState({
       expanded: false,
     });
   };
 
-  private _onFocus = () => {
+  private readonly _onFocus = () => {
     this.setState({
       hasFocus: true,
     });
   };
 
-  private _onBlur = () => {
+  private readonly _onBlur = () => {
     this.setState({
       hasFocus: false,
     });
   };
 
-  private _onPress = () => {
+  private readonly _onPress = () => {
     this.state.expanded ? this._collapse() : this._expand();
   };
 }
@@ -141,7 +141,7 @@ class MultiSelectionExample extends React.Component<{}, IMultiSelectionExampleSt
   }
 
   public handleAdd = item => {
-    if (this.state.selectedItems.indexOf(item) === -1) {
+    if (!this.state.selectedItems.includes(item)) {
       this.setState({
         selectedItems: this.state.selectedItems.concat([item]),
       });
@@ -149,7 +149,7 @@ class MultiSelectionExample extends React.Component<{}, IMultiSelectionExampleSt
   };
 
   public handleRemove = item => {
-    if (this.state.selectedItems.indexOf(item) > -1) {
+    if (this.state.selectedItems.includes(item)) {
       const array = [...this.state.selectedItems];
       const index = array.indexOf(item);
       array.splice(index, 1);
@@ -170,7 +170,7 @@ class MultiSelectionExample extends React.Component<{}, IMultiSelectionExampleSt
           size={3}
           addHandler={this.handleAdd}
           removeHandler={this.handleRemove}
-          isSelected={this.state.selectedItems.indexOf(1) > -1 ? true : false}
+          isSelected={this.state.selectedItems.includes(1) ? true : false}
         />
         <SelectionItemComponent
           value={2}
@@ -180,7 +180,7 @@ class MultiSelectionExample extends React.Component<{}, IMultiSelectionExampleSt
           size={3}
           addHandler={this.handleAdd}
           removeHandler={this.handleRemove}
-          isSelected={this.state.selectedItems.indexOf(2) > -1 ? true : false}
+          isSelected={this.state.selectedItems.includes(2) ? true : false}
         />
         <SelectionItemComponent
           value={3}
@@ -190,7 +190,7 @@ class MultiSelectionExample extends React.Component<{}, IMultiSelectionExampleSt
           size={3}
           addHandler={this.handleAdd}
           removeHandler={this.handleRemove}
-          isSelected={this.state.selectedItems.indexOf(3) > -1 ? true : false}
+          isSelected={this.state.selectedItems.includes(3) ? true : false}
         />
         <Text>Selected Items: {this.state.selectedItems.toString()}</Text>
       </ViewWin32>
@@ -287,13 +287,13 @@ class ListItem extends React.PureComponent<IListProps, IFocusableComponentState>
     );
   }
 
-  private _onFocus = () => {
+  private readonly _onFocus = () => {
     this.setState({
       hasFocus: true,
     });
   };
 
-  private _onBlur = () => {
+  private readonly _onBlur = () => {
     this.setState({
       hasFocus: false,
     });

--- a/packages/react-native-win32-tester/src/js/examples-win32/Theming/ThemingModuleAPI.tsx
+++ b/packages/react-native-win32-tester/src/js/examples-win32/Theming/ThemingModuleAPI.tsx
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 const Theming = NativeModules.Theming;
 
 const ifModuleAvailable = (wrappedComponent: JSX.Element) => {
-  return (Theming && wrappedComponent) || <Text>Theming Native Module not available</Text>;
+  return Theming ? wrappedComponent : <Text>Theming Native Module not available</Text>;
 };
 
 const RenderThemeFunction = () => {
@@ -49,7 +49,7 @@ const ThemingMethods: React.FunctionComponent<{}> = () => {
   );
 };
 
-const renderNestedObject = (obj: object) => {
+const renderNestedObject = (obj: Record<string, any>) => {
   return (
     <View style={styles.nestedContainer}>
       <ScrollView>
@@ -61,7 +61,7 @@ const renderNestedObject = (obj: object) => {
   );
 };
 
-const renderObject = (obj: object) => {
+const renderObject = (obj: Record<string, any>) => {
   const firstKey = Object.keys(obj)[0];
   const formattedOutput = JSON.stringify(obj)
     .replace(/],/g, '],\n\n')

--- a/packages/react-native-win32/.eslintrc.js
+++ b/packages/react-native-win32/.eslintrc.js
@@ -5,5 +5,16 @@ module.exports = {
       "react-hooks/exhaustive-deps": "warn",
       "react-hooks/rules-of-hooks": "warn",
     },
+    overrides: [
+      {
+        files: ['*.ts', '*.tsx'],
+        excludedFiles: ['*.d.ts'],
+        // Also not clean
+        rules: {
+          '@typescript-eslint/no-unnecessary-condition': 'off',
+          'no-restricted-syntax': 'off',
+        },
+      },
+    ],
     parserOptions: {tsconfigRootDir : __dirname},
 };

--- a/packages/react-native-win32/src/Libraries/Components/Button/ButtonWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/Button/ButtonWin32.tsx
@@ -55,35 +55,35 @@ export class ButtonWin32 extends React.Component<IButtonWin32Props, IButtonWin32
     );
   }
 
-  private _makeState = (select: SelectState): IButtonWin32State => {
+  private readonly _makeState = (select: SelectState): IButtonWin32State => {
     return {
       accessibilityState: {
-        disabled: this.props.disabled === true,
+        disabled: this.props.disabled,
         selected: select === SelectState.Selected,
       },
     };
   };
 
-  private _setState = (select: SelectState): void => {
+  private readonly _setState = (select: SelectState): void => {
     const state = this._makeState(select);
     this.setState(state);
   };
 
-  private _onFocus = (): void => {
+  private readonly _onFocus = (): void => {
     this._setState(SelectState.Selected);
     if (this.props.onFocus) {
       this.props.onFocus();
     }
   };
 
-  private _onBlur = (): void => {
+  private readonly _onBlur = (): void => {
     this._setState(SelectState.NotSelected);
     if (this.props.onBlur) {
       this.props.onBlur();
     }
   };
 
-  private _onTouchEnd = (event: RN.GestureResponderEvent): void => {
+  private readonly _onTouchEnd = (event: RN.GestureResponderEvent): void => {
     if (!this.props.disabled) {
       if (this.props.onPress) {
         this.props.onPress(event);

--- a/packages/react-native-win32/src/Libraries/Components/EnterString.win32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/EnterString.win32.tsx
@@ -97,12 +97,12 @@ export default class EnterString extends React.Component<IEnterStringProps, {}> 
   public render() {
     const args = { ...this.props };
     if (args.onChanged) {
-      args.onChanged = this._on_changed_native.bind(this);
+      args.onChanged = this._onChangedNative.bind(this);
     } // TODO how should this work without the cast
 
     return <EnterStringNative {...(args as any) as IEnterStringNativeProps} />;  }
 
-  private _on_changed_native(event: NativeSyntheticEvent<INativeOnChangedEventArgs>) {
+  private _onChangedNative(event: NativeSyntheticEvent<INativeOnChangedEventArgs>) {
     if (this.props.onChanged) {
       this.props.onChanged(event.nativeEvent.text);
     }

--- a/packages/react-native-win32/src/Libraries/Components/EnterString.win32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/EnterString.win32.tsx
@@ -28,8 +28,6 @@ interface IEnterStringNativeProps /*extends React.ClassAttributes<React.View>*/ 
   onChanged?: (event: NativeSyntheticEvent<INativeOnChangedEventArgs>) => void;
 }
 
-let RCTEnterString: React.ComponentClass<IEnterStringNativeProps>;
-
 class EnterStringNative extends React.Component<IEnterStringNativeProps, {}> {
   // mixins: [NativeMethodsMixin],
 
@@ -49,7 +47,7 @@ class EnterStringNative extends React.Component<IEnterStringNativeProps, {}> {
   },
   */
 
-  /* tslint:disable-next-line:no-any */ // TODO figure out how to get a real type here
+ // TODO figure out how to get a real type here
   public static propTypes: any = {
     // React.ValidationMap<IEnterStringNativeProps> = {
     // ...View.propTypes,
@@ -86,7 +84,7 @@ class EnterStringNative extends React.Component<IEnterStringNativeProps, {}> {
   }
 }
 
-RCTEnterString = requireNativeComponent('RCTEnterString');
+const RCTEnterString = requireNativeComponent('RCTEnterString');
 
 export default class EnterString extends React.Component<IEnterStringProps, {}> {
   public static DefaultProps: IEnterStringProps = {
@@ -102,8 +100,7 @@ export default class EnterString extends React.Component<IEnterStringProps, {}> 
       args.onChanged = this._on_changed_native.bind(this);
     } // TODO how should this work without the cast
 
-    return <EnterStringNative {...(args as any) as IEnterStringNativeProps} />; // tslint:disable-line:no-any
-  }
+    return <EnterStringNative {...(args as any) as IEnterStringNativeProps} />;  }
 
   private _on_changed_native(event: NativeSyntheticEvent<INativeOnChangedEventArgs>) {
     if (this.props.onChanged) {

--- a/packages/react-native-win32/src/Libraries/Components/TextInput/Tests/TextInputTest.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/TextInput/Tests/TextInputTest.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { StyleSheet, Text, TextInput, View } from 'react-native';
 
 // Disabling no-jsx-lambda so functional components are more convenient to use
-/*tslint:disable:next-line jsx-no-lambda*/
 
 const AutoFocusingTextInputTest: React.FC<{}> = () => {
   return (
@@ -42,7 +41,7 @@ const ControllingTextInputTest: React.FC<{}> = () => {
       <Text>This TextInput inserts spaces between characters</Text>
       <TextInput
         multiline
-        onChangeText={(text) => setValue(text.charAt(text.length - 1) === ' ' ? value : (text + ' '))}
+        onChangeText={(text) => setValue(text.endsWith(' ') ? value : (text + ' '))}
         style={styles.blue}
         value={value}
       />

--- a/packages/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.tsx
@@ -49,7 +49,6 @@ const RCTTextInput = requireNativeComponent<RCTTextInputProps>('RCTTextInput');
 
 // Adding typings on ViewManagers is problematic as available functionality is not known until
 // registration at runtime and would require native and js to always be in sync.
-/*tslint:disable-next-line no-any*/
 const TextInputViewManager: any = NativeModules.UIManager.getViewManagerConfig('RCTTextInput');
 
 class TextInput extends React.Component<TextInputProps, {}> {
@@ -59,7 +58,7 @@ class TextInput extends React.Component<TextInputProps, {}> {
 
   private _rafID: number;
 
-  private _inputRef: React.RefObject<React.Component<RCTTextInputProps> & Readonly<NativeMethods>>;
+  private readonly _inputRef: React.RefObject<React.Component<RCTTextInputProps> & Readonly<NativeMethods>>;
   private _lastNativeText: string;
   private _eventCount = 0;
 
@@ -173,13 +172,13 @@ class TextInput extends React.Component<TextInputProps, {}> {
     this.setNativeText('');
   }
 
-  private setEventCount = (): void => {
+  private readonly setEventCount = (): void => {
     NativeModules.UIManager.
       dispatchViewManagerCommand(findNodeHandle(this), TextInputViewManager.Commands.setEventCount,
         { eventCount: this._eventCount });
   }
 
-  private setNativeText = (val: string): void => {
+  private readonly setNativeText = (val: string): void => {
     if (this._lastNativeText !== val) {
       NativeModules.UIManager.
         dispatchViewManagerCommand(findNodeHandle(this), TextInputViewManager.Commands.setNativeText,
@@ -187,11 +186,11 @@ class TextInput extends React.Component<TextInputProps, {}> {
     }
   }
 
-  private _getText = (): string | null => {
+  private readonly _getText = (): string | null => {
     return this.props.value || (this.props.defaultValue || null);
   }
 
-  private _onChange = (e: IChangeEvent): void => {
+  private readonly _onChange = (e: IChangeEvent): void => {
     const text = e.nativeEvent.text;
     this._eventCount = e.nativeEvent.eventCount;
     this.setEventCount();
@@ -204,12 +203,12 @@ class TextInput extends React.Component<TextInputProps, {}> {
     return;
   }
 
-  private _onFocus = (e: IFocusEvent): void => {
+  private readonly _onFocus = (e: IFocusEvent): void => {
     this.focus();
     this.props.onFocus && this.props.onFocus(e);
   }
 
-  private _onBlur = (e: IBlurEvent): void => {
+  private readonly _onBlur = (e: IBlurEvent): void => {
     this.props.onBlur && this.props.onBlur(e);
   }
 }

--- a/packages/react-native-win32/src/Libraries/Components/Touchable/Tests/TouchableWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/Touchable/Tests/TouchableWin32Test.tsx
@@ -114,54 +114,54 @@ class TouchableWin32WithoutFeedback extends React.Component<ITouchableWin32Witho
     );
   }
 
-  private _touchableHandlePress = (e: IPressEvent) => {
+  private readonly _touchableHandlePress = (e: IPressEvent) => {
     this.props.onPress && this.props.onPress(e);
   };
 
-  private _touchableHandleActivePressIn = (e: IPressEvent) => {
+  private readonly _touchableHandleActivePressIn = (e: IPressEvent) => {
     this.props.onPressIn && this.props.onPressIn(e);
   };
 
-  private _touchableHandleActivePressOut = (e: IPressEvent) => {
+  private readonly _touchableHandleActivePressOut = (e: IPressEvent) => {
     this.props.onPressOut && this.props.onPressOut(e);
   };
 
-  private _touchableHandleLongPress = (e: IPressEvent) => {
+  private readonly _touchableHandleLongPress = (e: IPressEvent) => {
     this.props.onLongPress && this.props.onLongPress(e);
   };
 
-  private _touchableGetPressRectOffset = (): Insets => {
+  private readonly _touchableGetPressRectOffset = (): Insets => {
     return this.props.pressRetentionOffset || PRESS_RETENTION_OFFSET;
   };
 
-  private _touchableGetHitSlop = (): Insets => {
+  private readonly _touchableGetHitSlop = (): Insets => {
     return this.props.hitSlop;
   };
 
-  private _touchableGetHighlightDelayMS = (): number => {
+  private readonly _touchableGetHighlightDelayMS = (): number => {
     return this.props.delayPressIn || 0;
   };
 
-  private _touchableGetLongPressDelayMS = (): number => {
+  private readonly _touchableGetLongPressDelayMS = (): number => {
     return this.props.delayLongPress === 0 ? 0 : this.props.delayLongPress || 500;
   };
 
-  private _touchableGetPressOutDelayMS = (): number => {
+  private readonly _touchableGetPressOutDelayMS = (): number => {
     return this.props.delayPressOut || 0;
   };
 
-  private _onFocus = () => {
+  private readonly _onFocus = () => {
     this.setState({ isFocused: true });
   };
 
-  private _onBlur = () => {
+  private readonly _onBlur = () => {
     this.setState({ isFocused: false });
   };
 
   /**
    * The generated style uses hard-coded border width values
    */
-  private _generateStyle = (state: ITouchableWin32State): ViewStyle => {
+  private readonly _generateStyle = (state: ITouchableWin32State): ViewStyle => {
     const finalStyle: ViewStyle = {
       borderWidth: state.isFocused ? 5 : 0,
       borderColor: 'red',
@@ -227,55 +227,55 @@ class TouchableWin32HighlightComponent extends React.Component<ITouchableWin32Hi
     );
   }
 
-  private _touchableHandlePress = (e: IPressEvent) => {
+  private readonly _touchableHandlePress = (e: IPressEvent) => {
     this.props.onPress && this.props.onPress(e);
     this.setState({ isPressed: false });
   };
-  private _touchableHandleActivePressIn = (e: IPressEvent) => {
+  private readonly _touchableHandleActivePressIn = (e: IPressEvent) => {
     this.props.onPressIn && this.props.onPressIn(e);
     this.setState({ isPressed: true });
   };
-  private _touchableHandleActivePressOut = (e: IPressEvent) => {
+  private readonly _touchableHandleActivePressOut = (e: IPressEvent) => {
     this.props.onPressOut && this.props.onPressOut(e);
     this.setState({ isPressed: false });
   };
-  private _touchableHandleLongPress = (e: IPressEvent) => {
+  private readonly _touchableHandleLongPress = (e: IPressEvent) => {
     this.props.onLongPress && this.props.onLongPress(e);
   };
-  private _touchableGetPressRectOffset = (): Insets => {
+  private readonly _touchableGetPressRectOffset = (): Insets => {
     return this.props.pressRetentionOffset || PRESS_RETENTION_OFFSET;
   };
-  private _touchableGetHitSlop = (): Insets => {
+  private readonly _touchableGetHitSlop = (): Insets => {
     return { left: 100, right: 100, top: 100, bottom: 100 };
   };
-  private _touchableGetHighlightDelayMS = (): number => {
+  private readonly _touchableGetHighlightDelayMS = (): number => {
     return this.props.delayLongPressIn || 0;
   };
-  private _touchableGetLongPressDelayMS = (): number => {
+  private readonly _touchableGetLongPressDelayMS = (): number => {
     return this.props.delayLongPress || 500;
   };
-  private _touchableGetPressOutDelayMS = (): number => {
+  private readonly _touchableGetPressOutDelayMS = (): number => {
     return this.props.delayPressOut || 0;
   };
-  private _touchableHandleKeyPress = (ev: IKeyboardEvent) => {
+  private readonly _touchableHandleKeyPress = (ev: IKeyboardEvent) => {
     this.props.onKeyPress && this.props.onKeyPress(ev);
   }
-  private _touchableHandleKeyPressDown = (ev: IKeyboardEvent) => {
+  private readonly _touchableHandleKeyPressDown = (ev: IKeyboardEvent) => {
     this.props.onKeyPressDown && this.props.onKeyPressDown(ev);
   }
-  private _mouseEnter = (): void => {
+  private readonly _mouseEnter = (): void => {
     this.props.onMouseEnter && this.props.onMouseEnter();
     this.setState({ isMouseIn: true });
   };
-  private _mouseLeave = (): void => {
+  private readonly _mouseLeave = (): void => {
     this.props.onMouseLeave && this.props.onMouseLeave();
     this.setState({ isMouseIn: false });
   };
-  private _onFocus = (ev: NativeSyntheticEvent<{}>): void => {
+  private readonly _onFocus = (ev: NativeSyntheticEvent<{}>): void => {
     this.props.onFocus && this.props.onFocus(ev);
     this.setState({ isFocused: true });
   };
-  private _onBlur = (ev: NativeSyntheticEvent<{}>): void => {
+  private readonly _onBlur = (ev: NativeSyntheticEvent<{}>): void => {
     this.props.onBlur && this.props.onBlur(ev);
     this.setState({ isFocused: false });
   };
@@ -287,7 +287,7 @@ class TouchableWin32HighlightComponent extends React.Component<ITouchableWin32Hi
    * funtion passed on to TouchableWin32 and resolved according
    * to the internal state of TouchableWin32).
    */
-  private _generateStyle = (state: ITouchableWin32State): ViewStyle => {
+  private readonly _generateStyle = (state: ITouchableWin32State): ViewStyle => {
     const finalStyle: ViewStyle = {};
     finalStyle.borderColor = state.isFocused ? 'red' : 'blue';
     finalStyle.borderWidth = state.isFocused ? 10 : 5;
@@ -356,7 +356,7 @@ class TouchableWithoutFeedbackExample extends React.Component<{}, IExampleState>
     );
   }
 
-  private _onPress = () => {
+  private readonly _onPress = () => {
     this.setState({ numberOfPresses: this.state.numberOfPresses + 1 });
   };
 }
@@ -395,7 +395,7 @@ class TouchableHighlightExample extends React.Component<{}, IExampleState> {
    * This is primarily to demonstrate render children as a function
    * of state, here we change text color depending on interaction state.
    */
-  private _getChildrenOfInnerTouchable = (state: ITouchableWin32State) => {
+  private readonly _getChildrenOfInnerTouchable = (state: ITouchableWin32State) => {
     return (
       <ViewWin32
         style={{
@@ -434,14 +434,14 @@ class TouchableHighlightExample extends React.Component<{}, IExampleState> {
     }
   }
 
-  private _onPress = () => {
+  private readonly _onPress = () => {
     this.setState({ numberOfPresses: this.state.numberOfPresses + 1 });
   };
 }
 
 const TouchableFocusExample = () => {
   const [focused, setFocused] = React.useState(false);
-  let focusableRef = React.useRef<TouchableWin32>(null);
+  const focusableRef = React.useRef<TouchableWin32>(null);
 
   // onPress callback
   const focusOnPress = React.useCallback(() => {

--- a/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableNativeFeedback.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableNativeFeedback.Props.ts
@@ -2,7 +2,7 @@ import { IViewWin32Props } from '../View/ViewWin32.Props';
 
 export interface ITouchableNativeFeedbackProps extends IViewWin32Props {
   // ViewProperties {
-  onPress: (event: Object) => void;
+  onPress: (event: Record<string, any>) => void;
   disabled?: boolean;
   accessibilityLabel: string;
   tooltip?: string;

--- a/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableNativeFeedback.win32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableNativeFeedback.win32.tsx
@@ -16,14 +16,12 @@ import { requireNativeComponent } from 'react-native';
 
 import { ITouchableNativeFeedbackProps } from './TouchableNativeFeedback.Props';
 
-let RCTTouchableNativeFeedback: React.ComponentClass<ITouchableNativeFeedbackProps>;
-
 class TouchableNativeFeedback extends React.Component<ITouchableNativeFeedbackProps, {}> {
   public render() {
     return <RCTTouchableNativeFeedback {...this.props}>{this.props.children}</RCTTouchableNativeFeedback>;
   }
 }
 
-RCTTouchableNativeFeedback = requireNativeComponent('RCTTouchableNativeFeedback');
+const RCTTouchableNativeFeedback = requireNativeComponent('RCTTouchableNativeFeedback');
 
 export = TouchableNativeFeedback;

--- a/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/Touchable/TouchableWin32.tsx
@@ -190,7 +190,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   private _positionOnActivate: IPosition;
   private _dimensionsOnActivate: IDimensions;
 
-  private _internalRef: React.RefObject<ViewWin32>
+  private readonly _internalRef: React.RefObject<ViewWin32>
 
   constructor(props) {
     super(props);
@@ -272,26 +272,26 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   /**
    * The rejectResponderTermination prop provides a way to accept/reject termination requests
    */
-  private _touchableHandleResponderTerminationRequest = (): boolean => {
+  private readonly _touchableHandleResponderTerminationRequest = (): boolean => {
     return !this.props.rejectResponderTermination;
   };
 
   /**
    * Only reject an opportunity to become the responder on bubble if disabled
    */
-  private _touchableHandleStartShouldSetResponder = (): boolean => {
+  private readonly _touchableHandleStartShouldSetResponder = (): boolean => {
     return !this.props.disabled;
   };
 
   /** TODO: Long press cancel as a prop may be a good idea */
-  private _touchableLongPressCancelsPress = (): boolean => {
+  private readonly _touchableLongPressCancelsPress = (): boolean => {
     return true;
   };
 
   /**
    * On responder being granted, state and local data need to be set
    */
-  private _touchableHandleResponderGrant = (e: IPressEvent): void => {
+  private readonly _touchableHandleResponderGrant = (e: IPressEvent): void => {
     const dispatchID = findNodeHandle(e.currentTarget);
     e.persist();
 
@@ -323,7 +323,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   /**
    * Handle responder release
    */
-  private _touchableHandleResponderRelease = (e: IPressEvent) => {
+  private readonly _touchableHandleResponderRelease = (e: IPressEvent) => {
     this._pressInLocation = null;
     this._receiveSignal('RESPONDER_RELEASE', e);
   };
@@ -331,7 +331,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   /**
    * Handle responder terminate
    */
-  private _touchableHandleResponderTerminate = (e: IPressEvent) => {
+  private readonly _touchableHandleResponderTerminate = (e: IPressEvent) => {
     this._pressInLocation = null;
     this._receiveSignal('RESPONDER_TERMINATED', e);
   };
@@ -339,7 +339,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   /**
    * Handles move events
    */
-  private _touchableHandleResponderMove = (e: IPressEvent) => {
+  private readonly _touchableHandleResponderMove = (e: IPressEvent) => {
     if (!this._positionOnActivate) {
       return;
     }
@@ -403,7 +403,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
    * Used while performing side effects during state transitions,
    * to maintain proper bounding dimensions and positional information
    */
-  private _remeasureMetricsOnActivation = () => {
+  private readonly _remeasureMetricsOnActivation = () => {
     const tag = this._responderID;
     if (tag === null) {
       return;
@@ -415,7 +415,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   /**
    * Callback into measure, see _remeasureMetricsOnActivation
    */
-  private _handleQueryLayout = (l: number, t: number, w: number, h: number, globalX: number, globalY: number) => {
+  private readonly _handleQueryLayout = (l: number, t: number, w: number, h: number, globalX: number, globalY: number) => {
     if (!l && !t && !w && !h && !globalX && !globalY) {
       return;
     }
@@ -424,12 +424,12 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     this._dimensionsOnActivate = BoundingDimensions.getPooled(w, h);
   };
 
-  private _handleDelay = (e: IPressEvent) => {
+  private readonly _handleDelay = (e: IPressEvent) => {
     this._touchableDelayTimeout = null;
     this._receiveSignal('DELAY', e);
   };
 
-  private _handleLongDelay = (e: IPressEvent) => {
+  private readonly _handleLongDelay = (e: IPressEvent) => {
     this._longPressDelayTimeout = null;
     const currState = this._touchState;
 
@@ -450,7 +450,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
   /**
    * Manages state transitions
    */
-  private _receiveSignal = (signal: ISignal, e: IPressEvent) => {
+  private readonly _receiveSignal = (signal: ISignal, e: IPressEvent) => {
     const responderID = this._responderID;
     const currState = this._touchState;
     const nextState: IState = transitions[currState] ? transitions[currState][signal] : null;
@@ -470,16 +470,16 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     }
   };
 
-  private _cancelLongPressDelayTimeout = () => {
+  private readonly _cancelLongPressDelayTimeout = () => {
     this._longPressDelayTimeout && clearTimeout(this._longPressDelayTimeout);
     this._longPressDelayTimeout = null;
   };
 
-  private _isHighlight = (state: IState) => {
+  private readonly _isHighlight = (state: IState) => {
     return state === 'RESPONDER_ACTIVE_PRESS_IN' || state === 'RESPONDER_ACTIVE_LONG_PRESS_IN';
   };
 
-  private _savePressInLocation = (e: IPressEvent) => {
+  private readonly _savePressInLocation = (e: IPressEvent) => {
     const touch = extractSingleTouch(e);
     const pageX = touch && touch.pageX;
     const pageY = touch && touch.pageY;
@@ -488,7 +488,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     this._pressInLocation = { pageX, pageY, locationX, locationY };
   };
 
-  private _getDistanceBetweenPoints = (aX: number, aY: number, bX: number, bY: number): number => {
+  private readonly _getDistanceBetweenPoints = (aX: number, aY: number, bX: number, bY: number): number => {
     const deltaX = aX - bX;
     const deltaY = aY - bY;
     return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
@@ -498,7 +498,9 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
    * Any highlighting/visual effects is done here,
    * This is also where press callbacks are invoked from
    */
-  private _performSideEffectsForTransition = (currState: IState, nextState: IState, signal: ISignal, e: IPressEvent) => {
+  // Existing high cyclomatic complexity
+  // eslint-disable-next-line complexity
+  private readonly _performSideEffectsForTransition = (currState: IState, nextState: IState, signal: ISignal, e: IPressEvent) => {
     const currIsHighlight = this._isHighlight(currState);
     const newIsHighlight = this._isHighlight(nextState);
 
@@ -545,13 +547,13 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     this._touchableDelayTimeout = null;
   };
 
-  private _startHighlight = (e: IPressEvent) => {
+  private readonly _startHighlight = (e: IPressEvent) => {
     this._savePressInLocation(e);
     this.setState({ isPressed: true });
     this.props.touchableHandleActivePressIn && this.props.touchableHandleActivePressIn(e);
   };
 
-  private _endHighlight = (e: IPressEvent) => {
+  private readonly _endHighlight = (e: IPressEvent) => {
     function _handler() {
       this.props.touchableHandleActivePressOut(e);
     }
@@ -566,27 +568,27 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     }
   };
 
-  private _onMouseEnter = () => {
+  private readonly _onMouseEnter = () => {
     this.setState({ isHovered: true });
     this.props.onMouseEnter && this.props.onMouseEnter();
   };
 
-  private _onMouseLeave = () => {
+  private readonly _onMouseLeave = () => {
     this.setState({ isHovered: false });
     this.props.onMouseLeave && this.props.onMouseLeave();
   };
 
-  private _onFocus = (ev: NativeSyntheticEvent<{}>) => {
+  private readonly _onFocus = (ev: NativeSyntheticEvent<{}>) => {
     this.setState({ isFocused: true });
     this.props.onFocus && this.props.onFocus(ev);
   };
 
-  private _onBlur = (ev: NativeSyntheticEvent<{}>) => {
+  private readonly _onBlur = (ev: NativeSyntheticEvent<{}>) => {
     this.setState({ isFocused: false });
     this.props.onBlur && this.props.onBlur(ev);
   };
 
-  private _onKeyDown = (ev: IKeyboardEvent) => {
+  private readonly _onKeyDown = (ev: IKeyboardEvent) => {
     if (this._filterOnKey(ev)) {
       this.setState({ isKeyPressed: true });
       this.props.touchableHandleKeyPressDown && this.props.touchableHandleKeyPressDown(ev);
@@ -595,7 +597,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     this.props.onKeyDown && this.props.onKeyDown(ev);
   };
 
-  private _onKeyUp = (ev: IKeyboardEvent) => {
+  private readonly _onKeyUp = (ev: IKeyboardEvent) => {
     if (this._filterOnKey(ev)) {
       this.setState({ isKeyPressed: false });
       this.props.touchableHandleKeyPress && this.props.touchableHandleKeyPress(ev);
@@ -604,7 +606,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     this.props.onKeyUp && this.props.onKeyUp(ev);
   };
 
-  private _deriveStateFromInternalState = (): ITouchableWin32State => {
+  private readonly _deriveStateFromInternalState = (): ITouchableWin32State => {
     return {
       isPressed: this.state.isPressed || this.state.isKeyPressed,
       isHovered: this.state.isHovered,
@@ -612,7 +614,7 @@ export class TouchableWin32 extends React.Component<ITouchableWin32Props, IInter
     };
   }
 
-  private _filterOnKey = (ev: IKeyboardEvent): boolean => {
+  private readonly _filterOnKey = (ev: IKeyboardEvent): boolean => {
     if (this.props.filterKeys) {
       return this.props.filterKeys(ev.nativeEvent.key);
     }

--- a/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -31,7 +31,7 @@ interface IFocusableComponentState {
 
 class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentState> {
   private _focusTarget: ViewWin32 = null;
-  private _labeledBy: React.RefObject<ViewWin32>;
+  private readonly _labeledBy: React.RefObject<ViewWin32>;
 
   public constructor(props) {
     super(props);
@@ -62,23 +62,23 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
     );
   }
 
-  private _setRef = (ref: ViewWin32) => {
+  private readonly _setRef = (ref: ViewWin32) => {
     this._focusTarget = ref;
   };
 
-  private _onPress = () => {
+  private readonly _onPress = () => {
     if (this._focusTarget !== undefined) {
       this._focusTarget.focus();
     }
   };
 
-  private _onFocus = () => {
+  private readonly _onFocus = () => {
     this.setState({
       hasFocus: true,
     });
   };
 
-  private _onBlur = () => {
+  private readonly _onBlur = () => {
     this.setState({
       hasFocus: false,
     });
@@ -134,23 +134,23 @@ class KeyboardTestComponent extends React.Component<{}, IFocusableComponentState
     );
   }
 
-  private _onFocus = () => {
+  private readonly _onFocus = () => {
     this.setState({
       hasFocus: true,
     });
   };
 
-  private _onBlur = () => {
+  private readonly _onBlur = () => {
     this.setState({
       hasFocus: false,
     });
   };
 
-  private _onKeyUp = (ev: IKeyboardEvent) => {
+  private readonly _onKeyUp = (ev: IKeyboardEvent) => {
     this.setState({ lastKeyUp: ev.nativeEvent.key, lastKeyDown: null });
   };
 
-  private _onKeyDown = (ev: IKeyboardEvent) => {
+  private readonly _onKeyDown = (ev: IKeyboardEvent) => {
     this.setState({ lastKeyDown: ev.nativeEvent.key, lastKeyUp: null });
   };
 }
@@ -175,10 +175,10 @@ class HoverTestComponent extends React.Component<IHoverComponentProps, IFocusabl
       />
     );
   }
-  private _onMouseLeave = () => {
+  private readonly _onMouseLeave = () => {
     this.setState({ hasFocus: false });
   };
-  private _onMouseEnter = () => {
+  private readonly _onMouseEnter = () => {
     this.setState({ hasFocus: true });
   };
 }

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -179,8 +179,7 @@ export type ViewWin32OmitTypes = RN.ViewPropsAndroid &
  * Properties for ViewWin32 component
  */
 export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>, BasePropsWin32 {
-  // tslint:disable-next-line no-reserved-keywords -- type name matching facebook implementation
-  type?: React.ElementType;
+   type?: React.ElementType;
   children?: React.ReactNode;
   accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
   /**

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -47,7 +47,7 @@ export const ViewWin32 = React.forwardRef(
     const [describedByTarget, setDescribedByTarget] = React.useState(null);
     const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = props;
     React.useLayoutEffect(() => {
-      if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy?.current !== null)
+      if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy.current !== null)
       {
         setLabeledByTarget(findNodeHandle(accessibilityLabeledBy.current as
           | null
@@ -56,7 +56,7 @@ export const ViewWin32 = React.forwardRef(
           | React.ComponentClass<any, any>));
       }
 
-      if (accessibilityDescribedBy !== undefined && accessibilityDescribedBy?.current !== null)
+      if (accessibilityDescribedBy !== undefined && accessibilityDescribedBy.current !== null)
       {
         setDescribedByTarget(findNodeHandle(accessibilityDescribedBy.current as
           | null
@@ -69,7 +69,7 @@ export const ViewWin32 = React.forwardRef(
     /**
      * Set up the forwarding ref to enable adding the focus method.
      */
-    let focusRef = React.useRef<ViewWin32>();
+    const focusRef = React.useRef<ViewWin32>();
 
     const _setNativeRef = setAndForwardRef({
       getForwardedRef: () => ref,

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -71,7 +71,7 @@ export const ViewWin32 = React.forwardRef(
      */
     const focusRef = React.useRef<ViewWin32>();
 
-    const _setNativeRef = setAndForwardRef({
+    const setNativeRef = setAndForwardRef({
       getForwardedRef: () => ref,
       setLocalRef: localRef => {
         focusRef.current = localRef;
@@ -92,7 +92,7 @@ export const ViewWin32 = React.forwardRef(
       },
     });
 
-    return <View ref={_setNativeRef}
+    return <View ref={setNativeRef}
     {...(rest as InnerViewWin32Props)}
     {...((labeledByTarget !== null) ? {accessibilityLabeledBy:labeledByTarget} : {})}
     {...((describedByTarget !== null) ? {accessibilityDescribedBy:describedByTarget} : {})}

--- a/packages/react-native-windows-codegen/src/Cli.ts
+++ b/packages/react-native-windows-codegen/src/Cli.ts
@@ -121,7 +121,7 @@ function combineSchemas(files: string[]): SchemaType {
       if (
         contents &&
         (/export\s+default\s+\(?codegenNativeComponent</.test(contents) ||
-          /extends TurboModule/.test(contents))
+          contents.includes('extends TurboModule'))
       ) {
         const schema = parseFile(filename);
 

--- a/packages/react-native-windows-codegen/src/generators/GenerateNM2.ts
+++ b/packages/react-native-windows-codegen/src/generators/GenerateNM2.ts
@@ -76,6 +76,8 @@ function translateSpecFunctionParam(
       // TODO we have more information here, and could create a more specific type
       return 'React::JSValueObject';
     case 'ReservedFunctionValueTypeAnnotation':
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (param.typeAnnotation.name !== 'RootTag')
         throw new Error(
           `Unknown reserved function: ${param.typeAnnotation.name} in translateSpecFunctionParam`,
@@ -114,6 +116,8 @@ function translateFunctionParam(param: FunctionTypeAnnotationParam): string {
       // TODO we have more information here, and could create a more specific type
       return 'React::JSValueObject &&';
     case 'ReservedFunctionValueTypeAnnotation':
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (param.typeAnnotation.name !== 'RootTag')
         throw new Error(
           `Unknown reserved function: ${param.typeAnnotation.name} in translateFunctionParam`,
@@ -152,6 +156,8 @@ function translateSpecReturnType(
     case 'GenericObjectTypeAnnotation':
       return 'React::JSValueObject';
     case 'ReservedFunctionValueTypeAnnotation':
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (type.name !== 'RootTag')
         throw new Error(
           `Unknown reserved function: ${type.name} in translateSpecReturnType`,
@@ -190,6 +196,8 @@ function translateImplReturnType(
     case 'GenericObjectTypeAnnotation':
       return 'React::JSValueObject';
     case 'ReservedFunctionValueTypeAnnotation':
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (type.name !== 'RootTag')
         throw new Error(
           `Unknown reserved function: ${type.name} in translateSpecReturnType`,
@@ -232,20 +240,20 @@ function isPromise(prop: MethodTypeShape) {
 }
 
 function getPossibleMethodSignatures(prop: MethodTypeShape): string[] {
-  let args = translateArgs(prop.typeAnnotation.params);
+  const args = translateArgs(prop.typeAnnotation.params);
   if (isPromise(prop)) {
     // Sadly, currently, the schema doesn't currently provide us information on the type of the promise.
     args.push('React::ReactPromise<React::JSValue> &&result');
   }
 
   // TODO be much more exhastive on the possible method signatures that can be used..
-  let sig = `REACT_${isMethodSync(prop) ? 'SYNC_' : ''}METHOD(${
+  const sig = `REACT_${isMethodSync(prop) ? 'SYNC_' : ''}METHOD(${
     prop.name
   }) ${translateImplReturnType(prop.typeAnnotation.returnTypeAnnotation)} ${
     prop.name
   }(${args.join(', ')}) noexcept { /* implementation */ }}`;
 
-  let staticsig = `REACT_${isMethodSync(prop) ? 'SYNC_' : ''}METHOD(${
+  const staticsig = `REACT_${isMethodSync(prop) ? 'SYNC_' : ''}METHOD(${
     prop.name
   }) static ${translateImplReturnType(
     prop.typeAnnotation.returnTypeAnnotation,
@@ -268,7 +276,7 @@ function renderProperties(
   return properties
     .filter(prop => prop.name !== 'getConstants')
     .map((prop, index) => {
-      let params = prop.typeAnnotation.params;
+      const params = prop.typeAnnotation.params;
 
       const traversedArgs = translateSpecArgs(params);
 
@@ -303,7 +311,7 @@ export function createNM2Generator({namespace}: {namespace: string}) {
     schema: SchemaType,
     _moduleSpecName: string,
   ): FilesOutput => {
-    let files = new Map<string, string>();
+    const files = new Map<string, string>();
 
     const nativeModules = Object.keys(schema.modules)
       .map(moduleName => {

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -34,24 +34,24 @@ const NPM_REGISTRY_URL = validUrl.isUri(npmConfReg)
   : 'http://registry.npmjs.org';
 const npm = new Registry({registry: NPM_REGISTRY_URL});
 
-enum ExitCode {
-  SUCCESS = 0,
-  UNSUPPORTED_VERSION_RN = 3,
-  USER_CANCEL = 4,
-  NO_REACTNATIVE_FOUND = 5,
-  UNKNOWN_ERROR = 6,
-  NO_PACKAGE_JSON = 7,
-  NO_LATEST_RNW = 8,
-  NO_AUTO_MATCHING_RNW = 9,
-  INCOMPATIBLE_OPTIONS = 10,
-  DEVMODE_VERSION_MISMATCH = 11,
-  NO_REACTNATIVE_DEPENDENCIES = 12,
-}
+const ExitCode = {
+  SUCCESS: 0,
+  UNSUPPORTED_VERSION_RN: 3,
+  USER_CANCEL: 4,
+  NO_REACTNATIVE_FOUND: 5,
+  UNKNOWN_ERROR: 6,
+  NO_PACKAGE_JSON: 7,
+  NO_LATEST_RNW: 8,
+  NO_AUTO_MATCHING_RNW: 9,
+  INCOMPATIBLE_OPTIONS: 10,
+  DEVMODE_VERSION_MISMATCH: 11,
+  NO_REACTNATIVE_DEPENDENCIES: 12,
+};
 
 class UserError extends Error {
-  exitCode: ExitCode;
+  exitCode: number;
 
-  constructor(exitCode: ExitCode, message?: string) {
+  constructor(exitCode: number, message?: string) {
     super(message);
     this.exitCode = exitCode;
   }
@@ -243,7 +243,7 @@ function getLatestMatchingVersion(
       // as it fails to return pre-release versions
       npm.packages.releases(
         pkg,
-        (err: any, details: {[key: string]: object}) => {
+        (err: any, details: {[key: string]: Record<string, any>} | null) => {
           if (err) {
             reject(err);
           } else if (details) {
@@ -252,7 +252,7 @@ function getLatestMatchingVersion(
               const candidates = versions
                 .filter(v => semver.satisfies(v, versionSemVer))
                 .sort(semver.rcompare);
-              if (candidates && candidates.length > 0) {
+              if (candidates.length > 0) {
                 resolve(candidates[0]);
                 return;
               }
@@ -365,7 +365,7 @@ function installReactNativeWindows(
     internalError('Unable to find package.json');
   }
 
-  let pkgJson = require(pkgJsonPath);
+  const pkgJson = require(pkgJsonPath);
 
   // check how react-native is installed
   if ('dependencies' in pkgJson && 'react-native' in pkgJson.dependencies) {
@@ -415,14 +415,14 @@ function getRNWInitVersion(): string {
   return '';
 }
 
-function setExit(exitCode: ExitCode, error?: String): void {
+function setExit(exitCode: number, error?: string): void {
   if (!process.exitCode || process.exitCode === ExitCode.SUCCESS) {
     Telemetry.client?.trackEvent({
       name: 'init-exit',
       properties: {
         durationInSecs: process.uptime(),
         msftInternal: isMSFTInternal(),
-        exitCode: ExitCode[exitCode],
+        exitCode: exitCode,
         rnwinitVersion: getRNWInitVersion(),
         errorMessage: error,
       },
@@ -434,7 +434,7 @@ function setExit(exitCode: ExitCode, error?: String): void {
 /**
  * Throws a user or setup error
  */
-function userError(text: string, exitCode: ExitCode): never {
+function userError(text: string, exitCode: number): never {
   throw new UserError(exitCode, text);
 }
 

--- a/vnext/src/Libraries/Components/DatePicker/DatePicker.tsx
+++ b/vnext/src/Libraries/Components/DatePicker/DatePicker.tsx
@@ -23,7 +23,6 @@ export class DatePicker extends React.Component<IDatePickerProps> {
     dateFormat: 'dayofweek day month',
   };
 
-  // tslint:disable-next-line:no-any
   private _rctDatePicker: any;
 
   public constructor(props: IDatePickerProps) {
@@ -64,11 +63,11 @@ export class DatePicker extends React.Component<IDatePickerProps> {
     );
   }
 
-  private _setRef = (datepicker: any /*RCTDatePicker*/) => {
+  private readonly _setRef = (datepicker: any /*RCTDatePicker*/) => {
     this._rctDatePicker = datepicker;
   };
 
-  private _onChange = (event: IDatePickerChangeEvent) => {
+  private readonly _onChange = (event: IDatePickerChangeEvent) => {
     if (this.props.selectedDate) {
       const propsTimeStamp = this.props.selectedDate.getTime();
       if (this._rctDatePicker) {

--- a/vnext/src/Libraries/Components/DatePicker/DatePickerProps.ts
+++ b/vnext/src/Libraries/Components/DatePicker/DatePickerProps.ts
@@ -31,6 +31,8 @@ export interface IDatePickerChangeEvent {
   };
 }
 
+// Enum already part of our public API
+// eslint-disable-next-line no-restricted-syntax
 export enum DayOfWeek {
   Sunday = 0,
   Monday = 1,

--- a/vnext/src/Libraries/Components/Flyout/Flyout.tsx
+++ b/vnext/src/Libraries/Components/Flyout/Flyout.tsx
@@ -38,7 +38,6 @@ export class Flyout extends React.Component<IFlyoutProps, IFlyoutTargetState> {
     // Check if we're given a new target property; we need to resolve it to a node handle before render
     if (prevState.targetRef !== nextProps.target) {
       // Map the 'target' property to a node tag to use in the native layer
-      /* tslint:disable-next-line no-any */
       const newtarget: number | null = findNodeHandle(
         nextProps.target as
           | null

--- a/vnext/src/Libraries/Components/Glyph/GlyphProps.ts
+++ b/vnext/src/Libraries/Components/Glyph/GlyphProps.ts
@@ -6,12 +6,10 @@
 
 import {StyleProp, ViewProps, ViewStyle} from 'react-native';
 
-// tslint:disable-next-line:interface-name
 export interface GlyphStyle extends ViewStyle {
   color?: string;
 }
 
-// tslint:disable-next-line:interface-name
 export interface GlyphProps extends ViewProps {
   style?: StyleProp<GlyphStyle>;
   emSize?: number;

--- a/vnext/src/Libraries/Components/Keyboard/KeyboardExt.tsx
+++ b/vnext/src/Libraries/Components/Keyboard/KeyboardExt.tsx
@@ -8,17 +8,15 @@
 import * as React from 'react';
 import {IKeyboardProps} from './KeyboardExtProps';
 
-export const supportKeyboard = <P extends object>(
+export const supportKeyboard = <P extends Record<string, any>>(
   WrappedComponent: React.ComponentType<P>,
 ) => {
   interface IForwardRefProps {
-    // tslint:disable-next-line:no-any
     forwardedRef: React.Ref<any>;
   }
 
   // children is used to avoid error: Property 'children' does not exist on type 'IntrinsicAttributes & ViewProps &
   // IKeyboardProps & RefAttributes<any>
-  // tslint:disable-next-line:no-any
   type PropsWithoutForwardedRef = P & IKeyboardProps & {children?: any};
   type PropsWithForwardedRef = PropsWithoutForwardedRef & IForwardRefProps;
 
@@ -29,7 +27,6 @@ export const supportKeyboard = <P extends object>(
     }
   }
 
-  // tslint:disable-next-line:no-any
   return React.forwardRef(
     (props: PropsWithoutForwardedRef, ref: React.Ref<any>) => {
       return <SupportKeyboard {...props} forwardedRef={ref} />;

--- a/vnext/src/Libraries/Components/Keyboard/KeyboardExtProps.ts
+++ b/vnext/src/Libraries/Components/Keyboard/KeyboardExtProps.ts
@@ -8,6 +8,8 @@
 
 import * as RN from 'react-native';
 
+// Enum already part of public API
+// eslint-disable-next-line no-restricted-syntax
 export enum EventPhase {
   None = 0,
   Capturing,
@@ -15,6 +17,8 @@ export enum EventPhase {
   Bubbling,
 }
 
+// Enum already part of public API
+// eslint-disable-next-line no-restricted-syntax
 export enum HandledEventPhase {
   Capturing = EventPhase.Capturing,
   Bubbling = EventPhase.Bubbling,

--- a/vnext/src/Libraries/Components/Picker/PickerProps.ts
+++ b/vnext/src/Libraries/Components/Picker/PickerProps.ts
@@ -8,20 +8,17 @@ import {ViewProps} from 'react-native';
 
 export interface IPickerItemProps extends ViewProps {
   label: string;
-  // tslint:disable-next-line:no-any
   value?: any;
   color?: string;
   testID?: string;
 }
 
 export interface IPickerProps extends ViewProps {
-  // tslint:disable-next-line:no-any
   selectedValue?: any;
   enabled?: boolean;
   prompt?: string;
   testID?: string;
   onChange?: (event: IPickerChangeEvent) => void;
-  // tslint:disable-next-line:no-any
   onValueChange?: (value: any, itemIndex: number, text: string) => void;
 
   // Editable support
@@ -31,7 +28,6 @@ export interface IPickerProps extends ViewProps {
 
 export interface IPickerChangeEvent {
   nativeEvent: {
-    // tslint:disable-next-line:no-any
     value: any;
     itemIndex: number;
     text: string;

--- a/vnext/src/Libraries/Components/Picker/PickerWindows.tsx
+++ b/vnext/src/Libraries/Components/Picker/PickerWindows.tsx
@@ -29,12 +29,10 @@ class PickerItem extends React.Component<IPickerItemProps> {
 
 export interface IPickerItemData {
   label: string;
-  // tslint:disable-next-line:no-any
   value?: any;
   textColor?: ProcessedColorValue | null;
 }
 
-// tslint:disable-next-line:interface-name
 interface State {
   selectedIndex: number;
   items: IPickerItemData[];
@@ -55,7 +53,6 @@ type PickerPropsWithChildren = Readonly<{children?: React.ReactNode}> &
 export class Picker extends React.Component<IPickerProps, State> {
   public static Item = PickerItem;
 
-  // tslint:disable-next-line:no-any
   private _rctPicker: any;
 
   public static getDerivedStateFromProps(
@@ -105,11 +102,11 @@ export class Picker extends React.Component<IPickerProps, State> {
     );
   }
 
-  private _setRef = (comboBox: any /*RCTPicker*/) => {
+  private readonly _setRef = (comboBox: any /*RCTPicker*/) => {
     this._rctPicker = comboBox;
   };
 
-  private _onChange = (event: IPickerChangeEvent) => {
+  private readonly _onChange = (event: IPickerChangeEvent) => {
     if (this._rctPicker) {
       this._rctPicker.setNativeProps({
         selectedIndex: this.state.selectedIndex,

--- a/vnext/src/Libraries/Components/Popup/Popup.tsx
+++ b/vnext/src/Libraries/Components/Popup/Popup.tsx
@@ -38,7 +38,6 @@ export class Popup extends React.Component<IPopupProps, IPopupTargetState> {
     // Check if we're given a new target property; we need to resolve it to a node handle before render
     if (prevState.targetRef !== nextProps.target) {
       // Map the 'target' property to a node tag to use in the native layer
-      /* tslint:disable-next-line no-any */
       const newTarget: number | null = findNodeHandle(
         nextProps.target as
           | null

--- a/vnext/src/Libraries/Components/View/ViewWindowsProps.ts
+++ b/vnext/src/Libraries/Components/View/ViewWindowsProps.ts
@@ -14,7 +14,6 @@ import {ViewProps} from 'react-native';
  * Extends: {@link IKeyboardProps} and {@link https://facebook.github.io/react-native/docs/view | react-native's ViewProps}
  */
 export interface IViewWindowsProps extends IKeyboardProps, ViewProps {
-  // tslint:disable-next-line:no-any
   children?: any;
 
   /**


### PR DESCRIPTION
JavaScript and TypeScript have a number of sharp edges, especially for those coming from different ecosystems. We can help avoid some common errors and bad patterns with extra static analysis. This change enables additional ESLint rules for our TypeScript code. This does not enable for raw JS (where we have few files) or Flow (where we do not have control over all the code in our repo).

Tried to avoid anything too controversial/opinionated that hasn't already been discussed, but please do ask questions if you don't understand or disagree with a rule. A quick summary explaining a lot of these is available at https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin and https://eslint.org/docs/rules/.

If we want a more consistent codebase, there are many more stylistic choices we can enable (e.g. type vs interface). Passing on these for now though.

Most of these, e.g. var vs let vs const, or readonly members are applied automatically on save.

This did actually catch quite a few bugs! Like incorrect types or null-checking where something instead should have been catching, bad types in autolinking code, variables not assigned as expected, constant values sent in telemetry, dead code, forgotten parens on function calls, etc.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6598)