### PR TITLE
Don't run test bundling when doing intellisense builds in VS

### DIFF
--- a/change/react-native-windows-31c93351-ecbc-4fe1-9d24-98219e03f248.json
+++ b/change/react-native-windows-31c93351-ecbc-4fe1-9d24-98219e03f248.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Don't run bundling when doing intellisense builds",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestBundle.targets
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestBundle.targets
@@ -2,6 +2,7 @@
 	<Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.props" />
 	<Target
 		Name="MakeTestBundles"
+		Condition="'$(DesignTimeBuild)' != 'true'"
 		BeforeTargets="PrepareForBuild"
 		Inputs="@(JsBundleEntry)"
 		Outputs="@(JsBundleEntry->'$(OutputPath)%(Filename).bundle')">


### PR DESCRIPTION
Fixes #6599 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6600)