### PR TITLE
 Fix missing dependency / race condition in pacakge.json

### DIFF
--- a/change/react-native-platform-override-2020-12-11-15-19-22-master.json
+++ b/change/react-native-platform-override-2020-12-11-15-19-22-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix missing dependency / race condition in pacakge.json",
+  "packageName": "react-native-platform-override",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-11T23:19:22.676Z"
+}

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -45,6 +45,7 @@
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/jest-unittest-config": "0.1.1",
     "@rnw-scripts/just-task": "0.0.6",
+    "@rnw-scripts/package-utils": "0.0.11",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/async": "^3.2.3",
     "@types/chalk": "^2.2.0",


### PR DESCRIPTION
File `packages\react-native-platform-override\src\FileSearch.ts` imports `@rnw-scripts/package-utils` but didn't declare a package dependency. This cased a random failure in the MacOs Tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6733)