### PR TITLE
[0.63] Reverse order of AccessibilityView in TransferProperties().

### DIFF
--- a/change/react-native-windows-cc93ff7b-a218-4493-a198-f166cb586fc4.json
+++ b/change/react-native-windows-cc93ff7b-a218-4493-a198-f166cb586fc4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reverse order of AccessibilityView in TransferProperties().",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -114,8 +114,8 @@ void FrameworkElementViewManager::TransferProperties(const XamlView &oldView, co
   TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::PositionInSetProperty());
   TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::SizeOfSetProperty());
   auto accessibilityView = xaml::Automation::AutomationProperties::GetAccessibilityView(oldView);
-  xaml::Automation::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
   xaml::Automation::AutomationProperties::SetAccessibilityView(oldView, winrt::Peers::AccessibilityView::Raw);
+  xaml::Automation::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
   TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityRoleProperty());
   TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateSelectedProperty());
   TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateDisabledProperty());


### PR DESCRIPTION
In v0.63 setting `View.borderRadius` causes narrator to set its focus on the entire app windows, instead of the View in question. 

In `FrameworkElementViewManager::TransferProperties()`, if `oldView == newView`, then
```cpp
xaml::Automation::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
xaml::Automation::AutomationProperties::SetAccessibilityView(oldView, winrt::Peers::AccessibilityView::Raw);
```
results in the value being overwritten incorrectly. Reversing these 2 operations fixes the problem, and doesn't change anything if `oldView != newView`.

Issue doesn't occur in 0.64, though, despite this code being identical.

Fixes #6706 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6847)