### PR TITLE
[0.62] export win32 PlatformColor function for system colors access

### DIFF
--- a/change/@office-iss-react-native-win32-2021-01-07-15-23-04-0.62-exportPlatformColor.json
+++ b/change/@office-iss-react-native-win32-2021-01-07-15-23-04-0.62-exportPlatformColor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Export PlatformColor function that returns a system color object",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ppatboyd@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-07T23:23:04.473Z"
+}

--- a/packages/react-native-win32/etc/react-native-win32.api.md
+++ b/packages/react-native-win32/etc/react-native-win32.api.md
@@ -71,6 +71,12 @@ export class ButtonWin32 extends React_2.Component<IButtonWin32Props, IButtonWin
 export type ButtonWin32OmitStyles = RN.TextStyleIOS & RN.TextStyleAndroid;
 
 // @public (undocumented)
+export type ColorStop = {
+  color: string | number | NativeOrDynamicColorType;
+  offset: number;
+};
+
+// @public (undocumented)
 export type Cursor = 'auto' | 'pointer';
 
 // @public (undocumented)
@@ -381,6 +387,15 @@ export interface IViewWin32Props extends Omit_2<RN.ViewProps, ViewWin32OmitTypes
 }
 
 // @public (undocumented)
+export type NativeOrDynamicColorType = {
+  // Necessary Gradient members
+  gradientDirection?: string;
+  colorStops?: Array<ColorStop>;
+  // Necessary PlatformColor members
+  resource_paths?: Array<string>;
+};
+
+// @public (undocumented)
 export type OmittedAccessibilityPropsWin32 = {
     accessibilityActions?: ReadonlyArray<RN.AccessibilityActionInfo>;
     accessibilityRole?: RN.AccessibilityRole;
@@ -425,6 +440,9 @@ export enum PersonaCoinSize {
     // (undocumented)
     small = 1
 }
+
+// @public (undocumented)
+export function PlatformColor(...names: Array<string>): any;
 
 // @public (undocumented)
 export type SharedAccessibilityPropsIOSandWin32 = {

--- a/packages/react-native-win32/just-task.js
+++ b/packages/react-native-win32/just-task.js
@@ -46,6 +46,9 @@ task('eslint:fix', () => {
 task('copyFlowFiles', () => {
   return copyTask(['src/**/*.js'], '.');
 });
+task('copyTsTypeFiles', () => {
+  return copyTask(['src/**/*.d.ts'], '.');
+});
 task('copyPngFiles', () => {
   return copyTask(['src/**/*.png'], '.');
 });
@@ -96,6 +99,7 @@ task(
     condition('clean', () => argv().clean),
     'initRNLibraries',
     'copyFlowFiles',
+    'copyTsTypeFiles',
     'copyPngFiles',
     'ts',
     condition('apiExtractorVerify', () => argv().ci),

--- a/packages/react-native-win32/src/Libraries/StyleSheet/NativeOrDynamicColorType.win32.d.ts
+++ b/packages/react-native-win32/src/Libraries/StyleSheet/NativeOrDynamicColorType.win32.d.ts
@@ -22,6 +22,7 @@ export declare type NativeOrDynamicColorType = {
   resource_paths?: Array<string>;
 };
 
-export declare function PlatformColor(
-  ...names: Array<string>
-): NativeOrDynamicColorType;
+// React-Native 0.63 introduced OpaqueColorValue, replacing the use of 'string' across color properties.
+// Since this is a backport for 0.62, rather than assert a type inconsistent with OpaqueColorValue or string,
+// we'll treat the return as any.
+export declare function PlatformColor(...names: Array<string>): any;

--- a/packages/react-native-win32/src/Libraries/StyleSheet/NativeOrDynamicColorType.win32.d.ts
+++ b/packages/react-native-win32/src/Libraries/StyleSheet/NativeOrDynamicColorType.win32.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+'use strict';
+
+export declare type ColorStop = {
+  color: string | number | NativeOrDynamicColorType;
+  offset: number;
+};
+
+// Flexible color type that supports gradients and platform colors.
+// Member existence is checked in normalizeColorObject and ensures one set of necessary members is initialized.
+export declare type NativeOrDynamicColorType = {
+  // Necessary Gradient members
+  gradientDirection?: string;
+  colorStops?: Array<ColorStop>;
+  // Necessary PlatformColor members
+  resource_paths?: Array<string>;
+};
+
+export declare function PlatformColor(
+  ...names: Array<string>
+): NativeOrDynamicColorType;

--- a/packages/react-native-win32/src/index.win32.ts
+++ b/packages/react-native-win32/src/index.win32.ts
@@ -62,4 +62,11 @@ Object.defineProperty(Index, 'PersonaCoinPresence', {
   },
 });
 
+Object.defineProperty(Index, 'PlatformColor', {
+  get: () => {
+    return require('./Libraries/StyleSheet/NativeOrDynamicColorType.win32').PlatformColor;
+  },
+});
+
+
 export = Index;

--- a/packages/react-native-win32/src/overrides.json
+++ b/packages/react-native-win32/src/overrides.json
@@ -42,7 +42,7 @@
     },
     {
       "type": "platform",
-      "file": "Libraries\\StyleSheet\\NativeOrDynamicColorType.win32.js"
+      "file": "Libraries\\StyleSheet\\NativeOrDynamicColorType.win32.d.ts"
     },
     {
       "type": "platform",

--- a/packages/react-native-win32/src/overrides.json
+++ b/packages/react-native-win32/src/overrides.json
@@ -42,6 +42,10 @@
     },
     {
       "type": "platform",
+      "file": "Libraries\\StyleSheet\\NativeOrDynamicColorType.win32.js"
+    },
+    {
+      "type": "platform",
       "file": "Libraries\\Components\\Button\\ButtonWin32.tsx"
     },
     {

--- a/packages/react-native-win32/src/typings-index.ts
+++ b/packages/react-native-win32/src/typings-index.ts
@@ -26,3 +26,4 @@ export * from './Libraries/Components/Touchable/TouchableWin32.Types';
 export * from './Libraries/Components/Touchable/TouchableWin32';
 export * from './Libraries/PersonaCoin/PersonaCoin';
 export * from './Libraries/PersonaCoin/PersonaCoinTypes';
+export { PlatformColor } from './Libraries/StyleSheet/NativeOrDynamicColorType.win32';

--- a/packages/react-native-win32/src/typings-index.ts
+++ b/packages/react-native-win32/src/typings-index.ts
@@ -26,4 +26,4 @@ export * from './Libraries/Components/Touchable/TouchableWin32.Types';
 export * from './Libraries/Components/Touchable/TouchableWin32';
 export * from './Libraries/PersonaCoin/PersonaCoin';
 export * from './Libraries/PersonaCoin/PersonaCoinTypes';
-export { PlatformColor } from './Libraries/StyleSheet/NativeOrDynamicColorType.win32';
+export * from './Libraries/StyleSheet/NativeOrDynamicColorType.win32';


### PR DESCRIPTION
Missing export for the backported win32 PlatformColor function, to give access to system colors such as those provided by high contrast themes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6835)