### PR TITLE
Fix destruction of UIManager in UI thread

### DIFF
--- a/change/react-native-windows-a206e50b-eb3d-4f1e-bb61-35d4d333e417.json
+++ b/change/react-native-windows-a206e50b-eb3d-4f1e-bb61-35d4d333e417.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix destruction of UIManager in UI thread",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/Modules/UIManagerModule.cpp
+++ b/vnext/Desktop/Modules/UIManagerModule.cpp
@@ -9,6 +9,7 @@ using namespace std;
 #include <algorithm>
 #include <iostream>
 
+#include <Threading/MessageDispatchQueue.h>
 #include <unicode.h>
 #include "ShadowNode.h"
 #include "ShadowNodeRegistry.h"
@@ -459,7 +460,11 @@ UIManagerModule::UIManagerModule(
 UIManagerModule::~UIManagerModule() noexcept {
   if (m_uiQueue) {
     // To make sure that we destroy UI components in UI thread.
-    m_uiQueue->runOnQueue([manager = std::move(m_manager)]() {});
+    // We cannot use the m_uiQueue->runOnQueue directly because
+    // the UI MessageQueueThread is already stopped.
+    std::static_pointer_cast<Mso::React::MessageDispatchQueue>(m_uiQueue)
+        ->DispatchQueue()
+        .Post([manager = std::move(m_manager)]() noexcept {});
   }
 }
 


### PR DESCRIPTION
This PR is to augment the fix in PR #6321 where we wanted to make that the `UIManager` is destroyed from UI thread.
We are still getting reports that code crashes because the `UIManager` is destroyed in a background thread.
It happens because in the code below the `m_uiQueue` is already stopped and as a result we still destroy the `UIManager` in a BG thread instead of UI queue.
```C++
m_uiQueue->runOnQueue([manager = std::move(m_manager)]() {});
```
To address this issue we must take the underlying DispatchQueue which is not affected by the MessageQueueThread stop condition and use it to destroy the `UIManager`:
```C++
std::static_pointer_cast<Mso::React::MessageDispatchQueue>(m_uiQueue)
    ->DispatchQueue()
    .Post([manager = std::move(m_manager)]() noexcept {});
```

The fix must be propagated back to 0.63 to unblock our customers.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6680)