### PR TITLE
Fix facebook::jsi::Runtime lifetime for ABI JSI

### DIFF
--- a/change/react-native-windows-a3ba06da-a261-42a2-be5d-9b023d3493f9.json
+++ b/change/react-native-windows-a3ba06da-a261-42a2-be5d-9b023d3493f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix facebook::jsi::Runtime lifetime for ABI JSI",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -93,7 +93,7 @@ JsiHostObjectWrapper::JsiHostObjectWrapper(std::shared_ptr<HostObject> &&hostObj
     : m_hostObject(std::move(hostObject)) {}
 
 JsiValueRef JsiHostObjectWrapper::GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
+  JsiAbiRuntime* rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   JsiAbiRuntime::PropNameIDRef nameRef{name};
   return JsiAbiRuntime::DetachJsiValueRef(m_hostObject->get(*rt, nameRef));
 } catch (JSI_RUNTIME_SET_ERROR(runtime)) {
@@ -104,7 +104,7 @@ void JsiHostObjectWrapper::SetProperty(
     JsiRuntime const &runtime,
     JsiPropertyIdRef const &name,
     JsiValueRef const &value) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
+  JsiAbiRuntime *rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   m_hostObject->set(*rt, JsiAbiRuntime::PropNameIDRef{name}, JsiAbiRuntime::ValueRef(value));
 } catch (JSI_RUNTIME_SET_ERROR(runtime)) {
   throw;
@@ -112,7 +112,7 @@ void JsiHostObjectWrapper::SetProperty(
 
 Windows::Foundation::Collections::IVector<JsiPropertyIdRef> JsiHostObjectWrapper::GetPropertyIds(
     JsiRuntime const &runtime) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
+  JsiAbiRuntime *rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   auto names = m_hostObject->getPropertyNames(*rt);
   std::vector<JsiPropertyIdRef> result;
   result.reserve(names.size());
@@ -138,7 +138,7 @@ JsiHostFunctionWrapper::JsiHostFunctionWrapper(HostFunctionType &&hostFunction) 
 
 JsiValueRef JsiHostFunctionWrapper::
 operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<JsiValueRef const> args) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
+  JsiAbiRuntime *rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   JsiAbiRuntime::ValueRefArray valueRefArgs{args};
   return JsiAbiRuntime::DetachJsiValueRef(
       m_hostFunction(*rt, JsiAbiRuntime::ValueRef{thisArg}, valueRefArgs.Data(), valueRefArgs.Size()));
@@ -151,33 +151,6 @@ operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<Jsi
   JsiHostFunctionWrapper *self =
       static_cast<impl::delegate<JsiHostFunction, JsiHostFunctionWrapper> *>(hostFunctionAbi);
   return self->m_hostFunction;
-}
-
-//===========================================================================
-// JsiAbiRuntimeHolder implementation
-//===========================================================================
-
-JsiAbiRuntimeHolder::JsiAbiRuntimeHolder(std::unique_ptr<JsiAbiRuntime> jsiRuntime) noexcept
-    : m_jsiRuntime{std::move(jsiRuntime)}, m_isOwning{true} {}
-
-JsiAbiRuntimeHolder::JsiAbiRuntimeHolder(JsiAbiRuntime *jsiRuntime) noexcept : m_jsiRuntime{jsiRuntime} {}
-
-JsiAbiRuntimeHolder::operator bool() noexcept {
-  return m_jsiRuntime != nullptr;
-}
-
-JsiAbiRuntime &JsiAbiRuntimeHolder::operator*() noexcept {
-  return *m_jsiRuntime;
-}
-
-JsiAbiRuntime *JsiAbiRuntimeHolder::operator->() noexcept {
-  return m_jsiRuntime.get();
-}
-
-JsiAbiRuntimeHolder ::~JsiAbiRuntimeHolder() noexcept {
-  if (!m_isOwning) {
-    m_jsiRuntime.release();
-  }
 }
 
 //===========================================================================

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -93,7 +93,7 @@ JsiHostObjectWrapper::JsiHostObjectWrapper(std::shared_ptr<HostObject> &&hostObj
     : m_hostObject(std::move(hostObject)) {}
 
 JsiValueRef JsiHostObjectWrapper::GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name) try {
-  JsiAbiRuntime* rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
+  JsiAbiRuntime *rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   JsiAbiRuntime::PropNameIDRef nameRef{name};
   return JsiAbiRuntime::DetachJsiValueRef(m_hostObject->get(*rt, nameRef));
 } catch (JSI_RUNTIME_SET_ERROR(runtime)) {

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -12,14 +12,14 @@ namespace winrt::Microsoft::ReactNative {
 
 // The macro to simplify recording JSI exceptions.
 // It looks strange to keep the normal structure of the try/catch in code.
-#define JSI_RUNTIME_SET_ERROR(runtime)                         \
-facebook::jsi::JSError const &jsError) {                       \
-    JsiAbiRuntime::GetOrCreate(runtime)->SetJsiError(jsError); \
-    throw;                                                     \
-  }                                                            \
-  catch (std::exception const &ex) {                           \
-    JsiAbiRuntime::GetOrCreate(runtime)->SetJsiError(ex);      \
-    throw;                                                     \
+#define JSI_RUNTIME_SET_ERROR(runtime)                               \
+facebook::jsi::JSError const &jsError) {                             \
+    JsiAbiRuntime::GetFromJsiRuntime(runtime)->SetJsiError(jsError); \
+    throw;                                                           \
+  }                                                                  \
+  catch (std::exception const &ex) {                                 \
+    JsiAbiRuntime::GetFromJsiRuntime(runtime)->SetJsiError(ex);      \
+    throw;                                                           \
   } catch (...
 
 //===========================================================================
@@ -93,7 +93,7 @@ JsiHostObjectWrapper::JsiHostObjectWrapper(std::shared_ptr<HostObject> &&hostObj
     : m_hostObject(std::move(hostObject)) {}
 
 JsiValueRef JsiHostObjectWrapper::GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetOrCreate(runtime)};
+  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   JsiAbiRuntime::PropNameIDRef nameRef{name};
   return JsiAbiRuntime::DetachJsiValueRef(m_hostObject->get(*rt, nameRef));
 } catch (JSI_RUNTIME_SET_ERROR(runtime)) {
@@ -104,7 +104,7 @@ void JsiHostObjectWrapper::SetProperty(
     JsiRuntime const &runtime,
     JsiPropertyIdRef const &name,
     JsiValueRef const &value) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetOrCreate(runtime)};
+  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   m_hostObject->set(*rt, JsiAbiRuntime::PropNameIDRef{name}, JsiAbiRuntime::ValueRef(value));
 } catch (JSI_RUNTIME_SET_ERROR(runtime)) {
   throw;
@@ -112,7 +112,7 @@ void JsiHostObjectWrapper::SetProperty(
 
 Windows::Foundation::Collections::IVector<JsiPropertyIdRef> JsiHostObjectWrapper::GetPropertyIds(
     JsiRuntime const &runtime) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetOrCreate(runtime)};
+  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   auto names = m_hostObject->getPropertyNames(*rt);
   std::vector<JsiPropertyIdRef> result;
   result.reserve(names.size());
@@ -138,7 +138,7 @@ JsiHostFunctionWrapper::JsiHostFunctionWrapper(HostFunctionType &&hostFunction) 
 
 JsiValueRef JsiHostFunctionWrapper::
 operator()(JsiRuntime const &runtime, JsiValueRef const &thisArg, array_view<JsiValueRef const> args) try {
-  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetOrCreate(runtime)};
+  JsiAbiRuntimeHolder rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   JsiAbiRuntime::ValueRefArray valueRefArgs{args};
   return JsiAbiRuntime::DetachJsiValueRef(
       m_hostFunction(*rt, JsiAbiRuntime::ValueRef{thisArg}, valueRefArgs.Data(), valueRefArgs.Size()));
@@ -220,14 +220,6 @@ JsiAbiRuntime::~JsiAbiRuntime() {
     }
   }
   return nullptr;
