### PR TITLE
Allow Integration Script to Output Markdown

### DIFF
--- a/change/@rnw-scripts-integrate-rn-8c70f5f7-2ccb-4c2f-bfe3-bcb5a8b5d176.json
+++ b/change/@rnw-scripts-integrate-rn-8c70f5f7-2ccb-4c2f-bfe3-bcb5a8b5d176.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow Integration Script to Output Markdown",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/integrate-rn/src/integrateRN.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/integrateRN.ts
@@ -6,12 +6,12 @@
  */
 
 import * as fs from 'fs';
-import * as ora from 'ora';
 import * as path from 'path';
 import * as semver from 'semver';
 import * as yargs from 'yargs';
 
 import {
+  findPackage,
   enumerateRepoPackages,
   NpmPackage,
   WritableNpmPackage,
@@ -25,9 +25,19 @@ import {
 
 import runCommand from './runCommand';
 import upgradeDependencies from './upgradeDependencies';
+import {Logger, CompositeLogger, ConsoleLogger, MarkdownLogger} from './Logger';
+
+let logger: Logger;
 
 (async () => {
   const {argv} = yargs
+    .options({
+      reportPath: {
+        type: 'string',
+        describe: 'Optional path to generate a markdown output of results',
+        demandOption: false,
+      },
+    })
     .check(args => {
       if (args._.length === 1 && semver.valid(args._[0])) {
         return true;
@@ -39,9 +49,28 @@ import upgradeDependencies from './upgradeDependencies';
 
   const version = argv._[0];
 
+  logger = new CompositeLogger([
+    new ConsoleLogger(process.stdout),
+    ...(argv.reportPath
+      ? [new MarkdownLogger(fs.createWriteStream(argv.reportPath))]
+      : []),
+  ]);
+  try {
+    await performSteps(version);
+  } finally {
+    logger.close();
+  }
+})();
+
+async function performSteps(newVersion: string) {
+  logger.info(`Commits: ${await generateCommitsUrl(newVersion)}`);
+
   await funcStep(
-    `Updating packages and dependants to react-native@${version}`,
-    async () => await upgradeDependencies(version),
+    `Updating packages and dependants to react-native@${newVersion}`,
+    async () => {
+      await upgradeDependencies(newVersion);
+      return {status: 'success'};
+    },
   );
 
   await funcStep('Upgrading out-of-date overrides', upgradePlatformOverrides);
@@ -53,7 +82,7 @@ import upgradeDependencies from './upgradeDependencies';
   await failableCommandStep('yarn lint:fix');
   await commandStep('yarn build');
   await failableCommandStep('yarn lint');
-})();
+}
 
 /**
  * Enumerate packages subject to override validation
@@ -78,7 +107,7 @@ async function isOverridePackage(pkg: NpmPackage): Promise<boolean> {
  * Upgrade platform overrides in the repo to the current version of react
  * native, disallowing files with conflicts to be written
  */
-async function upgradePlatformOverrides(spinner: ora.Ora) {
+async function upgradePlatformOverrides(): Promise<StepResult> {
   const overridesWithConflicts: string[] = [];
 
   for (const pkg of await enumerateOverridePackages()) {
@@ -95,13 +124,15 @@ async function upgradePlatformOverrides(spinner: ora.Ora) {
     );
   }
 
-  if (overridesWithConflicts.length !== 0) {
-    spinner.warn();
-    console.warn(
-      `Conflicts detected in the following files. Use 'react-native-platform-override upgrade' to resolve: \n- ${overridesWithConflicts.join(
+  if (overridesWithConflicts.length === 0) {
+    return {status: 'success'};
+  } else {
+    return {
+      status: 'warn',
+      body: `Conflicts detected in the following files. Use 'react-native-platform-override upgrade' to resolve: \n- ${overridesWithConflicts.join(
         '\n- ',
       )}`,
-    );
+    };
   }
 }
 
@@ -109,7 +140,7 @@ async function upgradePlatformOverrides(spinner: ora.Ora) {
  * Perform additional validation on platform overrides apart from the previous
  * up-to-date check
  */
-async function validatePlatformOverrides(spinner: ora.Ora) {
+async function validatePlatformOverrides(): Promise<StepResult> {
   const errors: ValidationError[] = [];
 
   for (const pkg of await enumerateOverridePackages()) {
@@ -119,29 +150,66 @@ async function validatePlatformOverrides(spinner: ora.Ora) {
   }
 
   if (errors.filter(e => e.type !== 'outOfDate').length !== 0) {
-    spinner.warn();
-    console.warn(
-      "Additional errors detected. Run 'yarn validate-overrides' for more information",
-    );
+    return {
+      status: 'warn',
+      body:
+        'Override validation failed. Run `yarn validate-overrides` for more information',
+    };
+  } else {
+    return {status: 'success'};
   }
 }
 
 /**
+ * Creates a URL to show commits that have ocurred between the current RN
+ * version and the new version
+ */
+async function generateCommitsUrl(newRnVersion: string): Promise<string> {
+  const rnwPackage = (await findPackage('react-native-windows'))!;
+  const rnPackage = (await findPackage('react-native', {
+    searchPath: rnwPackage.path,
+  }))!;
+
+  return `https://github.com/facebook/react-native/compare/${refFromVersion(
+    rnPackage.json.version,
+  )}...${refFromVersion(newRnVersion)}`;
+}
+
+/**
+ * Returns a git ref that may be used in a GitHub comparison URL from an npm package version
+ */
+function refFromVersion(reactNativeVersion: string): string {
+  if (!semver.valid(reactNativeVersion)) {
+    throw new Error(`${reactNativeVersion} is not a valid semver version`);
+  }
+
+  // Stable releases of React Native use a tag where nightly releases embed
+  // a commit hash into the prerelease tag of 0.0.0 versions
+  if (semver.lt(reactNativeVersion, '0.0.0', {includePrerelease: true})) {
+    return semver.prerelease(reactNativeVersion)![0];
+  } else {
+    return `v${reactNativeVersion}`;
+  }
+}
+
+type StepResult = {
+  status: 'success' | 'warn' | 'error';
+  body?: string;
+};
+
+/**
  * Run the function while showing a spinner
  */
-async function funcStep<T>(
+async function funcStep(
   name: string,
-  func: (s: ora.Ora) => Promise<T>,
-): Promise<T> {
-  const spinner = ora(name).start();
+  func: () => Promise<StepResult>,
+): Promise<void> {
+  logger.newTask(name);
   try {
-    const t = await func(spinner);
-    if (spinner.isSpinning) {
-      spinner.succeed();
-    }
-    return t;
+    const result = await func();
+    logger[result.status](name, result.body);
   } catch (ex) {
-    spinner.fail();
+    logger.error(name, ex.stack);
     throw ex;
   }
 }
@@ -150,19 +218,21 @@ async function funcStep<T>(
  * Run the command while showing a spinner
  */
 async function commandStep(cmd: string) {
-  return funcStep(cmd, async () => runCommand(cmd));
+  return funcStep(cmd, async () => {
+    await runCommand(cmd);
+    return {status: 'success'};
+  });
 }
 
 /**
  * Run the command while showing a spinner. Continue if the command returns a non-zero exit code.
  */
 async function failableCommandStep(cmd: string) {
-  return funcStep(cmd, async spinner => {
-    try {
-      await runCommand(cmd);
-    } catch (ex) {
-      spinner.fail();
-      console.error(ex.message);
-    }
-  });
+  logger.newTask(cmd);
+  try {
+    await runCommand(cmd);
+    logger.success(cmd);
+  } catch (ex) {
+    logger.error(cmd, ex.stack);
+  }
 }

--- a/packages/@rnw-scripts/integrate-rn/src/logger.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/logger.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as ora from 'ora';
+
+export type Logger = {
+  newTask: (taskName: string) => void;
+  info: (message: string) => void;
+  success: (taskName: string, body?: string) => void;
+  warn: (taskName: string, body?: string) => void;
+  error: (taskName: string, body?: string) => void;
+  close: () => void;
+};
+
+export class ConsoleLogger implements Logger {
+  private readonly spinner: ora.Ora;
+
+  constructor(private readonly stream: NodeJS.WritableStream) {
+    this.spinner = ora({stream});
+  }
+
+  newTask(taskName: string) {
+    if (this.spinner.isSpinning) {
+      throw new Error('A task has already been started');
+    }
+
+    this.spinner.start(taskName);
+  }
+
+  info(message: string) {
+    this.spinner.info(message);
+  }
+
+  success(taskName: string, body?: string) {
+    this.spinner.succeed(this.combineBody(taskName, body));
+  }
+
+  warn(taskName: string, body?: string) {
+    this.spinner.warn(this.combineBody(taskName, body));
+  }
+
+  error(taskName: string, body?: string) {
+    this.spinner.fail(this.combineBody(taskName, body));
+  }
+
+  close() {
+    this.stream.end();
+  }
+
+  private combineBody(taskName: string, body?: string) {
+    if (body === undefined) {
+      return taskName;
+    } else {
+      return `${taskName}\n${body}`;
+    }
+  }
+}
+
+export class MarkdownLogger implements Logger {
+  constructor(private readonly stream: NodeJS.WritableStream) {}
+
+  newTask(_taskName: string) {
+    // Ignore until completion
+  }
+
+  info(message: string) {
+    this.stream.write(message + '\n');
+  }
+
+  success(taskName: string, body?: string) {
+    this.stream.write(`### ✅ ${taskName}\n`);
+    this.logBody(body);
+  }
+
+  warn(taskName: string, body?: string) {
+    this.stream.write(`### ⚠ ${taskName}\n`);
+    this.logBody(body);
+  }
+
+  error(taskName: string, body?: string) {
+    this.stream.write(`### ❌ ${taskName}\n`);
+    this.logBody(body);
+  }
+
+  close() {
+    this.stream.end();
+  }
+
+  private logBody(body?: string) {
+    if (body) {
+      this.stream.write('```\n' + body + '\n```\n');
+    }
+  }
+}
+
+export class CompositeLogger implements Logger {
+  constructor(private readonly loggers: Logger[]) {}
+
+  newTask(taskName: string) {
+    this.loggers.forEach(logger => logger.newTask(taskName));
+  }
+
+  info(message: string) {
+    this.loggers.forEach(logger => logger.info(message));
+  }
+
+  success(taskName: string, body?: string) {
+    this.loggers.forEach(logger => logger.success(taskName, body));
+  }
+
+  warn(taskName: string, body?: string) {
+    this.loggers.forEach(logger => logger.warn(taskName, body));
+  }
+
+  error(taskName: string, body?: string) {
+    this.loggers.forEach(logger => logger.error(taskName, body));
+  }
+
+  close() {
+    this.loggers.forEach(logger => logger.close());
+  }
+}

--- a/packages/@rnw-scripts/integrate-rn/src/logger.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/logger.ts
@@ -67,8 +67,9 @@ export class MarkdownLogger implements Logger {
     // Ignore until completion
   }
 
-  info(message: string) {
-    this.stream.write(message + '\n');
+  info(message: string, body?: string) {
+    this.stream.write(`### ℹ ${message}\n`);
+    this.logBody(body);
   }
 
   success(taskName: string, body?: string) {

--- a/packages/@rnw-scripts/integrate-rn/src/test/logger.test.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/test/logger.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import {PassThrough} from 'stream';
+import {MarkdownLogger, ConsoleLogger} from '../Logger';
+
+let outStream: NodeJS.WritableStream;
+let loggerOuptput: string;
+
+beforeEach(() => {
+  loggerOuptput = '';
+  outStream = new PassThrough();
+  outStream.on('data', chunk => {
+    loggerOuptput += chunk;
+  });
+});
+
+test('Markdown Output', () => {
+  const logger = new MarkdownLogger(outStream);
+
+  logger.info('Commits: foo');
+  logger.newTask('Updating dependencies');
+  logger.success('Dependencies updated');
+  logger.newTask('Updating overrides');
+  logger.warn('Out of date overrides', '- A\n- B');
+  logger.newTask('yarn build');
+  logger.error('yarn build');
+
+  logger.close();
+
+  expect(loggerOuptput).toBe(`Commits: foo
+### ✅ Dependencies updated
+### ⚠ Out of date overrides
+\`\`\`
+- A
+- B
+\`\`\`
+### ❌ yarn build\n`);
+});
+
+beforeEach(() => {
+  loggerOuptput = '';
+});
+
+test('Console Output', () => {
+  const logger = new ConsoleLogger(outStream);
+
+  logger.info('Commits: foo');
+  logger.newTask('Updating dependencies');
+  logger.success('Dependencies updated');
+  logger.newTask('Updating overrides');
+  logger.warn('Out of date overrides', '- A\n- B');
+  logger.newTask('yarn build');
+  logger.error('yarn build');
+
+  logger.close();
+
+  expect(stripAnsiColors(loggerOuptput)).toBe(
+    `i Commits: foo
+- Updating dependencies
+√ Dependencies updated
+- Updating overrides
+‼ Out of date overrides
+- A
+- B
+- yarn build
+× yarn build
+`,
+  );
+});
+
+function stripAnsiColors(str: string) {
+  // Taken from https://github.com/chalk/ansi-regex/blob/master/index.js
+  const pattern = [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+  ].join('|');
+
+  return str.replace(new RegExp(pattern, 'g'), '');
+}

--- a/packages/@rnw-scripts/integrate-rn/src/test/logger.test.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/test/logger.test.ts
@@ -32,7 +32,7 @@ test('Markdown Output', () => {
 
   logger.close();
 
-  expect(loggerOuptput).toBe(`Commits: foo
+  expect(loggerOuptput).toBe(`### ℹ Commits: foo
 ### ✅ Dependencies updated
 ### ⚠ Out of date overrides
 \`\`\`


### PR DESCRIPTION
This adds a flag to the RN integration script to generate a markdown report with status of checks. This will be used for automated integration as the body of pull requests created by the bot.

We additionally automate the addition of a URL in reports to show new commits since last integration.

Added some simple UTs for the logger and manually validated against an integration.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6862)