### PR TITLE
Fix getting JsiRuntime for host functions

### DIFF
--- a/change/react-native-windows-34026362-bdf7-4921-9cb1-90b87780623e.json
+++ b/change/react-native-windows-34026362-bdf7-4921-9cb1-90b87780623e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix getting JsiRuntime for host functions",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/JsiApi.h
+++ b/vnext/Microsoft.ReactNative/JsiApi.h
@@ -53,6 +53,9 @@ struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   ~JsiRuntime() noexcept;
 
   static ReactNative::JsiRuntime FromRuntime(facebook::jsi::Runtime &runtime) noexcept;
+  static ReactNative::JsiRuntime GetOrCreate(
+      std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+      std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept;
 
  public: // JsiRuntime
   static Microsoft::ReactNative::JsiRuntime MakeChakraRuntime();

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -839,8 +839,8 @@ winrt::Microsoft::ReactNative::JsiRuntime ReactInstanceWin::JsiRuntime() noexcep
     std::scoped_lock lock{m_mutex};
     if (!m_jsiRuntime && jsiRuntime) {
       // Set only if other thread did not do it yet.
-      m_jsiRuntime = winrt::make<winrt::Microsoft::ReactNative::implementation::JsiRuntime>(
-          std::move(jsiRuntimeHolder), std::move(jsiRuntime));
+      m_jsiRuntime =
+          winrt::Microsoft::ReactNative::implementation::JsiRuntime::GetOrCreate(jsiRuntimeHolder, jsiRuntime);
     }
 
     return m_jsiRuntime;


### PR DESCRIPTION
The new ExecuteJsi function fails in BabylonNative code because there is a bug getting the ABI-safe JSI runtime for host functions and host objects.  In this PR we fix the issue by properly mapping the ABI-safe JSI runtime with the internal one it contains.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6644)