### PR TITLE
[0.64] Cherry pick JS ABI and UI Manager destruction fixes

### DIFF
--- a/change/react-native-windows-34026362-bdf7-4921-9cb1-90b87780623e.json
+++ b/change/react-native-windows-34026362-bdf7-4921-9cb1-90b87780623e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix getting JsiRuntime for host functions",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-5e214434-8983-474c-8d79-cae036a5fc24.json
+++ b/change/react-native-windows-5e214434-8983-474c-8d79-cae036a5fc24.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix getting host objects and functions in JSI ABI",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-a206e50b-eb3d-4f1e-bb61-35d4d333e417.json
+++ b/change/react-native-windows-a206e50b-eb3d-4f1e-bb61-35d4d333e417.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix destruction of UIManager in UI thread",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/Modules/UIManagerModule.cpp
+++ b/vnext/Desktop/Modules/UIManagerModule.cpp
@@ -9,6 +9,7 @@ using namespace std;
 #include <algorithm>
 #include <iostream>
 
+#include <Threading/MessageDispatchQueue.h>
 #include <unicode.h>
 #include "ShadowNode.h"
 #include "ShadowNodeRegistry.h"
@@ -459,7 +460,11 @@ UIManagerModule::UIManagerModule(
 UIManagerModule::~UIManagerModule() noexcept {
   if (m_uiQueue) {
     // To make sure that we destroy UI components in UI thread.
-    m_uiQueue->runOnQueue([manager = std::move(m_manager)]() {});
+    // We cannot use the m_uiQueue->runOnQueue directly because
+    // the UI MessageQueueThread is already stopped.
+    std::static_pointer_cast<Mso::React::MessageDispatchQueue>(m_uiQueue)
+        ->DispatchQueue()
+        .Post([manager = std::move(m_manager)]() noexcept {});
   }
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -43,52 +43,29 @@ struct JsiPreparedJavaScriptWrapper : facebook::jsi::PreparedJavaScript {
 // An ABI-safe wrapper for facebook::jsi::HostObject.
 struct JsiHostObjectWrapper : implements<JsiHostObjectWrapper, IJsiHostObject> {
   JsiHostObjectWrapper(std::shared_ptr<facebook::jsi::HostObject> &&hostObject) noexcept;
-  ~JsiHostObjectWrapper() noexcept;
 
   JsiValueRef GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name);
   void SetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name, JsiValueRef const &value);
   Windows::Foundation::Collections::IVector<JsiPropertyIdRef> GetPropertyIds(JsiRuntime const &runtime);
 
-  static void RegisterHostObject(JsiObjectRef const &objectData, JsiHostObjectWrapper *hostObject) noexcept;
-  static bool IsHostObject(JsiObjectRef const &objectData) noexcept;
-  static std::shared_ptr<facebook::jsi::HostObject> GetHostObject(JsiObjectRef const &objectData) noexcept;
+  std::shared_ptr<facebook::jsi::HostObject> const &HostObjectSharedPtr() noexcept;
 
  private:
   std::shared_ptr<facebook::jsi::HostObject> m_hostObject;
-  JsiObjectRef m_objectData{};
-
-  static std::mutex s_mutex;
-  static std::map<uint64_t, JsiHostObjectWrapper *> s_objectDataToObjectWrapper;
 };
 
 // The function object that wraps up the facebook::jsi::HostFunctionType
 struct JsiHostFunctionWrapper {
   // We only support new and move constructors.
-  JsiHostFunctionWrapper(facebook::jsi::HostFunctionType &&hostFunction, uint32_t functionId) noexcept;
-  JsiHostFunctionWrapper(JsiHostFunctionWrapper &&other) noexcept;
-  ~JsiHostFunctionWrapper() noexcept;
-
-  // Disable other ways to construct or modify the wrapper.
-  JsiHostFunctionWrapper &operator=(JsiHostFunctionWrapper &&other) = delete;
-  JsiHostFunctionWrapper(JsiHostFunctionWrapper const &other) = delete;
-  JsiHostFunctionWrapper &operator=(JsiHostFunctionWrapper const &other) = delete;
+  JsiHostFunctionWrapper(facebook::jsi::HostFunctionType &&hostFunction) noexcept;
 
   JsiValueRef operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<JsiValueRef const> args);
 
-  static uint32_t GetNextFunctionId() noexcept;
-  static void RegisterHostFunction(uint32_t functionId, JsiObjectRef const &func) noexcept;
-  static bool IsHostFunction(JsiObjectRef const &func) noexcept;
-  static facebook::jsi::HostFunctionType &GetHostFunction(JsiObjectRef const &func) noexcept;
+  static facebook::jsi::HostFunctionType &GetHostFunction(JsiHostFunction const &hostFunction) noexcept;
 
  private:
   facebook::jsi::HostFunctionType m_hostFunction;
   JsiObjectRef m_functionData{};
-  uint32_t m_functionId{};
-
-  static std::mutex s_functionMutex;
-  static std::atomic<uint32_t> s_functionIdGenerator;
-  static std::map<uint32_t, JsiHostFunctionWrapper *> s_functionIdToFunctionWrapper;
-  static std::map<uint64_t, JsiHostFunctionWrapper *> s_functionDataToFunctionWrapper;
 };
 
 struct JsiAbiRuntime;

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -15,14 +15,48 @@ REACT_MODULE(TestHostModule)
 struct TestHostModule {
   REACT_INIT(Initialize)
   void Initialize(ReactContext const &reactContext) noexcept {
+    using namespace facebook::jsi;
     TestHostModule::Instance.set_value(*this);
 
     bool jsiExecuted{false};
-    ExecuteJsi(reactContext, [&](facebook::jsi::Runtime &rt) {
+    ExecuteJsi(reactContext, [&](Runtime &rt) {
       jsiExecuted = true;
       auto eval = rt.global().getPropertyAsFunction(rt, "eval");
       auto addFunc = eval.call(rt, "(function(x, y) { return x + y; })").getObject(rt).getFunction(rt);
       TestCheckEqual(7, addFunc.call(rt, 3, 4).getNumber());
+
+      Function hostGreeter = Function::createFromHostFunction(
+          rt,
+          PropNameID::forAscii(rt, "multFunc"),
+          1,
+          [](Runtime &rt, const Value & /*thisVal*/, const Value *args, size_t /*count*/) {
+            return Value{rt, String::createFromUtf8(rt, "Hello " + args[0].getString(rt).utf8(rt))};
+          });
+      TestCheckEqual("Hello World", hostGreeter.call(rt, "World").getString(rt).utf8(rt));
+      TestCheck(hostGreeter.getHostFunction(rt) != nullptr);
+
+      Function hostGreater2 = hostGreeter.getFunction(rt);
+      TestCheck(hostGreater2.isHostFunction(rt));
+      TestCheckEqual("Hello World", hostGreater2.call(rt, "World").getString(rt).utf8(rt));
+      TestCheck(hostGreater2.getHostFunction(rt) != nullptr);
+
+      class GreeterHostObject : public HostObject {
+        Value get(Runtime &rt, const PropNameID &) override {
+          return String::createFromAscii(rt, "Hello");
+        }
+        void set(Runtime &, const PropNameID &, const Value &) override {}
+      };
+
+      Object hostObjGreeter = Object::createFromHostObject(rt, std::make_shared<GreeterHostObject>());
+      TestCheckEqual(
+          "Hello", hostObjGreeter.getProperty(rt, PropNameID::forAscii(rt, "someProp")).getString(rt).utf8(rt));
+      TestCheck(hostObjGreeter.getHostObject(rt) != nullptr);
+
+      Object hostObjGreeter2 = Value{rt, hostObjGreeter}.getObject(rt);
+      TestCheck(hostObjGreeter2.isHostObject(rt));
+      TestCheckEqual(
+          "Hello", hostObjGreeter2.getProperty(rt, PropNameID::forAscii(rt, "someProp")).getString(rt).utf8(rt));
+      TestCheck(hostObjGreeter2.getHostObject(rt) != nullptr);
     });
     TestCheck(jsiExecuted);
   }

--- a/vnext/Microsoft.ReactNative/JsiApi.cpp
+++ b/vnext/Microsoft.ReactNative/JsiApi.cpp
@@ -171,9 +171,10 @@ static facebook::jsi::Value &&ToValue(JsiValueRef &&value) noexcept {
   return reinterpret_cast<facebook::jsi::Value &&>(value);
 }
 
-static facebook::jsi::HostFunctionType MakeHostFunction(Microsoft::ReactNative::JsiHostFunction const &hostFunc) {
-  // TODO: implement host function mapping
-  return [hostFunc](
+static facebook::jsi::HostFunctionType MakeHostFunction(
+    Microsoft::ReactNative::JsiHostFunction const &hostFunc,
+    std::shared_ptr<JsiRuntime::HostFunctionCleaner> &&cleaner) {
+  return [hostFunc, cleaner](
              facebook::jsi::Runtime &runtime,
              facebook::jsi::Value const &thisVal,
              facebook::jsi::Value const *args,
@@ -310,16 +311,57 @@ facebook::jsi::JSError const &jsError) {                             \
   } catch (...
 
 /*static*/ std::mutex JsiRuntime::s_mutex;
-/*static*/ std::map<uintptr_t, weak_ref<ReactNative::JsiRuntime>> JsiRuntime::s_jsiRuntimeMap;
+/*static*/ std::unordered_map<uintptr_t, weak_ref<ReactNative::JsiRuntime>> JsiRuntime::s_jsiRuntimeMap;
+/*static*/ std::unordered_map<int64_t, ReactNative::JsiHostFunction> JsiRuntime::s_jsiHostFunctionMap;
+/*static*/ int64_t JsiRuntime::s_jsiNextHostFunctionId{0};
 
-/*static*/ ReactNative::JsiRuntime JsiRuntime::FromRuntime(facebook::jsi::Runtime &runtime) noexcept {
+/*static*/ ReactNative::JsiRuntime JsiRuntime::FromRuntime(facebook::jsi::Runtime &jsiRuntime) noexcept {
   std::scoped_lock lock{s_mutex};
-  auto it = s_jsiRuntimeMap.find(reinterpret_cast<uintptr_t>(&runtime));
+  auto it = s_jsiRuntimeMap.find(reinterpret_cast<uintptr_t>(&jsiRuntime));
   if (it != s_jsiRuntimeMap.end()) {
     return it->second.get();
   } else {
     return nullptr;
   }
+}
+
+/*static*/ ReactNative::JsiRuntime JsiRuntime::GetOrCreate(
+    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+    std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept {
+  {
+    std::scoped_lock lock{s_mutex};
+    auto it = s_jsiRuntimeMap.find(reinterpret_cast<uintptr_t>(jsiRuntime.get()));
+    if (it != s_jsiRuntimeMap.end()) {
+      return it->second.get();
+    }
+  }
+
+  return Create(jsiRuntimeHolder, jsiRuntime);
+}
+
+/*static*/ ReactNative::JsiRuntime JsiRuntime::Create(
+    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+    std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept {
+  // There are some functions that we cannot do using JSI such as
+  // defining a property or using Symbol as a key.
+  // The __jsi_api defines functions to associate a hostFunctionId with a function object
+  // in a way that it is not discoverable by other components.
+  // We use a unique symbol and make read-only, non-enumerable, and non-configurable (deletable).
+  auto jsiPalBuffer = std::make_shared<facebook::jsi::StringBuffer>(R"JS(
+      var __jsi_pal = function() {
+        var hostFunctionId = Symbol('hostFunctionId');
+        return {
+          getHostFunctionId: function(func) { return func[hostFunctionId]; },
+          setHostFunctionId: function(func, id) { Object.defineProperty(func, hostFunctionId, { value: id }); }
+        };
+      }();
+    )JS");
+  // TODO: consider implementing this script as a resource file and loading it with the resource URL.
+  jsiRuntime->evaluateJavaScript(jsiPalBuffer, "Form_JSI_API_not_a_real_file");
+  ReactNative::JsiRuntime abiJsiResult{make<JsiRuntime>(Mso::Copy(jsiRuntimeHolder), Mso::Copy(jsiRuntime))};
+  std::scoped_lock lock{s_mutex};
+  s_jsiRuntimeMap.try_emplace(reinterpret_cast<uintptr_t>(jsiRuntime.get()), abiJsiResult);
+  return abiJsiResult;
 }
 
 ReactNative::JsiRuntime JsiRuntime::MakeChakraRuntime() {
@@ -330,10 +372,7 @@ ReactNative::JsiRuntime JsiRuntime::MakeChakraRuntime() {
   auto runtimeHolder = std::make_shared<::Microsoft::JSI::ChakraRuntimeHolder>(
       std::move(devSettings), std::move(jsThread), nullptr, nullptr);
   auto runtime = runtimeHolder->getRuntime();
-  ReactNative::JsiRuntime result{make<JsiRuntime>(std::move(runtimeHolder), Mso::Copy(runtime))};
-  std::scoped_lock lock{s_mutex};
-  s_jsiRuntimeMap.try_emplace(reinterpret_cast<uintptr_t>(runtime.get()), result);
-  return result;
+  return Create(runtimeHolder, runtime);
 }
 
 JsiRuntime::JsiRuntime(
@@ -564,8 +603,20 @@ IJsiHostObject JsiRuntime::GetHostObject(JsiObjectRef obj) try {
 
 JsiHostFunction JsiRuntime::GetHostFunction(JsiObjectRef func) try {
   auto funcPtr = AsPointerValue(func);
-  // auto hostFunction = m_runtime->getHostFunction(AsFunction(func));
-  // TODO: implement mapping
+  auto const &jsiFunc = AsFunction(&funcPtr);
+  auto &rt = *m_runtime;
+  int64_t hostFunctionId = static_cast<int64_t>(rt.global()
+                                                    .getPropertyAsObject(rt, "__jsi_pal")
+                                                    .getPropertyAsFunction(rt, "getHostFunctionId")
+                                                    .call(rt, jsiFunc)
+                                                    .getNumber());
+  {
+    std::scoped_lock lock{m_mutex};
+    auto it = s_jsiHostFunctionMap.find(hostFunctionId);
+    if (it != s_jsiHostFunctionMap.end()) {
+      return it->second;
+    }
+  }
   return nullptr;
 } catch (JSI_SET_ERROR) {
   throw;
@@ -694,13 +745,33 @@ void JsiRuntime::SetValueAtIndex(JsiObjectRef arr, uint32_t index, JsiValueRef c
   throw;
 }
 
+JsiRuntime::HostFunctionCleaner::HostFunctionCleaner(int64_t hostFunctionId) : m_hostFunctionId{hostFunctionId} {}
+
+JsiRuntime::HostFunctionCleaner::~HostFunctionCleaner() {
+  std::scoped_lock lock{s_mutex};
+  s_jsiHostFunctionMap.erase(m_hostFunctionId);
+}
+
 JsiObjectRef JsiRuntime::CreateFunctionFromHostFunction(
     JsiPropertyIdRef propNameId,
     uint32_t paramCount,
     JsiHostFunction const &hostFunc) try {
+  int64_t hostFunctionId;
+  {
+    std::scoped_lock lock{s_mutex};
+    hostFunctionId = ++s_jsiNextHostFunctionId;
+    s_jsiHostFunctionMap[hostFunctionId] = hostFunc;
+  }
+  auto cleaner = std::make_shared<HostFunctionCleaner>(hostFunctionId);
+  auto &rt = *m_runtime;
   auto propertyIdPtr = AsPointerValue(propNameId);
-  return MakeJsiFunctionData(
-      m_runtime->createFunctionFromHostFunction(AsPropNameID(&propertyIdPtr), paramCount, MakeHostFunction(hostFunc)));
+  auto func = rt.createFunctionFromHostFunction(
+      AsPropNameID(&propertyIdPtr), paramCount, MakeHostFunction(hostFunc, std::move(cleaner)));
+  rt.global()
+      .getPropertyAsObject(rt, "__jsi_pal")
+      .getPropertyAsFunction(rt, "setHostFunctionId")
+      .call(rt, func, static_cast<double>(hostFunctionId));
+  return MakeJsiFunctionData(std::move(func));
 } catch (JSI_SET_ERROR) {
   throw;
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -839,8 +839,8 @@ winrt::Microsoft::ReactNative::JsiRuntime ReactInstanceWin::JsiRuntime() noexcep
     std::scoped_lock lock{m_mutex};
     if (!m_jsiRuntime && jsiRuntime) {
       // Set only if other thread did not do it yet.
-      m_jsiRuntime = winrt::make<winrt::Microsoft::ReactNative::implementation::JsiRuntime>(
-          std::move(jsiRuntimeHolder), std::move(jsiRuntime));
+      m_jsiRuntime =
+          winrt::Microsoft::ReactNative::implementation::JsiRuntime::GetOrCreate(jsiRuntimeHolder, jsiRuntime);
     }
 
     return m_jsiRuntime;


### PR DESCRIPTION
The PR cherry picks 3 PRs from master to 0.64-stable:
- Fix getting host objects and functions in JSI ABI (#6693)
- Fix destruction of UIManager in UI thread (#6680)
- Fix getting JsiRuntime for host functions (#6644)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6712)