### PR TITLE
Self-signed certificate - timeout error fix

### DIFF
--- a/change/@react-native-windows-cli-4be26f48-0076-4686-9fb4-6fe14a114393.json
+++ b/change/@react-native-windows-cli-4be26f48-0076-4686-9fb4-6fe14a114393.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove the timeout from self-signed certificate generating",
+  "packageName": "@react-native-windows/cli",
+  "email": "Bartosz.Klonowski@callstack.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -58,7 +58,8 @@ async function generateCertificate(
       );
       return thumbprint;
     } catch (err) {
-      console.log(chalk.yellow('Failed to generate Self-signed certificate.'));
+      console.log(chalk.yellow('Unable to generate the self-signed certificate:'));
+      console.log(chalk.red(err));
     }
   }
 

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -55,7 +55,9 @@ async function generateCertificate(
       );
       return thumbprint;
     } catch (err) {
-      console.log(chalk.yellow('Unable to generate the self-signed certificate:'));
+      console.log(
+        chalk.yellow('Unable to generate the self-signed certificate:'),
+      );
       console.log(chalk.red(err));
     }
   }

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -34,11 +34,9 @@ async function generateCertificate(
   console.log('Generating self-signed certificate...');
   if (os.platform() === 'win32') {
     try {
-      const timeout = 10000; // 10 seconds;
       const thumbprint = childProcess
         .execSync(
           `powershell -NoProfile -Command "Write-Output (New-SelfSignedCertificate -KeyUsage DigitalSignature -KeyExportPolicy Exportable -Subject 'CN=${currentUser}' -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}Subject Type:End Entity') -CertStoreLocation 'Cert:\\CurrentUser\\My').Thumbprint"`,
-          {timeout},
         )
         .toString()
         .trim();
@@ -51,7 +49,6 @@ async function generateCertificate(
           newProjectName,
           newProjectName,
         )}_TemporaryKey.pfx -Password $pwd"`,
-        {timeout},
       );
       console.log(
         chalk.green('Self-signed certificate generated successfully.'),


### PR DESCRIPTION
This pull request fixes #6281 

Changes introduced in this PR provide the project with enhanced error printed when generating a self-signed certificate fails for any reason. The timeout set for generating the self-signed certificate is removed.

---

The implementation of this fix contains two main changes:
* Remove the *timeout* set for a powershell command creating the self-signed certificate.
This allows any machine to generate the self-signed certificate no matter how slow it is (please see the linked issue).
Another idea was to make this timeout value configurable, but in the end it would just reduce the comfort of creating the RNW project, as the timeout would be one of the arguments, or it would be default
(leaving it as default would require changing the value, but to which value would be risky, as we never know how slow some developer's machine can be).
* Enhance the error printed by the `generateCertificate()` function, by printing the original `err` message in additional to general dispatch saying that the generating failed.

For more information about the implementation please see the commit messages.

---

Results of changes provided in this pull request are presented below:

When the self-signed certificate generating fails (in this example the timeout was still implemented) the error is printed in red color right under the general failure message:
![obraz](https://user-images.githubusercontent.com/70535775/100850144-b7909c80-3483-11eb-8396-130a9f0914e0.png)

After removing the *timeout* completely, the self-signed certificate is created without any issue:
![obraz](https://user-images.githubusercontent.com/70535775/100850483-279f2280-3484-11eb-9d5a-fb125652cee0.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6646)