### PR TITLE
Add onPressIn/onPressOut Textinput events

### DIFF
--- a/change/react-native-windows-9b1e075e-6ff9-424b-99f6-d9bc58c34f86.json
+++ b/change/react-native-windows-9b1e075e-6ff9-424b-99f6-d9bc58c34f86.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add onPressIn / onPressOut events to TextInput",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -131,6 +131,31 @@ class AutogrowingTextInputExample extends React.Component<{...}> {
   }
 }
 
+class PressInOutEvents extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  constructor(props) {
+    super(props);
+    this.state = {text: 'PressIn/PressOut message'};
+  }
+  render() {
+    return (
+      <View>
+        <Text>{this.state.text}</Text>
+        <TextInput
+          placeholder="Click inside the box to observe events being fired."
+          style={[styles.singleLineWithHeightTextInput]}
+          onPressIn={() =>
+            this.setState({text: 'Holding down the click/touch'})
+          }
+          onPressOut={() => this.setState({text: 'Released click/touch'})}
+        />
+      </View>
+    );
+  }
+}
+
 const styles = StyleSheet.create({
   multiline: {
     height: 60,
@@ -422,6 +447,12 @@ exports.examples = ([
     title: 'Toggle Default Padding',
     render: function(): React.Node {
       return <ToggleDefaultPaddingExample />;
+    },
+  },
+  {
+    title: 'onPressIn, onPressOut events',
+    render: function(): React.Node {
+      return <PressInOutEvents />;
     },
   },
 ]: Array<RNTesterExampleModuleItem>);

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -18,7 +18,6 @@
 #include <IReactInstance.h>
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
-//#include <winrt/Windows.UI.Xaml.h>
 
 #ifdef USE_WINUI3
 namespace winrt::Microsoft::UI::Xaml::Controls {

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -18,6 +18,7 @@
 #include <IReactInstance.h>
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+//#include <winrt/Windows.UI.Xaml.h>
 
 #ifdef USE_WINUI3
 namespace winrt::Microsoft::UI::Xaml::Controls {
@@ -355,6 +356,22 @@ void TextInputShadowNode::registerEvents() {
           }
         });
   }
+
+  control.as<xaml::UIElement>().AddHandler(
+      xaml::UIElement::PointerPressedEvent(),
+      winrt::box_value(xaml::Input::PointerEventHandler([=](auto &&, xaml::Input::PointerRoutedEventArgs const &args) {
+        folly::dynamic eventData = folly::dynamic::object("target", tag);
+        GetViewManager()->GetReactContext().DispatchEvent(tag, "topTextInputPressIn", std::move(eventData));
+      })),
+      true);
+
+  control.as<xaml::UIElement>().AddHandler(
+      xaml::UIElement::PointerReleasedEvent(),
+      winrt::box_value(xaml::Input::PointerEventHandler([=](auto &&, xaml::Input::PointerRoutedEventArgs const &args) {
+        folly::dynamic eventData = folly::dynamic::object("target", tag);
+        GetViewManager()->GetReactContext().DispatchEvent(tag, "topTextInputPressOut", std::move(eventData));
+      })),
+      true);
 }
 
 xaml::Shapes::Shape TextInputShadowNode::FindCaret(xaml::DependencyObject element) {
@@ -688,6 +705,8 @@ void TextInputViewManager::GetExportedCustomDirectEventTypeConstants(
                                L"SelectionChange",
                                L"ContentSizeChange",
                                L"KeyPress",
+                               L"PressIn",
+                               L"PressOut",
                                L"OnScroll",
                                L"SubmitEditing"};
 


### PR DESCRIPTION
Fixes #6101 
RN v64 introduces two new events to TextInput - PressIn and PressOut - which get triggered when the user touches/clicks on the TextInput, and releases the click, respectively.

Need to use `UIElement.Addhandler(..., true)` in order to be able to listen for `PointerPressed/Released` events on the `TextBox` - they're marked as handled by one of its internal components.

As a side note, the RN commit only included JS code, which means Windows is actually ahead of RN Core in terms of native implementation. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6754)