### PR TITLE
Fix getting host objects and functions in JSI ABI

### DIFF
--- a/change/react-native-windows-5e214434-8983-474c-8d79-cae036a5fc24.json
+++ b/change/react-native-windows-5e214434-8983-474c-8d79-cae036a5fc24.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix getting host objects and functions in JSI ABI",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -147,8 +147,9 @@ operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<Jsi
 }
 
 /*static*/ HostFunctionType &JsiHostFunctionWrapper::GetHostFunction(JsiHostFunction const &hostFunction) noexcept {
-  void *hostFunctonAbi = get_abi(hostFunction);
-  JsiHostFunctionWrapper *self = static_cast<impl::delegate<JsiHostFunction, JsiHostFunctionWrapper> *>(hostFunctonAbi);
+  void *hostFunctionAbi = get_abi(hostFunction);
+  JsiHostFunctionWrapper *self =
+      static_cast<impl::delegate<JsiHostFunction, JsiHostFunctionWrapper> *>(hostFunctionAbi);
   return self->m_hostFunction;
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -89,18 +89,8 @@ JsiPreparedJavaScript const &JsiPreparedJavaScriptWrapper::Get() const noexcept 
 // JsiHostObjectWrapper implementation
 //===========================================================================
 
-/*static*/ std::mutex JsiHostObjectWrapper::s_mutex;
-/*static*/ std::map<uint64_t, JsiHostObjectWrapper *> JsiHostObjectWrapper::s_objectDataToObjectWrapper;
-
 JsiHostObjectWrapper::JsiHostObjectWrapper(std::shared_ptr<HostObject> &&hostObject) noexcept
     : m_hostObject(std::move(hostObject)) {}
-
-JsiHostObjectWrapper::~JsiHostObjectWrapper() noexcept {
-  if (m_objectData.Data) {
-    std::scoped_lock lock{s_mutex};
-    s_objectDataToObjectWrapper.erase(m_objectData.Data);
-  }
-}
 
 JsiValueRef JsiHostObjectWrapper::GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name) try {
   JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetOrCreate(runtime)};
@@ -135,71 +125,16 @@ Windows::Foundation::Collections::IVector<JsiPropertyIdRef> JsiHostObjectWrapper
   throw;
 }
 
