### PR TITLE
Fix dependency syncing for wildcard peer dependencies

### DIFF
--- a/change/@rnw-scripts-integrate-rn-1b0001cc-2902-477a-ba81-ec722cdb5fed.json
+++ b/change/@rnw-scripts-integrate-rn-1b0001cc-2902-477a-ba81-ec722cdb5fed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix dependency syncing for wildcard peer dependencies",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/integrate-rn/src/test/upgradeDependencies.test.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/test/upgradeDependencies.test.ts
@@ -806,6 +806,23 @@ test('Generic package (Newer repo-config devDependency)', () => {
   expectSortedDeps(deps);
 });
 
+test('RN library (Wildcard peer dependency unchanged)', () => {
+  const libraryDeps: LocalPackageDeps = {
+    packageName: '@react-native/tester',
+    peerDependencies: {
+      'react-native': '*',
+    },
+    outOfTreePlatform: false,
+  };
+
+  const deps = calcPackageDependencies('0.63.0', rnDiff, repoConfigDiff, [
+    libraryDeps,
+  ]);
+
+  expect(deps.length).toEqual(1);
+  expect(deps[0]).toEqual(libraryDeps);
+});
+
 test('Mixed types', () => {
   const outOfTreeDeps: LocalPackageDeps = {
     ...olderReactNative,

--- a/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
@@ -366,6 +366,9 @@ function ensureValidReactNativePeerDep(
   // If we have a range, such as in our stable branches, only bump if needed,
   // as changing the peer depenedncy is a breaking change.
   if (
+    // Semver satisfaction logic for * is too strict, so we need to special
+    // case it https://github.com/npm/node-semver/issues/130
+    pkg.peerDependencies['react-native'] === '*' ||
     semver.satisfies(
       newReactNativeVersion,
       pkg.peerDependencies['react-native'],
@@ -396,7 +399,12 @@ function ensureReactNativePeerDepsSatisfied(
   for (const [dep, rnDepVersion] of Object.entries(rnPeerDeps)) {
     if (!pkg.dependencies[dep]) {
       pkg.dependencies[dep] = rnDepVersion;
-    } else if (!semver.satisfies(pkg.dependencies[dep], rnDepVersion)) {
+    } else if (
+      // Semver satisfaction logic for * is too strict, so we need to special
+      // case it https://github.com/npm/node-semver/issues/130
+      rnDepVersion !== '*' &&
+      !semver.satisfies(pkg.dependencies[dep], rnDepVersion)
+    ) {
       pkg.dependencies[dep] = bumpSemver(pkg.dependencies[dep], rnDepVersion);
     }
   }


### PR DESCRIPTION
As part of integrating a new release of react-native we run an algorithm to synchronize dependencies, peer dependencies, and devDependencies across the repo. Part of this involves updating any peer dependencies to react-native that would be broken by a new version. We do that only if the existing peer dependency is unsatisfied by the new version.

The semver package has some surprising behavior when testing satisfaction of wildcard peer dependencies, where it does not count any prerelease build as satisfying it. This leads to us to try to bump the wildcard semver and fail if we encounter it.

Special case wildcard when doing semver satisfaction checks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6659)