-}
-
-/*static*/ JsiAbiRuntimeHolder JsiAbiRuntime::GetOrCreate(JsiRuntime const &runtime) noexcept {
-  JsiAbiRuntimeHolder result{GetFromJsiRuntime(runtime)};
-  if (!result) {
-    result = std::make_unique<JsiAbiRuntime>(runtime);
-  }
-  return result;
 }
 
 Value JsiAbiRuntime::evaluateJavaScript(const std::shared_ptr<const Buffer> &buffer, const std::string &sourceURL) try {

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -68,28 +68,6 @@ struct JsiHostFunctionWrapper {
   JsiObjectRef m_functionData{};
 };
 
-struct JsiAbiRuntime;
-
-// Keeps owning or not owning pointer to JsiAbiRuntime
-struct JsiAbiRuntimeHolder {
-  JsiAbiRuntimeHolder(std::unique_ptr<JsiAbiRuntime> jsiRuntime) noexcept;
-  JsiAbiRuntimeHolder(JsiAbiRuntime *jsiRuntime) noexcept;
-  ~JsiAbiRuntimeHolder() noexcept;
-
-  JsiAbiRuntimeHolder(JsiAbiRuntimeHolder const &) = delete;
-  JsiAbiRuntimeHolder &operator=(JsiAbiRuntimeHolder const &) = delete;
-  JsiAbiRuntimeHolder(JsiAbiRuntimeHolder &&) = default;
-  JsiAbiRuntimeHolder &operator=(JsiAbiRuntimeHolder &&) = default;
-
-  explicit operator bool() noexcept;
-  JsiAbiRuntime &operator*() noexcept;
-  JsiAbiRuntime *operator->() noexcept;
-
- private:
-  std::unique_ptr<JsiAbiRuntime> m_jsiRuntime;
-  bool m_isOwning{false};
-};
-
 // JSI runtime implementation as a wrapper for the ABI-safe JsiRuntime.
 struct JsiAbiRuntime : facebook::jsi::Runtime {
   JsiAbiRuntime(JsiRuntime const &runtime) noexcept;

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -98,9 +98,6 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
   // Get JsiAbiRuntime from JsiRuntime in current thread.
   static JsiAbiRuntime *GetFromJsiRuntime(JsiRuntime const &runtime) noexcept;
 
-  // Get JsiAbiRuntime from JsiRuntime in current thread or create a new one.
-  static JsiAbiRuntimeHolder GetOrCreate(JsiRuntime const &runtime) noexcept;
-
   facebook::jsi::Value evaluateJavaScript(
       const std::shared_ptr<const facebook::jsi::Buffer> &buffer,
       const std::string &sourceURL) override;

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
@@ -7,7 +7,54 @@
 #include "../ReactContext.h"
 #include "JsiAbiApi.h"
 
+// Use __ImageBase to get current DLL handle.
+// http://blogs.msdn.com/oldnewthing/archive/2004/10/25/247180.aspx
+extern "C" IMAGE_DOS_HEADER __ImageBase;
+
 namespace winrt::Microsoft::ReactNative {
+
+// Get JSI Runtime from the current JS dispatcher thread.
+// If it is not found, then create it and store it in the context.Properties().
+// Make sure that the JSI runtime holder is removed when the instance is unloaded.
+facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) noexcept {
+  ReactDispatcher jsDispatcher = context.JSDispatcher();
+  VerifyElseCrashSz(jsDispatcher.HasThreadAccess(), "Must be in JS thread");
+
+  // The JSI runtime is not available if we do Web debugging when JS is running in web browser.
+  JsiRuntime abiJsiRuntime = context.Handle().JSRuntime().as<JsiRuntime>();
+  VerifyElseCrashSz(abiJsiRuntime, "JSI runtime is not available");
+
+  // See if the JSI runtime was previously created.
+  JsiAbiRuntime *runtime = JsiAbiRuntime::GetFromJsiRuntime(abiJsiRuntime);
+  if (!runtime) {
+    // Create the runtime
+    std::unique_ptr<JsiAbiRuntime> runtimeHolder = std::make_unique<JsiAbiRuntime>(abiJsiRuntime);
+    runtime = runtimeHolder.get();
+
+    // We want to keep the JSI runtime while current instance is alive.
+    // The JSI runtime object must be local to our DLL.
+    // We create a property name based on the current DLL handle.
+    HMODULE currentDll = reinterpret_cast<HMODULE>(&__ImageBase);
+    std::wstring jsiRuntimeLocalName = L"jsiRuntime_" + std::to_wstring(reinterpret_cast<uintptr_t>(currentDll));
+    using ValueType = ReactNonAbiValue<std::unique_ptr<JsiAbiRuntime>>;
+    ReactPropertyId<ValueType> jsiRuntimeProperty{L"ReactNative.InstanceData", jsiRuntimeLocalName.c_str()};
+    ValueType runtimeValue{std::in_place, std::move(runtimeHolder)};
+    context.Properties().Set(jsiRuntimeProperty, runtimeValue);
+
+    // We remove the JSI runtime from properties when React instance is destroyed.
+    auto destroyInstanceNotificationId{
+        ReactNotificationId<InstanceDestroyedEventArgs>{L"ReactNative.InstanceSettings", L"InstanceDestroyed"}};
+    context.Notifications().Subscribe(destroyInstanceNotificationId, jsDispatcher, [
+      context,
+      jsiRuntimeProperty
+    ](IInspectable const & /*sender*/, ReactNotificationArgs<InstanceDestroyedEventArgs> const &args) noexcept {
+      context.Properties().Remove(jsiRuntimeProperty);
+      args.Subscription().Unsubscribe(); // Unsubscribe after we handle the notification.
+    });
+  }
+
+  return *runtime;
+}
 
 // Call provided lambda with the facebook::jsi::Runtime& parameter.
 // For example: ExecuteJsi(context, [](facebook::jsi::Runtime& runtime){...})
@@ -17,12 +64,10 @@ void ExecuteJsi(ReactContext const &context, TCodeWithRuntime const &code) {
   ReactDispatcher jsDispatcher = context.JSDispatcher();
   if (jsDispatcher.HasThreadAccess()) {
     // Execute immediately if we are in JS thread.
-    code(*JsiAbiRuntime::GetOrCreate(context.Handle().JSRuntime().as<JsiRuntime>()));
+    code(GetOrCreateContextRuntime(context));
   } else {
     // Otherwise, schedule work in JS thread.
-    jsDispatcher.Post([ context, code ]() noexcept {
-      code(*JsiAbiRuntime::GetOrCreate(context.Handle().JSRuntime().as<JsiRuntime>()));
-    });
+    jsDispatcher.Post([ context, code ]() noexcept { code(GetOrCreateContextRuntime(context)); });
   }
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
@@ -44,13 +44,15 @@ facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) n
     // We remove the JSI runtime from properties when React instance is destroyed.
     auto destroyInstanceNotificationId{
         ReactNotificationId<InstanceDestroyedEventArgs>{L"ReactNative.InstanceSettings", L"InstanceDestroyed"}};
-    context.Notifications().Subscribe(destroyInstanceNotificationId, jsDispatcher, [
-      context,
-      jsiRuntimeProperty
-    ](IInspectable const & /*sender*/, ReactNotificationArgs<InstanceDestroyedEventArgs> const &args) noexcept {
-      context.Properties().Remove(jsiRuntimeProperty);
-      args.Subscription().Unsubscribe(); // Unsubscribe after we handle the notification.
-    });
+    context.Notifications().Subscribe(
+        destroyInstanceNotificationId,
+        jsDispatcher,
+        [ context, jsiRuntimeProperty ](
+            winrt::Windows::Foundation::IInspectable const & /*sender*/,
+            ReactNotificationArgs<InstanceDestroyedEventArgs> const &args) noexcept {
+          context.Properties().Remove(jsiRuntimeProperty);
+          args.Subscription().Unsubscribe(); // Unsubscribe after we handle the notification.
+        });
   }
 
   return *runtime;

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApi.h
@@ -34,8 +34,8 @@ facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) n
     // We want to keep the JSI runtime while current instance is alive.
     // The JSI runtime object must be local to our DLL.
     // We create a property name based on the current DLL handle.
