### PR TITLE
Fix RedBox on topMouseLeave event.

### DIFF
--- a/change/react-native-windows-92856720-40ea-4e20-ac14-b1c0178f1ba0.json
+++ b/change/react-native-windows-92856720-40ea-4e20-ac14-b1c0178f1ba0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix RedBox on topMouseLeave event.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -172,11 +172,11 @@ void ViewManagerBase::GetExportedCustomBubblingEventTypeConstants(
 
 void ViewManagerBase::GetExportedCustomDirectEventTypeConstants(
     const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
-  const PCWSTR eventNames[] = {// Generic events
-                               L"Layout",
-                               L"MouseEnter",
-                               L"MouseLeave",
-                               L"AccessibilityAction"};
+  constexpr PCWSTR eventNames[] = {// Generic events
+                                   L"Layout",
+                                   L"MouseEnter",
+                                   L"MouseLeave",
+                                   L"AccessibilityAction"};
 
   for (auto &eventBaseName : eventNames) {
     using namespace std::string_literals;

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -175,6 +175,7 @@ void ViewManagerBase::GetExportedCustomDirectEventTypeConstants(
   const PCWSTR eventNames[] = {// Generic events
                                L"Layout",
                                L"MouseEnter",
+                               L"MouseLeave",
                                L"AccessibilityAction"};
 
   for (auto &eventBaseName : eventNames) {


### PR DESCRIPTION
Fixes #6738 
In #6268 we accidentally dropped the `topMouseLeave` event's registration in ViewManagerBase.cpp, which led to it missing in the ViewConfig in JS. 

Verified in Chrome debugger that the 'Unsupported top level event type..' exception is longer thrown from ReactNativeRenderer-dev.js@2426

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6739)