### PR TITLE
Print cwd if generator cannot detect project package

### DIFF
--- a/change/@react-native-windows-cli-74f5405f-0058-4b85-903d-1d2043b285a2.json
+++ b/change/@react-native-windows-cli-74f5405f-0058-4b85-903d-1d2043b285a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Print cwd if generator cannot detect project package",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -525,7 +525,9 @@ export async function installScriptsAndDependencies(options: {
 }) {
   const projectPackage = await WritableNpmPackage.fromPath(process.cwd());
   if (!projectPackage) {
-    throw new Error('The current directory is not the root of an npm package');
+    throw new Error(
+      `The current directory '${process.cwd()}' is not the root of an npm package`,
+    );
   }
 
   await projectPackage.mergeProps({


### PR DESCRIPTION
PR feedback from https://github.com/microsoft/react-native-windows/pull/6809#discussion_r551517453

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6820)