### PR TITLE
Fix: Control with "AccessibilityRole" automatically get tab focus no matter the value of focusable prop

### DIFF
--- a/change/react-native-windows-6b0a9e7b-b179-4854-91fa-a1752c5c89b7.json
+++ b/change/react-native-windows-6b0a9e7b-b179-4854-91fa-a1752c5c89b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "In Xaml, IsTabStop makes a control be able to receive focus or not so we also need to set it when IsFocusable is set.",
+  "packageName": "react-native-windows",
+  "email": "lamdoan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -124,6 +124,9 @@ class ViewShadowNode : public ShadowNodeBase {
   }
   void IsFocusable(bool isFocusable) {
     m_isFocusable = isFocusable;
+
+    if (IsControl())
+      GetControl().IsTabStop(m_isFocusable);
   }
 
   bool IsHitTestBrushRequired() const {
@@ -190,6 +193,7 @@ class ViewShadowNode : public ShadowNodeBase {
     // shadow node to the view
     EnableFocusRing(EnableFocusRing());
     TabIndex(TabIndex());
+    IsFocusable(IsFocusable());
     static_cast<FrameworkElementViewManager *>(GetViewManager())->RefreshTransformMatrix(this);
   }
 


### PR DESCRIPTION
#6652 

Setting accessibility props will make a ContentControl which will have keyboard focus on by default even if IsFocusable is set to false. To fix this, we need to also set the IsTabStop property on the ContentControl so that it isn't able to receive keyboard focus.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6728)