### PR TITLE
Fix publish pipeline due to ADO not recognizing `succeeded()` from template expression

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -77,7 +77,7 @@ jobs:
 
       - script: npx --ignore-existing @rnw-scripts/create-github-releases --authToken $(githubAuthToken)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
-        condition: ${{ and(succeeded(), not(parameters.skipGitPush), ne(variables['Build.SourceBranchName'], 'master')) }}
+        condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'master') }} )
 
       - template: templates/set-version-vars.yml
 


### PR DESCRIPTION
The error from ADO was:
```
/.ado/publish.yml (Line: 80, Col: 20): Unrecognized value: 'succeeded'. Located at position 5 within expression: and(succeeded(), not(parameters.skipGitPush), ne(variables['Build.SourceBranchName'], 'master')). For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6774)