### PR TITLE
Monorepo page capital letter fix in building-rnw page

### DIFF
--- a/docs/building-rnw.md
+++ b/docs/building-rnw.md
@@ -16,7 +16,7 @@
     yarn
     yarn build
     ```
-Note that react-native-windows is a monorepo and relies on monorepo tools like yarn and lage.  See [this page](Monorepo.md) for more details.
+Note that react-native-windows is a monorepo and relies on monorepo tools like yarn and lage.  See [this page](monorepo.md) for more details.
 
 # Running the Playground app
   There are two ways to run the app.  In a fully managed easy way, or by manually running all the required steps:


### PR DESCRIPTION
This pull request fixes the issue #6625 with monorepo page not found.

---

The monorepo details page for RNW leads currently to the 404 result, while the *monorepo.md* page is available in the docs.
Changes provided in this PR fix this issue by converting the capital letter used for the *monorepo.md* page in the *building-rnw.md* page source code.

Please see the commit message for more details in case of any doubts or questions.

---

Change has been tested and verified locally.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6626)