### PR TITLE
Fix unused parameter warning in AbiCallInvoker

### DIFF
--- a/change/react-native-windows-2612cd0f-8728-4026-a242-1ace7bb1bf67.json
+++ b/change/react-native-windows-2612cd0f-8728-4026-a242-1ace7bb1bf67.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix unused variable warning in AbiCallInvoker",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.cpp
@@ -14,7 +14,7 @@ struct AbiCallInvoker final : facebook::react::CallInvoker {
     m_jsDispatcher.Post([func = std::move(func)]() { func(); });
   }
 
-  void invokeSync(std::function<void()> &&func) override {
+  void invokeSync(std::function<void()> && /*func*/) override {
     // Throwing an exception in this method matches the behavior of
     // Instance::JSCallInvoker::invokeSync in react-native\ReactCommon\cxxreact\Instance.cpp
     throw std::runtime_error("Synchronous native -> JS calls are currently not supported.");


### PR DESCRIPTION
It is a small change to comment out unused parameter.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6860)