-/*static*/ void JsiHostObjectWrapper::RegisterHostObject(
-    JsiObjectRef const &objectData,
-    JsiHostObjectWrapper *hostObject) noexcept {
-  std::scoped_lock lock{s_mutex};
-  s_objectDataToObjectWrapper[objectData.Data] = hostObject;
-  hostObject->m_objectData = objectData;
-}
-
-/*static*/ bool JsiHostObjectWrapper::IsHostObject(JsiObjectRef const &objectData) noexcept {
-  std::scoped_lock lock{s_mutex};
-  auto it = s_objectDataToObjectWrapper.find(objectData.Data);
-  return it != s_objectDataToObjectWrapper.end();
-}
-
-/*static*/ std::shared_ptr<HostObject> JsiHostObjectWrapper::GetHostObject(JsiObjectRef const &objectData) noexcept {
-  auto it = s_objectDataToObjectWrapper.find(objectData.Data);
-  if (it != s_objectDataToObjectWrapper.end()) {
-    return it->second->m_hostObject;
-  } else {
-    return nullptr;
-  }
+std::shared_ptr<facebook::jsi::HostObject> const &JsiHostObjectWrapper::HostObjectSharedPtr() noexcept {
+  return m_hostObject;
 }
 
 //===========================================================================
 // JsiHostFunctionWrapper implementation
 //===========================================================================
 
-/*static*/ std::mutex JsiHostFunctionWrapper::s_functionMutex;
-/*static*/ std::atomic<uint32_t> JsiHostFunctionWrapper::s_functionIdGenerator;
-/*static*/ std::map<uint32_t, JsiHostFunctionWrapper *> JsiHostFunctionWrapper::s_functionIdToFunctionWrapper;
-/*static*/ std::map<uint64_t, JsiHostFunctionWrapper *> JsiHostFunctionWrapper::s_functionDataToFunctionWrapper;
-
-JsiHostFunctionWrapper::JsiHostFunctionWrapper(HostFunctionType &&hostFunction, uint32_t functionId) noexcept
-    : m_hostFunction{std::move(hostFunction)}, m_functionId{functionId} {
-  VerifyElseCrashSz(functionId, "Function Id must be not zero");
-  std::scoped_lock lock{s_functionMutex};
-  s_functionIdToFunctionWrapper[functionId] = this;
-}
-
-JsiHostFunctionWrapper::JsiHostFunctionWrapper(JsiHostFunctionWrapper &&other) noexcept
-    : m_hostFunction{std::move(other.m_hostFunction)},
-      m_functionId{std::exchange(other.m_functionId, 0)},
-      m_functionData{std::exchange(other.m_functionData, {0})} {
-  std::scoped_lock lock{s_functionMutex};
-  if (m_functionId) {
-    s_functionIdToFunctionWrapper[m_functionId] = this;
-  }
-  if (m_functionData.Data) {
-    s_functionDataToFunctionWrapper[m_functionData.Data] = this;
-  }
-}
-
-JsiHostFunctionWrapper::~JsiHostFunctionWrapper() noexcept {
-  if (m_functionId || m_functionData.Data) {
-    std::scoped_lock lock{s_functionMutex};
-    auto it1 = s_functionIdToFunctionWrapper.find(m_functionId);
-    if (it1 != s_functionIdToFunctionWrapper.end()) {
-      s_functionIdToFunctionWrapper.erase(it1);
-    }
-    auto it2 = s_functionDataToFunctionWrapper.find(m_functionData.Data);
-    if (it2 != s_functionDataToFunctionWrapper.end()) {
-      s_functionDataToFunctionWrapper.erase(it2);
-    }
-  }
-}
+JsiHostFunctionWrapper::JsiHostFunctionWrapper(HostFunctionType &&hostFunction) noexcept
+    : m_hostFunction{std::move(hostFunction)} {}
 
 JsiValueRef JsiHostFunctionWrapper::
 operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<JsiValueRef const> args) try {
@@ -211,34 +146,10 @@ operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<Jsi
   throw;
 }
 
