### PR TITLE
Refactor ReactContext API

### DIFF
--- a/change/react-native-windows-98d06b6c-abde-4e6a-9d1e-a910ca14bc4b.json
+++ b/change/react-native-windows-98d06b6c-abde-4e6a-9d1e-a910ca14bc4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor ReactContext API",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-win32.sln
+++ b/packages/playground/windows/playground-win32.sln
@@ -39,7 +39,6 @@ Global
 		..\..\..\vnext\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
 		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
 		..\..\..\vnext\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		..\..\..\vnext\JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\..\..\vnext\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\..\..\vnext\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\..\..\vnext\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -78,19 +78,19 @@ void MainPage::OnLoadClick(
         if (auto strongThis = wkThis.get()) {
           args.Context().UIDispatcher().Post([wkThis, context = args.Context()]() {
             if (auto strongThis = wkThis.get()) {
-              strongThis->x_UseWebDebuggerCheckBox().IsChecked(context.UseWebDebugger());
-              strongThis->x_UseFastRefreshCheckBox().IsChecked(context.UseFastRefresh());
-              strongThis->x_UseDirectDebuggerCheckBox().IsChecked(context.UseDirectDebugger());
-              strongThis->x_BreakOnFirstLineCheckBox().IsChecked(context.DebuggerBreakOnNextLine());
-              auto debugBundlePath = context.DebugBundlePath();
+              strongThis->x_UseWebDebuggerCheckBox().IsChecked(context.SettingsSnapshot().UseWebDebugger());
+              strongThis->x_UseFastRefreshCheckBox().IsChecked(context.SettingsSnapshot().UseFastRefresh());
+              strongThis->x_UseDirectDebuggerCheckBox().IsChecked(context.SettingsSnapshot().UseDirectDebugger());
+              strongThis->x_BreakOnFirstLineCheckBox().IsChecked(context.SettingsSnapshot().DebuggerBreakOnNextLine());
+              auto debugBundlePath = context.SettingsSnapshot().DebugBundlePath();
               for (auto item : strongThis->x_entryPointCombo().Items()) {
                 if (winrt::unbox_value<winrt::hstring>(item.as<ComboBoxItem>().Content()) == debugBundlePath) {
                   strongThis->x_entryPointCombo().SelectedItem(item);
                   break;
                 }
               }
-              strongThis->x_DebuggerPort().Text(winrt::to_hstring(context.DebuggerPort()));
-              if (context.UseWebDebugger()) {
+              strongThis->x_DebuggerPort().Text(winrt::to_hstring(context.SettingsSnapshot().DebuggerPort()));
+              if (context.SettingsSnapshot().UseWebDebugger()) {
                 strongThis->RequestedTheme(xaml::ElementTheme::Light);
               } else {
                 strongThis->RequestedTheme(xaml::ElementTheme::Default);

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -8,6 +8,10 @@
 using namespace winrt::Microsoft::ReactNative;
 
 struct ReactContextStub : implements<ReactContextStub, IReactContext> {
+  IReactSettingsSnapshot SettingsSnapshot() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   IReactPropertyBag Properties() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
@@ -24,7 +28,7 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
-  JsiRuntime JsiRuntime() noexcept {
+  IInspectable JSRuntime() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -111,6 +111,10 @@ struct ReactModuleBuilderMock {
 struct ReactContextMock : implements<ReactContextMock, IReactContext> {
   ReactContextMock(ReactModuleBuilderMock *builderMock) noexcept;
 
+  IReactSettingsSnapshot SettingsSnapshot() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   IReactPropertyBag Properties() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
@@ -127,7 +131,7 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
-  JsiRuntime JsiRuntime() noexcept {
+  IInspectable JSRuntime() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef MICROSOFT_REACTNATIVE_JSI_JSIAPI
+#define MICROSOFT_REACTNATIVE_JSI_JSIAPI
+#include "../ReactContext.h"
+#include "JsiAbiApi.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+// Call provided lambda with the facebook::jsi::Runtime& parameter.
+// For example: ExecuteJsi(context, [](facebook::jsi::Runtime& runtime){...})
+// The code is executed synchronously if it is already in JSDispatcher, or asynchronously otherwise.
+template <class TCodeWithRuntime>
+void ExecuteJsi(ReactContext const &context, TCodeWithRuntime const &code) {
+  ReactDispatcher jsDispatcher = context.JSDispatcher();
+  if (jsDispatcher.HasThreadAccess()) {
+    // Execute immediately if we are in JS thread.
+    code(*JsiAbiRuntime::GetOrCreate(context.Handle().JSRuntime().as<JsiRuntime>()));
+  } else {
+    // Otherwise, schedule work in JS thread.
+    jsDispatcher.Post([ context, code ]() noexcept {
+      code(*JsiAbiRuntime::GetOrCreate(context.Handle().JSRuntime().as<JsiRuntime>()));
+    });
+  }
+}
+
+} // namespace winrt::Microsoft::ReactNative
+
+#endif // MICROSOFT_REACTNATIVE_JSI_JSIAPI

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -27,6 +27,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)CppWinRTIncludes.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Crash.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JsiAbiApi.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JsiApi.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactHandleHelper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSValueReader.h" />

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
@@ -112,6 +112,9 @@
     <ClInclude Include="$(JSI_SourcePath)\jsi\instrumentation.h">
       <Filter>JSI</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JsiApi.h">
+      <Filter>JSI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="JSI">

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -12,7 +12,6 @@
 #include <CppWinRTIncludes.h>
 #endif
 #include <string_view>
-#include "JSI/JsiAbiApi.h"
 #include "JSValueWriter.h"
 #include "ReactNotificationService.h"
 #include "ReactPropertyBag.h"
@@ -49,22 +48,6 @@ struct ReactContext {
 
   ReactDispatcher JSDispatcher() const noexcept {
     return ReactDispatcher{m_handle.JSDispatcher()};
-  }
-
-  // Call provided lambda with the facebook::jsi::Runtime& parameter.
-  // For example: context.ExecuteJsi([](facebook::jsi::Runtime& runtime){...})
-  // The code is executed synchronously if it is already in JSDispatcher, or asynchronously otherwise.
-  template <class TCodeWithRuntime>
-  void ExecuteJsi(TCodeWithRuntime const &code) const {
-    ReactDispatcher jsDispatcher = JSDispatcher();
-    if (jsDispatcher.HasThreadAccess()) {
-      code(*JsiAbiRuntime::GetOrCreate(m_handle.JsiRuntime())); // Execute immediately if we are in JS thread.
-    } else {
-      // Otherwise, schedule work in JS thread.
-      jsDispatcher.Post([ context = ReactContext{*this}, code ]() noexcept {
-        code(*JsiAbiRuntime::GetOrCreate(context.m_handle.JsiRuntime()));
-      });
-    }
   }
 
   // Call methodName JS function of module with moduleName.

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+#include <JSI/JsiApi.h>
 #include <NativeModules.h>
 #include <winrt/Windows.System.h>
 #include "MockReactPackageProvider.h"
@@ -17,7 +18,7 @@ struct TestHostModule {
     TestHostModule::Instance.set_value(*this);
 
     bool jsiExecuted{false};
-    reactContext.ExecuteJsi([&](facebook::jsi::Runtime &rt) {
+    ExecuteJsi(reactContext, [&](facebook::jsi::Runtime &rt) {
       jsiExecuted = true;
       auto eval = rt.global().getPropertyAsFunction(rt, "eval");
       auto addFunc = eval.call(rt, "(function(x, y) { return x + y; })").getObject(rt).getFunction(rt);

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -301,6 +301,29 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     }
   }
 
+  class ReactSettingsSnapshot : IReactSettingsSnapshot
+  {
+    public bool DebuggerBreakOnNextLine => throw new NotImplementedException();
+
+    public ushort DebuggerPort => throw new NotImplementedException();
+
+    public bool UseDirectDebugger => throw new NotImplementedException();
+
+    public bool UseFastRefresh => throw new NotImplementedException();
+
+    public bool UseWebDebugger => throw new NotImplementedException();
+
+    public string BundleRootPath => throw new NotImplementedException();
+
+    public string DebugBundlePath => throw new NotImplementedException();
+
+    public string JavaScriptBundleFile => throw new NotImplementedException();
+
+    public string SourceBundleHost => throw new NotImplementedException();
+
+    public ushort SourceBundlePort => throw new NotImplementedException();
+  }
+
   class ReactContextMock : IReactContext
   {
     private readonly ReactModuleBuilderMock m_builder;
@@ -310,6 +333,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       m_builder = builder;
     }
 
+    public IReactSettingsSnapshot SettingsSnapshot => throw new NotImplementedException();
+
     public IReactPropertyBag Properties { get; } = ReactPropertyBagHelper.CreatePropertyBag();
 
     public IReactNotificationService Notifications { get; } = ReactNotificationServiceHelper.CreateNotificationService();
@@ -318,7 +343,7 @@ namespace Microsoft.ReactNative.Managed.UnitTests
 
     public IReactDispatcher JSDispatcher => Properties.Get(ReactDispatcherHelper.JSDispatcherProperty) as IReactDispatcher;
 
-    public JsiRuntime JsiRuntime => throw new NotImplementedException();
+    public Object JSRuntime => throw new NotImplementedException();
 
     public void DispatchEvent(FrameworkElement view, string eventName, JSValueArgWriter eventDataArgWriter)
     {
@@ -334,25 +359,5 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     {
       m_builder.EmitJSEvent(eventEmitterName, eventName, paramsArgWriter);
     }
-
-    bool IReactContext.DebuggerBreakOnNextLine => throw new NotImplementedException();
-
-    ushort IReactContext.DebuggerPort => throw new NotImplementedException();
-
-    bool IReactContext.UseDirectDebugger => throw new NotImplementedException();
-
-    bool IReactContext.UseFastRefresh => throw new NotImplementedException();
-
-    bool IReactContext.UseWebDebugger => throw new NotImplementedException();
-
-    string IReactContext.BundleRootPath => throw new NotImplementedException();
-
-    string IReactContext.DebugBundlePath => throw new NotImplementedException();
-
-    string IReactContext.JavaScriptBundleFile => throw new NotImplementedException();
-
-    string IReactContext.SourceBundleHost => throw new NotImplementedException();
-
-    ushort IReactContext.SourceBundlePort => throw new NotImplementedException();
   }
 }

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -10,7 +10,79 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-ReactContext::ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context{std::move(context)} {}
+//=============================================================================
+// ReactSettingsSnapshot implementation
+//=============================================================================
+
+#ifndef CORE_ABI
+ReactSettingsSnapshot::ReactSettingsSnapshot(Mso::CntPtr<const Mso::React::IReactSettingsSnapshot> &&settings) noexcept
+    : m_settings{std::move(settings)} {}
+
+bool ReactSettingsSnapshot::UseWebDebugger() const noexcept {
+  return m_settings->UseWebDebugger();
+}
+
+bool ReactSettingsSnapshot::UseFastRefresh() const noexcept {
+  return m_settings->UseFastRefresh();
+}
+
+bool ReactSettingsSnapshot::UseDirectDebugger() const noexcept {
+  return m_settings->UseDirectDebugger();
+}
+
+bool ReactSettingsSnapshot::DebuggerBreakOnNextLine() const noexcept {
+  return m_settings->DebuggerBreakOnNextLine();
+}
+
+uint16_t ReactSettingsSnapshot::DebuggerPort() const noexcept {
+  return m_settings->DebuggerPort();
+}
+
+hstring ReactSettingsSnapshot::DebugBundlePath() const noexcept {
+  return winrt::to_hstring(m_settings->DebugBundlePath());
+}
+
+hstring ReactSettingsSnapshot::BundleRootPath() const noexcept {
+  return winrt::to_hstring(m_settings->BundleRootPath());
+}
+
+hstring ReactSettingsSnapshot::SourceBundleHost() const noexcept {
+  return winrt::to_hstring(m_settings->SourceBundleHost());
+}
+
+uint16_t ReactSettingsSnapshot::SourceBundlePort() const noexcept {
+  return m_settings->SourceBundlePort();
+}
+
+hstring ReactSettingsSnapshot::JavaScriptBundleFile() const noexcept {
+  return winrt::to_hstring(m_settings->JavaScriptBundleFile());
+}
+
+Mso::React::IReactSettingsSnapshot const &ReactSettingsSnapshot::GetInner() const noexcept {
+  return *m_settings;
+}
+
+#endif
+
+//=============================================================================
+// ReactContext implementation
+//=============================================================================
+
+ReactContext::ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context {
+  std::move(context)
+}
+#ifndef CORE_ABI
+, m_settings {
+  winrt::make<ReactSettingsSnapshot>(&m_context->SettingsSnapshot())
+}
+#endif
+{}
+
+#ifndef CORE_ABI
+IReactSettingsSnapshot ReactContext::SettingsSnapshot() noexcept {
+  return m_settings;
+}
+#endif
 
 IReactPropertyBag ReactContext::Properties() noexcept {
   return m_context->Properties();
@@ -26,6 +98,10 @@ IReactDispatcher ReactContext::UIDispatcher() noexcept {
 
 IReactDispatcher ReactContext::JSDispatcher() noexcept {
   return Properties().Get(ReactDispatcherHelper::JSDispatcherProperty()).try_as<IReactDispatcher>();
+}
+
+IInspectable ReactContext::JSRuntime() noexcept {
+  return m_context->JsiRuntime();
 }
 
 #ifndef CORE_ABI
@@ -67,52 +143,6 @@ void ReactContext::EmitJSEvent(
   auto params = paramsWriter->TakeValue();
   m_context->CallJSFunction(to_string(eventEmitterName), "emit", std::move(params));
 }
-
-ReactNative::JsiRuntime ReactContext::JsiRuntime() noexcept {
-  return m_context->JsiRuntime();
-}
-
-#ifndef CORE_ABI
-bool ReactContext::UseWebDebugger() const noexcept {
-  return m_context->UseWebDebugger();
-}
-
-bool ReactContext::UseFastRefresh() const noexcept {
-  return m_context->UseFastRefresh();
-}
-
-bool ReactContext::UseDirectDebugger() const noexcept {
-  return m_context->UseDirectDebugger();
-}
-
-bool ReactContext::DebuggerBreakOnNextLine() const noexcept {
-  return m_context->DebuggerBreakOnNextLine();
-}
-
-uint16_t ReactContext::DebuggerPort() const noexcept {
-  return m_context->DebuggerPort();
-}
-
-hstring ReactContext::DebugBundlePath() const noexcept {
-  return winrt::to_hstring(m_context->DebugBundlePath());
-}
-
-hstring ReactContext::BundleRootPath() const noexcept {
-  return winrt::to_hstring(m_context->BundleRootPath());
-}
-
-hstring ReactContext::SourceBundleHost() const noexcept {
-  return winrt::to_hstring(m_context->SourceBundleHost());
-}
-
-uint16_t ReactContext::SourceBundlePort() const noexcept {
-  return m_context->SourceBundlePort();
-}
-
-hstring ReactContext::JavaScriptBundleFile() const noexcept {
-  return winrt::to_hstring(m_context->JavaScriptBundleFile());
-}
-#endif
 
 Mso::React::IReactContext &ReactContext::GetInner() const noexcept {
   return *m_context;

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -8,14 +8,43 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
+#ifndef CORE_ABI
+struct ReactSettingsSnapshot : winrt::implements<ReactSettingsSnapshot, IReactSettingsSnapshot> {
+  ReactSettingsSnapshot(Mso::CntPtr<const Mso::React::IReactSettingsSnapshot> &&settings) noexcept;
+
+ public: // IReactSettingsSnapshot
+  bool UseWebDebugger() const noexcept;
+  bool UseFastRefresh() const noexcept;
+  bool UseDirectDebugger() const noexcept;
+  bool DebuggerBreakOnNextLine() const noexcept;
+  uint16_t DebuggerPort() const noexcept;
+  hstring DebugBundlePath() const noexcept;
+  hstring BundleRootPath() const noexcept;
+  hstring SourceBundleHost() const noexcept;
+  uint16_t SourceBundlePort() const noexcept;
+  hstring JavaScriptBundleFile() const noexcept;
+
+ public:
+  // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods
+  Mso::React::IReactSettingsSnapshot const &GetInner() const noexcept;
+
+ private:
+  Mso::CntPtr<const Mso::React::IReactSettingsSnapshot> m_settings;
+};
+#endif
+
 struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
 
  public: // IReactContext
+#ifndef CORE_ABI
+  IReactSettingsSnapshot SettingsSnapshot() noexcept;
+#endif
   IReactPropertyBag Properties() noexcept;
   IReactNotificationService Notifications() noexcept;
   IReactDispatcher UIDispatcher() noexcept;
   IReactDispatcher JSDispatcher() noexcept;
+  IInspectable JSRuntime() noexcept;
 #ifndef CORE_ABI
   void DispatchEvent(
       xaml::FrameworkElement const &view,
@@ -31,25 +60,16 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
       hstring const &eventName,
       JSValueArgWriter const &paramsArgWriter) noexcept;
 
-  ReactNative::JsiRuntime JsiRuntime() noexcept;
-
-  bool UseWebDebugger() const noexcept;
-  bool UseFastRefresh() const noexcept;
-  bool UseDirectDebugger() const noexcept;
-  bool DebuggerBreakOnNextLine() const noexcept;
-  uint16_t DebuggerPort() const noexcept;
-  hstring DebugBundlePath() const noexcept;
-  hstring BundleRootPath() const noexcept;
-  hstring SourceBundleHost() const noexcept;
-  uint16_t SourceBundlePort() const noexcept;
-  hstring JavaScriptBundleFile() const noexcept;
-
+ public: // IReactContext
   // Not part of the public ABI interface
   // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods
   Mso::React::IReactContext &GetInner() const noexcept;
 
  private:
   Mso::CntPtr<Mso::React::IReactContext> m_context;
+#ifndef CORE_ABI
+  ReactNative::IReactSettingsSnapshot m_settings{nullptr};
+#endif
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -1,71 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import "IJSValueWriter.idl";
+import "IJSValueWriter.idl"; // The import is to be deprecated with IReactContext::DispatchEvent
 import "IReactNotificationService.idl";
 import "IReactPropertyBag.idl";
-import "JsiApi.idl";
 
 #ifndef CORE_ABI
-#include "NamespaceRedirect.h"
+#include "NamespaceRedirect.h" // The include is to be deprecated with IReactContext::DispatchEvent
 #endif
 
 #include "DocString.h"
 
 namespace Microsoft.ReactNative {
 
-  // The IReactContext is given to native modules to communicate with
-  // other native modules, views, application, and the ReactNative instance.
-  // It has the same lifetime as the React instance. When the React instance is reloaded or unloaded,
-  // the IReactContext is destroyed.
-  // Use the Properties to share native module's data with other components.
-  // Use the Notifications to exchange events with other components.
-  // Use CallJSFunction to call JavaScript functions, and EmitJSEvent to raise JavaScript events.
+#ifndef CORE_ABI
   [webhosthidden]
-  DOC_STRING("The `IReactContext` object is given to native modules to communicate with other native modules, views, application, and the React Native instance. \n\
-It has the same lifetime as the React instance. When the React instance is reloaded or unloaded, the `IReactContext` is destroyed. \n\
-- Use the Properties to share native module's data with other components. \n\
-- Use the Notifications to exchange events with other components. \n\
-- Use @.CallJSFunction to call JavaScript functions, and @.EmitJSEvent to raise JavaScript events.")
-  interface IReactContext {
-    // Properties shared with the IReactInstanceSettings.Properties. It can be used to share values and state between components.
-    DOC_STRING("Properties shared with the @ReactInstanceSettings.Properties. It can be used to share values and state between components.")
-    IReactPropertyBag Properties { get; };
-
-    // Notifications shared with the IReactInstanceSettings.Notifications. They can be used to exchange events between components.
-    // All subscriptions added to the IReactContext.Notifications are automatically removed after the IReactContext is destroyed.
-    // The subscriptions added to IReactInstanceSettings.Notifications kept as long as IReactInstanceSettings alive.
-    DOC_STRING("Notifications shared with the @ReactInstanceSettings.Notifications. They can be used to exchange events between components. \n\
-All subscriptions added to the `IReactContext.Notifications` are automatically removed after the `IReactContext` is destroyed. \n\
-The subscriptions added to the `ReactInstanceSettings.Notifications` are kept as long as `ReactInstanceSettings` is alive.")
-    IReactNotificationService Notifications { get; };
-
-    // Get ReactDispatcherHelper::UIDispatcherProperty from the Properties property bag.
-    DOC_STRING("Get `ReactDispatcherHelper::UIDispatcherProperty` from the Properties property bag.")
-    IReactDispatcher UIDispatcher { get; };
-
-    // Get ReactDispatcherHelper::JSDispatcherProperty from the Properties property bag.
-    DOC_STRING("Get `ReactDispatcherHelper::JSDispatcherProperty` from the Properties property bag.")
-    IReactDispatcher JSDispatcher { get; };
-
-    DOC_STRING("Get the JSI runtime for the running React instance. It can be null if Web debugging is used.")
-    JsiRuntime JsiRuntime { get; };
-
-#ifndef CORE_ABI
-    // Deprecated: Use DispatchEvent on XamlUIService instead
-    [deprecated("Use @XamlUIService.DispatchEvent instead", deprecate, 1)]
-    void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
-#endif
-
-    // Call JavaScript function methodName of moduleName.
-    DOC_STRING("Call the JavaScript function named `methodName` of `moduleName`.")
-    void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
-
-    // Call JavaScript module event. It is a specialized CallJSFunction call where method name is always 'emit'.
-    DOC_STRING("Call JavaScript module event. It is a specialized `CallJSFunction` call where method name is always 'emit'.")
-    void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
-
-#ifndef CORE_ABI
+  interface IReactSettingsSnapshot {
     Boolean UseWebDebugger { get; };
     Boolean UseFastRefresh { get; };
     Boolean UseDirectDebugger { get; };
@@ -76,6 +26,55 @@ The subscriptions added to the `ReactInstanceSettings.Notifications` are kept as
     String SourceBundleHost { get; };
     UInt16 SourceBundlePort { get; };
     String JavaScriptBundleFile { get; };
+  }
 #endif
+
+  [webhosthidden]
+  DOC_STRING(
+    "The `IReactContext` object is given to native modules to communicate with other native modules, views, application, and the React Native instance. \n"
+    "It has the same lifetime as the React instance. When the React instance is reloaded or unloaded, the `IReactContext` is destroyed. \n"
+    "- Use the Properties to share native module's data with other components. \n"
+    "- Use the Notifications to exchange events with other components. \n"
+    "- Use @.CallJSFunction to call JavaScript functions, and @.EmitJSEvent to raise JavaScript events. \n"
+    "- Use @.UIDispatcher to schedule work in UI thread. \n"
+    "- Use @.JSDispatcher to schedule work in UI thread.")
+  interface IReactContext {
+#ifndef CORE_ABI
+    DOC_STRING("Get settings snapshot that were used to start the React instance.")
+    IReactSettingsSnapshot SettingsSnapshot { get; };
+#endif
+
+    DOC_STRING("Properties shared with the @ReactInstanceSettings.Properties. It can be used to share values and state between components.")
+    IReactPropertyBag Properties { get; };
+
+    DOC_STRING(
+      "Notifications shared with the @ReactInstanceSettings.Notifications. They can be used to exchange events between components. \n"
+      "All subscriptions added to the `IReactContext.Notifications` are automatically removed after the `IReactContext` is destroyed. \n"
+      "The subscriptions added to the `ReactInstanceSettings.Notifications` are kept as long as `ReactInstanceSettings` is alive.")
+    IReactNotificationService Notifications { get; };
+
+    DOC_STRING(
+      "Get the UI thread dispatcher. \n"
+      "It is a shortcut for the `ReactDispatcherHelper::UIDispatcherProperty` from the @.Properties property bag.")
+    IReactDispatcher UIDispatcher { get; };
+
+    DOC_STRING(
+      "Get the JS thread dispatcher. \n "
+      "It is a shortcut for the `ReactDispatcherHelper::JSDispatcherProperty` from the @.Properties property bag.")
+    IReactDispatcher JSDispatcher { get; };
+
+    DOC_STRING("Get the JavaScript runtime for the running React instance. It can be null if Web debugging is used.")
+    Object JSRuntime { get; };
+
+#ifndef CORE_ABI
+    [deprecated("Use @XamlUIService.DispatchEvent instead", deprecate, 1)]
+    void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
+#endif
+
+    DOC_STRING("Call the JavaScript function named `methodName` of `moduleName`.")
+    void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
+
+    DOC_STRING("Call JavaScript module event. It is a specialized `CallJSFunction` call where method name is always 'emit'.")
+    void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -85,17 +85,8 @@ struct IReactInstance : IUnknown {
   virtual void DetachRootView(facebook::react::IReactRootView *rootView) noexcept = 0;
 };
 
-MSO_GUID(IReactContext, "a4309a29-8fc5-478e-abea-0ddb9ecc5e40")
-struct IReactContext : IUnknown {
-  virtual winrt::Microsoft::ReactNative::IReactNotificationService Notifications() const noexcept = 0;
-  virtual winrt::Microsoft::ReactNative::IReactPropertyBag Properties() const noexcept = 0;
-  virtual void CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept = 0;
-  virtual void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept = 0;
-  virtual winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() const noexcept = 0;
-#ifndef CORE_ABI
-  virtual ReactInstanceState State() const noexcept = 0;
-  virtual bool IsLoaded() const noexcept = 0;
-  virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept = 0;
+MSO_GUID(IReactSettingsSnapshot, "6652bb2e-4c5e-49f7-b642-e817b0fef4de")
+struct IReactSettingsSnapshot : IUnknown {
   virtual bool UseWebDebugger() const noexcept = 0;
   virtual bool UseFastRefresh() const noexcept = 0;
   virtual bool UseDirectDebugger() const noexcept = 0;
@@ -107,7 +98,20 @@ struct IReactContext : IUnknown {
   virtual uint16_t SourceBundlePort() const noexcept = 0;
   virtual std::string JavaScriptBundleFile() const noexcept = 0;
   virtual bool UseDeveloperSupport() const noexcept = 0;
+};
 
+MSO_GUID(IReactContext, "a4309a29-8fc5-478e-abea-0ddb9ecc5e40")
+struct IReactContext : IUnknown {
+  virtual winrt::Microsoft::ReactNative::IReactNotificationService Notifications() const noexcept = 0;
+  virtual winrt::Microsoft::ReactNative::IReactPropertyBag Properties() const noexcept = 0;
+  virtual void CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept = 0;
+  virtual void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept = 0;
+  virtual winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() const noexcept = 0;
+#ifndef CORE_ABI
+  virtual ReactInstanceState State() const noexcept = 0;
+  virtual bool IsLoaded() const noexcept = 0;
+  virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept = 0;
+  virtual IReactSettingsSnapshot const &SettingsSnapshot() const noexcept = 0;
 #endif
 };
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
@@ -4,9 +4,98 @@
 #include "ReactContext.h"
 #include <winrt/Microsoft.ReactNative.h>
 #include "Microsoft.ReactNative/IReactNotificationService.h"
+#include "MsoUtils.h"
 #include "ReactInstanceWin.h"
 
 namespace Mso::React {
+
+//=============================================================================================
+// ReactSettingsSnapshot implementation
+//=============================================================================================
+
+#ifndef CORE_ABI // requires instance
+
+ReactSettingsSnapshot::ReactSettingsSnapshot(Mso::WeakPtr<ReactInstanceWin> &&reactInstance) noexcept
+    : m_reactInstance{std::move(reactInstance)} {}
+
+bool ReactSettingsSnapshot::UseWebDebugger() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseWebDebugger();
+  }
+  return false;
+}
+
+bool ReactSettingsSnapshot::UseFastRefresh() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseFastRefresh();
+  }
+  return false;
+}
+
+bool ReactSettingsSnapshot::UseDirectDebugger() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseDirectDebugger();
+  }
+  return false;
+}
+
+bool ReactSettingsSnapshot::DebuggerBreakOnNextLine() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->DebuggerBreakOnNextLine();
+  }
+  return false;
+}
+
+uint16_t ReactSettingsSnapshot::DebuggerPort() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->DebuggerPort();
+  }
+  return 0;
+}
+
+std::string ReactSettingsSnapshot::DebugBundlePath() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->DebugBundlePath();
+  }
+  return {};
+}
+
+std::string ReactSettingsSnapshot::BundleRootPath() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->BundleRootPath();
+  }
+  return {};
+}
+
+std::string ReactSettingsSnapshot::SourceBundleHost() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->SourceBundleHost();
+  }
+  return {};
+}
+
+uint16_t ReactSettingsSnapshot::SourceBundlePort() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->SourceBundlePort();
+  }
+  return 0;
+}
+
+std::string ReactSettingsSnapshot::JavaScriptBundleFile() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->JavaScriptBundleFile();
+  }
+  return {};
+}
+
+bool ReactSettingsSnapshot::UseDeveloperSupport() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->UseDeveloperSupport();
+  }
+  return false;
+}
+
+#endif
 
 //=============================================================================================
 // ReactContext implementation
