### PR TITLE
[0.64] Fix newline issues in new cli project generated files (#6768)

### DIFF
--- a/change/@react-native-windows-cli-688ad427-1729-4f61-96fd-f3479242c0e0.json
+++ b/change/@react-native-windows-cli-688ad427-1729-4f61-96fd-f3479242c0e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix newline issues in new cli project generated files (#6768)",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-81f7cb8b-957a-4231-b298-4f325b9cbfe9.json
+++ b/change/react-native-windows-81f7cb8b-957a-4231-b298-4f325b9cbfe9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix newline issues in new cli project generated files (#6768)",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-common/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-common/index.ts
@@ -43,6 +43,22 @@ export function resolveContents(
 ): string {
   let content = fs.readFileSync(srcPath, 'utf8');
 
+  if (content.includes('\r\n')) {
+    // CRLF file, make sure multiline replacements are also CRLF
+    for (const key of Object.keys(replacements)) {
+      if (typeof replacements[key] === 'string') {
+        replacements[key] = replacements[key].replace(/(?<!\r)\n/g, '\r\n');
+      }
+    }
+  } else {
+    // LF file, make sure multiline replacements are also LF
+    for (const key of Object.keys(replacements)) {
+      if (typeof replacements[key] === 'string') {
+        replacements[key] = replacements[key].replace(/\r\n/g, '\n');
+      }
+    }
+  }
+
   if (replacements.useMustache) {
     content = mustache.render(content, replacements);
     (replacements.regExpPatternsToRemove || []).forEach(regexPattern => {

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -240,7 +240,7 @@ export async function copyProjectTemplateAndReplace(
 
   const templateVars: Record<string, any> = {
     useMustache: true,
-    regExpPatternsToRemove: ['//\\sclang-format\\s(on|off)\\s'],
+    regExpPatternsToRemove: [],
 
     name: newProjectName,
     namespace: namespace,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -60,26 +60,6 @@ function verboseMessage(message: any, verbose: boolean) {
 }
 
 /**
- * Loads a source template file and performs the given replacements, normalizing CRLF.
- * @param srcFile Path to the source file.
- * @param replacements e.g. {'TextToBeReplaced': 'Replacement'}
- * @return The contents of the file with the replacements applied.
- */
-function getNormalizedContents(
-  srcFile: string,
-  replacements: generatorCommon.Replacements,
-) {
-  // Template files are CRLF, JS-generated replacements are LF, normalize replacements to CRLF
-  for (const key of Object.keys(replacements)) {
-    replacements[key] = replacements[key].replace(/\n/g, '\r\n');
-  }
-
-  replacements.useMustache = true;
-
-  return generatorCommon.resolveContents(srcFile, replacements);
-}
-
-/**
  * Updates the target file with the expected contents if it's different.
  * @param filePath Path to the target file to update.
  * @param expectedContents The expected contents of the file.
@@ -301,7 +281,7 @@ async function updateAutoLink(
       }
     }
 
-    // Generating cs/h files for app code consumption
+    // Generating cs/cpp files for app code consumption
     if (projectLang === 'cs') {
       let csUsingNamespaces = '';
       let csReactPackageProviders = '';
@@ -338,7 +318,8 @@ async function updateAutoLink(
         verbose,
       );
 
-      const csContents = getNormalizedContents(srcCsFile, {
+      const csContents = generatorCommon.resolveContents(srcCsFile, {
+        useMustache: true,
         autolinkCsUsingNamespaces: csUsingNamespaces,
         autolinkCsReactPackageProviders: csReactPackageProviders,
       });
@@ -388,7 +369,8 @@ async function updateAutoLink(
         verbose,
       );
 
-      const cppContents = getNormalizedContents(srcCppFile, {
+      const cppContents = generatorCommon.resolveContents(srcCppFile, {
+        useMustache: true,
         autolinkCppIncludes: cppIncludes,
         autolinkCppPackageProviders: cppPackageProviders,
       });
@@ -433,7 +415,8 @@ async function updateAutoLink(
       verbose,
     );
 
-    const propsContents = getNormalizedContents(srcPropsFile, {
+    const propsContents = generatorCommon.resolveContents(srcPropsFile, {
+      useMustache: true,
       autolinkPropertiesForProps: propertiesForProps,
     });
 
@@ -482,7 +465,8 @@ async function updateAutoLink(
       verbose,
     );
 
-    const targetContents = getNormalizedContents(srcTargetFile, {
+    const targetContents = generatorCommon.resolveContents(srcTargetFile, {
+      useMustache: true,
       autolinkProjectReferencesForTargets: projectReferencesForTargets,
     });
 

--- a/vnext/template/.clang-format
+++ b/vnext/template/.clang-format
@@ -1,0 +1,4 @@
+# This file prevents clang-format from formating the template files
+
+DisableFormat: true
+SortIncludes: false

--- a/vnext/template/cpp-app/src/App.cpp
+++ b/vnext/template/cpp-app/src/App.cpp
@@ -5,7 +5,6 @@
 #include "AutolinkedNativeModules.g.h"
 #include "ReactPackageProvider.h"
 
-// clang-format off
 using namespace winrt::{{ namespaceCpp }};
 using namespace winrt::{{ namespaceCpp }}::implementation;
 using namespace winrt;

--- a/vnext/template/cpp-app/src/App.h
+++ b/vnext/template/cpp-app/src/App.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "App.xaml.g.h"
-// clang-format off
+
 {{#useWinUI3}}
 namespace activation = winrt::Microsoft::UI::Xaml;
 {{/useWinUI3}}
@@ -21,5 +21,3 @@ namespace winrt::{{ namespaceCpp }}::implementation
         using super = AppT<App>;
     };
 } // namespace winrt::{{ namespaceCpp }}::implementation
-
-// clang-format on

--- a/vnext/template/cpp-app/src/MainPage.cpp
+++ b/vnext/template/cpp-app/src/MainPage.cpp
@@ -6,8 +6,6 @@
 
 #include "App.h"
 
-// clang-format off
-
 using namespace winrt;
 using namespace {{ xamlNamespaceCpp }};
 
@@ -20,5 +18,3 @@ namespace winrt::{{ namespaceCpp }}::implementation
         ReactRootView().ReactNativeHost(app->Host());
     }
 }
-
-// clang-format on

--- a/vnext/template/cpp-app/src/MainPage.h
+++ b/vnext/template/cpp-app/src/MainPage.h
@@ -2,7 +2,6 @@
 #include "MainPage.g.h"
 #include <winrt/Microsoft.ReactNative.h>
 
-// clang-format off
 namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct MainPage : MainPageT<MainPage>
@@ -18,4 +17,3 @@ namespace winrt::{{ namespaceCpp }}::factory_implementation
     };
 }
 
-// clang-format on

--- a/vnext/template/cpp-app/src/ReactPackageProvider.cpp
+++ b/vnext/template/cpp-app/src/ReactPackageProvider.cpp
@@ -2,7 +2,6 @@
 #include "ReactPackageProvider.h"
 #include "NativeModules.h"
 
-// clang-format off
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::{{ namespaceCpp }}::implementation
@@ -14,5 +13,3 @@ void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuil
 }
 
 } // namespace winrt::{{ namespaceCpp }}::implementation
-
-// clang-format on

--- a/vnext/template/cpp-app/src/ReactPackageProvider.h
+++ b/vnext/template/cpp-app/src/ReactPackageProvider.h
@@ -2,7 +2,6 @@
 
 #include "winrt/Microsoft.ReactNative.h"
 
-// clang-format off
 namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct ReactPackageProvider : winrt::implements<ReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider>
@@ -12,4 +11,3 @@ namespace winrt::{{ namespaceCpp }}::implementation
     };
 } // namespace winrt::{{ namespaceCpp }}::implementation
 
-// clang-format on

--- a/vnext/template/cpp-lib/src/ReactNativeModule.h
+++ b/vnext/template/cpp-lib/src/ReactNativeModule.h
@@ -3,8 +3,6 @@
 #include "JSValue.h"
 #include "NativeModules.h"
 
-// clang-format off
-
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::{{ namespaceCpp }}
@@ -33,5 +31,3 @@ struct ReactNativeModule
 };
 
 } // namespace winrt::{{ namespaceCpp }}
-
-// clang-format on

--- a/vnext/template/cpp-lib/src/ReactPackageProvider.cpp
+++ b/vnext/template/cpp-lib/src/ReactPackageProvider.cpp
@@ -6,7 +6,6 @@
 
 #include "ReactNativeModule.h"
 
-// clang-format off
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::{{ namespaceCpp }}::implementation
@@ -18,5 +17,3 @@ void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuil
 }
 
 } // namespace winrt::{{ namespaceCpp }}::implementation
-
-// clang-format on

--- a/vnext/template/cpp-lib/src/ReactPackageProvider.h
+++ b/vnext/template/cpp-lib/src/ReactPackageProvider.h
@@ -3,7 +3,6 @@
 
 using namespace winrt::Microsoft::ReactNative;
 
-// clang-format off
 namespace winrt::{{ namespaceCpp }}::implementation
 {
     struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider>
@@ -20,5 +19,3 @@ namespace winrt::{{ namespaceCpp }}::factory_implementation
 struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider, implementation::ReactPackageProvider> {};
 
 } // namespace winrt::{{ namespaceCpp }}::factory_implementation
-
-// clang-format on


### PR DESCRIPTION
This PR ports #6768 to 0.64.

* Moves the line ending normalization used by autolinking into the main cli generation, to prevent creating mixed LF and CRLF files
* Updates autolinking code to exactly match new project code, so running autolinking on a fresh cli project produces 0 changes
* Fixed the removal of the clang-format guards from the template files to prevent creating mixed LF and CRLF files

Closes #6766
Closes #6767

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6802)