### PR TITLE
[0.63] Backport of bugfix for window dimensions fixed values

### DIFF
--- a/change/react-native-windows-2020-10-20-17-25-59-dimsfix.json
+++ b/change/react-native-windows-2020-10-20-17-25-59-dimsfix.json
@@ -1,8 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "raise change event when dimensions change",
-  "packageName": "react-native-windows",
-  "email": "kmelmon@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-10-21T00:25:59.575Z"
-}

--- a/change/react-native-windows-2020-10-20-17-25-59-dimsfix.json
+++ b/change/react-native-windows-2020-10-20-17-25-59-dimsfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "raise change event when dimensions change",
+  "packageName": "react-native-windows",
+  "email": "kmelmon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-21T00:25:59.575Z"
+}

--- a/change/react-native-windows-2021-01-12-15-06-36-backport-bugfix-dimension_never_fires_change_events.json
+++ b/change/react-native-windows-2021-01-12-15-06-36-backport-bugfix-dimension_never_fires_change_events.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Backport of bugfix: Dimension never fires change event",
+  "packageName": "react-native-windows",
+  "email": "Bartosz.Klonowski@callstack.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-12T14:06:36.159Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -112,6 +112,7 @@ void DeviceInfoHolder::updateDeviceInfo() noexcept {
   m_dpi = displayInfo.LogicalDpi();
   m_screenWidth = displayInfo.ScreenWidthInRawPixels();
   m_screenHeight = displayInfo.ScreenHeightInRawPixels();
+  notifyChanged();
 }
 
 void DeviceInfo::GetConstants(React::ReactConstantProvider &provider) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -125,7 +125,7 @@ void DeviceInfo::Initialize(React::ReactContext const &reactContext) noexcept {
   DeviceInfoHolder::SetCallback(
       m_context.Properties(), [weakThis = weak_from_this()](React::JSValueObject &&dimensions) {
         if (auto strongThis = weakThis.lock()) {
-          strongThis->m_context.EmitJSEvent(L"RCTDeviceEventEmitter", L"didUpdateDimensions", dimensions);
+          strongThis->m_context.CallJSFunction(L"RCTDeviceEventEmitter", L"emit", L"didUpdateDimensions", dimensions);
         }
       });
 }


### PR DESCRIPTION
This pull request fixes #6689 

These changes provide the fix already implemented in PR #6286 but instead of applying the dependency changes (please see #6285) it uses the `CallJSFunction()` as a direct replacement for `EmitJSEvent()` method.
Such workaround has already been discussed in #6286 conversation and the example of an implementation has been presented already in issue #5951.

---

Changes implemented in this pull request are:
* Directly cherry-pick the original fix
NOTE: Due to the branch implementing the changes has been deleted after the merge, there was no possibility to cherry-pick only the commit applying fix for `DeviceInfoModule`. So the *change/* files has also been cherry-picked, but were further removed when generating the proper change files.
* Apply the workaround for the `didUpdateDimensions` event
(already explained in the general description above).

`yarn format` did not apply any changes.

---

Results:

The implementation has been tested using the the RNTester in the Playground application:
![Dimension_RNTester](https://user-images.githubusercontent.com/70535775/104327796-71e7da80-54eb-11eb-9530-5c1f598e56a9.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6854)