### PR TITLE
Move CallInvoker.h to TurboModule filter folder

### DIFF
--- a/change/react-native-windows-91a8b6fc-6cd9-4917-909b-3657b2292dee.json
+++ b/change/react-native-windows-91a8b6fc-6cd9-4917-909b-3657b2292dee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move CallInvoker.h to TurboModule folder",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
@@ -133,7 +133,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JsiApiContext.h">
       <Filter>JSI</Filter>
     </ClInclude>
-    <ClInclude Include="$(CallInvoker_SourcePath)\ReactCommon\CallInvoker.h" />
+    <ClInclude Include="$(CallInvoker_SourcePath)\ReactCommon\CallInvoker.h">
+      <Filter>TurboModule</Filter>
+    </ClInclude>
     <ClInclude Include="$(TurboModule_SourcePath)\ReactCommon\TurboModule.h">
       <Filter>TurboModule</Filter>
     </ClInclude>


### PR DESCRIPTION
This is a "cosmetic" change in Microsoft.ReactNative.Cxx project.
We fix the location of the CallInvoker.h in the visual tree in the Visual Studio - no functional changes.
It is moved to the "TurboModule" folder along with other TurboModule related files.
Note, that the CallInvoker.h is referenced from the RN code. It is not part of RNW code.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6861)