-/*static*/ uint32_t JsiHostFunctionWrapper::GetNextFunctionId() noexcept {
-  return ++s_functionIdGenerator;
-}
-
-/*static*/ void JsiHostFunctionWrapper::RegisterHostFunction(
-    uint32_t functionId,
-    JsiObjectRef const &functionData) noexcept {
-  std::scoped_lock lock{s_functionMutex};
-  auto it = s_functionIdToFunctionWrapper.find(functionId);
-  VerifyElseCrashSz(it != s_functionIdToFunctionWrapper.end(), "Function Id is not found.");
-  JsiHostFunctionWrapper *functionWrapper = it->second;
-  s_functionDataToFunctionWrapper[functionData.Data] = functionWrapper;
-  functionWrapper->m_functionData = functionData;
-}
-
-/*static*/ bool JsiHostFunctionWrapper::IsHostFunction(JsiObjectRef const &functionData) noexcept {
-  std::scoped_lock lock{s_functionMutex};
-  return s_functionDataToFunctionWrapper.find(functionData.Data) != s_functionDataToFunctionWrapper.end();
-}
-
-/*static*/ HostFunctionType &JsiHostFunctionWrapper::GetHostFunction(JsiObjectRef const &functionData) noexcept {
-  std::scoped_lock lock{s_functionMutex};
-  auto it = s_functionDataToFunctionWrapper.find(functionData.Data);
-  if (it != s_functionDataToFunctionWrapper.end()) {
-    return it->second->m_hostFunction;
-  }
-
-  VerifyElseCrashSz(false, "Function is not a host function");
+/*static*/ HostFunctionType &JsiHostFunctionWrapper::GetHostFunction(JsiHostFunction const &hostFunction) noexcept {
+  void *hostFunctonAbi = get_abi(hostFunction);
+  JsiHostFunctionWrapper *self = static_cast<impl::delegate<JsiHostFunction, JsiHostFunctionWrapper> *>(hostFunctonAbi);
+  return self->m_hostFunction;
 }
 
 //===========================================================================
@@ -490,7 +401,6 @@ Object JsiAbiRuntime::createObject() try {
 Object JsiAbiRuntime::createObject(std::shared_ptr<HostObject> ho) try {
   auto hostObjectWrapper = winrt::make<JsiHostObjectWrapper>(std::move(ho));
   Object result = MakeObject(m_runtime.CreateObjectWithHostObject(hostObjectWrapper));
-  JsiHostObjectWrapper::RegisterHostObject(AsJsiObjectRef(result), get_self<JsiHostObjectWrapper>(hostObjectWrapper));
   return result;
 } catch (hresult_error const &) {
   RethrowJsiError();
@@ -498,14 +408,23 @@ Object JsiAbiRuntime::createObject(std::shared_ptr<HostObject> ho) try {
 }
 
 std::shared_ptr<HostObject> JsiAbiRuntime::getHostObject(const Object &obj) try {
-  return JsiHostObjectWrapper::GetHostObject(AsJsiObjectRef(obj));
+  std::shared_ptr<HostObject> result;
+  if (auto jsiHostObject = m_runtime.GetHostObject(AsJsiObjectRef(obj))) {
+    if (auto wrapper = get_self<JsiHostObjectWrapper>(jsiHostObject)) {
+      result = wrapper->HostObjectSharedPtr();
+    }
+  }
+  return result;
 } catch (hresult_error const &) {
   RethrowJsiError();
   throw;
 }
 
 HostFunctionType &JsiAbiRuntime::getHostFunction(const Function &func) try {
-  return JsiHostFunctionWrapper::GetHostFunction(AsJsiObjectRef(func));
+  if (auto jsiHostFunction = m_runtime.GetHostFunction(AsJsiObjectRef(func))) {
+    return JsiHostFunctionWrapper::GetHostFunction(jsiHostFunction);
+  }
+  throw winrt::hresult_invalid_argument(L"Not a host function");
 } catch (hresult_error const &) {
   RethrowJsiError();
   throw;
@@ -588,7 +507,7 @@ bool JsiAbiRuntime::isHostObject(const Object &obj) const try {
 }
 
 bool JsiAbiRuntime::isHostFunction(const Function &func) const try {
-  return JsiHostFunctionWrapper::IsHostFunction(AsJsiObjectRef(func));
+  return m_runtime.IsHostFunction(AsJsiObjectRef(func));
 } catch (hresult_error const &) {
   RethrowJsiError();
   throw;
@@ -665,11 +584,8 @@ Function JsiAbiRuntime::createFunctionFromHostFunction(
     const PropNameID &name,
     unsigned int paramCount,
     HostFunctionType func) try {
-  uint32_t functionId = JsiHostFunctionWrapper::GetNextFunctionId();
-  Function result = MakeFunction(m_runtime.CreateFunctionFromHostFunction(
-      AsJsiPropertyIdRef(name), paramCount, JsiHostFunctionWrapper(std::move(func), functionId)));
-  JsiHostFunctionWrapper::RegisterHostFunction(functionId, AsJsiObjectRef(result));
-  return result;
+  return MakeFunction(m_runtime.CreateFunctionFromHostFunction(
+      AsJsiPropertyIdRef(name), paramCount, JsiHostFunctionWrapper{std::move(func)}));
 } catch (hresult_error const &) {
   RethrowJsiError();
   throw;

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -43,52 +43,29 @@ struct JsiPreparedJavaScriptWrapper : facebook::jsi::PreparedJavaScript {
 // An ABI-safe wrapper for facebook::jsi::HostObject.
 struct JsiHostObjectWrapper : implements<JsiHostObjectWrapper, IJsiHostObject> {
   JsiHostObjectWrapper(std::shared_ptr<facebook::jsi::HostObject> &&hostObject) noexcept;
-  ~JsiHostObjectWrapper() noexcept;
 
   JsiValueRef GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name);
   void SetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name, JsiValueRef const &value);
   Windows::Foundation::Collections::IVector<JsiPropertyIdRef> GetPropertyIds(JsiRuntime const &runtime);
 
-  static void RegisterHostObject(JsiObjectRef const &objectData, JsiHostObjectWrapper *hostObject) noexcept;
-  static bool IsHostObject(JsiObjectRef const &objectData) noexcept;
-  static std::shared_ptr<facebook::jsi::HostObject> GetHostObject(JsiObjectRef const &objectData) noexcept;
+  std::shared_ptr<facebook::jsi::HostObject> const &HostObjectSharedPtr() noexcept;
 
  private:
   std::shared_ptr<facebook::jsi::HostObject> m_hostObject;
-  JsiObjectRef m_objectData{};
-
-  static std::mutex s_mutex;
-  static std::map<uint64_t, JsiHostObjectWrapper *> s_objectDataToObjectWrapper;
 };
 
 // The function object that wraps up the facebook::jsi::HostFunctionType
 struct JsiHostFunctionWrapper {
   // We only support new and move constructors.
-  JsiHostFunctionWrapper(facebook::jsi::HostFunctionType &&hostFunction, uint32_t functionId) noexcept;
-  JsiHostFunctionWrapper(JsiHostFunctionWrapper &&other) noexcept;
-  ~JsiHostFunctionWrapper() noexcept;
-
-  // Disable other ways to construct or modify the wrapper.
-  JsiHostFunctionWrapper &operator=(JsiHostFunctionWrapper &&other) = delete;
-  JsiHostFunctionWrapper(JsiHostFunctionWrapper const &other) = delete;
-  JsiHostFunctionWrapper &operator=(JsiHostFunctionWrapper const &other) = delete;
+  JsiHostFunctionWrapper(facebook::jsi::HostFunctionType &&hostFunction) noexcept;
 
   JsiValueRef operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<JsiValueRef const> args);
 
-  static uint32_t GetNextFunctionId() noexcept;
-  static void RegisterHostFunction(uint32_t functionId, JsiObjectRef const &func) noexcept;
-  static bool IsHostFunction(JsiObjectRef const &func) noexcept;
-  static facebook::jsi::HostFunctionType &GetHostFunction(JsiObjectRef const &func) noexcept;
+  static facebook::jsi::HostFunctionType &GetHostFunction(JsiHostFunction const &hostFunction) noexcept;
 
  private:
   facebook::jsi::HostFunctionType m_hostFunction;
   JsiObjectRef m_functionData{};
-  uint32_t m_functionId{};
-
-  static std::mutex s_functionMutex;
-  static std::atomic<uint32_t> s_functionIdGenerator;
-  static std::map<uint32_t, JsiHostFunctionWrapper *> s_functionIdToFunctionWrapper;
-  static std::map<uint64_t, JsiHostFunctionWrapper *> s_functionDataToFunctionWrapper;
 };
 
 struct JsiAbiRuntime;

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -32,7 +32,31 @@ struct TestHostModule {
           [](Runtime &rt, const Value & /*thisVal*/, const Value *args, size_t /*count*/) {
             return Value{rt, String::createFromUtf8(rt, "Hello " + args[0].getString(rt).utf8(rt))};
           });
-      TestCheckEqual("Hello boss", hostGreeter.call(rt, "boss").getString(rt).utf8(rt));
+      TestCheckEqual("Hello World", hostGreeter.call(rt, "World").getString(rt).utf8(rt));
+      TestCheck(hostGreeter.getHostFunction(rt) != nullptr);
+
+      Function hostGreater2 = hostGreeter.getFunction(rt);
+      TestCheck(hostGreater2.isHostFunction(rt));
+      TestCheckEqual("Hello World", hostGreater2.call(rt, "World").getString(rt).utf8(rt));
+      TestCheck(hostGreater2.getHostFunction(rt) != nullptr);
+
+      class GreeterHostObject : public HostObject {
+        Value get(Runtime &rt, const PropNameID &) override {
+          return String::createFromAscii(rt, "Hello");
+        }
+        void set(Runtime &, const PropNameID &, const Value &) override {}
+      };
+
+      Object hostObjGreeter = Object::createFromHostObject(rt, std::make_shared<GreeterHostObject>());
+      TestCheckEqual(
+          "Hello", hostObjGreeter.getProperty(rt, PropNameID::forAscii(rt, "someProp")).getString(rt).utf8(rt));
+      TestCheck(hostObjGreeter.getHostObject(rt) != nullptr);
+
+      Object hostObjGreeter2 = Value{rt, hostObjGreeter}.getObject(rt);
+      TestCheck(hostObjGreeter2.isHostObject(rt));
+      TestCheckEqual(
+          "Hello", hostObjGreeter2.getProperty(rt, PropNameID::forAscii(rt, "someProp")).getString(rt).utf8(rt));
+      TestCheck(hostObjGreeter2.getHostObject(rt) != nullptr);
     });
     TestCheck(jsiExecuted);
   }

--- a/vnext/Microsoft.ReactNative/JsiApi.cpp
+++ b/vnext/Microsoft.ReactNative/JsiApi.cpp
@@ -171,9 +171,10 @@ static facebook::jsi::Value &&ToValue(JsiValueRef &&value) noexcept {
   return reinterpret_cast<facebook::jsi::Value &&>(value);
 }
 
-static facebook::jsi::HostFunctionType MakeHostFunction(Microsoft::ReactNative::JsiHostFunction const &hostFunc) {
-  // TODO: implement host function mapping
-  return [hostFunc](
+static facebook::jsi::HostFunctionType MakeHostFunction(
+    Microsoft::ReactNative::JsiHostFunction const &hostFunc,
+    std::shared_ptr<JsiRuntime::HostFunctionCleaner> &&cleaner) {
+  return [hostFunc, cleaner](
              facebook::jsi::Runtime &runtime,
              facebook::jsi::Value const &thisVal,
              facebook::jsi::Value const *args,
@@ -310,7 +311,9 @@ facebook::jsi::JSError const &jsError) {                             \
   } catch (...
 
 /*static*/ std::mutex JsiRuntime::s_mutex;
-/*static*/ std::map<uintptr_t, weak_ref<ReactNative::JsiRuntime>> JsiRuntime::s_jsiRuntimeMap;
+/*static*/ std::unordered_map<uintptr_t, weak_ref<ReactNative::JsiRuntime>> JsiRuntime::s_jsiRuntimeMap;
+/*static*/ std::unordered_map<int64_t, ReactNative::JsiHostFunction> JsiRuntime::s_jsiHostFunctionMap;
+/*static*/ int64_t JsiRuntime::s_jsiNextHostFunctionId{0};
 
 /*static*/ ReactNative::JsiRuntime JsiRuntime::FromRuntime(facebook::jsi::Runtime &jsiRuntime) noexcept {
   std::scoped_lock lock{s_mutex};
@@ -325,15 +328,34 @@ facebook::jsi::JSError const &jsError) {                             \
 /*static*/ ReactNative::JsiRuntime JsiRuntime::GetOrCreate(
     std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
     std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept {
-  std::scoped_lock lock{s_mutex};
-  auto it = s_jsiRuntimeMap.find(reinterpret_cast<uintptr_t>(jsiRuntime.get()));
-  if (it != s_jsiRuntimeMap.end()) {
-    return it->second.get();
-  } else {
-    ReactNative::JsiRuntime abiJsiResult{make<JsiRuntime>(Mso::Copy(jsiRuntimeHolder), Mso::Copy(jsiRuntime))};
-    s_jsiRuntimeMap.try_emplace(reinterpret_cast<uintptr_t>(jsiRuntime.get()), abiJsiResult);
-    return abiJsiResult;
+  {
+    std::scoped_lock lock{s_mutex};
+    auto it = s_jsiRuntimeMap.find(reinterpret_cast<uintptr_t>(jsiRuntime.get()));
+    if (it != s_jsiRuntimeMap.end()) {
+      return it->second.get();
+    }
   }
+
+  return Create(jsiRuntimeHolder, jsiRuntime);
+}
+
+/*static*/ ReactNative::JsiRuntime JsiRuntime::Create(
+    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+    std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept {
+  auto buffer = std::make_shared<facebook::jsi::StringBuffer>(R"JS(
+      var __jsi_pal = function() {
+        var hostFunctionId = Symbol('hostFunctionId');
+        return {
+          getHostFunctionId: function(func) { return func[hostFunctionId]; },
+          setHostFunctionId: function(func, id) { Object.defineProperty(func, hostFunctionId, { value: id }); }
+        };
+      }();
+    )JS");
+  jsiRuntime->evaluateJavaScript(buffer, "JSI_PAL");
+  ReactNative::JsiRuntime abiJsiResult{make<JsiRuntime>(Mso::Copy(jsiRuntimeHolder), Mso::Copy(jsiRuntime))};
+  std::scoped_lock lock{s_mutex};
+  s_jsiRuntimeMap.try_emplace(reinterpret_cast<uintptr_t>(jsiRuntime.get()), abiJsiResult);
+  return abiJsiResult;
 }
 
 ReactNative::JsiRuntime JsiRuntime::MakeChakraRuntime() {
@@ -344,10 +366,7 @@ ReactNative::JsiRuntime JsiRuntime::MakeChakraRuntime() {
   auto runtimeHolder = std::make_shared<::Microsoft::JSI::ChakraRuntimeHolder>(
       std::move(devSettings), std::move(jsThread), nullptr, nullptr);
   auto runtime = runtimeHolder->getRuntime();
-  ReactNative::JsiRuntime result{make<JsiRuntime>(std::move(runtimeHolder), Mso::Copy(runtime))};
-  std::scoped_lock lock{s_mutex};
-  s_jsiRuntimeMap.try_emplace(reinterpret_cast<uintptr_t>(runtime.get()), result);
-  return result;
+  return Create(runtimeHolder, runtime);
 }
 
 JsiRuntime::JsiRuntime(
@@ -578,8 +597,20 @@ IJsiHostObject JsiRuntime::GetHostObject(JsiObjectRef obj) try {
 
 JsiHostFunction JsiRuntime::GetHostFunction(JsiObjectRef func) try {
   auto funcPtr = AsPointerValue(func);
-  // auto hostFunction = m_runtime->getHostFunction(AsFunction(func));
-  // TODO: implement mapping
+  auto const &jsiFunc = AsFunction(&funcPtr);
+  auto &rt = *m_runtime;
+  int64_t hostFunctionId = static_cast<int64_t>(rt.global()
+                                                    .getPropertyAsObject(rt, "__jsi_pal")
+                                                    .getPropertyAsFunction(rt, "getHostFunctionId")
+                                                    .call(rt, jsiFunc)
+                                                    .getNumber());
+  {
+    std::scoped_lock lock{m_mutex};
+    auto it = s_jsiHostFunctionMap.find(hostFunctionId);
+    if (it != s_jsiHostFunctionMap.end()) {
+      return it->second;
+    }
+  }
   return nullptr;
 } catch (JSI_SET_ERROR) {
   throw;
@@ -708,13 +739,33 @@ void JsiRuntime::SetValueAtIndex(JsiObjectRef arr, uint32_t index, JsiValueRef c
   throw;
 }
 
+JsiRuntime::HostFunctionCleaner::HostFunctionCleaner(int64_t hostFunctionId) : m_hostFunctionId{hostFunctionId} {}
+
+JsiRuntime::HostFunctionCleaner::~HostFunctionCleaner() {
+  std::scoped_lock lock{s_mutex};
+  s_jsiHostFunctionMap.erase(m_hostFunctionId);
+}
+
 JsiObjectRef JsiRuntime::CreateFunctionFromHostFunction(
     JsiPropertyIdRef propNameId,
     uint32_t paramCount,
     JsiHostFunction const &hostFunc) try {
+  int64_t hostFunctionId;
+  {
+    std::scoped_lock lock{s_mutex};
+    hostFunctionId = ++s_jsiNextHostFunctionId;
+    s_jsiHostFunctionMap[hostFunctionId] = hostFunc;
+  }
+  auto cleaner = std::make_shared<HostFunctionCleaner>(hostFunctionId);
+  auto &rt = *m_runtime;
   auto propertyIdPtr = AsPointerValue(propNameId);
-  return MakeJsiFunctionData(
-      m_runtime->createFunctionFromHostFunction(AsPropNameID(&propertyIdPtr), paramCount, MakeHostFunction(hostFunc)));
+  auto func = rt.createFunctionFromHostFunction(
+      AsPropNameID(&propertyIdPtr), paramCount, MakeHostFunction(hostFunc, std::move(cleaner)));
+  rt.global()
+      .getPropertyAsObject(rt, "__jsi_pal")
+      .getPropertyAsFunction(rt, "setHostFunctionId")
+      .call(rt, func, static_cast<double>(hostFunctionId));
+  return MakeJsiFunctionData(std::move(func));
 } catch (JSI_SET_ERROR) {
   throw;
 }

--- a/vnext/Microsoft.ReactNative/JsiApi.h
+++ b/vnext/Microsoft.ReactNative/JsiApi.h
@@ -11,11 +11,15 @@
 
 // facebook::jsi::Runtime hides all methods that we need to call.
 // We "open" them up here by redeclaring the private and protected keywords.
+#pragma push_macro("private")
+#pragma push_macro("protected")
 #define private public
 #define protected public
 #include "jsi/jsi.h"
 #undef protected
 #undef private
+#pragma pop_macro("protected")
+#pragma pop_macro("private")
 
 #include "ChakraRuntimeHolder.h"
 
@@ -54,6 +58,9 @@ struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
 
   static ReactNative::JsiRuntime FromRuntime(facebook::jsi::Runtime &runtime) noexcept;
   static ReactNative::JsiRuntime GetOrCreate(
+      std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+      std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept;
+  static ReactNative::JsiRuntime Create(
       std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
       std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept;
 
@@ -140,6 +147,15 @@ struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   void SetError(JsiErrorType errorType, hstring const &errorDetails, JsiValueRef const &value) noexcept;
   static void RethrowJsiError(facebook::jsi::Runtime &runtime);
 
+ public:
+  struct HostFunctionCleaner {
+    HostFunctionCleaner(int64_t hostFunctionId);
+    ~HostFunctionCleaner();
+
+   private:
+    int64_t m_hostFunctionId{0};
+  };
+
  private:
   void SetError(facebook::jsi::JSError const &jsError) noexcept;
   void SetError(facebook::jsi::JSINativeException const &nativeException) noexcept;
@@ -151,7 +167,9 @@ struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   ReactNative::JsiError m_error{nullptr};
 
   static std::mutex s_mutex;
-  static std::map<uintptr_t, winrt::weak_ref<ReactNative::JsiRuntime>> s_jsiRuntimeMap;
+  static std::unordered_map<uintptr_t, winrt::weak_ref<ReactNative::JsiRuntime>> s_jsiRuntimeMap;
+  static std::unordered_map<int64_t, ReactNative::JsiHostFunction> s_jsiHostFunctionMap;
+  static int64_t s_jsiNextHostFunctionId;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
Current implementation of JSI ABI has issues where the host object and host function do not behave correctly if `facebook::jsi::Object` or `facebook::jsi::Function` are cloned. In this PR we are changing how the mapping for host objects and functions work.
The ReactNativeHostTests is updated with the scenario that was failing before, but passes with this PR. All other JSI tests are passing too.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6693)