@@ -16,7 +105,13 @@ ReactContext::ReactContext(
     Mso::WeakPtr<ReactInstanceWin> &&reactInstance,
     winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
     winrt::Microsoft::ReactNative::IReactNotificationService const &notifications) noexcept
-    : m_reactInstance{std::move(reactInstance)}, m_properties{properties}, m_notifications{notifications} {}
+    : m_reactInstance{std::move(reactInstance)},
+#ifndef CORE_ABI
+      m_settings{Mso::Make<ReactSettingsSnapshot>(Mso::Copy(m_reactInstance))},
+#endif
+      m_properties{properties},
+      m_notifications{notifications} {
+}
 
 void ReactContext::Destroy() noexcept {
   if (auto notificationService =
@@ -86,81 +181,8 @@ std::shared_ptr<facebook::react::Instance> ReactContext::GetInnerInstance() cons
   return nullptr;
 }
 
-bool ReactContext::UseWebDebugger() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->UseWebDebugger();
-  }
-  return false;
-}
-
-bool ReactContext::UseFastRefresh() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->UseFastRefresh();
-  }
-  return false;
-}
-
-bool ReactContext::UseDirectDebugger() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->UseDirectDebugger();
-  }
-  return false;
-}
-
-bool ReactContext::DebuggerBreakOnNextLine() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->DebuggerBreakOnNextLine();
-  }
-  return false;
-}
-
-uint16_t ReactContext::DebuggerPort() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->DebuggerPort();
-  }
-  return 0;
-}
-
-std::string ReactContext::DebugBundlePath() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->DebugBundlePath();
-  }
-  return {};
-}
-
-std::string ReactContext::BundleRootPath() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->BundleRootPath();
-  }
-  return {};
-}
-
-std::string ReactContext::SourceBundleHost() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->SourceBundleHost();
-  }
-  return {};
-}
-
-uint16_t ReactContext::SourceBundlePort() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->SourceBundlePort();
-  }
-  return 0;
-}
-
-std::string ReactContext::JavaScriptBundleFile() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->JavaScriptBundleFile();
-  }
-  return {};
-}
-
-bool ReactContext::UseDeveloperSupport() const noexcept {
-  if (auto instance = m_reactInstance.GetStrongPtr()) {
-    return instance->UseDeveloperSupport();
-  }
-  return false;
+IReactSettingsSnapshot const &ReactContext::SettingsSnapshot() const noexcept {
+  return *m_settings;
 }
 
 #endif

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -13,6 +13,29 @@ namespace Mso::React {
 
 class ReactInstanceWin;
 
+#ifndef CORE_ABI
+class ReactSettingsSnapshot final : public Mso::UnknownObject<IReactSettingsSnapshot> {
+ public:
+  ReactSettingsSnapshot(Mso::WeakPtr<ReactInstanceWin> &&reactInstance) noexcept;
+
+ public: // IReactSettingsSnapshot
+  bool UseWebDebugger() const noexcept override;
+  bool UseFastRefresh() const noexcept override;
+  bool UseDirectDebugger() const noexcept override;
+  bool DebuggerBreakOnNextLine() const noexcept override;
+  uint16_t DebuggerPort() const noexcept override;
+  std::string DebugBundlePath() const noexcept override;
+  std::string BundleRootPath() const noexcept override;
+  std::string SourceBundleHost() const noexcept override;
+  uint16_t SourceBundlePort() const noexcept override;
+  std::string JavaScriptBundleFile() const noexcept override;
+  bool UseDeveloperSupport() const noexcept override;
+
+ private:
+  Mso::WeakPtr<ReactInstanceWin> m_reactInstance;
+};
+#endif
+
 class ReactContext final : public Mso::UnknownObject<IReactContext> {
  public:
   ReactContext(
@@ -35,22 +58,14 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   ReactInstanceState State() const noexcept override;
   bool IsLoaded() const noexcept override;
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept override;
-
-  bool UseWebDebugger() const noexcept override;
-  bool UseFastRefresh() const noexcept override;
-  bool UseDirectDebugger() const noexcept override;
-  bool DebuggerBreakOnNextLine() const noexcept override;
-  uint16_t DebuggerPort() const noexcept override;
-  std::string DebugBundlePath() const noexcept override;
-  std::string BundleRootPath() const noexcept override;
-  std::string SourceBundleHost() const noexcept override;
-  uint16_t SourceBundlePort() const noexcept override;
-  std::string JavaScriptBundleFile() const noexcept override;
-  bool UseDeveloperSupport() const noexcept override;
+  IReactSettingsSnapshot const &SettingsSnapshot() const noexcept override;
 #endif
 
  private:
   Mso::WeakPtr<ReactInstanceWin> m_reactInstance;
+#ifndef CORE_ABI
+  Mso::CntPtr<ReactSettingsSnapshot> m_settings;
+#endif
   winrt::Microsoft::ReactNative::IReactPropertyBag m_properties;
   winrt::Microsoft::ReactNative::IReactNotificationService m_notifications;
 };

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -165,7 +165,7 @@ void ImageViewManager::EmitImageEvent(winrt::Grid grid, const char *eventName, r
 
 void ImageViewManager::setSource(winrt::Grid grid, const winrt::Microsoft::ReactNative::JSValue &data) {
   auto sources{json_type_traits<std::vector<react::uwp::ReactImageSource>>::parseJson(data)};
-  sources[0].bundleRootPath = GetReactContext().BundleRootPath();
+  sources[0].bundleRootPath = GetReactContext().SettingsSnapshot().BundleRootPath();
 
   if (sources[0].packagerAsset && sources[0].uri.find("file://") == 0) {
     sources[0].uri.replace(0, 7, sources[0].bundleRootPath);

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -312,7 +312,7 @@ void ReactRootControl::ShowInstanceWaiting() noexcept {
 }
 
 void ReactRootControl::ShowInstanceLoading() noexcept {
-  if (!m_context->UseDeveloperSupport())
+  if (!m_context->SettingsSnapshot().UseDeveloperSupport())
     return;
 
   if (XamlView xamlRootView = m_weakXamlRootView.get()) {


### PR DESCRIPTION
In this PR we refactor changes that were introduced to ReactContext API during the 0.64 development.
The goal is to simplify the ReactContext  and to allow non-JSI based JS engine API to be used in future.
- A number of new `IReactContext` properties were extracted into a new `IReactSettingsSnapshot` interface and added `IReactContext::SettingsSnapshot` property to reference them.
- The `IReactContext::JsiRuntime` was replaced with  `IReactContext::JSRuntime` that has type `Object`. It should allow us to replace the JS Engine API with a an `IUnknown`-based implementation and avoid a hard dependency on the experimental JSI ABI implementation which we plan to remove in favor of another interface.
- The `ReactContext::ExecuteJsi` member function is removed and replaced with a standalone function `ExecuteJsi` in the new "JSI\JsiApi.h" header file.
- Updated doc comments in the IReactContext.idl 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6617)