### PR TITLE
Add some more logging to release creation script

### DIFF
--- a/change/@rnw-scripts-create-github-releases-5d3d6d63-eea1-443f-b040-18292eab4ff7.json
+++ b/change/@rnw-scripts-create-github-releases-5d3d6d63-eea1-443f-b040-18292eab4ff7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add some more logging to release creation script",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
+++ b/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
@@ -91,9 +91,13 @@ const argv = yargs
 
   console.log('Listing tags...');
   const localTags = (await simplegit().tags()).all;
+  console.log(localTags.map(tag => `  - ${tag}`).join('\n'));
 
   console.log('Fetching releases...');
   const githubReleases = await fetchReleases(argv.authToken);
+  console.log(
+    githubReleases.map(release => `  - ${release.tag_name}`).join('\n'),
+  );
 
   for (const changelog of changelogs) {
     for (const release of aggregateReleases(changelog)) {


### PR DESCRIPTION
We seem to not be creating releases when we should be sometimes. It's hard to understand why with current logging (running theory is a race on tag creation).  Add some logging.

No need to backport this to branches doing releases (stable branches) since they always run the latest published script.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6808)