### PR TITLE
[0.64] Add target annotation prop to AccessibilityAnnotationInfo (#6743)

### DIFF
--- a/change/@office-iss-react-native-win32-358d7e11-56fa-4d83-a480-524e5e3648f3.json
+++ b/change/@office-iss-react-native-win32-358d7e11-56fa-4d83-a480-524e5e3648f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add target prop to AccessibilityAnnotationInfo",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -97,6 +97,7 @@ export type AccessibilityAnnotationInfo = Readonly<{
   typeName?: string;
   author?: string;
   dateTime?: string;
+  target?: string;
 }>;
 
 export type AccessibilityActionName =


### PR DESCRIPTION
Backports [#6743 ](https://github.com/microsoft/react-native-windows/pull/6743) to 0.64

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6773)