### PR TITLE
Update Contributing Guidelines for yarn change

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,7 +38,7 @@ Run `yarn lint:fix` if making JS/TS changes.
 If you made API changes, run `yarn api` to update the auto-generated API docs.
 
 ### Provide changelog information
-Run `yarn change` in the root of the repo.
+Run `yarn change --branch upstream/master` in the root of the repo.
 
 ### Creating a Pull Request
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,9 +34,6 @@ Run `yarn format` in the repository's root directory if you're making C++ change
 
 Run `yarn lint:fix` if making JS/TS changes.
 
-### Run yarn api if you made API changes
-If you made API changes, run `yarn api` to update the auto-generated API docs.
-
 ### Provide changelog information
 Run `yarn change --branch upstream/master` in the root of the repo.
 


### PR DESCRIPTION
Updated Contributing Guidelines for yarn change. Update mentioned in #6789. Branch specification is a new requirement. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6794)