### PR TITLE
Split out Universal build in Build and Test

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -235,7 +235,7 @@ jobs:
     displayName: Verify Cli
     dependsOn:
       - Setup
-      - Universal
+      - UniversalBuild
     condition: |
       and
       (

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -72,7 +72,9 @@ jobs:
         parameters:
           yarnBuildCmd: build
           project: vnext/ReactWindows-Desktop.sln
-
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
+          
       - task: CmdLine@2
         displayName: Build react-native-win32 RNTester bundle
         inputs:
@@ -140,6 +142,8 @@ jobs:
       - template: ../templates/publish-build-artifacts-for-nuget.yml
         parameters:
           artifactName: ReactWindows
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
           contents: |
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -15,15 +15,15 @@ jobs:
     strategy:
       matrix:
         ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          Arm:
+          ARM:
             BuildPlatform: ARM
-          Arm64:
+          ARM64:
             BuildPlatform: ARM64
         # End Continuous only
-        x64:
+        X64:
           BuildPlatform: x64
         ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          x86:
+          X86:
             BuildPlatform: x86
         # End Continuous only
 

--- a/.ado/jobs/nuget-desktop.yml
+++ b/.ado/jobs/nuget-desktop.yml
@@ -6,7 +6,7 @@ jobs:
     displayName: Pack Desktop NuGet Package
     dependsOn:
       - Desktop
-      - Universal # Needed to have artifacts uploaded from LayoutHeaders
+      - UniversalBuild # Needed to have artifacts uploaded from LayoutHeaders
     condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
     pool:
       vmImage: $(VmImage)

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -16,7 +16,7 @@
             - Name: X64Release
               BuildConfiguration: Release
               BuildPlatform: X64
-            - Name: X64Release
+            - Name: X64Debug
               BuildConfiguration: Debug
               BuildPlatform: X86
               LayoutHeaders: true

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -10,41 +10,52 @@
       default:
         - BuildEnvironment: PullRequest
           Matrix:
-            - BuildConfiguration: Release
+            - Name: ArmRelease
+              BuildConfiguration: Release
               BuildPlatform: ARM
-            - BuildConfiguration: Release
-              BuildPlatform: x64
-            - BuildConfiguration: Debug
-              BuildPlatform: x86
+            - Name: X64Release
+              BuildConfiguration: Release
+              BuildPlatform: X64
+            - Name: X64Release
+              BuildConfiguration: Debug
+              BuildPlatform: X86
               LayoutHeaders: true
         - BuildEnvironment: Continuous
           Matrix:
-            - BuildConfiguration: Debug
+            - Name: ArmDebug
+              BuildConfiguration: Debug
               BuildPlatform: ARM
-            - BuildConfiguration: Release
+            - Name: ArmRelease
+              BuildConfiguration: Release
               BuildPlatform: ARM
-            - BuildConfiguration: Debug
+            - Name: Arm64RDebug
+              BuildConfiguration: Debug
               BuildPlatform: ARM64
-            - BuildConfiguration: Release
+            - Name: Arm64Release
+              BuildConfiguration: Release
               BuildPlatform: ARM64
-            - BuildConfiguration: Debug
-              BuildPlatform: x64
-            - BuildConfiguration: Release
-              BuildPlatform: x64
-            - BuildConfiguration: Debug
-              BuildPlatform: x86
+            - Name: X64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: X64
+            - Name: X64Release
+              BuildConfiguration: Release
+              BuildPlatform: X64
+            - Name: X86Debug
+              BuildConfiguration: Debug
+              BuildPlatform: X86
               LayoutHeaders: true
-            - BuildConfiguration: Release
-              BuildPlatform: x86
+            - Name: X86Release
+              BuildConfiguration: Release
+              BuildPlatform: X86
       
   jobs:
     - ${{ each config in parameters.buildMatrix }}:
       - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
         - ${{ each matrix in config.Matrix }}:
-            - job: UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+            - job: UniversalBuild${{ matrix.Name }}
               variables:
                 - template: ../variables/vs2019.yml
-              displayName: Universal Build ${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              displayName: Universal Build ${{ matrix.Name }}
               dependsOn:
                 - Setup
               condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
@@ -76,7 +87,7 @@
                     artifactName: ReactWindows
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
-                    layoutHeaders: eq('true', variables.LayoutHeaders)
+                    layoutHeaders: ${{ matrix.LayoutHeaders }}
                     contents: |
                       Microsoft.ReactNative\**
                       Microsoft.ReactNative.Managed\**
@@ -89,12 +100,12 @@
                     scanType: 'Register'
 
                 
-            - job: UniversalTest${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+            - job: UniversalTest${{ matrix.Name }}
               variables:
                 - template: ../variables/vs2019.yml
-              displayName: Universal Test ${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              displayName: Universal Test ${{ matrix.Name }}
               dependsOn:
-                - UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+                - UniversalBuild${{ matrix.Name }}
               condition: 
                 and
                 (
@@ -215,7 +226,7 @@
         - ${{ each config in parameters.buildMatrix }}:
           - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
             - ${{ each matrix in config.Matrix }}:
-              - UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              - UniversalBuild${{ matrix.Name }}
       pool:
         vmImage: $(VmImage)
       timeoutInMinutes: 60

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -1,147 +1,227 @@
-parameters:
-  - name: buildEnvironment
-    type: string
-    default : PullRequest
-    values: 
-     - PullRequest 
-     - Continuous 
-   
-jobs:
-  - job: Universal
-    variables:
-      - template: ../variables/vs2019.yml
-    displayName: Universal
-    dependsOn:
-     - Setup
-    condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
-    strategy:
-      matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
-        # Start Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          ArmDebug:
-            BuildConfiguration: Debug
-            BuildPlatform: ARM
-        # End Continuous only
-        ArmRelease:
-          BuildConfiguration: Release
-          BuildPlatform: ARM
-        # Start Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          Arm64Debug:
-            BuildConfiguration: Debug
-            BuildPlatform: ARM64
-          Arm64Release:
-            BuildConfiguration: Release
-            BuildPlatform: ARM64
-          X64Debug:
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-        # End Continuous only
-        X64Release:
-          BuildConfiguration: Release
-          BuildPlatform: x64
-        X86Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-          LayoutHeaders: true
-        # Start Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          X86Release:
-            BuildConfiguration: Release
-            BuildPlatform: x86
-        # End Continuous only
-    pool:
-      vmImage: $(VmImage)
-    timeoutInMinutes: 60
-    cancelTimeoutInMinutes: 5
-
-    steps:
-      - checkout: self
-        clean: false
-        submodules: false
-
-      - task: PowerShell@2
-        displayName: "Check if this environment meets the development dependencies"
-        inputs:
-          targetType: filePath
-          filePath: $(Build.SourcesDirectory)\vnext\Scripts\rnw-dependencies.ps1
-          arguments: -NoPrompt -Tags buildLab
-
-      - template: ../templates/build-rnw.yml
-        parameters:
-          yarnBuildCmd: build
-          project: vnext/Microsoft.ReactNative.sln
-
-      - powershell: |
-          Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
-          Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$(Invoke-Expression $env:GOOGLETESTADAPTERPATHEXPRESSION)"
-          Write-Host "Set environment variable to ($env:GoogleTestAdapterPath)"
-        displayName: Set GoogleTestAdapterPath
-
-      - task: VSTest@2
-        displayName: Run Universal Unit Tests (Native)
-        timeoutInMinutes: 5 # Set smaller timeout , due to hangs
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: |
-            Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.exe
-            Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.exe
-            Mso.UnitTests/Mso.UnitTests.exe
-          pathtoCustomTestAdapters: $(GoogleTestAdapterPath)
-          searchFolder: $(Build.SourcesDirectory)/vnext/target/$(BuildPlatform)/$(BuildConfiguration)
-          runTestsInIsolation: true
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          publishRunAttachments: true
-          collectDumpOn: onAbortOnly
-          vsTestVersion: latest
-        condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')))
-
-      - task: VSTest@2
-        displayName: Run Universal Unit Tests (UWP)
-        timeoutInMinutes: 5 # Set smaller timeout , due to hangs
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: |
-            Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.build.appxrecipe
-          searchFolder: $(Build.SourcesDirectory)/vnext/target/$(BuildPlatform)/$(BuildConfiguration)
-          runTestsInIsolation: true
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          publishRunAttachments: true
-          codeCoverageEnabled: true
-          collectDumpOn: onAbortOnly
-          vsTestVersion: latest
-        condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')))
-
-      - task: VSTest@2
-        displayName: Run Universal Unit Tests (NetCore)
-        timeoutInMinutes: 5 # Set smaller timeout , due to hangs
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: |
-            Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.dll
-          searchFolder: $(Build.SourcesDirectory)/vnext/target/$(BuildPlatform)/$(BuildConfiguration)
-          runTestsInIsolation: true
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          publishRunAttachments: true
-          codeCoverageEnabled: true
-          collectDumpOn: onAbortOnly
-          vsTestVersion: latest
-        condition: and(succeeded(), eq(variables.BuildPlatform, 'x64'))
-
-      - template: ../templates/publish-build-artifacts-for-nuget.yml
-        parameters:
-          artifactName: ReactWindows
-          layoutHeaders: eq('true', variables.LayoutHeaders)
-          contents: |
-            Microsoft.ReactNative\**
-            Microsoft.ReactNative.Managed\**
-            Microsoft.ReactNative.Managed.CodeGen\**
+  parameters:
+    - name: buildEnvironment
+      type: string
+      default : PullRequest
+      values: 
+      - PullRequest 
+      - Continuous 
+    - name: buildMatrix
+      type: object
+      default:
+        - BuildEnvironment: PullRequest
+          Matrix:
+            - BuildConfiguration: Release
+              BuildPlatform: ARM
+            - BuildConfiguration: Release
+              BuildPlatform: x64
+            - BuildConfiguration: Debug
+              BuildPlatform: x86
+              LayoutHeaders: true
+        - BuildEnvironment: Continuous
+          Matrix:
+            - BuildConfiguration: Debug
+              BuildPlatform: ARM
+            - BuildConfiguration: Release
+              BuildPlatform: ARM
+            - BuildConfiguration: Debug
+              BuildPlatform: ARM64
+            - BuildConfiguration: Release
+              BuildPlatform: ARM64
+            - BuildConfiguration: Debug
+              BuildPlatform: x64
+            - BuildConfiguration: Release
+              BuildPlatform: x64
+            - BuildConfiguration: Debug
+              BuildPlatform: x86
+              LayoutHeaders: true
+            - BuildConfiguration: Release
+              BuildPlatform: x86
       
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        displayName: 'Component Governance Detection'
-        inputs:
-          alertWarningLevel: Medium
-          scanType: 'Register'
+  jobs:
+    - ${{ each config in parameters.buildMatrix }}:
+      - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
+        - ${{ each matrix in config.Matrix }}:
+            - job: UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              variables:
+                - template: ../variables/vs2019.yml
+              displayName: Universal Build ${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              dependsOn:
+                - Setup
+              condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
+              pool: windevbuildagents
+              timeoutInMinutes: 60
+              cancelTimeoutInMinutes: 5
+
+              steps:
+                - checkout: self
+                  clean: false
+                  submodules: false
+
+                - template: ../templates/build-rnw.yml
+                  parameters:
+                    yarnBuildCmd: build
+                    project: vnext/Microsoft.ReactNative.sln
+                    buildPlatform: ${{ matrix.BuildPlatform }}
+                    buildConfiguration: ${{ matrix.BuildConfiguration }}
+                    multicoreBuild: true
+
+                - task: PublishPipelineArtifact@1
+                  displayName: "Publish binaries for testing"
+                  inputs:
+                    targetPath: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
+                    artifactName: "Universal-${{ matrix.BuildPlatform }}-${{ matrix.BuildConfiguration }}"
+
+                - template: ../templates/publish-build-artifacts-for-nuget.yml
+                  parameters:
+                    artifactName: ReactWindows
+                    buildPlatform: ${{ matrix.BuildPlatform }}
+                    buildConfiguration: ${{ matrix.BuildConfiguration }}
+                    layoutHeaders: eq('true', variables.LayoutHeaders)
+                    contents: |
+                      Microsoft.ReactNative\**
+                      Microsoft.ReactNative.Managed\**
+                      Microsoft.ReactNative.Managed.CodeGen\**
+                
+                - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+                  displayName: 'Component Governance Detection'
+                  inputs:
+                    alertWarningLevel: Medium
+                    scanType: 'Register'
+
+                
+            - job: UniversalTest${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              variables:
+                - template: ../variables/vs2019.yml
+              displayName: Universal Test ${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              dependsOn:
+                - UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+              condition: 
+                and
+                (
+                  ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' ),
+                  in(dependencies.UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+                )
+              pool:
+                vmImage: $(VmImage)
+              timeoutInMinutes: 60
+              cancelTimeoutInMinutes: 5
+
+              steps:
+                - checkout: self
+                  clean: false
+                  submodules: false
+
+                - task: PowerShell@2
+                  displayName: "Check if this environment meets the development dependencies"
+                  inputs:
+                    targetType: filePath
+                    filePath: $(Build.SourcesDirectory)\vnext\Scripts\rnw-dependencies.ps1
+                    arguments: -NoPrompt -Tags buildLab
+                    
+                - template: ../templates/prepare-env.yml
+                  parameters:
+                    yarnBuildCmd: build
+
+                - task: NuGetCommand@2
+                  displayName: NuGet restore
+                  inputs:
+                    command: restore
+                    restoreSolution: vnext/Microsoft.ReactNative.sln
+                    feedsToUse: config
+                    nugetConfigPath: $(Build.SourcesDirectory)/vnext/NuGet.config
+                    restoreDirectory: packages/
+                    verbosityRestore: Detailed # Options: quiet, normal, detailed
+                    
+                - task: DownloadPipelineArtifact@1
+                  displayName: "Download binaries for testing"
+                  inputs:
+                    targetPath: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
+                    artifactName: "Universal-${{ matrix.BuildPlatform }}-${{ matrix.BuildConfiguration }}"
+
+                # The WinDevBuild Agents run on the c-drive and the hosted agents run on the d-drive.
+                # Some of the output files have the c-drive expanded in the outputs, which results in file not found errors when running tests
+                # This script fixes those files to point to the d-drive of the hosted agents.
+                # We unfortunately can't run the tests on the WinDev  build pool because it lacks UI support
+                - powershell: |
+                    Get-ChildItem *.appxrecipe -recurse | ForEach { (Get-Content -Path $_) -replace "c:\\a\\1\\s", "$(System.DefaultWorkingDirectory)" | Set-Content -Path $_ }
+                  displayName: Fix Paths in appx files to deal with different enlistments between agent types.
+
+                - powershell: |
+                    Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
+                    Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$(Invoke-Expression $env:GOOGLETESTADAPTERPATHEXPRESSION)"
+                    Write-Host "Set environment variable to ($env:GoogleTestAdapterPath)"
+                  displayName: Set GoogleTestAdapterPath
+
+                - task: VSTest@2
+                  displayName: Run Universal Unit Tests (Native)
+                  timeoutInMinutes: 5 # Set smaller timeout , due to hangs
+                  inputs:
+                    testSelector: testAssemblies
+                    testAssemblyVer2: |
+                      Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.exe
+                      Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.exe
+                      Mso.UnitTests/Mso.UnitTests.exe
+                    pathtoCustomTestAdapters: $(GoogleTestAdapterPath)
+                    searchFolder: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
+                    runTestsInIsolation: true
+                    platform: ${{ matrix.BuildPlatform }}
+                    configuration: ${{ matrix.BuildConfiguration }}
+                    publishRunAttachments: true
+                    collectDumpOn: onAbortOnly
+                    vsTestVersion: latest
+                  condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')))
+
+                - task: VSTest@2
+                  displayName: Run Universal Unit Tests (UWP)
+                  timeoutInMinutes: 5 # Set smaller timeout , due to hangs
+                  inputs:
+                    testSelector: testAssemblies
+                    testAssemblyVer2: |
+                      Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.build.appxrecipe
+                    searchFolder: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
+                    runTestsInIsolation: true
+                    platform: ${{ matrix.BuildPlatform }}
+                    configuration: ${{ matrix.BuildConfiguration }}
+                    publishRunAttachments: true
+                    codeCoverageEnabled: true
+                    collectDumpOn: onAbortOnly
+                    vsTestVersion: latest
+                  condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')))
+
+                - task: VSTest@2
+                  displayName: Run Universal Unit Tests (NetCore)
+                  timeoutInMinutes: 5 # Set smaller timeout , due to hangs
+                  inputs:
+                    testSelector: testAssemblies
+                    testAssemblyVer2: |
+                      Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.dll
+                    searchFolder: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
+                    runTestsInIsolation: true
+                    platform: ${{ matrix.BuildPlatform }}
+                    configuration: ${{ matrix.BuildConfiguration }}
+                    publishRunAttachments: true
+                    codeCoverageEnabled: true
+                    collectDumpOn: onAbortOnly
+                    vsTestVersion: latest
+                  condition: and(succeeded(), eq(variables.BuildPlatform, 'x64'))
+
+    # This job is the one that accumulates the spread out build tasks into one dependency
+    - job: UniversalBuild
+      condition: ne( dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'], 'True' )
+      displayName: Universal Build 🏗
+      variables:
+        - template: ../variables/vs2019.yml
+      dependsOn: 
+        - ${{ each config in parameters.buildMatrix }}:
+          - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
+            - ${{ each matrix in config.Matrix }}:
+              - UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+      pool:
+        vmImage: $(VmImage)
+      timeoutInMinutes: 60
+      cancelTimeoutInMinutes: 5
+
+      steps:
+        - powershell: |
+            Write-Host "Waited for all Universal Build steps"
+          displayName: Waiting for all Universal Build steps

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -89,6 +89,8 @@ jobs:
       - template: templates/build-rnw.yml
         parameters:
           project: vnext/ReactWindows-Desktop.sln
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
           msbuildArguments:
             /p:RNW_PKG_VERSION_STR="$(RNW_PKG_VERSION_STR)"
             /p:RNW_PKG_VERSION_MAJOR="$(RNW_PKG_VERSION_MAJOR)"
@@ -98,6 +100,8 @@ jobs:
       - template: templates/publish-build-artifacts-for-nuget.yml
         parameters:
           artifactName: ReactWindows
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
           contents: |
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
@@ -150,10 +154,14 @@ jobs:
       - template: templates/build-rnw.yml
         parameters:
           project: vnext/Microsoft.ReactNative.sln
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
 
       - template: templates/publish-build-artifacts-for-nuget.yml
         parameters:
           artifactName: ReactWindows
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
           layoutHeaders: eq('true', variables['LayoutHeaders'])
           contents: |
             Microsoft.ReactNative\**

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -9,10 +9,11 @@ parameters:
   msBuildArchitecture: $(MSBuildArchitecture)
   preferredToolArchitecture: $(MSBuildPreferredToolArchitecture)
   platformToolset: $(MSBuildPlatformToolset)
+  buildPlatform: x64
+  buildConfiguration: Debug
   msbuildArguments: ''
   yarnBuildCmd: build
-  BuildLogDirectory: $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
-
+  multicoreBuild: false
 
   # Visual Studio Installer
   vsComponents: ''
@@ -20,6 +21,10 @@ parameters:
   installVsComponents: false
 
 steps:
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.buildPlatform }}\${{ parameters.buildConfiguration }}\BuildLogs"
+    displayName: Set Log directory
+
   - template: prepare-env.yml
     parameters:
       vsComponents: ${{ parameters.vsComponents }}
@@ -44,10 +49,10 @@ steps:
       solution: ${{parameters.project }}
       vsVersion: ${{parameters.msbuildVersion}}
       msbuildArchitecture: ${{parameters.msBuildArchitecture}}
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
+      platform: ${{ parameters.buildPlatform }}
+      configuration: ${{ parameters.buildConfiguration }}
       clean: false # Optional
-      maximumCpuCount: false # Optional
+      maximumCpuCount: ${{ parameters.multicoreBuild }} # Optional
       restoreNugetPackages: false # Optional
       createLogFile: true
       logFileVerbosity: detailed
@@ -57,12 +62,12 @@ steps:
         /p:BaseIntDir=$(BaseIntDir)
         /p:PublishToolDuringBuild=true
         /p:EnableSourceLink=true
-        /bl:${{ parameters.BuildLogDirectory }}\MsBuild.binlog
-        /flp1:errorsonly;logfile=${{ parameters.BuildLogDirectory }}\MsBuild.err
-        /flp2:warningsonly;logfile=${{ parameters.BuildLogDirectory }}\MsBuild.wrn
-        /flp3:verbosity=diagnostic;logfile=${{ parameters.BuildLogDirectory }}\MsBuild.log
+        /bl:$(BuildLogDirectory)\MsBuild.binlog
+        /flp1:errorsonly;logfile=$(BuildLogDirectory)\MsBuild.err
+        /flp2:warningsonly;logfile=$(BuildLogDirectory)\MsBuild.wrn
+        /flp3:verbosity=diagnostic;logfile=$(BuildLogDirectory)\MsBuild.log
         ${{parameters.msbuildArguments}}
 
   - template: upload-build-logs.yml
     parameters:
-      buildLogDirectory: '${{ parameters.BuildLogDirectory }}'
+      buildLogDirectory: $(BuildLogDirectory)

--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -1,7 +1,7 @@
 #
 parameters:
   name: ''
-  BuildPlatform: x86 # ARM, x86, x64
+  BuildPlatform: X86 # Arm, X86, X64
 
 jobs:
   - job: ${{ parameters.name }}

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -28,6 +28,16 @@ steps:
     inputs:
       versionSpec: ">=5.8.0"
 
+  - task: NodeTool@0
+    displayName: Installing Node
+    inputs:
+      versionSpec: '14.x' 
+
+  - task: CmdLine@2
+    displayName: Installing Yarm
+    inputs:
+      script: npm install -g yarn
+
   - template: yarn-install.yml
 
   - task: CmdLine@2

--- a/.ado/templates/publish-build-artifacts-for-nuget.yml
+++ b/.ado/templates/publish-build-artifacts-for-nuget.yml
@@ -2,6 +2,8 @@ parameters:
   artifactName:
   contents:
   layoutHeaders: false
+  buildPlatform: x64
+  buildConfiguration: Debug
 
 steps:
   # Prepare headers for NuGet deployment
@@ -15,8 +17,8 @@ steps:
   - task: CopyFiles@2
     displayName: Copy NuGet artifacts
     inputs:
-      sourceFolder: $(Build.SourcesDirectory)/vnext/target/$(BuildPlatform)/$(BuildConfiguration)
-      targetFolder: $(Build.StagingDirectory)/$(BuildPlatform)/$(BuildConfiguration)
+      sourceFolder: $(Build.SourcesDirectory)/vnext/target/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
+      targetFolder: $(Build.StagingDirectory)/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
       contents: ${{parameters.contents}}
 
   - task: PublishBuildArtifacts@1

--- a/change/react-native-windows-da27daf1-4c02-4914-a570-789b03ec2bcf.json
+++ b/change/react-native-windows-da27daf1-4c02-4914-a570-789b03ec2bcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Split out Universal build in Build and Test and have the Build run on the windev build agents",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>$(OutDir)bin\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -32,7 +32,7 @@
     <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
+    <OutputPath>$(OutDir)bin\x86\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
@@ -45,7 +45,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <OutputPath>$(OutDir)bin\ARM\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -56,7 +56,7 @@
     <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-    <OutputPath>bin\ARM\Release\</OutputPath>
+    <OutputPath>$(OutDir)bin\ARM\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
@@ -69,7 +69,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <OutputPath>$(OutDir)bin\ARM64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -79,7 +79,7 @@
     <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
-    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <OutputPath>$(OutDir)bin\ARM64\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
@@ -91,7 +91,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
+    <OutputPath>$(OutDir)bin\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -101,7 +101,7 @@
     <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
+    <OutputPath>$(OutDir)bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -178,6 +178,11 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Folly\Folly.vcxproj">
+      <Project>{A990658C-CE31-4BCC-976F-0FC6B1AF693D}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>


### PR DESCRIPTION
This PR updates the PR validation step for the 'Universal' build.
* It splits out the Build and the Test steps.
* It runs the Build phase on the new windevbuild agents and the tests on the old Hosted agents
  *  While for universal alone overall it would probably be faster to run the test at the same time as the build, but the build now runs on the windevbuild agents which don't support UI tests.  So overall the build completes faster
* To run tests as soon as the build unblocks this change uses Azure Devops templating infrastructure to expand the build matrix rather than the build-in matrix expansion. which would only start the first test after the last build completes. This injects a step 'UniversalBuild' to allow other jobs to wait on this one.

This allows the nuget tests to wait un just the right builds as well. But that is for later work.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6678)