### PR TITLE
Add tabIndex property for Button

### DIFF
--- a/change/react-native-windows-136ae86b-5757-4cb4-8cec-a50da19528c3.json
+++ b/change/react-native-windows-136ae86b-5757-4cb4-8cec-a50da19528c3.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Fix tabINdex property for Button",
+  "comment": "Fix tabIndex property for Button",
   "packageName": "react-native-windows",
   "email": "igklemen@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-136ae86b-5757-4cb4-8cec-a50da19528c3.json
+++ b/change/react-native-windows-136ae86b-5757-4cb4-8cec-a50da19528c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix tabINdex property for Button",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -418,11 +418,9 @@ bool ViewViewManager::UpdateProperty(
       else if (propertyValue.IsNull())
         pViewShadowNode->EnableFocusRing(false);
     } else if (propertyName == "tabIndex") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64) {
-        auto tabIndex = propertyValue.AsDouble();
-        if (tabIndex == static_cast<int32_t>(tabIndex)) {
-          pViewShadowNode->TabIndex(static_cast<int32_t>(tabIndex));
-        }
+      auto tabIndex = propertyValue.AsInt64();
+      if (tabIndex == static_cast<int32_t>(tabIndex)) {
+        pViewShadowNode->TabIndex(static_cast<int32_t>(tabIndex));
       } else if (propertyValue.IsNull()) {
         pViewShadowNode->TabIndex(std::numeric_limits<std::int32_t>::max());
       }

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -418,7 +418,7 @@ bool ViewViewManager::UpdateProperty(
       else if (propertyValue.IsNull())
         pViewShadowNode->EnableFocusRing(false);
     } else if (propertyName == "tabIndex") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double) {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64) {
         auto tabIndex = propertyValue.AsDouble();
         if (tabIndex == static_cast<int32_t>(tabIndex)) {
           pViewShadowNode->TabIndex(static_cast<int32_t>(tabIndex));

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -136,10 +136,12 @@ type ButtonProps = $ReadOnly<{|
    */
   testID?: ?string,
 
+  // [Windows
   /**
     Set the order in which elements receive focus when the user navigates through them by pressing Tab.
    */
   tabIndex?: ?number,
+  // Windows]
 |}>;
 
 /**

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -135,6 +135,11 @@ type ButtonProps = $ReadOnly<{|
     Used to locate this view in end-to-end tests.
    */
   testID?: ?string,
+
+  /**
+    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+   */
+  tabIndex?: ?number,
 |}>;
 
 /**
@@ -264,6 +269,7 @@ class Button extends React.Component<ButtonProps> {
       nextFocusUp,
       disabled,
       testID,
+      tabIndex,
     } = this.props;
     const buttonStyles = [styles.button];
     const textStyles = [styles.text];
@@ -304,6 +310,7 @@ class Button extends React.Component<ButtonProps> {
         testID={testID}
         disabled={disabled}
         onPress={onPress}
+        tabIndex={tabIndex}
         touchSoundDisabled={touchSoundDisabled}>
         <View style={buttonStyles}>
           <Text style={textStyles} disabled={disabled}>


### PR DESCRIPTION
Fixes #6200 

The tabIndex prop needs to be forwarded to the underlying TouchableHighlight in order to make its way to ViewViewManager, which implements it. 
Also had to change the JSValueType that is expected from Double to Int64 for it to work.

Tested locally running:
```
<Button title="button 1" {...{tabIndex: 1}} />
<Button title="button 3" {...{tabIndex: 3}} />
<Button title="button 2" {...{tabIndex: 2}} />
```
![buttonIndex](https://user-images.githubusercontent.com/12816515/101960834-29bc5c00-3bbd-11eb-854a-8576690d42bb.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6732)