### PR TITLE
Add Workaround for XAML Bug with textDecorationLine

### DIFF
--- a/change/react-native-windows-0702e81f-38d9-4c98-9040-a29aec2eaa58.json
+++ b/change/react-native-windows-0702e81f-38d9-4c98-9040-a29aec2eaa58.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "#6715 Add Workaround to Resolve textDecorationLine Bug",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -164,8 +164,7 @@ bool TextViewManager::UpdateProperty(
     // Temporary workaround for bug in XAML which fails to flush old TextDecorationLine render
     // Link to Bug: https://github.com/microsoft/microsoft-ui-xaml/issues/1093#issuecomment-514282402
     winrt::hstring text(textBlock.Text().c_str());
-    winrt::hstring empty_text{L""};
-    textBlock.Text(empty_text);
+    textBlock.Text(L"");
     textBlock.Text(text);
   } else if (TryUpdateCharacterSpacing(textBlock, propertyName, propertyValue)) {
   } else if (propertyName == "numberOfLines") {

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -161,6 +161,11 @@ bool TextViewManager::UpdateProperty(
   } else if (TryUpdateTextAlignment(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextTrimming(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine(textBlock, propertyName, propertyValue)) {
+    std::wstring text(textBlock.Text().c_str());
+    text.push_back('a');
+    textBlock.Text(winrt::hstring(text));
+    text.pop_back();
+    textBlock.Text(winrt::hstring(text));
   } else if (TryUpdateCharacterSpacing(textBlock, propertyName, propertyValue)) {
   } else if (propertyName == "numberOfLines") {
     if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -162,11 +162,11 @@ bool TextViewManager::UpdateProperty(
   } else if (TryUpdateTextTrimming(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine(textBlock, propertyName, propertyValue)) {
     // Temporary workaround for bug in XAML which fails to flush old TextDecorationLine render
-    std::wstring text(textBlock.Text().c_str());
-    text.push_back('a');
-    textBlock.Text(winrt::hstring(text));
-    text.pop_back();
-    textBlock.Text(winrt::hstring(text));
+    // Link to Bug: https://github.com/microsoft/microsoft-ui-xaml/issues/1093#issuecomment-514282402
+    winrt::hstring text(textBlock.Text().c_str());
+    winrt::hstring empty_text{L""};
+    textBlock.Text(empty_text);
+    textBlock.Text(text);
   } else if (TryUpdateCharacterSpacing(textBlock, propertyName, propertyValue)) {
   } else if (propertyName == "numberOfLines") {
     if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -161,6 +161,7 @@ bool TextViewManager::UpdateProperty(
   } else if (TryUpdateTextAlignment(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextTrimming(textBlock, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine(textBlock, propertyName, propertyValue)) {
+    // Temporary workaround for bug in XAML which fails to flush old TextDecorationLine render
     std::wstring text(textBlock.Text().c_str());
     text.push_back('a');
     textBlock.Text(winrt::hstring(text));


### PR DESCRIPTION
Fix #6715 

**_Why_**
The issue is a bug with the textDecorationLine prop for the Text component where the UI is failing to display the correct styling. When the textDecorationLine prop is set to ‘underline’, an underline appears. But if the prop is then set to ‘none’ or even removed entirely, the underline still persists. This buggy behavior also happens for the other values for this prop, ‘line-through’ and ‘underline-line-through’. Another instance of buggy behavior is when the textDecorationLine prop is initially set to ‘underline’, an underline appears. But if the prop is then set to ‘line-through’, the underline still persists along with the strikethrough.

**_What_**
Turns out buggy behavior in RNW is the result of a bug in XAML, where updates to the textDecorationLine prop are incorrectly marked as not needing rendering when the value is changed. This bug will not be able to be resolved until WinUI3 I believe. Inside the issue there is a link to a XAML issue which details a workaround which can be implemented to resolve the bug. Essentially, following a change in the textDecorationLine prop, the user should change and change back the Text contents of the TextBlock in order to trigger the re-rendering of the component. 

**_How_**
Added workaround code following TryUpdateTextDecorationLine returning true, signaling that the prop has changed in value or been removed. Added comment above workaround noting that this it is one, so the excerpt can be identified later once the bug in XAML is resolved. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6855)