### PR TITLE
Touch event crash

### DIFF
--- a/change/react-native-windows-dc57cc91-1d10-4457-b1fc-56069b55edff.json
+++ b/change/react-native-windows-dc57cc91-1d10-4457-b1fc-56069b55edff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "TagProperty only exists on FrameworkElement and hyperlinks aren't FE",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/E2ETest/windows/ReactUWPTestApp/TreeDumpControlViewManager.cs
+++ b/packages/E2ETest/windows/ReactUWPTestApp/TreeDumpControlViewManager.cs
@@ -237,10 +237,10 @@ namespace TreeDumpLibrary
         private static IList<Inline> GetInlines(StorageFile masterFile, StorageFile outFile, UIElement anchor)
         {
             Hyperlink masterLink = new Hyperlink();
-            masterLink.Click += (_1, _2) => { Windows.System.Launcher.LaunchFileAsync(masterFile); };
+            masterLink.Click += async (_1, _2) => { await Windows.System.Launcher.LaunchFileAsync(masterFile); };
             masterLink.Inlines.Add(new Run() { Text = "master" });
             Hyperlink outLink = new Hyperlink();
-            outLink.Click += (_1, _2) => { Windows.System.Launcher.LaunchFileAsync(outFile); };
+            outLink.Click += async (_1, _2) => { await Windows.System.Launcher.LaunchFileAsync(outFile); };
             outLink.Inlines.Add(new Run() { Text = "output" });
             List<Inline> inlines = new List<Inline>()
             {

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -409,28 +409,29 @@ bool TouchEventHandler::TagFromOriginalSource(
   winrt::IPropertyValue tag(nullptr);
 
   while (sourceElement) {
-    tag = sourceElement.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-    if (tag) {
-      // If a TextBlock was the UIElement event source, perform a more accurate hit test,
-      // searching for the tag of the nested Run/Span XAML elements that the user actually clicked.
-      // This is to support nested <Text> elements in React.
-      // Nested React <Text> elements get translated into nested XAML <Span> elements,
-      // while the content of the <Text> becomes a list of XAML <Run> elements.
-      // However, we should report the Text element as the target, not the contexts of the text.
-      if (const auto textBlock = sourceElement.try_as<xaml::Controls::TextBlock>()) {
-        const auto pointerPos = args.GetCurrentPoint(textBlock).RawPosition();
-        const auto inlines = textBlock.Inlines().GetView();
+    if (auto fe = sourceElement.try_as<xaml::FrameworkElement>()) {
+      tag = fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+      if (tag) {
+        // If a TextBlock was the UIElement event source, perform a more accurate hit test,
+        // searching for the tag of the nested Run/Span XAML elements that the user actually clicked.
+        // This is to support nested <Text> elements in React.
+        // Nested React <Text> elements get translated into nested XAML <Span> elements,
+        // while the content of the <Text> becomes a list of XAML <Run> elements.
+        // However, we should report the Text element as the target, not the contexts of the text.
+        if (const auto textBlock = sourceElement.try_as<xaml::Controls::TextBlock>()) {
+          const auto pointerPos = args.GetCurrentPoint(textBlock).RawPosition();
+          const auto inlines = textBlock.Inlines().GetView();
 
-        bool isHit = false;
-        const auto finerTag = TestHit(inlines, pointerPos, isHit);
-        if (finerTag) {
-          tag = finerTag;
+          bool isHit = false;
+          const auto finerTag = TestHit(inlines, pointerPos, isHit);
+          if (finerTag) {
+            tag = finerTag;
+          }
         }
+
+        break;
       }
-
-      break;
     }
-
     sourceElement = winrt::VisualTreeHelper::GetParent(sourceElement).try_as<xaml::UIElement>();
   }
 
@@ -460,9 +461,11 @@ winrt::IPropertyValue TouchEventHandler::TestHit(
         return resTag;
 
       if (isHit) {
-        tag = el.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-        if (tag) {
-          return tag;
+        if (auto fe = el.try_as<xaml::FrameworkElement>()) {
+          tag = fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+          if (tag) {
+            return tag;
+          }
         }
       }
     } else if (const auto run = el.try_as<xaml::Documents::Run>()) {

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -9,8 +9,16 @@ namespace Microsoft::ReactNative {
 
 using XamlView = xaml::DependencyObject;
 
+inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
+  assert(fe);
+  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+}
+
 inline int64_t GetTag(XamlView view) {
-  return view.GetValue(xaml::FrameworkElement::TagProperty()).as<winrt::IPropertyValue>().GetInt64();
+  if (auto fe = view.try_as<xaml::FrameworkElement>()) {
+    return GetTagAsPropertyValue(fe).GetInt64();
+  }
+  return 0;
 }
 
 inline void SetTag(XamlView view, int64_t tag) {
@@ -29,11 +37,6 @@ inline bool IsValidTag(winrt::IPropertyValue value) {
 inline int64_t GetTag(winrt::IPropertyValue value) {
   assert(value);
   return value.GetInt64();
-}
-
-inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
-  assert(fe);
-  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);


### PR DESCRIPTION
Fixes #6682 
the Tag property is available on FrameworkElement, so when the app has elements that are not FE like hyperlinks (which are UIElements but not FE), we crash

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6692)