-    HMODULE currentDll = reinterpret_cast<HMODULE>(&__ImageBase);
-    std::wstring jsiRuntimeLocalName = L"jsiRuntime_" + std::to_wstring(reinterpret_cast<uintptr_t>(currentDll));
+    HMODULE currentDllHanlde = reinterpret_cast<HMODULE>(&__ImageBase);
+    std::wstring jsiRuntimeLocalName = L"jsiRuntime_" + std::to_wstring(reinterpret_cast<uintptr_t>(currentDllHanlde));
     using ValueType = ReactNonAbiValue<std::unique_ptr<JsiAbiRuntime>>;
     ReactPropertyId<ValueType> jsiRuntimeProperty{L"ReactNative.InstanceData", jsiRuntimeLocalName.c_str()};
     ValueType runtimeValue{std::in_place, std::move(runtimeHolder)};

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -18,8 +18,10 @@ struct TestHostModule {
     using namespace facebook::jsi;
     TestHostModule::Instance.set_value(*this);
 
+    Runtime *jsiRuntime{nullptr};
     bool jsiExecuted{false};
     ExecuteJsi(reactContext, [&](Runtime &rt) {
+      jsiRuntime = &rt;
       jsiExecuted = true;
       auto eval = rt.global().getPropertyAsFunction(rt, "eval");
       auto addFunc = eval.call(rt, "(function(x, y) { return x + y; })").getObject(rt).getFunction(rt);
@@ -57,6 +59,14 @@ struct TestHostModule {
       TestCheckEqual(
           "Hello", hostObjGreeter2.getProperty(rt, PropNameID::forAscii(rt, "someProp")).getString(rt).utf8(rt));
       TestCheck(hostObjGreeter2.getHostObject(rt) != nullptr);
+    });
+    TestCheck(jsiExecuted);
+
+    jsiExecuted = false;
+    ExecuteJsi(reactContext, [&](Runtime &rt) {
+      jsiExecuted = true;
+      // Make sure that our ReactContext offers the same facebook::jsi::Runtime
+      TestCheckEqual(jsiRuntime, &rt);
     });
     TestCheck(jsiExecuted);
   }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -20,6 +20,7 @@ struct TestHostModule {
 
     Runtime *jsiRuntime{nullptr};
     bool jsiExecuted{false};
+    // The JSI executed synchronously here because we are in JS thread.
     ExecuteJsi(reactContext, [&](Runtime &rt) {
       jsiRuntime = &rt;
       jsiExecuted = true;
@@ -63,9 +64,9 @@ struct TestHostModule {
     TestCheck(jsiExecuted);
 
     jsiExecuted = false;
+    // Make sure that we use the same facebook::jsi::Runtime when we run second time.
     ExecuteJsi(reactContext, [&](Runtime &rt) {
       jsiExecuted = true;
-      // Make sure that our ReactContext offers the same facebook::jsi::Runtime
       TestCheckEqual(jsiRuntime, &rt);
     });
     TestCheck(jsiExecuted);

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -59,7 +59,7 @@ namespace Microsoft.ReactNative {
     IReactDispatcher UIDispatcher { get; };
 
     DOC_STRING(
-      "Get the JS thread dispatcher. \n "
+      "Get the JS thread dispatcher. \n"
       "It is a shortcut for the `ReactDispatcherHelper::JSDispatcherProperty` from the @.Properties property bag.")
     IReactDispatcher JSDispatcher { get; };
 


### PR DESCRIPTION
This is to address an issue in the ABI-safe JSI implementation:
- When we run `ExecuteJsi` we are getting new instances of `facebook::jsi::Runtime`.

The source of the issue is that the ownership of `JsiAbiRuntime`, which is a thin wrapper around the ABI-safe interface, was not well defined. In the current implementation it is held on the callstack. If some other component keeps the provided instance, it may experience crashes. The issue was identified by N-API implementation on top of JSI from the BabylonNative project. This implementation needs to keep the `Runtime` inside of the `napi_env`.

In this PR we address the issue by keeping the `JsiAbiRuntime` inside of the `context.Properties()`. We use a property name derived from the current DLL handle. It allows each native module DLL to have their own `JsiAbiRuntime` wrapper for JSI ABI. Also, we subscribe to the React instance destruction event to remove the `JsiAbiRuntime` from properties when the instance is unloaded. When we need to map from the JSI ABI runtime to the existing `JsiAbiRuntime` wrapper, we continue to use the existing mapping created in the JS thread TLS (thread local storage).

To verify the fix we call the ExecuteJsi twice in our test and check that both of them use the same `facebook::jsi::Runtime` instance.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6745)