### PR TITLE
Reader/Writer for winrt::hstring

### DIFF
--- a/change/react-native-windows-0f6efe1f-8377-4920-9644-b25e46538084.json
+++ b/change/react-native-windows-0f6efe1f-8377-4920-9644-b25e46538084.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Introduce reader/writer for winrt::hstring",
+  "packageName": "react-native-windows",
+  "email": "Bartosz.Klonowski@callstack.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
@@ -451,6 +451,9 @@ TEST_CLASS (JSValueReaderTest) {
     WriteProperty(writer, L"StringValue1", "");
     WriteProperty(writer, L"StringValue2", "5");
     WriteProperty(writer, L"StringValue3", "Hello");
+    WriteProperty(writer, L"StringValue4", L"Hello wchar_t type!");
+    WriteProperty(writer, L"StringValue5", winrt::hstring{L"Hello winrt::hstring type!"});
+    WriteProperty(writer, L"StringValue6", winrt::param::hstring{L"Hello winrt::param::hstring type!"});
     WriteProperty(writer, L"BoolValue1", false);
     WriteProperty(writer, L"BoolValue2", true);
     WriteProperty(writer, L"IntValue1", 0);
@@ -463,6 +466,9 @@ TEST_CLASS (JSValueReaderTest) {
     TestCheck(jsValue["StringValue1"] == "");
     TestCheck(jsValue["StringValue2"] == "5");
     TestCheck(jsValue["StringValue3"] == "Hello");
+    TestCheck(jsValue["StringValue4"] == "Hello wchar_t type!");
+    TestCheck(jsValue["StringValue5"] == "Hello winrt::hstring type!");
+    TestCheck(jsValue["StringValue6"] == "Hello winrt::param::hstring type!");
     TestCheck(jsValue["BoolValue1"] == false);
     TestCheck(jsValue["BoolValue2"] == true);
     TestCheck(jsValue["IntValue1"] == 0);

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
@@ -298,6 +298,7 @@ TEST_CLASS (JSValueReaderTest) {
       if (propertyName == L"StringValue1") {
         TestCheck(ReadValue<std::string>(reader) == "");
         TestCheck(ReadValue<std::wstring>(reader) == L"");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"");
         TestCheck(ReadValue<bool>(reader) == false);
         TestCheck(ReadValue<int8_t>(reader) == 0);
         TestCheck(ReadValue<int16_t>(reader) == 0);
@@ -313,6 +314,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"StringValue2") {
         TestCheck(ReadValue<std::string>(reader) == "5");
         TestCheck(ReadValue<std::wstring>(reader) == L"5");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"5");
         TestCheck(ReadValue<bool>(reader) == true);
         TestCheck(ReadValue<int8_t>(reader) == 5);
         TestCheck(ReadValue<int16_t>(reader) == 5);
@@ -328,6 +330,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"StringValue3") {
         TestCheck(ReadValue<std::string>(reader) == "Hello");
         TestCheck(ReadValue<std::wstring>(reader) == L"Hello");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"Hello");
         TestCheck(ReadValue<bool>(reader) == true);
         TestCheck(ReadValue<int8_t>(reader) == 0);
         TestCheck(ReadValue<int16_t>(reader) == 0);
@@ -343,6 +346,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"BoolValue1") {
         TestCheck(ReadValue<std::string>(reader) == "false");
         TestCheck(ReadValue<std::wstring>(reader) == L"false");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"false");
         TestCheck(ReadValue<bool>(reader) == false);
         TestCheck(ReadValue<int8_t>(reader) == 0);
         TestCheck(ReadValue<int16_t>(reader) == 0);
@@ -358,6 +362,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"BoolValue2") {
         TestCheck(ReadValue<std::string>(reader) == "true");
         TestCheck(ReadValue<std::wstring>(reader) == L"true");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"true");
         TestCheck(ReadValue<bool>(reader) == true);
         TestCheck(ReadValue<int8_t>(reader) == 1);
         TestCheck(ReadValue<int16_t>(reader) == 1);
