### PR TITLE
set strings for telem exit codes

### DIFF
--- a/change/react-native-windows-init-8de4ce60-313c-4b58-aa80-92eb307869e9.json
+++ b/change/react-native-windows-init-8de4ce60-313c-4b58-aa80-92eb307869e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use strings for telem exit codes",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes #6610

I missed during eslint rule enabling that we were converting user exit codes from integers back to the original strings when sending to telem. This change makes us send the string instead of int for telem to keep schema consistency (although a larger telem payload).

Instead of the enum method of object access to integer, then reverse mapping from ordinal back to string, we just pass the string as a union type and convert to int from the map in the place where we set process exit code.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6616)