### PR TITLE
Allow unreleased RNW versions with react-native-windows-init --useDevMode

### DIFF
--- a/change/@rnw-scripts-create-github-releases-71c0b2d9-e2d4-44aa-a2dd-23463d22f3a3.json
+++ b/change/@rnw-scripts-create-github-releases-71c0b2d9-e2d4-44aa-a2dd-23463d22f3a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump yargs to 15.4.1",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-integrate-rn-264060b3-e018-4fe5-a23c-114e2b493cc5.json
+++ b/change/@rnw-scripts-integrate-rn-264060b3-e018-4fe5-a23c-114e2b493cc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump yargs to 15.4.1",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-promote-release-886c8d49-5a3c-4360-be9b-280c4e982782.json
+++ b/change/@rnw-scripts-promote-release-886c8d49-5a3c-4360-be9b-280c4e982782.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump yargs to 15.4.1",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-take-screenshot-53b0d611-b841-40ef-8fcf-99cd5486db3b.json
+++ b/change/@rnw-scripts-take-screenshot-53b0d611-b841-40ef-8fcf-99cd5486db3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump yargs to 15.4.1",
+  "packageName": "@rnw-scripts/take-screenshot",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-d4f4757d-82bb-4069-afa7-7e34d653dd28.json
+++ b/change/react-native-platform-override-d4f4757d-82bb-4069-afa7-7e34d653dd28.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump yargs to 15.4.1",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-codegen-ec623ba9-5181-402f-aaee-a3c7a750dff5.json
+++ b/change/react-native-windows-codegen-ec623ba9-5181-402f-aaee-a3c7a750dff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump yargs to 15.4.1",
+  "packageName": "react-native-windows-codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-5af39e72-8d77-4cea-a8ff-e96edda20a54.json
+++ b/change/react-native-windows-init-5af39e72-8d77-4cea-a8ff-e96edda20a54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow unreleased RNW versions with react-native-windows-init --useDevMode",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -20,7 +20,7 @@
     "node-fetch": "^2.6.0",
     "semver": "^7.3.2",
     "simple-git": "^1.131.0",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.6",

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -21,7 +21,7 @@
     "ora": "^3.4.0",
     "react-native-platform-override": "^0.4.3",
     "semver": "^7.3.2",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -17,7 +17,7 @@
     "@rnw-scripts/package-utils": "^0.0.11",
     "chalk": "^4.1.0",
     "simple-git": "^1.131.0",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.6",

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "screenshot-desktop": "^1.12.2",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.6",

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -36,7 +36,7 @@
     "semver": "^7.3.2",
     "simple-git": "^1.131.0",
     "upath": "^1.2.0",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/react-native-windows-codegen/package.json
+++ b/packages/react-native-windows-codegen/package.json
@@ -22,7 +22,7 @@
     "globby": "^9.2.0",
     "mustache": "^4.0.1",
     "react-native-tscodegen": "0.66.1",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.6",

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -25,7 +25,7 @@
     "prompts": "^2.3.0",
     "semver": "^7.3.2",
     "valid-url": "^1.0.9",
-    "yargs": "^15.3.1"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@react-native-windows/cli": "0.0.0-canary.42",

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -135,16 +135,10 @@ const argv = yargs
       describe:
         '[internalTesting] Link rather than Add/Install the react-native-windows package. This option is for the development workflow of the developers working on react-native-windows.',
       hidden: true,
-      default: false,
       conflicts: 'version',
     },
   })
-  .check(a => {
-    if (a._.length !== 0) {
-      throw `Unrecognized option ${a._}`;
-    }
-    return true;
-  }).argv;
+  .strict(true).argv;
 
 if (argv.verbose) {
   console.log(argv);
@@ -446,7 +440,7 @@ function isProjectUsingYarn(cwd: string): boolean {
   try {
     const name = getReactNativeProjectName();
     const ns = argv.namespace || name;
-    const useDevMode = argv.useDevMode;
+    const useDevMode = !!argv.useDevMode;
     let version = argv.version;
 
     if (argv.useWinUI3 && argv.experimentalNuGetDependency) {
@@ -569,7 +563,7 @@ function isProjectUsingYarn(cwd: string): boolean {
       experimentalNuGetDependency: argv.experimentalNuGetDependency,
       useWinUI3: argv.useWinUI3,
       useHermes: argv.useHermes,
-      useDevMode: argv.useDevMode,
+      useDevMode: useDevMode,
       nuGetTestVersion: argv.nuGetTestVersion,
       nuGetTestFeed: argv.nuGetTestFeed,
       telemetry: argv.telemetry,

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -44,7 +44,6 @@ const exitCodes = {
   NO_LATEST_RNW: 8,
   NO_AUTO_MATCHING_RNW: 9,
   INCOMPATIBLE_OPTIONS: 10,
-  DEVMODE_VERSION_MISMATCH: 11,
   NO_REACTNATIVE_DEPENDENCIES: 12,
 };
 
@@ -137,6 +136,7 @@ const argv = yargs
         '[internalTesting] Link rather than Add/Install the react-native-windows package. This option is for the development workflow of the developers working on react-native-windows.',
       hidden: true,
       default: false,
+      conflicts: 'version',
     },
   })
   .check(a => {
@@ -337,19 +337,7 @@ function installReactNativeWindows(
   if (useDevMode) {
     const packageCmd = isProjectUsingYarn(cwd) ? 'yarn' : 'npm';
     execSync(`${packageCmd} link react-native-windows`, execOptions);
-    const rnwPkgJsonPath = require.resolve(
-      'react-native-windows/package.json',
-      {paths: [cwd]},
-    );
-    const rnwVersion = require(rnwPkgJsonPath).version;
-    if (version && version !== rnwVersion) {
-      userError(
-        `Requested react-native-windows version: '${version}' does not match version '${rnwVersion}' of the linked module. When using '--useDevMode' you do not need to pass a version. If you do, you should pass '--version ${rnwVersion}'`,
-        'DEVMODE_VERSION_MISMATCH',
-      );
-    } else if (!version) {
-      version = rnwVersion;
-    }
+    version = '*';
   } else if (!version) {
     internalError(
       'Unexpected error encountered. If you are able, please file an issue on: https://github.com/microsoft/react-native-windows/issues/new/choose',


### PR DESCRIPTION
Fixes #6631

When cutting an unreleased version we may not have an available npm package. We can link a local unreleased package, but doing a yarn install will complain if the version is not found in the npm registry. This change modified useDevMode logic to instead specify a wildcard version, which keeps yarn happy with the linked but unreleased version.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6662)