### PR TITLE
[0.63] Print error message when vswhere/msbuild tools are missing

### DIFF
--- a/change/@react-native-windows-cli-2020-12-18-04-39-09-vswhere-0.63.json
+++ b/change/@react-native-windows-cli-2020-12-18-04-39-09-vswhere-0.63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Print error message when vswhere is missing",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-18T12:39:08.986Z"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -198,8 +198,13 @@ async function runWindowsInternal(
   }
 
   let buildTools: MSBuildTools;
-  runWindowsPhase = RunWindowsPhase.FindBuildTools;
-  buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose);
+  try {
+    runWindowsPhase = RunWindowsPhase.FindBuildTools;
+    buildTools = MSBuildTools.findAvailableVersion(options.arch, verbose);
+  } catch (e) {
+    newError(e.message);
+    throw e;
+  }
 
   if (options.build) {
     runWindowsPhase = RunWindowsPhase.FindSolution;


### PR DESCRIPTION
Fixes #6769 

When vswhere is missing (or we fail to find msbuild tools), we fail to print an error message before exiting

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6770)