### PR TITLE
Print error message when vswhere/msbuild tools are missing

### DIFF
--- a/change/@react-native-windows-cli-ce9bd95b-9609-4aa9-8cc1-aac2b148ea3b.json
+++ b/change/@react-native-windows-cli-ce9bd95b-9609-4aa9-8cc1-aac2b148ea3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Print error message when missing vswhere/msbuild",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -226,7 +226,8 @@ async function runWindowsInternal(
         verbose,
         true, // preRelease
       );
-    } catch {
+    } catch (e) {
+      newError(e.message);
       throw error;
     }
   }


### PR DESCRIPTION
Fixes #6769

When vswhere is missing (or we fail to find msbuild tools), we fail to print an error message before exiting

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6772)