### PR TITLE
[0.62] Update V8 package version

### DIFF
--- a/change/react-native-windows-2020-12-04-12-29-09-62updatev8.json
+++ b/change/react-native-windows-2020-12-04-12-29-09-62updatev8.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[0.62] Update V8 package version",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-04T20:29:09.373Z"
+}

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -3,7 +3,7 @@
   <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.3" targetFramework="native" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->

--- a/vnext/Desktop/packages.config
+++ b/vnext/Desktop/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.72.0.0" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.3" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />

--- a/vnext/JSI.Desktop.UnitTests/packages.config
+++ b/vnext/JSI.Desktop.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.72.0.0" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.3" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.1" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.3" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -30,7 +30,7 @@
     <HERMES_ARCH Condition="'$(HERMES_ARCH)' == ''">uwp</HERMES_ARCH>
 
     <USE_V8 Condition="('$(USE_V8)' == '') OR ('$(Platform)' == 'ARM')">false</USE_V8>
-    <V8_Version Condition="'$(V8_Version)' == ''">0.63.1</V8_Version>
+    <V8_Version Condition="'$(V8_Version)' == ''">0.63.3</V8_Version>
     <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' == 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
     <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' != 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.$(V8_Version)</V8_Package>
 

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.cpp
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.cpp
@@ -173,6 +173,7 @@ void V8JSIRuntimeHolder::initRuntime() noexcept {
     args.inspectorPort = debuggerPort_;
 
   args.enableInspector = useDirectDebugger_;
+  args.waitForDebugger = debuggerBreakOnNextLine_;
 
   args.foreground_task_runner =
       std::make_unique<TaskRunnerAdapter>(std::make_shared<ReactQueueBackedTaskRunner>(jsQueue_));

--- a/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
+++ b/vnext/ReactWindowsCore/V8JSIRuntimeHolder.h
@@ -20,6 +20,7 @@ class V8JSIRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
       std::unique_ptr<facebook::jsi::ScriptStore> &&scriptStore,
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept
       : useDirectDebugger_(devSettings->useDirectDebugger),
+        debuggerBreakOnNextLine_(devSettings->debuggerBreakOnNextLine),
         debuggerPort_(devSettings->debuggerPort),
         jsQueue_(std::move(jsQueue)),
         scriptStore_(std::move(scriptStore)),
@@ -39,6 +40,7 @@ class V8JSIRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
 
   uint16_t debuggerPort_;
   bool useDirectDebugger_;
+  bool debuggerBreakOnNextLine_;
 };
 
 } // namespace react

--- a/vnext/ReactWindowsCore/packages.ReactWindowsCore-Desktop.config
+++ b/vnext/ReactWindowsCore/packages.ReactWindowsCore-Desktop.config
@@ -3,5 +3,5 @@
   <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" Condition="$(USE_HERMES)' == 'true'" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.63.1" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.3" targetFramework="native" Condition="'$(USE_V8)' == 'true'" />
 </packages>


### PR DESCRIPTION
Update V8 to the latest package version (includes V8 version 8.7);
Properly pass through the debuggerBreakOnNextLine engine option to V8;

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6679)