@@ -373,6 +378,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"IntValue1") {
         TestCheck(ReadValue<std::string>(reader) == "0");
         TestCheck(ReadValue<std::wstring>(reader) == L"0");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"0");
         TestCheck(ReadValue<bool>(reader) == false);
         TestCheck(ReadValue<int8_t>(reader) == 0);
         TestCheck(ReadValue<int16_t>(reader) == 0);
@@ -388,6 +394,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"IntValue2") {
         TestCheck(ReadValue<std::string>(reader) == "42");
         TestCheck(ReadValue<std::wstring>(reader) == L"42");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"42");
         TestCheck(ReadValue<bool>(reader) == true);
         TestCheck(ReadValue<int8_t>(reader) == 42);
         TestCheck(ReadValue<int16_t>(reader) == 42);
@@ -403,6 +410,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"FloatValue") {
         TestCheck(ReadValue<std::string>(reader) == "3.14");
         TestCheck(ReadValue<std::wstring>(reader) == L"3.14");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"3.14");
         TestCheck(ReadValue<bool>(reader) == true);
         TestCheck(ReadValue<int8_t>(reader) == 3);
         TestCheck(ReadValue<int16_t>(reader) == 3);
@@ -418,6 +426,7 @@ TEST_CLASS (JSValueReaderTest) {
       } else if (propertyName == L"NullValue") {
         TestCheck(ReadValue<std::string>(reader) == "");
         TestCheck(ReadValue<std::wstring>(reader) == L"");
+        TestCheck(ReadValue<winrt::hstring>(reader) == L"");
         TestCheck(ReadValue<bool>(reader) == false);
         TestCheck(ReadValue<int8_t>(reader) == 0);
         TestCheck(ReadValue<int16_t>(reader) == 0);

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -56,6 +56,7 @@ void ReadValue(TJSValue const &jsValue, /*out*/ T &value) noexcept;
 
 void ReadValue(IJSValueReader const &reader, /*out*/ std::string &value) noexcept;
 void ReadValue(IJSValueReader const &reader, /*out*/ std::wstring &value) noexcept;
+void ReadValue(IJSValueReader const &reader, /*out*/ winrt::hstring &value) noexcept;
 void ReadValue(IJSValueReader const &reader, /*out*/ bool &value) noexcept;
 void ReadValue(IJSValueReader const &reader, /*out*/ int8_t &value) noexcept;
 void ReadValue(IJSValueReader const &reader, /*out*/ int16_t &value) noexcept;
@@ -176,6 +177,26 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ std::wstring &value)
       value = std::to_wstring(reader.GetDouble());
       value.erase(value.find_last_not_of('0') + 1, std::wstring::npos);
       value.erase(value.find_last_not_of('.') + 1, std::wstring::npos);
