### PR TITLE
Cherry-pick: Fix RedBox on topMouseLeave event. (#6739)

### DIFF
--- a/change/react-native-windows-92856720-40ea-4e20-ac14-b1c0178f1ba0.json
+++ b/change/react-native-windows-92856720-40ea-4e20-ac14-b1c0178f1ba0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix RedBox on topMouseLeave event.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -172,10 +172,11 @@ void ViewManagerBase::GetExportedCustomBubblingEventTypeConstants(
 
 void ViewManagerBase::GetExportedCustomDirectEventTypeConstants(
     const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
-  const PCWSTR eventNames[] = {// Generic events
-                               L"Layout",
-                               L"MouseEnter",
-                               L"AccessibilityAction"};
+  constexpr PCWSTR eventNames[] = {// Generic events
+                                   L"Layout",
+                                   L"MouseEnter",
+                                   L"MouseLeave",
+                                   L"AccessibilityAction"};
 
   for (auto &eventBaseName : eventNames) {
     using namespace std::string_literals;


### PR DESCRIPTION
Cherry-pick #6739 
* Fix RedBox on topMouseLeave event.

* Change files

* make event array constexpr

Co-authored-by: Igor Klemenski <igklemen@microsoft.com>

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6746)