### PR TITLE
Fix react-native-windows version

### DIFF
--- a/change/react-native-windows-f13d8d0e-a58a-4fae-981d-f677627c032d.json
+++ b/change/react-native-windows-f13d8d0e-a58a-4fae-981d-f677627c032d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix version",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "react-native": "0.0.0-19d4cc2d4",
-    "react-native-windows": "^0.0.0"
+    "react-native-windows": "^0.0.0-canary.220"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.6",
@@ -24,7 +24,7 @@
     "just-scripts": "^0.44.7",
     "react-native": "0.0.0-19d4cc2d4",
     "react-native-platform-override": "^0.4.3",
-    "react-native-windows": "^0.0.0",
+    "react-native-windows": "^0.0.0-canary.220",
     "typescript": "^3.8.3"
   }
 }

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
     "prompt-sync": "^4.2.0",
     "react": "17.0.1",
     "react-native": "0.0.0-19d4cc2d4",
-    "react-native-windows": "0.0.0"
+    "react-native-windows": "0.0.0-canary.220"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -13,7 +13,7 @@
     "chai": "^4.2.0",
     "react": "17.0.1",
     "react-native": "0.0.0-19d4cc2d4",
-    "react-native-windows": "^0.0.0"
+    "react-native-windows": "^0.0.0-canary.220"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "17.0.1",
     "react-native": "0.0.0-19d4cc2d4",
-    "react-native-windows": "0.0.0"
+    "react-native-windows": "0.0.0-canary.220"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
     "@react-native-windows/tester": "0.0.1",
     "react": "17.0.1",
     "react-native": "0.0.0-19d4cc2d4",
-    "react-native-windows": "0.0.0"
+    "react-native-windows": "0.0.0-canary.220"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows",
-  "version": "0.0.0",
+  "version": "0.0.0-canary.220",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "@react-native-community/cli": "^4.13.0",
     "@react-native-community/cli-platform-android": "^4.13.0",
     "@react-native-community/cli-platform-ios": "^4.13.0",
-    "@react-native-windows/cli": "0.0.0-canary.42",
+    "@react-native-windows/cli": "0.0.0-canary.41",
     "@react-native/assets": "1.0.0",
     "@react-native/normalize-color": "1.0.0",
     "@react-native/polyfills": "1.0.0",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -25,7 +25,7 @@
     "@react-native-community/cli": "^4.13.0",
     "@react-native-community/cli-platform-android": "^4.13.0",
     "@react-native-community/cli-platform-ios": "^4.13.0",
-    "@react-native-windows/cli": "0.0.0-canary.41",
+    "@react-native-windows/cli": "0.0.0-canary.42",
     "@react-native/assets": "1.0.0",
     "@react-native/normalize-color": "1.0.0",
     "@react-native/polyfills": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3851,9 +3851,9 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 beachball@^1.32.0:
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.45.0.tgz#e7c1446c1a4fa0201f02580b96f25b97062e9626"
-  integrity sha512-Tm2fn5HjzxKtlfPAlRg3iiY37s5MsHZNSKNdRj+kdFO3WpU8RBOZf/M57L+dceFBCsU1VgWask8YskmFcJ/ldw==
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.44.0.tgz#25f2745acff96ebfc7a35e9487452ce265087f02"
+  integrity sha512-nfkokpGEq3qCqQXSI7WuUEZNhp54FdRH4ZdiDmpys3abnWooNiiuWitX5vAESEWARk4ZpOLcDzsMM17PmCaYkg==
   dependencies:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"


### PR DESCRIPTION
A beachball update made our nightly publish go off the rails and release "0.0.0". Revert the beachball update and reset versions so that we continue the canary series.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6666)