### PR TITLE
Check deps when builds fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ bld/
 tsdoc-metadata.json
 *.dmp
 *.pp
+*.orig
+
+# cppwinrt
+nul

--- a/change/@react-native-windows-cli-3b609198-fa72-476b-943b-df441c5784d6.json
+++ b/change/@react-native-windows-cli-3b609198-fa72-476b-943b-df441c5784d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check whether dependencies have been installed",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-b973e5dc-d862-4a91-8e81-e846331c5c82.json
+++ b/change/react-native-windows-b973e5dc-d862-4a91-8e81-e846331c5c82.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check whether dependencies have been installed",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -94,6 +94,10 @@ async function runWindows(
   delete process.env.NPM_CONFIG_CACHE;
   delete process.env.NPM_CONFIG_PREFIX;
 
+  const hasRunRnwDependencies =
+    process.env.LocalAppData &&
+    fs.existsSync(path.join(process.env.LocalAppData, 'rnw-dependencies.txt')); // CODESYNC \vnext\scripts\rnw-dependencies.ps1
+
   if (options.info) {
     try {
       const output = await info.getEnvironmentInfo();
@@ -115,6 +119,22 @@ async function runWindows(
   } catch (e) {
     Telemetry.client?.trackException({exception: e});
     runWindowsError = e;
+    if (!hasRunRnwDependencies) {
+      const rnwPkgJsonPath = require.resolve(
+        'react-native-windows/package.json',
+        {
+          paths: [process.cwd(), __dirname],
+        },
+      );
+      const rnwDependenciesPath = path.join(
+        path.dirname(rnwPkgJsonPath),
+        'scripts/rnw-dependencies.ps1',
+      );
+
+      newError(
+        `Please install the necessary dependencies by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
+      );
+    }
     return setExitProcessWithError(options.logging);
   } finally {
     Telemetry.client?.trackEvent({
@@ -153,6 +173,7 @@ async function runWindows(
         diskFree: getDiskFreeSpace(__dirname),
         cpus: cpus().length,
         project: await getAnonymizedProjectName(config.root),
+        hasRunRnwDependencies: hasRunRnwDependencies,
       },
     });
     Telemetry.client?.flush();

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -9,6 +9,9 @@ param(
     [String[]]$Tags = @('appDev')
 )
 
+# CODESYNC \packages\@react-native-windows\cli\src\runWindows\runWindows.ts
+$MarkerFile = "$env:LOCALAPPDATA\rnw-dependencies.txt"
+
 # Create a set to handle with case insensitivy of the tags
 $tagsToInclude = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::OrdinalIgnorecase)
 foreach ($tag in $Tags) { $tagsToInclude.Add($tag) | Out-null }
@@ -181,7 +184,7 @@ $requirements = @(
         Name = 'NodeJS 12, 13 or 14 installed';
         Tags = @('appDev');
         Valid = CheckNode;
-        Install = { choco install -y nodejs.install --version=12.9.1 };
+        Install = { choco install -y nodejs-lts };
     },
     @{
         Name = 'Chrome';
@@ -287,6 +290,10 @@ foreach ($req in $requirements)
     }
 }
 
+if (Test-Path $MarkerFile) {
+    Remove-Item $MarkerFile
+}
+
 foreach ($req in $filteredRequirements)
 {
     Write-Host -NoNewline "Checking $($req.Name)    ";
@@ -324,6 +331,7 @@ if ($NeedsRerun -ne 0) {
     throw;
 } else {
     Write-Output "All mandatory requirements met";
+    $Tags | Out-File $MarkerFile
     return;
 }
 


### PR DESCRIPTION
We keep getting reports from folks who hit build issues that turn out to be due to them not running the dependencies script.

When building fails, check whether rnw-dependencies has been run. Update the script to leave a sentinel file behind so we can check it. Also plan to submit whether the sentinel is there in telemetry.

Also move node to use LTS version (currently 14).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6792)