+      break;
+    default:
+      value = L"";
+      break;
+  }
+}
+
+inline void ReadValue(IJSValueReader const &reader, /*out*/ winrt::hstring &value) noexcept {
+  switch (reader.ValueType()) {
+    case JSValueType::String:
+      value = reader.GetString();
+      break;
+    case JSValueType::Boolean:
+      value = reader.GetBoolean() ? L"true" : L"false";
+      break;
+    case JSValueType::Int64:
+      value = to_hstring(reader.GetInt64());
+      break;
+    case JSValueType::Double:
+      value = to_hstring(reader.GetDouble());
       break;
     default:
       value = L"";

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -195,9 +195,13 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ winrt::hstring &valu
     case JSValueType::Int64:
       value = to_hstring(reader.GetInt64());
       break;
-    case JSValueType::Double:
-      value = to_hstring(reader.GetDouble());
+    case JSValueType::Double: {
+      std::wstring conversionValue = std::to_wstring(reader.GetDouble());
+      conversionValue.erase(conversionValue.find_last_not_of('0') + 1, std::wstring::npos);
+      conversionValue.erase(conversionValue.find_last_not_of('.') + 1, std::wstring::npos);
+      value = conversionValue;
       break;
+    }
     default:
       value = L"";
       break;

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -89,7 +89,7 @@ inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
   writer.WriteString(value);
 }
 
-inline void WriteValue(IJSValueWriter const& writer, const winrt::hstring value) noexcept {
+inline void WriteValue(IJSValueWriter const &writer, const winrt::hstring value) noexcept {
   writer.WriteString(value);
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -23,6 +23,8 @@ template <class T, std::enable_if_t<std::is_convertible_v<T, std::string_view>, 
 void WriteValue(IJSValueWriter const &writer, T const &value) noexcept;
 template <class T, std::enable_if_t<std::is_convertible_v<T, std::wstring_view>, int> = 1>
 void WriteValue(IJSValueWriter const &writer, T const &value) noexcept;
+void WriteValue(IJSValueWriter const &writer, winrt::hstring value) noexcept;
+void WriteValue(IJSValueWriter const &writer, const winrt::param::hstring value) noexcept;
 void WriteValue(IJSValueWriter const &writer, bool value) noexcept;
 void WriteValue(IJSValueWriter const &writer, int8_t value) noexcept;
 void WriteValue(IJSValueWriter const &writer, int16_t value) noexcept;
@@ -84,6 +86,14 @@ inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
 
 template <class T, std::enable_if_t<std::is_convertible_v<T, std::wstring_view>, int>>
 inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
+  writer.WriteString(value);
+}
+
+inline void WriteValue(IJSValueWriter const& writer, const winrt::hstring value) noexcept {
+  writer.WriteString(value);
+}
+
+inline void WriteValue(IJSValueWriter const &writer, const winrt::param::hstring value) noexcept {
   writer.WriteString(value);
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -23,8 +23,8 @@ template <class T, std::enable_if_t<std::is_convertible_v<T, std::string_view>, 
 void WriteValue(IJSValueWriter const &writer, T const &value) noexcept;
 template <class T, std::enable_if_t<std::is_convertible_v<T, std::wstring_view>, int> = 1>
 void WriteValue(IJSValueWriter const &writer, T const &value) noexcept;
-void WriteValue(IJSValueWriter const &writer, winrt::hstring value) noexcept;
-void WriteValue(IJSValueWriter const &writer, const winrt::param::hstring value) noexcept;
+void WriteValue(IJSValueWriter const &writer, winrt::hstring const &value) noexcept;
+void WriteValue(IJSValueWriter const &writer, winrt::param::hstring const &value) noexcept;
 void WriteValue(IJSValueWriter const &writer, bool value) noexcept;
 void WriteValue(IJSValueWriter const &writer, int8_t value) noexcept;
 void WriteValue(IJSValueWriter const &writer, int16_t value) noexcept;
@@ -89,11 +89,11 @@ inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
   writer.WriteString(value);
 }
 
-inline void WriteValue(IJSValueWriter const &writer, const winrt::hstring value) noexcept {
+inline void WriteValue(IJSValueWriter const &writer, winrt::hstring const &value) noexcept {
   writer.WriteString(value);
 }
 
-inline void WriteValue(IJSValueWriter const &writer, const winrt::param::hstring value) noexcept {
+inline void WriteValue(IJSValueWriter const &writer, winrt::param::hstring const &value) noexcept {
   writer.WriteString(value);
 }
 


### PR DESCRIPTION
This pull request fixes #6166
The `winrt::hstring` is now handled separately when performing read/write operations on JS<->Native values passing.

---

This pull request implements the ReadValue and WriteValue functions as a separate overloads.
The benefit of this approach is that when passing the `winrt::hstring` value it is considered directly as this type, so there's no conversion required.
Without those overloads, the templated functions would catch the `is_convertible` and would pass it as the `std::string` or `std::wstring` which would cause yet another conversions after selecting and entering the overloaded constructor of `winrt::hstring`.

Changes introduced in this PR are:
* add `WriteValue` overloaded functions for both `winrt::hstring` and `winrt::param::hstring`
Even if using `winrt::param::` namespace should be avoided (see [hstring](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/strings#the-rationale-for-winrthstring-and-winrtparamhstring) docs) implementing explicit overloaded function for this type ensures that `winrt::param::` namespace won't be considered as `is_convertible` which would result in still inefficient conversions.
* add `ReadValue` function which takes the `winrt::hstring` type
There's no separation for `winrt::param::` anymore as there's no risk of falling into templated functions. Subset of `winrt::` namespace should be always considered as the best match for their parents overload.

For more details about the implementation please check the commit messages.

---

Unit tests are not modified in this PR as they are not affected by this implementation (no change in passing/failing ratio between before and after).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6704)