### PR TITLE
Fix error for failing autolink check

### DIFF
--- a/change/@react-native-windows-cli-bfbf031e-dd77-473b-82ba-c4909afa4d75.json
+++ b/change/@react-native-windows-cli-bfbf031e-dd77-473b-82ba-c4909afa4d75.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix error for failing autolink check",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -561,17 +561,20 @@ async function updateAutoLink(
         )}ms)`,
       );
     } else if (checkMode) {
+      // Just log a warning here to be bubbled up into VS, otherwise the build will fail.
+      const autolinkCommand = 'npx react-native autolink-windows';
+      const autolinkArgs = `--sln "${path.relative(
+        windowsAppConfig.folder,
+        solutionFile,
+      )}" --proj "${path.relative(windowsAppConfig.folder, projectFile)}"`;
       console.log(
         `${chalk.yellow(
           'Warning:',
         )} Auto-linking changes were necessary but ${chalk.bold(
           '--check',
         )} specified. Run ${chalk.bold(
-          "'npx react-native autolink-windows'",
+          `'${autolinkCommand} ${autolinkArgs}'`,
         )} to apply the changes. (${Math.round(endTime - startTime)}ms)`,
-      );
-      throw new Error(
-        'Auto-linking changes were necessary but --check was specified',
       );
     } else {
       console.log(


### PR DESCRIPTION
The autolinking check part of an app's build can fail if the autolinked
files are out of date, but the result should be an actionable warning,
not an actual build failure.

This address part of #6761.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6763)