### PR TITLE
[0.64] Adding Typescript declaration file for FocusManager API (#6834)

### DIFF
--- a/change/@office-iss-react-native-win32-0d8d6c5c-d153-432d-aa59-dac541419b81.json
+++ b/change/@office-iss-react-native-win32-0d8d6c5c-d153-432d-aa59-dac541419b81.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding FocusManager type decl file",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -367,6 +367,10 @@
     },
     {
       "type": "platform",
+      "file": "src/Libraries/Utilities/FocusManager.win32.d.ts"
+    },
+    {
+      "type": "platform",
       "file": "src/Libraries/Utilities/FocusManager.win32.js"
     },
     {

--- a/packages/react-native-win32/src/Libraries/Utilities/FocusManager.win32.d.ts
+++ b/packages/react-native-win32/src/Libraries/Utilities/FocusManager.win32.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+
+export declare class FocusManager {
+  static focus(ref: React.Ref<any>, setWindowFocus: boolean): void;
+}

--- a/packages/react-native-win32/src/Libraries/Utilities/FocusManager.win32.d.ts
+++ b/packages/react-native-win32/src/Libraries/Utilities/FocusManager.win32.d.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  *
- * @flow
  * @format
  */
 

--- a/packages/react-native-win32/src/typings-index.ts
+++ b/packages/react-native-win32/src/typings-index.ts
@@ -27,3 +27,4 @@ export * from './Libraries/Components/Touchable/TouchableWin32.Types';
 export * from './Libraries/Components/Touchable/TouchableWin32';
 export * from './Libraries/PersonaCoin/PersonaCoin';
 export * from './Libraries/PersonaCoin/PersonaCoinTypes';
+export * from './Libraries/Utilities/FocusManager.win32';


### PR DESCRIPTION
Adding a Typescript declaration file for the FocusManager API.

Backporting to 0.64

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6844)