### PR TITLE
[0.64] Add resolution for axios@^0.21.1 to pass CG (#6810)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "appium-android-driver": "4.12.0-stub.0",
     "appium-selendroid-driver": "1.13.4-stub.0",
     "appium-tizen-driver": "1.1.1-stub.0",
+    "axios": "^0.21.1",
     "eslint-plugin-react": "^7.14.1",
     "eslint-plugin-react-hooks": "4.0.7",
     "kind-of": "6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,10 +3512,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+axios@^0.20.0, axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 


### PR DESCRIPTION
Backporting #6810 to 0.64.

Appium support brings in axios. Appium support has updated to ^0.21.1 in their master, but have not published the fix.

We can remove this resolution if we remove Appium.

Closes #6702

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6813)